### PR TITLE
2197 Use descriptive app-name http header in sync

### DIFF
--- a/server/service/src/sync/api/core.rs
+++ b/server/service/src/sync/api/core.rs
@@ -31,11 +31,18 @@ fn generate_headers(hardware_id: &str, sync_version: u32) -> HeaderMap {
         HeaderName::from_static("app-version"),
         Version::from_package_json().to_string().parse().unwrap(),
     );
-    // TODO omSupply ? And maybe seperate header for app-os etc..
+
+    #[cfg(target_os = "android")]
     headers.insert(
         HeaderName::from_static("app-name"),
-        "remote_server".parse().unwrap(),
+        "Open mSupply Mobile".parse().unwrap(),
     );
+    #[cfg(not(target_os = "android"))]
+    headers.insert(
+        HeaderName::from_static("app-name"),
+        "Open mSupply Desktop".parse().unwrap(),
+    );
+
     headers.insert(
         HeaderName::from_static("version"),
         sync_version.to_string().parse().unwrap(),
@@ -211,7 +218,7 @@ mod tests {
             when.method(POST)
                 .header("msupply-site-uuid", "site_id")
                 .header("app-version", Version::from_package_json().to_string())
-                .header("app-name", "remote_server")
+                .header("app-name", "Open mSupply Desktop")
                 .path("/sync/v5/acknowledged_records");
             then.status(204);
         });


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2197 

# 👩🏻‍💻 What does this PR do? 
Send a more descriptive app name based on android or pc

# 🧪 How has/should this change been tested? 
- [ ] Initialise on PC
- [ ] See `Open mSupply Desktop` in central -> synchronisation
- [ ] Initialise on Android
- [ ] See `Open mSupply Mobile`