### PR TITLE
2512 missing progress indication when saving an patient/encounter/enrolment

### DIFF
--- a/client/packages/system/src/ContactTrace/DetailView/DetailView.tsx
+++ b/client/packages/system/src/ContactTrace/DetailView/DetailView.tsx
@@ -87,6 +87,7 @@ export const DetailView: FC<DetailViewProps> = ({
     setData,
     saveData,
     isDirty,
+    isSaving,
     validationError,
     revert,
   } = useJsonForms(
@@ -190,6 +191,7 @@ export const DetailView: FC<DetailViewProps> = ({
       <Footer
         documentName={contactData?.documentName}
         onSave={saveData}
+        isSaving={isSaving}
         onCancel={revert}
         isDisabled={!isDirty || !!validationError}
         contactTrace={data as ContactTraceRowFragment}

--- a/client/packages/system/src/ContactTrace/DetailView/Footer.tsx
+++ b/client/packages/system/src/ContactTrace/DetailView/Footer.tsx
@@ -12,6 +12,7 @@ import {
   DialogButton,
   ClockIcon,
   useDialog,
+  LoadingButton,
 } from '@openmsupply-client/common';
 import {
   DocumentHistory,
@@ -21,6 +22,7 @@ import {
 interface FooterProps {
   documentName?: string;
   isDisabled: boolean;
+  isSaving: boolean;
   onCancel: () => void;
   onSave: () => void;
   contactTrace?: ContactTraceRowFragment;
@@ -29,6 +31,7 @@ interface FooterProps {
 export const Footer: FC<FooterProps> = ({
   documentName,
   isDisabled,
+  isSaving,
   onCancel,
   onSave,
 }) => {
@@ -69,14 +72,16 @@ export const Footer: FC<FooterProps> = ({
               }}
               label={t('button.cancel')}
             />
-            <ButtonWithIcon
-              variant="outlined"
+            <LoadingButton
               color="secondary"
-              Icon={<CheckIcon />}
+              variant="outlined"
+              disabled={isDisabled || isSaving}
+              isLoading={isSaving}
               onClick={onSave}
-              label={t('button.save')}
-              disabled={isDisabled}
-            />
+              startIcon={<CheckIcon />}
+            >
+              {t('button.save')}
+            </LoadingButton>
           </Box>
 
           <Modal

--- a/client/packages/system/src/ContactTrace/DetailView/Footer.tsx
+++ b/client/packages/system/src/ContactTrace/DetailView/Footer.tsx
@@ -74,6 +74,7 @@ export const Footer: FC<FooterProps> = ({
             />
             <LoadingButton
               color="secondary"
+              loadingStyle={{ iconColor: 'secondary.main' }}
               variant="outlined"
               disabled={isDisabled || isSaving}
               isLoading={isSaving}

--- a/client/packages/system/src/Encounter/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Encounter/DetailView/DetailView.tsx
@@ -166,6 +166,7 @@ export const DetailView: FC = () => {
     setData,
     saveData,
     isDirty,
+    isSaving,
     validationError,
     revert,
   } = useJsonForms(
@@ -290,6 +291,7 @@ export const DetailView: FC = () => {
           }
         }}
         onCancel={revert}
+        isSaving={isSaving}
         isDisabled={!isDirty || !!validationError}
         encounter={data as EncounterFragment}
       />

--- a/client/packages/system/src/Encounter/DetailView/Footer.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Footer.tsx
@@ -109,6 +109,7 @@ export const Footer: FC<FooterProps> = ({
             />
             <LoadingButton
               color="secondary"
+              loadingStyle={{ iconColor: 'secondary.main' }}
               variant="outlined"
               disabled={isDisabled || isSaving}
               isLoading={isSaving}

--- a/client/packages/system/src/Encounter/DetailView/Footer.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Footer.tsx
@@ -4,7 +4,7 @@ import {
   useTranslation,
   AppFooterPortal,
   ButtonWithIcon,
-  CheckIcon,
+  SaveIcon,
   XCircleIcon,
   useNavigate,
   Typography,
@@ -14,6 +14,7 @@ import {
   useDialog,
   StatusCrumbs,
   EncounterNodeStatus,
+  LoadingButton,
 } from '@openmsupply-client/common';
 import {
   DocumentHistory,
@@ -24,6 +25,7 @@ import { encounterStatusTranslation } from '../utils';
 interface FooterProps {
   documentName?: string;
   isDisabled: boolean;
+  isSaving: boolean;
   onCancel: () => void;
   onSave: () => void;
   encounter?: EncounterFragment;
@@ -62,6 +64,7 @@ const EncounterStatusCrumbs: FC<{ encounter: EncounterFragment }> = ({
 export const Footer: FC<FooterProps> = ({
   documentName,
   isDisabled,
+  isSaving,
   onCancel,
   onSave,
   encounter,
@@ -104,14 +107,16 @@ export const Footer: FC<FooterProps> = ({
               }}
               label={t('button.cancel')}
             />
-            <ButtonWithIcon
-              variant="outlined"
+            <LoadingButton
               color="secondary"
-              Icon={<CheckIcon />}
+              variant="outlined"
+              disabled={isDisabled || isSaving}
+              isLoading={isSaving}
               onClick={onSave}
-              label={t('button.save')}
-              disabled={isDisabled}
-            />
+              startIcon={<SaveIcon />}
+            >
+              {t('button.save')}
+            </LoadingButton>
           </Box>
 
           <Modal

--- a/client/packages/system/src/Patient/ProgramEnrolment/Components/DetailModal.tsx
+++ b/client/packages/system/src/Patient/ProgramEnrolment/Components/DetailModal.tsx
@@ -2,8 +2,11 @@ import React, { FC } from 'react';
 import {
   BasicSpinner,
   Box,
+  CheckIcon,
   DialogButton,
+  LoadingButton,
   ModalTabs,
+  SaveIcon,
   Typography,
   useDialog,
   useTranslation,
@@ -57,7 +60,7 @@ export const ProgramDetailModal: FC = () => {
     document?.createDocument,
     handleSave
   );
-  const { JsonForm, isLoading, saveData, isDirty, validationError } =
+  const { JsonForm, isLoading, isSaving, saveData, isDirty, validationError } =
     useJsonForms(
       {
         documentName: document?.name,
@@ -106,14 +109,19 @@ export const ProgramDetailModal: FC = () => {
       title=""
       cancelButton={<DialogButton variant="cancel" onClick={reset} />}
       okButton={
-        <DialogButton
-          variant={isCreating ? 'save' : 'ok'}
+        <LoadingButton
+          color="secondary"
           disabled={!isDirty || !!validationError}
+          isLoading={isSaving}
           onClick={async () => {
             await saveData();
             reset();
           }}
-        />
+          startIcon={isCreating ? <SaveIcon /> : <CheckIcon />}
+          sx={{ marginLeft: 2 }}
+        >
+          {isCreating ? t('button.save') : t('button.ok')}
+        </LoadingButton>
       }
       width={700}
     >

--- a/client/packages/system/src/Patient/ProgramEnrolment/Components/DetailModal.tsx
+++ b/client/packages/system/src/Patient/ProgramEnrolment/Components/DetailModal.tsx
@@ -111,6 +111,7 @@ export const ProgramDetailModal: FC = () => {
       okButton={
         <LoadingButton
           color="secondary"
+          loadingStyle={{ iconColor: 'secondary.main' }}
           disabled={!isDirty || !!validationError}
           isLoading={isSaving}
           onClick={async () => {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2512 

# 👩🏻‍💻 What does this PR do? 
Use loading buttons for encounter, contact trace and program enrolment saving.

# 🧪 How has/should this change been tested? 
- [ ] Go to any of the above areas
- [ ] Fill out form and save
- [ ] See spinny indication if data takes a while to save