### PR TITLE
Prevent acknowledgment of ongoing breaches

### DIFF
--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureBreach/useAcknowledgeBreachModal.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureBreach/useAcknowledgeBreachModal.tsx
@@ -1,8 +1,12 @@
 import React, { FC, useState } from 'react';
-import { BasicTextInput, DialogButton, Typography } from '@common/components';
+import {
+  BasicTextInput,
+  DialogButton,
+  ErrorWithDetails,
+  Typography,
+} from '@common/components';
 import { ModalProps, useDialog, useNotification } from '@common/hooks';
 import { useFormatDateTime, useIntlUtils, useTranslation } from '@common/intl';
-// import { alpha, useTheme } from '@common/styles';
 import {
   Box,
   TextWithLabelRow,
@@ -136,19 +140,28 @@ const BreachModal = ({
             </Box>
           </>
         )}
-        <Box paddingTop={3}>
-          <Typography sx={{ fontWeight: 'bold' }}>
-            {t('label.comment')}
-          </Typography>
-          <BasicTextInput
-            fullWidth
-            multiline
-            rows={3}
-            onChange={event => setComment(event.target.value)}
-            value={comment}
-            helperText={t('message.acknowledge-breach-helptext')}
-          />
-        </Box>
+        {!breach?.endDatetime ? (
+          <Box paddingTop={3}>
+            <ErrorWithDetails
+              error={t('message.breach-ongoing')}
+              details={''}
+            />
+          </Box>
+        ) : (
+          <Box paddingTop={3}>
+            <Typography sx={{ fontWeight: 'bold' }}>
+              {t('label.comment')}
+            </Typography>
+            <BasicTextInput
+              fullWidth
+              multiline
+              rows={3}
+              onChange={event => setComment(event.target.value)}
+              value={comment}
+              helperText={t('message.acknowledge-breach-helptext')}
+            />
+          </Box>
+        )}
       </Box>
     </Modal>
   );

--- a/client/packages/common/src/intl/locales/en/coldchain.json
+++ b/client/packages/common/src/intl/locales/en/coldchain.json
@@ -30,6 +30,7 @@
   "label.temperature-unit": "°C",
   "label.unacknowledged": "Unacknowledged",
   "message.acknowledge-breach-helptext": "Enter a comment and click OK to acknowledge the breach.",
+  "message.breach-ongoing": "This breach is ongoing and cannot be acknowledged until it has ended.",
   "message.confirm-sensor-update": "This will confirm changes you have made to this sensor",
   "message.device": "Device:",
   "message.last-temperature": "Last temperature reading: {{temperature}}°C",


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2718

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

If you try to acknowledge an ongoing breach, a message is shown and the `OK` button is not enabled:

<img width="635" alt="Screenshot 2024-01-15 at 5 16 25 PM" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/6ac03250-b236-4594-9a5d-495218b4892c">



# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Try to acknowledge an ongoing breach

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
- [ ] Say that you cannot ack ongoing
