### PR TITLE
Name merging: stock_line.supplier_id translator get actual name.id

### DIFF
--- a/server/graphql/location/src/mutations/delete.rs
+++ b/server/graphql/location/src/mutations/delete.rs
@@ -260,7 +260,7 @@ mod test {
                     stock_line_row: mock_stock_line_a(),
                     item_row: mock_item_a(),
                     location_row: None,
-                    name_row: None,
+                    supplier_name_row: None,
                     barcode_row: None,
                 }],
                 invoice_lines: vec![successful_invoice_line()],

--- a/server/graphql/stock_line/src/mutations/update.rs
+++ b/server/graphql/stock_line/src/mutations/update.rs
@@ -279,7 +279,7 @@ mod test {
                 stock_line_row: mock_stock_line_a(),
                 item_row: mock_item_a(),
                 location_row: None,
-                name_row: None,
+                supplier_name_row: None,
                 barcode_row: None,
             })
         }));

--- a/server/repository/src/db_diesel/stock_line.rs
+++ b/server/repository/src/db_diesel/stock_line.rs
@@ -30,7 +30,7 @@ pub struct StockLine {
     pub stock_line_row: StockLineRow,
     pub item_row: ItemRow,
     pub location_row: Option<LocationRow>,
-    pub name_row: Option<NameRow>,
+    pub supplier_name_row: Option<NameRow>,
     pub barcode_row: Option<BarcodeRow>,
 }
 
@@ -257,7 +257,7 @@ pub fn to_domain(
         stock_line_row,
         item_row,
         location_row,
-        name_row: name_link_join.map(|(_, name_row)| name_row),
+        supplier_name_row: name_link_join.map(|(_, name_row)| name_row),
         barcode_row,
     }
 }
@@ -330,7 +330,7 @@ impl StockLine {
     }
 
     pub fn supplier_name(&self) -> Option<&str> {
-        self.name_row
+        self.supplier_name_row
             .as_ref()
             .map(|name_row| name_row.name.as_str())
     }

--- a/server/service/src/sync/translations/stock_line.rs
+++ b/server/service/src/sync/translations/stock_line.rs
@@ -136,7 +136,7 @@ impl SyncTranslation for StockLineTranslation {
                     barcode_id,
                 },
             item_row,
-            name_row,
+            supplier_name_row,
             ..
         } = stock_line;
 
@@ -154,7 +154,7 @@ impl SyncTranslation for StockLineTranslation {
             cost_price: cost_price_per_pack,
             sell_price: sell_price_per_pack,
             note,
-            supplier_id: name_row.and_then(|name| Some(name.id)),
+            supplier_id: supplier_name_row.and_then(|supplier| Some(supplier.id)),
             barcode_id,
         };
 

--- a/server/service/src/sync/translations/stock_line.rs
+++ b/server/service/src/sync/translations/stock_line.rs
@@ -132,10 +132,11 @@ impl SyncTranslation for StockLineTranslation {
                     expiry_date,
                     on_hold,
                     note,
-                    supplier_id,
+                    supplier_id: _,
                     barcode_id,
                 },
             item_row,
+            name_row,
             ..
         } = stock_line;
 
@@ -153,7 +154,7 @@ impl SyncTranslation for StockLineTranslation {
             cost_price: cost_price_per_pack,
             sell_price: sell_price_per_pack,
             note,
-            supplier_id,
+            supplier_id: name_row.and_then(|name| Some(name.id)),
             barcode_id,
         };
 
@@ -178,7 +179,7 @@ impl SyncTranslation for StockLineTranslation {
 
 #[cfg(test)]
 mod tests {
-    use crate::sync::test::merge_helpers::merge_all_item_links;
+    use crate::sync::test::merge_helpers::{merge_all_item_links, merge_all_name_links};
 
     use super::*;
     use repository::{
@@ -206,13 +207,11 @@ mod tests {
     #[actix_rt::test]
     async fn test_stock_line_push_merged() {
         // The item_links_merged function will merge ALL items into item_a, so all stock_lines should have an item_id of "item_a" regardless of their original item_id.
-        let (mock_data, connection, _, _) = setup_all(
-            "test_stock_line_push_item_link_merged",
-            MockDataInserts::all(),
-        )
-        .await;
+        let (mock_data, connection, _, _) =
+            setup_all("test_stock_line_push_link_merged", MockDataInserts::all()).await;
 
         merge_all_item_links(&connection, &mock_data).unwrap();
+        merge_all_name_links(&connection, &mock_data).unwrap();
 
         let repo = ChangelogRepository::new(&connection);
         let changelogs = repo
@@ -231,7 +230,12 @@ mod tests {
                 .unwrap()
                 .unwrap();
 
-            assert_eq!(translated[0].record.data["item_ID"], json!("item_a"))
+            assert_eq!(translated[0].record.data["item_ID"], json!("item_a"));
+
+            // Supplier ID can be null. We want to check if the non-null supplier_ids is "name_a".
+            if translated[0].record.data["name_ID"] != json!(null) {
+                assert_eq!(translated[0].record.data["name_ID"], json!("name_a"));
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2750

# 👩🏻‍💻 What does this PR do? 
Make sure `StockLine` translator pushes correct name id.

# 🧪 How has/should this change been tested? 
Run tests