### PR TITLE
2607 drop migration changelog rows

### DIFF
--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -141,9 +141,11 @@ impl<'a> ChangelogRepository<'a> {
         Ok(result.unwrap_or(0) as u64)
     }
 
-    // Drop all change logs (for tests), can't set test flag as it's used in another crate
-    pub fn drop_all(&self) -> Result<(), RepositoryError> {
-        diesel::delete(changelog::dsl::changelog).execute(&self.connection.connection)?;
+    // Delete all change logs with cursor greater-equal cursor_ge
+    pub fn delete(&self, cursor_ge: i64) -> Result<(), RepositoryError> {
+        diesel::delete(changelog::dsl::changelog)
+            .filter(changelog::dsl::cursor.ge(cursor_ge))
+            .execute(&self.connection.connection)?;
         Ok(())
     }
 
@@ -160,10 +162,7 @@ impl<'a> ChangelogRepository<'a> {
 
 type BoxedChangelogQuery = IntoBoxed<'static, changelog_deduped::table, DBType>;
 
-fn create_filtered_query<'a>(
-    earliest: u64,
-    filter: Option<ChangelogFilter>,
-) -> BoxedChangelogQuery {
+fn create_filtered_query(earliest: u64, filter: Option<ChangelogFilter>) -> BoxedChangelogQuery {
     let mut query = changelog_deduped::dsl::changelog_deduped
         .filter(changelog_deduped::dsl::cursor.ge(earliest.try_into().unwrap_or(0)))
         .into_boxed();

--- a/server/repository/src/db_diesel/changelog/test.rs
+++ b/server/repository/src/db_diesel/changelog/test.rs
@@ -24,7 +24,7 @@ async fn test_changelog() {
     let repo = ChangelogRepository::new(&connection);
     // Clear change log and get starting cursor
     let starting_cursor = repo.latest_cursor().unwrap();
-    repo.drop_all().unwrap();
+    repo.delete(0).unwrap();
     // single entry:
     location_repo.upsert_one(&mock_location_1()).unwrap();
     let mut result = repo.changelogs(starting_cursor + 0, 10, None).unwrap();
@@ -138,7 +138,7 @@ async fn test_changelog_iteration() {
     let repo = ChangelogRepository::new(&connection);
     // Clear change log and get starting cursor
     let starting_cursor = repo.latest_cursor().unwrap();
-    repo.drop_all().unwrap();
+    repo.delete(0).unwrap();
 
     location_repo.upsert_one(&mock_location_1()).unwrap();
     location_repo.upsert_one(&mock_location_on_hold()).unwrap();
@@ -303,7 +303,7 @@ fn test_changelog_name_and_store_id<T, F>(
 ) where
     F: Fn(&StorageConnection, &T),
 {
-    let repo = ChangelogRepository::new(&connection);
+    let repo = ChangelogRepository::new(connection);
 
     db_op(connection, &record.record);
 

--- a/server/repository/src/migrations/v1_07_00/mod.rs
+++ b/server/repository/src/migrations/v1_07_00/mod.rs
@@ -396,7 +396,7 @@ async fn migration_1_07_00_merge() {
     let version = V1_07_00.version();
 
     let SetupResult { connection, .. } = setup_test(SetupOption {
-        db_name: &format!("migration_{version}_aye"),
+        db_name: &format!("migration_{version}_merge"),
         version: Some(previous_version.clone()),
         ..Default::default()
     })

--- a/server/service/src/sync/sync_status/test.rs
+++ b/server/service/src/sync/sync_status/test.rs
@@ -84,7 +84,7 @@ async fn sync_status() {
 
     // Test PUSH and ERROR
     // Clear change log
-    ChangelogRepository::new(&connection).drop_all().unwrap();
+    ChangelogRepository::new(&connection).delete(0).unwrap();
     // Insert some location rows to be pushed
     insert_extra_mock_data(
         &connection,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2607

# 👩🏻‍💻 What does this PR do? 
Remembers latest changelog and delete all changelog entries created during the merge migrations.

@Chris-Petty do we need to test this a bit more? or do you think it should be ok. For example, are there any cases where a migration change need to be synced?

Probably good to wrap all merge migrations into a function to group them by feature and to not accidentally put an unrelated migration in (after moving to 1.7 https://github.com/msupply-foundation/open-msupply/issues/2733)...
