### PR TITLE
2415 Unify programs and coldchain time component 

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -299,6 +299,7 @@
   "label.showing": "Showing",
   "label.snapshot-num-of-packs": "Snapshot Packs",
   "label.soh": "SOH",
+  "label.start-datetime": "Start date / time",
   "label.status": "Status",
   "label.stock-on-hand": "SoH (Est. remaining)",
   "label.stocktake-comment": "Comment",

--- a/client/packages/system/src/Encounter/ListView/Toolbar.tsx
+++ b/client/packages/system/src/Encounter/ListView/Toolbar.tsx
@@ -35,7 +35,7 @@ export const Toolbar: FC<{ filter: FilterController }> = () => {
             },
             {
               type: 'group',
-              name: 'Date/Time Range',
+              name: 'label.start-datetime',
               elements: [
                 {
                   type: 'dateTime',

--- a/client/packages/system/src/Encounter/ListView/Toolbar.tsx
+++ b/client/packages/system/src/Encounter/ListView/Toolbar.tsx
@@ -35,7 +35,7 @@ export const Toolbar: FC<{ filter: FilterController }> = () => {
             },
             {
               type: 'group',
-              name: 'label.start-datetime',
+              name: t('label.start-datetime'),
               elements: [
                 {
                   type: 'dateTime',

--- a/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
@@ -13,8 +13,8 @@ import {
   useNavigate,
   useNotification,
   useAuthContext,
-  DatePickerInput,
   TextArea,
+  DateTimePickerInput,
 } from '@openmsupply-client/common';
 import { DateUtils, useIntlUtils, useTranslation } from '@common/intl';
 import {
@@ -162,7 +162,7 @@ export const CreateEncounterModal: FC = () => {
                 <InputWithLabelRow
                   label={t('label.visit-date')}
                   Input={
-                    <DatePickerInput
+                    <DateTimePickerInput
                       value={DateUtils.getDateOrNull(draft?.startDatetime)}
                       onChange={setStartDatetime}
                       onError={validationError =>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2415

# 👩🏻‍💻 What does this PR do? 
- Changed the encounter modal date to include date time selection since the start time for this was being funky in detail view.
- Have left the detail view date time separate since it's recording two different values: start and end date times.  

# 🧪 How has/should this change been tested? 
- Create an Encounter
- See the date time change in modal

## 💌 Any notes for the reviewer?
Couldn't find anymore date time components but lemme know if I missed any (: 

Also not related but while playing with the filters for encounters... I noticed that maybe we want a filter that can filter by startDatetime: afterOrEqualTo and endDatetime: beforeOrEqualTo... idk if it's useful but makes sense to me...