### PR TITLE
Name merging name store join.name id translator get actual name.id

### DIFF
--- a/server/service/src/sync/translations/name_store_join.rs
+++ b/server/service/src/sync/translations/name_store_join.rs
@@ -166,8 +166,13 @@ impl SyncTranslation for NameStoreJoinTranslation {
 
 #[cfg(test)]
 mod tests {
+    use crate::sync::test::merge_helpers::name_links_merged;
+
     use super::*;
-    use repository::{mock::MockDataInserts, test_db::setup_all};
+    use repository::{
+        mock::MockDataInserts, test_db::setup_all, ChangelogFilter, ChangelogRepository,
+    };
+    use serde_json::json;
 
     #[actix_rt::test]
     async fn test_name_store_join_translation() {
@@ -202,6 +207,35 @@ mod tests {
                 .unwrap();
 
             assert_eq!(translation_result, record.translated_record);
+        }
+    }
+
+    #[actix_rt::test]
+    async fn test_name_store_join_push_merged() {
+        let (mock_data, connection, _, _) =
+            setup_all("test_name_store_join_push_merged", MockDataInserts::all()).await;
+
+        name_links_merged(&connection, &mock_data).unwrap();
+
+        let repo = ChangelogRepository::new(&connection);
+        let changelogs = repo
+            .changelogs(
+                0,
+                1_000_000,
+                Some(
+                    ChangelogFilter::new().table_name(ChangelogTableName::NameStoreJoin.equal_to()),
+                ),
+            )
+            .unwrap();
+
+        let translator = NameStoreJoinTranslation {};
+        for changelog in changelogs {
+            let translated = translator
+                .try_translate_push_upsert(&connection, &changelog)
+                .unwrap()
+                .unwrap();
+
+            assert_eq!(translated[0].record.data["name_ID"], json!("name_a"));
         }
     }
 }

--- a/server/service/src/sync/translations/special/name_to_name_store_join.rs
+++ b/server/service/src/sync/translations/special/name_to_name_store_join.rs
@@ -52,9 +52,9 @@ impl SyncTranslation for NameToNameStoreJoinTranslation {
         let upserts: Vec<PullUpsertRecord> = name_store_joins
             .into_iter()
             .map(|mut r| {
-                r.name_is_customer = data.name_is_customer;
-                r.name_is_supplier = data.name_is_supplier;
-                PullUpsertRecord::NameStoreJoin(r)
+                r.name_store_join.name_is_customer = data.name_is_customer;
+                r.name_store_join.name_is_supplier = data.name_is_supplier;
+                PullUpsertRecord::NameStoreJoin(r.name_store_join)
             })
             .collect();
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2749

# 👩🏻‍💻 What does this PR do? 
Create a join that also returns `name_row` and use that to get the correct name_id.

# 🧪 How has/should this change been tested? 
- Run tests