### PR TITLE
Remove some service items restrictions

### DIFF
--- a/client/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -212,7 +212,6 @@ const DataTableComponent = <T extends RecordWithId>({
       sx={{
         display: 'flex',
         flexDirection: 'column',
-        height: '100%',
         overflowX,
         overflowY: 'auto',
       }}

--- a/client/packages/system/src/Item/api/api.ts
+++ b/client/packages/system/src/Item/api/api.ts
@@ -98,9 +98,10 @@ export const getItemQueries = (sdk: Sdk, storeId: string) => ({
         isDesc: sortBy.isDesc,
         offset,
         storeId,
+        // the filter previously only showed type: { equalTo: ItemNodeType.Stock },
+        // because service items don't have SOH & AMC so it's odd to show them alongside stock items
         filter: {
           ...filterBy,
-          type: { equalTo: ItemNodeType.Stock },
           isVisible: true,
         },
       });

--- a/client/packages/system/src/Item/api/hooks/useDefaultServiceItem/useDefaultServiceItem.tsx
+++ b/client/packages/system/src/Item/api/hooks/useDefaultServiceItem/useDefaultServiceItem.tsx
@@ -3,9 +3,10 @@ import { useServiceItems } from '../useServiceItems';
 export const useDefaultServiceItem = () => {
   const { data: items, isLoading, error } = useServiceItems();
 
-  const defaultServiceItem = items?.nodes.find(
-    ({ code }) => code === 'service'
-  );
+  // find the first service item with the code 'service'
+  // or if that fails, simply the first service item
+  const defaultServiceItem =
+    items?.nodes.find(({ code }) => code === 'service') ?? items?.nodes?.[0];
 
   return { defaultServiceItem, isLoading, error };
 };

--- a/client/packages/system/src/Item/api/hooks/useItems/useItems.ts
+++ b/client/packages/system/src/Item/api/hooks/useItems/useItems.ts
@@ -6,9 +6,7 @@ export const useItems = () => {
     filters: [{ key: 'codeOrName' }],
   });
   const api = useItemApi();
-  return {
-    ...useQuery(api.keys.paramList(queryParams), () =>
-      api.get.stockItemsWithStats(queryParams)
-    ),
-  };
+  return useQuery(api.keys.paramList(queryParams), () =>
+    api.get.stockItemsWithStats(queryParams)
+  );
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2467

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Removes the restriction in the item list, which was only showing STOCK items
Removes the check for a 'default' service item which matches the code to be 'service'

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Tested using the site, to see if I can add service charges now.

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
