### PR TITLE
2429 change formatter.naive date time to formatter.to iso string

### DIFF
--- a/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
+++ b/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
@@ -11,7 +11,12 @@ import {
   RecordWithId,
   useLocalStorage,
 } from '@openmsupply-client/common';
-import { FilterBy, FilterByWithBoolean, FilterController, SortBy } from '../useQueryParams';
+import {
+  FilterBy,
+  FilterByWithBoolean,
+  FilterController,
+  SortBy,
+} from '../useQueryParams';
 
 // This hook uses the state of the url query parameters (from useUrlQuery hook)
 // to provide query parameters and update methods to tables.
@@ -179,8 +184,8 @@ const getFilterEntry = (
 
     if (filter.key.toLowerCase().includes('datetime')) {
       return {
-        afterOrEqualTo: Formatter.naiveDateTime(dateAfter),
-        beforeOrEqualTo: Formatter.naiveDateTime(dateBefore),
+        afterOrEqualTo: Formatter.toIsoString(dateAfter),
+        beforeOrEqualTo: Formatter.toIsoString(dateBefore),
       };
     }
     return {
@@ -189,7 +194,7 @@ const getFilterEntry = (
     };
   }
   const condition = filter.condition ? filter.condition : 'like';
-  if(condition === '=') {
+  if (condition === '=') {
     return Boolean(filterValue);
   }
 

--- a/client/packages/common/src/utils/formatters/formatters.test.ts
+++ b/client/packages/common/src/utils/formatters/formatters.test.ts
@@ -7,7 +7,7 @@ describe('Formatter', () => {
     expect(Formatter.expiryDate).toBeDefined();
     expect(Formatter.expiryDateString).toBeDefined();
     expect(Formatter.naiveDate).toBeDefined();
-    expect(Formatter.naiveDateTime).toBeDefined();
+    expect(Formatter.toIsoString).toBeDefined();
     expect(Formatter.tax).toBeDefined();
   });
 
@@ -48,12 +48,12 @@ describe('Formatter', () => {
   });
 
   it('naiveDateTime', () => {
-    expect(Formatter.naiveDateTime(null)).toBe(null);
-    expect(Formatter.naiveDateTime(new Date('1984/3/13'))).toBe(
-      '1984-03-13T00:00:00+00:00'
+    expect(Formatter.toIsoString(null)).toBe(null);
+    expect(Formatter.toIsoString(new Date('1984/3/13'))).toBe(
+      '1984-03-12T12:00:00.000Z'
     );
-    expect(Formatter.naiveDateTime(new Date('1984/3/13 11:12:13'))).toBe(
-      '1984-03-13T11:12:13+00:00'
+    expect(Formatter.toIsoString(new Date('1984/3/13 11:12:13'))).toBe(
+      '1984-03-12T23:12:13.000Z'
     );
   });
 

--- a/client/packages/common/src/utils/formatters/formatters.ts
+++ b/client/packages/common/src/utils/formatters/formatters.ts
@@ -12,9 +12,8 @@ export const Formatter = {
     if (date && isValid(date)) return format(date, 'yyyy-MM-dd');
     else return null;
   },
-  naiveDateTime: (date?: Date | null): string | null => {
-    if (date && isValid(date))
-      return format(date, "yyyy-MM-dd'T'HH:mm:ss+mm:mm");
+  toIsoString: (date?: Date | null): string | null => {
+    if (date && isValid(date)) return date.toISOString();
     else return null;
   },
   dateTime: (date?: Date | null): string =>

--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
@@ -11,6 +11,8 @@ import {
   getLinesFromRow,
   TooltipTextCell,
   useTranslation,
+  TypedTFunction,
+  LocaleKey,
 } from '@openmsupply-client/common';
 import { InventoryAdjustmentReasonRowFragment } from '@openmsupply-client/system';
 import { StocktakeSummaryItem } from '../../../types';
@@ -29,10 +31,9 @@ const expandColumn = getRowExpandColumn<
 >();
 
 const getStocktakeReasons = (
-  rowData: StocktakeLineFragment | StocktakeSummaryItem
+  rowData: StocktakeLineFragment | StocktakeSummaryItem,
+  t: TypedTFunction<LocaleKey>
 ) => {
-  const t = useTranslation();
-
   if ('lines' in rowData) {
     const { lines } = rowData;
     const inventoryAdjustmentReasons = lines
@@ -355,8 +356,8 @@ export const useStocktakeColumns = ({
       {
         key: 'inventoryAdjustmentReason',
         label: 'label.reason',
-        accessor: ({ rowData }) => getStocktakeReasons(rowData),
-        getSortValue: rowData => getStocktakeReasons(rowData),
+        accessor: ({ rowData }) => getStocktakeReasons(rowData, t),
+        getSortValue: rowData => getStocktakeReasons(rowData, t),
       },
       {
         key: 'comment',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2429 

# 👩🏻‍💻 What does this PR do? 
Return iso string to api for datetime and fix tests

# 🧪 How has/should this change been tested? 
- [ ] try use any of the datetime filters and check api call to see the parameters sent