### PR TITLE
2626 item merge sync push translators item

### DIFF
--- a/server/repository/src/db_diesel/stock_line.rs
+++ b/server/repository/src/db_diesel/stock_line.rs
@@ -43,7 +43,7 @@ pub enum StockLineSortField {
     SupplierName,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct StockLineFilter {
     pub id: Option<EqualFilter<String>>,
     pub item_code_or_name: Option<StringFilter>,

--- a/server/repository/src/db_diesel/stock_line.rs
+++ b/server/repository/src/db_diesel/stock_line.rs
@@ -43,7 +43,7 @@ pub enum StockLineSortField {
     SupplierName,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct StockLineFilter {
     pub id: Option<EqualFilter<String>>,
     pub item_code_or_name: Option<StringFilter>,

--- a/server/repository/src/mock/mod.rs
+++ b/server/repository/src/mock/mod.rs
@@ -98,10 +98,10 @@ use crate::{
     ContextRowRepository, Document, DocumentRegistryRow, DocumentRegistryRowRepository,
     DocumentRepository, FormSchema, FormSchemaRowRepository, InventoryAdjustmentReasonRow,
     InventoryAdjustmentReasonRowRepository, InvoiceLineRow, InvoiceLineRowRepository, InvoiceRow,
-    ItemLinkRowRepository, ItemRow, KeyValueStoreRepository, KeyValueStoreRow, LocationRow,
-    LocationRowRepository, MasterListNameJoinRepository, MasterListNameJoinRow, MasterListRow,
-    MasterListRowRepository, NameLinkRowRepository, NameTagJoinRepository, NameTagJoinRow,
-    NameTagRow, NameTagRowRepository, NumberRow, NumberRowRepository, PeriodRow,
+    ItemLinkRow, ItemLinkRowRepository, ItemRow, KeyValueStoreRepository, KeyValueStoreRow,
+    LocationRow, LocationRowRepository, MasterListNameJoinRepository, MasterListNameJoinRow,
+    MasterListRow, MasterListRowRepository, NameLinkRowRepository, NameTagJoinRepository,
+    NameTagJoinRow, NameTagRow, NameTagRowRepository, NumberRow, NumberRowRepository, PeriodRow,
     PeriodRowRepository, PeriodScheduleRow, PeriodScheduleRowRepository, PluginDataRow,
     PluginDataRowRepository, ProgramRequisitionOrderTypeRow,
     ProgramRequisitionOrderTypeRowRepository, ProgramRequisitionSettingsRow,
@@ -133,6 +133,7 @@ pub struct MockData {
     pub stores: Vec<StoreRow>,
     pub units: Vec<UnitRow>,
     pub items: Vec<ItemRow>,
+    pub item_links_merged: Vec<ItemLinkRow>,
     pub locations: Vec<LocationRow>,
     pub sensors: Vec<SensorRow>,
     pub temperature_breaches: Vec<TemperatureBreachRow>,
@@ -196,6 +197,7 @@ pub struct MockDataInserts {
     pub stores: bool,
     pub units: bool,
     pub items: bool,
+    pub item_links_merged: bool,
     pub locations: bool,
     pub sensors: bool,
     pub temperature_breaches: bool,
@@ -278,6 +280,7 @@ impl MockDataInserts {
             clinician_store_joins: true,
             contexts: true,
             plugin_data: true,
+            item_links_merged: false, // This will change many item_id values to become "item_a", so is only used if explicit!
         }
     }
 
@@ -342,6 +345,12 @@ impl MockDataInserts {
 
     pub fn items(mut self) -> Self {
         self.items = true;
+        self
+    }
+
+    // This is used to crudely merge all items into "item_a"
+    pub fn item_links_merged(mut self) -> Self {
+        self.item_links_merged = true;
         self
     }
 
@@ -700,6 +709,16 @@ pub fn insert_mock_data(
             }
         }
 
+        // Crudely make all item_links point to `"item_a"` for testing correct mapping of item_id
+        if inserts.item_links_merged {
+            let item_link_repo = ItemLinkRowRepository::new(connection);
+            for row in &mock_data.items {
+                let mut link = mock_item_link_from_item(&row);
+                link.item_id = "item_a".to_string();
+                item_link_repo.upsert_one(&link).unwrap();
+            }
+        }
+
         if inserts.locations {
             let repo = LocationRowRepository::new(connection);
             for row in &mock_data.locations {
@@ -982,6 +1001,7 @@ impl MockData {
             mut clinician_store_joins,
             mut contexts,
             plugin_data: _,
+            item_links_merged: _,
         } = other;
 
         self.user_accounts.append(&mut user_accounts);

--- a/server/repository/src/tests.rs
+++ b/server/repository/src/tests.rs
@@ -346,8 +346,7 @@ mod repository_test {
 
         let item_link_repo = ItemLinkRowRepository::new(&connection);
         item_link_repo
-            .insert_one(&mock_item_link_from_item(&item))
-            .await
+            .insert_one_or_ignore(&mock_item_link_from_item(&item))
             .unwrap();
     }
 

--- a/server/service/src/sync/translations/stock_line.rs
+++ b/server/service/src/sync/translations/stock_line.rs
@@ -189,11 +189,8 @@ mod tests {
         use crate::sync::test::test_data::stock_line as test_data;
         let translator = StockLineTranslation {};
 
-        let (_, connection, _, _) = setup_all(
-            "test_stock_line_translation",
-            MockDataInserts::none().units().items().item_links_merged(),
-        )
-        .await;
+        let (_, connection, _, _) =
+            setup_all("test_stock_line_translation", MockDataInserts::none()).await;
 
         for record in test_data::test_pull_upsert_records() {
             let translation_result = translator

--- a/server/service/src/sync/translations/stock_line.rs
+++ b/server/service/src/sync/translations/stock_line.rs
@@ -230,8 +230,6 @@ mod tests {
             )
             .unwrap();
 
-        dbg!(&changelogs);
-
         let translator = StockLineTranslation {};
         for changelog in changelogs {
             // Translate and sort

--- a/server/service/src/sync/translations/stock_line.rs
+++ b/server/service/src/sync/translations/stock_line.rs
@@ -230,11 +230,10 @@ mod tests {
         let translator = StockLineTranslation {};
         for changelog in changelogs {
             // Translate and sort
-            let Some(translated) = translator
+            let translated = translator
                 .try_translate_push_upsert(&connection, &changelog)
-                .unwrap() else {
-                    panic!("Where is my stuff");
-                };
+                .unwrap()
+                .unwrap();
 
             assert_eq!(translated[0].record.data["item_ID"], json!("item_a"))
         }


### PR DESCRIPTION
Fixes #2626 (will change the scope of that issue to stockline and make issues for other tables)

# 👩🏻‍💻 What does this PR do? 

Makes the translator use the `StockLineRepository` rather than `StockLineRowRepository` to get the correct item_id.

# 🧪 How has/should this change been tested? 

Running tests
