### PR TITLE
Cold chain: handle data issues

### DIFF
--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/TemperatureChart.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/TemperatureChart.tsx
@@ -25,7 +25,7 @@ import { BreachIndicator } from './BreachIndicator';
 export const TemperatureChart = () => {
   const t = useTranslation('coldchain');
   const theme = useTheme();
-  const { breachConfig, hasData, isLoading, sensors } =
+  const { breachConfig, hasData, isLoading, sensors, yAxisDomain } =
     useTemperatureChartData();
   const { dayMonthTime } = useFormatDateTime();
   const dateFormatter = (date: string) => dayMonthTime(date);
@@ -102,6 +102,7 @@ export const TemperatureChart = () => {
               <YAxis
                 tick={{ fontSize: 12 }}
                 tickFormatter={formatTemperature}
+                domain={yAxisDomain}
               />
               <ChartTooltip content={TemperatureTooltip} />
               <Legend

--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/useTemperatureChartData.ts
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/useTemperatureChartData.ts
@@ -6,6 +6,7 @@ import { Log, Sensor } from './types';
 import { useUrlQueryParams } from '@common/hooks';
 
 const MAX_DATA_POINTS = 30;
+const BREACH_RANGE = 2;
 
 export const useTemperatureChartData = () => {
   const theme = useTheme();
@@ -18,6 +19,8 @@ export const useTemperatureChartData = () => {
   const { data, isLoading } = useTemperatureLog.document.list(queryParams);
   const sensors: Sensor[] = [];
   const logs: Log[] = [];
+  let minTemperature = 2;
+  let maxTemperature = 2;
 
   data?.nodes?.forEach(
     ({ datetime, temperature, sensor, temperatureBreach }) => {
@@ -45,6 +48,8 @@ export const useTemperatureChartData = () => {
         temperature,
         breach: temperatureBreach ? { row: temperatureBreach, sensor } : null,
       });
+      minTemperature = Math.min(minTemperature, temperature);
+      maxTemperature = Math.max(maxTemperature, temperature);
     }
   );
   const numOfDataPoints = Math.min(MAX_DATA_POINTS, logs.length);
@@ -102,11 +107,16 @@ export const useTemperatureChartData = () => {
       temperature: 8,
     })),
   };
+  const yAxisDomain = [
+    minTemperature - BREACH_RANGE,
+    maxTemperature + BREACH_RANGE,
+  ];
 
   return {
     hasData: logs.length > 0,
     isLoading,
     sensors,
     breachConfig,
+    yAxisDomain,
   };
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2440

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

- For the chart - determines the min and max temperature values, then sets the y axis domain to be 2° either side of those values, with a 2° and 8° default
- The missing temperature is because a breach was uploaded which did not have an associated log entry. The CCA is uploading logs first, so this should not be a valid scenario. Have added a check - that when you upload a breach; with this PR when you upload a breach, the ID must be attached to an existing log entry. 

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
For the chart, you need a sensor which does not exceed the 8°C threshold. 
You may find it useful to use this version of the database:

[dump-omsupply_cold_chain-202311071455.backup.zip](https://github.com/msupply-foundation/open-msupply/files/13274661/dump-omsupply_cold_chain-202311071455.backup.zip)

In the opua store there are sensors configured. Using the `CE:89:30:BIGBATT` sensor you will see the original error.
Note: If you have a filter on the chart (which is part of #2436) then it's easier to isolate the sensors. Otherwise, just delete the other sensors from the database.

For the breaches you can test using postman, with a random string as the breach ID. then set the `temperature_breach_id` field of an existing temperature log row to the breach id value and try again.

The range was looking like this:

<img width="1253" alt="Screenshot 2023-11-06 at 12 12 15 PM" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/e2345503-6997-4abf-9f49-093ba04890c1">

and now is improved to this:

<img width="1138" alt="Screenshot 2023-11-07 at 2 21 22 PM" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/4a272d98-0fe9-49e8-898d-502bbecc4208">
