### PR TITLE
Replace manufacturer

### DIFF
--- a/client/packages/coldchain/src/Sensor/ListView/ListView.tsx
+++ b/client/packages/coldchain/src/Sensor/ListView/ListView.tsx
@@ -10,6 +10,7 @@ import {
   Formatter,
   useEditModal,
   useUrlQuery,
+  SensorNodeType,
 } from '@openmsupply-client/common';
 import { useSensor, SensorFragment } from '../api';
 import { SensorEditModal } from '../Components';
@@ -84,7 +85,9 @@ export const SensorListView: FC = () => {
         key: 'type',
         label: 'label.sensor-type',
         accessor: ({ rowData }) => {
-          return Formatter.enumCase(rowData?.type);
+          return rowData?.type === SensorNodeType.BlueMaestro
+            ? t('label.rtmd')
+            : Formatter.enumCase(rowData?.type);
         },
         sortable: false,
       },

--- a/client/packages/common/src/intl/locales/en/coldchain.json
+++ b/client/packages/common/src/intl/locales/en/coldchain.json
@@ -27,6 +27,7 @@
   "label.hot-cumulative": "Hot Cumulative",
   "label.last-record": "Last recording date / time",
   "label.last-recording-value": "Last temperature recording value",
+  "label.rtmd": "mSupply RTMD",
   "label.temperature-unit": "°C",
   "label.unacknowledged": "Unacknowledged",
   "message.acknowledge-breach-helptext": "Enter a comment and click OK to acknowledge the breach.",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2816,6 +2816,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "graphql_core",
+ "regex",
  "repository",
  "reqwest",
  "serde 1.0.137",

--- a/server/graphql/types/Cargo.toml
+++ b/server/graphql/types/Cargo.toml
@@ -24,6 +24,7 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+regex = "1.5.5"
 
 [dev-dependencies]
 actix-rt = { workspace = true }

--- a/server/graphql/types/src/types/sensor.rs
+++ b/server/graphql/types/src/types/sensor.rs
@@ -79,8 +79,12 @@ impl SensorNode {
         &self.row().name
     }
 
-    pub async fn serial(&self) -> &str {
-        &self.row().serial
+    pub async fn serial(&self) -> String {
+        // the serial is stored as `| SENSOR_MANUFACTURER` in the database
+        // and the front end does not want to know about the manufacturer
+        let re = regex::Regex::new(r"\| .+$").unwrap();
+
+        re.replace(&self.row().serial, "").to_string()
     }
 
     pub async fn r#type(&self) -> SensorNodeType {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2717

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The replacement to `mSupply RTMD` I've made a front end substitution - this is because the concern was a f/e display issue, and the current method of formatting (`Formatter.enumCase`) would not provide the correct result (mSupply). I thought that by using a translation, we could (a) display in a local language if required and (b) update when the PM whimsy strikes.

The serial replacement however, has been done in the GQL query so that it is handled for both the sensor detail modal and the list view:

<img width="692" alt="Screenshot 2024-01-15 at 5 58 42 PM" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/8a200d33-4784-4d38-8e50-46b8fcd6cfc9">

(the list is slightly visible behind the modal)

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Check the sensor list and detail views


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
