### PR TITLE
2618 sync and expose custom data on name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "1.5.00",
+  "version": "1.5.04",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/graphql/types/src/types/name.rs
+++ b/server/graphql/types/src/types/name.rs
@@ -3,7 +3,10 @@ use chrono::{DateTime, NaiveDate, Utc};
 use dataloader::DataLoader;
 use repository::{Gender, Name, NameRow, NameType};
 
-use graphql_core::{loader::StoreByIdLoader, simple_generic_errors::NodeError, ContextExt};
+use graphql_core::{
+    loader::StoreByIdLoader, simple_generic_errors::NodeError,
+    standard_graphql_error::StandardGraphqlError, ContextExt,
+};
 use serde::Serialize;
 
 use super::StoreNode;
@@ -229,8 +232,10 @@ impl NameNode {
         self.row().date_of_birth
     }
 
-    pub async fn custom_data(&self) -> Option<serde_json::Value> {
-        Some(serde_json::json!({ "check": "check" }))
+    pub async fn custom_data(&self) -> Result<Option<serde_json::Value>> {
+        self.name
+            .custom_data()
+            .map_err(|err| StandardGraphqlError::from_error(&err))
     }
 }
 

--- a/server/graphql/types/src/types/name.rs
+++ b/server/graphql/types/src/types/name.rs
@@ -228,6 +228,10 @@ impl NameNode {
     pub async fn date_of_birth(&self) -> Option<NaiveDate> {
         self.row().date_of_birth
     }
+
+    pub async fn custom_data(&self) -> Option<serde_json::Value> {
+        Some(serde_json::json!({ "check": "check" }))
+    }
 }
 
 #[derive(Union)]
@@ -304,6 +308,7 @@ mod test {
                                     .unwrap(),
                             );
                             r.date_of_birth = Some(NaiveDate::from_ymd_opt(1995, 05, 15).unwrap());
+                            r.custom_data_string = Some(r#"{"check": "check""#.to_string());
                         }),
                         name_store_join_row: None,
                         store_row: None,
@@ -333,6 +338,9 @@ mod test {
                 "address2": "address2",
                 "createdDatetime": "2022-05-18T12:07:12+00:00",
                 "dateOfBirth": "1995-05-15",
+                "customData": {
+                    "check": "check"
+                }
             }
         }
         );
@@ -359,6 +367,7 @@ mod test {
                createdDatetime
                isOnHold
                dateOfBirth
+               customData
             }
         }
         "#;

--- a/server/graphql/types/src/types/name.rs
+++ b/server/graphql/types/src/types/name.rs
@@ -313,7 +313,7 @@ mod test {
                                     .unwrap(),
                             );
                             r.date_of_birth = Some(NaiveDate::from_ymd_opt(1995, 05, 15).unwrap());
-                            r.custom_data_string = Some(r#"{"check": "check""#.to_string());
+                            r.custom_data_string = Some(r#"{"check": "check"}"#.to_string());
                         }),
                         name_store_join_row: None,
                         store_row: None,

--- a/server/repository/src/db_diesel/name.rs
+++ b/server/repository/src/db_diesel/name.rs
@@ -234,6 +234,14 @@ impl Name {
             store_row,
         }
     }
+
+    pub fn custom_data(&self) -> Result<Option<serde_json::Value>, serde_json::Error> {
+        self.name_row
+            .custom_data_string
+            .as_ref()
+            .map(|custom_data_string| serde_json::from_str(&custom_data_string))
+            .transpose()
+    }
 }
 
 // name_store_join_dsl::name_id.eq(name_dsl::id)

--- a/server/repository/src/db_diesel/name_row.rs
+++ b/server/repository/src/db_diesel/name_row.rs
@@ -38,6 +38,7 @@ table! {
         is_deceased -> Bool,
         national_health_number -> Nullable<Text>,
         date_of_death -> Nullable<Date>,
+        custom_data -> Nullable<Text>,
     }
 }
 
@@ -100,6 +101,12 @@ impl Default for NameType {
     }
 }
 
+impl NameType {
+    pub fn is_facility_or_store(&self) -> bool {
+        *self == NameType::Facility || *self == NameType::Store
+    }
+}
+
 #[derive(Clone, Queryable, Insertable, Debug, PartialEq, Eq, AsChangeset, Default)]
 #[changeset_options(treat_none_as_null = "true")]
 #[table_name = "name"]
@@ -141,6 +148,8 @@ pub struct NameRow {
     pub is_deceased: bool,
     pub national_health_number: Option<String>,
     pub date_of_death: Option<NaiveDate>,
+    #[column_name = "custom_data"]
+    pub custom_data_string: Option<String>,
 }
 
 pub struct NameRowRepository<'a> {

--- a/server/repository/src/migrations/mod.rs
+++ b/server/repository/src/migrations/mod.rs
@@ -14,6 +14,7 @@ mod v1_02_01;
 mod v1_03_00;
 mod v1_04_00;
 mod v1_05_00;
+mod v1_05_04;
 mod version;
 
 pub(crate) use self::types::*;
@@ -85,6 +86,7 @@ pub fn migrate(
         Box::new(v1_03_00::V1_03_00),
         Box::new(v1_04_00::V1_04_00),
         Box::new(v1_05_00::V1_05_00),
+        Box::new(v1_05_04::V1_05_04),
     ];
 
     // Historic diesel migrations

--- a/server/repository/src/migrations/v1_05_04/mod.rs
+++ b/server/repository/src/migrations/v1_05_04/mod.rs
@@ -1,0 +1,43 @@
+use super::{sql, version::Version, Migration};
+
+use crate::StorageConnection;
+
+pub(crate) struct V1_05_04;
+
+impl Migration for V1_05_04 {
+    fn version(&self) -> Version {
+        Version::from_str("1.5.04")
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        sql!(
+            connection,
+            r#"
+                ALTER TABLE name ADD COLUMN custom_data TEXT DEFAULT NULL;
+            "#
+        )?;
+
+        // Re-sync (so custom data is available)
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[actix_rt::test]
+async fn migration_1_05_04() {
+    use crate::migrations::*;
+    use crate::test_db::*;
+
+    let version = V1_05_04.version();
+
+    // This test allows checking sql syntax
+    let SetupResult { connection, .. } = setup_test(SetupOption {
+        db_name: &format!("migration_{version}"),
+        version: Some(version.clone()),
+        ..Default::default()
+    })
+    .await;
+
+    assert_eq!(get_database_version(&connection), version);
+}

--- a/server/repository/src/migrations/v1_05_04/mod.rs
+++ b/server/repository/src/migrations/v1_05_04/mod.rs
@@ -10,14 +10,16 @@ impl Migration for V1_05_04 {
     }
 
     fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        // Update integartion_datetime on facility/store type name records in sync_buffer
+        // when server start, or on next sync these will be re-integrated
         sql!(
             connection,
             r#"
                 ALTER TABLE name ADD COLUMN custom_data TEXT DEFAULT NULL;
+                UPDATE sync_buffer SET integration_datetime = NULL 
+                    WHERE record_id IN (SELECT id FROM name where name."type" IN ('FACILITY', 'STORE'));
             "#
         )?;
-
-        // Re-sync (so custom data is available)
 
         Ok(())
     }

--- a/server/service/src/programs/patient/patient_updated.rs
+++ b/server/service/src/programs/patient/patient_updated.rs
@@ -128,6 +128,7 @@ pub fn update_patient_row(
         is_deceased: patient.is_deceased.unwrap_or(false),
         date_of_death,
         national_health_number: code_2,
+        custom_data_string: None,
     };
 
     if is_sync_update {

--- a/server/service/src/sync/test/test_data/name.rs
+++ b/server/service/src/sync/test/test_data/name.rs
@@ -144,6 +144,7 @@ fn name_1() -> TestSyncPullRecord {
                     .unwrap(),
             ),
             date_of_death: None,
+            custom_data_string: None,
         }),
     )
 }
@@ -277,6 +278,7 @@ fn name_2() -> TestSyncPullRecord {
             is_deceased: false,
             national_health_number: None,
             date_of_death: None,
+            custom_data_string: None,
         }),
     )
 }
@@ -368,7 +370,7 @@ const NAME_3: (&'static str, &'static str) = (
     "license_number": "",
     "license_expiry": "0000-00-00",
     "has_current_license": false,
-    "custom_data": null,
+    "custom_data": {"check":"check"},
     "maximum_credit": 0,
     "nationality_ID": "",
     "created_date": "0000-00-00",
@@ -410,6 +412,7 @@ fn name_3() -> TestSyncPullRecord {
             is_deceased: false,
             national_health_number: Some("NHN002".to_string()),
             date_of_death: None,
+            custom_data_string: Some(r#"{"check":"check"}"#.to_string()),
         }),
     )
 }
@@ -549,6 +552,7 @@ fn name_4() -> TestSyncPullRecord {
             is_deceased: true,
             national_health_number: Some("NHN003".to_string()),
             date_of_death: None,
+            custom_data_string: None,
         }),
     )
 }
@@ -591,6 +595,7 @@ fn name_push_record_1() -> TestSyncPushRecord {
             ),
             gender: Some(Gender::Female),
             date_of_death: None,
+            custom_data: None
         }),
     }
 }
@@ -633,6 +638,7 @@ fn name_push_record_2() -> TestSyncPushRecord {
             ),
             gender: Some(Gender::Female),
             date_of_death: None,
+            custom_data: None
         }),
     }
 }

--- a/server/service/src/sync/translations/name.rs
+++ b/server/service/src/sync/translations/name.rs
@@ -5,6 +5,7 @@ use crate::sync::{
         zero_date_as_option,
     },
 };
+use anyhow::Context;
 use chrono::{NaiveDate, NaiveDateTime};
 use repository::{
     ChangelogRow, ChangelogTableName, Gender, NameRow, NameRowRepository, NameType,
@@ -131,6 +132,7 @@ pub struct LegacyNameRow {
     #[serde(deserialize_with = "zero_date_as_option")]
     #[serde(serialize_with = "date_option_to_isostring")]
     pub date_of_death: Option<NaiveDate>,
+    pub custom_data: Option<serde_json::Value>,
 }
 
 const LEGACY_TABLE_NAME: &'static str = LegacyTableName::NAME;
@@ -165,7 +167,7 @@ impl SyncTranslation for NameTranslation {
             id,
             name,
             code,
-            r#type,
+            r#type: legacy_type,
             is_customer,
             is_supplier,
             supplying_store_id,
@@ -190,16 +192,25 @@ impl SyncTranslation for NameTranslation {
             created_datetime,
             gender,
             date_of_death,
+            custom_data,
         } = serde_json::from_str::<LegacyNameRow>(&sync_record.data)?;
+
+        // Custom data for facility or name only (for others, say patient, don't need to have extra overhead or push translation back to json)
+        let r#type = legacy_type.to_name_type();
+        let custom_data_string = r#type
+            .is_facility_or_store()
+            .then(|| custom_data.as_ref().map(serde_json::to_string))
+            .flatten()
+            .transpose()
+            .context("Error serialising custom data to string")?;
 
         let result = NameRow {
             id,
             name,
-            r#type: r#type.to_name_type(),
+            r#type,
             code,
             is_customer,
             is_supplier,
-
             supplying_store_id,
             first_name,
             last_name,
@@ -217,7 +228,7 @@ impl SyncTranslation for NameTranslation {
             on_hold,
             is_deceased,
             national_health_number,
-            gender: gender.or(if r#type == LegacyNameType::Patient {
+            gender: gender.or(if legacy_type == LegacyNameType::Patient {
                 if female {
                     Some(Gender::Female)
                 } else {
@@ -229,6 +240,7 @@ impl SyncTranslation for NameTranslation {
             created_datetime: created_datetime
                 .or(created_date.map(|date| date.and_hms_opt(0, 0, 0).unwrap())),
             date_of_death,
+            custom_data_string,
         };
 
         Ok(Some(IntegrationRecords::from_upsert(
@@ -284,6 +296,8 @@ impl SyncTranslation for NameTranslation {
             is_deceased,
             date_of_death,
             national_health_number,
+            // See comment in pull translation
+            custom_data_string: _,
         } = NameRowRepository::new(connection)
             .find_one_by_id(&changelog.record_id)?
             .ok_or(anyhow::Error::msg(format!(
@@ -326,6 +340,7 @@ impl SyncTranslation for NameTranslation {
             created_datetime,
             gender,
             date_of_death,
+            custom_data: None,
         };
 
         Ok(Some(vec![RemoteSyncRecordV5::new_upsert(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2618

# 👩🏻‍💻 What does this PR do? 
 
Add custom data field (text) to name table, add translations for custom data for sync, expose in API. Clear integration_time for name records in sync buffer, so that they are re-integrated on startup

# 🧪 How has/should this change been tested? 
* Add custom data to name in mSupply ( first in preferences add “custom fields” to name, then for a name add custom data )
* Start previous version of omSupply (prior to 1.5.04), sync
* Stop previous version of omSupply and start new version of omSupply
* Use name API, see custom field being populated (without re-sync)
* Update custom field on name, sync, see it being updated in API

## 💌 Any notes for the reviewer?

This PR is for main branch, with version increase for migration, I'll make a build as soon as it's merged, and deploy on demo server that requires it (DJ)