### PR TITLE
Manually add local server to discovery for local host

### DIFF
--- a/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
@@ -164,13 +165,7 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
         if (isAdvertising) {
             return;
         }
-        NsdServiceInfo serviceInfo = new NsdServiceInfo();
-        serviceInfo.setServiceName(discoveryConstants.SERVICE_NAME);
-        serviceInfo.setServiceType(discoveryConstants.SERVICE_TYPE);
-        serviceInfo.setPort(discoveryConstants.PORT);
-        serviceInfo.setAttribute(discoveryConstants.PROTOCOL_KEY, "https");
-        serviceInfo.setAttribute(discoveryConstants.CLIENT_VERSION_KEY, "unspecified");
-        serviceInfo.setAttribute(discoveryConstants.HARDWARE_ID_KEY, discoveryConstants.hardwareId);
+        NsdServiceInfo serviceInfo = createLocalServiceInfo();
 
         discoveryManager = (NsdManager) this.getActivity()
                 .getSystemService(NSD_SERVICE);
@@ -194,6 +189,8 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
                     }
                 });
         isAdvertising = true;
+        // See method comment
+        addLocalServerToDiscovery();
     }
 
     private void stopServerDiscovery() {
@@ -323,6 +320,34 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
 
     }
 
+    private NsdServiceInfo createLocalServiceInfo() {
+        NsdServiceInfo serviceInfo = new NsdServiceInfo();
+        serviceInfo.setServiceName(discoveryConstants.SERVICE_NAME);
+        serviceInfo.setServiceType(discoveryConstants.SERVICE_TYPE);
+        serviceInfo.setPort(discoveryConstants.PORT);
+        serviceInfo.setAttribute(discoveryConstants.PROTOCOL_KEY, "https");
+        serviceInfo.setAttribute(discoveryConstants.CLIENT_VERSION_KEY, "unspecified");
+        serviceInfo.setAttribute(discoveryConstants.HARDWARE_ID_KEY, discoveryConstants.hardwareId);
+       return serviceInfo;
+    }
+
+    // Had issues resolving local server when wifi and mobile data is off
+    // getting onResolveFailed with errorCode = 0 (internal error) with no more information
+    // manually adding this server should work
+    private void addLocalServerToDiscovery() {
+        if(isAdvertising && isDiscovering && discoveredServers != null) {
+            try {
+                NsdServiceInfo serviceInfo = createLocalServiceInfo();
+                serviceInfo.setHost(InetAddress.getByName("localhost"));
+                discoveredServers.put(serviceInfoToObject(serviceInfo));
+            } catch(Exception E) {
+                Log.d(OM_SUPPLY, "problem adding localhost to discovery");
+            }
+        }
+    }
+
+
+
     private String parseAttribute(NsdServiceInfo serviceInfo, String name) {
         byte[] attributeBytes = serviceInfo.getAttributes().get(name);
         if (attributeBytes == null) {
@@ -350,6 +375,8 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
     @Override
     public void onDiscoveryStarted(String serviceType) {
         isDiscovering = true;
+        // See method comment
+        addLocalServerToDiscovery();
     }
 
     // NsdManager.DiscoveryListener


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1349 

# 👩🏻‍💻 What does this PR do? 

When wifi and mobile data are turned of found out that discovery wasn't working on mobile, errorCode = 0 was returned for `onResolveFailed` method. Now adding local server discovery manually

# 🧪 How has/should this change been tested? 

Reinstall app

- [ ] Turn wifi off and mobile data off
- [ ] Start app in server mode (should go to initialisation screen)
- [ ] Stop app, turn wifi on
- [ ] Start app (should go to initialisation screen)

Try the same in reverse order:

Reinstall app

- [ ] Turn wifi on
- [ ] Start app in server mode (should go to initialisation screen)
- [ ] Stop app, turn wifi off and mobile data off
- [ ] Start app (should go to initialisation screen)

## 💌 Any notes for the reviewer?


