### PR TITLE
2600 fix datetime display

### DIFF
--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -1,4 +1,4 @@
-import { SupportedLocales, useIntlUtils } from '@common/intl';
+import { getLocale, useIntlUtils } from '@common/intl';
 import {
   addMinutes,
   addDays,
@@ -33,17 +33,6 @@ import {
   previousMonday,
   endOfWeek,
 } from 'date-fns';
-// importing individually to reduce bundle size
-// the date-fns methods are tree shaking correctly
-// but the locales are not. when adding, please add as below
-import enGB from 'date-fns/locale/en-GB';
-import enUS from 'date-fns/locale/en-US';
-import fr from 'date-fns/locale/fr';
-import ar from 'date-fns/locale/ar';
-import es from 'date-fns/locale/es';
-
-// Map locale string (from i18n) to locale object (from date-fns)
-const getLocaleObj = { fr, ar, es };
 
 export const MINIMUM_EXPIRY_MONTHS = 3;
 
@@ -150,19 +139,6 @@ export const DateUtils = {
   HOUR,
   /** Number of milliseconds in one day */
   DAY,
-};
-
-const getLocale = (language: SupportedLocales) => {
-  switch (language) {
-    case 'en':
-      return navigator.language === 'en-US' ? enUS : enGB;
-    case 'tet':
-      return enGB;
-    case 'fr-DJ':
-      return fr;
-    default:
-      return getLocaleObj[language];
-  }
 };
 
 export const useFormatDateTime = () => {

--- a/client/packages/common/src/intl/utils/IntlUtils.ts
+++ b/client/packages/common/src/intl/utils/IntlUtils.ts
@@ -4,6 +4,31 @@ import { LanguageType } from '../../types/schema';
 import { LocalStorage } from '../../localStorage';
 import { IntlContext } from '../context';
 
+// importing individually to reduce bundle size
+// the date-fns methods are tree shaking correctly
+// but the locales are not. when adding, please add as below
+import enGB from 'date-fns/locale/en-GB';
+import enUS from 'date-fns/locale/en-US';
+import fr from 'date-fns/locale/fr';
+import ar from 'date-fns/locale/ar';
+import es from 'date-fns/locale/es';
+
+// Map locale string (from i18n) to locale object (from date-fns)
+const getLocaleObj = { fr, ar, es };
+
+export const getLocale = (language: SupportedLocales) => {
+  switch (language) {
+    case 'en':
+      return navigator.language === 'en-US' ? enUS : enGB;
+    case 'tet':
+      return enGB;
+    case 'fr-DJ':
+      return fr;
+    default:
+      return getLocaleObj[language];
+  }
+};
+
 export const useIntl = () => React.useContext(IntlContext);
 
 const languageOptions = [
@@ -92,6 +117,7 @@ export const useIntlUtils = () => {
     languageOptions,
     changeLanguage,
     getLocaleCode,
+    getLocale: () => getLocale(currentLanguage),
     getUserLocale,
     setUserLocale,
     getLocalisedFullName,

--- a/client/packages/common/src/styles/ThemeProvider.tsx
+++ b/client/packages/common/src/styles/ThemeProvider.tsx
@@ -10,6 +10,7 @@ import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider/LocalizationProvider';
 import { PropsWithChildrenOnly } from '@common/types';
 import { createRegisteredContext } from 'react-singleton-context';
+import { useIntlUtils } from '..';
 
 /**
  * Need a cache with the rtl plugin for when we are using rtl.
@@ -46,8 +47,13 @@ export const ThemeProviderProxy: FC<PropsWithChildrenOnly> = ({ children }) => {
 const ThemeProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
   const appTheme = useAppTheme();
 
+  const { getLocale } = useIntlUtils();
+
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider
+      dateAdapter={AdapterDateFns}
+      adapterLocale={getLocale()}
+    >
       <CacheProvider value={appTheme.direction === 'rtl' ? cacheRtl : cacheLtr}>
         <RTLProvider>
           <ThemeContext.Provider value={{ theme: appTheme }}>

--- a/client/packages/common/src/ui/components/inputs/DatePickers/DatePickerInput/DatePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/DatePickerInput/DatePickerInput.tsx
@@ -30,7 +30,7 @@ export const DatePickerInput: FC<DatePickerInputProps> = ({
   return (
     <BaseDatePickerInput
       disabled={disabled}
-      format="dd/MM/yyyy"
+      format="P"
       onChange={onChange}
       value={value || null}
       onError={onError}

--- a/client/packages/common/src/ui/components/inputs/DatePickers/DateTimePickerInput/DateTimePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/DateTimePickerInput/DateTimePickerInput.tsx
@@ -30,7 +30,7 @@ export const DateTimePickerInput: FC<
   width,
   label,
   textFieldProps,
-  format = 'dd/MM/yyyy HH:mm',
+  format = 'P p',
   minDate,
   maxDate,
   ...props

--- a/client/packages/programs/src/JsonForms/common/components/Date.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Date.tsx
@@ -55,7 +55,7 @@ const UIComponent = (props: ControlProps) => {
             handleChange(path, !e ? undefined : dateFormatter(e, 'yyyy-MM-dd'));
             if (customError) setCustomError(undefined);
           }}
-          format="dd/MM/yyyy"
+          format="P"
           disabled={!props.enabled}
           error={customError ?? props.errors ?? zErrors ?? ''}
           disableFuture={disableFuture}

--- a/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
+++ b/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
@@ -89,7 +89,7 @@ const UIComponent = (props: ControlProps) => {
             // undefined is displayed as "now" and null as unset
             value={dob ?? null}
             onChange={onChangeDoB}
-            format="dd/MM/yyyy"
+            format="P"
             width={135}
             disableFuture
             disabled={!props.enabled}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2600

The LocalizationProvider defaults to en-US (https://mui.com/x/react-date-pickers/adapters-locale/#getting-started)
Use the selected language instead.

Use localized format instead of hard coded format.

## Testing
Changing the browser language between en-US and en-GB/en-NZ should change date format in:
- Encoutner header
- Encounter list view
- JSON forms controls