### PR TITLE
Ignore time deserialisation in sync and add logging for invoice serialisation in sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "1.5.01",
+  "version": "1.5.00",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "1.5.00",
+  "version": "1.5.00-ss1",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "1.5.00-ss1",
+  "version": "1.5.01",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -278,6 +278,9 @@ impl SyncTranslation for InvoiceTranslation {
 
         let invoice_row =
             InvoiceRowRepository::new(connection).find_one_by_id(&changelog.record_id)?;
+
+        log::info!("Translating invoice row: {:#?}", invoice_row);
+
         let confirm_datetime = to_legacy_confirm_time(&invoice_row);
 
         let InvoiceRow {
@@ -354,10 +357,18 @@ impl SyncTranslation for InvoiceTranslation {
             prescriber_ID: clinician_id,
         };
 
+        let json_recod = serde_json::to_value(&legacy_row)?;
+
+        log::info!(
+            "Translated row {}",
+            serde_json::to_string_pretty(&json_recod)
+                .unwrap_or("Failed to stringify json".to_string())
+        );
+
         Ok(Some(vec![RemoteSyncRecordV5::new_upsert(
             changelog,
             LEGACY_TABLE_NAME,
-            serde_json::to_value(&legacy_row)?,
+            json_recod,
         )]))
     }
 

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -279,7 +279,7 @@ impl SyncTranslation for InvoiceTranslation {
         let invoice_row =
             InvoiceRowRepository::new(connection).find_one_by_id(&changelog.record_id)?;
 
-        log::info!("Translating invoice row: {:#?}", invoice_row);
+        // log::info!("Translating invoice row: {:#?}", invoice_row);
 
         let confirm_datetime = to_legacy_confirm_time(&invoice_row);
 
@@ -359,11 +359,11 @@ impl SyncTranslation for InvoiceTranslation {
 
         let json_recod = serde_json::to_value(&legacy_row)?;
 
-        log::info!(
-            "Translated row {}",
-            serde_json::to_string_pretty(&json_recod)
-                .unwrap_or("Failed to stringify json".to_string())
-        );
+        // log::info!(
+        //     "Translated row {}",
+        //     serde_json::to_string_pretty(&json_recod)
+        //         .unwrap_or("Failed to stringify json".to_string())
+        // );
 
         Ok(Some(vec![RemoteSyncRecordV5::new_upsert(
             changelog,


### PR DESCRIPTION
This is exploratory version to temporary fix this issue and help us identify the origin of the problem: https://github.com/msupply-foundation/open-msupply-internal/issues/37

A test APK based on this branch can be found with [this link](https://www.dropbox.com/scl/fi/3oiuudim2no0vvg98v8jg/open-msupply-1.5.01-release.apk?rlkey=kkej90s8r9zut5n9lf2ahfatr&dl=1)

Or use this QR code (just open camera and it should give an option to navigate to browser and download), might be easier to use drop box link if you using MDM to update the tablets.

![Screenshot 2023-11-21 at 4 40 03 PM](https://github.com/msupply-foundation/open-msupply/assets/26194949/c0900b1c-290d-4cb1-bcc5-2b4f749ff667)

### To Test

To test, try the data file and site mentioned in the issue, you should see historic outbound shipments starting at serial number 1 (as oppose to missing outbound shipments and serial numbers starting > 1),  during initial sync these warnings should be present:

```
2023-11-21 15:42:44.127586000 [WARN] <service::sync::sync_serde:67>:Problem deserialising time: invalid value: integer `40804840578`, expected u32 at line 1 column 370
2023-11-21 15:42:44.127634000 [WARN] <service::sync::sync_serde:67>:Problem deserialising time: invalid value: integer `54462071919`, expected u32 at line 1 column 581
2023-11-21 15:42:44.143036000 [WARN] <service::sync::sync_serde:67>:Problem deserialising time: invalid value: integer `54528480312`, expected u32 at line 1 column 571
2023-11-21 15:42:44.144545000 [WARN] <service::sync::sync_serde:67>:Problem 
```

And during sync push of invoices, there should be this log:

```
2023-11-21 15:44:54.294851000 [INFO] <service::sync::translations::invoice:282>:Translating invoice row: InvoiceRow {
    id: "352f7213-dc20-419c-95dd-cc4d2e35f66c",
    name_id: "951D16FF34644C78B7B203E69F12B53E",
    name_store_id: Some(
        "2B0A83EE4A7F4C32AB057376359937CC",
    ),
    store_id: "8F5F5D23660C46FE929B472D2ACE6550",
    user_id: Some(
        "F1E3A235704C4AD7A9B37F3DF3A2F010",
    ),
    invoice_number: 6,
    type: OutboundShipment,
    status: Shipped,
    on_hold: false,
    comment: None,
    their_reference: None,
    transport_reference: None,
    created_datetime: 2023-11-21T02:44:36.287408,
    allocated_datetime: Some(
        2023-11-21T02:44:51.708288,
    ),
    picked_datetime: Some(
        2023-11-21T02:44:51.708288,
    ),
    shipped_datetime: Some(
        2023-11-21T02:44:51.708288,
    ),
    delivered_datetime: None,
    verified_datetime: None,
    colour: None,
    requisition_id: None,
    linked_invoice_id: None,
    tax: None,
    clinician_id: None,
}
2023-11-21 15:44:54.295077000 [INFO] <service::sync::translations::invoice:362>:Translated row {
  "ID": "352f7213-dc20-419c-95dd-cc4d2e35f66c",
  "arrival_date_actual": null,
  "comment": null,
  "confirm_date": "2023-11-21T00:00:00",
  "confirm_time": "02:44:51.708288",
  "entry_date": "2023-11-21T00:00:00",
  "entry_time": "02:44:36.287408",
  "hold": false,
  "invoice_num": 6,
  "linked_transaction_id": null,
  "mode": "store",
  "name_ID": "951D16FF34644C78B7B203E69F12B53E",
  "om_allocated_datetime": "2023-11-21T02:44:51.708288",
  "om_colour": null,
  "om_created_datetime": "2023-11-21T02:44:36.287408",
  "om_delivered_datetime": null,
  "om_picked_datetime": "2023-11-21T02:44:51.708288",
  "om_shipped_datetime": "2023-11-21T02:44:51.708288",
  "om_status": "SHIPPED",
  "om_transport_reference": null,
  "om_type": "OUTBOUND_SHIPMENT",
  "om_verified_datetime": null,
  "prescriber_ID": null,
  "requisition_ID": null,
  "ship_date": "2023-11-21T00:00:00",
  "status": "fn",
  "store_ID": "8F5F5D23660C46FE929B472D2ACE6550",
  "tax": null,
  "their_ref": null,
  "type": "ci",
  "user_ID": "F1E3A235704C4AD7A9B37F3DF3A2F010"
}
```



