### PR TITLE
Change the default dates for temperature chart

### DIFF
--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/TemperatureChart.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/TemperatureChart.tsx
@@ -141,8 +141,11 @@ const Chart = ({
 
   useEffect(() => {
     if (!urlQuery['datetime']) {
-      const from = customDate(DateUtils.startOfToday(), 'yyyy-MM-dd HH:mm');
-      const to = customDate(DateUtils.endOfDay(new Date()), 'yyyy-MM-dd HH:mm');
+      const from = customDate(
+        DateUtils.addDays(new Date(), -1),
+        'yyyy-MM-dd HH:mm'
+      );
+      const to = customDate(new Date(), 'yyyy-MM-dd HH:mm');
       updateQuery({ datetime: { from, to } });
     }
   }, []);

--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/useTemperatureChartData.ts
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/useTemperatureChartData.ts
@@ -39,8 +39,8 @@ export const useTemperatureChartData = () => {
   const { datetime, ...filterBy } =
     filter?.filterBy as TemperatureLogFilterInput;
 
-  let fromDatetime = DateUtils.startOfToday().toISOString();
-  let toDatetime = DateUtils.endOfDay(new Date()).toISOString();
+  let fromDatetime = DateUtils.addDays(new Date(), -1).toISOString();
+  let toDatetime = new Date().toISOString();
 
   if (!!datetime && typeof datetime === 'object') {
     const hasAfterOrEqualTo =

--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureLog/Toolbar.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureLog/Toolbar.tsx
@@ -44,7 +44,7 @@ export const Toolbar: FC<{ filter: FilterController }> = () => {
                   name: t('label.from-datetime'),
                   urlParameter: 'datetime',
                   range: 'from',
-                  maxDate: new Date(),
+                  maxDate: DateUtils.addMinutes(new Date(), -30),
                   isDefault: true,
                 },
                 {
@@ -52,7 +52,7 @@ export const Toolbar: FC<{ filter: FilterController }> = () => {
                   name: t('label.to-datetime'),
                   urlParameter: 'datetime',
                   range: 'to',
-                  maxDate: DateUtils.endOfDay(new Date()),
+                  maxDate: new Date(),
                   isDefault: true,
                 },
               ],


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2700 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Defaults the filter dates and times for the charts, and updates the max date values for the filters.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
View the chart! by default you'll see entries going back in time (for one day) from now
