### PR TITLE
Use tanstack to cache pack units

### DIFF
--- a/client/packages/host/src/Host.tsx
+++ b/client/packages/host/src/Host.tsx
@@ -29,6 +29,7 @@ import { Site } from './Site';
 import { AuthenticationAlert } from './components/AuthenticationAlert';
 import { Discovery } from './components/Discovery';
 import { Android } from './components/Android';
+import { usePackUnits } from '@openmsupply-client/system';
 
 const appVersion = require('../../../../package.json').version; // eslint-disable-line @typescript-eslint/no-var-requires
 
@@ -58,6 +59,16 @@ Bugsnag.start({
 const skipRequest = () =>
   LocalStorage.getItem('/auth/error') === AuthError.NoStoreAssigned;
 
+/**
+ * Empty component which can be used to call startup hooks.
+ * For example, this component is called when auth information such as user or store id changed.
+ */
+const Init = () => {
+  // Fetch pack units at startup. Note, the units are cached, i.e. they are not fetched repeatedly.
+  usePackUnits();
+  return <></>;
+};
+
 const Host = () => (
   <React.Suspense fallback={<div />}>
     <IntlProvider>
@@ -69,6 +80,7 @@ const Host = () => (
               skipRequest={skipRequest}
             >
               <AuthProvider>
+                <Init />
                 <AppThemeProvider>
                   <ConfirmationModalProvider>
                     <AlertModalProvider>

--- a/client/packages/host/src/Host.tsx
+++ b/client/packages/host/src/Host.tsx
@@ -29,7 +29,7 @@ import { Site } from './Site';
 import { AuthenticationAlert } from './components/AuthenticationAlert';
 import { Discovery } from './components/Discovery';
 import { Android } from './components/Android';
-import { usePackUnits } from '@openmsupply-client/system';
+import { useRefreshUnitVariant } from '@openmsupply-client/system';
 
 const appVersion = require('../../../../package.json').version; // eslint-disable-line @typescript-eslint/no-var-requires
 
@@ -65,7 +65,8 @@ const skipRequest = () =>
  */
 const Init = () => {
   // Fetch pack units at startup. Note, the units are cached, i.e. they are not fetched repeatedly.
-  usePackUnits();
+  // They will be refetched on page reload or when store is changed based on cache usePackUnits api keys
+  useRefreshUnitVariant();
   return <></>;
 };
 

--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
@@ -13,7 +13,6 @@ import {
 import {
   InventoryAdjustmentReasonRowFragment,
   PackUnitCell,
-  useInitUnitStore,
 } from '@openmsupply-client/system';
 import { StocktakeSummaryItem } from '../../../types';
 import { StocktakeLineFragment } from '../../api';
@@ -57,8 +56,6 @@ export const useStocktakeColumns = ({
   StocktakeLineFragment | StocktakeSummaryItem
 >[] => {
   const { getError } = useStocktakeLineErrorContext();
-  // TODO this is not the right place for it, see comment in method
-  useInitUnitStore();
 
   return useColumns<StocktakeLineFragment | StocktakeSummaryItem>(
     [

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -11,11 +11,7 @@ import {
   ColumnAlign,
   PositiveNumberCell,
 } from '@openmsupply-client/common';
-import {
-  LocationRowFragment,
-  PackUnitCell,
-  useInitUnitStore,
-} from '@openmsupply-client/system';
+import { LocationRowFragment, PackUnitCell } from '@openmsupply-client/system';
 import { InboundItem } from './../../../types';
 import { InboundLineFragment } from '../../api';
 import { isInboundPlaceholderRow } from '../../../utils';
@@ -31,8 +27,6 @@ export const useInboundShipmentColumns = () => {
   const { c } = useCurrency();
   const getSellPrice = (row: InboundLineFragment) =>
     isInboundPlaceholderRow(row) ? '' : c(row.sellPricePerPack).format();
-  // TODO this is not the right place for it, see comment in method
-  useInitUnitStore();
 
   const columns = useColumns<InboundLineFragment | InboundItem>(
     [

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -19,7 +19,6 @@ import { DraftInboundLine } from '../../../../types';
 import {
   getLocationInputColumn,
   LocationRowFragment,
-  useInitUnitStore,
   useUnitVariant,
 } from '@openmsupply-client/system';
 import { getPackUnitEntryCell } from '@openmsupply-client/system';
@@ -84,8 +83,6 @@ const PackUnitEntryCell = getPackUnitEntryCell<DraftInboundLine>({
 export const QuantityTableComponent: FC<
   TableProps & { item: InboundLineFragment['item'] | null }
 > = ({ item, lines, updateDraftLine, isDisabled = false }) => {
-  // TODO this is not the right place for it, see comment in method
-  useInitUnitStore();
   const { unitVariantsExist } = useUnitVariant(item?.id || '', null);
   const theme = useTheme();
 

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -18,7 +18,6 @@ import {
 import {
   StockItemSearchInput,
   ItemRowFragment,
-  useInitUnitStore,
   useUnitVariant,
 } from '@openmsupply-client/system';
 import { useOutbound } from '../../api';
@@ -54,8 +53,6 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
   canAutoAllocate,
   isAutoAllocated,
 }) => {
-  // TODO this is not the right place for it, see comment in method
-  useInitUnitStore();
   const t = useTranslation('distribution');
   const [showAllocationWarning, setShowAllocationWarning] = useState(false);
   const [placeholderQuantity, setPlaceholderQuantity] = useState(0);

--- a/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -12,11 +12,7 @@ import {
   InvoiceLineNodeType,
   PositiveNumberCell,
 } from '@openmsupply-client/common';
-import {
-  LocationRowFragment,
-  PackUnitCell,
-  useInitUnitStore,
-} from '@openmsupply-client/system';
+import { LocationRowFragment, PackUnitCell } from '@openmsupply-client/system';
 import { StockOutLineFragment } from '../../StockOut';
 import { StockOutItem } from '../../types';
 
@@ -46,8 +42,6 @@ export const useOutboundColumns = ({
   onChangeSortBy,
 }: UseOutboundColumnOptions): Column<StockOutLineFragment | StockOutItem>[] => {
   const { c } = useCurrency();
-  // TODO this is not the right place for it, see comment in method
-  useInitUnitStore();
   return useColumns(
     [
       [

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
@@ -16,7 +16,6 @@ import {
 import {
   StockItemSearchInput,
   ItemRowFragment,
-  useInitUnitStore,
   useUnitVariant,
 } from '@openmsupply-client/system';
 import { usePrescription } from '../../api';
@@ -56,8 +55,6 @@ export const PrescriptionLineEditForm: React.FC<
   draftPrescriptionLines,
 }) => {
   const t = useTranslation('dispensary');
-  // TODO this is not the right place for it, see comment in method
-  useInitUnitStore();
 
   const quantity =
     allocatedQuantity /

--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -11,11 +11,7 @@ import {
   useCurrency,
   PositiveNumberCell,
 } from '@openmsupply-client/common';
-import {
-  LocationRowFragment,
-  PackUnitCell,
-  useInitUnitStore,
-} from '@openmsupply-client/system';
+import { LocationRowFragment, PackUnitCell } from '@openmsupply-client/system';
 import { StockOutLineFragment } from '../../StockOut';
 import { StockOutItem } from '../../types';
 
@@ -38,8 +34,6 @@ export const usePrescriptionColumn = ({
   StockOutLineFragment | StockOutItem
 >[] => {
   const { c } = useCurrency();
-  // TODO this is not the right place for it, see comment in method
-  useInitUnitStore();
   return useColumns(
     [
       [

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -10,7 +10,6 @@ import {
 } from '@openmsupply-client/common';
 import {
   ItemRowWithStatsFragment,
-  useInitUnitStore,
   useUnitVariant,
 } from '@openmsupply-client/system';
 import { RequestLineEditForm } from './RequestLineEditForm';
@@ -33,9 +32,6 @@ export const RequestLineEdit = ({
   mode,
   item,
 }: RequestLineEditProps) => {
-  // TODO this is not the right place for it, see comment in method
-  useInitUnitStore();
-
   const disabled = useRequest.utils.isDisabled();
   const { Modal } = useDialog({ onClose, isOpen, animationTimeout: 100 });
   const [currentItem, setCurrentItem] = useBufferState(item);

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
@@ -12,7 +12,6 @@ import {
   StockItemSearchInputWithStats,
   ItemRowWithStatsFragment,
   VariantControl,
-  useInitUnitStore,
   PackUnitSelect,
 } from '@openmsupply-client/system';
 import { useRequest } from '../../api';
@@ -98,8 +97,6 @@ export const RequestLineEditForm = ({
   numberOfPacksFromQuantity,
   numberOfPacksToTotalQuantity,
 }: RequestLineEditFormProps) => {
-  // TODO this is not the right place for it, see comment in method
-  useInitUnitStore();
   const t = useTranslation('replenishment');
   const formatNumber = useFormatNumber();
   const { lines } = useRequest.line.list();

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
@@ -15,7 +15,6 @@ import { useRequest } from '../api';
 import {
   getPackUnitQuantityCell,
   getPackUnitSelectCell,
-  useInitUnitStore,
   useUnitVariant,
 } from '@openmsupply-client/system';
 
@@ -48,8 +47,6 @@ export const useRequestColumns = () => {
     queryParams: { sortBy },
   } = useUrlQueryParams({ initialSort: { key: 'itemName', dir: 'asc' } });
   const { usesRemoteAuthorisation } = useRequest.utils.isRemoteAuthorisation();
-  // TODO this is not the right place for it, see comment in method
-  useInitUnitStore();
 
   const columnDefinitions: ColumnDescription<RequestLineFragment>[] = [
     getCommentPopoverColumn(),

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
@@ -10,7 +10,6 @@ import {
 import { ResponseLineFragment, useResponse } from './../api';
 import {
   getPackUnitQuantityCell,
-  useInitUnitStore,
   useUnitVariant,
 } from '@openmsupply-client/system';
 
@@ -19,8 +18,6 @@ export const useResponseColumns = () => {
     updateSortQuery,
     queryParams: { sortBy },
   } = useUrlQueryParams({ initialSort: { key: 'itemName', dir: 'asc' } });
-  // TODO this is not the right place for it, see comment in method
-  useInitUnitStore();
   const { isRemoteAuthorisation } = useResponse.utils.isRemoteAuthorisation();
   const columnDefinitions: ColumnDescription<ResponseLineFragment>[] = [
     getCommentPopoverColumn(),

--- a/client/packages/system/src/Item/Components/index.ts
+++ b/client/packages/system/src/Item/Components/index.ts
@@ -3,4 +3,3 @@ export * from './ServiceItemSearchInput';
 export * from './StockItemSearchInputWithStats';
 export * from './StockItemSelectModal';
 export * from './StockItemSearchInput';
-export * from './ItemVariant';

--- a/client/packages/system/src/Item/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Item/DetailView/DetailView.tsx
@@ -14,15 +14,13 @@ import { Toolbar } from './Toolbar';
 import { GeneralTab } from './Tabs/General';
 import { MasterListsTab } from './Tabs/MasterLists';
 import { AppRoute } from '@openmsupply-client/config';
-import { useInitUnitStore, useUnitVariant } from '../context';
+import { useUnitVariant } from '../context';
 
 export const ItemDetailView: FC = () => {
   const { data, isLoading } = useItem();
   const navigate = useNavigate();
   const t = useTranslation('catalogue');
   const { setSuffix } = useBreadcrumbs();
-  // TODO this is not the right place for it, see comment in method
-  useInitUnitStore();
   const { variantsControl, numberOfPacksFromQuantity } = useUnitVariant(
     data?.id ?? '',
     data?.name ?? null

--- a/client/packages/system/src/Item/ListView/ListView.tsx
+++ b/client/packages/system/src/Item/ListView/ListView.tsx
@@ -17,7 +17,6 @@ import {
   getPackUnitQuantityCell,
   getPackUnitSelectCell,
 } from '../Components/ItemVariant';
-import { useInitUnitStore } from '../context';
 
 const ItemListComponent: FC = () => {
   const {
@@ -29,8 +28,6 @@ const ItemListComponent: FC = () => {
     initialSort: { key: 'name', dir: 'asc' },
     filterKey: 'codeOrName',
   });
-  // TODO this is not the right place for it, see comment in method
-  useInitUnitStore();
   const { data, isError, isLoading } = useItems();
   const pagination = { page, first, offset };
   const navigate = useNavigate();

--- a/client/packages/system/src/Item/api/hooks/usePackUnits/usePackUnits.ts
+++ b/client/packages/system/src/Item/api/hooks/usePackUnits/usePackUnits.ts
@@ -4,5 +4,11 @@ import { useItemApi } from '../useItemApi';
 export const usePackUnits = () => {
   const api = useItemApi();
 
-  return useQuery(api.keys.packUnits(), api.get.packUnits);
+  // Assume pack units don't change often, i.e. don't do an API calls every time you need them
+  const cacheTime = 60 * 60 * 1000; // 1h
+  return useQuery(api.keys.packUnits(), api.get.packUnits, {
+    cacheTime,
+    // don't refetch
+    staleTime: cacheTime,
+  });
 };

--- a/client/packages/system/src/Item/api/hooks/usePackUnits/usePackUnits.ts
+++ b/client/packages/system/src/Item/api/hooks/usePackUnits/usePackUnits.ts
@@ -4,11 +4,12 @@ import { useItemApi } from '../useItemApi';
 export const usePackUnits = () => {
   const api = useItemApi();
 
-  // Assume pack units don't change often, i.e. don't do an API calls every time you need them
-  const cacheTime = 60 * 60 * 1000; // 1h
+  // Always use previously fetched values
+  const cacheTime = 10 * 365 * 24 * 60 * 60 * 1000; // 10 years
+  // Assume pack units don't change often, i.e. only refetch every once a while
+  const staleTime = 60 * 60 * 1000; // 1h
   return useQuery(api.keys.packUnits(), api.get.packUnits, {
     cacheTime,
-    // don't refetch
-    staleTime: cacheTime,
+    staleTime,
   });
 };

--- a/client/packages/system/src/Item/context/useUnitVariant.ts
+++ b/client/packages/system/src/Item/context/useUnitVariant.ts
@@ -40,22 +40,6 @@ const useUnitStore = create<UnitState>(set => {
   };
 });
 
-export const useInitUnitStore = () => {
-  const { setItems } = useUnitStore();
-  // This should happen on startup and when store is changed (when the store changed, calculated values of mostUsedVariant and app data userSelected would change)
-  // Suggested places:
-  // https://github.com/openmsupply/open-msupply/blob/312b837c3d17a1ead05e140b7668cd5f45dffbc3/client/packages/common/src/authentication/api/hooks/useLogin.ts#L107
-  // https://github.com/openmsupply/open-msupply/blob/312b837c3d17a1ead05e140b7668cd5f45dffbc3/client/packages/common/src/authentication/AuthContext.tsx#L125
-  const { data } = usePackUnits();
-
-  useEffect(() => {
-    if (!data) return;
-    setItems(data.nodes || []);
-  }, [data]);
-
-  // TODO add user selected from app data
-};
-
 type CommonAsPackUnit = (_: {
   packSize: number;
   packUnitName?: string;
@@ -98,14 +82,21 @@ export const useUnitVariant = (
   variantsControl?: VariantControl;
   unitVariantsExist: boolean;
 } => {
-  const [item, userSelectedVariantId, setUserSelectedVariant] = useUnitStore(
-    state => [
-      state.items[itemId],
-      state.userSelectedVariants[itemId],
-      state.setUserSelectedVariant,
-    ],
-    isEqual
-  );
+  const [setItems, item, userSelectedVariantId, setUserSelectedVariant] =
+    useUnitStore(
+      state => [
+        state.setItems,
+        state.items[itemId],
+        state.userSelectedVariants[itemId],
+        state.setUserSelectedVariant,
+      ],
+      isEqual
+    );
+  const { data: packUnitsData } = usePackUnits();
+  useEffect(() => {
+    setItems(packUnitsData?.nodes || []);
+  }, [packUnitsData, setItems]);
+
   const t = useTranslation();
 
   if (!item || item.packUnits.length == 0) {

--- a/client/packages/system/src/Item/context/useUnitVariant.ts
+++ b/client/packages/system/src/Item/context/useUnitVariant.ts
@@ -69,6 +69,18 @@ export interface VariantControl {
   setUserSelectedVariant: (variantId: string) => void;
 }
 
+// Will call API to refresh unit variant if cache is expired
+// or if store is change (based on api keys)
+export const useRefreshUnitVariant = () => {
+  const { setItems } = useUnitStore();
+
+  const { data } = usePackUnits();
+
+  useEffect(() => {
+    setItems(data?.nodes || []);
+  }, [data, setItems]);
+};
+
 export const useUnitVariant = (
   itemId: string,
   unitName: string | null
@@ -82,20 +94,14 @@ export const useUnitVariant = (
   variantsControl?: VariantControl;
   unitVariantsExist: boolean;
 } => {
-  const [setItems, item, userSelectedVariantId, setUserSelectedVariant] =
-    useUnitStore(
-      state => [
-        state.setItems,
-        state.items[itemId],
-        state.userSelectedVariants[itemId],
-        state.setUserSelectedVariant,
-      ],
-      isEqual
-    );
-  const { data: packUnitsData } = usePackUnits();
-  useEffect(() => {
-    setItems(packUnitsData?.nodes || []);
-  }, [packUnitsData, setItems]);
+  const [item, userSelectedVariantId, setUserSelectedVariant] = useUnitStore(
+    state => [
+      state.items[itemId],
+      state.userSelectedVariants[itemId],
+      state.setUserSelectedVariant,
+    ],
+    isEqual
+  );
 
   const t = useTranslation();
 

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -18,7 +18,7 @@ import {
 import { RepackModal, StockLineEditModal, Toolbar } from '../Components';
 import { StockLineRowFragment, useStock } from '../api';
 import { AppBarButtons } from './AppBarButtons';
-import { PackUnitCell, useInitUnitStore } from '@openmsupply-client/system';
+import { PackUnitCell } from '@openmsupply-client/system';
 
 const StockListComponent: FC = () => {
   const {
@@ -32,8 +32,6 @@ const StockListComponent: FC = () => {
   });
   const pagination = { page, first, offset };
   const t = useTranslation('inventory');
-  // TODO this is not the right place for it, see comment in method
-  useInitUnitStore();
   const { data, isLoading, isError } = useStock.line.list();
   const [repackId, setRepackId] = React.useState<string | null>(null);
   const EditStockLineCell = <T extends StockLineRowFragment>({


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Part of #2313

Fetches and caches the pack units on first use.

A bit different to what suggested in the TODO, so just a draft. Idea is to use tan stack query to cache the pack units for an hour and then just use `usePackUnits` in `useUnitVariant`.

Some drawbacks though:
1) pack units are cached in tanstack AND in the `useUnitStore`
2) the initial use will be slower since the query has to run first

So actually think doing the query at startup is better. However, doing the initial call in `useLogin` or `useAuthContext` also doesn't seem right (both are quite "clean" right now doing just login/auth, and both are in `common`). So wonder if this solution is good enough.