### PR TITLE
Strip empty additions before comparing data and initial data

### DIFF
--- a/client/packages/programs/src/JsonForms/stripEmptyAdditions.test.ts
+++ b/client/packages/programs/src/JsonForms/stripEmptyAdditions.test.ts
@@ -1,4 +1,7 @@
-import { stripEmptyAdditions } from './stripEmptyAdditions';
+import {
+  isEqualIgnoreUndefinedAndEmpty,
+  stripEmptyAdditions,
+} from './stripEmptyAdditions';
 
 describe('stripEmptyAdditions', () => {
   it('should remove empty objects and arrays', () => {
@@ -36,16 +39,14 @@ describe('stripEmptyAdditions', () => {
       array: [],
     };
     const add1 = {
-      some: 3,
-      someMore: { value: false, add1: undefined },
-      add2: undefined,
+      some: 2,
+      someMore: { obj: { value: undefined } },
+      array: [],
     };
 
-    expect(stripEmptyAdditions(old, add1)).toStrictEqual({
-      some: 3,
-      someMore: {},
-      array: [],
-    });
+    expect(
+      isEqualIgnoreUndefinedAndEmpty(old, stripEmptyAdditions(old, add1))
+    ).toBeTruthy();
   });
 
   it('should ignore undefined in array objects', () => {
@@ -54,14 +55,10 @@ describe('stripEmptyAdditions', () => {
       array: [{ value: false }],
     };
     const add1 = {
-      some: 3,
+      some: 2,
       array: [{ value: false, add1: undefined }],
     };
 
-    expect(stripEmptyAdditions(old, add1)).toStrictEqual({
-      some: 3,
-      someMore: {},
-      array: [],
-    });
+    expect(isEqualIgnoreUndefinedAndEmpty(old, add1)).toBeTruthy();
   });
 });

--- a/client/packages/programs/src/JsonForms/stripEmptyAdditions.test.ts
+++ b/client/packages/programs/src/JsonForms/stripEmptyAdditions.test.ts
@@ -35,17 +35,43 @@ describe('stripEmptyAdditions', () => {
   it('should keep existing empty objects and arrays', () => {
     const old = {
       some: 2,
-      someMore: {},
       array: [],
+      obj: {},
+      someMore: { obj2: {} },
     };
     const add1 = {
       some: 2,
-      someMore: { obj: { value: undefined } },
-      array: [],
+      array: [{ emptyArray: undefined }],
+      obj: { emptyObj: undefined },
+      someMore: { obj2: { emptyObj2: undefined } },
     };
 
+    const stripped = stripEmptyAdditions(old, add1);
+    expect(isEqualIgnoreUndefinedAndEmpty(old, stripped)).toBeTruthy();
+  });
+
+  it('should remove existing empty when deleted in new', () => {
+    const old = {
+      some: 2,
+      someMore: { someArray: [], someObj: {} },
+      obj: {},
+      array: [],
+      obj2: { emptyObj: {}, emptyArray: [], keep: {} },
+    };
+    const add1 = {
+      some: 2,
+      obj2: { keep: { empty: undefined } },
+    };
+
+    const stripped = stripEmptyAdditions(old, add1);
     expect(
-      isEqualIgnoreUndefinedAndEmpty(old, stripEmptyAdditions(old, add1))
+      isEqualIgnoreUndefinedAndEmpty(
+        {
+          some: 2,
+          obj2: { keep: {} },
+        },
+        stripped
+      )
     ).toBeTruthy();
   });
 

--- a/client/packages/programs/src/JsonForms/stripEmptyAdditions.test.ts
+++ b/client/packages/programs/src/JsonForms/stripEmptyAdditions.test.ts
@@ -1,0 +1,67 @@
+import { stripEmptyAdditions } from './stripEmptyAdditions';
+
+describe('stripEmptyAdditions', () => {
+  it('should remove empty objects and arrays', () => {
+    const old = {
+      some: 2,
+      someMore: { value: false },
+    };
+    const add1 = {
+      some: 3,
+      someMore: { value: false, add1: undefined },
+      add2: undefined,
+    };
+    const add2 = {
+      some: 4,
+      someMore: { value: false, add1: { val2: undefined } },
+      add2: {
+        obj: { obj2: { undefined }, array: [{ val: undefined }] },
+      },
+    };
+
+    expect(stripEmptyAdditions(old, add1)).toStrictEqual({
+      some: 3,
+      someMore: { value: false },
+    });
+    expect(stripEmptyAdditions(old, add2)).toStrictEqual({
+      some: 4,
+      someMore: { value: false },
+    });
+  });
+
+  it('should keep existing empty objects and arrays', () => {
+    const old = {
+      some: 2,
+      someMore: {},
+      array: [],
+    };
+    const add1 = {
+      some: 3,
+      someMore: { value: false, add1: undefined },
+      add2: undefined,
+    };
+
+    expect(stripEmptyAdditions(old, add1)).toStrictEqual({
+      some: 3,
+      someMore: {},
+      array: [],
+    });
+  });
+
+  it('should ignore undefined in array objects', () => {
+    const old = {
+      some: 2,
+      array: [{ value: false }],
+    };
+    const add1 = {
+      some: 3,
+      array: [{ value: false, add1: undefined }],
+    };
+
+    expect(stripEmptyAdditions(old, add1)).toStrictEqual({
+      some: 3,
+      someMore: {},
+      array: [],
+    });
+  });
+});

--- a/client/packages/programs/src/JsonForms/stripEmptyAdditions.ts
+++ b/client/packages/programs/src/JsonForms/stripEmptyAdditions.ts
@@ -1,0 +1,109 @@
+import _ from 'lodash';
+import { JsonData } from './common';
+
+/**
+ * Checks if the input object or array is empty.
+ * An object is considered empty if all values are either undefined, empty objects, or arrays.
+ * For example, `{ value: undefined, obj: {} }`.
+ * An empty array this an array that is empty or only contains empty objects,
+ * e.g. `[{ value: undefined}]`.
+ */
+const objectOrArrayIsEmpty = (obj: JsonData | undefined): boolean => {
+  if (obj === undefined || obj === null) return true;
+  if (typeof obj !== 'object') return false;
+
+  // array
+  if (Array.isArray(obj)) {
+    if (obj.length === 0) return true;
+    return obj.every(it => objectOrArrayIsEmpty(it));
+  }
+
+  // object
+  if (Object.keys(obj).length === 0) return true;
+  const allValuesEmpty = Object.values(obj).every(it => {
+    if (typeof it === 'object') return objectOrArrayIsEmpty(it);
+    return it === undefined;
+  });
+  if (allValuesEmpty) {
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Recursively removes all empty data which has been added to the newData compared to the old
+ * input object.
+ *
+ * For example, given:
+ *
+ * old: { some: "value" }
+ * newData: { some: "value", obj: { add1: undefined }, array: [], add2: undefined}
+ *
+ * stripEmptyAdditions(old, newData) will return { some: "value" }.
+ */
+export const stripEmptyAdditions = (
+  old: JsonData | undefined,
+  newData: JsonData | undefined
+): JsonData | undefined => {
+  if (newData === undefined) return undefined;
+  if (!_.isObject(newData)) return newData;
+
+  if (_.isObject(newData) && !_.isArray(newData)) {
+    const object: JsonData = {};
+    const oldObj = !old || !_.isObject(old) || _.isArray(old) ? {} : old;
+
+    const allKeys = new Set<string>();
+    Object.keys(oldObj).reduce((prev, cur) => prev.add(cur), allKeys);
+    Object.keys(newData).reduce((prev, cur) => prev.add(cur), allKeys);
+    for (const key of allKeys) {
+      const o = oldObj[key];
+      let n = newData[key];
+      if (_.isObject(n) && !_.isArray(n)) {
+        n = stripEmptyAdditions(o, n);
+        if (objectOrArrayIsEmpty(n)) {
+          if (_.isEqual(o, {}) || _.isEqual(o, [])) {
+            // keep existing empty object
+            object[key] = o;
+          }
+          // ignore the empty addition
+          continue;
+        }
+      }
+      if (n !== undefined) object[key] = n;
+    }
+    if (Object.keys(object).length === 0) return undefined;
+    return object;
+  }
+
+  return newData;
+};
+
+// https://stackoverflow.com/questions/57874879/how-to-treat-missing-undefined-properties-as-equivalent-in-lodashs-isequalwit
+const isEqualIgnoreUndefined = (
+  a: JsonData | undefined,
+  b: JsonData | undefined
+) => {
+  const comparisonFunc = (a: JsonData | undefined, b: JsonData | undefined) => {
+    if (_.isArray(a) || _.isArray(b)) return;
+    if (!_.isObject(a) || !_.isObject(b)) return;
+
+    if (!_.includes(a, undefined) && !_.includes(b, undefined)) return;
+
+    // Call recursively, after filtering all undefined properties
+    return _.isEqualWith(
+      _.omitBy(a, value => value === undefined),
+      _.omitBy(b, value => value === undefined),
+      comparisonFunc
+    );
+  };
+  return _.isEqualWith(a, b, comparisonFunc);
+};
+
+export const isEqualIgnoreUndefinedAndEmpty = (
+  old: JsonData | undefined,
+  newData: JsonData | undefined
+) => {
+  const stripped = stripEmptyAdditions(old, newData);
+  // ignore undefined (e.g. in array objects which haven't been stripped) when comparing
+  return isEqualIgnoreUndefined(old, stripped);
+};

--- a/client/packages/programs/src/JsonForms/stripEmptyAdditions.ts
+++ b/client/packages/programs/src/JsonForms/stripEmptyAdditions.ts
@@ -5,7 +5,6 @@ import {
   isEqualWith,
   includes,
   omitBy,
-  filter,
 } from 'lodash';
 import { JsonData } from './common';
 
@@ -60,13 +59,10 @@ export const stripEmptyAdditions = (
     const object: JsonData = {};
     const oldObj = !old || !isObject(old) || isArray(old) ? {} : old;
 
-    const allKeys = new Set<string>();
-    Object.keys(oldObj).reduce((prev, cur) => prev.add(cur), allKeys);
-    Object.keys(newData).reduce((prev, cur) => prev.add(cur), allKeys);
-    for (const key of allKeys) {
-      const o = oldObj[key];
+    for (const key of Object.keys(newData)) {
       let n = newData[key];
       if (isObject(n) && !isArray(n)) {
+        const o = oldObj[key];
         n = stripEmptyAdditions(o, n);
         if (objectOrArrayIsEmpty(n)) {
           if (isEqual(o, {}) || isEqual(o, [])) {

--- a/client/packages/programs/src/JsonForms/stripEmptyAdditions.ts
+++ b/client/packages/programs/src/JsonForms/stripEmptyAdditions.ts
@@ -1,4 +1,12 @@
-import _ from 'lodash';
+import {
+  isObject,
+  isArray,
+  isEqual,
+  isEqualWith,
+  includes,
+  omitBy,
+  filter,
+} from 'lodash';
 import { JsonData } from './common';
 
 /**
@@ -46,11 +54,11 @@ export const stripEmptyAdditions = (
   newData: JsonData | undefined
 ): JsonData | undefined => {
   if (newData === undefined) return undefined;
-  if (!_.isObject(newData)) return newData;
+  if (!isObject(newData)) return newData;
 
-  if (_.isObject(newData) && !_.isArray(newData)) {
+  if (isObject(newData) && !isArray(newData)) {
     const object: JsonData = {};
-    const oldObj = !old || !_.isObject(old) || _.isArray(old) ? {} : old;
+    const oldObj = !old || !isObject(old) || isArray(old) ? {} : old;
 
     const allKeys = new Set<string>();
     Object.keys(oldObj).reduce((prev, cur) => prev.add(cur), allKeys);
@@ -58,10 +66,10 @@ export const stripEmptyAdditions = (
     for (const key of allKeys) {
       const o = oldObj[key];
       let n = newData[key];
-      if (_.isObject(n) && !_.isArray(n)) {
+      if (isObject(n) && !isArray(n)) {
         n = stripEmptyAdditions(o, n);
         if (objectOrArrayIsEmpty(n)) {
-          if (_.isEqual(o, {}) || _.isEqual(o, [])) {
+          if (isEqual(o, {}) || isEqual(o, [])) {
             // keep existing empty object
             object[key] = o;
           }
@@ -78,25 +86,25 @@ export const stripEmptyAdditions = (
   return newData;
 };
 
-// https://stackoverflow.com/questions/57874879/how-to-treat-missing-undefined-properties-as-equivalent-in-lodashs-isequalwit
+// https://stackoverflow.com/questions/57874879
 const isEqualIgnoreUndefined = (
   a: JsonData | undefined,
   b: JsonData | undefined
 ) => {
   const comparisonFunc = (a: JsonData | undefined, b: JsonData | undefined) => {
-    if (_.isArray(a) || _.isArray(b)) return;
-    if (!_.isObject(a) || !_.isObject(b)) return;
+    if (isArray(a) || isArray(b)) return;
+    if (!isObject(a) || !isObject(b)) return;
 
-    if (!_.includes(a, undefined) && !_.includes(b, undefined)) return;
+    if (!includes(a, undefined) && !includes(b, undefined)) return;
 
     // Call recursively, after filtering all undefined properties
-    return _.isEqualWith(
-      _.omitBy(a, value => value === undefined),
-      _.omitBy(b, value => value === undefined),
+    return isEqualWith(
+      omitBy(a, value => value === undefined),
+      omitBy(b, value => value === undefined),
       comparisonFunc
     );
   };
-  return _.isEqualWith(a, b, comparisonFunc);
+  return isEqualWith(a, b, comparisonFunc);
 };
 
 export const isEqualIgnoreUndefinedAndEmpty = (

--- a/client/packages/programs/src/JsonForms/useJsonForms.tsx
+++ b/client/packages/programs/src/JsonForms/useJsonForms.tsx
@@ -5,7 +5,6 @@ import {
   useConfirmOnLeaving,
 } from '@openmsupply-client/common';
 import { JsonData, JsonForm, JsonFormsConfig } from './common';
-import _ from 'lodash';
 import {
   JsonFormsRendererRegistryEntry,
   JsonSchema,
@@ -38,28 +37,10 @@ import {
   BloodPressure,
 } from './components';
 import { EnrolmentId, enrolmentIdTester } from './components/EnrolmentId';
-
-// https://stackoverflow.com/questions/57874879/how-to-treat-missing-undefined-properties-as-equivalent-in-lodashs-isequalwit
-// TODO: handle undefined and empty string as equal? e.g. initial data is undefined and current data is ""
-const isEqualIgnoreUndefined = (
-  a: JsonData | undefined,
-  b: JsonData | undefined
-) => {
-  const comparisonFunc = (a: JsonData | undefined, b: JsonData | undefined) => {
-    if (_.isArray(a) || _.isArray(b)) return;
-    if (!_.isObject(a) || !_.isObject(b)) return;
-
-    if (!_.includes(a, undefined) && !_.includes(b, undefined)) return;
-
-    // Call recursively, after filtering all undefined properties
-    return _.isEqualWith(
-      _.omitBy(a, value => value === undefined),
-      _.omitBy(b, value => value === undefined),
-      comparisonFunc
-    );
-  };
-  return _.isEqualWith(a, b, comparisonFunc);
-};
+import {
+  isEqualIgnoreUndefinedAndEmpty,
+  stripEmptyAdditions,
+} from './stripEmptyAdditions';
 
 export interface SchemaData {
   formSchemaId?: string;
@@ -157,12 +138,13 @@ export const useJsonForms = <R,>(
 
     // Run mutation...
     try {
-      const result = await save?.(data);
+      const sanitizedData = stripEmptyAdditions(initialData, data);
+      const result = await save?.(sanitizedData);
 
       const successSnack = success(t('success.data-saved'));
       successSnack();
 
-      setInitialData(data);
+      setInitialData(sanitizedData);
       return result;
     } catch (err) {
       const errorSnack = errorNotification(t('error.problem-saving'));
@@ -184,11 +166,10 @@ export const useJsonForms = <R,>(
   useEffect(() => {
     const dirty =
       isSaving ||
-      isLoading ||
       // document doesn't exist yet; always set the isDirty flag
       isCreating ||
-      !isEqualIgnoreUndefined(initialData, data);
-    setIsDirty(dirty);
+      !isEqualIgnoreUndefinedAndEmpty(initialData, data);
+    setIsDirty(isLoading ? false : dirty);
     if (data === undefined) {
       setData(initialData);
     }

--- a/client/packages/programs/src/JsonForms/useJsonForms.tsx
+++ b/client/packages/programs/src/JsonForms/useJsonForms.tsx
@@ -169,7 +169,7 @@ export const useJsonForms = <R,>(
       // document doesn't exist yet; always set the isDirty flag
       isCreating ||
       !isEqualIgnoreUndefinedAndEmpty(initialData, data);
-    setIsDirty(isLoading ? false : dirty);
+    setIsDirty(isLoading || !data ? false : dirty);
     if (data === undefined) {
       setData(initialData);
     }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2510

Strips all empty objects before comparing initial data to the modified data. This makes it actually much nicer to use now.


## Testing
- Create a new HIV care encounter. Navigate to the different bubbles, the save button should stay disabled.
- In the same encounter modify some value and revert -> save button should revert to disabled.
- Navigate to patient detail view and do similar test, i.e. reverted edits should not leave the save button enabled