### PR TITLE
Name merging requisition.name id translator get actual name.id

### DIFF
--- a/server/repository/src/mock/mod.rs
+++ b/server/repository/src/mock/mod.rs
@@ -387,6 +387,11 @@ impl MockDataInserts {
         self
     }
 
+    pub fn requisitions(mut self) -> Self {
+        self.requisitions = true;
+        self
+    }
+
     pub fn full_requisitions(mut self) -> Self {
         self.full_requisitions = true;
         self

--- a/server/repository/src/mock/test_requisition_service.rs
+++ b/server/repository/src/mock/test_requisition_service.rs
@@ -41,7 +41,7 @@ pub fn mock_test_requisition_service() -> MockData {
         .push(mock_request_draft_requisition_calculation_test());
     result
         .full_requisitions
-        .push(mock_new_response_requisition_for_update_test());
+        .push(mock_full_draft_response_requisition_for_update_test());
     result
         .full_requisitions
         .push(mock_new_response_requisition_test());
@@ -201,10 +201,10 @@ pub fn mock_draft_response_requisition_for_update_test_line() -> RequisitionLine
     })
 }
 
-pub fn mock_new_response_requisition_for_update_test() -> FullMockRequisition {
+pub fn mock_full_draft_response_requisition_for_update_test() -> FullMockRequisition {
     FullMockRequisition {
         requisition: inline_init(|r: &mut RequisitionRow| {
-            r.id = "mock_new_response_requisition_for_update_test".to_owned();
+            r.id = "mock_full_draft_response_requisition_for_update_test".to_owned();
             r.requisition_number = 10;
             r.name_id = "name_a".to_owned();
             r.store_id = mock_store_a().id;
@@ -218,8 +218,8 @@ pub fn mock_new_response_requisition_for_update_test() -> FullMockRequisition {
             r.min_months_of_stock = 0.9;
         }),
         lines: vec![inline_init(|r: &mut RequisitionLineRow| {
-            r.id = "mock_new_response_requisition_for_update_test_line".to_owned();
-            r.requisition_id = "mock_new_response_requisition_for_update_test".to_string();
+            r.id = "mock_full_draft_response_requisition_for_update_test_line".to_owned();
+            r.requisition_id = "mock_full_draft_response_requisition_for_update_test".to_string();
             r.item_id = mock_item_a().id;
             r.requested_quantity = 10;
             r.suggested_quantity = 5;

--- a/server/repository/src/mock/test_requisition_service.rs
+++ b/server/repository/src/mock/test_requisition_service.rs
@@ -21,7 +21,7 @@ pub fn mock_test_requisition_service() -> MockData {
         .push(mock_sent_request_requisition_line());
     result
         .requisition_lines
-        .push(mock_draft_response_requisition_for_update_test_line());
+        .push(mock_new_response_requisition_for_update_test_line());
     result
         .requisition_lines
         .push(mock_finalised_request_requisition_line());
@@ -30,7 +30,7 @@ pub fn mock_test_requisition_service() -> MockData {
         .push(mock_draft_request_requisition_for_update_test());
     result
         .requisitions
-        .push(mock_draft_response_requisition_for_update_test());
+        .push(mock_new_response_requisition_for_update_test());
     result
         .requisitions
         .push(mock_finalised_response_requisition());
@@ -155,9 +155,9 @@ pub fn mock_finalised_request_requisition_line() -> RequisitionLineRow {
     })
 }
 
-pub fn mock_draft_response_requisition_for_update_test() -> RequisitionRow {
+pub fn mock_new_response_requisition_for_update_test() -> RequisitionRow {
     inline_init(|r: &mut RequisitionRow| {
-        r.id = "mock_draft_response_requisition_for_update_test".to_owned();
+        r.id = "mock_new_response_requisition_for_update_test".to_owned();
         r.requisition_number = 3;
         r.name_id = "name_a".to_owned();
         r.store_id = mock_store_a().id;
@@ -189,10 +189,10 @@ pub fn mock_new_response_requisition() -> RequisitionRow {
     })
 }
 
-pub fn mock_draft_response_requisition_for_update_test_line() -> RequisitionLineRow {
+pub fn mock_new_response_requisition_for_update_test_line() -> RequisitionLineRow {
     inline_init(|r: &mut RequisitionLineRow| {
-        r.id = "mock_draft_response_requisition_for_update_test_line".to_owned();
-        r.requisition_id = mock_draft_response_requisition_for_update_test().id;
+        r.id = "mock_new_response_requisition_for_update_test_line".to_owned();
+        r.requisition_id = mock_new_response_requisition_for_update_test().id;
         r.item_id = mock_item_a().id;
         r.requested_quantity = 10;
         r.suggested_quantity = 5;

--- a/server/repository/src/mock/test_requisition_service.rs
+++ b/server/repository/src/mock/test_requisition_service.rs
@@ -41,6 +41,9 @@ pub fn mock_test_requisition_service() -> MockData {
         .push(mock_request_draft_requisition_calculation_test());
     result
         .full_requisitions
+        .push(mock_full_draft_response_requisition_for_update_test());
+    result
+        .full_requisitions
         .push(mock_new_response_requisition_test());
     result
         .full_master_lists
@@ -159,7 +162,7 @@ pub fn mock_draft_response_requisition_for_update_test() -> RequisitionRow {
         r.name_id = "name_a".to_owned();
         r.store_id = mock_store_a().id;
         r.r#type = RequisitionRowType::Response;
-        r.status = RequisitionRowStatus::Draft;
+        r.status = RequisitionRowStatus::New;
         r.created_datetime = NaiveDate::from_ymd_opt(2021, 01, 01)
             .unwrap()
             .and_hms_opt(0, 0, 0)
@@ -196,6 +199,34 @@ pub fn mock_draft_response_requisition_for_update_test_line() -> RequisitionLine
         r.available_stock_on_hand = 1;
         r.average_monthly_consumption = 1;
     })
+}
+
+pub fn mock_full_draft_response_requisition_for_update_test() -> FullMockRequisition {
+    FullMockRequisition {
+        requisition: inline_init(|r: &mut RequisitionRow| {
+            r.id = "mock_full_draft_response_requisition_for_update_test".to_owned();
+            r.requisition_number = 10;
+            r.name_id = "name_a".to_owned();
+            r.store_id = mock_store_a().id;
+            r.r#type = RequisitionRowType::Response;
+            r.status = RequisitionRowStatus::Draft;
+            r.created_datetime = NaiveDate::from_ymd_opt(2021, 01, 01)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap();
+            r.max_months_of_stock = 1.0;
+            r.min_months_of_stock = 0.9;
+        }),
+        lines: vec![inline_init(|r: &mut RequisitionLineRow| {
+            r.id = "mock_full_draft_response_requisition_for_update_test_line".to_owned();
+            r.requisition_id = "mock_full_draft_response_requisition_for_update_test".to_string();
+            r.item_id = mock_item_a().id;
+            r.requested_quantity = 10;
+            r.suggested_quantity = 5;
+            r.available_stock_on_hand = 1;
+            r.average_monthly_consumption = 1;
+        })],
+    }
 }
 
 pub fn mock_request_draft_requisition_calculation_test() -> FullMockRequisition {

--- a/server/repository/src/mock/test_requisition_service.rs
+++ b/server/repository/src/mock/test_requisition_service.rs
@@ -41,7 +41,7 @@ pub fn mock_test_requisition_service() -> MockData {
         .push(mock_request_draft_requisition_calculation_test());
     result
         .full_requisitions
-        .push(mock_full_draft_response_requisition_for_update_test());
+        .push(mock_new_response_requisition_for_update_test());
     result
         .full_requisitions
         .push(mock_new_response_requisition_test());
@@ -201,10 +201,10 @@ pub fn mock_draft_response_requisition_for_update_test_line() -> RequisitionLine
     })
 }
 
-pub fn mock_full_draft_response_requisition_for_update_test() -> FullMockRequisition {
+pub fn mock_new_response_requisition_for_update_test() -> FullMockRequisition {
     FullMockRequisition {
         requisition: inline_init(|r: &mut RequisitionRow| {
-            r.id = "mock_full_draft_response_requisition_for_update_test".to_owned();
+            r.id = "mock_new_response_requisition_for_update_test".to_owned();
             r.requisition_number = 10;
             r.name_id = "name_a".to_owned();
             r.store_id = mock_store_a().id;
@@ -218,8 +218,8 @@ pub fn mock_full_draft_response_requisition_for_update_test() -> FullMockRequisi
             r.min_months_of_stock = 0.9;
         }),
         lines: vec![inline_init(|r: &mut RequisitionLineRow| {
-            r.id = "mock_full_draft_response_requisition_for_update_test_line".to_owned();
-            r.requisition_id = "mock_full_draft_response_requisition_for_update_test".to_string();
+            r.id = "mock_new_response_requisition_for_update_test_line".to_owned();
+            r.requisition_id = "mock_new_response_requisition_for_update_test".to_string();
             r.item_id = mock_item_a().id;
             r.requested_quantity = 10;
             r.suggested_quantity = 5;

--- a/server/service/src/requisition/request_requisition/add_from_master_list.rs
+++ b/server/service/src/requisition/request_requisition/add_from_master_list.rs
@@ -144,10 +144,10 @@ mod test {
         mock::{
             common::FullMockMasterList,
             mock_draft_request_requisition_for_update_test,
-            mock_draft_response_requisition_for_update_test, mock_item_a, mock_item_b, mock_item_c,
-            mock_item_d, mock_name_store_a, mock_request_draft_requisition_calculation_test,
-            mock_sent_request_requisition, mock_store_a, mock_store_b,
-            mock_test_not_store_a_master_list,
+            mock_full_draft_response_requisition_for_update_test, mock_item_a, mock_item_b,
+            mock_item_c, mock_item_d, mock_name_store_a,
+            mock_request_draft_requisition_calculation_test, mock_sent_request_requisition,
+            mock_store_a, mock_store_b, mock_test_not_store_a_master_list,
             test_item_stats::{self},
             MockData, MockDataInserts,
         },
@@ -204,7 +204,9 @@ mod test {
             service.add_from_master_list(
                 &context,
                 AddFromMasterList {
-                    request_requisition_id: mock_draft_response_requisition_for_update_test().id,
+                    request_requisition_id: mock_full_draft_response_requisition_for_update_test()
+                        .requisition
+                        .id,
                     master_list_id: "n/a".to_owned()
                 },
             ),

--- a/server/service/src/requisition/request_requisition/add_from_master_list.rs
+++ b/server/service/src/requisition/request_requisition/add_from_master_list.rs
@@ -143,8 +143,9 @@ mod test {
     use repository::{
         mock::{
             common::FullMockMasterList,
-            mock_draft_request_requisition_for_update_test, mock_item_a, mock_item_b, mock_item_c,
-            mock_item_d, mock_name_store_a, mock_new_response_requisition_for_update_test,
+            mock_draft_request_requisition_for_update_test,
+            mock_full_draft_response_requisition_for_update_test, mock_item_a, mock_item_b,
+            mock_item_c, mock_item_d, mock_name_store_a,
             mock_request_draft_requisition_calculation_test, mock_sent_request_requisition,
             mock_store_a, mock_store_b, mock_test_not_store_a_master_list,
             test_item_stats::{self},
@@ -203,7 +204,7 @@ mod test {
             service.add_from_master_list(
                 &context,
                 AddFromMasterList {
-                    request_requisition_id: mock_new_response_requisition_for_update_test()
+                    request_requisition_id: mock_full_draft_response_requisition_for_update_test()
                         .requisition
                         .id,
                     master_list_id: "n/a".to_owned()

--- a/server/service/src/requisition/request_requisition/add_from_master_list.rs
+++ b/server/service/src/requisition/request_requisition/add_from_master_list.rs
@@ -143,9 +143,8 @@ mod test {
     use repository::{
         mock::{
             common::FullMockMasterList,
-            mock_draft_request_requisition_for_update_test,
-            mock_full_draft_response_requisition_for_update_test, mock_item_a, mock_item_b,
-            mock_item_c, mock_item_d, mock_name_store_a,
+            mock_draft_request_requisition_for_update_test, mock_item_a, mock_item_b, mock_item_c,
+            mock_item_d, mock_name_store_a, mock_new_response_requisition_for_update_test,
             mock_request_draft_requisition_calculation_test, mock_sent_request_requisition,
             mock_store_a, mock_store_b, mock_test_not_store_a_master_list,
             test_item_stats::{self},
@@ -204,7 +203,7 @@ mod test {
             service.add_from_master_list(
                 &context,
                 AddFromMasterList {
-                    request_requisition_id: mock_full_draft_response_requisition_for_update_test()
+                    request_requisition_id: mock_new_response_requisition_for_update_test()
                         .requisition
                         .id,
                     master_list_id: "n/a".to_owned()

--- a/server/service/src/requisition/request_requisition/batch.rs
+++ b/server/service/src/requisition/request_requisition/batch.rs
@@ -130,7 +130,7 @@ pub fn batch_request_requisition(
 mod test {
     use repository::{
         mock::{
-            mock_draft_response_requisition_for_update_test, mock_item_a, mock_name_store_c,
+            mock_full_draft_response_requisition_for_update_test, mock_item_a, mock_name_store_c,
             mock_store_a, MockDataInserts,
         },
         test_db::setup_all,
@@ -160,7 +160,9 @@ mod test {
         let service = service_provider.requisition_service;
 
         let delete_requisition_input = inline_init(|input: &mut DeleteRequestRequisition| {
-            input.id = mock_draft_response_requisition_for_update_test().id;
+            input.id = mock_full_draft_response_requisition_for_update_test()
+                .requisition
+                .id;
         });
 
         let mut input = BatchRequestRequisition {

--- a/server/service/src/requisition/request_requisition/batch.rs
+++ b/server/service/src/requisition/request_requisition/batch.rs
@@ -130,7 +130,7 @@ pub fn batch_request_requisition(
 mod test {
     use repository::{
         mock::{
-            mock_item_a, mock_name_store_c, mock_new_response_requisition_for_update_test,
+            mock_full_draft_response_requisition_for_update_test, mock_item_a, mock_name_store_c,
             mock_store_a, MockDataInserts,
         },
         test_db::setup_all,
@@ -160,7 +160,7 @@ mod test {
         let service = service_provider.requisition_service;
 
         let delete_requisition_input = inline_init(|input: &mut DeleteRequestRequisition| {
-            input.id = mock_new_response_requisition_for_update_test()
+            input.id = mock_full_draft_response_requisition_for_update_test()
                 .requisition
                 .id;
         });

--- a/server/service/src/requisition/request_requisition/batch.rs
+++ b/server/service/src/requisition/request_requisition/batch.rs
@@ -130,7 +130,7 @@ pub fn batch_request_requisition(
 mod test {
     use repository::{
         mock::{
-            mock_full_draft_response_requisition_for_update_test, mock_item_a, mock_name_store_c,
+            mock_item_a, mock_name_store_c, mock_new_response_requisition_for_update_test,
             mock_store_a, MockDataInserts,
         },
         test_db::setup_all,
@@ -160,7 +160,7 @@ mod test {
         let service = service_provider.requisition_service;
 
         let delete_requisition_input = inline_init(|input: &mut DeleteRequestRequisition| {
-            input.id = mock_full_draft_response_requisition_for_update_test()
+            input.id = mock_new_response_requisition_for_update_test()
                 .requisition
                 .id;
         });

--- a/server/service/src/requisition/request_requisition/delete.rs
+++ b/server/service/src/requisition/request_requisition/delete.rs
@@ -122,7 +122,7 @@ mod test_delete {
     use repository::{
         mock::{
             mock_draft_request_requisition_for_update_test,
-            mock_new_response_requisition_for_update_test, mock_sent_request_requisition,
+            mock_full_draft_response_requisition_for_update_test, mock_sent_request_requisition,
             mock_store_a, mock_store_b, MockDataInserts,
         },
         test_db::setup_all,
@@ -174,7 +174,7 @@ mod test_delete {
             service.delete_request_requisition(
                 &context,
                 DeleteRequestRequisition {
-                    id: mock_new_response_requisition_for_update_test()
+                    id: mock_full_draft_response_requisition_for_update_test()
                         .requisition
                         .id,
                 },

--- a/server/service/src/requisition/request_requisition/delete.rs
+++ b/server/service/src/requisition/request_requisition/delete.rs
@@ -122,7 +122,7 @@ mod test_delete {
     use repository::{
         mock::{
             mock_draft_request_requisition_for_update_test,
-            mock_full_draft_response_requisition_for_update_test, mock_sent_request_requisition,
+            mock_new_response_requisition_for_update_test, mock_sent_request_requisition,
             mock_store_a, mock_store_b, MockDataInserts,
         },
         test_db::setup_all,
@@ -174,7 +174,7 @@ mod test_delete {
             service.delete_request_requisition(
                 &context,
                 DeleteRequestRequisition {
-                    id: mock_full_draft_response_requisition_for_update_test()
+                    id: mock_new_response_requisition_for_update_test()
                         .requisition
                         .id,
                 },

--- a/server/service/src/requisition/request_requisition/delete.rs
+++ b/server/service/src/requisition/request_requisition/delete.rs
@@ -122,7 +122,7 @@ mod test_delete {
     use repository::{
         mock::{
             mock_draft_request_requisition_for_update_test,
-            mock_draft_response_requisition_for_update_test, mock_sent_request_requisition,
+            mock_full_draft_response_requisition_for_update_test, mock_sent_request_requisition,
             mock_store_a, mock_store_b, MockDataInserts,
         },
         test_db::setup_all,
@@ -174,7 +174,9 @@ mod test_delete {
             service.delete_request_requisition(
                 &context,
                 DeleteRequestRequisition {
-                    id: mock_draft_response_requisition_for_update_test().id,
+                    id: mock_full_draft_response_requisition_for_update_test()
+                        .requisition
+                        .id,
                 },
             ),
             Err(ServiceError::NotARequestRequisition)

--- a/server/service/src/requisition/request_requisition/update/test.rs
+++ b/server/service/src/requisition/request_requisition/update/test.rs
@@ -4,7 +4,7 @@ mod test_update {
     use repository::{
         mock::{
             mock_draft_request_requisition_for_update_test,
-            mock_draft_response_requisition_for_update_test, mock_name_store_c,
+            mock_full_draft_response_requisition_for_update_test, mock_name_store_c,
             mock_request_draft_requisition_calculation_test, mock_request_program_requisition,
             mock_sent_request_requisition, mock_store_a, mock_store_b, MockData, MockDataInserts,
         },
@@ -89,7 +89,9 @@ mod test_update {
             service.update_request_requisition(
                 &context,
                 inline_init(|r: &mut UpdateRequestRequisition| {
-                    r.id = mock_draft_response_requisition_for_update_test().id;
+                    r.id = mock_full_draft_response_requisition_for_update_test()
+                        .requisition
+                        .id;
                 }),
             ),
             Err(ServiceError::NotARequestRequisition)

--- a/server/service/src/requisition/request_requisition/update/test.rs
+++ b/server/service/src/requisition/request_requisition/update/test.rs
@@ -3,8 +3,8 @@ mod test_update {
     use chrono::{NaiveDate, Utc};
     use repository::{
         mock::{
-            mock_draft_request_requisition_for_update_test,
-            mock_full_draft_response_requisition_for_update_test, mock_name_store_c,
+            mock_draft_request_requisition_for_update_test, mock_name_store_c,
+            mock_new_response_requisition_for_update_test,
             mock_request_draft_requisition_calculation_test, mock_request_program_requisition,
             mock_sent_request_requisition, mock_store_a, mock_store_b, MockData, MockDataInserts,
         },
@@ -89,7 +89,7 @@ mod test_update {
             service.update_request_requisition(
                 &context,
                 inline_init(|r: &mut UpdateRequestRequisition| {
-                    r.id = mock_full_draft_response_requisition_for_update_test()
+                    r.id = mock_new_response_requisition_for_update_test()
                         .requisition
                         .id;
                 }),

--- a/server/service/src/requisition/request_requisition/update/test.rs
+++ b/server/service/src/requisition/request_requisition/update/test.rs
@@ -3,8 +3,8 @@ mod test_update {
     use chrono::{NaiveDate, Utc};
     use repository::{
         mock::{
-            mock_draft_request_requisition_for_update_test, mock_name_store_c,
-            mock_new_response_requisition_for_update_test,
+            mock_draft_request_requisition_for_update_test,
+            mock_full_draft_response_requisition_for_update_test, mock_name_store_c,
             mock_request_draft_requisition_calculation_test, mock_request_program_requisition,
             mock_sent_request_requisition, mock_store_a, mock_store_b, MockData, MockDataInserts,
         },
@@ -89,7 +89,7 @@ mod test_update {
             service.update_request_requisition(
                 &context,
                 inline_init(|r: &mut UpdateRequestRequisition| {
-                    r.id = mock_new_response_requisition_for_update_test()
+                    r.id = mock_full_draft_response_requisition_for_update_test()
                         .requisition
                         .id;
                 }),

--- a/server/service/src/requisition/request_requisition/use_suggested_quantity.rs
+++ b/server/service/src/requisition/request_requisition/use_suggested_quantity.rs
@@ -110,7 +110,7 @@ mod test {
     use repository::{
         mock::{
             mock_draft_request_requisition_for_update_test,
-            mock_new_response_requisition_for_update_test,
+            mock_full_draft_response_requisition_for_update_test,
             mock_request_draft_requisition_calculation_test, mock_sent_request_requisition,
             mock_store_a, mock_store_b, MockDataInserts,
         },
@@ -165,7 +165,7 @@ mod test {
             service.use_suggested_quantity(
                 &context,
                 UseSuggestedQuantity {
-                    request_requisition_id: mock_new_response_requisition_for_update_test()
+                    request_requisition_id: mock_full_draft_response_requisition_for_update_test()
                         .requisition
                         .id,
                 },

--- a/server/service/src/requisition/request_requisition/use_suggested_quantity.rs
+++ b/server/service/src/requisition/request_requisition/use_suggested_quantity.rs
@@ -110,7 +110,7 @@ mod test {
     use repository::{
         mock::{
             mock_draft_request_requisition_for_update_test,
-            mock_draft_response_requisition_for_update_test,
+            mock_full_draft_response_requisition_for_update_test,
             mock_request_draft_requisition_calculation_test, mock_sent_request_requisition,
             mock_store_a, mock_store_b, MockDataInserts,
         },
@@ -165,7 +165,9 @@ mod test {
             service.use_suggested_quantity(
                 &context,
                 UseSuggestedQuantity {
-                    request_requisition_id: mock_draft_response_requisition_for_update_test().id,
+                    request_requisition_id: mock_full_draft_response_requisition_for_update_test()
+                        .requisition
+                        .id,
                 },
             ),
             Err(ServiceError::NotARequestRequisition)

--- a/server/service/src/requisition/request_requisition/use_suggested_quantity.rs
+++ b/server/service/src/requisition/request_requisition/use_suggested_quantity.rs
@@ -110,7 +110,7 @@ mod test {
     use repository::{
         mock::{
             mock_draft_request_requisition_for_update_test,
-            mock_full_draft_response_requisition_for_update_test,
+            mock_new_response_requisition_for_update_test,
             mock_request_draft_requisition_calculation_test, mock_sent_request_requisition,
             mock_store_a, mock_store_b, MockDataInserts,
         },
@@ -165,7 +165,7 @@ mod test {
             service.use_suggested_quantity(
                 &context,
                 UseSuggestedQuantity {
-                    request_requisition_id: mock_full_draft_response_requisition_for_update_test()
+                    request_requisition_id: mock_new_response_requisition_for_update_test()
                         .requisition
                         .id,
                 },

--- a/server/service/src/requisition/response_requisition/create_requisition_shipment/test.rs
+++ b/server/service/src/requisition/response_requisition/create_requisition_shipment/test.rs
@@ -4,7 +4,7 @@ mod test_update {
     use repository::EqualFilter;
     use repository::{
         mock::{
-            mock_draft_response_requisition_for_update_test, mock_finalised_response_requisition,
+            mock_finalised_response_requisition, mock_new_response_requisition_for_update_test,
             mock_new_response_requisition_test, mock_sent_request_requisition, MockDataInserts,
         },
         test_db::setup_all,
@@ -70,7 +70,7 @@ mod test_update {
             service.create_requisition_shipment(
                 &context,
                 CreateRequisitionShipment {
-                    response_requisition_id: mock_draft_response_requisition_for_update_test().id,
+                    response_requisition_id: mock_new_response_requisition_for_update_test().id,
                 },
             ),
             Err(ServiceError::NotThisStoreRequisition)

--- a/server/service/src/requisition/response_requisition/supply_requested_quantity.rs
+++ b/server/service/src/requisition/response_requisition/supply_requested_quantity.rs
@@ -139,7 +139,8 @@ impl From<RepositoryError> for SupplyRequestedQuantityError {
 mod test {
     use repository::{
         mock::{
-            mock_draft_response_requisition_for_update_test, mock_finalised_response_requisition,
+            mock_finalised_response_requisition,
+            mock_full_draft_response_requisition_for_update_test,
             mock_new_response_requisition_test, mock_sent_request_requisition, mock_store_a,
             mock_store_b, mock_user_account_b, MockDataInserts,
         },
@@ -209,7 +210,9 @@ mod test {
             service.supply_requested_quantity(
                 &context,
                 SupplyRequestedQuantity {
-                    response_requisition_id: mock_draft_response_requisition_for_update_test().id,
+                    response_requisition_id: mock_full_draft_response_requisition_for_update_test()
+                        .requisition
+                        .id,
                 },
             ),
             Err(ServiceError::NotThisStoreRequisition)

--- a/server/service/src/requisition/response_requisition/supply_requested_quantity.rs
+++ b/server/service/src/requisition/response_requisition/supply_requested_quantity.rs
@@ -139,7 +139,8 @@ impl From<RepositoryError> for SupplyRequestedQuantityError {
 mod test {
     use repository::{
         mock::{
-            mock_finalised_response_requisition, mock_new_response_requisition_for_update_test,
+            mock_finalised_response_requisition,
+            mock_full_draft_response_requisition_for_update_test,
             mock_new_response_requisition_test, mock_sent_request_requisition, mock_store_a,
             mock_store_b, mock_user_account_b, MockDataInserts,
         },
@@ -209,7 +210,7 @@ mod test {
             service.supply_requested_quantity(
                 &context,
                 SupplyRequestedQuantity {
-                    response_requisition_id: mock_new_response_requisition_for_update_test()
+                    response_requisition_id: mock_full_draft_response_requisition_for_update_test()
                         .requisition
                         .id,
                 },

--- a/server/service/src/requisition/response_requisition/supply_requested_quantity.rs
+++ b/server/service/src/requisition/response_requisition/supply_requested_quantity.rs
@@ -139,8 +139,7 @@ impl From<RepositoryError> for SupplyRequestedQuantityError {
 mod test {
     use repository::{
         mock::{
-            mock_finalised_response_requisition,
-            mock_full_draft_response_requisition_for_update_test,
+            mock_finalised_response_requisition, mock_new_response_requisition_for_update_test,
             mock_new_response_requisition_test, mock_sent_request_requisition, mock_store_a,
             mock_store_b, mock_user_account_b, MockDataInserts,
         },
@@ -210,7 +209,7 @@ mod test {
             service.supply_requested_quantity(
                 &context,
                 SupplyRequestedQuantity {
-                    response_requisition_id: mock_full_draft_response_requisition_for_update_test()
+                    response_requisition_id: mock_new_response_requisition_for_update_test()
                         .requisition
                         .id,
                 },

--- a/server/service/src/requisition/response_requisition/update.rs
+++ b/server/service/src/requisition/response_requisition/update.rs
@@ -144,8 +144,8 @@ mod test_update {
     use chrono::Utc;
     use repository::{
         mock::{
-            mock_draft_response_requisition_for_update_test, mock_finalised_response_requisition,
-            mock_new_response_requisition, mock_response_program_requisition,
+            mock_finalised_response_requisition, mock_new_response_requisition,
+            mock_new_response_requisition_for_update_test, mock_response_program_requisition,
             mock_sent_request_requisition, mock_store_a, mock_store_b, mock_user_account_b,
             MockDataInserts,
         },
@@ -225,7 +225,7 @@ mod test_update {
             service.update_response_requisition(
                 &context,
                 UpdateResponseRequisition {
-                    id: mock_draft_response_requisition_for_update_test().id,
+                    id: mock_new_response_requisition_for_update_test().id,
                     colour: None,
                     status: None,
                     their_reference: None,

--- a/server/service/src/requisition_line/chart/mod.rs
+++ b/server/service/src/requisition_line/chart/mod.rs
@@ -173,7 +173,7 @@ mod test {
     use repository::{
         db_diesel::requisition_row::RequisitionRowType,
         mock::{
-            mock_draft_response_requisition_for_update_test_line, mock_item_a, mock_name_a,
+            mock_item_a, mock_name_a, mock_new_response_requisition_for_update_test_line,
             mock_store_a, mock_store_b, MockData, MockDataInserts,
         },
         test_db::{setup_all, setup_all_with_data},
@@ -208,7 +208,7 @@ mod test {
             Err(ServiceError::RequisitionLineDoesNotExist)
         );
 
-        let test_line = mock_draft_response_requisition_for_update_test_line();
+        let test_line = mock_new_response_requisition_for_update_test_line();
 
         // NotARequestRequisition
         assert_eq!(

--- a/server/service/src/requisition_line/request_requisition_line/delete.rs
+++ b/server/service/src/requisition_line/request_requisition_line/delete.rs
@@ -79,7 +79,7 @@ impl From<RepositoryError> for DeleteRequestRequisitionLineError {
 mod test {
     use repository::{
         mock::{
-            mock_draft_response_requisition_for_update_test_line,
+            mock_full_draft_response_requisition_for_update_test,
             mock_request_draft_requisition_calculation_test, mock_sent_request_requisition_line,
             mock_store_a, mock_store_b, MockDataInserts,
         },
@@ -135,7 +135,9 @@ mod test {
             service.delete_request_requisition_line(
                 &context,
                 DeleteRequestRequisitionLine {
-                    id: mock_draft_response_requisition_for_update_test_line().id,
+                    id: mock_full_draft_response_requisition_for_update_test().lines[0]
+                        .id
+                        .clone(),
                 },
             ),
             Err(ServiceError::NotARequestRequisition)

--- a/server/service/src/requisition_line/request_requisition_line/delete.rs
+++ b/server/service/src/requisition_line/request_requisition_line/delete.rs
@@ -79,7 +79,7 @@ impl From<RepositoryError> for DeleteRequestRequisitionLineError {
 mod test {
     use repository::{
         mock::{
-            mock_full_draft_response_requisition_for_update_test,
+            mock_new_response_requisition_for_update_test,
             mock_request_draft_requisition_calculation_test, mock_sent_request_requisition_line,
             mock_store_a, mock_store_b, MockDataInserts,
         },
@@ -135,7 +135,7 @@ mod test {
             service.delete_request_requisition_line(
                 &context,
                 DeleteRequestRequisitionLine {
-                    id: mock_full_draft_response_requisition_for_update_test().lines[0]
+                    id: mock_new_response_requisition_for_update_test().lines[0]
                         .id
                         .clone(),
                 },

--- a/server/service/src/requisition_line/request_requisition_line/delete.rs
+++ b/server/service/src/requisition_line/request_requisition_line/delete.rs
@@ -79,7 +79,7 @@ impl From<RepositoryError> for DeleteRequestRequisitionLineError {
 mod test {
     use repository::{
         mock::{
-            mock_new_response_requisition_for_update_test,
+            mock_full_draft_response_requisition_for_update_test,
             mock_request_draft_requisition_calculation_test, mock_sent_request_requisition_line,
             mock_store_a, mock_store_b, MockDataInserts,
         },
@@ -135,7 +135,7 @@ mod test {
             service.delete_request_requisition_line(
                 &context,
                 DeleteRequestRequisitionLine {
-                    id: mock_new_response_requisition_for_update_test().lines[0]
+                    id: mock_full_draft_response_requisition_for_update_test().lines[0]
                         .id
                         .clone(),
                 },

--- a/server/service/src/requisition_line/request_requisition_line/insert.rs
+++ b/server/service/src/requisition_line/request_requisition_line/insert.rs
@@ -140,11 +140,11 @@ impl From<RepositoryError> for InsertRequestRequisitionLineError {
 mod test {
     use repository::{
         mock::{
-            mock_draft_request_requisition_for_update_test, mock_item_c,
-            mock_new_response_requisition_for_update_test, mock_request_draft_requisition,
-            mock_request_draft_requisition_calculation_test, mock_request_program_requisition,
-            mock_sent_request_requisition, mock_store_a, mock_store_b, test_item_stats,
-            MockDataInserts,
+            mock_draft_request_requisition_for_update_test,
+            mock_full_draft_response_requisition_for_update_test, mock_item_c,
+            mock_request_draft_requisition, mock_request_draft_requisition_calculation_test,
+            mock_request_program_requisition, mock_sent_request_requisition, mock_store_a,
+            mock_store_b, test_item_stats, MockDataInserts,
         },
         test_db::{setup_all, setup_all_with_data},
         RequisitionLineRowRepository,
@@ -229,7 +229,7 @@ mod test {
             service.insert_request_requisition_line(
                 &context,
                 inline_init(|r: &mut InsertRequestRequisitionLine| {
-                    r.requisition_id = mock_new_response_requisition_for_update_test()
+                    r.requisition_id = mock_full_draft_response_requisition_for_update_test()
                         .requisition
                         .id;
                 }),

--- a/server/service/src/requisition_line/request_requisition_line/insert.rs
+++ b/server/service/src/requisition_line/request_requisition_line/insert.rs
@@ -141,7 +141,7 @@ mod test {
     use repository::{
         mock::{
             mock_draft_request_requisition_for_update_test,
-            mock_draft_response_requisition_for_update_test, mock_item_c,
+            mock_full_draft_response_requisition_for_update_test, mock_item_c,
             mock_request_draft_requisition, mock_request_draft_requisition_calculation_test,
             mock_request_program_requisition, mock_sent_request_requisition, mock_store_a,
             mock_store_b, test_item_stats, MockDataInserts,
@@ -229,7 +229,9 @@ mod test {
             service.insert_request_requisition_line(
                 &context,
                 inline_init(|r: &mut InsertRequestRequisitionLine| {
-                    r.requisition_id = mock_draft_response_requisition_for_update_test().id;
+                    r.requisition_id = mock_full_draft_response_requisition_for_update_test()
+                        .requisition
+                        .id;
                 }),
             ),
             Err(ServiceError::NotARequestRequisition)

--- a/server/service/src/requisition_line/request_requisition_line/insert.rs
+++ b/server/service/src/requisition_line/request_requisition_line/insert.rs
@@ -140,11 +140,11 @@ impl From<RepositoryError> for InsertRequestRequisitionLineError {
 mod test {
     use repository::{
         mock::{
-            mock_draft_request_requisition_for_update_test,
-            mock_full_draft_response_requisition_for_update_test, mock_item_c,
-            mock_request_draft_requisition, mock_request_draft_requisition_calculation_test,
-            mock_request_program_requisition, mock_sent_request_requisition, mock_store_a,
-            mock_store_b, test_item_stats, MockDataInserts,
+            mock_draft_request_requisition_for_update_test, mock_item_c,
+            mock_new_response_requisition_for_update_test, mock_request_draft_requisition,
+            mock_request_draft_requisition_calculation_test, mock_request_program_requisition,
+            mock_sent_request_requisition, mock_store_a, mock_store_b, test_item_stats,
+            MockDataInserts,
         },
         test_db::{setup_all, setup_all_with_data},
         RequisitionLineRowRepository,
@@ -229,7 +229,7 @@ mod test {
             service.insert_request_requisition_line(
                 &context,
                 inline_init(|r: &mut InsertRequestRequisitionLine| {
-                    r.requisition_id = mock_full_draft_response_requisition_for_update_test()
+                    r.requisition_id = mock_new_response_requisition_for_update_test()
                         .requisition
                         .id;
                 }),

--- a/server/service/src/requisition_line/request_requisition_line/update.rs
+++ b/server/service/src/requisition_line/request_requisition_line/update.rs
@@ -107,7 +107,7 @@ impl From<RepositoryError> for UpdateRequestRequisitionLineError {
 mod test {
     use repository::{
         mock::{
-            mock_new_response_requisition_for_update_test,
+            mock_full_draft_response_requisition_for_update_test,
             mock_request_draft_requisition_calculation_test, mock_sent_request_requisition_line,
             mock_store_a, mock_store_b, MockDataInserts,
         },
@@ -164,7 +164,7 @@ mod test {
             service.update_request_requisition_line(
                 &context,
                 inline_init(|r: &mut UpdateRequestRequisitionLine| {
-                    r.id = mock_new_response_requisition_for_update_test().lines[0]
+                    r.id = mock_full_draft_response_requisition_for_update_test().lines[0]
                         .id
                         .clone();
                 }),

--- a/server/service/src/requisition_line/request_requisition_line/update.rs
+++ b/server/service/src/requisition_line/request_requisition_line/update.rs
@@ -107,7 +107,7 @@ impl From<RepositoryError> for UpdateRequestRequisitionLineError {
 mod test {
     use repository::{
         mock::{
-            mock_draft_response_requisition_for_update_test_line,
+            mock_full_draft_response_requisition_for_update_test,
             mock_request_draft_requisition_calculation_test, mock_sent_request_requisition_line,
             mock_store_a, mock_store_b, MockDataInserts,
         },
@@ -164,7 +164,9 @@ mod test {
             service.update_request_requisition_line(
                 &context,
                 inline_init(|r: &mut UpdateRequestRequisitionLine| {
-                    r.id = mock_draft_response_requisition_for_update_test_line().id;
+                    r.id = mock_full_draft_response_requisition_for_update_test().lines[0]
+                        .id
+                        .clone();
                 }),
             ),
             Err(ServiceError::NotARequestRequisition)

--- a/server/service/src/requisition_line/request_requisition_line/update.rs
+++ b/server/service/src/requisition_line/request_requisition_line/update.rs
@@ -107,7 +107,7 @@ impl From<RepositoryError> for UpdateRequestRequisitionLineError {
 mod test {
     use repository::{
         mock::{
-            mock_full_draft_response_requisition_for_update_test,
+            mock_new_response_requisition_for_update_test,
             mock_request_draft_requisition_calculation_test, mock_sent_request_requisition_line,
             mock_store_a, mock_store_b, MockDataInserts,
         },
@@ -164,7 +164,7 @@ mod test {
             service.update_request_requisition_line(
                 &context,
                 inline_init(|r: &mut UpdateRequestRequisitionLine| {
-                    r.id = mock_full_draft_response_requisition_for_update_test().lines[0]
+                    r.id = mock_new_response_requisition_for_update_test().lines[0]
                         .id
                         .clone();
                 }),

--- a/server/service/src/sync/translations/requisition.rs
+++ b/server/service/src/sync/translations/requisition.rs
@@ -323,7 +323,7 @@ impl SyncTranslation for RequisitionTranslation {
                 RequisitionFilter::new().id(EqualFilter::equal_to(&changelog.record_id)),
             )?
             .pop()
-            .ok_or(anyhow::anyhow!("Requisition not found"))?;
+            .ok_or_else(|| anyhow::anyhow!("Requisition not found"))?;
 
         let has_outbound_shipment = InvoiceRepository::new(&connection)
             .query_by_filter(InvoiceFilter::new().requisition_id(EqualFilter::equal_to(&id)))?

--- a/server/service/src/sync/translations/requisition.rs
+++ b/server/service/src/sync/translations/requisition.rs
@@ -523,7 +523,7 @@ impl LegacyAuthorisationStatus {
 
 #[cfg(test)]
 mod tests {
-    use crate::sync::test::merge_helpers::name_links_merged;
+    use crate::sync::test::merge_helpers::merge_all_name_links;
 
     use super::*;
     use repository::{
@@ -558,10 +558,13 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_requisition_push_merged() {
-        let (mock_data, connection, _, _) =
-            setup_all("test_requisition_push_merged", MockDataInserts::all()).await;
+        let (mock_data, connection, _, _) = setup_all(
+            "test_requisition_push_merged",
+            MockDataInserts::none().names().stores().requisitions(),
+        )
+        .await;
 
-        name_links_merged(&connection, &mock_data).unwrap();
+        merge_all_name_links(&connection, &mock_data).unwrap();
 
         let repo = ChangelogRepository::new(&connection);
         let changelogs = repo


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2746

# 👩🏻‍💻 What does this PR do? 
Makes the translator use the `RequisitionRepository` rather than `RequisitionRowRepository` to get the correct name_id.

# 🧪 How has/should this change been tested? 
- Run tests