### PR TITLE
Increase sqlite busy timout

### DIFF
--- a/server/repository/src/database_settings.rs
+++ b/server/repository/src/database_settings.rs
@@ -4,9 +4,10 @@ use diesel::r2d2::{ConnectionManager, Pool};
 use log::info;
 use serde;
 
-//WAIT up to 5 SECONDS for lock in SQLITE (https://www.sqlite.org/c3ref/busy_timeout.html)
+// Timeout for waiting for the SQLite lock (https://www.sqlite.org/c3ref/busy_timeout.html).
+// A locked DB results in the "SQLite database is locked" error.
 #[cfg(not(feature = "postgres"))]
-const SQLITE_LOCKWAIT_MS: u32 = 5000;
+const SQLITE_LOCKWAIT_MS: u32 = 30 * 1000;
 
 #[cfg(all(not(feature = "postgres"), not(feature = "memory")))]
 const SQLITE_WAL_PRAGMA: &str = "PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;";


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2579

I increased the timeout to 30sec (was my first guess, too long?). Since then I haven't seen any busy timeout errors anymore (even with 10 concurrent import requests which speeds up the data import dramatically)