### PR TITLE
Let Autocomplete use the same show option as the Select component

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/Autocomplete.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Autocomplete.tsx
@@ -53,9 +53,10 @@ const UIComponent = (props: ControlProps) => {
     [schemaOptions]
   );
   useEffect(() => {
-    if (!schemaOptions?.freeText) {
-      setLocalData(options.find(option => option.value === data));
-    } else if (data) {
+    const matchingOption = options.find(option => option.value === data);
+    if (matchingOption) {
+      setLocalData(matchingOption);
+    } else if (schemaOptions?.freeText) {
       setLocalData({ value: data, label: data });
     }
   }, [data, options, schemaOptions]);
@@ -64,19 +65,10 @@ const UIComponent = (props: ControlProps) => {
     return null;
   }
 
-  // In free text mode we don't get an onChange update when changing focus; do an update manually
-  const onClose = () => {
-    if (!schemaOptions?.freeText) {
-      return;
-    }
-    handleChange(path, localData);
-  };
-
   const onInputChange = (_event: React.SyntheticEvent, value: string) => {
     if (schemaOptions?.freeText) {
-      // set the local data so that we have it in onClose; don't set it otherwise because it would
-      // affect the normal behaviour, i.e. the input wouldn't clear if the value is not valid
       setLocalData({ value, label: value });
+      handleChange(path, value);
     }
   };
 
@@ -84,17 +76,11 @@ const UIComponent = (props: ControlProps) => {
     _event: React.SyntheticEvent,
     option: DisplayOption | null
   ) => {
-    let s = '';
-    if (typeof option === 'string') {
-      // from freeText mode
-      s = option;
-    } else {
-      s = option?.label ?? '';
-    }
+    const inputString = option?.label ?? '';
     if (
       !schemaOptions?.freeText &&
       !(schemaOptions?.show ?? []).some(([value, label]) =>
-        label ? label === s : value === s
+        label ? label === inputString : value === inputString
       )
     ) {
       handleChange(path, undefined);
@@ -119,7 +105,6 @@ const UIComponent = (props: ControlProps) => {
           value={localData ?? { value: '', label: '' }}
           // some type problem here, freeSolo seems to have type `undefined`
           freeSolo={schemaOptions?.freeText as undefined}
-          onClose={onClose}
           onChange={onChange}
           onInputChange={onInputChange}
           clearable={!props.config?.required}

--- a/client/packages/programs/src/JsonForms/common/components/Autocomplete.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { ControlProps, rankWith, uiTypeIs } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import {
@@ -9,21 +9,35 @@ import { z } from 'zod';
 import { useZodOptionsValidation } from '../hooks/useZodOptionsValidation';
 import { DefaultFormRowSx, FORM_LABEL_WIDTH } from '../styleConstants';
 
-type Options = {
-  freeText?: boolean;
-  values?: string[];
-};
-const Options: z.ZodType<Options | undefined> = z
+const Options = z
   .object({
     freeText: z.boolean().optional(),
-    values: z.array(z.string()).optional(),
+    /**
+     * Option to provide pre-defined values for the autocomplete and also to optionally show a
+     * different value.
+     *
+     * For example, ["A", "Display option A"] would show as "Display option A" but record "A" in the
+     * data object.
+     */
+    show: z.array(z.tuple([z.string()]).rest(z.string().optional())).optional(),
   })
   .strict()
   .optional();
 
+type Options = z.infer<typeof Options>;
+
 export const autocompleteTester = rankWith(10, uiTypeIs('Autocomplete'));
 
-type DisplayOption = { label: string };
+type DisplayOption = { label: string; value: string };
+
+const getDisplayOptions = (options?: Options): DisplayOption[] => {
+  if (!options?.show) return [];
+
+  return options.show.reduce<DisplayOption[]>((prev, [key, value]) => {
+    prev.push({ value: key, label: value ?? key });
+    return prev;
+  }, []);
+};
 
 const UIComponent = (props: ControlProps) => {
   const { data, handleChange, label, path, errors } = props;
@@ -32,7 +46,19 @@ const UIComponent = (props: ControlProps) => {
     props.uischema.options
   );
 
-  const [localData, setLocalData] = useState<string | undefined>(data);
+  const [localData, setLocalData] = useState<DisplayOption | undefined>();
+
+  const options: DisplayOption[] = useMemo(
+    () => getDisplayOptions(schemaOptions),
+    [schemaOptions]
+  );
+  useEffect(() => {
+    if (!schemaOptions?.freeText) {
+      setLocalData(options.find(option => option.value === data));
+    } else if (data) {
+      setLocalData({ value: data, label: data });
+    }
+  }, [data, options, schemaOptions]);
 
   if (!props.visible) {
     return null;
@@ -50,38 +76,33 @@ const UIComponent = (props: ControlProps) => {
     if (schemaOptions?.freeText) {
       // set the local data so that we have it in onClose; don't set it otherwise because it would
       // affect the normal behaviour, i.e. the input wouldn't clear if the value is not valid
-      setLocalData(value);
+      setLocalData({ value, label: value });
     }
   };
 
   const onChange = (
     _event: React.SyntheticEvent,
-    value: DisplayOption | null | string
+    option: DisplayOption | null
   ) => {
     let s = '';
-    if (typeof value === 'string') {
+    if (typeof option === 'string') {
       // from freeText mode
-      s = value;
+      s = option;
     } else {
-      s = value?.label ?? '';
+      s = option?.label ?? '';
     }
     if (
       !schemaOptions?.freeText &&
-      !(schemaOptions?.values ?? []).includes(s)
+      !(schemaOptions?.show ?? []).some(([value, label]) =>
+        label ? label === s : value === s
+      )
     ) {
-      setLocalData(undefined);
       handleChange(path, undefined);
     } else {
-      setLocalData(s);
-      handleChange(path, s === '' ? undefined : s);
+      handleChange(path, option?.value ?? undefined);
     }
   };
 
-  const options: DisplayOption[] = (schemaOptions?.values ?? []).map(
-    (option: string) => ({
-      label: option,
-    })
-  );
   return (
     <DetailInputWithLabelRow
       sx={DefaultFormRowSx}
@@ -95,7 +116,7 @@ const UIComponent = (props: ControlProps) => {
             flexBasis: '100%',
           }}
           options={options}
-          value={{ label: localData ?? '' }}
+          value={localData ?? { value: '', label: '' }}
           // some type problem here, freeSolo seems to have type `undefined`
           freeSolo={schemaOptions?.freeText as undefined}
           onClose={onClose}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Part of #2329

For the HIV contact tracing I tried to keep the original codes which are stored in original data, e.g. "C" for a "Children" relationship.

This PR replaces the existing `values` option for the Autocomplete control with a `show` option similar to the `show` option of the Select control. I thought it would be nice to have the same option and to be able to customize how thing are displayed and how they are stored.

However, there is one problem. The contact tracing table column now shows "C" instead of "Children". Had a chat with Richard, and he was fine with it. If this is a problem we can still update the UI schema to use the display options...