### PR TITLE
Fix for Temperature Chart date filter

### DIFF
--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/useTemperatureChartData.ts
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/useTemperatureChartData.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useTheme } from '@common/styles';
 import { DateUtils } from '@common/intl';
 import { Sensor } from './types';
@@ -6,14 +7,57 @@ import {
   TemperatureChartFragment,
   useTemperatureChart,
 } from '../../api/TemperatureChart';
-import { TemperatureLogFilterInput } from '@common/types';
+import {
+  DatetimeFilterInput,
+  InputMaybe,
+  TemperatureLogFilterInput,
+} from '@common/types';
 
 const MAX_DATA_POINTS = 30;
 const BREACH_RANGE = 2;
 const BREACH_MIN = 2;
 const BREACH_MAX = 8;
 
+const useFilterDates = (
+  filterDatetime: InputMaybe<DatetimeFilterInput> | undefined
+) => {
+  const now = DateUtils.setMilliseconds(new Date(), 0);
+  let fromDatetime = DateUtils.addDays(now, -1).toISOString();
+  let toDatetime = now.toISOString();
+
+  if (!!filterDatetime && typeof filterDatetime === 'object') {
+    const hasAfterOrEqualTo =
+      'afterOrEqualTo' in filterDatetime && !!filterDatetime['afterOrEqualTo'];
+
+    if (hasAfterOrEqualTo)
+      fromDatetime = String(filterDatetime['afterOrEqualTo']);
+
+    if (
+      'beforeOrEqualTo' in filterDatetime &&
+      !!filterDatetime['beforeOrEqualTo']
+    ) {
+      toDatetime = String(filterDatetime['beforeOrEqualTo']);
+
+      // the 'from' date needs to be before the 'to' date
+      // if this isn't the case, and if 'from' is not set,
+      // then set to a day prior to the 'to' date
+      if (fromDatetime >= toDatetime && !hasAfterOrEqualTo) {
+        fromDatetime = DateUtils.addDays(
+          new Date(toDatetime),
+          -1
+        ).toISOString();
+      }
+    }
+  }
+
+  return useMemo(
+    () => ({ fromDatetime, toDatetime }),
+    [fromDatetime, toDatetime]
+  );
+};
+
 export const useTemperatureChartData = () => {
+  console.info('RENDER');
   const theme = useTheme();
   const { filter } = useUrlQueryParams({
     filters: [
@@ -38,30 +82,7 @@ export const useTemperatureChartData = () => {
   // will result in no data
   const { datetime, ...filterBy } =
     filter?.filterBy as TemperatureLogFilterInput;
-
-  let fromDatetime = DateUtils.addDays(new Date(), -1).toISOString();
-  let toDatetime = new Date().toISOString();
-
-  if (!!datetime && typeof datetime === 'object') {
-    const hasAfterOrEqualTo =
-      'afterOrEqualTo' in datetime && !!datetime['afterOrEqualTo'];
-
-    if (hasAfterOrEqualTo) fromDatetime = String(datetime['afterOrEqualTo']);
-
-    if ('beforeOrEqualTo' in datetime && !!datetime['beforeOrEqualTo']) {
-      toDatetime = String(datetime['beforeOrEqualTo']);
-
-      // the 'from' date needs to be before the 'to' date
-      // if this isn't the case, and if 'from' is not set,
-      // then set to a day prior to the 'to' date
-      if (fromDatetime >= toDatetime && !hasAfterOrEqualTo) {
-        fromDatetime = DateUtils.addDays(
-          new Date(toDatetime),
-          -1
-        ).toISOString();
-      }
-    }
-  }
+  const { fromDatetime, toDatetime } = useFilterDates(datetime);
 
   const { data, isLoading } = useTemperatureChart.document.chart({
     filterBy,

--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/useTemperatureChartData.ts
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/useTemperatureChartData.ts
@@ -57,7 +57,6 @@ const useFilterDates = (
 };
 
 export const useTemperatureChartData = () => {
-  console.info('RENDER');
   const theme = useTheme();
   const { filter } = useUrlQueryParams({
     filters: [

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -32,6 +32,7 @@ import {
   formatRFC3339,
   previousMonday,
   endOfWeek,
+  setMilliseconds,
 } from 'date-fns';
 
 export const MINIMUM_EXPIRY_MONTHS = 3;
@@ -131,6 +132,7 @@ export const DateUtils = {
   startOfYear,
   previousMonday,
   endOfWeek,
+  setMilliseconds,
 
   /** Number of milliseconds in one second, i.e. SECOND = 1000*/
   SECOND,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2757 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
When either part of the date filter was null, the date value was being set to the current datetime ( to the nearest millisecond ) which updates the filter and causes `TemperatureChart` to re-render, causing the `Toolbar` to re-render which updates the filter.

To fix, I've lifted out the to/from date extraction, rounded off the time to the nearest second and memoised the resulting date strings.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
The original repro step has been fixed, sorry. This is what I've been doing:
- On the Temperature Chart, click on the from (or to) date
- click on the day part of the day, hit `del`
- the page then re-renders, you'll see lots and lots of api requests for the `temperatureChart` query


## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->
One concern, if you clear the 'from' date it defaults to a day ago, but doesn't tell you that it has. There can be no value in the date input, but that isn't treated as 'no from date' it is treated as 'a day ago'.

That's a little misleading. is it something to address, do you think?

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
