### PR TITLE
Filter nested key fails

### DIFF
--- a/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
+++ b/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
@@ -96,13 +96,15 @@ export const useUrlQueryParams = ({
     filters.reduce<FilterByWithBoolean>((prev, filter) => {
       const filterValue = getFilterValue(urlQuery, filter.key);
       if (filterValue === undefined) return prev;
+      // create a new object to prevent mutating the existing filter
+      const f = { ...filter };
 
-      const [key, nestedKey] = filter.key.split(NESTED_SPLIT_CHAR);
-      if (filter.key.includes(NESTED_SPLIT_CHAR)) {
-        filter.key = key ?? '';
+      const [key, nestedKey] = f.key.split(NESTED_SPLIT_CHAR);
+      if (f.key.includes(NESTED_SPLIT_CHAR)) {
+        f.key = key ?? '';
       }
 
-      prev[filter.key] = getFilterEntry(filter, filterValue, nestedKey);
+      prev[f.key] = getFilterEntry(f, filterValue, nestedKey);
       return prev;
     }, {});
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2763 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
When a nested key is used (e.g. `sensor.name`) the filter object is being mutated, therefore when the component renders again, the filter key is not correct (e.g. `sensor` not `sensor.name`) which means the value is not fetched from the query.


# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Try the filter!

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
