### PR TITLE
2554 item merge handle sync merge messages

### DIFF
--- a/server/repository/src/db_diesel/item_link_row.rs
+++ b/server/repository/src/db_diesel/item_link_row.rs
@@ -108,6 +108,13 @@ impl<'a> ItemLinkRowRepository<'a> {
         Ok(result)
     }
 
+    pub fn find_many_by_item_id(&self, item_id: &str) -> Result<Vec<ItemLinkRow>, RepositoryError> {
+        let result = item_link_dsl::item_link
+            .filter(item_link::item_id.eq(item_id))
+            .load(&self.connection.connection)?;
+        Ok(result)
+    }
+
     pub fn delete(&self, item_link_id: &str) -> Result<(), RepositoryError> {
         diesel::delete(item_link_dsl::item_link.filter(item_link::id.eq(item_link_id)))
             .execute(&self.connection.connection)?;

--- a/server/repository/src/tests.rs
+++ b/server/repository/src/tests.rs
@@ -346,8 +346,7 @@ mod repository_test {
 
         let item_link_repo = ItemLinkRowRepository::new(&connection);
         item_link_repo
-            .insert_one(&mock_item_link_from_item(&item))
-            .await
+            .insert_one_or_ignore(&mock_item_link_from_item(&item))
             .unwrap();
     }
 

--- a/server/service/src/sync/sync_buffer.rs
+++ b/server/service/src/sync/sync_buffer.rs
@@ -52,7 +52,7 @@ impl<'a> SyncBuffer<'a> {
         let order: Vec<&str> = match action {
             SyncBufferAction::Upsert => ordered_table_names.collect(),
             SyncBufferAction::Delete => ordered_table_names.rev().collect(),
-            SyncBufferAction::Merge => unimplemented!(),
+            SyncBufferAction::Merge => ordered_table_names.collect(),
         };
 
         let mut result = Vec::new();

--- a/server/service/src/sync/test/integration/central/master_list.rs
+++ b/server/service/src/sync/test/integration/central/master_list.rs
@@ -20,6 +20,7 @@ impl SyncRecordTester for MasterListTester {
             name: uuid(),
             code: uuid(),
             description: "".to_string(),
+            is_active: true,
         };
         let master_list_json1 = json!({
             "ID": master_list_row1.id,
@@ -43,6 +44,7 @@ impl SyncRecordTester for MasterListTester {
             name: uuid(),
             code: uuid(),
             description: uuid(),
+            is_active: true,
         };
         let master_list_json2 = json!({
             "ID": master_list_row2.id,

--- a/server/service/src/sync/test/integration/central/unit_and_item.rs
+++ b/server/service/src/sync/test/integration/central/unit_and_item.rs
@@ -52,6 +52,7 @@ impl SyncRecordTester for UnitAndItemTester {
             r#type: ItemRowType::NonStock,
             legacy_record: "".to_string(),
             default_pack_size: 1,
+            is_active: true,
         };
         let item_json1 = extend_base(json!({
             "ID": item_row1.id,
@@ -70,6 +71,7 @@ impl SyncRecordTester for UnitAndItemTester {
             r#type: ItemRowType::Stock,
             legacy_record: "".to_string(),
             default_pack_size: 1,
+            is_active: true,
         };
         let item_json2 = extend_base(json!({
             "ID": item_row2.id,
@@ -88,6 +90,7 @@ impl SyncRecordTester for UnitAndItemTester {
             r#type: ItemRowType::Service,
             legacy_record: "".to_string(),
             default_pack_size: 1,
+            is_active: true,
         };
         let item_json3 = extend_base(json!({
             "ID": item_row3.id,

--- a/server/service/src/sync/test/integration/remote/program_requisition.rs
+++ b/server/service/src/sync/test/integration/remote/program_requisition.rs
@@ -58,6 +58,7 @@ impl SyncRecordTester for ProgramRequisitionTester {
             name: uuid(),
             code: uuid(),
             description: uuid(),
+            is_active: true,
         };
         let master_list_json = json!({
         "ID": master_list_row.id,
@@ -173,6 +174,7 @@ impl SyncRecordTester for ProgramRequisitionTester {
             name: uuid(),
             code: uuid(),
             description: uuid(),
+            is_active: true,
         };
         let master_list_json2 = json!({
         "ID": master_list_row2.id,

--- a/server/service/src/sync/test/mod.rs
+++ b/server/service/src/sync/test/mod.rs
@@ -27,6 +27,7 @@ impl TestSyncPullRecord {
     ) -> TestSyncPullRecord {
         Self::new_pull_upserts(table_name, id_and_data, vec![result])
     }
+
     fn new_pull_upserts(
         table_name: &str,
         // .0 = id .1 = data
@@ -62,6 +63,7 @@ impl TestSyncPullRecord {
             },
         )
     }
+
     fn new_pull_deletes(
         table_name: &str,
         id: &str,
@@ -327,6 +329,7 @@ pub(crate) async fn check_records_against_database(
                 record,
                 "DocumentRegistry"
             ),
+            ItemLink(_) => todo!(),
         }
     }
 

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -222,6 +222,7 @@ impl PullUpsertRecord {
             FormSchema(record) => FormSchemaRowRepository::new(con).upsert_one(record),
             DocumentRegistry(record) => DocumentRegistryRowRepository::new(con).upsert_one(record),
             Document(record) => sync_upsert_document(con, record),
+            ItemLink(_) => todo!(),
         }
     }
 }

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -51,7 +51,9 @@ impl<'a> TranslationAndIntegration<'a> {
                 SyncBufferAction::Delete => {
                     translator.try_translate_pull_delete(self.connection, &sync_record)?
                 }
-                SyncBufferAction::Merge => return Err(anyhow::anyhow!("Merge not implemented")),
+                SyncBufferAction::Merge => {
+                    translator.try_translate_pull_merge(self.connection, &sync_record)?
+                }
             };
 
             if let Some(translation_result) = translation_result {
@@ -222,7 +224,7 @@ impl PullUpsertRecord {
             FormSchema(record) => FormSchemaRowRepository::new(con).upsert_one(record),
             DocumentRegistry(record) => DocumentRegistryRowRepository::new(con).upsert_one(record),
             Document(record) => sync_upsert_document(con, record),
-            ItemLink(_) => todo!(),
+            ItemLink(record) => ItemLinkRowRepository::new(con).upsert_one(record),
         }
     }
 }

--- a/server/service/src/sync/translations/mod.rs
+++ b/server/service/src/sync/translations/mod.rs
@@ -204,6 +204,7 @@ pub(crate) enum PullUpsertRecord {
     FormSchema(FormSchemaJson),
     Document(Document),
     DocumentRegistry(DocumentRegistryRow),
+    ItemLink(ItemLinkRow),
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/server/service/src/sync/translations/mod.rs
+++ b/server/service/src/sync/translations/mod.rs
@@ -87,6 +87,7 @@ pub(crate) fn all_translators() -> SyncTranslators {
         Box::new(document::DocumentTranslation {}),
         // Special translations
         Box::new(special::NameToNameStoreJoinTranslation {}),
+        Box::new(special::ItemMergeTranslation {}),
     ]
 }
 
@@ -316,6 +317,14 @@ pub(crate) trait SyncTranslation {
     }
 
     fn try_translate_pull_delete(
+        &self,
+        _: &StorageConnection,
+        _: &SyncBufferRow,
+    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
+        Ok(None)
+    }
+
+    fn try_translate_pull_merge(
         &self,
         _: &StorageConnection,
         _: &SyncBufferRow,

--- a/server/service/src/sync/translations/special/item_merge.rs
+++ b/server/service/src/sync/translations/special/item_merge.rs
@@ -39,7 +39,6 @@ impl SyncTranslation for ItemMergeTranslation {
         let data = serde_json::from_str::<ItemMergeMessage>(&sync_record.data)?;
 
         let item_link_repo = ItemLinkRowRepository::new(connection);
-        // let mut item_links = vec![];
         let item_links = item_link_repo.find_many_by_item_id(&data.mergeIdToDelete)?;
         if item_links.len() == 0 {
             return Ok(None);

--- a/server/service/src/sync/translations/special/item_merge.rs
+++ b/server/service/src/sync/translations/special/item_merge.rs
@@ -71,7 +71,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_item_merge() {
-        util::init_logger(util::LogLevel::Info);
+        // util::init_logger(util::LogLevel::Info);
 
         let mut sync_records = vec![
             SyncBufferRow {

--- a/server/service/src/sync/translations/special/item_merge.rs
+++ b/server/service/src/sync/translations/special/item_merge.rs
@@ -8,11 +8,12 @@ use crate::sync::translations::{
     IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
 };
 
-#[allow(non_snake_case)]
 #[derive(Deserialize)]
 pub struct ItemMergeMessage {
-    pub mergeIdToKeep: String,
-    pub mergeIdToDelete: String,
+    #[serde(rename = "mergeIdToKeep")]
+    pub merge_id_to_keep: String,
+    #[serde(rename = "mergeIdToDelete")]
+    pub merge_id_to_delete: String,
 }
 
 // Conceptually this isn't a translation, so the abstraction should probably be changed or this doesn't belong here
@@ -39,11 +40,13 @@ impl SyncTranslation for ItemMergeTranslation {
         let data = serde_json::from_str::<ItemMergeMessage>(&sync_record.data)?;
 
         let item_link_repo = ItemLinkRowRepository::new(connection);
-        let item_links = item_link_repo.find_many_by_item_id(&data.mergeIdToDelete)?;
+        let item_links = item_link_repo.find_many_by_item_id(&data.merge_id_to_delete)?;
         if item_links.len() == 0 {
             return Ok(None);
         }
-        let indirect_link = item_link_repo.find_one_by_id(&data.mergeIdToKeep)?.unwrap();
+        let indirect_link = item_link_repo
+            .find_one_by_id(&data.merge_id_to_keep)?
+            .unwrap();
 
         let upsert_records: Vec<PullUpsertRecord> = item_links
             .into_iter()

--- a/server/service/src/sync/translations/special/item_merge.rs
+++ b/server/service/src/sync/translations/special/item_merge.rs
@@ -1,6 +1,4 @@
-use repository::{
-    ItemLinkRow, ItemLinkRowRepository, StorageConnection, SyncBufferAction, SyncBufferRow,
-};
+use repository::{ItemLinkRow, ItemLinkRowRepository, StorageConnection, SyncBufferRow};
 
 use serde::Deserialize;
 
@@ -31,9 +29,7 @@ impl SyncTranslation for ItemMergeTranslation {
         connection: &StorageConnection,
         sync_record: &SyncBufferRow,
     ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if sync_record.table_name != LegacyTableName::ITEM
-            || sync_record.action != SyncBufferAction::Merge
-        {
+        if sync_record.table_name != LegacyTableName::ITEM {
             return Ok(None);
         }
 

--- a/server/service/src/sync/translations/special/item_merge.rs
+++ b/server/service/src/sync/translations/special/item_merge.rs
@@ -1,0 +1,61 @@
+use repository::{
+    ItemLinkRow, ItemLinkRowRepository, StorageConnection, SyncBufferAction, SyncBufferRow,
+};
+
+use serde::Deserialize;
+
+use crate::sync::translations::{
+    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
+};
+
+#[allow(non_snake_case)]
+#[derive(Deserialize)]
+pub struct ItemMergeMessage {
+    pub mergeIdToKeep: String,
+    pub mergeIdToDelete: String,
+}
+
+// Conceptually this isn't a translation, so the abstraction should probably be changed or this doesn't belong here
+pub(crate) struct ItemMergeTranslation {}
+impl SyncTranslation for ItemMergeTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::ITEM,
+            dependencies: vec![],
+        }
+    }
+
+    fn try_translate_pull_upsert(
+        &self,
+        connection: &StorageConnection,
+        sync_record: &SyncBufferRow,
+    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
+        if sync_record.table_name != LegacyTableName::ITEM
+            || sync_record.action != SyncBufferAction::Merge
+        {
+            return Ok(None);
+        }
+
+        let data = serde_json::from_str::<ItemMergeMessage>(&sync_record.data)?;
+
+        let item_link_repo = ItemLinkRowRepository::new(connection);
+        let item_links = item_link_repo.find_many_by_item_id(&data.mergeIdToDelete)?;
+
+        if item_links.len() == 0 {
+            return Ok(None);
+        }
+
+        let upsert_records = dbg!(item_links)
+            .into_iter()
+            .map(|ItemLinkRow { id, .. }| {
+                PullUpsertRecord::ItemLink(ItemLinkRow {
+                    id,
+                    item_id: data.mergeIdToKeep.clone(),
+                })
+            })
+            .collect();
+
+        Ok(Some(IntegrationRecords::from_upserts(upsert_records)))
+    }
+}
+

--- a/server/service/src/sync/translations/special/mod.rs
+++ b/server/service/src/sync/translations/special/mod.rs
@@ -1,3 +1,4 @@
 mod name_to_name_store_join;
 pub(crate) use name_to_name_store_join::*;
 mod item_merge;
+pub(crate) use item_merge::*;

--- a/server/service/src/sync/translations/special/mod.rs
+++ b/server/service/src/sync/translations/special/mod.rs
@@ -1,2 +1,3 @@
 mod name_to_name_store_join;
 pub(crate) use name_to_name_store_join::*;
+mod item_merge;

--- a/server/service/src/sync/translations/special/name_to_name_store_join.rs
+++ b/server/service/src/sync/translations/special/name_to_name_store_join.rs
@@ -20,7 +20,7 @@ pub struct PartialLegacyNameRow {
 
 // In omSupply, is_customer and is_supplier relationship between store and name is stored
 // in name_store_join, in mSupply it's stored on name. This translator updates all name_store_joins
-// for name when name is pulled (setting is_customer and is_supplier appropriatly)
+// for name when name is pulled (setting is_customer and is_supplier appropriately)
 // NOTE Translator should be removed when central server configures these properties on name_store_join
 pub(crate) struct NameToNameStoreJoinTranslation {}
 impl SyncTranslation for NameToNameStoreJoinTranslation {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2554

# 👩🏻‍💻 What does this PR do? 
- adds an item merge translator and handles merge message types throughout sync.
- merge message order does not matter, will still chain merges correctly.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

## 💌 Any notes for the reviewer?

Regarding message order the problem is as follows...

Items A, B and C, each with corresponding links:
```
A->A
B->B
C->C
```
and 2 messages to merge
```
A->B
B->C
```
In that order all works well, we'd end up with
```
// First message integrated (A->B)
A->B
B->B
C->C

// Second message integrated (B->C)
A->C
B->C
C->C
```
But if the messages are in reverse order we risk:
```
// First message integrated (B->C)
A->A
B->C
C->C

// Second message integrated (A->B)
A->B
B->C
C->C
```
So now link A is pointing to item B, which is no longer a valid item! So to ensure that the link is already updated correctly regardless of order we look up what the original link for B is looking at, `B->C`, and instead of `A->B` as stated in the message we update `A->C`.
