### PR TITLE
1727 filter view stock list by master list & location

### DIFF
--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureBreach/Toolbar.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureBreach/Toolbar.tsx
@@ -31,6 +31,7 @@ export const Toolbar: FC<{ filter: FilterController }> = () => {
               type: 'text',
               name: t('label.location'),
               urlParameter: 'location.name',
+              placeholder: t('placeholder.search-by-location-name'),
             },
             {
               type: 'group',

--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureLog/Toolbar.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureLog/Toolbar.tsx
@@ -31,6 +31,7 @@ export const Toolbar: FC<{ filter: FilterController }> = () => {
               type: 'text',
               name: t('label.location'),
               urlParameter: 'location.name',
+              placeholder: t('placeholder.search-by-location-name'),
             },
             {
               type: 'group',

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -392,6 +392,7 @@
   "multiple": "[multiple]",
   "placeholder.filter-by-status": "Filter by status",
   "placeholder.filter-items": "Filter items",
+  "placeholder.search-by-location-name": "Search by location name",
   "placeholder.search-by-name": "Search by name",
   "placeholder.search-by-name-or-code": "Search by name or code",
   "success": "Success!",

--- a/client/packages/common/src/intl/locales/en/inventory.json
+++ b/client/packages/common/src/intl/locales/en/inventory.json
@@ -21,6 +21,7 @@
   "label.add-new-line": "Add a new line",
   "label.batch": "Batch",
   "label.cant-delete-disabled": "Can only delete lines when status is New",
+  "label.code-or-name": "Code or Name",
   "label.cost-price": "Cost price",
   "label.counted-num-of-packs": "Counted # of Packs",
   "label.create-location": "Create Location",

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -4502,6 +4502,7 @@ export type StockLineFilterInput = {
   isAvailable?: InputMaybe<Scalars['Boolean']['input']>;
   itemCodeOrName?: InputMaybe<StringFilterInput>;
   itemId?: InputMaybe<EqualFilterStringInput>;
+  location?: InputMaybe<LocationFilterInput>;
   locationId?: InputMaybe<EqualFilterStringInput>;
   storeId?: InputMaybe<EqualFilterStringInput>;
 };

--- a/client/packages/system/src/Stock/Components/Toolbar.tsx
+++ b/client/packages/system/src/Stock/Components/Toolbar.tsx
@@ -2,21 +2,13 @@ import React, { FC } from 'react';
 import {
   AppBarContentPortal,
   useTranslation,
-  SearchBar,
   FilterController,
-  FilterRule,
+  Box,
+  FilterMenu,
 } from '@openmsupply-client/common';
-import { StockLineRowFragment } from '../api';
 
-interface ToolbarProps {
-  filter: FilterController;
-}
-
-export const Toolbar: FC<ToolbarProps> = ({ filter }) => {
+export const Toolbar: FC<{ filter: FilterController }> = () => {
   const t = useTranslation('inventory');
-  const key = 'itemCodeOrName' as keyof StockLineRowFragment;
-  const filterString =
-    ((filter.filterBy?.[key] as FilterRule)?.like as string) || '';
 
   return (
     <AppBarContentPortal
@@ -27,20 +19,24 @@ export const Toolbar: FC<ToolbarProps> = ({ filter }) => {
         display: 'flex',
       }}
     >
-      <SearchBar
-        placeholder={t('placeholder.enter-an-item-code-or-name')}
-        value={filterString ?? ''}
-        onChange={newValue => {
-          if (!newValue) {
-            return filter.onClearFilterRule('itemCodeOrName');
-          }
-          return filter.onChangeStringFilterRule(
-            'itemCodeOrName',
-            'like',
-            newValue
-          );
-        }}
-      />
+      <Box display="flex" gap={1}>
+        <FilterMenu
+          filters={[
+            {
+              type: 'text',
+              name: t('label.code-or-name'),
+              urlParameter: 'itemCodeOrName',
+              placeholder: t('placeholder.enter-an-item-code-or-name'),
+            },
+            {
+              type: 'text',
+              name: t('label.location'),
+              urlParameter: 'location.name',
+              placeholder: t('placeholder.search-by-location-name'),
+            },
+          ]}
+        />
+      </Box>
     </AppBarContentPortal>
   );
 };

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -25,14 +25,26 @@ const StockListComponent: FC = () => {
     filter,
     updatePaginationQuery,
     updateSortQuery,
-    queryParams: { sortBy, page, first, offset },
+    queryParams: { sortBy, page, first, offset, filterBy },
   } = useUrlQueryParams({
     initialSort: { key: 'expiryDate', dir: 'asc' },
-    filters: [{ key: 'itemCodeOrName' }],
+    filters: [
+      { key: 'itemCodeOrName' },
+      {
+        key: 'location.name',
+      },
+    ],
   });
+  const queryParams = {
+    filterBy,
+    offset,
+    sortBy,
+    first,
+  };
+
   const pagination = { page, first, offset };
   const t = useTranslation('inventory');
-  const { data, isLoading, isError } = useStock.line.list();
+  const { data, isLoading, isError } = useStock.line.list(queryParams);
   const [repackId, setRepackId] = React.useState<string | null>(null);
   const EditStockLineCell = <T extends StockLineRowFragment>({
     rowData,

--- a/client/packages/system/src/Stock/api/hooks/line/useStockLines.ts
+++ b/client/packages/system/src/Stock/api/hooks/line/useStockLines.ts
@@ -1,13 +1,9 @@
-import { useQuery, useUrlQueryParams } from '@openmsupply-client/common';
-import { useStockApi } from '../utils/useStockApi';
+import { useQuery } from '@openmsupply-client/common';
+import { ListParams, useStockApi } from '../utils/useStockApi';
 
-export const useStockLines = () => {
+export const useStockLines = (queryParams: ListParams) => {
   const api = useStockApi();
 
-  const { queryParams } = useUrlQueryParams({
-    initialSort: { key: 'expiryDate', dir: 'desc' },
-    filters: [{ key: 'itemCodeOrName' }],
-  });
   return {
     ...useQuery(api.keys.paramList(queryParams), () =>
       api.get.list(queryParams)

--- a/server/graphql/stock_line/src/lib.rs
+++ b/server/graphql/stock_line/src/lib.rs
@@ -8,7 +8,8 @@ use graphql_core::{
 };
 use graphql_types::types::*;
 use repository::{
-    DateFilter, EqualFilter, PaginationOption, StockLineFilter, StockLineSort, StockLineSortField,
+    location::LocationFilter, DateFilter, EqualFilter, PaginationOption, StockLineFilter,
+    StockLineSort, StockLineSortField,
 };
 use service::auth::{Resource, ResourceAccessRequest};
 
@@ -45,6 +46,7 @@ pub struct StockLineFilterInput {
     pub location_id: Option<EqualFilterStringInput>,
     pub store_id: Option<EqualFilterStringInput>,
     pub has_packs_in_store: Option<bool>,
+    pub location: Option<LocationFilterInput>,
 }
 
 impl From<StockLineFilterInput> for StockLineFilter {
@@ -58,6 +60,7 @@ impl From<StockLineFilterInput> for StockLineFilter {
             location_id: f.location_id.map(EqualFilter::from),
             store_id: None,
             has_packs_in_store: f.has_packs_in_store,
+            location: f.location.map(LocationFilter::from),
         }
     }
 }

--- a/server/service/src/stock_line/tests/query.rs
+++ b/server/service/src/stock_line/tests/query.rs
@@ -150,6 +150,7 @@ mod query {
             store_id: None,
             item_code_or_name: None,
             has_packs_in_store: None,
+            location: None,
         });
 
         // Test ExpiryDate sort with default sort order
@@ -202,6 +203,7 @@ mod query {
             store_id: None,
             item_code_or_name: None,
             has_packs_in_store: None,
+            location: None,
         });
 
         // Test ExpiryDate sort with desc sort order


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1727

# 👩🏻‍💻 What does this PR do? 
Refactors stock line filters to match how filters look in other parts of UI and add location name search

# 🧪 How has/should this change been tested? 
- [ ] Go to `Stock`
- [ ] Test filters

## 💌 Any notes for the reviewer?
Not too sure about the filter by master list for stock view though... since we don't show master list name or anything as a column and seems weird to me to be able to filter an invisible column 🤔 
