### PR TITLE
Display server error

### DIFF
--- a/client/packages/common/src/api/GqlContext.tsx
+++ b/client/packages/common/src/api/GqlContext.tsx
@@ -47,7 +47,7 @@ const hasPermissionException = (errors: ResponseError[]) =>
 
 const handleResponseError = (errors: ResponseError[]) => {
   if (hasError(errors, AuthError.Unauthenticated)) {
-    LocalStorage.setItem('/auth/error', AuthError.Unauthenticated);
+    LocalStorage.setItem('/error/auth', AuthError.Unauthenticated);
     return;
   }
 
@@ -55,7 +55,7 @@ const handleResponseError = (errors: ResponseError[]) => {
     if (hasPermissionException(errors)) {
       throw errors[0];
     }
-    LocalStorage.setItem('/auth/error', AuthError.PermissionDenied);
+    LocalStorage.setItem('/error/auth', AuthError.PermissionDenied);
     return;
   }
 

--- a/client/packages/common/src/authentication/AuthContext.tsx
+++ b/client/packages/common/src/authentication/AuthContext.tsx
@@ -103,7 +103,7 @@ const { Provider } = AuthContext;
 export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
   const authCookie = getAuthCookie();
   const [cookie, setCookie] = useState<AuthCookie | undefined>(authCookie);
-  const [error, setError] = useLocalStorage('/auth/error');
+  const [error, setError] = useLocalStorage('/error/auth');
   const storeId = cookie?.store?.id ?? '';
   const {
     login,

--- a/client/packages/common/src/authentication/api/api.ts
+++ b/client/packages/common/src/authentication/api/api.ts
@@ -94,7 +94,8 @@ export const getAuthQueries = (sdk: Sdk, t: TypedTFunction<LocaleKey>) => ({
         return result.me;
       } catch (e) {
         console.error(e);
-        LocalStorage.setItem('/auth/error', AuthError.ServerError);
+        LocalStorage.setItem('/error/auth', AuthError.ServerError);
+        LocalStorage.setItem('/error/server', (e as Error).message);
       }
     },
     permissions: async ({

--- a/client/packages/common/src/authentication/api/hooks/useLogin.ts
+++ b/client/packages/common/src/authentication/api/hooks/useLogin.ts
@@ -29,7 +29,7 @@ const skipNoStoreRequests = (documentNode?: DocumentNode) => {
 
   if (documentNode.definitions.some(isAuthRequest)) return false;
 
-  switch (LocalStorage.getItem('/auth/error')) {
+  switch (LocalStorage.getItem('/error/auth')) {
     case AuthError.NoStoreAssigned:
     case AuthError.Unauthenticated:
     case AuthError.Timeout:
@@ -71,7 +71,7 @@ export const useLogin = (
     useLocalStorage('/mru/credentials');
   const getUserPermissions = useGetUserPermissions();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [_error, setError, removeError] = useLocalStorage('/auth/error');
+  const [_error, setError, removeError] = useLocalStorage('/error/auth');
   const mostRecentCredentials = getMostRecentCredentials(
     mostRecentlyUsedCredentials
   );
@@ -108,7 +108,7 @@ export const useLogin = (
   };
 
   const setLoginError = (isLoggedIn: boolean, hasValidStore: boolean) => {
-    if (LocalStorage.getItem('/auth/error') === AuthError.ServerError) return;
+    if (LocalStorage.getItem('/error/auth') === AuthError.ServerError) return;
 
     switch (true) {
       case isLoggedIn && hasValidStore: {
@@ -159,7 +159,7 @@ export const useLogin = (
     setCookie(authCookie);
     setLoginError(!!token, !!store);
     setSkipRequest(
-      () => LocalStorage.getItem('/auth/error') === AuthError.NoStoreAssigned
+      () => LocalStorage.getItem('/error/auth') === AuthError.NoStoreAssigned
     );
 
     return { token, error };

--- a/client/packages/common/src/authentication/hooks/usePermissionCheck.ts
+++ b/client/packages/common/src/authentication/hooks/usePermissionCheck.ts
@@ -6,12 +6,10 @@ import { useLocalStorage } from '../../localStorage';
 import { useNavigate } from 'react-router-dom';
 import { RouteBuilder } from '../../utils/navigation';
 
-export const usePermissionCheck = (
-  permission: UserPermission
-) => {
+export const usePermissionCheck = (permission: UserPermission) => {
   const { userHasPermission } = useAuthContext();
   const navigate = useNavigate();
-  const [error, setError] = useLocalStorage('/auth/error');
+  const [error, setError] = useLocalStorage('/error/auth');
   const previous = useRef(error);
 
   useEffect(() => {

--- a/client/packages/common/src/intl/locales/en/app.json
+++ b/client/packages/common/src/intl/locales/en/app.json
@@ -58,6 +58,7 @@
   "error.unable-to-save-settings": "Unable to save settings",
   "error.unknown-sync-error": "Unknown sync error",
   "heading.password": "Password",
+  "heading.server-error": "Server Error",
   "heading.username": "Username",
   "inbound-shipment": "Inbound Shipment",
   "inbound-shipments": "Inbound Shipments",

--- a/client/packages/common/src/localStorage/keys.ts
+++ b/client/packages/common/src/localStorage/keys.ts
@@ -23,7 +23,8 @@ export type LocalStorageRecord = {
   '/theme/logo': string;
   '/theme/logohash': string;
   '/mru/credentials': AuthenticationCredentials | AuthenticationCredentials[];
-  '/auth/error': AuthError | undefined;
+  '/error/auth': AuthError | undefined;
+  '/error/server': string;
   '/pagination/rowsperpage': number;
   '/columns/hidden': Record<string, string[]> | undefined;
 };

--- a/client/packages/host/src/Host.tsx
+++ b/client/packages/host/src/Host.tsx
@@ -25,7 +25,7 @@ import {
 import { AppRoute, Environment } from '@openmsupply-client/config';
 import { Initialise, Login, Viewport } from './components';
 import { Site } from './Site';
-import { AuthenticationAlert } from './components/AuthenticationAlert';
+import { ErrorAlert } from './components/ErrorAlert';
 import { Discovery } from './components/Discovery';
 import { Android } from './components/Android';
 import { useInitPlugins } from './plugins';
@@ -79,7 +79,7 @@ const Host = () => (
                     <ConfirmationModalProvider>
                       <AlertModalProvider>
                         <BrowserRouter>
-                          <AuthenticationAlert />
+                          <ErrorAlert />
                           <Viewport>
                             <Box display="flex" style={{ minHeight: '100%' }}>
                               <Routes>

--- a/client/packages/host/src/Host.tsx
+++ b/client/packages/host/src/Host.tsx
@@ -56,7 +56,7 @@ Bugsnag.start({
 });
 
 const skipRequest = () =>
-  LocalStorage.getItem('/auth/error') === AuthError.NoStoreAssigned;
+  LocalStorage.getItem('/error/auth') === AuthError.NoStoreAssigned;
 
 const PluginProvider: React.FC<PropsWithChildren> = ({ children }) => {
   useInitPlugins();

--- a/client/packages/host/src/QueryErrorHandler.tsx
+++ b/client/packages/host/src/QueryErrorHandler.tsx
@@ -15,7 +15,7 @@ export const QueryErrorHandler = () => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const location = useLocation();
   const generalError = t('error.general-query-error');
-  const [authError] = useLocalStorage('/auth/error');
+  const [authError] = useLocalStorage('/error/auth');
 
   useEffect(() => {
     if (!!errorMessage && authError !== AuthError.Unauthenticated) {

--- a/client/packages/host/src/components/AuthenticationAlert.tsx
+++ b/client/packages/host/src/components/AuthenticationAlert.tsx
@@ -3,6 +3,7 @@ import { AppRoute } from '@openmsupply-client/config';
 import React, { useEffect } from 'react';
 import {
   AuthError,
+  LocalStorage,
   Location,
   RouteBuilder,
   matchPath,
@@ -10,7 +11,7 @@ import {
   useLocation,
   useNavigate,
 } from '@openmsupply-client/common';
-import { AlertModal } from '@common/components';
+import { AlertModal, Typography } from '@common/components';
 import { LocaleKey, TypedTFunction, useTranslation } from '@common/intl';
 
 export const AuthenticationAlert = () => {
@@ -18,7 +19,7 @@ export const AuthenticationAlert = () => {
   const { isOn, toggleOff, toggleOn } = useToggle();
   const t = useTranslation('app');
   const location = useLocation();
-  const [error, , removeError] = useLocalStorage('/auth/error');
+  const [error, , removeError] = useLocalStorage('/error/auth');
 
   useEffect(() => {
     if (!!error) toggleOn();
@@ -97,9 +98,22 @@ const translateErrorMessage = (
         message: t('auth.permission-denied'),
       };
     case AuthError.ServerError:
+      const error = LocalStorage.getItem('/error/server');
+      const message =
+        error === null ? (
+          t('auth.server-error')
+        ) : (
+          <>
+            {t('auth.server-error')}
+            <Typography color="error" paddingBottom={2} paddingTop={2}>
+              {error}
+            </Typography>
+          </>
+        );
+
       return {
-        title: t('auth.alert-title'),
-        message: t('auth.server-error'),
+        title: t('heading.server-error'),
+        message,
       };
     default:
       return undefined;

--- a/client/packages/host/src/components/ErrorAlert.tsx
+++ b/client/packages/host/src/components/ErrorAlert.tsx
@@ -14,7 +14,8 @@ import {
 import { AlertModal, Typography } from '@common/components';
 import { LocaleKey, TypedTFunction, useTranslation } from '@common/intl';
 
-export const AuthenticationAlert = () => {
+// primarily used to display an error message when the user is not logged in
+export const ErrorAlert = () => {
   const navigate = useNavigate();
   const { isOn, toggleOff, toggleOn } = useToggle();
   const t = useTranslation('app');
@@ -24,9 +25,9 @@ export const AuthenticationAlert = () => {
   useEffect(() => {
     if (!!error) toggleOn();
     return () => toggleOff();
-  }, [error]);
+  }, [error, toggleOff, toggleOn]);
 
-  // no need to alert if you are on the login screen!
+  // no need to alert if you are on the login screen
   if (
     matchPath(
       RouteBuilder.create(AppRoute.Login).addWildCard().build(),

--- a/client/packages/host/src/components/Login/Login.tsx
+++ b/client/packages/host/src/components/Login/Login.tsx
@@ -51,7 +51,7 @@ export const Login = () => {
 
   useEffect(() => {
     setPageTitle(`${t('app.login')} | ${t('app')} `);
-    LocalStorage.removeItem('/auth/error');
+    LocalStorage.removeItem('/error/auth');
   }, []);
 
   return (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2710

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Have made the error display more prominent. The server error was being caught already, but the heading was still 'Authentication Error' and I wasn't stopping to read the text.

So the change here is to upgrade the heading to 'Server Error' and also include the text, in the error colour, as below:

<img width="564" alt="Screenshot 2024-01-15 at 12 34 07 PM" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/0083a73f-08c7-411f-b83f-6ad47e4cab3b">

While it isn't the prettiest - it should be a situation that no normal user would see, only developers. I didn't want to parse the error object coming back from the server, which is text by the time we get it.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
As per the issue - delete a column, and login to see the fun.


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
