### PR TITLE
Refetch notifications

### DIFF
--- a/client/packages/coldchain/src/Monitoring/api/TemperatureNotification/hooks/document/useTemperatureNotifications.ts
+++ b/client/packages/coldchain/src/Monitoring/api/TemperatureNotification/hooks/document/useTemperatureNotifications.ts
@@ -6,7 +6,9 @@ import {
 } from '@openmsupply-client/common';
 import { ListParams } from '../../api';
 
-const POLLING_INTERVAL_IN_MINUTES = 5;
+const MILLISECONDS_PER_MINUTE = 60 * 1000;
+const POLLING_INTERVAL_IN_MILLISECONDS = 3 * MILLISECONDS_PER_MINUTE;
+const STALE_TIME_IN_MILLISECONDS = 1 * MILLISECONDS_PER_MINUTE;
 
 export const useTemperatureNotifications = (queryParams: ListParams) => {
   const api = useTemperatureNotificationApi();
@@ -22,8 +24,9 @@ export const useTemperatureNotifications = (queryParams: ListParams) => {
           warning(`${t('error.fetch-notifications')}: ${e.message}`)()
         ),
     {
-      cacheTime: 0,
-      refetchInterval: 1000 * 60 * POLLING_INTERVAL_IN_MINUTES,
+      cacheTime: POLLING_INTERVAL_IN_MILLISECONDS,
+      refetchInterval: POLLING_INTERVAL_IN_MILLISECONDS,
+      staleTime: STALE_TIME_IN_MILLISECONDS,
     }
   );
 };

--- a/client/packages/coldchain/src/Monitoring/api/TemperatureNotification/hooks/document/useTemperatureNotifications.ts
+++ b/client/packages/coldchain/src/Monitoring/api/TemperatureNotification/hooks/document/useTemperatureNotifications.ts
@@ -6,14 +6,24 @@ import {
 } from '@openmsupply-client/common';
 import { ListParams } from '../../api';
 
+const POLLING_INTERVAL_IN_MINUTES = 5;
+
 export const useTemperatureNotifications = (queryParams: ListParams) => {
   const api = useTemperatureNotificationApi();
   const { warning } = useNotification();
   const t = useTranslation('coldchain');
 
-  return useQuery(api.keys.paramList(queryParams), () =>
-    api.get
-      .list(queryParams)()
-      .catch(e => warning(`${t('error.fetch-notifications')}: ${e.message}`)())
+  return useQuery(
+    api.keys.paramList(queryParams),
+    () =>
+      api.get
+        .list(queryParams)()
+        .catch(e =>
+          warning(`${t('error.fetch-notifications')}: ${e.message}`)()
+        ),
+    {
+      cacheTime: 0,
+      refetchInterval: 1000 * 60 * POLLING_INTERVAL_IN_MINUTES,
+    }
   );
 };

--- a/client/packages/common/src/api/GqlContext.tsx
+++ b/client/packages/common/src/api/GqlContext.tsx
@@ -31,6 +31,12 @@ const permissionExceptions = [
   'requisitionCounts',
   'temperatureNotifications',
 ];
+
+// these queries are not considered to be part of the user's activity
+// they occur in the background and should not be used to determine
+// if the user has remained active
+const ignoredQueries = ['refreshToken', 'syncInfo', 'temperatureNotifications'];
+
 interface ResponseError {
   message?: string;
   path?: string[];
@@ -64,8 +70,6 @@ const handleResponseError = (errors: ResponseError[]) => {
   const { details } = extensions || {};
   throw new Error(details || error?.message || 'Unknown error');
 };
-
-const ignoredQueries = ['refreshToken', 'syncInfo'];
 
 const shouldIgnoreQuery = (definitionNode: DefinitionNode) => {
   const operationNode = definitionNode as OperationDefinitionNode;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2762

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Adds a regular refetch of notifications (breaches & excursions) so that if the site ends up in a state like the one in the issue (a breach is identified but no notification shown) then a refetch will happen and the notification will be shown.

Have also disabled the cache for that query - though I'm concerned that the notification query is a little slow, so I set the refetch to be five minutes. Didn't want it to be called too often.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Not sure if you'll be able to recreate the scenario in the issue - I wasn't able to.
You can check that the site will fetch notifications every 5 minutes ( reduce the polling interval if you are impatient )

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
- [ ] Worth mentioning that the notification is refetched
