### PR TITLE
show errors and prevent location on hold allocation

### DIFF
--- a/client/packages/common/src/ui/layout/tables/components/Cells/LocationCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/LocationCell.tsx
@@ -4,6 +4,7 @@ import {
   RecordWithId,
   Tooltip,
   Typography,
+  useTranslation,
 } from '@openmsupply-client/common';
 
 export const LocationCell = <
@@ -13,9 +14,11 @@ export const LocationCell = <
   column,
   rowData,
 }: CellProps<K>): React.ReactElement<CellProps<K>> => {
-  const text = `${column.accessor({ rowData }) ?? ''}${
-    rowData?.location?.onHold ? ' (On Hold)' : ''
-  }`;
+  const t = useTranslation();
+  const onHoldText = rowData?.location?.onHold
+    ? ` (${t('label.on-hold')})`
+    : '';
+  const text = `${column.accessor({ rowData }) ?? ''}${onHoldText}`;
 
   return (
     <Tooltip title={text} placement="bottom-start">

--- a/client/packages/common/src/ui/layout/tables/components/Cells/LocationCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/LocationCell.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {
+  CellProps,
+  RecordWithId,
+  Tooltip,
+  Typography,
+} from '@openmsupply-client/common';
+
+export const LocationCell = <
+  T extends { onHold: boolean },
+  K extends RecordWithId & { location?: T | null },
+>({
+  column,
+  rowData,
+}: CellProps<K>): React.ReactElement<CellProps<K>> => {
+  const text = `${column.accessor({ rowData }) ?? ''}${
+    rowData?.location?.onHold ? ' (On Hold)' : ''
+  }`;
+
+  return (
+    <Tooltip title={text} placement="bottom-start">
+      <Typography
+        component="div"
+        sx={{
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          color: !!rowData.location?.onHold ? 'error.main' : 'inherit',
+        }}
+      >
+        {text}
+      </Typography>
+    </Tooltip>
+  );
+};

--- a/client/packages/common/src/ui/layout/tables/components/Cells/index.ts
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/index.ts
@@ -7,3 +7,4 @@ export * from './CurrencyCell';
 export * from './CheckCell';
 export * from './TooltipTextCell';
 export * from './DotCell';
+export * from './LocationCell';

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
@@ -7,6 +7,7 @@ import {
   CurrencyCell,
   Column,
   useCurrency,
+  LocationCell,
 } from '@openmsupply-client/common';
 import { DraftStockOutLine } from '../../../types';
 import { PackQuantityCell, StockOutLineFragment } from '../../../StockOut';
@@ -39,6 +40,7 @@ export const useOutboundLineEditColumns = ({
         {
           accessor: ({ rowData }) => rowData.location?.name,
           width: 70,
+          Cell: LocationCell,
         },
       ],
       ['packSize', { width: 90 }],

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useOutboundLineEditRows.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useOutboundLineEditRows.ts
@@ -11,7 +11,8 @@ export const useOutboundLineEditRows = (
 ) => {
   const tableStore = useTableStore();
 
-  const isOnHold = (row: DraftStockOutLine) => !!row.stockLine?.onHold;
+  const isOnHold = (row: DraftStockOutLine) =>
+    !!row.stockLine?.onHold || !!row.location?.onHold;
   const hasNoStock = (row: DraftStockOutLine) =>
     row.stockLine?.availableNumberOfPacks === 0;
 

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
@@ -59,7 +59,7 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
     'status',
     'id',
   ]);
-  const { mutateAsync } = usePrescription.line.save(status);
+  const { mutateAsync } = usePrescription.line.save();
   const { mutateAsync: mutateStatus } = usePrescription.document.update();
   const isDisabled = usePrescription.utils.isDisabled();
   const {

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/columns.ts
@@ -3,6 +3,7 @@ import {
   Column,
   ColumnAlign,
   ExpiryDateCell,
+  LocationCell,
   PositiveNumberCell,
   useColumns,
 } from '@openmsupply-client/common';
@@ -36,6 +37,7 @@ export const usePrescriptionLineEditColumns = ({
         {
           accessor: ({ rowData }) => rowData.location?.name,
           width: 70,
+          Cell: LocationCell,
         },
       ],
       ['packSize', { width: 90 }],

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/hooks/usePrescriptionLineEditRows.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/hooks/usePrescriptionLineEditRows.ts
@@ -10,7 +10,8 @@ export const usePrescriptionLineEditRows = (
 ) => {
   const tableStore = useTableStore();
 
-  const isOnHold = (row: DraftStockOutLine) => !!row.stockLine?.onHold;
+  const isOnHold = (row: DraftStockOutLine) =>
+    !!row.stockLine?.onHold || !!row.location?.onHold;
   const hasNoStock = (row: DraftStockOutLine) =>
     row.stockLine?.availableNumberOfPacks === 0;
 

--- a/client/packages/invoices/src/Prescriptions/api/api.ts
+++ b/client/packages/invoices/src/Prescriptions/api/api.ts
@@ -189,42 +189,39 @@ export const getPrescriptionQueries = (sdk: Sdk, storeId: string) => ({
 
     throw new Error('Could not delete invoices');
   },
-  updateLines:
-    (status: InvoiceNodeStatus) =>
-    async (draftPrescriptionLine: DraftStockOutLine[]) => {
-      const input = {
-        insertPrescriptionLines: draftPrescriptionLine
-          .filter(
-            ({ type, isCreated, numberOfPacks }) =>
-              isCreated &&
-              type === InvoiceLineNodeType.StockOut &&
-              (numberOfPacks > 0 || status === InvoiceNodeStatus.New)
-          )
-          .map(prescriptionParsers.toInsertLine),
-        updatePrescriptionLines: draftPrescriptionLine
-          .filter(
-            ({ type, isCreated, isUpdated, numberOfPacks }) =>
-              !isCreated &&
-              isUpdated &&
-              type === InvoiceLineNodeType.StockOut &&
-              (numberOfPacks > 0 || status === InvoiceNodeStatus.New)
-          )
-          .map(prescriptionParsers.toUpdateLine),
-        deletePrescriptionLines: draftPrescriptionLine
-          .filter(
-            ({ type, isCreated, isUpdated, numberOfPacks }) =>
-              !isCreated &&
-              isUpdated &&
-              type === InvoiceLineNodeType.StockOut &&
-              numberOfPacks === 0 &&
-              !(status === InvoiceNodeStatus.New && isUpdated)
-          )
-          .map(prescriptionParsers.toDeleteLine),
-      };
-      const result = await sdk.upsertPrescription({ storeId, input });
+  updateLines: async (draftPrescriptionLine: DraftStockOutLine[]) => {
+    const input = {
+      insertPrescriptionLines: draftPrescriptionLine
+        .filter(
+          ({ type, isCreated, numberOfPacks }) =>
+            isCreated &&
+            type === InvoiceLineNodeType.StockOut &&
+            numberOfPacks > 0
+        )
+        .map(prescriptionParsers.toInsertLine),
+      updatePrescriptionLines: draftPrescriptionLine
+        .filter(
+          ({ type, isCreated, isUpdated, numberOfPacks }) =>
+            !isCreated &&
+            isUpdated &&
+            type === InvoiceLineNodeType.StockOut &&
+            numberOfPacks > 0
+        )
+        .map(prescriptionParsers.toUpdateLine),
+      deletePrescriptionLines: draftPrescriptionLine
+        .filter(
+          ({ type, isCreated, isUpdated, numberOfPacks }) =>
+            !isCreated &&
+            isUpdated &&
+            type === InvoiceLineNodeType.StockOut &&
+            numberOfPacks === 0
+        )
+        .map(prescriptionParsers.toDeleteLine),
+    };
+    const result = await sdk.upsertPrescription({ storeId, input });
 
-      return result;
-    },
+    return result;
+  },
   deleteLines: async (lines: { id: string }[]) => {
     return sdk.deletePrescriptionLines({
       storeId,

--- a/client/packages/invoices/src/StockOut/utils.tsx
+++ b/client/packages/invoices/src/StockOut/utils.tsx
@@ -170,12 +170,14 @@ export const allocateQuantities =
       numberOfPacks: 0,
       isUpdated: batch.numberOfPacks > 0,
     }));
+
     const validBatches = newDraftStockOutLines
       .filter(
-        ({ expiryDate, packSize, stockLine }) =>
+        ({ expiryDate, packSize, stockLine, location }) =>
           (issuePackSize ? packSize === issuePackSize : true) &&
           (stockLine?.availableNumberOfPacks ?? 0) > 0 &&
           !stockLine?.onHold &&
+          !location?.onHold &&
           !(!!expiryDate && DateUtils.isExpired(new Date(expiryDate)))
       )
       .sort(SortUtils.byExpiryAsc);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2628

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
A couple of issues identified:
- The status of a new prescription is still `New` when it comes to checking if we can update or insert lines with zero quantity. Unfortunately, prescriptions auto update the status to `Picked` but this happens at the time of saving, so lines are not pruned, but should be
- Stock lines that are for on hold locations cannot be used, but were available to be selected, manually and automatically
- Errors in the batch mutation are not shown to the user

I've addressed those issues, viz:
- display errors (and yes, this could be neater; ideally the API would be easier to surface the error from)
- prevent on hold locations from being selected
- prune zero quantity lines in prescriptions, regardless of status

Now, the stock lines which have an on-hold location are not available. If all lines are unavailable for selection you get this:

<img width="1037" alt="Screenshot 2023-12-14 at 7 58 29 PM" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/ceb041cf-86ec-47cc-bc7e-7fa229f0cef3">

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
I took the demo server backup (dump-omsupply-202312141926.backup) which is in [this folder](https://drive.google.com/open?id=1Ax4J-x4-ZXbyOzpM_VixVGQ9WxW4jn2Q&usp=drive_fs) and created a new database, restored and tested using that. (you'll need postgres)

Alternatively, put a location on hold. 

For the 'below zero' error:
- create a new prescription
- add item
- select an item which has multiple stock lines
- enter a small quantity, so that not all stock lines have a quantity selected (i.e. some stock lines have 0 quantity)
- click OK

this will no longer give an error.

For the location on-hold scenario, simply put a location on hold and try to prescribe stock which is in that location.
To see the error, you'd need to roll back the changes which prevent the error.
Revert the change in `usePrescriptionLineEditRows.ts` and the change in `StockOut/utils.tsx`; you can then select the stock line which has a location on hold, and get the error displaying.


## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
