### PR TITLE
2683 name merge contact trace

### DIFF
--- a/server/repository/src/db_diesel/contact_trace_row.rs
+++ b/server/repository/src/db_diesel/contact_trace_row.rs
@@ -12,6 +12,47 @@ table! {
       document_id -> Text,
       datetime -> Timestamp,
       contact_trace_id -> Nullable<Text>,
+      patient_link_id -> Text,
+      contact_patient_link_id -> Nullable<Text>,
+      first_name -> Nullable<Text>,
+      last_name -> Nullable<Text>,
+      gender -> Nullable<crate::db_diesel::name_row::GenderMapping>,
+      date_of_birth -> Nullable<Date>,
+      store_id -> Nullable<Text>,
+      relationship -> Nullable<Text>,
+    }
+}
+
+#[derive(Clone, Insertable, Queryable, Debug, PartialEq, AsChangeset, Eq)]
+#[changeset_options(treat_none_as_null = "true")]
+#[table_name = "contact_trace"]
+struct ContactTraceRawRow {
+    pub id: String,
+    pub program_id: String,
+    /// The document version used to populate this row
+    pub document_id: String,
+    pub datetime: NaiveDateTime,
+    /// User definable id of the contact trace
+    pub contact_trace_id: Option<String>,
+    /// Patient id of the patient this contact belongs to.
+    pub patient_link_id: String,
+    /// Linked patient id of the contact.
+    pub contact_patient_link_id: Option<String>,
+    pub first_name: Option<String>,
+    pub last_name: Option<String>,
+    pub gender: Option<Gender>,
+    pub date_of_birth: Option<NaiveDate>,
+    pub store_id: Option<String>,
+    pub relationship: Option<String>,
+}
+
+table! {
+    contact_trace_name_link_view (id) {
+      id -> Text,
+      program_id -> Text,
+      document_id -> Text,
+      datetime -> Timestamp,
+      contact_trace_id -> Nullable<Text>,
       patient_id -> Text,
       contact_patient_id -> Nullable<Text>,
       first_name -> Nullable<Text>,
@@ -23,14 +64,12 @@ table! {
     }
 }
 
-joinable!(contact_trace -> program (program_id));
-allow_tables_to_appear_in_same_query!(contact_trace, program);
-joinable!(contact_trace -> document (document_id));
-allow_tables_to_appear_in_same_query!(contact_trace, document);
+joinable!(contact_trace_name_link_view -> program (program_id));
+allow_tables_to_appear_in_same_query!(contact_trace_name_link_view, program);
+joinable!(contact_trace_name_link_view -> document (document_id));
+allow_tables_to_appear_in_same_query!(contact_trace_name_link_view, document);
 
-#[derive(Clone, Insertable, Queryable, Debug, PartialEq, AsChangeset, Eq)]
-#[changeset_options(treat_none_as_null = "true")]
-#[table_name = "contact_trace"]
+#[derive(Clone, Queryable, Debug, PartialEq, Eq)]
 pub struct ContactTraceRow {
     pub id: String,
     pub program_id: String,
@@ -39,9 +78,9 @@ pub struct ContactTraceRow {
     pub datetime: NaiveDateTime,
     /// User definable id of the contact trace
     pub contact_trace_id: Option<String>,
-    /// Patient id of the patient this contact belongs to.
+    /// Patient id of the patient this contact belongs to (name_id not the name_link_id).
     pub patient_id: String,
-    /// Linked patient id of the contact.
+    /// Linked patient id of the contact (name_id not the name_link_id).
     pub contact_patient_id: Option<String>,
     pub first_name: Option<String>,
     pub last_name: Option<String>,
@@ -49,6 +88,42 @@ pub struct ContactTraceRow {
     pub date_of_birth: Option<NaiveDate>,
     pub store_id: Option<String>,
     pub relationship: Option<String>,
+}
+
+impl ContactTraceRow {
+    fn to_raw(&self) -> ContactTraceRawRow {
+        let ContactTraceRow {
+            id,
+            program_id,
+            document_id,
+            datetime,
+            contact_trace_id,
+            patient_id,
+            contact_patient_id,
+            first_name,
+            last_name,
+            gender,
+            date_of_birth,
+            store_id,
+            relationship,
+        } = self.clone();
+        ContactTraceRawRow {
+            id,
+            program_id,
+            document_id,
+            datetime,
+            contact_trace_id,
+            // use name ids as name_link_ids
+            patient_link_id: patient_id,
+            contact_patient_link_id: contact_patient_id,
+            first_name,
+            last_name,
+            gender,
+            date_of_birth,
+            store_id,
+            relationship,
+        }
+    }
 }
 
 pub struct ContactTraceRowRepository<'a> {
@@ -63,10 +138,10 @@ impl<'a> ContactTraceRowRepository<'a> {
     #[cfg(feature = "postgres")]
     pub fn upsert_one(&self, row: &ContactTraceRow) -> Result<(), RepositoryError> {
         diesel::insert_into(contact_trace::dsl::contact_trace)
-            .values(row)
+            .values(row.to_raw())
             .on_conflict(contact_trace::dsl::id)
             .do_update()
-            .set(row)
+            .set(row.to_raw())
             .execute(&self.connection.connection)?;
         Ok(())
     }
@@ -74,28 +149,75 @@ impl<'a> ContactTraceRowRepository<'a> {
     #[cfg(not(feature = "postgres"))]
     pub fn upsert_one(&self, row: &ContactTraceRow) -> Result<(), RepositoryError> {
         diesel::replace_into(contact_trace::dsl::contact_trace)
-            .values(row)
+            .values(row.to_raw())
             .execute(&self.connection.connection)?;
         Ok(())
     }
 
     pub async fn insert_one(&self, row: &ContactTraceRow) -> Result<(), RepositoryError> {
         diesel::insert_into(contact_trace::dsl::contact_trace)
-            .values(row)
+            .values(row.to_raw())
             .execute(&self.connection.connection)?;
         Ok(())
     }
+}
 
-    pub async fn find_all(&self) -> Result<Vec<ContactTraceRow>, RepositoryError> {
-        let result = contact_trace::dsl::contact_trace.load(&self.connection.connection);
-        Ok(result?)
-    }
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDate;
 
-    pub fn find_one_by_id(&self, row_id: &str) -> Result<Option<ContactTraceRow>, RepositoryError> {
-        let result = contact_trace::dsl::contact_trace
-            .filter(contact_trace::dsl::id.eq(row_id))
-            .first(&self.connection.connection)
-            .optional()?;
-        Ok(result)
+    use crate::{
+        contact_trace::ContactTraceRepository,
+        contact_trace_row::ContactTraceRow,
+        mock::{
+            document_a, mock_merged_patient_name_link, mock_program_a, mock_store_a,
+            MockDataInserts,
+        },
+        test_db, Gender, Pagination,
+    };
+
+    use super::ContactTraceRowRepository;
+
+    // This trivial looking test has been added to test name_id -> name_link_id changes
+    #[actix_rt::test]
+    async fn test_contact_trace_name_links() {
+        let (_, connection, _, _) =
+            test_db::setup_all("test_contact_trace_name_links", MockDataInserts::all()).await;
+        let row_repo = ContactTraceRowRepository::new(&connection);
+        let repo = ContactTraceRepository::new(&connection);
+
+        let patient_link = mock_merged_patient_name_link();
+        let row = ContactTraceRow {
+            id: "ct1".to_string(),
+            program_id: mock_program_a().id,
+            document_id: document_a().id,
+            datetime: NaiveDate::from_ymd_opt(2024, 01, 15)
+                .unwrap()
+                .and_hms_opt(00, 00, 00)
+                .unwrap(),
+            contact_trace_id: Some("id".to_string()),
+            // use the link id here, i.e. the patient id of the soft deleted patient:
+            patient_id: patient_link.id.clone(),
+            contact_patient_id: Some(patient_link.id.clone()),
+            first_name: Some("first".to_string()),
+            last_name: Some("last".to_string()),
+            gender: Some(Gender::Female),
+            date_of_birth: Some(NaiveDate::from_ymd_opt(2000, 01, 15).unwrap()),
+            store_id: Some(mock_store_a().id),
+            relationship: Some("rel".to_string()),
+        };
+        row_repo.upsert_one(&row).unwrap();
+
+        // the query result should point to the actual name_ids
+        let mut expected = row;
+        expected.patient_id = patient_link.name_id.clone();
+        expected.contact_patient_id = Some(patient_link.name_id.clone());
+        let contact_trace = repo
+            .query(Pagination::all(), None, None)
+            .unwrap()
+            .pop()
+            .unwrap()
+            .contact_trace;
+        assert_eq!(&expected, &contact_trace);
     }
 }

--- a/server/repository/src/db_diesel/item.rs
+++ b/server/repository/src/db_diesel/item.rs
@@ -257,12 +257,12 @@ mod tests {
     use util::inline_init;
 
     use crate::{
-        mock::{mock_item_b, mock_item_link_from_item, mock_name_link_from_name, MockDataInserts},
+        mock::{mock_item_b, mock_item_link_from_item, MockDataInserts},
         test_db, EqualFilter, ItemFilter, ItemLinkRowRepository, ItemRepository, ItemRow,
         ItemRowRepository, ItemRowType, MasterListLineRow, MasterListLineRowRepository,
         MasterListNameJoinRepository, MasterListNameJoinRow, MasterListRow,
-        MasterListRowRepository, NameLinkRowRepository, NameRow, NameRowRepository, Pagination,
-        StoreRow, StoreRowRepository, StringFilter, DEFAULT_PAGINATION_LIMIT,
+        MasterListRowRepository, NameRow, NameRowRepository, Pagination, StoreRow,
+        StoreRowRepository, StringFilter, DEFAULT_PAGINATION_LIMIT,
     };
 
     use super::{Item, ItemSort, ItemSortField};
@@ -579,10 +579,6 @@ mod tests {
 
         NameRowRepository::new(&storage_connection)
             .upsert_one(&name_row)
-            .unwrap();
-
-        NameLinkRowRepository::new(&storage_connection)
-            .upsert_one(&mock_name_link_from_name(&name_row))
             .unwrap();
 
         StoreRowRepository::new(&storage_connection)

--- a/server/repository/src/db_diesel/name.rs
+++ b/server/repository/src/db_diesel/name.rs
@@ -386,10 +386,10 @@ mod tests {
     use util::{constants::INVENTORY_ADJUSTMENT_NAME_CODE, inline_init};
 
     use crate::{
+        mock::MockDataInserts,
         mock::{mock_name_1, mock_test_name_query_store_1, mock_test_name_query_store_2},
-        mock::{mock_name_link_from_name, MockDataInserts},
-        test_db, NameFilter, NameLinkRowRepository, NameRepository, NameRow, NameRowRepository,
-        Pagination, StringFilter, DEFAULT_PAGINATION_LIMIT,
+        test_db, NameFilter, NameRepository, NameRow, NameRowRepository, Pagination, StringFilter,
+        DEFAULT_PAGINATION_LIMIT,
     };
 
     use std::convert::TryFrom;
@@ -432,12 +432,8 @@ mod tests {
 
         let (rows, queries) = data();
         let name_repo = NameRowRepository::new(&storage_connection);
-        let name_link_repo = NameLinkRowRepository::new(&storage_connection);
         for row in rows {
             name_repo.upsert_one(&row).unwrap();
-            name_link_repo
-                .upsert_one(&mock_name_link_from_name(&row))
-                .unwrap();
         }
 
         let default_page_size = usize::try_from(DEFAULT_PAGINATION_LIMIT).unwrap();

--- a/server/repository/src/migrations/v1_06_00/contact_trace_link_id.rs
+++ b/server/repository/src/migrations/v1_06_00/contact_trace_link_id.rs
@@ -1,0 +1,112 @@
+use crate::{migrations::sql, StorageConnection};
+
+pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
+    #[cfg(feature = "postgres")]
+    sql!(
+        connection,
+        r#"
+          -- Adding contact_trace.patient_link_id and contact_trace.contact_patient_link_id
+          ALTER TABLE contact_trace
+          ADD COLUMN patient_link_id TEXT NOT NULL DEFAULT 'temp_for_migration';
+          ALTER TABLE contact_trace
+          ADD COLUMN contact_patient_link_id TEXT;
+
+          UPDATE contact_trace SET patient_link_id = patient_id;
+          UPDATE contact_trace SET contact_patient_link_id = contact_patient_id;
+
+          ALTER TABLE contact_trace ADD CONSTRAINT contact_trace_patient_link_id
+            FOREIGN KEY (patient_link_id)
+            REFERENCES name_link(id);
+          ALTER TABLE contact_trace ADD CONSTRAINT contact_trace_contact_patient_link_id
+            FOREIGN KEY (contact_patient_link_id)
+            REFERENCES name_link(id);
+     "#,
+    )?;
+    #[cfg(not(feature = "postgres"))]
+    sql!(
+        connection,
+        r#"
+        -- Adding contact_trace.patient_link_id and contact_trace.contact_patient_link_id
+          PRAGMA foreign_keys = OFF;
+
+          ALTER TABLE contact_trace
+          ADD COLUMN patient_link_id TEXT NOT NULL REFERENCES name_link (id) DEFAULT 'temp_for_migration'; 
+          ALTER TABLE contact_trace
+          ADD COLUMN contact_patient_link_id TEXT REFERENCES name_link (id); 
+
+          UPDATE contact_trace SET patient_link_id = patient_id;
+          UPDATE contact_trace SET contact_patient_link_id = contact_patient_id;
+
+          PRAGMA foreign_keys = ON;
+          "#,
+    )?;
+
+    sql!(
+        connection,
+        r#"
+        DROP INDEX index_contact_trace_patient_id;
+        DROP INDEX index_contact_trace_contact_patient_id;
+        ALTER TABLE contact_trace DROP COLUMN patient_id;
+        ALTER TABLE contact_trace DROP COLUMN contact_patient_id;
+        CREATE INDEX "index_contact_trace_patient_link_id" ON "contact_trace" ("patient_link_id");
+        CREATE INDEX "index_contact_trace_contact_patient_link_id" ON "contact_trace" ("contact_patient_link_id");
+    "#
+    )?;
+
+    #[cfg(feature = "postgres")]
+    sql!(
+        connection,
+        r#"
+        CREATE VIEW contact_trace_name_link_view AS
+          SELECT 
+            ct.id AS id,
+            ct.program_id AS program_id,
+            ct.document_id AS document_id,
+            ct.datetime AS datetime,
+            ct.contact_trace_id AS contact_trace_id,
+            patient_name_link.name_id AS patient_id,
+            contact_patient_name_link.name_id AS contact_patient_id,
+            ct.first_name AS first_name,
+            ct.last_name AS last_name,
+            ct.gender AS gender,
+            CAST(ct.date_of_birth AS DATE) AS date_of_birth,
+            ct.store_id AS store_id,
+            ct.relationship AS relationship
+          FROM contact_trace ct
+          INNER JOIN name_link as patient_name_link
+            ON ct.patient_link_id = patient_name_link.id
+          LEFT JOIN name_link as contact_patient_name_link
+            ON ct.contact_patient_link_id = contact_patient_name_link.id
+        ;
+        "#
+    )?;
+
+    #[cfg(not(feature = "postgres"))]
+    sql!(
+        connection,
+        r#"
+        CREATE VIEW contact_trace_name_link_view AS
+          SELECT 
+            ct.id AS id,
+            ct.program_id AS program_id,
+            ct.document_id AS document_id,
+            ct.datetime AS datetime,
+            ct.contact_trace_id AS contact_trace_id,
+            patient_name_link.name_id AS patient_id,
+            contact_patient_name_link.name_id AS contact_patient_id,
+            ct.first_name AS first_name,
+            ct.last_name AS last_name,
+            ct.gender AS gender,
+            ct.date_of_birth AS date_of_birth,
+            ct.store_id AS store_id,
+            ct.relationship AS relationship
+          FROM contact_trace ct
+          INNER JOIN name_link as patient_name_link
+            ON ct.patient_link_id = patient_name_link.id
+          LEFT JOIN name_link as contact_patient_name_link
+            ON ct.contact_patient_link_id = contact_patient_name_link.id
+        ;
+        "#
+    )?;
+    Ok(())
+}

--- a/server/repository/src/migrations/v1_06_00/mod.rs
+++ b/server/repository/src/migrations/v1_06_00/mod.rs
@@ -6,6 +6,7 @@ mod changelog_deduped;
 mod clinician_link;
 mod clinician_store_join_add_clinician_link_id;
 mod contact_trace;
+mod contact_trace_link_id;
 mod encounter_add_clinician_link_id;
 mod encounter_status;
 mod indexes;
@@ -68,6 +69,9 @@ impl Migration for V1_06_00 {
         indexes::migrate(connection)?;
         encounter_status::migrate(connection)?;
         changelog_deduped::migrate(connection)?;
+
+        // run after indexes, TODO move when moving migrations to v1_07_00
+        contact_trace_link_id::migrate(connection)?;
         Ok(())
     }
 }

--- a/server/repository/src/mock/mod.rs
+++ b/server/repository/src/mock/mod.rs
@@ -102,19 +102,19 @@ use crate::{
     InventoryAdjustmentReasonRowRepository, InvoiceLineRow, InvoiceLineRowRepository, InvoiceRow,
     ItemLinkRow, ItemLinkRowRepository, ItemRow, KeyValueStoreRepository, KeyValueStoreRow,
     LocationRow, LocationRowRepository, MasterListNameJoinRepository, MasterListNameJoinRow,
-    MasterListRow, MasterListRowRepository, NameLinkRowRepository, NameTagJoinRepository,
-    NameTagJoinRow, NameTagRow, NameTagRowRepository, NumberRow, NumberRowRepository, PeriodRow,
-    PeriodRowRepository, PeriodScheduleRow, PeriodScheduleRowRepository, PluginDataRow,
-    PluginDataRowRepository, ProgramRequisitionOrderTypeRow,
-    ProgramRequisitionOrderTypeRowRepository, ProgramRequisitionSettingsRow,
-    ProgramRequisitionSettingsRowRepository, ProgramRow, ProgramRowRepository, RequisitionLineRow,
-    RequisitionLineRowRepository, RequisitionRow, RequisitionRowRepository, SensorRow,
-    SensorRowRepository, StockLineRowRepository, StocktakeLineRowRepository,
-    StocktakeRowRepository, SyncBufferRow, SyncBufferRowRepository, SyncLogRow,
-    SyncLogRowRepository, TemperatureBreachConfigRow, TemperatureBreachConfigRowRepository,
-    TemperatureBreachRow, TemperatureBreachRowRepository, TemperatureLogRow,
-    TemperatureLogRowRepository, UserAccountRow, UserAccountRowRepository, UserPermissionRow,
-    UserPermissionRowRepository, UserStoreJoinRow, UserStoreJoinRowRepository,
+    MasterListRow, MasterListRowRepository, NameLinkRow, NameLinkRowRepository,
+    NameTagJoinRepository, NameTagJoinRow, NameTagRow, NameTagRowRepository, NumberRow,
+    NumberRowRepository, PeriodRow, PeriodRowRepository, PeriodScheduleRow,
+    PeriodScheduleRowRepository, PluginDataRow, PluginDataRowRepository,
+    ProgramRequisitionOrderTypeRow, ProgramRequisitionOrderTypeRowRepository,
+    ProgramRequisitionSettingsRow, ProgramRequisitionSettingsRowRepository, ProgramRow,
+    ProgramRowRepository, RequisitionLineRow, RequisitionLineRowRepository, RequisitionRow,
+    RequisitionRowRepository, SensorRow, SensorRowRepository, StockLineRowRepository,
+    StocktakeLineRowRepository, StocktakeRowRepository, SyncBufferRow, SyncBufferRowRepository,
+    SyncLogRow, SyncLogRowRepository, TemperatureBreachConfigRow,
+    TemperatureBreachConfigRowRepository, TemperatureBreachRow, TemperatureBreachRowRepository,
+    TemperatureLogRow, TemperatureLogRowRepository, UserAccountRow, UserAccountRowRepository,
+    UserPermissionRow, UserPermissionRowRepository, UserStoreJoinRow, UserStoreJoinRowRepository,
 };
 
 use self::{activity_log::mock_activity_logs, unit::mock_units};
@@ -131,6 +131,7 @@ pub struct MockData {
     pub user_store_joins: Vec<UserStoreJoinRow>,
     pub user_permissions: Vec<UserPermissionRow>,
     pub names: Vec<NameRow>,
+    pub name_links: Vec<NameLinkRow>,
     pub period_schedules: Vec<PeriodScheduleRow>,
     pub periods: Vec<PeriodRow>,
     pub stores: Vec<StoreRow>,
@@ -540,6 +541,7 @@ pub(crate) fn all_mock_data() -> MockDataCollection {
             user_store_joins: mock_user_store_joins(),
             user_permissions: mock_user_permissions(),
             names: mock_names(),
+            name_links: mock_name_links(),
             name_tags: mock_name_tags(),
             period_schedules: mock_period_schedules(),
             periods: mock_periods(),
@@ -636,13 +638,12 @@ pub fn insert_mock_data(
     for (_, mock_data) in &mock_data.data {
         if inserts.names {
             let name_repo = NameRowRepository::new(connection);
-            let name_link_repo = NameLinkRowRepository::new(connection);
-
             for row in &mock_data.names {
-                name_repo.upsert_one(&row).unwrap();
-                name_link_repo
-                    .upsert_one(&mock_name_link_from_name(&row))
-                    .unwrap();
+                name_repo.upsert_one(row).unwrap();
+            }
+            let name_link_repo = NameLinkRowRepository::new(connection);
+            for row in &mock_data.name_links {
+                name_link_repo.upsert_one(row).unwrap();
             }
         }
 
@@ -977,6 +978,7 @@ impl MockData {
         let MockData {
             mut user_accounts,
             mut names,
+            mut name_links,
             mut name_tags,
             mut period_schedules,
             mut periods,
@@ -1026,6 +1028,7 @@ impl MockData {
 
         self.user_accounts.append(&mut user_accounts);
         self.names.append(&mut names);
+        self.name_links.append(&mut name_links);
         self.name_tags.append(&mut name_tags);
         self.period_schedules.append(&mut period_schedules);
         self.periods.append(&mut periods);

--- a/server/repository/src/mock/name.rs
+++ b/server/repository/src/mock/name.rs
@@ -5,13 +5,6 @@ use util::{
 
 use crate::{NameLinkRow, NameRow, NameType};
 
-pub fn mock_name_link_from_name(name: &NameRow) -> NameLinkRow {
-    NameLinkRow {
-        id: name.id.clone(),
-        name_id: name.id.clone(),
-    }
-}
-
 pub fn mock_name_store_a() -> NameRow {
     inline_init(|r: &mut NameRow| {
         r.id = String::from("name_store_a");

--- a/server/repository/src/mock/name.rs
+++ b/server/repository/src/mock/name.rs
@@ -133,6 +133,24 @@ pub fn mock_patient_b() -> NameRow {
     })
 }
 
+// Deleted through a merge
+fn mock_merged_patient() -> NameRow {
+    inline_init(|r: &mut NameRow| {
+        r.id = String::from("softdeleted");
+        r.name = String::from("softdeleted");
+        r.code = String::from("softdeleted");
+        r.is_customer = true;
+        r.r#type = NameType::Patient;
+    })
+}
+
+pub fn mock_merged_patient_name_link() -> NameLinkRow {
+    NameLinkRow {
+        id: mock_merged_patient().id,
+        name_id: mock_patient().id,
+    }
+}
+
 pub fn mock_names() -> Vec<NameRow> {
     vec![
         mock_name_a(),
@@ -147,5 +165,10 @@ pub fn mock_names() -> Vec<NameRow> {
         mock_patient(),
         mock_patient_b(),
         mock_program_master_list_test(),
+        mock_merged_patient(),
     ]
+}
+
+pub fn mock_name_links() -> Vec<NameLinkRow> {
+    vec![mock_merged_patient_name_link()]
 }

--- a/server/repository/src/tests.rs
+++ b/server/repository/src/tests.rs
@@ -274,12 +274,11 @@ mod repository_test {
         mock::{
             mock_draft_request_requisition_line, mock_draft_request_requisition_line2,
             mock_inbound_shipment_number_store_a, mock_item_link_from_item,
-            mock_master_list_master_list_line_filter_test, mock_name_link_from_name,
-            mock_outbound_shipment_number_store_a, mock_request_draft_requisition,
-            mock_request_draft_requisition2, mock_test_master_list_name1,
-            mock_test_master_list_name2, mock_test_master_list_name_filter1,
-            mock_test_master_list_name_filter2, mock_test_master_list_name_filter3,
-            mock_test_master_list_store1, MockDataInserts,
+            mock_master_list_master_list_line_filter_test, mock_outbound_shipment_number_store_a,
+            mock_request_draft_requisition, mock_request_draft_requisition2,
+            mock_test_master_list_name1, mock_test_master_list_name2,
+            mock_test_master_list_name_filter1, mock_test_master_list_name_filter2,
+            mock_test_master_list_name_filter3, mock_test_master_list_store1, MockDataInserts,
         },
         requisition_row::RequisitionRowStatus,
         test_db, ActivityLogRowRepository, InvoiceFilter, InvoiceLineRepository,
@@ -287,8 +286,8 @@ mod repository_test {
         ItemLinkRowRepository, ItemRow, ItemRowRepository, KeyValueStoreRepository, KeyValueType,
         MasterListFilter, MasterListLineFilter, MasterListLineRepository,
         MasterListLineRowRepository, MasterListNameJoinRepository, MasterListRepository,
-        MasterListRowRepository, NameLinkRowRepository, NameRowRepository, NumberRowRepository,
-        NumberRowType, RequisitionFilter, RequisitionLineFilter, RequisitionLineRepository,
+        MasterListRowRepository, NameRowRepository, NumberRowRepository, NumberRowType,
+        RequisitionFilter, RequisitionLineFilter, RequisitionLineRepository,
         RequisitionLineRowRepository, RequisitionRepository, RequisitionRowRepository,
         StockLineFilter, StockLineRepository, StockLineRowRepository, StorageConnection,
         StoreRowRepository, UserAccountRowRepository,
@@ -571,9 +570,6 @@ mod repository_test {
         // setup
         let name_repo = NameRowRepository::new(&connection);
         name_repo.insert_one(&data::name_1()).await.unwrap();
-        NameLinkRowRepository::new(&connection)
-            .upsert_one(&mock_name_link_from_name(&data::name_1()))
-            .unwrap();
         MasterListRowRepository::new(&connection)
             .upsert_one(&data::master_list_1())
             .unwrap();


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2683 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
This was tricky one because the contact_trace table has a reference to two name_id and the used diesel version doesn't support joining a table twice. The solution was to create view that does all the joining. On the plus side the Rust changes are comparatively small and the link logic is completely hidden in the repository layer.

Added some mock functionality to update name_links (simulate merges). Just saw in another PR that there was something similar for items (?). Might have to align it, let me know what you think.

Also did some clean up where name_link were updated twice...