### PR TITLE
2594 sensor back end link temperature logs to breaches

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -5332,7 +5332,7 @@ dependencies = [
 [[package]]
 name = "temperature-sensor"
 version = "0.1.0"
-source = "git+https://github.com/openmsupply/temperature-sensor.git?tag=v0.1.0-beta.2#4b0c11631366821f9c7a993c07b6c2627490f49a"
+source = "git+https://github.com/openmsupply/temperature-sensor.git?tag=v0.1.0-beta3#5764b9b4d8f673060ec492d95f11bf13bbf19b46"
 dependencies = [
  "chrono",
  "json",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -5332,7 +5332,7 @@ dependencies = [
 [[package]]
 name = "temperature-sensor"
 version = "0.1.0"
-source = "git+https://github.com/openmsupply/temperature-sensor.git#4b0c11631366821f9c7a993c07b6c2627490f49a"
+source = "git+https://github.com/openmsupply/temperature-sensor.git?tag=v0.1.0-beta.2#4b0c11631366821f9c7a993c07b6c2627490f49a"
 dependencies = [
  "chrono",
  "json",

--- a/server/service/Cargo.toml
+++ b/server/service/Cargo.toml
@@ -36,7 +36,7 @@ pretty_assertions = "1.3.0"
 flate2 = "1.0.26"
 simple-log = { version = "1.6" }
 # dependencies for temperature_sensor
-temperature-sensor = { git = "https://github.com/openmsupply/temperature-sensor.git", tag = "v0.1.0-beta.2" }
+temperature-sensor = { git = "https://github.com/openmsupply/temperature-sensor.git", tag = "v0.1.0-beta3" }
 # plugin:
 hex = "0.4"
 pem = "3"

--- a/server/service/Cargo.toml
+++ b/server/service/Cargo.toml
@@ -36,7 +36,7 @@ pretty_assertions = "1.3.0"
 flate2 = "1.0.26"
 simple-log = { version = "1.6" }
 # dependencies for temperature_sensor
-temperature-sensor = { git = "https://github.com/openmsupply/temperature-sensor.git" }
+temperature-sensor = { git = "https://github.com/openmsupply/temperature-sensor.git", tag = "v0.1.0-beta.2" }
 # plugin:
 hex = "0.4"
 pem = "3"

--- a/server/service/src/sensor/berlinger.rs
+++ b/server/service/src/sensor/berlinger.rs
@@ -72,7 +72,7 @@ pub fn get_matching_sensor_breach(
 
     match breach_type {
         TemperatureBreachRowType::ColdCumulative | TemperatureBreachRowType::HotCumulative => {
-            // Cumulative breach can start any time on the same day (can only be at most one per day)
+            // Cumulative breach can start any time on the same day (can only be at most one hot/cold per day)
             let start_breach = start_datetime.date().and_hms_opt(0, 0, 0).unwrap();
             let end_breach = start_datetime.date().and_hms_opt(23, 59, 59).unwrap();
             filter = filter.start_datetime(DatetimeFilter::date_range(start_breach, end_breach));

--- a/server/service/src/sensor/berlinger.rs
+++ b/server/service/src/sensor/berlinger.rs
@@ -1,3 +1,4 @@
+use super::update::update_sensor_logs_for_breach;
 use anyhow::Context;
 use chrono::NaiveDateTime;
 use repository::{DatetimeFilter, EqualFilter};
@@ -11,7 +12,6 @@ use repository::{
 };
 use serde::Serialize;
 use std::path::PathBuf;
-use super::update::update_sensor_logs_for_breach;
 use thiserror::Error;
 use util::uuid::uuid;
 
@@ -65,10 +65,9 @@ pub fn get_matching_sensor_breach(
     _end_datetime: NaiveDateTime, // don't match on the end time, just the breach type and start time
     breach_type: &TemperatureBreachRowType,
 ) -> Result<Vec<TemperatureBreach>, RepositoryError> {
-
     let mut filter = TemperatureBreachFilter::new()
-    .sensor(SensorFilter::new().id(EqualFilter::equal_to(sensor_id)))
-    .r#type(EqualFilter::equal_to_breach_type(&breach_type));
+        .sensor(SensorFilter::new().id(EqualFilter::equal_to(sensor_id)))
+        .r#type(EqualFilter::equal_to_breach_type(&breach_type));
 
     match breach_type {
         TemperatureBreachRowType::ColdCumulative | TemperatureBreachRowType::HotCumulative => {
@@ -81,7 +80,7 @@ pub fn get_matching_sensor_breach(
             filter = filter.start_datetime(DatetimeFilter::equal_to(start_datetime));
         }
     }
-    
+
     TemperatureBreachRepository::new(connection).query_by_filter(filter)
 }
 

--- a/server/service/src/sensor/query.rs
+++ b/server/service/src/sensor/query.rs
@@ -1,5 +1,8 @@
 use repository::{
-    DatetimeFilter, EqualFilter, Pagination, PaginationOption, RepositoryError, Sensor, SensorFilter, SensorRepository, SensorSort, Sort, StorageConnection, TemperatureBreachRowRepository, TemperatureBreachRowType, TemperatureLog, TemperatureLogFilter, TemperatureLogRepository, TemperatureLogSortField,
+    DatetimeFilter, EqualFilter, Pagination, PaginationOption, RepositoryError, Sensor,
+    SensorFilter, SensorRepository, SensorSort, Sort, StorageConnection,
+    TemperatureBreachRowRepository, TemperatureBreachRowType, TemperatureLog, TemperatureLogFilter,
+    TemperatureLogRepository, TemperatureLogSortField,
 };
 
 use crate::{
@@ -38,18 +41,19 @@ pub fn get_sensor(ctx: &ServiceContext, id: String) -> Result<Sensor, SingleReco
     }
 }
 
-pub fn get_sensor_logs_for_breach(connection: &StorageConnection, breach_id: &String) -> Result<Vec<TemperatureLog>, RepositoryError> {
-   
+pub fn get_sensor_logs_for_breach(
+    connection: &StorageConnection,
+    breach_id: &String,
+) -> Result<Vec<TemperatureLog>, RepositoryError> {
     let mut temperature_logs: Vec<TemperatureLog> = Vec::new();
 
-    let breach_result = 
-    TemperatureBreachRowRepository::new(connection).find_one_by_id(breach_id)?;
+    let breach_result =
+        TemperatureBreachRowRepository::new(connection).find_one_by_id(breach_id)?;
 
     if let Some(breach_record) = breach_result {
-        
         if let Some(end_datetime) = breach_record.end_datetime {
             // Find all temperature logs in the breach time range, sorted by date/time
-            
+
             let mut filter = TemperatureLogFilter::new()
                 .sensor(SensorFilter::new().id(EqualFilter::equal_to(&breach_record.sensor_id)));
             let sort = Sort {
@@ -58,38 +62,61 @@ pub fn get_sensor_logs_for_breach(connection: &StorageConnection, breach_id: &St
             };
 
             match breach_record.r#type {
-                TemperatureBreachRowType::ColdCumulative | TemperatureBreachRowType::HotCumulative => {
+                TemperatureBreachRowType::ColdCumulative
+                | TemperatureBreachRowType::HotCumulative => {
                     // Cumulative breach can include any time on the same day (can only be at most one per day)
-                    let start_breach = breach_record.start_datetime.date().and_hms_opt(0, 0, 0).unwrap();
-                    let end_breach = breach_record.start_datetime.date().and_hms_opt(23, 59, 59).unwrap();
+                    let start_breach = breach_record
+                        .start_datetime
+                        .date()
+                        .and_hms_opt(0, 0, 0)
+                        .unwrap();
+                    let end_breach = breach_record
+                        .start_datetime
+                        .date()
+                        .and_hms_opt(23, 59, 59)
+                        .unwrap();
                     filter = filter.datetime(DatetimeFilter::date_range(start_breach, end_breach));
                 }
-                TemperatureBreachRowType::ColdConsecutive | TemperatureBreachRowType::HotConsecutive => {
-                    filter = filter.datetime(DatetimeFilter::date_range(breach_record.start_datetime, end_datetime));
+                TemperatureBreachRowType::ColdConsecutive
+                | TemperatureBreachRowType::HotConsecutive => {
+                    filter = filter.datetime(DatetimeFilter::date_range(
+                        breach_record.start_datetime,
+                        end_datetime,
+                    ));
                 }
             }
-               
-            let log_result = TemperatureLogRepository::new(connection).query(Pagination::all(),Some(filter), Some(sort))?;
-            
-            for temperature_log in log_result {      
+
+            let log_result = TemperatureLogRepository::new(connection).query(
+                Pagination::all(),
+                Some(filter),
+                Some(sort),
+            )?;
+
+            for temperature_log in log_result {
                 // Add log to breach if temperature is outside breach parameters
                 match breach_record.r#type {
-                    TemperatureBreachRowType::ColdCumulative | TemperatureBreachRowType::ColdConsecutive => {
-                        if temperature_log.temperature_log_row.temperature < breach_record.threshold_minimum {     
+                    TemperatureBreachRowType::ColdCumulative
+                    | TemperatureBreachRowType::ColdConsecutive => {
+                        if temperature_log.temperature_log_row.temperature
+                            < breach_record.threshold_minimum
+                        {
                             temperature_logs.push(temperature_log.clone());
-                        } 
+                        }
                     }
-                    TemperatureBreachRowType::HotCumulative | TemperatureBreachRowType::HotConsecutive => {
-                        if temperature_log.temperature_log_row.temperature > breach_record.threshold_maximum {
+                    TemperatureBreachRowType::HotCumulative
+                    | TemperatureBreachRowType::HotConsecutive => {
+                        if temperature_log.temperature_log_row.temperature
+                            > breach_record.threshold_maximum
+                        {
                             temperature_logs.push(temperature_log.clone());
-                        } 
+                        }
                     }
                 }
             }
         } else {
             log::info!("Breach {:?} has no end time", breach_record);
-        } 
-        
+        }
+
         Ok(temperature_logs)
     } else {
         Err(RepositoryError::NotFound)

--- a/server/service/src/sensor/query.rs
+++ b/server/service/src/sensor/query.rs
@@ -73,11 +73,18 @@ pub fn get_sensor_logs_for_breach(connection: &StorageConnection, breach_id: &St
             
             for temperature_log in log_result {      
                 // Add log to breach if temperature is outside breach parameters
-                if (temperature_log.temperature_log_row.temperature > breach_record.threshold_maximum)
-                 | (temperature_log.temperature_log_row.temperature < breach_record.threshold_minimum)      
-                {
-                   temperature_logs.push(temperature_log.clone());
-                } 
+                match breach_record.r#type {
+                    TemperatureBreachRowType::ColdCumulative | TemperatureBreachRowType::ColdConsecutive => {
+                        if temperature_log.temperature_log_row.temperature < breach_record.threshold_minimum {     
+                            temperature_logs.push(temperature_log.clone());
+                        } 
+                    }
+                    TemperatureBreachRowType::HotCumulative | TemperatureBreachRowType::HotConsecutive => {
+                        if temperature_log.temperature_log_row.temperature > breach_record.threshold_maximum {
+                            temperature_logs.push(temperature_log.clone());
+                        } 
+                    }
+                }
             }
         } else {
             log::info!("Breach {:?} has no end time", breach_record);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2594

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The core of it is in two new functions - `get_sensor_logs_for_breach` (in `sensor\query.rs`) and `update_sensor_logs_for_breach` (in `sensor\update.rs`), both of which take a connection and a breach ID

- `get_sensor_logs_for_breach` returns all of the temperature logs which are considered to be part of the breach i.e. any which have temperatures outside the breach range, and which happen between the start & end of the breach. 
- `update_sensor_logs_for_breach` then uses `get_sensor_logs_for_breach` to return the matching temperature logs and assign them to the breach ID

Note that if it's a cumulative breach, that includes the whole day, as the start/end times for FridgeTag breaches (which are all cumulative) are not specified directly and have to be worked out, based only on the breach activation time (and the breach duration (cumulative time that day) outside the breach temperature range. That only works if the cumulative breach is actually consecutive i.e. if it doesn't have more than one continuous period of time during the day when the temperature was out of range. E.g. it could be out of range for an hour from 11am in the morning and then again for an hour from 4pm in the afternoon, in which case the duration of the breach is 2 hours, but the start time is 11am and the end time is 4pm => all temperature logs within that period are part of the breach if they're outside the temperature range. In that case, the start/end times of the breach are also extended to include the first & last temperature logs which fall outside the temperature range. 

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

I had a DB with existing sensor data, so to allow me to re-import the same Berlinger text file again, I used DB Browser to edit the SQL directly - I edited the `sensor` last connected date to before the first entry in the Berlinger text file, and set the end date of all existing breaches to null. The temperature_breach_id for temperature logs was already null, but if you're re-running a test, then you'll need to set those all to null as well.

(re) importing a Berlinger text file should then correctly assign breaches to temperature logs as described above.

TBC tomorrow...

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
Import fridge tag docs _may_ need updated to include this, although the functionality already seems to work on the UI side once the breach IDs are assigned ;-) The only thing is that the displayed breach Duration is based on the difference between start/end timestamps, which isn't true for most cumulative breaches (see example above) - there is a `duration` field => better to use that instead => I'll submit a bug report tomorrow...
or