### PR TITLE
2513 count spinner control needs an option to unset the value

### DIFF
--- a/client/packages/common/src/intl/locales/en/programs.json
+++ b/client/packages/common/src/intl/locales/en/programs.json
@@ -10,5 +10,7 @@
   "control.search.error.no-data": "Unable to extract path \"{{docPath}}\" from document",
   "control.search.error.no-patient-contact": "No matching patient contact found",
   "control.search.below-min-chars": "Please enter at least {{minChars}} characters",
-  "label.bmi-prev-height-message": "Using height of {{height}}m from previous measurement"
+  "label.bmi-prev-height-message": "Using height of {{height}}m from previous measurement",
+  "label.systolic": "Systolic",
+  "label.diastolic": "Diastolic"
 }

--- a/client/packages/common/src/intl/locales/en/programs.json
+++ b/client/packages/common/src/intl/locales/en/programs.json
@@ -1,16 +1,16 @@
 {
   "control.adherence-status-warning": "Pill Count: after last visit = {{previousCountOnHand}} < before visit = {{remainingCount}}",
-  "control.note.text-label": "Text",
   "control.note.author-label": "Author",
-  "control.search.searching-label": "Searching...",
+  "control.note.text-label": "Text",
+  "control.search.below-min-chars": "Please enter at least {{minChars}} characters",
+  "control.search.error.no-data": "Unable to extract path \"{{docPath}}\" from document",
+  "control.search.error.no-document": "Unable to access requested document",
+  "control.search.error.no-patient-contact": "No matching patient contact found",
+  "control.search.matching-patients": "We've found some existing patients that match the above entered data. Please select from this list if applicable",
   "control.search.no-results-label": "No results",
   "control.search.reset-button": "Unlink matched patient",
-  "control.search.matching-patients": "We've found some existing patients that match the above entered data. Please select from this list if applicable",
-  "control.search.error.no-document": "Unable to access requested document",
-  "control.search.error.no-data": "Unable to extract path \"{{docPath}}\" from document",
-  "control.search.error.no-patient-contact": "No matching patient contact found",
-  "control.search.below-min-chars": "Please enter at least {{minChars}} characters",
+  "control.search.searching-label": "Searching...",
   "label.bmi-prev-height-message": "Using height of {{height}}m from previous measurement",
-  "label.systolic": "Systolic",
-  "label.diastolic": "Diastolic"
+  "label.diastolic": "Diastolic",
+  "label.systolic": "Systolic"
 }

--- a/client/packages/programs/src/JsonForms/components/BloodPressure.tsx
+++ b/client/packages/programs/src/JsonForms/components/BloodPressure.tsx
@@ -81,8 +81,6 @@ export const UIComponent = (props: ControlProps) => {
 
   const inputProps = {
     type: 'number',
-    min: schema.minimum ?? 0,
-    max: schema.maximum ?? NumUtils.MAX_SAFE_API_INTEGER,
     error: !!customError,
     InputLabelProps: { shrink: true },
   };
@@ -100,6 +98,11 @@ export const UIComponent = (props: ControlProps) => {
               onChange={onChangeSystolic}
               value={systolic}
               label={t('label.systolic')}
+              min={schema.properties?.['systolic']?.minimum ?? 0}
+              max={
+                schema.properties?.['systolic']?.maximum ??
+                NumUtils.MAX_SAFE_API_INTEGER
+              }
               {...inputProps}
             />
             <Typography margin={1} paddingTop={2}>
@@ -110,6 +113,11 @@ export const UIComponent = (props: ControlProps) => {
               value={diastolic}
               label={t('label.diastolic')}
               width={100}
+              min={schema.properties?.['diastolic']?.minimum ?? 0}
+              max={
+                schema.properties?.['diastolic']?.maximum ??
+                NumUtils.MAX_SAFE_API_INTEGER
+              }
               {...inputProps}
             />
           </Box>

--- a/client/packages/programs/src/JsonForms/components/BloodPressure.tsx
+++ b/client/packages/programs/src/JsonForms/components/BloodPressure.tsx
@@ -35,8 +35,6 @@ export const UIComponent = (props: ControlProps) => {
     'BloodPressure'
   );
 
-  console.log('core ', core?.errors);
-
   useEffect(() => {
     if (core) {
       const getChildErrors = subErrorsAt(path, schema);

--- a/client/packages/programs/src/JsonForms/components/BloodPressure.tsx
+++ b/client/packages/programs/src/JsonForms/components/BloodPressure.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect } from 'react';
+import {
+  ControlProps,
+  composePaths,
+  rankWith,
+  uiTypeIs,
+} from '@jsonforms/core';
+import {
+  Box,
+  DetailInputWithLabelRow,
+  NumUtils,
+  NumericTextInput,
+} from '@openmsupply-client/common';
+import { FORM_LABEL_WIDTH } from '../common';
+import { withJsonFormsControlProps } from '@jsonforms/react';
+
+export const bloodPressureTester = rankWith(10, uiTypeIs('BloodPressure'));
+
+export const UIComponent = (props: ControlProps) => {
+  const { data, handleChange, label, path, errors, schema } = props;
+  const [systolic, setSystolic] = React.useState<number | undefined>(undefined);
+  const [diastolic, setDiastolic] = React.useState<number | undefined>(
+    undefined
+  );
+  const systolicPath = composePaths(path, 'systolic');
+  const diastolicPath = composePaths(path, 'diastolic');
+
+  if (!props.visible) {
+    return null;
+  }
+
+  const onChangeSystolic = (value: number | undefined) => {
+    setSystolic(value);
+    handleChange(systolicPath, value);
+
+    if (!value && diastolic === undefined) {
+      handleChange(path, undefined);
+    }
+  };
+
+  const onChangeDiastolic = (value: number | undefined) => {
+    setDiastolic(value);
+    handleChange(diastolicPath, value);
+
+    if (!value && systolic === undefined) {
+      handleChange(path, undefined);
+    }
+  };
+
+  useEffect(() => {
+    if (data) {
+      setSystolic(data.systolic);
+      setDiastolic(data.diastolic);
+    }
+  }, [data]);
+
+  const inputProps = {
+    type: 'number',
+    error: !!errors,
+    helperText: errors,
+    min: schema.minimum ?? 0,
+    max: schema.maximum ?? NumUtils.MAX_SAFE_API_INTEGER,
+  };
+
+  return (
+    <DetailInputWithLabelRow
+      label={label}
+      labelWidthPercentage={FORM_LABEL_WIDTH}
+      inputAlignment="start"
+      sx={{ paddingTop: 0.5 }}
+      Input={
+        <Box display="flex" flexDirection="row" paddingLeft={0.5}>
+          <NumericTextInput
+            onChange={onChangeSystolic}
+            value={systolic}
+            {...inputProps}
+          />
+          <Box mx={1}>/</Box>
+          <NumericTextInput
+            onChange={onChangeDiastolic}
+            value={diastolic}
+            {...inputProps}
+          />
+        </Box>
+      }
+    />
+  );
+};
+
+export const BloodPressure = withJsonFormsControlProps(UIComponent);

--- a/client/packages/programs/src/JsonForms/components/BloodPressure.tsx
+++ b/client/packages/programs/src/JsonForms/components/BloodPressure.tsx
@@ -12,6 +12,7 @@ import {
   NumUtils,
   NumericTextInput,
   Typography,
+  useDebounceCallback,
   useTranslation,
 } from '@openmsupply-client/common';
 import { FORM_LABEL_WIDTH } from '../common';
@@ -43,27 +44,29 @@ export const UIComponent = (props: ControlProps) => {
     }
   }, [core]);
 
-  if (!props.visible) {
-    return null;
-  }
+  const onChangeSystolic = useDebounceCallback(
+    (value: number | undefined) => {
+      setSystolic(value);
+      handleChange(systolicPath, value);
 
-  const onChangeSystolic = (value: number | undefined) => {
-    setSystolic(value);
-    handleChange(systolicPath, value);
+      if (!value && diastolic === undefined) {
+        handleChange(path, undefined);
+      }
+    },
+    [path]
+  );
 
-    if (!value && diastolic === undefined) {
-      handleChange(path, undefined);
-    }
-  };
+  const onChangeDiastolic = useDebounceCallback(
+    (value: number | undefined) => {
+      setDiastolic(value);
+      handleChange(diastolicPath, value);
 
-  const onChangeDiastolic = (value: number | undefined) => {
-    setDiastolic(value);
-    handleChange(diastolicPath, value);
-
-    if (!value && systolic === undefined) {
-      handleChange(path, undefined);
-    }
-  };
+      if (!value && systolic === undefined) {
+        handleChange(path, undefined);
+      }
+    },
+    [path]
+  );
 
   useEffect(() => {
     if (data) {
@@ -71,6 +74,10 @@ export const UIComponent = (props: ControlProps) => {
       setDiastolic(data.diastolic);
     }
   }, [data]);
+
+  if (!props.visible) {
+    return null;
+  }
 
   const inputProps = {
     type: 'number',

--- a/client/packages/programs/src/JsonForms/components/BloodPressure.tsx
+++ b/client/packages/programs/src/JsonForms/components/BloodPressure.tsx
@@ -3,6 +3,7 @@ import {
   ControlProps,
   composePaths,
   rankWith,
+  subErrorsAt,
   uiTypeIs,
 } from '@jsonforms/core';
 import {
@@ -10,20 +11,39 @@ import {
   DetailInputWithLabelRow,
   NumUtils,
   NumericTextInput,
+  Typography,
+  useTranslation,
 } from '@openmsupply-client/common';
 import { FORM_LABEL_WIDTH } from '../common';
-import { withJsonFormsControlProps } from '@jsonforms/react';
+import { useJsonForms, withJsonFormsControlProps } from '@jsonforms/react';
+import { useJSONFormsCustomError } from '../common/hooks/useJSONFormsCustomError';
 
 export const bloodPressureTester = rankWith(10, uiTypeIs('BloodPressure'));
 
 export const UIComponent = (props: ControlProps) => {
-  const { data, handleChange, label, path, errors, schema } = props;
+  const t = useTranslation('programs');
+  const { data, handleChange, label, path, schema } = props;
+  const { core } = useJsonForms();
   const [systolic, setSystolic] = React.useState<number | undefined>(undefined);
   const [diastolic, setDiastolic] = React.useState<number | undefined>(
     undefined
   );
   const systolicPath = composePaths(path, 'systolic');
   const diastolicPath = composePaths(path, 'diastolic');
+  const { customError, setCustomError } = useJSONFormsCustomError(
+    path,
+    'BloodPressure'
+  );
+
+  console.log('core ', core?.errors);
+
+  useEffect(() => {
+    if (core) {
+      const getChildErrors = subErrorsAt(path, schema);
+      const errors = getChildErrors(core);
+      setCustomError(errors[0]?.message);
+    }
+  }, [core]);
 
   if (!props.visible) {
     return null;
@@ -56,10 +76,10 @@ export const UIComponent = (props: ControlProps) => {
 
   const inputProps = {
     type: 'number',
-    error: !!errors,
-    helperText: errors,
     min: schema.minimum ?? 0,
     max: schema.maximum ?? NumUtils.MAX_SAFE_API_INTEGER,
+    error: !!customError,
+    InputLabelProps: { shrink: true },
   };
 
   return (
@@ -67,20 +87,32 @@ export const UIComponent = (props: ControlProps) => {
       label={label}
       labelWidthPercentage={FORM_LABEL_WIDTH}
       inputAlignment="start"
-      sx={{ paddingTop: 0.5 }}
+      sx={{ paddingTop: 1 }}
       Input={
-        <Box display="flex" flexDirection="row" paddingLeft={0.5}>
-          <NumericTextInput
-            onChange={onChangeSystolic}
-            value={systolic}
-            {...inputProps}
-          />
-          <Box mx={1}>/</Box>
-          <NumericTextInput
-            onChange={onChangeDiastolic}
-            value={diastolic}
-            {...inputProps}
-          />
+        <Box display="flex" flexDirection="column">
+          <Box display="flex" flexDirection="row" paddingLeft={0.5}>
+            <NumericTextInput
+              onChange={onChangeSystolic}
+              value={systolic}
+              label={t('label.systolic')}
+              {...inputProps}
+            />
+            <Typography margin={1} paddingTop={2}>
+              /
+            </Typography>
+            <NumericTextInput
+              onChange={onChangeDiastolic}
+              value={diastolic}
+              label={t('label.diastolic')}
+              width={100}
+              {...inputProps}
+            />
+          </Box>
+          <Box display="flex" flexDirection="row" alignSelf="center">
+            {customError && (
+              <Typography variant="caption">{customError}</Typography>
+            )}
+          </Box>
         </Box>
       }
     />

--- a/client/packages/programs/src/JsonForms/components/index.ts
+++ b/client/packages/programs/src/JsonForms/components/index.ts
@@ -9,3 +9,4 @@ export * from './QuantityDispensed';
 export * from './Search/Search';
 export * from './ProgramEvent';
 export * from './HistoricEncounterData';
+export * from './BloodPressure';

--- a/client/packages/programs/src/JsonForms/useJsonForms.tsx
+++ b/client/packages/programs/src/JsonForms/useJsonForms.tsx
@@ -34,6 +34,8 @@ import {
   ProgramEvent,
   historicEncounterDataTester,
   HistoricEncounterData,
+  bloodPressureTester,
+  BloodPressure,
 } from './components';
 import { EnrolmentId, enrolmentIdTester } from './components/EnrolmentId';
 
@@ -95,6 +97,7 @@ const additionalRenderers: JsonFormsRendererRegistryEntry[] = [
   { tester: programEventTester, renderer: ProgramEvent },
   { tester: historicEncounterDataTester, renderer: HistoricEncounterData },
   { tester: enrolmentIdTester, renderer: EnrolmentId },
+  { tester: bloodPressureTester, renderer: BloodPressure },
 ];
 
 /**


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2513 

# 👩🏻‍💻 What does this PR do? 
Sets up a custom control for `blood pressure`. This control shows systolic and diastolic values next to each other separated by `/` which is normal(?) since blood pressure is usually shown as e.g. 120/80. And also doesn't prompt error if none of these values are set.

https://github.com/msupply-foundation/open-msupply/assets/61820074/1ce2cb6d-409b-4aa6-a210-0436b70b35a0



# 🧪 How has/should this change been tested? 
- [ ] Have programs set up (make sure to have latest program updates)
- [ ] Add encounter to patient
- [ ] Go to `physical exam`
- [ ] Enter different values into blood pressure