### PR TITLE
2469 fix rust analyzer stack overlfow

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -767,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8056f1455169ab86dd47b47391e4ab0cbd25410a70e9fe675544f49bafaf952"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
 dependencies = [
  "async-channel",
  "async-global-executor",
@@ -785,7 +785,6 @@ dependencies = [
  "kv-log-macro",
  "log",
  "memchr",
- "num_cpus",
  "once_cell",
  "pin-project-lite",
  "pin-utils",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,6 +16,7 @@ thiserror = "1.0.30"
 # dev dependencies used in graphql crates:
 actix-rt = "2.6.0"
 assert-json-diff = "2.0.1"
+async-std = "1.12.0"
 
 anyhow = "1.0.56"
 

--- a/server/graphql/core/Cargo.toml
+++ b/server/graphql/core/Cargo.toml
@@ -23,9 +23,10 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+async-std = { workspace = true }
 
 tokio = { version = "1.17.0", features = ["macros"] }
-async-std = "1.9.0"
+
 strum = { version = "0.25", features = ["derive"] }
 
 [features]

--- a/server/graphql/programs/Cargo.toml
+++ b/server/graphql/programs/Cargo.toml
@@ -15,9 +15,10 @@ graphql_core = { path = "../core" }
 graphql_general = { path = "../general" }
 graphql_types = { path = "../types" }
 
+async-std = { workspace = true }
+
 actix-web = { version = "4.0.1", default-features = false, features = ["macros"] }
 anymap = "0.12"
-async-std = "1.9.0"
 async-graphql = { version = "3.0.35", features = ["dataloader", "chrono"] }
 async-graphql-actix-web = "3.0.35"
 async-trait = "0.1.30"

--- a/server/service/src/stocktake/update.rs
+++ b/server/service/src/stocktake/update.rs
@@ -883,7 +883,7 @@ mod test {
                 line: mock_stocktake_line_a(),
                 stock_line: Some(stock_line),
                 location: None,
-                item: None,
+                item: Some(mock_item_a()),
             }])
         );
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2469

# 👩🏻‍💻 What does this PR do? 

Updates async-std dependency

# 🧪 How has/should this change been tested? 

Try using main version of rust analyzer with 1.73.0 of rust. Without this change rust analyzer fails (i.e. no annotation, no cmd + click navigation). With this change should work (after restarting vs code)

## 💌 Any notes for the reviewer?


