### PR TITLE
2604 add patient id indices

### DIFF
--- a/server/repository/src/migrations/v1_06_00/mod.rs
+++ b/server/repository/src/migrations/v1_06_00/mod.rs
@@ -4,6 +4,7 @@ use crate::StorageConnection;
 
 mod contact_trace;
 mod master_list;
+mod patient_id_indices;
 mod plugin_data;
 mod temperature_breach;
 
@@ -19,6 +20,7 @@ impl Migration for V1_06_00 {
         plugin_data::migrate(connection)?;
         master_list::migrate(connection)?;
         temperature_breach::migrate(connection)?;
+        patient_id_indices::migrate(connection)?;
         Ok(())
     }
 }

--- a/server/repository/src/migrations/v1_06_00/patient_id_indices.rs
+++ b/server/repository/src/migrations/v1_06_00/patient_id_indices.rs
@@ -1,0 +1,14 @@
+use crate::{migrations::sql, StorageConnection};
+
+pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
+    sql!(
+        connection,
+        r#"
+        CREATE INDEX index_encounter_patient_id ON encounter (patient_id);
+        CREATE INDEX index_program_enrolment_patient_id ON program_enrolment (patient_id);
+        CREATE INDEX index_program_event_patient_id ON program_event (patient_id);
+        "#,
+    )?;
+
+    Ok(())
+}

--- a/server/repository/src/mock/mod.rs
+++ b/server/repository/src/mock/mod.rs
@@ -113,9 +113,7 @@ use crate::{
     UserPermissionRow, UserPermissionRowRepository, UserStoreJoinRow, UserStoreJoinRowRepository,
 };
 
-use self::{
-    activity_log::mock_activity_logs, document_registry::mock_document_registries, unit::mock_units,
-};
+use self::{activity_log::mock_activity_logs, unit::mock_units};
 
 use super::{
     InvoiceRowRepository, ItemRowRepository, NameRow, NameRowRepository, NameStoreJoinRepository,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2604 

Add some indices to speed up report queries. I experimented with secondary indices like (patient_id, type, active_start_datetime) but it didn't improve things consistently. For this reason I decided for a smaller index. If needed a more optimized index can be create at a later point.

As a reference the report I was working on took about 17sec to query and is now down to <1s.