### PR TITLE
Ignore acknowledge status from CCA

### DIFF
--- a/server/server/src/cold_chain/temperature_breach.rs
+++ b/server/server/src/cold_chain/temperature_breach.rs
@@ -24,7 +24,7 @@ use super::validate_request;
 #[serde(rename_all = "camelCase")]
 pub struct TemperatureBreach {
     id: String,
-    acknowledged: bool,
+    // acknowledged: bool,
     #[serde(rename = "endTimestamp")]
     end_unix_timestamp: Option<i64>,
     sensor_id: String,
@@ -157,7 +157,8 @@ fn upsert_temperature_breach(
                 threshold_duration_milliseconds: breach.threshold_duration_milliseconds,
                 threshold_maximum: breach.threshold_maximum,
                 threshold_minimum: breach.threshold_minimum,
-                comment: breach.comment,
+                // updating the comment is not supported by the API
+                comment: existing_breach.temperature_breach_row.comment,
             };
             service
                 .update_temperature_breach(&ctx, breach)

--- a/server/server/src/cold_chain/temperature_breach.rs
+++ b/server/server/src/cold_chain/temperature_breach.rs
@@ -140,8 +140,10 @@ fn upsert_temperature_breach(
         None => None,
     };
 
+    // acknowledgement is the concern of open mSupply - to allow entry of comments
+    // therefore ignore the acknowledgement status of the incoming breach
     let result = match service.get_temperature_breach(&ctx, id.clone()) {
-        Ok(_) => {
+        Ok(existing_breach) => {
             let breach = UpdateTemperatureBreach {
                 id: id.clone(),
                 location_id: sensor.sensor_row.location_id,
@@ -150,7 +152,8 @@ fn upsert_temperature_breach(
                 r#type: breach.r#type,
                 start_datetime,
                 end_datetime,
-                unacknowledged: !breach.acknowledged,
+                // ignore the acknowledgement status of the breach when updating
+                unacknowledged: existing_breach.temperature_breach_row.unacknowledged,
                 threshold_duration_milliseconds: breach.threshold_duration_milliseconds,
                 threshold_maximum: breach.threshold_maximum,
                 threshold_minimum: breach.threshold_minimum,
@@ -169,7 +172,7 @@ fn upsert_temperature_breach(
                 r#type: breach.r#type,
                 start_datetime,
                 end_datetime,
-                unacknowledged: !breach.acknowledged,
+                unacknowledged: true, // new breaches are always unacknowledged
                 threshold_duration_milliseconds: breach.threshold_duration_milliseconds,
                 threshold_maximum: breach.threshold_maximum,
                 threshold_minimum: breach.threshold_minimum,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2704

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Ignore the breach acknowledgement status sent by the CCA via the API

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Send a breach using the API
- new breaches: unacknowledged is always true
- updated breaches: unacknowledged remains as it was
- the comment entered by a user won't be overwritten by the CCA API call either

here's my postman collection which has the login and breach creation calls:

[Cold Chain.postman_collection.json](https://github.com/msupply-foundation/open-msupply/files/13943252/Cold.Chain.postman_collection.json)


## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
