### PR TITLE
Parse dates in date filter

### DIFF
--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -83,13 +83,14 @@ export const DateUtils = {
   addCurrentTime,
   getDateOrNull: (
     date?: Date | string | null,
-    format?: string
+    format?: string,
+    options?: Parameters<typeof parse>[3]
   ): Date | null => {
     if (!date) return null;
     if (date instanceof Date) return date;
     const maybeDate =
       format && typeof date === 'string'
-        ? parse(date, format, new Date())
+        ? parse(date, format, new Date(), options)
         : new Date(date);
     return isValid(maybeDate) ? maybeDate : null;
   },

--- a/client/packages/common/src/ui/components/inputs/DatePickers/DateTimePickerInput/DateTimePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/DateTimePickerInput/DateTimePickerInput.tsx
@@ -130,7 +130,7 @@ export const DateTimePickerInput: FC<
       minDate={minDate}
       maxDate={maxDate}
       {...props}
-      value={DateUtils.getDateOrNull(props.value, undefined, dateParseOptions)}
+      value={props.value}
     />
   );
 };

--- a/client/packages/common/src/ui/components/inputs/DatePickers/DateTimePickerInput/DateTimePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/DateTimePickerInput/DateTimePickerInput.tsx
@@ -3,7 +3,7 @@ import { DateTimePicker, DateTimePickerProps } from '@mui/x-date-pickers';
 import { BasicTextInput } from '../../TextInput/BasicTextInput';
 import { useAppTheme } from '@common/styles';
 import { StandardTextFieldProps, TextFieldProps } from '@mui/material';
-import { DateUtils, useTranslation } from '@common/intl';
+import { DateUtils, useIntlUtils, useTranslation } from '@common/intl';
 import { getFormattedDateError } from '../BaseDatePickerInput';
 
 const TextField = (params: TextFieldProps) => {
@@ -39,6 +39,8 @@ export const DateTimePickerInput: FC<
   const [internalError, setInternalError] = useState<string | null>(null);
   const [isInitialEntry, setIsInitialEntry] = useState(true);
   const t = useTranslation('common');
+  const { getLocale } = useIntlUtils();
+  const dateParseOptions = { locale: getLocale() };
 
   // Max/Min should be restricted by the UI, but it's not restricting TIME input
   // (only Date component). So this function will enforce the max/min after
@@ -109,7 +111,9 @@ export const DateTimePickerInput: FC<
           error: !isInitialEntry && (!!error || !!internalError),
           helperText: !isInitialEntry ? error ?? internalError ?? '' : '',
           onBlur: e => {
-            handleDateInput(DateUtils.getDateOrNull(e.target.value, format));
+            handleDateInput(
+              DateUtils.getDateOrNull(e.target.value, format, dateParseOptions)
+            );
             setIsInitialEntry(false);
           },
           label,
@@ -126,7 +130,7 @@ export const DateTimePickerInput: FC<
       minDate={minDate}
       maxDate={maxDate}
       {...props}
-      value={DateUtils.getDateOrNull(props.value)}
+      value={DateUtils.getDateOrNull(props.value, undefined, dateParseOptions)}
     />
   );
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2712 #2713

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The DateTimePickerInput was failing to parse the date - the default format of `P p` is used to both format a date object to a string and to parse the date string.

However, the parse was failing silently with the result that the input was setting the date value to `null` on a blur event, resetting the input value.

The fix, for me at least, is to provide a locale to the `parse` call.
An alternative is to set the date format at `dd/MM/yyyy HH:mm` as this works for parsing as well. However, I thought it best to use the local regional format if possible. I've tried setting my OS regional settings to something different, however this has no effect.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
As per the issues, focus on a date input and then click elsewhere, triggering a blur event.
If the input is populated with a date, you should see no effect i.e. the current date value remains.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

or

- [ ] Functional change 1
- [ ] Functional change 2