### PR TITLE
Add ticks to the yaxis to show 2° and 8°

### DIFF
--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/TemperatureChart.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/TemperatureChart.tsx
@@ -25,6 +25,8 @@ import { BreachIndicator } from './BreachIndicator';
 import { Toolbar } from '../TemperatureLog/Toolbar';
 
 const NUMBER_OF_HORIZONTAL_LINES = 4;
+const LOWER_THRESHOLD = 2;
+const UPPER_THRESHOLD = 8;
 
 const Chart = ({
   breachConfig,
@@ -103,8 +105,8 @@ const Chart = ({
     (_, index) => (index + 1) * tickSpace
   );
   ticks.push(yAxisDomain[0]);
-  ticks.push(2);
-  ticks.push(8);
+  ticks.push(LOWER_THRESHOLD);
+  ticks.push(UPPER_THRESHOLD);
   ticks.push(yAxisDomain[1]);
   ticks.sort((a, b) => (a > b ? 1 : -1));
 
@@ -112,9 +114,9 @@ const Chart = ({
   const CustomisedTick = ({ x, y, payload }: any) => {
     const theme = useTheme();
     const textColour =
-      payload.value === 2
+      payload.value === LOWER_THRESHOLD
         ? theme.palette.chart.cold.main
-        : payload.value === 8
+        : payload.value === UPPER_THRESHOLD
         ? theme.palette.chart.hot.main
         : theme.palette.gray.dark;
     return (
@@ -128,7 +130,10 @@ const Chart = ({
           style={{
             fontSize: 12,
             fontWeight:
-              payload.value === 2 || payload.value === 8 ? 'bold' : '',
+              payload.value === LOWER_THRESHOLD ||
+              payload.value === UPPER_THRESHOLD
+                ? 'bold'
+                : '',
           }}
         >
           <tspan dy="0.355em">
@@ -136,20 +141,6 @@ const Chart = ({
           </tspan>
         </text>
       </g>
-    );
-  };
-
-  const horizontalCoordinatesGenerator = ({
-    height,
-    offset,
-  }: {
-    height: number;
-    offset: { top: number; bottom: number };
-  }) => {
-    const spacing =
-      (offset.top + height - offset.bottom) / (NUMBER_OF_HORIZONTAL_LINES + 1);
-    return Array.from({ length: NUMBER_OF_HORIZONTAL_LINES }).map(
-      (_, index) => (index + 1) * spacing
     );
   };
 
@@ -161,10 +152,7 @@ const Chart = ({
 
       <ResponsiveContainer width="90%" height="90%">
         <ComposedChart>
-          <CartesianGrid
-            vertical={false}
-            horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
-          />
+          <CartesianGrid vertical={false} />
           <XAxis
             dataKey="date"
             tickFormatter={dateFormatter}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2483 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Adds the 2°C and 8°C y axis numbers. unfortunately it required a lot more work than expected, as you cannot get the generated ticks, or have multiple yAxis components.

I've implemented the horizontal lines and the ticks, which allows for formatting control as well as determining the number of horizontal lines. It's looking pretty good now:

<img width="1135" alt="Screenshot 2023-11-15 at 2 35 20 PM" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/60613c1f-787c-4077-8050-ba6ede1ffc96">


# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Have checked using local data. Here's a 4BK which has some data in it, if that helps:

[oms_cold_chain[0016].4BK.zip](https://github.com/msupply-foundation/open-msupply/files/13358980/oms_cold_chain.0016.4BK.zip)

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
