### PR TITLE
Prevent android crashing when network disabled

### DIFF
--- a/client/packages/android/app/src/main/java/org/openmsupply/client/CertWebViewClient.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/CertWebViewClient.java
@@ -199,10 +199,14 @@ class CertWebViewClient extends ExtendedWebViewClient {
         // will not only reload, but will open the URL in a browser tab
         // for local URLs we don't want this to happen!
         Uri url = request.getUrl();
-        if (url.toString().startsWith(nativeApi.getServerUrl())) {
-            return false;
+        try {
+            if (url.toString().startsWith(nativeApi.getServerUrl())) {
+                return false;
+            }
         }
-
+        catch(Exception e){
+            Log.e(TAG,e.getMessage());
+        }
         return bridge.launchIntent(url);
     }
 }

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
@@ -350,8 +350,8 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
     // Attempt to get a non-loopback address for the local server
     // and fallback to loopback if there is an error
     private String getHostAddress(NsdServiceInfo serviceInfo, Boolean isLocal){
-        if (isLocal) {
-            try {
+        try {
+            if (isLocal) {
                 for (Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces(); en.hasMoreElements(); ) {
                     NetworkInterface intf = en.nextElement();
                     for (Enumeration<InetAddress> enumIpAddr = intf.getInetAddresses(); enumIpAddr.hasMoreElements(); ) {
@@ -361,19 +361,17 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
                         }
                     }
                 }
-            } catch (Exception ex) {
-                Log.e(OM_SUPPLY, ex.toString());
             }
-        }
-        try {
             return serviceInfo.getHost().getHostAddress();
         } catch (Exception ex) {
             Log.e(OM_SUPPLY, ex.toString());
         }
-        // with no network available the getHostAddress() will
-        // throw an Exception - in this case default to local loopback
-        // as no other network is reachable!
-        return "127.0.0.1";
+        finally {
+            // with no network available the getHostAddress() will
+            // throw an Exception - in this case default to local loopback
+            // as no other network is reachable!
+            return "127.0.0.1";
+        }
     }
 
     private JSObject serviceInfoToObject(NsdServiceInfo serviceInfo) {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2526

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Two fatal exceptions observed when running the android app without a network
- `CertWebViewClient.shouldOverrideUrlLoading` was raising an Exception about String.length() of a null object
- `NativeApi.java` also raised a null object Exception in the `getHostAddress` call

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Turning off wifi on the tablet and starting the app was enough to have the app crash. 

I've cleared app data and run in both Client and Server modes, without a network when displaying the list of servers, only `127.0.0.1` is available - which is a bit of an issue if you are configuring cold chain, but then the network isn't available so cold chain wouldn't be able to connect anyway!

I've uploaded a debug apk file (open-msupply-1.5.00-debug.apk) to a [google drive folder](https://drive.google.com/open?id=117AXnR0If3I_GD6fOW7CAkrH66-zB9PL&usp=drive_fs) to help with testing. The app does not need to be initialised, it will crash prior to that 😉 

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
