### PR TITLE
Prevent item code overlapping

### DIFF
--- a/client/packages/system/src/Item/Components/ItemOptionRenderer/ItemOptionRenderer.tsx
+++ b/client/packages/system/src/Item/Components/ItemOptionRenderer/ItemOptionRenderer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ItemRowWithStatsFragment, ItemStockOnHandFragment } from '../../api';
 import { ItemOption } from '../../utils';
+import { Tooltip } from '@common/components';
 
 export const getItemOptionRenderer =
   (label: string, formatNumber: (value: number) => string) =>
@@ -8,15 +9,25 @@ export const getItemOptionRenderer =
     props: React.HTMLAttributes<HTMLLIElement>,
     item: ItemStockOnHandFragment | ItemRowWithStatsFragment
   ) => (
-    <ItemOption {...props} key={item.code}>
-      <span style={{ whiteSpace: 'nowrap', width: 100 }}>{item.code}</span>
-      <span style={{ whiteSpace: 'normal', width: 500 }}>{item.name}</span>
-      <span
-        style={{
-          width: 200,
-          textAlign: 'right',
-          // whiteSpace: 'wrap',
-        }}
-      >{`${formatNumber(item.availableStockOnHand)} ${label}`}</span>
-    </ItemOption>
+    <Tooltip title={`${item.code} ${item.name}`}>
+      <ItemOption {...props} key={item.code}>
+        <span
+          style={{
+            whiteSpace: 'nowrap',
+            width: 150,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {item.code}
+        </span>
+        <span style={{ whiteSpace: 'normal', width: 500 }}>{item.name}</span>
+        <span
+          style={{
+            width: 200,
+            textAlign: 'right',
+          }}
+        >{`${formatNumber(item.availableStockOnHand)} ${label}`}</span>
+      </ItemOption>
+    </Tooltip>
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1764

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
For the `StockItemSearchInput` make the `item.code` space a little wider, and add in overflow hidden, with an ellipsis. 
Have also added a tooltip to the row, in case the code is obscured.

In the screenshot `Acetylsalicylic Acid 100mg tabs` has a strangely long code. The `Amoxicillin 250mg tabs` has also had the name elongated to show that this is wrapping correctly. 

The tooltip is also shown, where you can see the full item code.

<img width="1063" alt="Screenshot 2023-11-23 at 4 16 06 PM" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/b16dc5f7-ca1d-44e1-b3fc-0e4c0a0b1ad9">


# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
I've changed the code and name of items to check the overlap.



## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
