### PR TITLE
1400 Can send internal orders without lines

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -383,6 +383,7 @@
   "messages.native-mode-client": "This mode allows you to select which server to connect to.",
   "messages.native-mode-server": "Selecting this option will start the local server and automatically connect to it. Other users on the network will also be able to connect to this server.",
   "messages.no-data-available": "No data available",
+  "messages.no-lines": "Cannot change the status because there are no lines",
   "messages.no-log-entries": "No log entries available",
   "messages.no-scanners-found": "No scanners found",
   "messages.not-applicable": "N/A",

--- a/client/packages/common/src/ui/components/buttons/standard/SplitButton.tsx
+++ b/client/packages/common/src/ui/components/buttons/standard/SplitButton.tsx
@@ -4,7 +4,7 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import { ChevronDownIcon } from '../../../icons';
 import { ButtonWithIcon, ButtonWithIconProps } from './ButtonWithIcon';
-import { ShrinkableBaseButton } from '@common/components';
+import { ShrinkableBaseButton, Tooltip } from '@common/components';
 
 export interface SplitButtonOption<T> {
   label: string;
@@ -22,6 +22,7 @@ export interface SplitButtonProps<T> {
   isDisabled?: boolean;
   selectedOption: SplitButtonOption<T>;
   onSelectOption: (option: SplitButtonOption<T>) => void;
+  label?: string;
 }
 
 export const SplitButton = <T,>({
@@ -34,76 +35,79 @@ export const SplitButton = <T,>({
   isDisabled = false,
   selectedOption,
   onSelectOption,
+  label,
 }: SplitButtonProps<T>) => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const buttonLabel = selectedOption.label;
   const open = !!anchorEl;
 
   return (
-    <ButtonGroup color={color} variant="outlined" aria-label={ariaLabel}>
-      <ButtonWithIcon
-        color={color}
-        disabled={isDisabled}
-        sx={{
-          borderRadius: 0,
-          borderStartStartRadius: '24px',
-          borderEndStartRadius: '24px',
-        }}
-        onClick={() => {
-          onClick(selectedOption);
-        }}
-        label={buttonLabel}
-        Icon={Icon}
-      />
+    <Tooltip title={label}>
+      <ButtonGroup color={color} variant="outlined" aria-label={ariaLabel}>
+        <ButtonWithIcon
+          color={color}
+          disabled={isDisabled}
+          sx={{
+            borderRadius: 0,
+            borderStartStartRadius: '24px',
+            borderEndStartRadius: '24px',
+          }}
+          onClick={() => {
+            onClick(selectedOption);
+          }}
+          label={buttonLabel}
+          Icon={Icon}
+        />
 
-      <ShrinkableBaseButton
-        shrink
-        disabled={isDisabled}
-        color={color}
-        size="small"
-        aria-controls={open ? ariaControlLabel : undefined}
-        aria-expanded={open ? 'true' : undefined}
-        aria-label={ariaLabel}
-        aria-haspopup="menu"
-        onClick={e => {
-          setAnchorEl(e.currentTarget);
-        }}
-        sx={{
-          borderRadius: 0,
-          borderStartEndRadius: '24px',
-          borderEndEndRadius: '24px',
-        }}
-      >
-        <ChevronDownIcon />
-      </ShrinkableBaseButton>
-      <Menu
-        anchorEl={anchorEl}
-        open={open}
-        onClose={() => setAnchorEl(null)}
-        elevation={5}
-        anchorOrigin={{
-          vertical: 'top',
-          horizontal: 'right',
-        }}
-        transformOrigin={{
-          vertical: 'bottom',
-          horizontal: 'right',
-        }}
-      >
-        {options.map(option => (
-          <MenuItem
-            key={option.label}
-            disabled={option?.isDisabled}
-            selected={option.value === selectedOption.value}
-            onClick={() => {
-              onSelectOption(option);
-              setAnchorEl(null);
-            }}
-          >
-            {option.label}
-          </MenuItem>
-        ))}
-      </Menu>
-    </ButtonGroup>
+        <ShrinkableBaseButton
+          shrink
+          disabled={isDisabled}
+          color={color}
+          size="small"
+          aria-controls={open ? ariaControlLabel : undefined}
+          aria-expanded={open ? 'true' : undefined}
+          aria-label={ariaLabel}
+          aria-haspopup="menu"
+          onClick={e => {
+            setAnchorEl(e.currentTarget);
+          }}
+          sx={{
+            borderRadius: 0,
+            borderStartEndRadius: '24px',
+            borderEndEndRadius: '24px',
+          }}
+        >
+          <ChevronDownIcon />
+        </ShrinkableBaseButton>
+        <Menu
+          anchorEl={anchorEl}
+          open={open}
+          onClose={() => setAnchorEl(null)}
+          elevation={5}
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'right',
+          }}
+          transformOrigin={{
+            vertical: 'bottom',
+            horizontal: 'right',
+          }}
+        >
+          {options.map(option => (
+            <MenuItem
+              key={option.label}
+              disabled={option?.isDisabled}
+              selected={option.value === selectedOption.value}
+              onClick={() => {
+                onSelectOption(option);
+                setAnchorEl(null);
+              }}
+            >
+              {option.label}
+            </MenuItem>
+          ))}
+        </Menu>
+      </ButtonGroup>
+    </Tooltip>
   );
 };

--- a/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
@@ -189,13 +189,16 @@ export const StatusChangeButton = () => {
     lines,
   } = useStatusChangeButton();
   const isStatusChangeDisabled = useInbound.utils.isStatusChangeDisabled();
+  const noLines = lines?.totalCount === 0;
+  const t = useTranslation();
 
   if (!selectedOption) return null;
   if (isStatusChangeDisabled) return null;
 
   return (
     <SplitButton
-      isDisabled={lines?.totalCount === 0 || onHold}
+      label={noLines ? t('messages.no-lines') : ''}
+      isDisabled={noLines || onHold}
       options={options}
       selectedOption={selectedOption}
       onSelectOption={setSelectedOption}

--- a/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
@@ -20,7 +20,7 @@ const getStatusOptions = (
     SplitButtonOption<InvoiceNodeStatus>,
     SplitButtonOption<InvoiceNodeStatus>,
     SplitButtonOption<InvoiceNodeStatus>,
-    SplitButtonOption<InvoiceNodeStatus>
+    SplitButtonOption<InvoiceNodeStatus>,
   ] = [
     {
       value: InvoiceNodeStatus.New,
@@ -71,7 +71,7 @@ const getManualStatusOptions = (
   const options: [
     SplitButtonOption<InvoiceNodeStatus>,
     SplitButtonOption<InvoiceNodeStatus>,
-    SplitButtonOption<InvoiceNodeStatus>
+    SplitButtonOption<InvoiceNodeStatus>,
   ] = [
     {
       value: InvoiceNodeStatus.New,
@@ -124,9 +124,8 @@ const getButtonLabel =
   };
 
 const useStatusChangeButton = () => {
-  const { status, onHold, linkedShipment, update } = useInbound.document.fields(
-    ['status', 'onHold', 'linkedShipment']
-  );
+  const { status, onHold, linkedShipment, update, lines } =
+    useInbound.document.fields(['status', 'onHold', 'linkedShipment', 'lines']);
   const { success, error } = useNotification();
   const t = useTranslation('replenishment');
   const isManuallyCreated = !linkedShipment?.id;
@@ -176,6 +175,7 @@ const useStatusChangeButton = () => {
     setSelectedOption,
     getConfirmation,
     onHold,
+    lines,
   };
 };
 
@@ -186,6 +186,7 @@ export const StatusChangeButton = () => {
     setSelectedOption,
     getConfirmation,
     onHold,
+    lines,
   } = useStatusChangeButton();
   const isStatusChangeDisabled = useInbound.utils.isStatusChangeDisabled();
 
@@ -194,7 +195,7 @@ export const StatusChangeButton = () => {
 
   return (
     <SplitButton
-      isDisabled={onHold}
+      isDisabled={lines?.totalCount === 0 || onHold}
       options={options}
       selectedOption={selectedOption}
       onSelectOption={setSelectedOption}

--- a/client/packages/invoices/src/OutboundShipment/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Footer/StatusChangeButton.tsx
@@ -95,9 +95,10 @@ const getButtonLabel =
   };
 
 const useStatusChangeButton = () => {
-  const { status, onHold, update } = useOutbound.document.fields([
+  const { lines, status, onHold, update } = useOutbound.document.fields([
     'status',
     'onHold',
+    'lines',
   ]);
   const { success, error } = useNotification();
   const t = useTranslation('distribution');
@@ -150,6 +151,7 @@ const useStatusChangeButton = () => {
     setSelectedOption,
     getConfirmation,
     onHold,
+    lines,
   };
 };
 
@@ -180,6 +182,7 @@ export const StatusChangeButton = () => {
     setSelectedOption,
     getConfirmation,
     onHold,
+    lines,
   } = useStatusChangeButton();
   const { hasPlaceholder, alert } = useStatusChangePlaceholderCheck();
   const isDisabled = useOutbound.utils.isDisabled();
@@ -194,7 +197,7 @@ export const StatusChangeButton = () => {
 
   return (
     <SplitButton
-      isDisabled={onHold}
+      isDisabled={lines?.totalCount === 0 || onHold}
       options={options}
       selectedOption={selectedOption}
       onSelectOption={setSelectedOption}

--- a/client/packages/invoices/src/OutboundShipment/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Footer/StatusChangeButton.tsx
@@ -186,6 +186,8 @@ export const StatusChangeButton = () => {
   } = useStatusChangeButton();
   const { hasPlaceholder, alert } = useStatusChangePlaceholderCheck();
   const isDisabled = useOutbound.utils.isDisabled();
+  const t = useTranslation();
+  const noLines = lines?.totalCount === 0;
 
   if (!selectedOption) return null;
   if (isDisabled) return null;
@@ -197,7 +199,8 @@ export const StatusChangeButton = () => {
 
   return (
     <SplitButton
-      isDisabled={lines?.totalCount === 0 || onHold}
+      label={noLines ? t('messages.no-lines') : ''}
+      isDisabled={noLines || onHold}
       options={options}
       selectedOption={selectedOption}
       onSelectOption={setSelectedOption}

--- a/client/packages/invoices/src/Prescriptions/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Footer/StatusChangeButton.tsx
@@ -72,7 +72,10 @@ const getButtonLabel =
   };
 
 const useStatusChangeButton = () => {
-  const { status, update } = usePrescription.document.fields(['status']);
+  const { status, update, lines } = usePrescription.document.fields([
+    'status',
+    'lines',
+  ]);
   const { success, error } = useNotification();
   const t = useTranslation('dispensary');
   const { data } = usePrescription.document.get();
@@ -121,11 +124,12 @@ const useStatusChangeButton = () => {
     selectedOption,
     setSelectedOption,
     getConfirmation,
+    lines,
   };
 };
 
 export const StatusChangeButton = () => {
-  const { options, selectedOption, setSelectedOption, getConfirmation } =
+  const { options, selectedOption, setSelectedOption, getConfirmation, lines } =
     useStatusChangeButton();
   const isDisabled = usePrescription.utils.isDisabled();
 
@@ -138,6 +142,7 @@ export const StatusChangeButton = () => {
 
   return (
     <SplitButton
+      isDisabled={lines?.totalCount === 0}
       options={options}
       selectedOption={selectedOption}
       onSelectOption={setSelectedOption}

--- a/client/packages/invoices/src/Prescriptions/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Footer/StatusChangeButton.tsx
@@ -132,6 +132,8 @@ export const StatusChangeButton = () => {
   const { options, selectedOption, setSelectedOption, getConfirmation, lines } =
     useStatusChangeButton();
   const isDisabled = usePrescription.utils.isDisabled();
+  const t = useTranslation();
+  const noLines = lines?.totalCount === 0;
 
   if (!selectedOption) return null;
   if (isDisabled) return null;
@@ -142,7 +144,8 @@ export const StatusChangeButton = () => {
 
   return (
     <SplitButton
-      isDisabled={lines?.totalCount === 0}
+      label={noLines ? t('messages.no-lines') : ''}
+      isDisabled={noLines}
       options={options}
       selectedOption={selectedOption}
       onSelectOption={setSelectedOption}

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
@@ -21,7 +21,7 @@ const getStatusOptions = (
   const options: [
     SplitButtonOption<RequisitionNodeStatus>,
     SplitButtonOption<RequisitionNodeStatus>,
-    SplitButtonOption<RequisitionNodeStatus>
+    SplitButtonOption<RequisitionNodeStatus>,
   ] = [
     {
       value: RequisitionNodeStatus.Draft,
@@ -67,9 +67,10 @@ const getButtonLabel =
   };
 
 const useStatusChangeButton = () => {
-  const { status, update, comment } = useRequest.document.fields([
+  const { status, update, comment, lines } = useRequest.document.fields([
     'status',
     'comment',
+    'lines',
   ]);
   const { success, error } = useNotification();
   const t = useTranslation('replenishment');
@@ -131,11 +132,11 @@ const useStatusChangeButton = () => {
     setSelectedOption(() => getNextStatusOption(status, options));
   }, [status, options]);
 
-  return { options, selectedOption, setSelectedOption, getConfirmation };
+  return { options, selectedOption, setSelectedOption, getConfirmation, lines };
 };
 
 export const StatusChangeButton = () => {
-  const { selectedOption, getConfirmation } = useStatusChangeButton();
+  const { selectedOption, getConfirmation, lines } = useStatusChangeButton();
   const isDisabled = useRequest.utils.isDisabled();
   const { userHasPermission } = useAuthContext();
   const t = useTranslation('app');
@@ -155,7 +156,7 @@ export const StatusChangeButton = () => {
           <ButtonWithIcon
             color="secondary"
             variant="contained"
-            disabled={!hasPermission}
+            disabled={!hasPermission || lines?.totalCount === 0}
             label={selectedOption.label}
             Icon={<ArrowRightIcon />}
             onClick={() => getConfirmation()}

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
@@ -140,6 +140,7 @@ export const StatusChangeButton = () => {
   const isDisabled = useRequest.utils.isDisabled();
   const { userHasPermission } = useAuthContext();
   const t = useTranslation('app');
+  const noLines = lines?.totalCount === 0;
 
   if (!selectedOption) return null;
   if (isDisabled) return null;
@@ -148,10 +149,12 @@ export const StatusChangeButton = () => {
     selectedOption.value === RequisitionNodeStatus.Sent
       ? userHasPermission(UserPermission.RequisitionSend)
       : true;
+  const permissionDenied = hasPermission ? '' : t('auth.permission-denied');
+  const disabledNoLines = noLines ? t('messages.no-lines') : '';
 
   return (
     <>
-      <Tooltip title={hasPermission ? '' : t('auth.permission-denied')}>
+      <Tooltip title={permissionDenied || disabledNoLines}>
         <div>
           <ButtonWithIcon
             color="secondary"

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
@@ -159,7 +159,7 @@ export const StatusChangeButton = () => {
           <ButtonWithIcon
             color="secondary"
             variant="contained"
-            disabled={!hasPermission || lines?.totalCount === 0}
+            disabled={!hasPermission || noLines}
             label={selectedOption.label}
             Icon={<ArrowRightIcon />}
             onClick={() => getConfirmation()}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1400

# 👩🏻‍💻 What does this PR do? 
Disable confirmation buttons if no lines for:
- Outbound Shipment
- Inbound Shipment 
- Internal Order
- Prescriptions

# 🧪 How has/should this change been tested? 
- Create an invoice/requisition for any of the above
- See that the status confirmation button is disabled