### PR TITLE
2608 add cancel buttons to modals

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/ListView/CreateRequisitionModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/ListView/CreateRequisitionModal.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import {
   BasicSpinner,
+  DialogButton,
   ModalTabs,
   useDialog,
   useTranslation,
@@ -80,6 +81,7 @@ export const CreateRequisitionModal: FC<CreateRequisitionModalProps> = ({
       width={500}
       slideAnimation={false}
       title={t('label.new-requisition')}
+      cancelButton={<DialogButton variant="cancel" onClick={onClose} />}
     >
       <InnerComponent />
     </Modal>

--- a/client/packages/requisitions/src/RequestRequisition/ListView/CreateRequisitionModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/ListView/CreateRequisitionModal.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 import {
   BasicSpinner,
-  DialogButton,
   ModalTabs,
   useDialog,
   useTranslation,
@@ -40,7 +39,7 @@ export const CreateRequisitionModal: FC<CreateRequisitionModalProps> = ({
 }) => {
   const { data: programSettings, isLoading } =
     useRequest.utils.programSettings();
-  const { Modal } = useDialog({ isOpen, onClose });
+  const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: false });
   const { height: windowHeight } = useWindowDimensions();
   const height = windowHeight * 0.8;
 
@@ -81,7 +80,6 @@ export const CreateRequisitionModal: FC<CreateRequisitionModalProps> = ({
       width={500}
       slideAnimation={false}
       title={t('label.new-requisition')}
-      cancelButton={<DialogButton variant="cancel" onClick={onClose} />}
     >
       <InnerComponent />
     </Modal>


### PR DESCRIPTION
Fixes #2608

# 👩🏻‍💻 What does this PR do? 
Enables background click or tap closing for Internal Orders modal.

A number of other modals are closed by clicking outside (such as inbound shipment modal). This matches this pattern.

An alternative option would be to add a cancel button - though this may be more confusing? I'm not sure.

# 🧪 How has/should this change been tested? 
You can test this by going to
- Replenishment
- Internal Orders
- Create new
- Clicking outside (or tapping on table) to close the modal
