### PR TITLE
4 unset bmi when no height weight

### DIFF
--- a/client/packages/common/src/utils/numbers/NumUtils.ts
+++ b/client/packages/common/src/utils/numbers/NumUtils.ts
@@ -6,6 +6,13 @@ export const NumUtils = {
   isPositive: (num: number): boolean => {
     return num > 0;
   },
+  /**
+   * Parses a string into a number, constraining it to the given min and max values.
+   *
+   * With the default `min` and `max` parameters this method will return a number >= 0.
+   *
+   * If the input `str` can't be parsed the min value is returned.
+   */
   parseString(str: string, min = 0, max = Number.MAX_SAFE_INTEGER): number {
     const parsed = Number(str);
     if (Number.isNaN(parsed)) return min;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes https://github.com/msupply-foundation/programschemas/issues/4

This was actually an issue in the BMI control and not in the schema config. I.e. the issue is in the wrong repo.

## Testing:

- create 2 encounters
- In first encounter: set height
- In second encounter: set weight -> BMI should be calculated
  - unset weight -> BMI should be cleared
- Back in first encounter: unset height. In the second encounter setting a weight shouldn't calculate the BMI because there is no height value 
- Test other combinations...