### PR TITLE
2455 Clear selection shouldn't show if there is only one pack size

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Select/Select.tsx
+++ b/client/packages/common/src/ui/components/inputs/Select/Select.tsx
@@ -30,7 +30,8 @@ export const Select: FC<SelectProps> = React.forwardRef(
   ) => {
     const t = useTranslation();
 
-    const showClearOption = !!props?.value && !!props?.onChange && clearable;
+    const showClearOption =
+      !!props?.value && !!props?.onChange && clearable && options.length > 1;
 
     return (
       <TextField

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -216,6 +216,7 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
                   sx={{ width: 110 }}
                   options={packSizeController.options}
                   value={packSizeController.selected?.value ?? ''}
+                  clearable={false}
                   onChange={e => {
                     const { value } = e.target;
                     onChangePackSize(Number(value));

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
@@ -263,6 +263,7 @@ export const PrescriptionLineEditForm: React.FC<
                   sx={{ width: 110 }}
                   options={packSizeController.options}
                   value={packSizeController.selected?.value ?? ''}
+                  clearable={false}
                   onChange={e => {
                     const { value } = e.target;
                     onChangePackSize(Number(value));


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2455

# 👩🏻‍💻 What does this PR do? 
Only show `clear selection` if there is more than one option and don't allow clearing for outbound/prescription pack size since user has to select one anyway... Branched off develop since this issue shows up here as well (: 

# 🧪 How has/should this change been tested? 
- [ ] Create a prescription or outbound shipment
- [ ] Add item
- [ ] See that clear selection is gone