### PR TITLE
Move tab logic from useUrlQuery to DetailTabs

### DIFF
--- a/client/packages/common/src/hooks/useUrlQuery/useUrlQuery.ts
+++ b/client/packages/common/src/hooks/useUrlQuery/useUrlQuery.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 export interface UrlQueryObject {
@@ -51,7 +52,7 @@ interface useUrlQueryProps {
   skipParse?: string[];
 }
 
-export const useUrlQuery = ({ skipParse = [] }: useUrlQueryProps = {}) => {
+export const useUrlQuery = ({ skipParse }: useUrlQueryProps = {}) => {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const updateQuery = (values: UrlQueryObject, overwrite = false) => {
@@ -65,12 +66,7 @@ export const useUrlQuery = ({ skipParse = [] }: useUrlQueryProps = {}) => {
 
     Object.entries(values).forEach(([key, value]) => {
       if (!value) delete newQueryObject[key];
-      else if (key === 'tab') {
-        newQueryObject[key] = String(value);
-        Object.entries(newQueryObject).forEach(([k, v]) => {
-          if (v !== value) delete newQueryObject[k];
-        });
-      } else {
+      else {
         if (typeof value === 'object' && ('from' in value || 'to' in value)) {
           const range = parseRangeString(newQueryObject[key]) as RangeObject<
             string | number
@@ -89,11 +85,14 @@ export const useUrlQuery = ({ skipParse = [] }: useUrlQueryProps = {}) => {
     setSearchParams(newQueryObject, { replace: true });
   };
 
-  return {
-    urlQuery: parseSearchParams(searchParams, skipParse),
-    updateQuery,
-    parseRangeString,
-  };
+  return useMemo(
+    () => ({
+      urlQuery: parseSearchParams(searchParams, skipParse ?? []),
+      updateQuery,
+      parseRangeString,
+    }),
+    [searchParams, skipParse]
+  );
 };
 
 // Coerces url params to appropriate type

--- a/client/packages/common/src/ui/components/navigation/Tabs/DetailTabs.tsx
+++ b/client/packages/common/src/ui/components/navigation/Tabs/DetailTabs.tsx
@@ -47,18 +47,29 @@ export const DetailTabs: FC<DetailTabsProps> = ({
     handleResize();
   }, [detailPanelOpen, drawerOpen]);
 
-  const onChange = (_: React.SyntheticEvent, tab: string) => {
-    const tabConfirm = tabs.find(({ value }) => value === currentTab);
+  const [tabQueryParams, setTabQueryParams] = useState<
+    Record<string, UrlQueryObject>
+  >({});
+
+  const getDefaultTabQueryParams = (tab: string): UrlQueryObject => {
     const tabDefinition = tabs.find(({ value }) => value === tab);
     const sort = tabDefinition?.sort;
     const query: UrlQueryObject = sort
       ? { tab, sort: sort.key, dir: sort.dir }
       : { tab };
+    return query;
+  };
+
+  const onChange = (_: React.SyntheticEvent, tab: string) => {
+    const tabConfirm = tabs.find(({ value }) => value === currentTab);
+    // restore the query params for the tab
+    const query: UrlQueryObject =
+      tabQueryParams[tab] ?? getDefaultTabQueryParams(tab);
 
     if (!!tabConfirm?.confirmOnLeaving && requiresConfirmation(currentTab)) {
-      showConfirmation(() => updateQuery(query));
+      showConfirmation(() => updateQuery(query, true));
     } else {
-      updateQuery(query);
+      updateQuery(query, true);
     }
   };
 
@@ -69,6 +80,14 @@ export const DetailTabs: FC<DetailTabsProps> = ({
     const tab = urlQuery['tab'] as string | undefined;
     if (isValidTab(tab)) {
       setCurrentTab(tab);
+
+      // store the query params for the current tab
+      setTabQueryParams(value => {
+        return {
+          ...value,
+          [tab]: urlQuery,
+        };
+      });
     }
   }, [urlQuery]);
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2431 

# 👩🏻‍💻 What does this PR do? 
- Removes the tab specific code from useUrlQuery and moves it to DetailTabs (tab query is set when changing the tab)
- Remembers query parameters for each tab (only for as long as being on the tab view)

For the second point, is this actually something we want to have or should I revert to the old behaviour where all filter params are reset when changing between tabs?

# 🧪 How has/should this change been tested? 

Best to be tested with a cold chain dataset (Monitoring tabs)
https://github.com/msupply-foundation/open-msupply/files/13303292/oms_cold_chain.zip

- Set filter for each tab and move back and forth between tabs

