### PR TITLE
1641 suppliers/customer list: add the "house" icon to the names using mSupply 

### DIFF
--- a/client/packages/system/src/Name/Components/NameOptionRenderer/NameOptionRenderer.tsx
+++ b/client/packages/system/src/Name/Components/NameOptionRenderer/NameOptionRenderer.tsx
@@ -3,36 +3,26 @@ import {
   DefaultAutocompleteItemOption,
   AutocompleteOptionRenderer,
   Typography,
-  HomeIcon,
   Box,
 } from '@openmsupply-client/common';
 import { NameRowFragment } from '../../api';
+import { NameRenderer } from '../NameRenderer/NameRenderer';
 
 export const getNameOptionRenderer =
   (onHoldLabel: string): AutocompleteOptionRenderer<NameRowFragment> =>
-  (props, item) =>
-    (
-      <DefaultAutocompleteItemOption {...props} key={item.id}>
-        <Box display="flex" alignItems="flex-end" gap={1} height={25}>
-          <Box display="flex" flexDirection="row" gap={1} width={110}>
-            <Box flex={0} style={{ height: 24, minWidth: 20 }}>
-              {!!item.store && <HomeIcon fontSize="small" />}
-            </Box>
-            <Typography
-              overflow="hidden"
-              fontWeight="bold"
-              textOverflow="ellipsis"
-              sx={{
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {item.code}
-            </Typography>
-          </Box>
-          <Typography>
-            {item.name}
-            {item.isOnHold ? ` (${onHoldLabel})` : ''}
-          </Typography>
-        </Box>
-      </DefaultAutocompleteItemOption>
-    );
+  (props, item) => (
+    <DefaultAutocompleteItemOption {...props} key={item.id}>
+      <Box display="flex" alignItems="flex-end" gap={1} height={25}>
+        <NameRenderer
+          label={item.code}
+          isStore={!!item.store}
+          width={110}
+          sx={{ fontWeight: 'bold' }}
+        />
+        <Typography>
+          {item.name}
+          {item.isOnHold ? ` (${onHoldLabel})` : ''}
+        </Typography>
+      </Box>
+    </DefaultAutocompleteItemOption>
+  );

--- a/client/packages/system/src/Name/Components/NameRenderer/NameRenderer.tsx
+++ b/client/packages/system/src/Name/Components/NameRenderer/NameRenderer.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Box, SxProps, Theme, Typography } from '@openmsupply-client/common';
+import { HomeIcon } from '@common/icons';
+
+export const NameRenderer = ({
+  label,
+  iconFlex,
+  isStore,
+  sx,
+  width,
+}: {
+  label: string;
+  iconFlex?: number;
+  isStore: boolean;
+  sx?: SxProps<Theme>;
+  width?: number;
+}) => (
+  <Box
+    display="flex"
+    flexDirection="row"
+    gap={1}
+    width={width}
+    alignItems="center"
+  >
+    <Box flex={iconFlex} style={{ height: 24, minWidth: 20 }}>
+      {isStore && <HomeIcon fontSize="small" />}
+    </Box>
+    <Typography
+      overflow="hidden"
+      textOverflow="ellipsis"
+      sx={{
+        whiteSpace: 'nowrap',
+        ...sx,
+      }}
+    >
+      {label}
+    </Typography>
+  </Box>
+);

--- a/client/packages/system/src/Name/Components/NameRenderer/index.ts
+++ b/client/packages/system/src/Name/Components/NameRenderer/index.ts
@@ -1,0 +1,1 @@
+export * from './NameRenderer';

--- a/client/packages/system/src/Name/Components/index.ts
+++ b/client/packages/system/src/Name/Components/index.ts
@@ -5,3 +5,4 @@ export * from './CustomerSearchModal';
 export * from './InternalSupplierSearchInput';
 export * from './InternalSupplierSearchModal';
 export { getNameOptionRenderer } from './NameOptionRenderer';
+export * from './NameRenderer';

--- a/client/packages/system/src/Name/DetailModal/DetailModal.tsx
+++ b/client/packages/system/src/Name/DetailModal/DetailModal.tsx
@@ -8,13 +8,12 @@ import {
   Checkbox,
   Grid,
   useFormatDateTime,
-  Typography,
   Box,
   BasicSpinner,
   MuiLink,
-  HomeIcon,
 } from '@openmsupply-client/common';
 import { useName } from '../api';
+import { NameRenderer } from '../Components';
 
 interface DetailModalProps {
   nameId: string;
@@ -36,14 +35,11 @@ export const DetailModal: FC<DetailModalProps> = ({ nameId }) => {
   return !!data ? (
     <DetailContainer>
       <Box display="flex" flexDirection="column" alignItems="center" gap={2}>
-        <Box display="flex" flexDirection="row" gap={1}>
-          <Box style={{ height: 24, minWidth: 20 }}>
-            {!!data.store && <HomeIcon />}
-          </Box>
-          <Typography sx={{ fontSize: 18, fontWeight: 700 }}>
-            {data.name}
-          </Typography>
-        </Box>
+        <NameRenderer
+          isStore={!!data?.store}
+          label={data?.name}
+          sx={{ fontWeight: 'bold', fontSize: 18 }}
+        />
         <Grid container flex={1} flexDirection="row" gap={4}>
           <DetailSection title="">
             <DetailInputWithLabelRow

--- a/client/packages/system/src/Name/DetailModal/DetailModal.tsx
+++ b/client/packages/system/src/Name/DetailModal/DetailModal.tsx
@@ -12,6 +12,7 @@ import {
   Box,
   BasicSpinner,
   MuiLink,
+  HomeIcon,
 } from '@openmsupply-client/common';
 import { useName } from '../api';
 
@@ -35,9 +36,14 @@ export const DetailModal: FC<DetailModalProps> = ({ nameId }) => {
   return !!data ? (
     <DetailContainer>
       <Box display="flex" flexDirection="column" alignItems="center" gap={2}>
-        <Typography sx={{ fontSize: 18, fontWeight: 700 }}>
-          {data.name}
-        </Typography>
+        <Box display="flex" flexDirection="row" gap={1}>
+          <Box style={{ height: 24, minWidth: 20 }}>
+            {!!data.store && <HomeIcon />}
+          </Box>
+          <Typography sx={{ fontSize: 18, fontWeight: 700 }}>
+            {data.name}
+          </Typography>
+        </Box>
         <Grid container flex={1} flexDirection="row" gap={4}>
           <DetailSection title="">
             <DetailInputWithLabelRow

--- a/client/packages/system/src/Name/ListView/ListView.tsx
+++ b/client/packages/system/src/Name/ListView/ListView.tsx
@@ -9,13 +9,11 @@ import {
   Fade,
   NothingHere,
   useUrlQueryParams,
-  HomeIcon,
-  Box,
-  Typography,
 } from '@openmsupply-client/common';
 import { TransitionProps } from '@mui/material/transitions';
 import { DetailModal } from '../DetailModal';
 import { useName, NameRowFragment } from '../api';
+import { NameRenderer } from '../Components';
 
 const NameListComponent: FC<{ type: 'customer' | 'supplier' }> = ({ type }) => {
   const [selectedId, setSelectedId] = useState<string>('');
@@ -34,16 +32,9 @@ const NameListComponent: FC<{ type: 'customer' | 'supplier' }> = ({ type }) => {
       {
         key: 'code',
         label: 'label.code',
-        Cell: ({ rowData }) => {
-          return (
-            <Box display="flex" flexDirection="row" gap={1}>
-              <Box style={{ height: 24, width: 25 }}>
-                {!!rowData.store && <HomeIcon />}
-              </Box>
-              <Typography>{rowData.code}</Typography>
-            </Box>
-          );
-        },
+        Cell: ({ rowData }) => (
+          <NameRenderer label={rowData.code} isStore={!!rowData.store} />
+        ),
         width: 60,
       },
       'name',

--- a/client/packages/system/src/Name/ListView/ListView.tsx
+++ b/client/packages/system/src/Name/ListView/ListView.tsx
@@ -9,6 +9,9 @@ import {
   Fade,
   NothingHere,
   useUrlQueryParams,
+  HomeIcon,
+  Box,
+  Typography,
 } from '@openmsupply-client/common';
 import { TransitionProps } from '@mui/material/transitions';
 import { DetailModal } from '../DetailModal';
@@ -27,7 +30,24 @@ const NameListComponent: FC<{ type: 'customer' | 'supplier' }> = ({ type }) => {
   const { Modal, showDialog, hideDialog } = useDialog();
 
   const columns = useColumns<NameRowFragment>(
-    ['code', 'name'],
+    [
+      {
+        key: 'code',
+        label: 'label.code',
+        Cell: ({ rowData }) => {
+          return (
+            <Box display="flex" flexDirection="row" gap={1}>
+              <Box style={{ height: 24, width: 25 }}>
+                {!!rowData.store && <HomeIcon />}
+              </Box>
+              <Typography>{rowData.code}</Typography>
+            </Box>
+          );
+        },
+        width: 60,
+      },
+      'name',
+    ],
     {
       sortBy,
       onChangeSortBy: updateSortQuery,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1641 

# 👩🏻‍💻 What does this PR do? 
Add the home icon to the supplier/customer list and modal
![Screenshot 2023-11-14 at 05 59 51](https://github.com/msupply-foundation/open-msupply/assets/61820074/d0675d9d-6060-47eb-94ba-70d939322649)
![Screenshot 2023-11-14 at 06 00 08](https://github.com/msupply-foundation/open-msupply/assets/61820074/8d85f610-ad46-4f90-9194-e31916888c49)
![Screenshot 2023-11-14 at 06 00 00](https://github.com/msupply-foundation/open-msupply/assets/61820074/47c60cf5-669b-45a9-b1e4-6eb9f4c7748c)

# 🧪 How has/should this change been tested? 
- [ ] Go to Supplier or Customer list
- [ ] See icon added to stores that use mSupply