### PR TITLE
2633 location sort function

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -1095,6 +1095,7 @@ export type EncounterFilterInput = {
   documentName?: InputMaybe<EqualFilterStringInput>;
   endDatetime?: InputMaybe<DatetimeFilterInput>;
   id?: InputMaybe<EqualFilterStringInput>;
+  /** Only if this filter is set encounters with status DELETED are returned */
   includeDeleted?: InputMaybe<Scalars['Boolean']['input']>;
   patient?: InputMaybe<PatientFilterInput>;
   patientId?: InputMaybe<EqualFilterStringInput>;
@@ -4720,6 +4721,7 @@ export enum StockLineSortFieldInput {
   ExpiryDate = 'expiryDate',
   ItemCode = 'itemCode',
   ItemName = 'itemName',
+  LocationCode = 'locationCode',
   NumberOfPacks = 'numberOfPacks',
   PackSize = 'packSize',
   SupplierName = 'supplierName'

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -117,9 +117,8 @@ const StockListComponent: FC = () => {
     [
       'location',
       {
-        sortable: false,
         Cell: TooltipTextCell,
-        width: 75,
+        width: 100,
         accessor: ({ rowData }) => rowData.location?.code,
       },
     ],

--- a/client/packages/system/src/Stock/api/api.ts
+++ b/client/packages/system/src/Stock/api/api.ts
@@ -27,6 +27,8 @@ const stockLineParsers = {
         return StockLineSortFieldInput.SupplierName;
       case 'numberOfPacks':
         return StockLineSortFieldInput.NumberOfPacks;
+      case 'location':
+        return StockLineSortFieldInput.LocationCode;
       case 'expiryDate':
       default: {
         return StockLineSortFieldInput.ExpiryDate;

--- a/server/graphql/stock_line/src/lib.rs
+++ b/server/graphql/stock_line/src/lib.rs
@@ -26,6 +26,7 @@ pub enum StockLineSortFieldInput {
     Batch,
     PackSize,
     SupplierName,
+    LocationCode,
 }
 #[derive(InputObject)]
 pub struct StockLineSortInput {
@@ -77,6 +78,7 @@ impl StockLineSortInput {
             from::Batch => to::Batch,
             from::PackSize => to::PackSize,
             from::SupplierName => to::SupplierName,
+            from::LocationCode => to::LocationCode,
         };
 
         StockLineSort {

--- a/server/repository/src/db_diesel/stock_line.rs
+++ b/server/repository/src/db_diesel/stock_line.rs
@@ -40,6 +40,7 @@ pub enum StockLineSortField {
     Batch,
     PackSize,
     SupplierName,
+    LocationCode,
 }
 
 #[derive(Debug, Clone)]
@@ -135,6 +136,9 @@ impl<'a> StockLineRepository<'a> {
                 }
                 StockLineSortField::SupplierName => {
                     apply_sort_no_case!(query, sort, name_dsl::name_);
+                }
+                StockLineSortField::LocationCode => {
+                    apply_sort_no_case!(query, sort, location_dsl::code);
                 }
             }
         } else {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2633

# 👩🏻‍💻 What does this PR do? 
Allow stock to be sort by location code... Did it by code since location code is the only thing shown under the location column.

# 🧪 How has/should this change been tested? 
- [ ] Have stock in different locations
- [ ] Go to `View Stock`
- [ ] Sort by location (code)