### PR TITLE
Rename patient patient id filter name #2516

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -251,7 +251,7 @@
   "label.packs-of_one": "pack of",
   "label.packs-of_other": "packs of",
   "label.patient": "Patient",
-  "label.patient-id": "National ID (NID)",
+  "label.patient-id": "Patient ID",
   "label.patient-nuic": "NUIC",
   "label.period": "Period",
   "label.phone": "Phone",


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2516 

# 👩🏻‍💻 What does this PR do? 
Quick change to `label.patient-id`.
![Screenshot 2023-11-23 at 21 22 15](https://github.com/msupply-foundation/open-msupply/assets/61820074/90e53fd2-91a6-4e21-86f9-a44985900ef6)

# 🧪 How has/should this change been tested? 
- Go to patient
- Click filters
- See rename