### PR TITLE
Confirmation modal icon

### DIFF
--- a/client/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.tsx
+++ b/client/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Grid, Typography } from '@mui/material';
 import { BasicModal } from '../BasicModal';
-import { AlertIcon, InfoIcon } from '@common/icons';
+import { AlertIcon, HelpIcon, InfoIcon } from '@common/icons';
 import { DialogButton, LoadingButton } from '../../buttons';
 
 interface ConfirmationModalProps {
@@ -12,11 +12,12 @@ interface ConfirmationModalProps {
   onCancel: () => void;
   title: string;
   message: string;
-  iconType?: 'alert' | 'info';
+  iconType?: 'alert' | 'info' | 'help';
 }
 
 const iconLookup = {
   alert: AlertIcon,
+  help: HelpIcon,
   info: InfoIcon,
 };
 
@@ -38,7 +39,7 @@ export const ConfirmationModal = ({
       <Grid container gap={1} flex={1} padding={4} flexDirection="column">
         <Grid container gap={1} flexDirection="row">
           <Grid item>
-            <Icon color={iconType === 'info' ? 'secondary' : 'primary'} />
+            <Icon color={iconType === 'alert' ? 'primary' : 'secondary'} />
           </Grid>
           <Grid item>
             <Typography variant="h6">{title}</Typography>

--- a/client/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModalContext.ts
+++ b/client/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModalContext.ts
@@ -1,10 +1,11 @@
 import { createContext } from 'react';
 
+export type IconType = 'alert' | 'help' | 'info';
 export interface ConfirmationModalState {
   open: boolean;
   message: string;
   title: string;
-  iconType?: 'alert' | 'info';
+  iconType?: IconType;
   onConfirm?: (() => void) | (() => Promise<void>);
   onCancel?: (() => void) | (() => Promise<void>);
 }
@@ -12,6 +13,7 @@ export interface ConfirmationModalState {
 export interface ConfirmationModalControllerState
   extends ConfirmationModalState {
   setState: (state: ConfirmationModalState) => void;
+  setIconType: (iconType: IconType) => void;
   setMessage: (message: string) => void;
   setTitle: (title: string) => void;
   setOnConfirm: (

--- a/client/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModalProvider.tsx
+++ b/client/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModalProvider.tsx
@@ -3,6 +3,7 @@ import {
   ConfirmationModalContext,
   ConfirmationModalState,
   ConfirmationModalControllerState,
+  IconType,
 } from './ConfirmationModalContext';
 import { ConfirmationModal } from './ConfirmationModal';
 import { PropsWithChildrenOnly } from '@common/types';
@@ -14,13 +15,15 @@ export const ConfirmationModalProvider: FC<PropsWithChildrenOnly> = ({
     open: false,
     message: '',
     title: '',
-    iconType: 'info',
+    iconType: 'help',
   });
   const { open, message, title, iconType, onConfirm, onCancel } =
     confirmationModalState;
 
   const confirmationModalController: ConfirmationModalControllerState = useMemo(
     () => ({
+      setIconType: (iconType: IconType) =>
+        setState(state => ({ ...state, iconType })),
       setMessage: (message: string) =>
         setState(state => ({ ...state, message })),
       setTitle: (title: string) => setState(state => ({ ...state, title })),

--- a/client/packages/common/src/ui/components/modals/ConfirmationModal/useConfirmationModal.ts
+++ b/client/packages/common/src/ui/components/modals/ConfirmationModal/useConfirmationModal.ts
@@ -10,9 +10,16 @@ export const useConfirmationModal = ({
   message,
   title,
   onCancel,
+  iconType = 'help',
 }: PartialBy<ConfirmationModalState, 'open'>) => {
-  const { setOpen, setMessage, setOnConfirm, setOnCancel, setTitle } =
-    useContext(ConfirmationModalContext);
+  const {
+    setIconType,
+    setOpen,
+    setMessage,
+    setOnConfirm,
+    setOnCancel,
+    setTitle,
+  } = useContext(ConfirmationModalContext);
 
   const trigger = (
     paramPatch?: Partial<PartialBy<ConfirmationModalState, 'open'>>
@@ -21,6 +28,7 @@ export const useConfirmationModal = ({
     setOnConfirm(paramPatch?.onConfirm ?? onConfirm);
     setTitle(paramPatch?.title ?? title);
     setOnCancel(paramPatch?.onCancel ?? onCancel);
+    setIconType(iconType);
     setOpen(true);
   };
 
@@ -32,5 +40,6 @@ export const useConfirmationModal = ({
     setOnConfirm,
     setTitle,
     setOpen,
+    iconType,
   ]);
 };

--- a/client/packages/common/src/ui/icons/Help.tsx
+++ b/client/packages/common/src/ui/icons/Help.tsx
@@ -7,7 +7,7 @@ export const HelpIcon = (props: SvgIconProps): JSX.Element => {
       {...props}
       style={{
         fill: 'currentColor',
-        strokeWidth: 2,
+        strokeWidth: 2.5,
         strokeLinecap: 'round',
         strokeLinejoin: 'round',
       }}

--- a/client/packages/common/src/ui/icons/Help.tsx
+++ b/client/packages/common/src/ui/icons/Help.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
+
+export const HelpIcon = (props: SvgIconProps): JSX.Element => {
+  return (
+    <SvgIcon
+      {...props}
+      style={{
+        fill: 'currentColor',
+        strokeWidth: 2,
+        strokeLinecap: 'round',
+        strokeLinejoin: 'round',
+      }}
+      viewBox="0 0 24 24"
+    >
+      <circle cx="12" cy="12" r="10"></circle>
+      <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" stroke="#fff"></path>
+      <line x1="12" y1="17" x2="12.01" y2="17" stroke="#fff"></line>
+    </SvgIcon>
+  );
+};

--- a/client/packages/common/src/ui/icons/Icon.stories.tsx
+++ b/client/packages/common/src/ui/icons/Icon.stories.tsx
@@ -29,6 +29,7 @@ import { ExternalLinkIcon } from './ExternalLink';
 import { EyeIcon } from './Eye';
 import { EyeOffIcon } from './EyeOff';
 import { FilterIcon } from './Filter';
+import { HelpIcon } from './Help';
 import { HomeIcon } from './Home';
 import { InfoIcon } from './Info';
 import { InfoOutlineIcon } from './InfoOutline';
@@ -120,6 +121,7 @@ const Template: ComponentStory<React.FC<SvgIconProps>> = args => {
     { icon: <EyeIcon {...args} />, name: 'Eye' },
     { icon: <EyeOffIcon {...args} />, name: 'EyeOff' },
     { icon: <FilterIcon {...args} />, name: 'Filter' },
+    { icon: <HelpIcon {...args} />, name: 'Help' },
     { icon: <HomeIcon {...args} />, name: 'Home' },
     { icon: <InfoIcon {...args} />, name: 'Info' },
     { icon: <InfoOutlineIcon {...args} />, name: 'InfoOutline' },

--- a/client/packages/common/src/ui/icons/index.ts
+++ b/client/packages/common/src/ui/icons/index.ts
@@ -25,6 +25,7 @@ export { ExternalLinkIcon } from './ExternalLink';
 export { EyeIcon } from './Eye';
 export { EyeOffIcon } from './EyeOff';
 export { FilterIcon } from './Filter';
+export { HelpIcon } from './Help';
 export { HomeIcon } from './Home';
 export { InfoIcon } from './Info';
 export { InfoOutlineIcon } from './InfoOutline';

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/UseSuggestedQuantityButton.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/UseSuggestedQuantityButton.tsx
@@ -14,6 +14,7 @@ export const UseSuggestedQuantityButtonComponent = () => {
   const isDisabled = useRequest.utils.isDisabled();
 
   const getConfirmation = useConfirmationModal({
+    iconType: 'info',
     onConfirm: setRequestedToSuggested,
     message: t('messages.requested-to-suggested'),
     title: t('heading.requested-to-suggested'),

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/CreateShipmentButton.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/CreateShipmentButton.tsx
@@ -18,6 +18,7 @@ export const CreateShipmentButtonComponent = () => {
   const isDisabled = useResponse.utils.isDisabled();
 
   const getConfirmation = useConfirmationModal({
+    iconType: 'info',
     onConfirm: createOutbound,
     message: t('messages.create-outbound-from-requisition'),
     title: t('heading.create-outbound-shipment'),

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/SupplyRequestedQuantityButton.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/SupplyRequestedQuantityButton.tsx
@@ -19,6 +19,7 @@ export const SupplyRequestedQuantityButtonComponent = () => {
     : t('button.supply-to-requested');
 
   const getConfirmation = useConfirmationModal({
+    iconType: 'info',
     onConfirm: supplyRequestedQuantity,
     message: isRemoteAuthorisation
       ? t('messages.supply-to-approved')


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2497

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
- Created a new icon
- Added icon to storybook
- Updated the confirmation modal to default to the new icon
- Added ability to set the icon when using `useConfirmationModal`
- Used the info icon in suggested quantity and create shipment buttons. All other usages were using the heading 'Are you sure?' (or similar) and it made sense to have them as a question mark

No change for these two:

<img width="636" alt="Screenshot 2023-11-17 at 11 29 16 AM" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/1218f2de-45ec-431d-9162-2a601750df2d">

<img width="576" alt="Screenshot 2023-11-17 at 11 24 16 AM" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/1b65b09b-8823-4c24-a083-c53679c1614c">

All others:

<img width="554" alt="image" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/7bde48d9-34aa-44fa-bcaf-743a7eb5b5fa">



# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Check a few confirmation modals.. and that storybook shows the new icon.


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

