### PR TITLE
Rework the changelog_deduped view

### DIFF
--- a/server/repository/src/migrations/v1_06_00/changelog_deduped.rs
+++ b/server/repository/src/migrations/v1_06_00/changelog_deduped.rs
@@ -1,0 +1,32 @@
+use crate::{migrations::*, StorageConnection};
+
+pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
+    sql!(
+        connection,
+        r#"
+            DROP VIEW changelog_deduped;
+
+            -- View of the changelog that only contains the most recent changes to a row, i.e. previous row
+            -- edits are removed.
+            -- Note, an insert + delete will show up as an orphaned delete.
+            CREATE VIEW changelog_deduped AS
+                SELECT c.cursor,
+                  c.table_name,
+                  c.record_id,
+                  c.row_action,
+                  c.name_id,
+                  c.store_id,
+                  c.is_sync_update
+                FROM (
+                  SELECT record_id, MAX(cursor) AS max_cursor
+                  FROM changelog
+                  GROUP BY record_id
+                ) grouped
+                INNER JOIN changelog c
+                  ON c.record_id = grouped.record_id AND c.cursor = grouped.max_cursor
+                ORDER BY c.cursor;
+        "#
+    )?;
+
+    Ok(())
+}

--- a/server/repository/src/migrations/v1_06_00/changelog_deduped.rs
+++ b/server/repository/src/migrations/v1_06_00/changelog_deduped.rs
@@ -28,5 +28,11 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
         "#
     )?;
 
+    sql!(
+        connection,
+        r#"
+        CREATE INDEX index_changelog_record_id ON changelog (record_id);
+        "#
+    )?;
     Ok(())
 }

--- a/server/repository/src/migrations/v1_06_00/mod.rs
+++ b/server/repository/src/migrations/v1_06_00/mod.rs
@@ -2,6 +2,7 @@ use super::{version::Version, Migration};
 
 use crate::StorageConnection;
 
+mod changelog_deduped;
 mod contact_trace;
 mod encounter_status;
 mod indexes;
@@ -27,6 +28,7 @@ impl Migration for V1_06_00 {
         program_enrolment_status::migrate(connection)?;
         indexes::migrate(connection)?;
         encounter_status::migrate(connection)?;
+        changelog_deduped::migrate(connection)?;
         Ok(())
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2688 

# 👩🏻‍💻 What does this PR do? 
Replaces the existing view:

```sql
CREATE VIEW changelog_deduped AS
            SELECT t1.cursor,
                t1.table_name,
                t1.record_id,
                t1.row_action,
                t1.name_id,
                t1.store_id,
                t1.is_sync_update
            FROM changelog t1
            WHERE t1.cursor = (SELECT max(t2.cursor) 
                            from changelog t2
                            where t2.record_id = t1.record_id)
            ORDER BY t1.cursor;
```

with 

```sql
CREATE VIEW changelog_deduped AS
                SELECT c.cursor,
                  c.table_name,
                  c.record_id,
                  c.row_action,
                  c.name_id,
                  c.store_id,
                  c.is_sync_update
                FROM (
                  SELECT record_id, MAX(cursor) AS max_cursor
                  FROM changelog
                  GROUP BY record_id
                ) grouped
                INNER JOIN changelog c
                  ON c.record_id = grouped.record_id AND c.cursor = grouped.max_cursor
                ORDER BY c.cursor;
```

The first view query was a problem for both, sqlite and postgres. Now the query seems to be fast so I haven't experimented with putting another index on record_id...

The problem was worse when there where lots of unsynced changelog entries. In the code there is always a clause like `WHERE cursor > 1000`. This speeds up the old query when you caught up with the changelog but didn't help much when there are lots of newer entries in the changelog... Now a full query of the view is fast but I haven't tested how far this scales up, e.g. 1 year of unsynced sensor data.

# 🧪 How has/should this change been tested? 
Check that both SQL queries give identicale results. (There is a test for the view which passes but a manual logic check would be good as well)

If you have a database with many changelog entries you can run both queries, e.g. in sqlite browser, and see the query time differences.

I used the programs import script to generate lots of remote records. Might be tricky to share this datafile but can do if needed, e.g. if you don't have an way to generate lots of sensor events... 

