### PR TITLE
2514 Patient list view: have some default filter auto selected

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Filters/FilterMenu.tsx
+++ b/client/packages/common/src/ui/components/inputs/Filters/FilterMenu.tsx
@@ -20,6 +20,7 @@ import { BooleanFilter, BooleanFilterDefinition } from './BooleanFilter';
 export interface FilterDefinitionCommon {
   name: string;
   urlParameter: string;
+  isDefault?: boolean;
 }
 
 interface GroupFilterDefinition {
@@ -47,8 +48,8 @@ export const FilterMenu: FC<FilterDefinitions> = ({ filters }) => {
   const t = useTranslation();
   const { urlQuery, updateQuery } = useUrlQuery();
   const [activeFilters, setActiveFilters] = useState<FilterDefinition[]>(
-    flattenFilterDefinitions(filters).filter(fil =>
-      Object.keys(urlQuery).includes(fil.urlParameter)
+    flattenFilterDefinitions(filters).filter(
+      fil => Object.keys(urlQuery).includes(fil.urlParameter) || fil.isDefault
     )
   );
 
@@ -62,7 +63,7 @@ export const FilterMenu: FC<FilterDefinitions> = ({ filters }) => {
         activeFilters.map(({ urlParameter }) => [urlParameter, ''])
       );
       updateQuery(queryPatch);
-      setActiveFilters([]);
+      setActiveFilters(activeFilters.filter(fil => fil.isDefault));
       return;
     }
     if (selected.type === 'group') {

--- a/client/packages/system/src/Patient/ListView/Toolbar.tsx
+++ b/client/packages/system/src/Patient/ListView/Toolbar.tsx
@@ -28,18 +28,21 @@ export const Toolbar: FC<{ filter: FilterController }> = () => {
               name: t('label.first-name'),
               urlParameter: 'firstName',
               placeholder: t('placeholder.search-by-first-name'),
+              isDefault: true,
             },
             {
               type: 'text',
               name: t('label.last-name'),
               urlParameter: 'lastName',
               placeholder: t('placeholder.search-by-last-name'),
+              isDefault: true,
             },
             {
               type: 'text',
               name: t('label.patient-id'),
               urlParameter: 'identifier',
               placeholder: t('placeholder.search-by-identifier'),
+              isDefault: true,
             },
             {
               type: 'date',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2514

# 👩🏻‍💻 What does this PR do? 
Allows default filters
![Screenshot 2023-11-28 at 08 33 43](https://github.com/msupply-foundation/open-msupply/assets/61820074/e10d1aef-0ebe-45f0-bcb1-320b2411b5a8)

# 🧪 How has/should this change been tested? 
- [ ] Go to patients list view
- [ ] See default filters