### PR TITLE
2488 item -> master list tab shows all master lists

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -2369,6 +2369,7 @@ export type MasterListFilterInput = {
   existsForStoreId?: InputMaybe<EqualFilterStringInput>;
   id?: InputMaybe<EqualFilterStringInput>;
   isProgram?: InputMaybe<Scalars['Boolean']['input']>;
+  itemId?: InputMaybe<EqualFilterStringInput>;
   name?: InputMaybe<StringFilterInput>;
 };
 

--- a/client/packages/system/src/Item/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Item/DetailView/DetailView.tsx
@@ -25,7 +25,7 @@ export const ItemDetailView: FC = () => {
     setSuffix(data?.name ?? '');
   }, [data]);
 
-  if (isLoading) return <DetailFormSkeleton />;
+  if (isLoading || !data) return <DetailFormSkeleton />;
 
   const tabs = [
     {
@@ -33,7 +33,7 @@ export const ItemDetailView: FC = () => {
       value: 'General',
     },
     {
-      Component: <MasterListsTab />,
+      Component: <MasterListsTab itemId={data.id} />,
       value: 'Master Lists',
     },
   ];

--- a/client/packages/system/src/Item/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Item/DetailView/DetailView.tsx
@@ -25,7 +25,7 @@ export const ItemDetailView: FC = () => {
     setSuffix(data?.name ?? '');
   }, [data]);
 
-  if (isLoading || !data) return <DetailFormSkeleton />;
+  if (isLoading) return <DetailFormSkeleton />;
 
   const tabs = [
     {
@@ -33,7 +33,7 @@ export const ItemDetailView: FC = () => {
       value: 'General',
     },
     {
-      Component: <MasterListsTab itemId={data.id} />,
+      Component: <MasterListsTab itemId={data?.id} />,
       value: 'Master Lists',
     },
   ];

--- a/client/packages/system/src/Item/DetailView/Tabs/MasterLists.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/MasterLists.tsx
@@ -13,8 +13,8 @@ import {
   createQueryParamsStore,
 } from '@openmsupply-client/common';
 
-const MasterListsTable: FC<{ itemId: string }> = ({ itemId }) => {
-  const { data, isLoading } = useMasterList.document.listByItemId(itemId);
+const MasterListsTable: FC<{ itemId?: string }> = ({ itemId }) => {
+  const { data, isLoading } = useMasterList.document.listByItemId(itemId ?? '');
   const columns = useColumns<MasterListRowFragment>([
     'code',
     ['name', { width: 150 }],
@@ -28,7 +28,7 @@ const MasterListsTable: FC<{ itemId: string }> = ({ itemId }) => {
   );
 };
 
-export const MasterListsTab: FC<{ itemId: string }> = ({ itemId }) => (
+export const MasterListsTab: FC<{ itemId?: string }> = ({ itemId }) => (
   <Box justifyContent="center" display="flex" flex={1} paddingTop={3}>
     <Box flex={1} display="flex" style={{ maxWidth: 1000 }}>
       <TableProvider

--- a/client/packages/system/src/Item/DetailView/Tabs/MasterLists.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/MasterLists.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import {
   MasterListRowFragment,
   useMasterList,
@@ -13,8 +13,8 @@ import {
   createQueryParamsStore,
 } from '@openmsupply-client/common';
 
-const MasterListsTable = () => {
-  const { data, isLoading } = useMasterList.document.list();
+const MasterListsTable: FC<{ itemId: string }> = ({ itemId }) => {
+  const { data, isLoading } = useMasterList.document.listByItemId(itemId);
   const columns = useColumns<MasterListRowFragment>([
     'code',
     ['name', { width: 150 }],
@@ -28,7 +28,7 @@ const MasterListsTable = () => {
   );
 };
 
-export const MasterListsTab = () => (
+export const MasterListsTab: FC<{ itemId: string }> = ({ itemId }) => (
   <Box justifyContent="center" display="flex" flex={1} paddingTop={3}>
     <Box flex={1} display="flex" style={{ maxWidth: 1000 }}>
       <TableProvider
@@ -37,7 +37,7 @@ export const MasterListsTab = () => (
           initialSortBy: { key: 'name' },
         })}
       >
-        <MasterListsTable />
+        <MasterListsTable itemId={itemId} />
       </TableProvider>
     </Box>
   </Box>

--- a/client/packages/system/src/MasterList/api/api.ts
+++ b/client/packages/system/src/MasterList/api/api.ts
@@ -35,6 +35,10 @@ export const getMasterListQueries = (sdk: Sdk, storeId: string) => ({
       });
       return result?.masterLists;
     },
+    byItemId: async (itemId: string) => {
+      const result = await sdk.masterListsByItemId({ itemId, storeId });
+      return result?.masterLists;
+    },
     listAll: async ({
       sortBy,
       filter,

--- a/client/packages/system/src/MasterList/api/hooks/document/index.ts
+++ b/client/packages/system/src/MasterList/api/hooks/document/index.ts
@@ -2,10 +2,12 @@ import { useMasterList } from './useMasterList';
 import { useMasterListFields } from './useMasterListFields';
 import { useMasterLists } from './useMasterLists';
 import { useMasterListsAll } from './useMasterListsAll';
+import { useMasterListsByItemId } from './useMasterListsByItemId';
 
 export const Document = {
   useMasterList,
   useMasterListFields,
   useMasterLists,
+  useMasterListsByItemId,
   useMasterListsAll,
 };

--- a/client/packages/system/src/MasterList/api/hooks/document/useMasterListsByItemId.ts
+++ b/client/packages/system/src/MasterList/api/hooks/document/useMasterListsByItemId.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@openmsupply-client/common';
+import { useMasterListApi } from '../utils/useMasterListApi';
+
+export const useMasterListsByItemId = (itemId: string) => {
+  const api = useMasterListApi();
+
+  return {
+    ...useQuery(api.keys.base(), () => api.get.byItemId(itemId)),
+  };
+};

--- a/client/packages/system/src/MasterList/api/hooks/index.ts
+++ b/client/packages/system/src/MasterList/api/hooks/index.ts
@@ -7,7 +7,7 @@ export const useMasterList = {
     get: Document.useMasterList,
     list: Document.useMasterLists,
     listAll: Document.useMasterListsAll,
-
+    listByItemId: Document.useMasterListsByItemId,
     fields: Document.useMasterListFields,
   },
   line: {

--- a/client/packages/system/src/MasterList/api/operations.generated.ts
+++ b/client/packages/system/src/MasterList/api/operations.generated.ts
@@ -24,6 +24,14 @@ export type MasterListsQueryVariables = Types.Exact<{
 
 export type MasterListsQuery = { __typename: 'Queries', masterLists: { __typename: 'MasterListConnector', totalCount: number, nodes: Array<{ __typename: 'MasterListNode', name: string, code: string, description: string, id: string, lines: { __typename: 'MasterListLineConnector', totalCount: number } }> } };
 
+export type MasterListsByItemIdQueryVariables = Types.Exact<{
+  storeId: Types.Scalars['String']['input'];
+  itemId: Types.Scalars['String']['input'];
+}>;
+
+
+export type MasterListsByItemIdQuery = { __typename: 'Queries', masterLists: { __typename: 'MasterListConnector', totalCount: number, nodes: Array<{ __typename: 'MasterListNode', name: string, code: string, description: string, id: string, lines: { __typename: 'MasterListLineConnector', totalCount: number } }> } };
+
 export type MasterListQueryVariables = Types.Exact<{
   filter?: Types.InputMaybe<Types.MasterListFilterInput>;
   storeId: Types.Scalars['String']['input'];
@@ -94,6 +102,22 @@ export const MasterListsDocument = gql`
   }
 }
     ${MasterListRowFragmentDoc}`;
+export const MasterListsByItemIdDocument = gql`
+    query masterListsByItemId($storeId: String!, $itemId: String!) {
+  masterLists(
+    filter: {itemId: {equalTo: $itemId}, existsForStoreId: {equalTo: $storeId}}
+    storeId: $storeId
+  ) {
+    ... on MasterListConnector {
+      __typename
+      totalCount
+      nodes {
+        ...MasterListRow
+      }
+    }
+  }
+}
+    ${MasterListRowFragmentDoc}`;
 export const MasterListDocument = gql`
     query masterList($filter: MasterListFilterInput, $storeId: String!) {
   masterLists(filter: $filter, storeId: $storeId) {
@@ -118,6 +142,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     masterLists(variables: MasterListsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<MasterListsQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<MasterListsQuery>(MasterListsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'masterLists', 'query');
     },
+    masterListsByItemId(variables: MasterListsByItemIdQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<MasterListsByItemIdQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<MasterListsByItemIdQuery>(MasterListsByItemIdDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'masterListsByItemId', 'query');
+    },
     masterList(variables: MasterListQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<MasterListQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<MasterListQuery>(MasterListDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'masterList', 'query');
     }
@@ -139,6 +166,23 @@ export type Sdk = ReturnType<typeof getSdk>;
 export const mockMasterListsQuery = (resolver: ResponseResolver<GraphQLRequest<MasterListsQueryVariables>, GraphQLContext<MasterListsQuery>, any>) =>
   graphql.query<MasterListsQuery, MasterListsQueryVariables>(
     'masterLists',
+    resolver
+  )
+
+/**
+ * @param resolver a function that accepts a captured request and may return a mocked response.
+ * @see https://mswjs.io/docs/basics/response-resolver
+ * @example
+ * mockMasterListsByItemIdQuery((req, res, ctx) => {
+ *   const { storeId, itemId } = req.variables;
+ *   return res(
+ *     ctx.data({ masterLists })
+ *   )
+ * })
+ */
+export const mockMasterListsByItemIdQuery = (resolver: ResponseResolver<GraphQLRequest<MasterListsByItemIdQueryVariables>, GraphQLContext<MasterListsByItemIdQuery>, any>) =>
+  graphql.query<MasterListsByItemIdQuery, MasterListsByItemIdQueryVariables>(
+    'masterListsByItemId',
     resolver
   )
 

--- a/client/packages/system/src/MasterList/api/operations.graphql
+++ b/client/packages/system/src/MasterList/api/operations.graphql
@@ -62,6 +62,24 @@ query masterLists(
   }
 }
 
+query masterListsByItemId(
+  $storeId: String!
+  $itemId: String!
+) {
+  masterLists(
+    filter: { itemId: { equalTo: $itemId }, existsForStoreId: { equalTo: $storeId } } 
+    storeId: $storeId
+  ) {
+    ... on MasterListConnector {
+      __typename
+      totalCount
+      nodes {
+        ...MasterListRow
+      }
+    }
+  }
+}
+
 query masterList($filter: MasterListFilterInput, $storeId: String!) {
   masterLists(filter: $filter, storeId: $storeId) {
     ... on MasterListConnector {

--- a/server/graphql/general/src/queries/master_list.rs
+++ b/server/graphql/general/src/queries/master_list.rs
@@ -50,6 +50,7 @@ pub struct MasterListFilterInput {
     pub exists_for_name_id: Option<EqualFilterStringInput>,
     pub exists_for_store_id: Option<EqualFilterStringInput>,
     pub is_program: Option<bool>,
+    pub item_id: Option<EqualFilterStringInput>,
 }
 
 impl MasterListFilterInput {
@@ -63,6 +64,7 @@ impl MasterListFilterInput {
             exists_for_name_id: self.exists_for_name_id.map(EqualFilter::from),
             exists_for_store_id: self.exists_for_store_id.map(EqualFilter::from),
             is_program: self.is_program,
+            item_id: self.item_id.map(EqualFilter::from),
         }
     }
 }

--- a/server/repository/src/db_diesel/item.rs
+++ b/server/repository/src/db_diesel/item.rs
@@ -106,7 +106,7 @@ impl<'a> ItemRepository<'a> {
         store_id: String,
         filter: Option<ItemFilter>,
     ) -> Result<i64, RepositoryError> {
-        let query = create_filtered_query(store_id, filter);
+        let query = Self::create_filtered_query(store_id, filter);
 
         Ok(query.count().get_result(&self.connection.connection)?)
     }
@@ -134,7 +134,7 @@ impl<'a> ItemRepository<'a> {
         sort: Option<ItemSort>,
         store_id: Option<String>,
     ) -> Result<Vec<Item>, RepositoryError> {
-        let mut query = create_filtered_query(store_id.unwrap_or_default(), filter);
+        let mut query = Self::create_filtered_query(store_id.unwrap_or_default(), filter);
 
         if let Some(sort) = sort {
             match sort.key {
@@ -166,6 +166,56 @@ impl<'a> ItemRepository<'a> {
 
         Ok(result.into_iter().map(to_domain).collect())
     }
+
+    pub fn create_filtered_query(store_id: String, filter: Option<ItemFilter>) -> BoxedItemQuery {
+        let mut query = item_dsl::item.left_join(unit_dsl::unit).into_boxed();
+
+        if let Some(f) = filter {
+            let ItemFilter {
+                id,
+                name,
+                code,
+                r#type,
+                is_visible,
+                code_or_name,
+            } = f;
+
+            // or filter need to be applied before and filters
+            if code_or_name.is_some() {
+                apply_string_filter!(query, code_or_name.clone(), item_dsl::code);
+                apply_string_or_filter!(query, code_or_name, item_dsl::name);
+            }
+
+            apply_equal_filter!(query, id, item_dsl::id);
+            apply_string_filter!(query, code, item_dsl::code);
+            apply_string_filter!(query, name, item_dsl::name);
+            apply_equal_filter!(query, r#type, item_dsl::type_);
+
+            let visible_item_ids = master_list_line_dsl::master_list_line
+                .select(master_list_line_dsl::item_id)
+                .inner_join(
+                    master_list_dsl::master_list
+                        .on(master_list_line_dsl::master_list_id.eq(master_list_dsl::id)),
+                )
+                .inner_join(
+                    master_list_name_join_dsl::master_list_name_join
+                        .on(master_list_name_join_dsl::master_list_id.eq(master_list_dsl::id)),
+                )
+                .inner_join(
+                    store_dsl::store.on(store_dsl::name_id
+                        .eq(master_list_name_join_dsl::name_id)
+                        .and(store_dsl::id.eq(store_id))),
+                )
+                .into_boxed();
+
+            query = match is_visible {
+                Some(true) => query.filter(item_dsl::id.eq_any(visible_item_ids)),
+                Some(false) => query.filter(item_dsl::id.ne_all(visible_item_ids)),
+                None => query,
+            }
+        }
+        query
+    }
 }
 
 fn to_domain((item_row, unit_row): ItemAndMasterList) -> Item {
@@ -173,56 +223,6 @@ fn to_domain((item_row, unit_row): ItemAndMasterList) -> Item {
 }
 
 type BoxedItemQuery = IntoBoxed<'static, LeftJoin<item::table, unit::table>, DBType>;
-
-fn create_filtered_query(store_id: String, filter: Option<ItemFilter>) -> BoxedItemQuery {
-    let mut query = item_dsl::item.left_join(unit_dsl::unit).into_boxed();
-
-    if let Some(f) = filter {
-        let ItemFilter {
-            id,
-            name,
-            code,
-            r#type,
-            is_visible,
-            code_or_name,
-        } = f;
-
-        // or filter need to be applied before and filters
-        if code_or_name.is_some() {
-            apply_string_filter!(query, code_or_name.clone(), item_dsl::code);
-            apply_string_or_filter!(query, code_or_name, item_dsl::name);
-        }
-
-        apply_equal_filter!(query, id, item_dsl::id);
-        apply_string_filter!(query, code, item_dsl::code);
-        apply_string_filter!(query, name, item_dsl::name);
-        apply_equal_filter!(query, r#type, item_dsl::type_);
-
-        let visible_item_ids = master_list_line_dsl::master_list_line
-            .select(master_list_line_dsl::item_id)
-            .inner_join(
-                master_list_dsl::master_list
-                    .on(master_list_line_dsl::master_list_id.eq(master_list_dsl::id)),
-            )
-            .inner_join(
-                master_list_name_join_dsl::master_list_name_join
-                    .on(master_list_name_join_dsl::master_list_id.eq(master_list_dsl::id)),
-            )
-            .inner_join(
-                store_dsl::store.on(store_dsl::name_id
-                    .eq(master_list_name_join_dsl::name_id)
-                    .and(store_dsl::id.eq(store_id))),
-            )
-            .into_boxed();
-
-        query = match is_visible {
-            Some(true) => query.filter(item_dsl::id.eq_any(visible_item_ids)),
-            Some(false) => query.filter(item_dsl::id.ne_all(visible_item_ids)),
-            None => query,
-        }
-    }
-    query
-}
 
 impl Item {
     pub fn unit_name(&self) -> Option<&str> {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2488

# 👩🏻‍💻 What does this PR do? 
- Load master lists that contain the item in `Item -> Master List` tab.

# 🧪 How has/should this change been tested? 
- [ ] Have more than one `master list`
- [ ] Have items in one while not in the other
- [ ] Go to item -> master list tab for each item
- [ ] See that the master lists associated with each item is loaded 