### PR TITLE
Display current item in OS and Stocktake when you have many items in the system

### DIFF
--- a/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
+++ b/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
@@ -141,9 +141,9 @@ export const useUrlQueryParams = ({
         : 0,
     first: rowsPerPage,
     sortBy: {
-      key: urlQuery['sort'] ?? '',
-      direction: urlQuery['dir'] ?? 'asc',
-      isDesc: urlQuery['dir'] === 'desc',
+      key: urlQuery['sort'] ?? initialSort?.key ?? '',
+      direction: urlQuery['dir'] ?? initialSort?.dir ?? 'asc',
+      isDesc: (urlQuery['dir'] ?? initialSort?.dir) === 'desc',
     } as SortBy<unknown>,
     filterBy: filter.filterBy,
   };

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -3160,6 +3160,7 @@ export type NameNode = {
   comment?: Maybe<Scalars['String']['output']>;
   country?: Maybe<Scalars['String']['output']>;
   createdDatetime?: Maybe<Scalars['DateTime']['output']>;
+  customData?: Maybe<Scalars['JSON']['output']>;
   dateOfBirth?: Maybe<Scalars['NaiveDate']['output']>;
   email?: Maybe<Scalars['String']['output']>;
   firstName?: Maybe<Scalars['String']['output']>;

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
@@ -10,13 +10,14 @@ import {
 import {
   StockItemSearchInput,
   ItemRowFragment,
+  ItemStockOnHandFragment,
 } from '@openmsupply-client/system';
 import { useStocktake } from '../../../api';
 
 interface StocktakeLineEditProps {
   item: ItemRowFragment | null;
   mode: ModalMode | null;
-  onChangeItem: (item: ItemRowFragment | null) => void;
+  onChangeItem: (item: ItemStockOnHandFragment | null) => void;
 }
 
 export const StocktakeLineEditForm: FC<StocktakeLineEditProps> = ({

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
@@ -6,7 +6,10 @@ import {
   useTranslation,
   BasicTextInput,
 } from '@openmsupply-client/common';
-import { StockItemSearchInput } from '@openmsupply-client/system';
+import {
+  ItemStockOnHandFragment,
+  StockItemSearchInput,
+} from '@openmsupply-client/system';
 import { InboundLineFragment, useInbound } from '../../../api';
 
 type InboundLineItem = InboundLineFragment['item'];
@@ -14,7 +17,7 @@ type InboundLineItem = InboundLineFragment['item'];
 interface InboundLineEditProps {
   item: InboundLineItem | null;
   disabled: boolean;
-  onChangeItem: (item: InboundLineItem) => void;
+  onChangeItem: (item: ItemStockOnHandFragment) => void;
 }
 
 export const InboundLineEditForm: FC<InboundLineEditProps> = ({

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -15,8 +15,8 @@ import {
   useDebounceCallback,
 } from '@openmsupply-client/common';
 import {
+  ItemStockOnHandFragment,
   StockItemSearchInput,
-  ItemRowFragment,
 } from '@openmsupply-client/system';
 import { useOutbound } from '../../api';
 import { DraftItem } from '../../..';
@@ -33,7 +33,7 @@ interface OutboundLineEditFormProps {
   allocatedQuantity: number;
   availableQuantity: number;
   item: DraftItem | null;
-  onChangeItem: (newItem: ItemRowFragment | null) => void;
+  onChangeItem: (newItem: ItemStockOnHandFragment | null) => void;
   onChangeQuantity: (
     quantity: number,
     packSize: number | null,

--- a/client/packages/system/src/Item/Components/ItemOptionRenderer/ItemOptionRenderer.tsx
+++ b/client/packages/system/src/Item/Components/ItemOptionRenderer/ItemOptionRenderer.tsx
@@ -1,33 +1,31 @@
 import React from 'react';
-import { ItemRowWithStatsFragment, ItemStockOnHandFragment } from '../../api';
 import { ItemOption } from '../../utils';
 import { Tooltip } from '@common/components';
+import { ItemStockOnHandFragment } from '../../api';
 
 export const getItemOptionRenderer =
   (label: string, formatNumber: (value: number) => string) =>
-  (
-    props: React.HTMLAttributes<HTMLLIElement>,
-    item: ItemStockOnHandFragment | ItemRowWithStatsFragment
-  ) => (
-    <Tooltip title={`${item.code} ${item.name}`}>
-      <ItemOption {...props} key={item.code}>
-        <span
-          style={{
-            whiteSpace: 'nowrap',
-            width: 150,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-          }}
-        >
-          {item.code}
-        </span>
-        <span style={{ whiteSpace: 'normal', width: 500 }}>{item.name}</span>
-        <span
-          style={{
-            width: 200,
-            textAlign: 'right',
-          }}
-        >{`${formatNumber(item.availableStockOnHand)} ${label}`}</span>
-      </ItemOption>
-    </Tooltip>
-  );
+  (props: React.HTMLAttributes<HTMLLIElement>, item: ItemStockOnHandFragment) =>
+    (
+      <Tooltip title={`${item.code} ${item.name}`}>
+        <ItemOption {...props} key={item.code}>
+          <span
+            style={{
+              whiteSpace: 'nowrap',
+              width: 150,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {item.code}
+          </span>
+          <span style={{ whiteSpace: 'normal', width: 500 }}>{item.name}</span>
+          <span
+            style={{
+              width: 200,
+              textAlign: 'right',
+            }}
+          >{`${formatNumber(item.availableStockOnHand)} ${label}`}</span>
+        </ItemOption>
+      </Tooltip>
+    );

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
@@ -8,7 +8,11 @@ import {
   ArrayUtils,
   useDebounceCallback,
 } from '@openmsupply-client/common';
-import { ItemStockOnHandFragment, useItemStockOnHand } from '../../api';
+import {
+  ItemStockOnHandFragment,
+  useItemById,
+  useItemStockOnHand,
+} from '../../api';
 import { itemFilterOptions, StockItemSearchInputProps } from '../../utils';
 import { getItemOptionRenderer } from '../ItemOptionRenderer';
 import { useItemFilter, usePagination } from './hooks';
@@ -32,10 +36,15 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
     pagination,
     filter,
   });
+  // changed from useStockLines even though that is more appropriate
+  // when viewing a stocktake, you may have a stocktake line which has no stock lines.
+  // this call is to fetch the current item; if you have a large number of items
+  // then the current item may not be in the available list of items due to pagination batching
+  const { data: currentItem } = useItemById(currentItemId ?? undefined);
+
   const t = useTranslation('common');
   const formatNumber = useFormatNumber();
 
-  const value = items.find(({ id }) => id === currentItemId) ?? null;
   const selectControl = useToggle();
 
   const options = useMemo(
@@ -47,10 +56,15 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
     [items]
   );
 
-  const cachedSearchedItems = useMemo(
-    () => ArrayUtils.uniqBy([...items, ...(data?.nodes ?? [])], 'id'),
-    [data]
-  );
+  const cachedSearchedItems = useMemo(() => {
+    const newItems = [...items, ...(data?.nodes ?? [])];
+    if (!!currentItem) newItems.unshift(currentItem);
+
+    return ArrayUtils.uniqBy(newItems, 'id');
+  }, [data, currentItem]);
+
+  const value =
+    cachedSearchedItems.find(({ id }) => id === currentItemId) ?? null;
 
   const debounceOnFilter = useDebounceCallback(
     (searchText: string) => {

--- a/client/packages/system/src/Item/api/operations.generated.ts
+++ b/client/packages/system/src/Item/api/operations.generated.ts
@@ -52,7 +52,7 @@ export type ItemStockOnHandQueryVariables = Types.Exact<{
 }>;
 
 
-export type ItemStockOnHandQuery = { __typename: 'Queries', items: { __typename: 'ItemConnector', totalCount: number, nodes: Array<{ __typename: 'ItemNode', code: string, id: string, name: string, unitName?: string | null, defaultPackSize: number, availableStockOnHand: number }> } };
+export type ItemStockOnHandQuery = { __typename: 'Queries', items: { __typename: 'ItemConnector', totalCount: number, nodes: Array<{ __typename: 'ItemNode', availableStockOnHand: number, defaultPackSize: number, id: string, code: string, name: string, unitName?: string | null }> } };
 
 export type ItemsWithStatsQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -226,19 +226,13 @@ export const ItemStockOnHandDocument = gql`
     ... on ItemConnector {
       __typename
       nodes {
-        __typename
-        code
-        id
-        name
-        unitName
-        defaultPackSize
-        availableStockOnHand(storeId: $storeId)
+        ...ItemStockOnHand
       }
       totalCount
     }
   }
 }
-    `;
+    ${ItemStockOnHandFragmentDoc}`;
 export const ItemsWithStatsDocument = gql`
     query itemsWithStats($storeId: String!, $key: ItemSortFieldInput, $isDesc: Boolean, $filter: ItemFilterInput, $first: Int, $offset: Int) {
   items(

--- a/client/packages/system/src/Item/api/operations.graphql
+++ b/client/packages/system/src/Item/api/operations.graphql
@@ -159,13 +159,7 @@ query itemStockOnHand(
     ... on ItemConnector {
       __typename
       nodes {
-        __typename
-        code
-        id
-        name
-        unitName
-        defaultPackSize
-        availableStockOnHand(storeId: $storeId)
+        ...ItemStockOnHand
       }
       totalCount
     }

--- a/client/packages/system/src/Item/types.ts
+++ b/client/packages/system/src/Item/types.ts
@@ -1,4 +1,4 @@
-import { ItemRowFragment } from './api';
+import { ItemRowFragment, ItemStockOnHandFragment } from './api';
 
 export type ItemLike = ItemLikeLine | ItemLikeAggregate;
 
@@ -10,3 +10,8 @@ export interface ItemLikeAggregate {
   itemId: string;
   lines: ItemLikeLine[];
 }
+
+export type ItemOptionType = Pick<
+  ItemStockOnHandFragment,
+  'id' | 'code' | 'name' | 'availableStockOnHand'
+>;

--- a/client/packages/system/src/Item/utils.ts
+++ b/client/packages/system/src/Item/utils.ts
@@ -50,6 +50,5 @@ export const ItemOption = styled('li')(({ theme }) => ({
 }));
 
 export const itemFilterOptions = {
-  stringify: (item: ItemStockOnHandFragment | ItemRowWithStatsFragment) =>
-    `${item.code} ${item.name}`,
+  stringify: (item: ItemStockOnHandFragment) => `${item.code} ${item.name}`,
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2614

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The current item i.e. the selected value in the autocomplete, is picked from the list of available items which is fetched with the `useItemStockOnHand` hook. If you have more than 500 items available, and the current item is further than position 500 when the list is sorted by name, then that item won't be in the first set of paginated results.

This means that the item won't be shown in the disabled autocomplete component.

The fix here is to also fetch the current item by id, and add that to the list of items. This list is already unique by id, so we won't be adding a duplicate. When editing a stocktake or OS line, the selected items aren't changeable, so the input will be disabled when showing the current item. This means that the position in the list is also not important.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
You can edit `packages/system/src/Item/Components/StockItemSearchInput/hooks.ts` and change the page size to something smaller than your available items, or you can use a large dataset, such as that linked to in the issue.

Then, create an OS or stocktake with an item that starts with a letter low down in the alphabet (V? Z?)
Refresh the page, open the edit modal again. You will see the item name.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
