### PR TITLE
Sync refactoring

### DIFF
--- a/server/cli/src/refresh_dates.rs
+++ b/server/cli/src/refresh_dates.rs
@@ -43,23 +43,10 @@ fn get_timestamp_fields() -> Vec<TableAndFieldName> {
         ("sensor", "last_connection_datetime"),
         ("stocktake", "created_datetime"),
         ("stocktake", "finalised_datetime"),
-        ("sync_log", "started_datetime"),
-        ("sync_log", "finished_datetime"),
-        ("sync_log", "prepare_initial_started_datetime"),
-        ("sync_log", "prepare_initial_finished_datetime"),
-        ("sync_log", "push_started_datetime"),
-        ("sync_log", "push_finished_datetime"),
-        ("sync_log", "pull_central_started_datetime"),
-        ("sync_log", "pull_central_finished_datetime"),
-        ("sync_log", "pull_remote_started_datetime"),
-        ("sync_log", "pull_remote_finished_datetime"),
-        ("sync_log", "integration_started_datetime"),
-        ("sync_log", "integration_finished_datetime"),
         ("temperature_breach", "start_datetime"),
         ("temperature_breach", "end_datetime"),
         ("temperature_log", "datetime"),
         ("activity_log", "datetime"),
-        ("user_account", "last_successful_sync"),
     ]
     .iter()
     .map(|(table_name, field_name)| TableAndFieldName {
@@ -87,6 +74,7 @@ fn get_exclude_timestamp_fields() -> Vec<TableAndFieldName> {
         ("sync_log", "pull_remote_finished_datetime"),
         ("sync_log", "integration_started_datetime"),
         ("sync_log", "integration_finished_datetime"),
+        ("user_account", "last_successful_sync"),
     ]
     .iter()
     .map(|(table_name, field_name)| TableAndFieldName {

--- a/server/repository/src/db_diesel/activity_log_row.rs
+++ b/server/repository/src/db_diesel/activity_log_row.rs
@@ -1,6 +1,8 @@
 use super::{activity_log_row::activity_log::dsl as activity_log_dsl, StorageConnection};
 
-use crate::{db_diesel::store_row::store, repository_error::RepositoryError, user_account};
+use crate::{
+    db_diesel::store_row::store, repository_error::RepositoryError, user_account, Delete, Upsert,
+};
 
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
@@ -102,5 +104,36 @@ impl<'a> ActivityLogRowRepository<'a> {
             .filter(activity_log_dsl::record_id.eq(id))
             .get_results(&self.connection.connection)?;
         Ok(result)
+    }
+}
+
+impl Upsert for ActivityLogRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        ActivityLogRowRepository::new(con).insert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            ActivityLogRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+// Only used in tests
+pub struct ActivityLogRowDelete(pub String);
+impl Delete for ActivityLogRowDelete {
+    fn delete(&self, _: &StorageConnection) -> Result<(), RepositoryError> {
+        // Not deletiing in tests, just want to check asserted_deleted
+        Ok(())
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            ActivityLogRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
+        )
     }
 }

--- a/server/repository/src/db_diesel/activity_log_row.rs
+++ b/server/repository/src/db_diesel/activity_log_row.rs
@@ -126,7 +126,7 @@ impl Upsert for ActivityLogRow {
 pub struct ActivityLogRowDelete(pub String);
 impl Delete for ActivityLogRowDelete {
     fn delete(&self, _: &StorageConnection) -> Result<(), RepositoryError> {
-        // Not deletiing in tests, just want to check asserted_deleted
+        // Not deleting in tests, just want to check asserted_deleted
         Ok(())
     }
     // Test only

--- a/server/repository/src/db_diesel/barcode_row.rs
+++ b/server/repository/src/db_diesel/barcode_row.rs
@@ -3,6 +3,7 @@ use super::{barcode_row::barcode::dsl as barcode_dsl, StorageConnection};
 use crate::{
     db_diesel::{invoice_line_row::invoice_line, item_row::item},
     repository_error::RepositoryError,
+    Upsert,
 };
 
 use diesel::prelude::*;
@@ -125,6 +126,21 @@ impl<'a> BarcodeRowRepository<'a> {
             .first(&self.connection.connection)
             .optional()?;
         Ok(result)
+    }
+}
+
+pub struct BarcodeRowDelete(pub String);
+impl Upsert for BarcodeRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        BarcodeRowRepository::new(con).sync_upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            BarcodeRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }
 

--- a/server/repository/src/db_diesel/clinician_row.rs
+++ b/server/repository/src/db_diesel/clinician_row.rs
@@ -1,6 +1,6 @@
 use super::StorageConnection;
 
-use crate::{Gender, RepositoryError};
+use crate::{Gender, RepositoryError, Upsert};
 
 use diesel::prelude::*;
 
@@ -120,6 +120,22 @@ impl<'a> ClinicianRowRepository<'a> {
             .first(&self.connection.connection)
             .optional()?;
         Ok(result)
+    }
+}
+
+pub struct ClinicianRowDelete(pub String);
+
+impl Upsert for ClinicianRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        ClinicianRowRepository::new(con).sync_upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            ClinicianRowRepository::new(con).find_one_by_id_option(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }
 

--- a/server/repository/src/db_diesel/clinician_store_join_row.rs
+++ b/server/repository/src/db_diesel/clinician_store_join_row.rs
@@ -1,6 +1,6 @@
 use super::{clinician_row::clinician, StorageConnection};
 
-use crate::RepositoryError;
+use crate::{RepositoryError, Upsert};
 
 use diesel::prelude::*;
 
@@ -107,6 +107,22 @@ impl<'a> ClinicianStoreJoinRowRepository<'a> {
             .first(&self.connection.connection)
             .optional()?;
         Ok(result)
+    }
+}
+
+pub struct ClinicianStoreJoinRowDelete(pub String);
+
+impl Upsert for ClinicianStoreJoinRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        ClinicianStoreJoinRowRepository::new(con).sync_upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            ClinicianStoreJoinRowRepository::new(con).find_one_by_id_option(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }
 

--- a/server/repository/src/db_diesel/context_row.rs
+++ b/server/repository/src/db_diesel/context_row.rs
@@ -1,6 +1,6 @@
 use super::StorageConnection;
 
-use crate::repository_error::RepositoryError;
+use crate::{repository_error::RepositoryError, Upsert};
 
 use diesel::prelude::*;
 
@@ -64,5 +64,19 @@ impl<'a> ContextRowRepository<'a> {
             .first(&self.connection.connection)
             .optional()?;
         Ok(result)
+    }
+}
+
+impl Upsert for ContextRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        ContextRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            ContextRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/document_registry_row.rs
+++ b/server/repository/src/db_diesel/document_registry_row.rs
@@ -2,7 +2,7 @@ use super::{
     document_registry_row::document_registry::dsl as document_registry_dsl, StorageConnection,
 };
 
-use crate::{db_diesel::form_schema_row::form_schema, RepositoryError};
+use crate::{db_diesel::form_schema_row::form_schema, RepositoryError, Upsert};
 
 use diesel::prelude::*;
 use diesel_derive_enum::DbEnum;
@@ -97,5 +97,19 @@ impl<'a> DocumentRegistryRowRepository<'a> {
         )
         .execute(&self.connection.connection)?;
         Ok(())
+    }
+}
+
+impl Upsert for DocumentRegistryRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        DocumentRegistryRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            DocumentRegistryRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/form_schema_row.rs
+++ b/server/repository/src/db_diesel/form_schema_row.rs
@@ -1,6 +1,6 @@
 use super::StorageConnection;
 
-use crate::RepositoryError;
+use crate::{RepositoryError, Upsert};
 
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -126,5 +126,19 @@ impl<'a> FormSchemaRowRepository<'a> {
             result.push(schema_from_row(row)?);
         }
         Ok(result)
+    }
+}
+
+impl Upsert for FormSchemaJson {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        FormSchemaRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            FormSchemaRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/inventory_adjustment_reason_row.rs
+++ b/server/repository/src/db_diesel/inventory_adjustment_reason_row.rs
@@ -3,7 +3,7 @@ use super::{
     StorageConnection,
 };
 
-use crate::repository_error::RepositoryError;
+use crate::{repository_error::RepositoryError, Delete, Upsert};
 
 use diesel::prelude::*;
 use diesel_derive_enum::DbEnum;
@@ -91,5 +91,35 @@ impl<'a> InventoryAdjustmentReasonRowRepository<'a> {
             .filter(inventory_adjustment_reason_dsl::id.eq(inventory_adjustment_reason_id))
             .execute(&self.connection.connection)?;
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct InventoryAdjustmentReasonRowDelete(pub String);
+// TODO soft delete
+impl Delete for InventoryAdjustmentReasonRowDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        InventoryAdjustmentReasonRowRepository::new(con).delete(&self.0)
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            InventoryAdjustmentReasonRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
+        )
+    }
+}
+
+impl Upsert for InventoryAdjustmentReasonRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        InventoryAdjustmentReasonRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            InventoryAdjustmentReasonRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/invoice_line_row.rs
+++ b/server/repository/src/db_diesel/invoice_line_row.rs
@@ -5,6 +5,7 @@ use super::{
 };
 
 use crate::repository_error::RepositoryError;
+use crate::{Delete, Upsert};
 
 use diesel::prelude::*;
 
@@ -179,5 +180,34 @@ impl<'a> InvoiceLineRowRepository<'a> {
             .filter(invoice_id.eq(invoice_id_param))
             .get_results(&self.connection.connection)?;
         Ok(result)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct InvoiceLineRowDelete(pub String);
+impl Delete for InvoiceLineRowDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        InvoiceLineRowRepository::new(con).delete(&self.0)
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            InvoiceLineRowRepository::new(con).find_one_by_id_option(&self.0),
+            Ok(None)
+        )
+    }
+}
+
+impl Upsert for InvoiceLineRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        InvoiceLineRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            InvoiceLineRowRepository::new(con).find_one_by_id_option(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/invoice_row.rs
+++ b/server/repository/src/db_diesel/invoice_row.rs
@@ -1,9 +1,11 @@
+use std::any::Any;
+
 use super::{
     clinician_row::clinician, invoice_row::invoice::dsl::*, name_row::name, store_row::store,
     user_row::user_account, StorageConnection,
 };
 
-use crate::repository_error::RepositoryError;
+use crate::{repository_error::RepositoryError, Delete, Upsert};
 
 use diesel::{dsl::max, prelude::*};
 
@@ -237,5 +239,38 @@ impl<'a> OutboundShipmentRowRepository<'a> {
             )
             .get_results(&self.connection.connection)?;
         Ok(result)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct InvoiceRowDelete(pub String);
+impl Delete for InvoiceRowDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        InvoiceRowRepository::new(con).delete(&self.0)
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            InvoiceRowRepository::new(con).find_one_by_id_option(&self.0),
+            Ok(None)
+        )
+    }
+}
+
+impl Upsert for InvoiceRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        InvoiceRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            InvoiceRowRepository::new(con).find_one_by_id_option(&self.id),
+            Ok(Some(self.clone()))
+        )
+    }
+
+    fn as_mut_any(&mut self) -> Option<&mut dyn Any> {
+        Some(self)
     }
 }

--- a/server/repository/src/db_diesel/location_movement_row.rs
+++ b/server/repository/src/db_diesel/location_movement_row.rs
@@ -3,7 +3,7 @@ use super::{
     stock_line_row::stock_line, store_row::store, StorageConnection,
 };
 
-use crate::repository_error::RepositoryError;
+use crate::{repository_error::RepositoryError, Upsert};
 
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
@@ -76,5 +76,19 @@ impl<'a> LocationMovementRowRepository<'a> {
         )
         .execute(&self.connection.connection)?;
         Ok(())
+    }
+}
+
+impl Upsert for LocationMovementRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        LocationMovementRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            LocationMovementRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/location_row.rs
+++ b/server/repository/src/db_diesel/location_row.rs
@@ -1,7 +1,7 @@
 use super::{location_row::location::dsl as location_dsl, store_row::store, StorageConnection};
 
 use crate::repository_error::RepositoryError;
-
+use crate::{Delete, Upsert};
 use diesel::prelude::*;
 
 table! {
@@ -75,5 +75,35 @@ impl<'a> LocationRowRepository<'a> {
         diesel::delete(location_dsl::location.filter(location_dsl::id.eq(id)))
             .execute(&self.connection.connection)?;
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+// Only used in tests
+pub struct LocationRowDelete(pub String);
+impl Delete for LocationRowDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        LocationRowRepository::new(con).delete(&self.0)
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            LocationRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
+        )
+    }
+}
+
+impl Upsert for LocationRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        LocationRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            LocationRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/master_list_line_row.rs
+++ b/server/repository/src/db_diesel/master_list_line_row.rs
@@ -2,8 +2,8 @@ use super::{
     item_row::item, master_list_line_row::master_list_line::dsl::*, master_list_row::master_list,
     StorageConnection,
 };
-
 use crate::repository_error::RepositoryError;
+use crate::Upsert;
 
 use diesel::prelude::*;
 
@@ -79,5 +79,19 @@ impl<'a> MasterListLineRowRepository<'a> {
         diesel::delete(master_list_line.filter(id.eq(line_id)))
             .execute(&self.connection.connection)?;
         Ok(())
+    }
+}
+
+impl Upsert for MasterListLineRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        MasterListLineRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            MasterListLineRowRepository::new(con).find_one_by_id_option(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/master_list_name_join.rs
+++ b/server/repository/src/db_diesel/master_list_name_join.rs
@@ -4,7 +4,7 @@ use super::{
 };
 
 use crate::repository_error::RepositoryError;
-
+use crate::{Delete, Upsert};
 use diesel::prelude::*;
 
 table! {
@@ -79,5 +79,34 @@ impl<'a> MasterListNameJoinRepository<'a> {
         diesel::delete(master_list_name_join.filter(id.eq(record_id)))
             .execute(&self.connection.connection)?;
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MasterListNameJoinRowDelete(pub String);
+impl Delete for MasterListNameJoinRowDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        MasterListNameJoinRepository::new(con).delete(&self.0)
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            MasterListNameJoinRepository::new(con).find_one_by_id_option(&self.0),
+            Ok(None)
+        )
+    }
+}
+
+impl Upsert for MasterListNameJoinRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        MasterListNameJoinRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            MasterListNameJoinRepository::new(con).find_one_by_id_option(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/master_list_row.rs
+++ b/server/repository/src/db_diesel/master_list_row.rs
@@ -75,7 +75,7 @@ impl Upsert for MasterListRow {
         MasterListRowRepository::new(con).upsert_one(self)
     }
 
-    // Test only    #[cfg(test)]
+    // Test only
     fn assert_upserted(&self, con: &StorageConnection) {
         assert_eq!(
             MasterListRowRepository::new(con).find_one_by_id(&self.id),

--- a/server/repository/src/db_diesel/master_list_row.rs
+++ b/server/repository/src/db_diesel/master_list_row.rs
@@ -1,6 +1,6 @@
 use super::{master_list_row::master_list::dsl::*, StorageConnection};
 
-use crate::repository_error::RepositoryError;
+use crate::{repository_error::RepositoryError, Upsert};
 
 use diesel::prelude::*;
 
@@ -52,22 +52,12 @@ impl<'a> MasterListRowRepository<'a> {
         Ok(())
     }
 
-    pub async fn find_one_by_id(
-        &self,
-        master_list_id: &str,
-    ) -> Result<MasterListRow, RepositoryError> {
-        let result = master_list
-            .filter(id.eq(master_list_id).and(is_active.eq(true)))
-            .first(&self.connection.connection)?;
-        Ok(result)
-    }
-
-    pub fn find_one_by_id_option(
+    pub fn find_one_by_id(
         &self,
         master_list_id: &str,
     ) -> Result<Option<MasterListRow>, RepositoryError> {
         let result = master_list
-            .filter(id.eq(master_list_id).and(is_active.eq(true)))
+            .filter(id.eq(master_list_id))
             .first(&self.connection.connection)
             .optional()?;
         Ok(result)
@@ -77,5 +67,19 @@ impl<'a> MasterListRowRepository<'a> {
         diesel::delete(master_list.filter(id.eq(master_list_id)))
             .execute(&self.connection.connection)?;
         Ok(())
+    }
+}
+
+impl Upsert for MasterListRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        MasterListRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only    #[cfg(test)]
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            MasterListRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/name_store_join.rs
+++ b/server/repository/src/db_diesel/name_store_join.rs
@@ -6,7 +6,7 @@ use super::{
 use crate::{
     diesel_macros::apply_equal_filter, repository_error::RepositoryError, DBType, EqualFilter,
 };
-
+use crate::{Delete, Upsert};
 use diesel::{dsl::IntoBoxed, prelude::*};
 
 table! {
@@ -162,6 +162,34 @@ impl NameStoreJoinFilter {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct NameStoreJoinRowDelete(pub String);
+impl Delete for NameStoreJoinRowDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        NameStoreJoinRepository::new(con).delete(&self.0)
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            NameStoreJoinRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
+        )
+    }
+}
+
+impl Upsert for NameStoreJoinRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        NameStoreJoinRepository::new(con).sync_upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            NameStoreJoinRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
+    }
+}
 #[cfg(test)]
 mod test {
     use util::uuid::uuid;

--- a/server/repository/src/db_diesel/name_tag_join.rs
+++ b/server/repository/src/db_diesel/name_tag_join.rs
@@ -1,5 +1,6 @@
 use super::{name_tag_join::name_tag_join::dsl as name_tag_join_dsl, StorageConnection};
 use crate::{db_diesel::name_row::name, repository_error::RepositoryError};
+use crate::{Delete, Upsert};
 
 use diesel::prelude::*;
 
@@ -61,6 +62,35 @@ impl<'a> NameTagJoinRepository<'a> {
         diesel::delete(name_tag_join_dsl::name_tag_join.filter(name_tag_join_dsl::id.eq(id)))
             .execute(&self.connection.connection)?;
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NameTagJoinRowDelete(pub String);
+impl Delete for NameTagJoinRowDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        NameTagJoinRepository::new(con).delete(&self.0)
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            NameTagJoinRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
+        )
+    }
+}
+
+impl Upsert for NameTagJoinRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        NameTagJoinRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            NameTagJoinRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }
 

--- a/server/repository/src/db_diesel/name_tag_row.rs
+++ b/server/repository/src/db_diesel/name_tag_row.rs
@@ -1,6 +1,6 @@
 use super::{name_tag_row::name_tag::dsl as name_tag_dsl, StorageConnection};
 
-use crate::repository_error::RepositoryError;
+use crate::{repository_error::RepositoryError, Upsert};
 
 use diesel::prelude::*;
 
@@ -66,6 +66,20 @@ impl<'a> NameTagRowRepository<'a> {
         diesel::delete(name_tag_dsl::name_tag.filter(name_tag_dsl::id.eq(id)))
             .execute(&self.connection.connection)?;
         Ok(())
+    }
+}
+
+impl Upsert for NameTagRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        NameTagRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            NameTagRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }
 

--- a/server/repository/src/db_diesel/period/period_row.rs
+++ b/server/repository/src/db_diesel/period/period_row.rs
@@ -1,6 +1,6 @@
 use super::period_row::period::dsl as period_dsl;
 
-use crate::{repository_error::RepositoryError, StorageConnection};
+use crate::{repository_error::RepositoryError, StorageConnection, Upsert};
 
 use chrono::NaiveDate;
 use diesel::prelude::*;
@@ -69,5 +69,19 @@ impl<'a> PeriodRowRepository<'a> {
             .filter(period_dsl::period_schedule_id.eq_any(period_schedule_ids))
             .load(&self.connection.connection)?;
         Ok(result)
+    }
+}
+
+impl Upsert for PeriodRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        PeriodRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            PeriodRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/period/period_schedule_row.rs
+++ b/server/repository/src/db_diesel/period/period_schedule_row.rs
@@ -2,6 +2,7 @@ use super::period_schedule_row::period_schedule::dsl as period_schedule_dsl;
 
 use crate::{repository_error::RepositoryError, StorageConnection};
 
+use crate::Upsert;
 use diesel::prelude::*;
 
 table! {
@@ -63,5 +64,19 @@ impl<'a> PeriodScheduleRowRepository<'a> {
             .first(&self.connection.connection)
             .optional()?;
         Ok(result)
+    }
+}
+
+impl Upsert for PeriodScheduleRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        PeriodScheduleRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            PeriodScheduleRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/program_requisition/program_requisition_order_type_row.rs
+++ b/server/repository/src/db_diesel/program_requisition/program_requisition_order_type_row.rs
@@ -17,6 +17,7 @@ table! {
         max_order_per_period -> Integer,
     }
 }
+use crate::{Delete, Upsert};
 
 joinable!(program_requisition_order_type -> program_requisition_settings (program_requisition_settings_id));
 
@@ -88,5 +89,34 @@ impl<'a> ProgramRequisitionOrderTypeRowRepository<'a> {
         )
         .execute(&self.connection.connection)?;
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ProgramRequisitionOrderTypeRowDelete(pub String);
+impl Delete for ProgramRequisitionOrderTypeRowDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        ProgramRequisitionOrderTypeRowRepository::new(con).delete(&self.0)
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            ProgramRequisitionOrderTypeRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
+        )
+    }
+}
+
+impl Upsert for ProgramRequisitionOrderTypeRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        ProgramRequisitionOrderTypeRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            ProgramRequisitionOrderTypeRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/program_requisition/program_requisition_settings_row.rs
+++ b/server/repository/src/db_diesel/program_requisition/program_requisition_settings_row.rs
@@ -7,7 +7,7 @@ use crate::{
     db_diesel::name_tag_row::name_tag, period_schedule_row::period_schedule,
     repository_error::RepositoryError, StorageConnection,
 };
-
+use crate::{Delete, Upsert};
 use diesel::prelude::*;
 
 table! {
@@ -88,5 +88,34 @@ impl<'a> ProgramRequisitionSettingsRowRepository<'a> {
         )
         .execute(&self.connection.connection)?;
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ProgramRequisitionSettingsRowDelete(pub String);
+impl Delete for ProgramRequisitionSettingsRowDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        ProgramRequisitionSettingsRowRepository::new(con).delete(&self.0)
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            ProgramRequisitionSettingsRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
+        )
+    }
+}
+
+impl Upsert for ProgramRequisitionSettingsRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        ProgramRequisitionSettingsRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            ProgramRequisitionSettingsRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/program_requisition/program_row.rs
+++ b/server/repository/src/db_diesel/program_requisition/program_row.rs
@@ -3,7 +3,7 @@ use super::program_row::program::dsl as program_dsl;
 use crate::{
     db_diesel::{context_row::context, document::document, master_list_row::master_list},
     repository_error::RepositoryError,
-    StorageConnection,
+    StorageConnection, Upsert,
 };
 
 use diesel::prelude::*;
@@ -64,5 +64,19 @@ impl<'a> ProgramRowRepository<'a> {
             .first(&self.connection.connection)
             .optional()?;
         Ok(result)
+    }
+}
+
+impl Upsert for ProgramRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        ProgramRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            ProgramRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/report_row.rs
+++ b/server/repository/src/db_diesel/report_row.rs
@@ -3,7 +3,7 @@ use super::{
 };
 
 use crate::repository_error::RepositoryError;
-
+use crate::{Delete, Upsert};
 use diesel::prelude::*;
 
 use diesel_derive_enum::DbEnum;
@@ -117,5 +117,34 @@ impl<'a> ReportRowRepository<'a> {
         diesel::delete(report_dsl::report.filter(report_dsl::id.eq(id)))
             .execute(&self.connection.connection)?;
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ReportRowDelete(pub String);
+impl Delete for ReportRowDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        ReportRowRepository::new(con).delete(&self.0)
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            ReportRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
+        )
+    }
+}
+
+impl Upsert for ReportRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        ReportRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            ReportRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/requisition/requisition_row.rs
+++ b/server/repository/src/db_diesel/requisition/requisition_row.rs
@@ -7,10 +7,10 @@ use crate::db_diesel::{
 use crate::repository_error::RepositoryError;
 use crate::StorageConnection;
 
+use crate::{Delete, Upsert};
+use chrono::{NaiveDate, NaiveDateTime};
 use diesel::dsl::max;
 use diesel::prelude::*;
-
-use chrono::{NaiveDate, NaiveDateTime};
 use diesel_derive_enum::DbEnum;
 use serde::{Deserialize, Serialize};
 use util::Defaults;
@@ -227,6 +227,35 @@ impl<'a> RequisitionRowRepository<'a> {
             .first(&self.connection.connection)
             .optional()?;
         Ok(result)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RequisitionRowDelete(pub String);
+impl Delete for RequisitionRowDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        RequisitionRowRepository::new(con).delete(&self.0)
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            RequisitionRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
+        )
+    }
+}
+
+impl Upsert for RequisitionRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        RequisitionRowRepository::new(con).sync_upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            RequisitionRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }
 

--- a/server/repository/src/db_diesel/requisition_line/requisition_line_row.rs
+++ b/server/repository/src/db_diesel/requisition_line/requisition_line_row.rs
@@ -5,6 +5,8 @@ use crate::repository_error::RepositoryError;
 use crate::StorageConnection;
 use diesel::prelude::*;
 
+use crate::{Delete, Upsert};
+
 use chrono::NaiveDateTime;
 
 table! {
@@ -126,6 +128,35 @@ impl<'a> RequisitionLineRowRepository<'a> {
             .first(&self.connection.connection)
             .optional()?;
         Ok(result)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RequisitionLineRowDelete(pub String);
+impl Delete for RequisitionLineRowDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        RequisitionLineRowRepository::new(con).delete(&self.0)
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            RequisitionLineRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
+        )
+    }
+}
+
+impl Upsert for RequisitionLineRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        RequisitionLineRowRepository::new(con).sync_upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            RequisitionLineRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }
 

--- a/server/repository/src/db_diesel/stock_line_row.rs
+++ b/server/repository/src/db_diesel/stock_line_row.rs
@@ -3,7 +3,7 @@ use super::{
     stock_line_row::stock_line::dsl as stock_line_dsl, store_row::store, StorageConnection,
 };
 
-use crate::{db_diesel::barcode_row::barcode, repository_error::RepositoryError};
+use crate::{db_diesel::barcode_row::barcode, repository_error::RepositoryError, Delete, Upsert};
 
 use diesel::prelude::*;
 
@@ -117,5 +117,35 @@ impl<'a> StockLineRowRepository<'a> {
             .filter(stock_line_dsl::store_id.eq(store_id))
             .load::<StockLineRow>(&self.connection.connection)
             .map_err(RepositoryError::from)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StockLineRowDelete(pub String);
+// For tests only
+impl Delete for StockLineRowDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        StockLineRowRepository::new(con).delete(&self.0)
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            StockLineRowRepository::new(con).find_one_by_id_option(&self.0),
+            Ok(None)
+        )
+    }
+}
+
+impl Upsert for StockLineRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        StockLineRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            StockLineRowRepository::new(con).find_one_by_id_option(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/stocktake_line_row.rs
+++ b/server/repository/src/db_diesel/stocktake_line_row.rs
@@ -5,7 +5,7 @@ use super::{
     StorageConnection,
 };
 
-use crate::repository_error::RepositoryError;
+use crate::{repository_error::RepositoryError, Delete, Upsert};
 
 use diesel::prelude::*;
 
@@ -115,5 +115,35 @@ impl<'a> StocktakeLineRowRepository<'a> {
             .filter(stocktake_line_dsl::id.eq_any(ids))
             .load(&self.connection.connection)?;
         Ok(result)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StocktakeLineRowDelete(pub String);
+// For tests only
+impl Delete for StocktakeLineRowDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        StocktakeLineRowRepository::new(con).delete(&self.0)
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            StocktakeLineRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
+        )
+    }
+}
+
+impl Upsert for StocktakeLineRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        StocktakeLineRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            StocktakeLineRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/stocktake_row.rs
+++ b/server/repository/src/db_diesel/stocktake_row.rs
@@ -2,11 +2,11 @@ use super::{
     stocktake_row::stocktake::dsl as stocktake_dsl, user_row::user_account, StorageConnection,
 };
 
-use crate::repository_error::RepositoryError;
+use crate::{repository_error::RepositoryError, Delete};
 
-use diesel::{dsl::max, prelude::*};
-
+use crate::Upsert;
 use chrono::{NaiveDate, NaiveDateTime};
+use diesel::{dsl::max, prelude::*};
 use diesel_derive_enum::DbEnum;
 use util::Defaults;
 
@@ -141,5 +141,35 @@ impl<'a> StocktakeRowRepository<'a> {
             .select(max(stocktake_dsl::stocktake_number))
             .first(&self.connection.connection)?;
         Ok(result)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StocktakeRowDelete(pub String);
+// For tests only
+impl Delete for StocktakeRowDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        StocktakeRowRepository::new(con).delete(&self.0)
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            StocktakeRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
+        )
+    }
+}
+
+impl Upsert for StocktakeRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        StocktakeRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            StocktakeRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/store_preference_row.rs
+++ b/server/repository/src/db_diesel/store_preference_row.rs
@@ -3,7 +3,7 @@ use super::{
     user_store_join_row::user_store_join, StorageConnection,
 };
 
-use crate::repository_error::RepositoryError;
+use crate::{repository_error::RepositoryError, Upsert};
 
 use super::{store_row::store, user_row::user_account};
 use diesel::prelude::*;
@@ -105,5 +105,19 @@ impl<'a> StorePreferenceRowRepository<'a> {
             .filter(store_preference_dsl::id.eq_any(ids))
             .load(&self.connection.connection)?;
         Ok(result)
+    }
+}
+
+impl Upsert for StorePreferenceRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        StorePreferenceRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            StorePreferenceRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/store_row.rs
+++ b/server/repository/src/db_diesel/store_row.rs
@@ -1,6 +1,6 @@
 use super::{name_row::name, store_row::store::dsl as store_dsl, StorageConnection};
 
-use crate::repository_error::RepositoryError;
+use crate::{repository_error::RepositoryError, Delete, Upsert};
 
 use diesel::prelude::*;
 use diesel_derive_enum::DbEnum;
@@ -110,5 +110,35 @@ impl<'a> StoreRowRepository<'a> {
         diesel::delete(store_dsl::store.filter(store_dsl::id.eq(id)))
             .execute(&self.connection.connection)?;
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StoreRowDelete(pub String);
+// TODO soft delete
+impl Delete for StoreRowDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        StoreRowRepository::new(con).delete(&self.0)
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            StoreRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
+        )
+    }
+}
+
+impl Upsert for StoreRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        StoreRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            StoreRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/user_permission_row.rs
+++ b/server/repository/src/db_diesel/user_permission_row.rs
@@ -4,7 +4,7 @@ use crate::{
     db_diesel::user_permission_row::user_permission::dsl as user_permission_dsl,
     repository_error::RepositoryError,
 };
-
+use crate::{Delete, Upsert};
 use diesel::prelude::*;
 
 use diesel_derive_enum::DbEnum;
@@ -131,5 +131,34 @@ impl<'a> UserPermissionRowRepository<'a> {
         diesel::delete(user_permission_dsl::user_permission.filter(user_permission_dsl::id.eq(id)))
             .execute(&self.connection.connection)?;
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UserPermissionRowDelete(pub String);
+impl Delete for UserPermissionRowDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        UserPermissionRowRepository::new(con).delete(&self.0)
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            UserPermissionRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
+        )
+    }
+}
+
+impl Upsert for UserPermissionRow {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        UserPermissionRowRepository::new(con).upsert_one(self)
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            UserPermissionRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/lib.rs
+++ b/server/repository/src/lib.rs
@@ -15,6 +15,7 @@ pub use self::db_diesel::*;
 pub use self::repository_error::RepositoryError;
 pub use database_settings::get_storage_connection_manager;
 use diesel::sql_types::Text;
+use std::any::Any;
 use std::str;
 
 mod tests;
@@ -36,4 +37,52 @@ pub fn run_db_migrations(connection: &StorageConnection) -> Result<(), String> {
         str::from_utf8(&boxed_buffer).map_err(|e| e.to_string())?
     );
     Ok(())
+}
+
+use std::fmt::Debug as DebugTrait;
+pub trait Delete: DebugTrait {
+    fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError>;
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection);
+}
+
+pub trait Upsert: DebugTrait {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError>;
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection);
+    // Test only, can be used to drill down to concrete type (see test below)
+    // also casting to any must be implemented by concrete type to be able to downcast to it
+    // This is needed for integration test (where test record is generated for inventory adjustment, but id is not know until site is created)
+    fn as_mut_any(&mut self) -> Option<&mut dyn Any> {
+        None
+    }
+}
+
+#[test]
+fn downcast_example() {
+    let mut boxed: Vec<Box<dyn Upsert>> = vec![
+        Box::new(InvoiceRow::default()),
+        Box::new(InvoiceLineRow::default()),
+    ];
+
+    for record in &mut boxed {
+        let Some(mut_invoice) = record
+            .as_mut_any()
+            .map(|any| any.downcast_mut::<InvoiceRow>())
+            .flatten() else  {
+            continue;
+        };
+
+        mut_invoice.id = "changed_id".to_string()
+    }
+
+    let compare_to: Vec<Box<dyn Upsert>> = vec![
+        Box::new(InvoiceRow {
+            id: "changed_id".to_string(),
+            ..Default::default()
+        }),
+        Box::new(InvoiceLineRow::default()),
+    ];
+
+    assert_eq!(format!("{boxed:?}"), format!("{compare_to:?}"))
 }

--- a/server/repository/src/tests.rs
+++ b/server/repository/src/tests.rs
@@ -420,7 +420,7 @@ mod repository_test {
         repo.upsert_one(&master_list_1).unwrap();
         let loaded_item = repo
             .find_one_by_id(master_list_1.id.as_str())
-            .await
+            .unwrap()
             .unwrap();
         assert_eq!(master_list_1, loaded_item);
 
@@ -428,7 +428,7 @@ mod repository_test {
         repo.upsert_one(&master_list_upsert_1).unwrap();
         let loaded_item = repo
             .find_one_by_id(master_list_upsert_1.id.as_str())
-            .await
+            .unwrap()
             .unwrap();
         assert_eq!(master_list_upsert_1, loaded_item);
     }

--- a/server/service/src/sync/integrate_document.rs
+++ b/server/service/src/sync/integrate_document.rs
@@ -24,7 +24,12 @@ impl Upsert for DocumentUpsert {
         sync_upsert_document(con, &self.0)
     }
 
-    fn assert_upserted(&self, _: &StorageConnection) {}
+    fn assert_upserted(&self, con: &StorageConnection) {
+      assert_eq!(
+          DocumentRepository::new(con).find_one_by_id(&self.0.id),
+          Ok(Some(self.0.clone()))
+      );
+    }
 }
 
 fn sync_upsert_document(

--- a/server/service/src/sync/integrate_document.rs
+++ b/server/service/src/sync/integrate_document.rs
@@ -1,7 +1,7 @@
 use repository::{
     Document, DocumentRegistryCategory, DocumentRegistryFilter, DocumentRegistryRepository,
     DocumentRepository, EncounterFilter, EncounterRepository, EqualFilter, ProgramFilter,
-    ProgramRepository, RepositoryError, StorageConnection,
+    ProgramRepository, RepositoryError, StorageConnection, Upsert,
 };
 
 use crate::{
@@ -16,8 +16,18 @@ use crate::{
         program_enrolment::program_schema::SchemaProgramEnrolment,
     },
 };
+#[derive(Debug)]
+pub(crate) struct DocumentUpsert(pub(crate) Document);
 
-pub(crate) fn sync_upsert_document(
+impl Upsert for DocumentUpsert {
+    fn upsert_sync(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        sync_upsert_document(con, &self.0)
+    }
+
+    fn assert_upserted(&self, _: &StorageConnection) {}
+}
+
+fn sync_upsert_document(
     con: &StorageConnection,
     document: &Document,
 ) -> Result<(), RepositoryError> {

--- a/server/service/src/sync/sync_buffer.rs
+++ b/server/service/src/sync/sync_buffer.rs
@@ -80,14 +80,14 @@ mod test {
     };
     use util::{inline_init, Defaults};
 
-    use crate::sync::translations::{all_translators, pull_integration_order, LegacyTableName};
+    use crate::sync::translations::{all_translators, pull_integration_order};
 
     use super::SyncBuffer;
 
     fn row_1() -> SyncBufferRow {
         inline_init(|r: &mut SyncBufferRow| {
             r.record_id = "1".to_string();
-            r.table_name = LegacyTableName::TRANSACT.to_string();
+            r.table_name = "transact".to_string();
             r.received_datetime = Defaults::naive_date_time();
         })
     }
@@ -95,7 +95,7 @@ mod test {
     fn row_2() -> SyncBufferRow {
         inline_init(|r: &mut SyncBufferRow| {
             r.record_id = "2".to_string();
-            r.table_name = LegacyTableName::TRANS_LINE.to_string();
+            r.table_name = "trans_line".to_string();
             r.received_datetime = Defaults::naive_date_time();
         })
     }
@@ -103,7 +103,7 @@ mod test {
     fn row_3() -> SyncBufferRow {
         inline_init(|r: &mut SyncBufferRow| {
             r.record_id = "3".to_string();
-            r.table_name = LegacyTableName::STORE.to_string();
+            r.table_name = "store".to_string();
             r.received_datetime = Defaults::naive_date_time();
         })
     }
@@ -111,7 +111,7 @@ mod test {
     fn row_4() -> SyncBufferRow {
         inline_init(|r: &mut SyncBufferRow| {
             r.record_id = "4".to_string();
-            r.table_name = LegacyTableName::NAME.to_string();
+            r.table_name = "name".to_string();
             r.received_datetime = Defaults::naive_date_time();
         })
     }
@@ -119,7 +119,7 @@ mod test {
     fn row_5() -> SyncBufferRow {
         inline_init(|r: &mut SyncBufferRow| {
             r.record_id = "5".to_string();
-            r.table_name = LegacyTableName::LIST_MASTER.to_string();
+            r.table_name = "list_master".to_string();
             r.received_datetime = Defaults::naive_date_time();
             r.action = SyncBufferAction::Delete;
         })
@@ -128,7 +128,7 @@ mod test {
     fn row_6() -> SyncBufferRow {
         inline_init(|r: &mut SyncBufferRow| {
             r.record_id = "6".to_string();
-            r.table_name = LegacyTableName::LIST_MASTER_LINE.to_string();
+            r.table_name = "list_master_line".to_string();
             r.received_datetime = Defaults::naive_date_time();
             r.action = SyncBufferAction::Delete;
         })

--- a/server/service/src/sync/test/integration/README.md
+++ b/server/service/src/sync/test/integration/README.md
@@ -23,7 +23,7 @@ The following environment variables should be provided for sync integration test
 * SYNC_URL
 
 As `1`, can provide via cli or rust analyzer:
-`"rust-analyzer.runnableEnv": { "SYNC_URL": "http://localhost:2048", "SYNC_SITE_NAME": "demo","SYNC_SITE_PASSWORD": "pass" }`
+`"rust-analyzer.runnables.extraEnv": { "SYNC_URL": "http://localhost:2048", "SYNC_SITE_NAME": "demo","SYNC_SITE_PASSWORD": "pass" }`
 
 ## 3 `central server`
 

--- a/server/service/src/sync/test/integration/central/document_registry.rs
+++ b/server/service/src/sync/test/integration/central/document_registry.rs
@@ -2,7 +2,7 @@ use crate::sync::{
     test::integration::{
         central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
     },
-    translations::{IntegrationRecords, PullUpsertRecord},
+    translations::IntegrationOperation,
 };
 use repository::{ContextRow, DocumentRegistryCategory, DocumentRegistryRow, FormSchemaJson};
 use serde_json::json;
@@ -65,10 +65,10 @@ impl SyncRecordTester for DocumentRegistryTester {
                 "om_document_registry": [doc_registry_json1],
             }),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::FormSchema(form_row1),
-                PullUpsertRecord::DocumentRegistry(doc_registry1),
-            ]),
+            integration_records: vec![
+                IntegrationOperation::upsert(form_row1),
+                IntegrationOperation::upsert(doc_registry1),
+            ],
         });
 
         result

--- a/server/service/src/sync/test/integration/central/form_schema.rs
+++ b/server/service/src/sync/test/integration/central/form_schema.rs
@@ -2,7 +2,7 @@ use crate::sync::{
     test::integration::{
         central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
     },
-    translations::{IntegrationRecords, PullUpsertRecord},
+    translations::IntegrationOperation,
 };
 use repository::FormSchemaJson;
 use serde_json::json;
@@ -32,9 +32,7 @@ impl SyncRecordTester for FormSchemaTester {
                 "form_schema": [json1],
             }),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::FormSchema(row1),
-            ]),
+            integration_records: vec![IntegrationOperation::upsert(row1)],
         });
 
         result

--- a/server/service/src/sync/test/integration/central/inventory_adjustment_reason.rs
+++ b/server/service/src/sync/test/integration/central/inventory_adjustment_reason.rs
@@ -2,7 +2,7 @@ use crate::sync::{
     test::integration::{
         central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
     },
-    translations::{IntegrationRecords, PullUpsertRecord},
+    translations::IntegrationOperation,
 };
 use repository::{InventoryAdjustmentReasonRow, InventoryAdjustmentReasonType};
 
@@ -68,12 +68,12 @@ impl SyncRecordTester for InventoryAdjustmentReasonTester {
                   }],
             }),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::InventoryAdjustmentReason(pos_1),
-                PullUpsertRecord::InventoryAdjustmentReason(pos_2),
-                PullUpsertRecord::InventoryAdjustmentReason(neg_1),
-                PullUpsertRecord::InventoryAdjustmentReason(neg_2),
-            ]),
+            integration_records: vec![
+                IntegrationOperation::upsert(pos_1),
+                IntegrationOperation::upsert(pos_2),
+                IntegrationOperation::upsert(neg_1),
+                IntegrationOperation::upsert(neg_2),
+            ],
         });
         // STEP 2 - deletes
         // TODO should be soft deleted

--- a/server/service/src/sync/test/integration/central/master_list.rs
+++ b/server/service/src/sync/test/integration/central/master_list.rs
@@ -2,7 +2,7 @@ use crate::sync::{
     test::integration::{
         central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
     },
-    translations::{IntegrationRecords, PullUpsertRecord},
+    translations::IntegrationOperation,
 };
 use repository::{MasterListLineRow, MasterListNameJoinRow, MasterListRow};
 
@@ -20,11 +20,13 @@ impl SyncRecordTester for MasterListTester {
             name: uuid(),
             code: uuid(),
             description: "".to_string(),
+            is_active: true,
         };
         let master_list_json1 = json!({
             "ID": master_list_row1.id,
             "description":  master_list_row1.name,
             "code": master_list_row1.code,
+            "is_active": true,
         });
 
         let master_list_name_join_row1 = MasterListNameJoinRow {
@@ -36,6 +38,7 @@ impl SyncRecordTester for MasterListTester {
             "ID": master_list_name_join_row1.id,
             "list_master_ID":  master_list_name_join_row1.master_list_id,
             "name_ID": master_list_name_join_row1.name_id,
+            "is_active": false,
         });
 
         let master_list_row2 = MasterListRow {
@@ -43,6 +46,7 @@ impl SyncRecordTester for MasterListTester {
             name: uuid(),
             code: uuid(),
             description: uuid(),
+            is_active: false,
         };
         let master_list_json2 = json!({
             "ID": master_list_row2.id,
@@ -82,13 +86,13 @@ impl SyncRecordTester for MasterListTester {
                 "item": [{"ID": item_id, "type_of": "general"}]
             }),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::MasterList(master_list_row1.clone()),
-                PullUpsertRecord::MasterList(master_list_row2),
-                PullUpsertRecord::MasterListNameJoin(master_list_name_join_row1.clone()),
-                PullUpsertRecord::MasterListNameJoin(master_list_name_join_row2),
-                PullUpsertRecord::MasterListLine(master_list_line_row.clone()),
-            ]),
+            integration_records: vec![
+                IntegrationOperation::upsert(master_list_row1),
+                IntegrationOperation::upsert(master_list_row2),
+                IntegrationOperation::upsert(master_list_name_join_row1),
+                IntegrationOperation::upsert(master_list_name_join_row2),
+                IntegrationOperation::upsert(master_list_line_row),
+            ],
         });
 
         result

--- a/server/service/src/sync/test/integration/central/master_list.rs
+++ b/server/service/src/sync/test/integration/central/master_list.rs
@@ -20,13 +20,13 @@ impl SyncRecordTester for MasterListTester {
             name: uuid(),
             code: uuid(),
             description: "".to_string(),
-            is_active: true,
+            is_active: false,
         };
         let master_list_json1 = json!({
             "ID": master_list_row1.id,
             "description":  master_list_row1.name,
             "code": master_list_row1.code,
-            "is_active": true,
+            "inactive": true,
         });
 
         let master_list_name_join_row1 = MasterListNameJoinRow {
@@ -38,7 +38,6 @@ impl SyncRecordTester for MasterListTester {
             "ID": master_list_name_join_row1.id,
             "list_master_ID":  master_list_name_join_row1.master_list_id,
             "name_ID": master_list_name_join_row1.name_id,
-            "is_active": false,
         });
 
         let master_list_row2 = MasterListRow {
@@ -52,7 +51,8 @@ impl SyncRecordTester for MasterListTester {
             "ID": master_list_row2.id,
             "description":  master_list_row2.name,
             "code": master_list_row2.code,
-            "note": master_list_row2.description
+            "note": master_list_row2.description,
+            "inactive": true,
         });
 
         let master_list_name_join_row2 = MasterListNameJoinRow {

--- a/server/service/src/sync/test/integration/central/mod.rs
+++ b/server/service/src/sync/test/integration/central/mod.rs
@@ -10,7 +10,7 @@ mod unit_and_item;
 
 use super::{central_server_configurations::ConfigureCentralServer, SyncRecordTester};
 use crate::sync::test::{
-    check_records_against_database,
+    check_integrated,
     integration::{
         central_server_configurations::SiteConfiguration, init_test_context, SyncIntegrationContext,
     },
@@ -57,7 +57,7 @@ async fn test_central_sync_record(identifier: &str, tester: &dyn SyncRecordTeste
             .expect("Problem deleting central data");
 
         synchroniser.sync().await.unwrap();
-        check_records_against_database(&connection, step_data.integration_records).await;
+        check_integrated(&connection, step_data.integration_records)
     }
 
     // With re-initialisation
@@ -95,6 +95,7 @@ async fn test_central_sync_record(identifier: &str, tester: &dyn SyncRecordTeste
         } = init_test_context(&sync_settings, &inner_identifier).await;
 
         synchroniser.sync().await.unwrap();
-        check_records_against_database(&connection, step_data.integration_records).await;
+
+        check_integrated(&connection, step_data.integration_records)
     }
 }

--- a/server/service/src/sync/test/integration/central/period_schedule_and_period.rs
+++ b/server/service/src/sync/test/integration/central/period_schedule_and_period.rs
@@ -2,7 +2,7 @@ use crate::sync::{
     test::integration::{
         central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
     },
-    translations::{IntegrationRecords, PullUpsertRecord},
+    translations::IntegrationOperation,
 };
 use repository::{PeriodRow, PeriodScheduleRow};
 
@@ -74,12 +74,12 @@ impl SyncRecordTester for PeriodScheduleAndPeriodTester {
                 "period": [period_1_json, period_2_json]
             }),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::PeriodSchedule(period_schedule_1.clone()),
-                PullUpsertRecord::PeriodSchedule(period_schedule_2),
-                PullUpsertRecord::Period(period_1.clone()),
-                PullUpsertRecord::Period(period_2),
-            ]),
+            integration_records: vec![
+                IntegrationOperation::upsert(period_schedule_1),
+                IntegrationOperation::upsert(period_schedule_2),
+                IntegrationOperation::upsert(period_1),
+                IntegrationOperation::upsert(period_2),
+            ],
         });
 
         result

--- a/server/service/src/sync/test/integration/central/report.rs
+++ b/server/service/src/sync/test/integration/central/report.rs
@@ -2,9 +2,9 @@ use crate::sync::{
     test::integration::{
         central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
     },
-    translations::{IntegrationRecords, PullDeleteRecord, PullDeleteRecordTable, PullUpsertRecord},
+    translations::IntegrationOperation,
 };
-use repository::{ReportContext, ReportRow, ReportType};
+use repository::{ReportContext, ReportRow, ReportRowDelete, ReportType};
 use serde_json::json;
 use util::{inline_init, uuid::uuid};
 
@@ -69,22 +69,21 @@ impl SyncRecordTester for ReportTester {
                 "report": [report_json1,report_json2,report_json3,report_json4],
             }),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::Report(report_row1.clone()),
-                PullUpsertRecord::Report(report_row2),
-                PullUpsertRecord::Report(report_row3),
-                PullUpsertRecord::Report(report_row4),
-            ]),
+            integration_records: vec![
+                IntegrationOperation::upsert(report_row1.clone()),
+                IntegrationOperation::upsert(report_row2),
+                IntegrationOperation::upsert(report_row3),
+                IntegrationOperation::upsert(report_row4),
+            ],
         });
 
         // STEP 2 - deletes
         result.push(TestStepData {
             central_upsert: json!({}),
             central_delete: json!({ "report": [report_row1.id] }),
-            integration_records: IntegrationRecords::from_deletes(vec![PullDeleteRecord {
-                id: report_row1.id,
-                table: PullDeleteRecordTable::Report,
-            }]),
+            integration_records: vec![IntegrationOperation::delete(ReportRowDelete(
+                report_row1.id,
+            ))],
         });
         result
     }

--- a/server/service/src/sync/test/integration/central/unit_and_item.rs
+++ b/server/service/src/sync/test/integration/central/unit_and_item.rs
@@ -5,9 +5,9 @@ use crate::sync::{
         },
         test_data::item::test_pull_upsert_records,
     },
-    translations::{IntegrationRecords, PullDeleteRecord, PullDeleteRecordTable, PullUpsertRecord},
+    translations::IntegrationOperation,
 };
-use repository::{ItemRow, ItemRowType, UnitRow};
+use repository::{ItemRow, ItemRowDelete, ItemRowType, UnitRow, UnitRowDelete};
 
 use serde_json::json;
 use util::{merge_json, uuid::uuid};
@@ -104,28 +104,22 @@ impl SyncRecordTester for UnitAndItemTester {
                 "unit": [unit_json1, unit_json2]
             }),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::Unit(unit_row1.clone()),
-                PullUpsertRecord::Unit(unit_row2),
-                PullUpsertRecord::Item(item_row1),
-                PullUpsertRecord::Item(item_row2.clone()),
-                PullUpsertRecord::Item(item_row3),
-            ]),
+            integration_records: vec![
+                IntegrationOperation::upsert(unit_row1.clone()),
+                IntegrationOperation::upsert(unit_row2),
+                IntegrationOperation::upsert(item_row1),
+                IntegrationOperation::upsert(item_row2.clone()),
+                IntegrationOperation::upsert(item_row3),
+            ],
         });
         // STEP 2 - deletes
         result.push(TestStepData {
             central_upsert: json!({}),
             central_delete: json!({ "item": [item_row2.id], "unit": [unit_row1.id] }),
-            integration_records: IntegrationRecords::from_deletes(vec![
-                PullDeleteRecord {
-                    id: unit_row1.id,
-                    table: PullDeleteRecordTable::Unit,
-                },
-                PullDeleteRecord {
-                    id: item_row2.id,
-                    table: PullDeleteRecordTable::Item,
-                },
-            ]),
+            integration_records: vec![
+                IntegrationOperation::delete(UnitRowDelete(unit_row1.id)),
+                IntegrationOperation::delete(ItemRowDelete(item_row2.id)),
+            ],
         });
         result
     }

--- a/server/service/src/sync/test/integration/mod.rs
+++ b/server/service/src/sync/test/integration/mod.rs
@@ -9,9 +9,7 @@ use self::central_server_configurations::NewSiteProperties;
 use crate::{
     service_provider::ServiceProvider,
     sync::{
-        settings::SyncSettings,
-        synchroniser::Synchroniser,
-        translations::{IntegrationRecords, PullDeleteRecord},
+        settings::SyncSettings, synchroniser::Synchroniser, translations::IntegrationOperation,
     },
     test_helpers::{setup_all_and_service_provider, ServiceTestContext},
 };
@@ -66,16 +64,7 @@ async fn init_test_context(
 struct TestStepData {
     central_upsert: serde_json::Value,
     central_delete: serde_json::Value,
-    integration_records: IntegrationRecords,
-}
-
-impl IntegrationRecords {
-    fn from_deletes(rows: Vec<PullDeleteRecord>) -> IntegrationRecords {
-        IntegrationRecords {
-            upserts: Vec::new(),
-            deletes: rows,
-        }
-    }
+    integration_records: Vec<IntegrationOperation>,
 }
 
 trait SyncRecordTester {

--- a/server/service/src/sync/test/integration/remote/activity_log.rs
+++ b/server/service/src/sync/test/integration/remote/activity_log.rs
@@ -2,10 +2,10 @@ use crate::sync::{
     test::integration::{
         central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
     },
-    translations::{IntegrationRecords, PullDeleteRecord, PullDeleteRecordTable, PullUpsertRecord},
+    translations::IntegrationOperation,
 };
 use chrono::NaiveDate;
-use repository::{ActivityLogRow, ActivityLogType};
+use repository::{ActivityLogRow, ActivityLogRowDelete, ActivityLogType};
 use serde_json::json;
 use util::{inline_edit, uuid::uuid};
 
@@ -50,14 +50,12 @@ impl SyncRecordTester for ActivityLogRecordTester {
         result.push(TestStepData {
             central_upsert: json!({}),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::ActivityLog(log_1.clone()),
-                PullUpsertRecord::ActivityLog(log_2.clone()),
-            ])
-            .join(IntegrationRecords::from_deletes(vec![PullDeleteRecord {
-                id: log_3.id.clone(),
-                table: PullDeleteRecordTable::ActivityLog,
-            }])),
+            integration_records: vec![
+                IntegrationOperation::upsert(log_1),
+                IntegrationOperation::upsert(log_2),
+                // Should not sync out thus need to check if it's missing after re-initialisation
+                IntegrationOperation::delete(ActivityLogRowDelete(log_3.id)),
+            ],
         });
         result
     }

--- a/server/service/src/sync/test/integration/remote/clinician.rs
+++ b/server/service/src/sync/test/integration/remote/clinician.rs
@@ -2,7 +2,7 @@ use crate::sync::{
     test::integration::{
         central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
     },
-    translations::{IntegrationRecords, PullUpsertRecord},
+    translations::IntegrationOperation,
 };
 use repository::{ClinicianRow, ClinicianStoreJoinRow, Gender, StoreMode, StoreRow};
 use serde_json::json;
@@ -75,11 +75,11 @@ impl SyncRecordTester for ClinicianRecordTester {
                 "clinician_store_join": [join_json],
             }),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::Store(store_row),
-                PullUpsertRecord::Clinician(clinician_row.clone()),
-                PullUpsertRecord::ClinicianStoreJoin(join_row.clone()),
-            ]),
+            integration_records: vec![
+                IntegrationOperation::upsert(store_row),
+                IntegrationOperation::upsert(clinician_row.clone()),
+                IntegrationOperation::upsert(join_row),
+            ],
         });
 
         // STEP 2 - mutate
@@ -100,9 +100,7 @@ impl SyncRecordTester for ClinicianRecordTester {
         result.push(TestStepData {
             central_upsert: json!({}),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::Clinician(row.clone()),
-            ]),
+            integration_records: vec![IntegrationOperation::upsert(row)],
         });
         result
     }

--- a/server/service/src/sync/test/integration/remote/document.rs
+++ b/server/service/src/sync/test/integration/remote/document.rs
@@ -1,8 +1,9 @@
 use crate::sync::{
+    integrate_document::DocumentUpsert,
     test::integration::{
         central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
     },
-    translations::{IntegrationRecords, PullUpsertRecord},
+    translations::IntegrationOperation,
 };
 use chrono::{Timelike, Utc};
 use repository::{ContextRow, Document, DocumentStatus};
@@ -72,9 +73,7 @@ impl SyncRecordTester for DocumentRecordTester {
                 "form_schema": [schema_json],
             }),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::Document(row.clone()),
-            ]),
+            integration_records: vec![IntegrationOperation::upsert(DocumentUpsert(row))],
         });
 
         result

--- a/server/service/src/sync/test/integration/remote/invoice.rs
+++ b/server/service/src/sync/test/integration/remote/invoice.rs
@@ -2,7 +2,7 @@ use crate::sync::{
     test::integration::{
         central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
     },
-    translations::{IntegrationRecords, PullDeleteRecord, PullDeleteRecordTable, PullUpsertRecord},
+    translations::IntegrationOperation,
 };
 use chrono::NaiveDate;
 use repository::mock::mock_request_draft_requisition;
@@ -162,20 +162,20 @@ impl SyncRecordTester for InvoiceRecordTester {
                 }]
             }),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::Location(location_row),
-                PullUpsertRecord::Invoice(invoice_row_1.clone()),
-                PullUpsertRecord::Invoice(invoice_row_2.clone()),
-                PullUpsertRecord::Invoice(invoice_row_3),
-                PullUpsertRecord::Invoice(invoice_row_4),
-                PullUpsertRecord::Invoice(invoice_row_5),
-                PullUpsertRecord::Invoice(invoice_row_6),
-                PullUpsertRecord::InvoiceLine(invoice_line_row_1.clone()),
-                PullUpsertRecord::InvoiceLine(invoice_line_row_2),
-                PullUpsertRecord::InvoiceLine(invoice_line_row_3),
-                PullUpsertRecord::InvoiceLine(invoice_line_row_4),
-                PullUpsertRecord::InvoiceLine(invoice_line_row_5),
-            ]),
+            integration_records: vec![
+                IntegrationOperation::upsert(location_row),
+                IntegrationOperation::upsert(invoice_row_1.clone()),
+                IntegrationOperation::upsert(invoice_row_2.clone()),
+                IntegrationOperation::upsert(invoice_row_3),
+                IntegrationOperation::upsert(invoice_row_4),
+                IntegrationOperation::upsert(invoice_row_5),
+                IntegrationOperation::upsert(invoice_row_6),
+                IntegrationOperation::upsert(invoice_line_row_1.clone()),
+                IntegrationOperation::upsert(invoice_line_row_2),
+                IntegrationOperation::upsert(invoice_line_row_3),
+                IntegrationOperation::upsert(invoice_line_row_4),
+                IntegrationOperation::upsert(invoice_line_row_5),
+            ],
         });
         // STEP 2 - mutate
         let stock_line_row = inline_init(|r: &mut StockLineRow| {
@@ -249,13 +249,13 @@ impl SyncRecordTester for InvoiceRecordTester {
         result.push(TestStepData {
             central_upsert: json!({}),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::StockLine(stock_line_row),
-                PullUpsertRecord::Requisition(requisition_row),
-                PullUpsertRecord::Invoice(invoice_row_1.clone()),
-                PullUpsertRecord::Invoice(invoice_row_2.clone()),
-                PullUpsertRecord::InvoiceLine(invoice_line_row_1.clone()),
-            ]),
+            integration_records: vec![
+                IntegrationOperation::upsert(stock_line_row),
+                IntegrationOperation::upsert(requisition_row),
+                IntegrationOperation::upsert(invoice_row_1.clone()),
+                IntegrationOperation::upsert(invoice_row_2.clone()),
+                IntegrationOperation::upsert(invoice_line_row_1.clone()),
+            ],
         });
         // STEP 3 - delete
         let invoice_row_2 = inline_edit(&invoice_row_2, |mut d| {
@@ -265,19 +265,11 @@ impl SyncRecordTester for InvoiceRecordTester {
         result.push(TestStepData {
             central_upsert: json!({}),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upsert(PullUpsertRecord::Invoice(
-                invoice_row_2,
-            ))
-            .join(IntegrationRecords::from_deletes(vec![
-                PullDeleteRecord {
-                    id: invoice_line_row_1.id.clone(),
-                    table: PullDeleteRecordTable::InvoiceLine,
-                },
-                PullDeleteRecord {
-                    id: invoice_row_1.id.clone(),
-                    table: PullDeleteRecordTable::Invoice,
-                },
-            ])),
+            integration_records: vec![
+                IntegrationOperation::upsert(invoice_row_2),
+                IntegrationOperation::delete(InvoiceLineRowDelete(invoice_line_row_1.id.clone())),
+                IntegrationOperation::delete(InvoiceRowDelete(invoice_row_1.id.clone())),
+            ],
         });
         result
     }

--- a/server/service/src/sync/test/integration/remote/location.rs
+++ b/server/service/src/sync/test/integration/remote/location.rs
@@ -2,9 +2,9 @@ use crate::sync::{
     test::integration::{
         central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
     },
-    translations::{IntegrationRecords, PullUpsertRecord},
+    translations::IntegrationOperation,
 };
-use repository::LocationRow;
+use repository::{LocationRow, LocationRowDelete};
 use serde_json::json;
 use util::{inline_edit, uuid::uuid};
 
@@ -25,9 +25,7 @@ impl SyncRecordTester for LocationRecordTester {
         result.push(TestStepData {
             central_upsert: json!({}),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::Location(row.clone()),
-            ]),
+            integration_records: vec![IntegrationOperation::upsert(row.clone())],
         });
         // STEP 2 - mutate
         let row = inline_edit(&row, |mut d| {
@@ -39,18 +37,13 @@ impl SyncRecordTester for LocationRecordTester {
         result.push(TestStepData {
             central_upsert: json!({}),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::Location(row.clone()),
-            ]),
+            integration_records: vec![IntegrationOperation::upsert(row.clone())],
         });
         // STEP 3 - delete
         result.push(TestStepData {
             central_upsert: json!({}),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_delete(
-                &row.id,
-                crate::sync::translations::PullDeleteRecordTable::Location,
-            ),
+            integration_records: vec![IntegrationOperation::delete(LocationRowDelete(row.id))],
         });
         result
     }

--- a/server/service/src/sync/test/integration/remote/location_movement.rs
+++ b/server/service/src/sync/test/integration/remote/location_movement.rs
@@ -2,7 +2,7 @@ use crate::sync::{
     test::integration::{
         central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
     },
-    translations::{IntegrationRecords, PullUpsertRecord},
+    translations::IntegrationOperation,
 };
 use chrono::NaiveDate;
 use repository::{LocationMovementRow, LocationRow, StockLineRow};
@@ -55,11 +55,11 @@ impl SyncRecordTester for LocationMovementRecordTester {
                 "type_of": "general"
             }]}),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::Location(location_row.clone()),
-                PullUpsertRecord::StockLine(stock_line_row.clone()),
-                PullUpsertRecord::LocationMovement(location_movement_row.clone()),
-            ]),
+            integration_records: vec![
+                IntegrationOperation::upsert(location_row.clone()),
+                IntegrationOperation::upsert(stock_line_row.clone()),
+                IntegrationOperation::upsert(location_movement_row.clone()),
+            ],
         });
 
         // STEP 2 - mutate
@@ -82,9 +82,7 @@ impl SyncRecordTester for LocationMovementRecordTester {
         result.push(TestStepData {
             central_upsert: json!({}),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::LocationMovement(location_movement.clone()),
-            ]),
+            integration_records: vec![IntegrationOperation::upsert(location_movement.clone())],
         });
 
         result

--- a/server/service/src/sync/test/integration/remote/mod.rs
+++ b/server/service/src/sync/test/integration/remote/mod.rs
@@ -12,18 +12,21 @@ pub(crate) mod stocktake;
 mod test;
 pub(crate) mod user_permission;
 
-use repository::{ChangelogRepository, InvoiceRowType, NameRowRepository, StorageConnection};
+use repository::{
+    ChangelogRepository, InvoiceRow, InvoiceRowType, NameRowRepository, StorageConnection,
+};
 use util::constants::INVENTORY_ADJUSTMENT_NAME_CODE;
 
 use crate::sync::{
     test::{
-        check_records_against_database,
+        check_integrated,
         integration::{
             central_server_configurations::{ConfigureCentralServer, SiteConfiguration},
             init_test_context, SyncIntegrationContext,
         },
     },
-    translations::{IntegrationRecords, PullUpsertRecord},
+    translation_and_integration::integrate,
+    translations::IntegrationOperation,
 };
 
 use super::SyncRecordTester;
@@ -81,7 +84,7 @@ async fn test_remote_sync_record(identifier: &str, tester: &dyn SyncRecordTester
         {
             let changelog_repo = ChangelogRepository::new(&previous_connection);
             let cursor = changelog_repo.latest_cursor().unwrap();
-            integration_records.integrate(&previous_connection).unwrap();
+            integrate(&previous_connection, &integration_records).unwrap();
             // Need to reset is_sync_update since we've inserted test data with sync methods
             // they need to sync to central (if is_sync_update is set to true they will not sync to central)
             changelog_repo.reset_is_sync_update(cursor).unwrap();
@@ -99,24 +102,36 @@ async fn test_remote_sync_record(identifier: &str, tester: &dyn SyncRecordTester
         previous_synchroniser.sync().await.unwrap();
 
         // Confirm records have synced back correctly
-        check_records_against_database(&previous_connection, integration_records).await;
+        check_integrated(&previous_connection, integration_records)
     }
 }
 
-fn replace_system_name_ids(records: &mut IntegrationRecords, connection: &StorageConnection) {
+fn replace_system_name_ids(
+    records: &mut Vec<IntegrationOperation>,
+    connection: &StorageConnection,
+) {
     let inventory_adjustment_name = NameRowRepository::new(connection)
         .find_one_by_code(INVENTORY_ADJUSTMENT_NAME_CODE)
         .unwrap()
         .expect("Cannot find inventory adjustment name");
 
-    for mut record in records.upserts.iter_mut() {
-        if let PullUpsertRecord::Invoice(invoice) = &mut record {
-            if invoice.r#type == InvoiceRowType::InventoryAddition
-                || invoice.r#type == InvoiceRowType::InventoryReduction
-            {
-                invoice.name_id = inventory_adjustment_name.id.clone();
-                invoice.name_store_id = None;
-            }
+    for record in records {
+        let IntegrationOperation::Upsert(record) = record else {
+            continue;
+        };
+
+        let Some(mut_invoice) = record
+            .as_mut_any()
+            .map(|any| any.downcast_mut::<InvoiceRow>())
+            .flatten() else  {
+            continue;
+        };
+
+        if mut_invoice.r#type == InvoiceRowType::InventoryAddition
+            || mut_invoice.r#type == InvoiceRowType::InventoryReduction
+        {
+            mut_invoice.name_id = inventory_adjustment_name.id.clone();
+            mut_invoice.name_store_id = None;
         }
     }
 }

--- a/server/service/src/sync/test/integration/remote/patient_name_and_store_and_name_store_join.rs
+++ b/server/service/src/sync/test/integration/remote/patient_name_and_store_and_name_store_join.rs
@@ -2,7 +2,7 @@ use crate::sync::{
     test::integration::{
         central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
     },
-    translations::{IntegrationRecords, PullUpsertRecord},
+    translations::IntegrationOperation,
 };
 use chrono::NaiveDate;
 use repository::{Gender, NameRow, NameStoreJoinRow, NameType, StoreMode, StoreRow};
@@ -90,12 +90,12 @@ impl SyncRecordTester for PatientNameAndStoreAndNameStoreJoinTester {
                 "name_store_join": [patient_name_store_join_json],
             }),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::Name(patient_name_row.clone()),
-                PullUpsertRecord::Name(facility_name_row),
-                PullUpsertRecord::NameStoreJoin(patient_name_store_join_row),
-                PullUpsertRecord::Store(store_row),
-            ]),
+            integration_records: vec![
+                IntegrationOperation::upsert(patient_name_row.clone()),
+                IntegrationOperation::upsert(facility_name_row),
+                IntegrationOperation::upsert(patient_name_store_join_row),
+                IntegrationOperation::upsert(store_row),
+            ],
         });
 
         // STEP 2 - update patient name
@@ -109,9 +109,7 @@ impl SyncRecordTester for PatientNameAndStoreAndNameStoreJoinTester {
         result.push(TestStepData {
             central_upsert: json!({}),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![PullUpsertRecord::Name(
-                patient_row,
-            )]),
+            integration_records: vec![IntegrationOperation::upsert(patient_row)],
         });
 
         result

--- a/server/service/src/sync/test/integration/remote/program_requisition.rs
+++ b/server/service/src/sync/test/integration/remote/program_requisition.rs
@@ -2,11 +2,12 @@ use crate::sync::{
     test::integration::{
         central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
     },
-    translations::{IntegrationRecords, PullDeleteRecord, PullDeleteRecordTable, PullUpsertRecord},
+    translations::IntegrationOperation,
 };
 use repository::{
     MasterListNameJoinRow, MasterListRow, NameTagRow, PeriodScheduleRow,
-    ProgramRequisitionOrderTypeRow, ProgramRequisitionSettingsRow, ProgramRow,
+    ProgramRequisitionOrderTypeRow, ProgramRequisitionOrderTypeRowDelete,
+    ProgramRequisitionSettingsRow, ProgramRequisitionSettingsRowDelete, ProgramRow,
 };
 
 use serde_json::json;
@@ -58,6 +59,7 @@ impl SyncRecordTester for ProgramRequisitionTester {
             name: uuid(),
             code: uuid(),
             description: uuid(),
+            is_active: true,
         };
         let master_list_json = json!({
         "ID": master_list_row.id,
@@ -173,6 +175,7 @@ impl SyncRecordTester for ProgramRequisitionTester {
             name: uuid(),
             code: uuid(),
             description: uuid(),
+            is_active: false,
         };
         let master_list_json2 = json!({
         "ID": master_list_row2.id,
@@ -180,6 +183,7 @@ impl SyncRecordTester for ProgramRequisitionTester {
         "code": master_list_row2.code,
         "note": master_list_row2.description,
         "isProgram": true,
+        "inactive": true,
         "programSettings": {
             "elmisCode": "",
             "storeTags": {
@@ -223,24 +227,24 @@ impl SyncRecordTester for ProgramRequisitionTester {
                 "list_master_name_join": [master_list_name_join_json, master_list_name_join_json2],
             }),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::PeriodSchedule(period_schedule1.clone()),
-                PullUpsertRecord::PeriodSchedule(period_schedule2),
-                PullUpsertRecord::NameTag(name_tag1),
-                PullUpsertRecord::NameTag(name_tag2),
-                PullUpsertRecord::MasterList(master_list_row.clone()),
-                PullUpsertRecord::MasterList(master_list_row2),
-                PullUpsertRecord::MasterListNameJoin(master_list_name_join_row),
-                PullUpsertRecord::MasterListNameJoin(master_list_name_join_row2),
-                PullUpsertRecord::Program(program),
-                PullUpsertRecord::Program(program2),
-                PullUpsertRecord::ProgramRequisitionSettings(program_requisition_settings1.clone()),
-                PullUpsertRecord::ProgramRequisitionSettings(program_requisition_settings2.clone()),
-                PullUpsertRecord::ProgramRequisitionSettings(program_requisition_settings3),
-                PullUpsertRecord::ProgramRequisitionOrderType(order_type1.clone()),
-                PullUpsertRecord::ProgramRequisitionOrderType(order_type2.clone()),
-                PullUpsertRecord::ProgramRequisitionOrderType(order_type3.clone()),
-            ]),
+            integration_records: vec![
+                IntegrationOperation::upsert(period_schedule1.clone()),
+                IntegrationOperation::upsert(period_schedule2),
+                IntegrationOperation::upsert(name_tag1),
+                IntegrationOperation::upsert(name_tag2),
+                IntegrationOperation::upsert(master_list_row.clone()),
+                IntegrationOperation::upsert(master_list_row2),
+                IntegrationOperation::upsert(master_list_name_join_row),
+                IntegrationOperation::upsert(master_list_name_join_row2),
+                IntegrationOperation::upsert(program),
+                IntegrationOperation::upsert(program2),
+                IntegrationOperation::upsert(program_requisition_settings1.clone()),
+                IntegrationOperation::upsert(program_requisition_settings2.clone()),
+                IntegrationOperation::upsert(program_requisition_settings3),
+                IntegrationOperation::upsert(order_type1.clone()),
+                IntegrationOperation::upsert(order_type2.clone()),
+                IntegrationOperation::upsert(order_type3.clone()),
+            ],
         });
 
         // STEP 2 - mutate from central
@@ -294,42 +298,26 @@ impl SyncRecordTester for ProgramRequisitionTester {
             max_order_per_period: 1,
         };
 
-        let upserts = vec![
-            PullUpsertRecord::NameTag(upsert_name_tag),
-            PullUpsertRecord::ProgramRequisitionSettings(upsert_program_requisition_settings),
-            PullUpsertRecord::ProgramRequisitionOrderType(upsert_order_type),
-        ];
-
-        let deletes = vec![
-            PullDeleteRecord {
-                id: order_type1.id,
-                table: PullDeleteRecordTable::ProgramRequisitionOrderType,
-            },
-            PullDeleteRecord {
-                id: order_type2.id,
-                table: PullDeleteRecordTable::ProgramRequisitionOrderType,
-            },
-            PullDeleteRecord {
-                id: order_type3.id,
-                table: PullDeleteRecordTable::ProgramRequisitionOrderType,
-            },
-            PullDeleteRecord {
-                id: program_requisition_settings1.id,
-                table: PullDeleteRecordTable::ProgramRequisitionSettings,
-            },
-            PullDeleteRecord {
-                id: program_requisition_settings2.id,
-                table: PullDeleteRecordTable::ProgramRequisitionSettings,
-            },
-        ];
-
         result.push(TestStepData {
             central_upsert: json!({
                 "name_tag": [upsert_name_tag_json],
                 "list_master": [upsert_master_list_json],
             }),
             central_delete: json!({}),
-            integration_records: IntegrationRecords { upserts, deletes },
+            integration_records: vec![
+                IntegrationOperation::upsert(upsert_name_tag),
+                IntegrationOperation::upsert(upsert_program_requisition_settings),
+                IntegrationOperation::upsert(upsert_order_type),
+                IntegrationOperation::delete(ProgramRequisitionOrderTypeRowDelete(order_type1.id)),
+                IntegrationOperation::delete(ProgramRequisitionOrderTypeRowDelete(order_type2.id)),
+                IntegrationOperation::delete(ProgramRequisitionOrderTypeRowDelete(order_type3.id)),
+                IntegrationOperation::delete(ProgramRequisitionSettingsRowDelete(
+                    program_requisition_settings1.id,
+                )),
+                IntegrationOperation::delete(ProgramRequisitionSettingsRowDelete(
+                    program_requisition_settings2.id,
+                )),
+            ],
         });
 
         result

--- a/server/service/src/sync/test/integration/remote/requisition.rs
+++ b/server/service/src/sync/test/integration/remote/requisition.rs
@@ -2,12 +2,12 @@ use crate::sync::{
     test::integration::{
         central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
     },
-    translations::{IntegrationRecords, PullDeleteRecord, PullDeleteRecordTable, PullUpsertRecord},
+    translations::IntegrationOperation,
 };
 use chrono::NaiveDate;
 use repository::{
     requisition_row::{RequisitionRowStatus, RequisitionRowType},
-    RequisitionLineRow, RequisitionRow,
+    RequisitionLineRow, RequisitionLineRowDelete, RequisitionRow, RequisitionRowDelete,
 };
 use serde_json::json;
 use util::{inline_edit, uuid::uuid};
@@ -90,13 +90,13 @@ impl SyncRecordTester for RequisitionRecordTester {
                 }],
             }),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::Requisition(requisition_row_1.clone()),
-                PullUpsertRecord::Requisition(requisition_row_2.clone()),
-                PullUpsertRecord::Requisition(requisition_row_3),
-                PullUpsertRecord::Requisition(requisition_row_4),
-                PullUpsertRecord::RequisitionLine(requisition_line_row_1.clone()),
-            ]),
+            integration_records: vec![
+                IntegrationOperation::upsert(requisition_row_1.clone()),
+                IntegrationOperation::upsert(requisition_row_2.clone()),
+                IntegrationOperation::upsert(requisition_row_3),
+                IntegrationOperation::upsert(requisition_row_4),
+                IntegrationOperation::upsert(requisition_line_row_1.clone()),
+            ],
         });
 
         // STEP 2 - mutate
@@ -141,11 +141,11 @@ impl SyncRecordTester for RequisitionRecordTester {
         result.push(TestStepData {
             central_upsert: json!({}),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::Requisition(requisition_row_1.clone()),
-                PullUpsertRecord::Requisition(requisition_row_2.clone()),
-                PullUpsertRecord::RequisitionLine(requisition_line_row_1.clone()),
-            ]),
+            integration_records: vec![
+                IntegrationOperation::upsert(requisition_row_1.clone()),
+                IntegrationOperation::upsert(requisition_row_2.clone()),
+                IntegrationOperation::upsert(requisition_line_row_1.clone()),
+            ],
         });
         // STEP 3 - delete
         let requisition_row_2 = inline_edit(&requisition_row_2, |mut d| {
@@ -155,19 +155,13 @@ impl SyncRecordTester for RequisitionRecordTester {
         result.push(TestStepData {
             central_upsert: json!({}),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upsert(PullUpsertRecord::Requisition(
-                requisition_row_2,
-            ))
-            .join(IntegrationRecords::from_deletes(vec![
-                PullDeleteRecord {
-                    id: requisition_line_row_1.id.clone(),
-                    table: PullDeleteRecordTable::RequisitionLine,
-                },
-                PullDeleteRecord {
-                    id: requisition_row_1.id.clone(),
-                    table: PullDeleteRecordTable::Requisition,
-                },
-            ])),
+            integration_records: vec![
+                IntegrationOperation::upsert(requisition_row_2),
+                IntegrationOperation::delete(RequisitionLineRowDelete(
+                    requisition_line_row_1.id.clone(),
+                )),
+                IntegrationOperation::delete(RequisitionRowDelete(requisition_row_1.id.clone())),
+            ],
         });
         result
     }

--- a/server/service/src/sync/test/integration/remote/user_permission.rs
+++ b/server/service/src/sync/test/integration/remote/user_permission.rs
@@ -2,10 +2,10 @@ use crate::sync::{
     test::integration::{
         central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
     },
-    translations::{IntegrationRecords, PullDeleteRecord, PullDeleteRecordTable, PullUpsertRecord},
+    translations::IntegrationOperation,
 };
 
-use repository::{ContextRow, Permission, UserPermissionRow};
+use repository::{ContextRow, Permission, UserPermissionRow, UserPermissionRowDelete};
 use serde_json::json;
 use util::uuid::uuid;
 
@@ -65,10 +65,10 @@ impl SyncRecordTester for UserPermissionTester {
                 "om_user_permission": [user_permission_row_1_json, user_permission_row_2_json],
             }),
             central_delete: json!({}),
-            integration_records: IntegrationRecords::from_upserts(vec![
-                PullUpsertRecord::UserPermission(user_permission_row_1.clone()),
-                PullUpsertRecord::UserPermission(user_permission_row_2),
-            ]),
+            integration_records: vec![
+                IntegrationOperation::upsert(user_permission_row_1.clone()),
+                IntegrationOperation::upsert(user_permission_row_2),
+            ],
         });
 
         // STEP 2 - deletes
@@ -77,10 +77,9 @@ impl SyncRecordTester for UserPermissionTester {
             central_delete: json!({
                 "om_user_permission": [user_permission_row_1.id],
             }),
-            integration_records: IntegrationRecords::from_deletes(vec![PullDeleteRecord {
-                id: user_permission_row_1.id,
-                table: PullDeleteRecordTable::UserPermission,
-            }]),
+            integration_records: vec![IntegrationOperation::delete(UserPermissionRowDelete(
+                user_permission_row_1.id,
+            ))],
         });
         result
     }

--- a/server/service/src/sync/test/mod.rs
+++ b/server/service/src/sync/test/mod.rs
@@ -3,15 +3,13 @@ mod integration;
 mod pull_and_push;
 pub(crate) mod test_data;
 
-use super::translations::{IntegrationRecords, PullDeleteRecord, PullDeleteRecordTable};
-use crate::sync::translations::PullUpsertRecord;
+use super::translations::{IntegrationOperation, PullTranslateResult};
 use repository::{mock::MockData, *};
 use util::inline_init;
 
-#[derive(Clone)]
 pub(crate) struct TestSyncPullRecord {
     /// Expected result for the imported data
-    pub(crate) translated_record: Option<IntegrationRecords>,
+    pub(crate) translated_record: PullTranslateResult,
     /// Row as stored in the remote sync buffer
     pub(crate) sync_buffer_row: SyncBufferRow,
     // Extra data that translation test relies on
@@ -19,22 +17,17 @@ pub(crate) struct TestSyncPullRecord {
 }
 
 impl TestSyncPullRecord {
-    fn new_pull_upsert(
+    fn new_pull_upsert<U>(
         table_name: &str,
         // .0 = id .1 = data
         id_and_data: (&str, &str),
-        result: PullUpsertRecord,
-    ) -> TestSyncPullRecord {
-        Self::new_pull_upserts(table_name, id_and_data, vec![result])
-    }
-    fn new_pull_upserts(
-        table_name: &str,
-        // .0 = id .1 = data
-        id_and_data: (&str, &str),
-        results: Vec<PullUpsertRecord>,
-    ) -> TestSyncPullRecord {
+        upsert: U,
+    ) -> TestSyncPullRecord
+    where
+        U: Upsert + 'static,
+    {
         TestSyncPullRecord {
-            translated_record: Some(IntegrationRecords::from_upserts(results)),
+            translated_record: PullTranslateResult::upsert(upsert),
             sync_buffer_row: inline_init(|r: &mut SyncBufferRow| {
                 r.table_name = table_name.to_owned();
                 r.record_id = id_and_data.0.to_owned();
@@ -45,30 +38,18 @@ impl TestSyncPullRecord {
         }
     }
 
-    fn new_pull_delete(
-        table_name: &str,
-        id: &str,
-        result_table: PullDeleteRecordTable,
-    ) -> TestSyncPullRecord {
-        Self::new_pull_deletes(
-            table_name,
-            id,
-            IntegrationRecords {
-                upserts: vec![],
-                deletes: vec![PullDeleteRecord {
-                    table: result_table,
-                    id: id.to_string(),
-                }],
-            },
-        )
+    fn new_pull_delete<U>(table_name: &str, id: &str, result: U) -> TestSyncPullRecord
+    where
+        U: Delete + 'static,
+    {
+        Self::new_pull_deletes(table_name, id, vec![result])
     }
-    fn new_pull_deletes(
-        table_name: &str,
-        id: &str,
-        delete_records: IntegrationRecords,
-    ) -> TestSyncPullRecord {
+    fn new_pull_deletes<U>(table_name: &str, id: &str, deletes: Vec<U>) -> TestSyncPullRecord
+    where
+        U: Delete + 'static,
+    {
         TestSyncPullRecord {
-            translated_record: Some(delete_records),
+            translated_record: PullTranslateResult::deletes(deletes),
             sync_buffer_row: inline_init(|r: &mut SyncBufferRow| {
                 r.table_name = table_name.to_owned();
                 r.record_id = id.to_string();
@@ -115,268 +96,28 @@ pub(crate) async fn insert_all_extra_data(
     }
 }
 
-macro_rules! check_record_by_id {
-    ($repository:ident, $connection:ident, $comparison_record:ident, $record_string:expr) => {{
-        assert_eq!(
-            $repository::new(&$connection)
-                .find_one_by_id(&$comparison_record.id)
-                .unwrap()
-                .expect(&format!(
-                    "{} row not found: {}",
-                    $record_string, $comparison_record.id
-                )),
-            $comparison_record
-        )
-    }};
-}
-
-macro_rules! check_record_by_option_id {
-    ($repository:ident, $connection:ident, $comparison_record:ident, $record_string:expr) => {{
-        assert_eq!(
-            $repository::new(&$connection)
-                .find_one_by_id_option(&$comparison_record.id)
-                .unwrap()
-                .expect(&format!(
-                    "{} row not found: {}",
-                    $record_string, $comparison_record.id
-                )),
-            $comparison_record
-        )
-    }};
-}
-
-macro_rules! check_delete_record_by_id {
-    ($repository:ident, $connection:ident, $id:ident) => {{
-        assert_eq!(
-            $repository::new(&$connection).find_one_by_id(&$id).unwrap(),
-            None
-        )
-    }};
-}
-
-macro_rules! check_delete_record_by_id_option {
-    ($repository:ident, $connection:ident, $id:ident) => {{
-        assert_eq!(
-            $repository::new(&$connection)
-                .find_one_by_id_option(&$id)
-                .unwrap(),
-            None
-        )
-    }};
-}
-pub(crate) async fn check_records_against_database(
-    con: &StorageConnection,
-    records: IntegrationRecords,
-) {
-    for upsert in records.upserts {
-        use PullUpsertRecord::*;
-        match upsert {
-            UserPermission(record) => {
-                check_record_by_id!(UserPermissionRowRepository, con, record, "UserPermisson")
-            }
-            Sensor(record) => {
-                check_record_by_id!(SensorRowRepository, con, record, "Sensor");
-            }
-            TemperatureLog(record) => {
-                check_record_by_id!(TemperatureLogRowRepository, con, record, "TemperatureLog");
-            }
-            TemperatureBreach(record) => {
-                check_record_by_id!(
-                    TemperatureBreachRowRepository,
-                    con,
-                    record,
-                    "TemperatureBreach"
-                );
-            }
-            Location(record) => {
-                check_record_by_id!(LocationRowRepository, con, record, "Location");
-            }
-            LocationMovement(record) => check_record_by_id!(
-                LocationMovementRowRepository,
-                con,
-                record,
-                "LocationMovement"
-            ),
-            StockLine(record) => {
-                check_record_by_option_id!(StockLineRowRepository, con, record, "StockLine");
-            }
-            Name(record) => {
-                check_record_by_id!(NameRowRepository, con, record, "Name");
-            }
-            NameTag(record) => {
-                check_record_by_id!(NameTagRowRepository, con, record, "NameTag");
-            }
-            NameTagJoin(record) => {
-                check_record_by_id!(NameTagJoinRepository, con, record, "NameTagJoin");
-            }
-            NameStoreJoin(record) => {
-                check_record_by_id!(NameStoreJoinRepository, con, record, "NameStoreJoin");
-            }
-            Invoice(record) => {
-                check_record_by_option_id!(InvoiceRowRepository, con, record, "Invoice");
-            }
-            InvoiceLine(record) => {
-                check_record_by_option_id!(InvoiceLineRowRepository, con, record, "InvoiceLine");
-            }
-            Stocktake(record) => {
-                check_record_by_id!(StocktakeRowRepository, con, record, "Stocktake");
-            }
-            StocktakeLine(record) => {
-                check_record_by_id!(StocktakeLineRowRepository, con, record, "StocktakeLine");
-            }
-            Requisition(record) => {
-                check_record_by_id!(RequisitionRowRepository, con, record, "Requisition");
-            }
-            RequisitionLine(record) => {
-                check_record_by_id!(RequisitionLineRowRepository, con, record, "RequisitionLine");
-            }
-            Unit(record) => {
-                check_record_by_option_id!(UnitRowRepository, con, record, "Unit");
-            }
-            Item(record) => check_record_by_id!(ItemRowRepository, con, record, "Item"),
-            Store(record) => check_record_by_id!(StoreRowRepository, con, record, "Store"),
-            MasterList(record) => {
-                check_record_by_option_id!(MasterListRowRepository, con, record, "Masterlist")
-            }
-
-            MasterListLine(record) => {
-                check_record_by_option_id!(
-                    MasterListLineRowRepository,
-                    con,
-                    record,
-                    "MasterListLine"
-                )
-            }
-
-            MasterListNameJoin(record) => check_record_by_option_id!(
-                MasterListNameJoinRepository,
-                con,
-                record,
-                "MasterListNameJoin"
-            ),
-
-            PeriodSchedule(record) => {
-                check_record_by_id!(PeriodScheduleRowRepository, con, record, "PeriodSchedule")
-            }
-
-            Period(record) => check_record_by_id!(PeriodRowRepository, con, record, "Period"),
-            Context(record) => check_record_by_id!(ContextRowRepository, con, record, "Context"),
-            Program(record) => check_record_by_id!(ProgramRowRepository, con, record, "Program"),
-            ProgramRequisitionSettings(record) => check_record_by_id!(
-                ProgramRequisitionSettingsRowRepository,
-                con,
-                record,
-                "ProgramRequisitionSettings"
-            ),
-            ProgramRequisitionOrderType(record) => check_record_by_id!(
-                ProgramRequisitionOrderTypeRowRepository,
-                con,
-                record,
-                "ProgramRequisitionOrderType"
-            ),
-            Report(record) => check_record_by_id!(ReportRowRepository, con, record, "Report"),
-
-            ActivityLog(record) => {
-                check_record_by_id!(ActivityLogRowRepository, con, record, "ActivityLog")
-            }
-
-            InventoryAdjustmentReason(record) => check_record_by_id!(
-                InventoryAdjustmentReasonRowRepository,
-                con,
-                record,
-                "InventoryAdjustmentReason"
-            ),
-
-            StorePreference(record) => {
-                check_record_by_id!(StorePreferenceRowRepository, con, record, "StorePreference")
-            }
-            Barcode(record) => check_record_by_id!(BarcodeRowRepository, con, record, "Barcode"),
-
-            Clinician(record) => {
-                check_record_by_option_id!(ClinicianRowRepository, con, record, "Clinician")
-            }
-
-            ClinicianStoreJoin(record) => {
-                check_record_by_option_id!(
-                    ClinicianStoreJoinRowRepository,
-                    con,
-                    record,
-                    "ClinicianStoreJoin"
-                )
-            }
-            FormSchema(record) => {
-                check_record_by_id!(FormSchemaRowRepository, con, record, "FormSchema")
-            }
-            Document(record) => check_record_by_id!(DocumentRepository, con, record, "Document"),
-            DocumentRegistry(record) => check_record_by_id!(
-                DocumentRegistryRowRepository,
-                con,
-                record,
-                "DocumentRegistry"
-            ),
-        }
-    }
-
-    for delete in records.deletes {
-        use PullDeleteRecordTable::*;
-        let id = delete.id;
-        match delete.table {
-            UserPermission => {
-                check_delete_record_by_id!(UserPermissionRowRepository, con, id)
-            }
-            Name => {
-                check_delete_record_by_id!(NameRowRepository, con, id)
-            }
-            NameTagJoin => {
-                check_delete_record_by_id!(NameTagJoinRepository, con, id)
-            }
-            Unit => {
-                check_delete_record_by_id_option!(UnitRowRepository, con, id)
-            }
-            Item => check_delete_record_by_id!(ItemRowRepository, con, id),
-            Store => check_delete_record_by_id!(StoreRowRepository, con, id),
-            ProgramRequisitionOrderType => {
-                check_delete_record_by_id!(ProgramRequisitionOrderTypeRowRepository, con, id)
-            }
-            ProgramRequisitionSettings => {
-                check_delete_record_by_id!(ProgramRequisitionSettingsRowRepository, con, id)
-            }
-            MasterListNameJoin => {
-                check_delete_record_by_id_option!(MasterListNameJoinRepository, con, id)
-            }
-            Report => check_delete_record_by_id!(ReportRowRepository, con, id),
-            NameStoreJoin => check_delete_record_by_id!(ReportRowRepository, con, id),
-            Invoice => check_delete_record_by_id_option!(MasterListNameJoinRepository, con, id),
-            InvoiceLine => {
-                check_delete_record_by_id_option!(MasterListNameJoinRepository, con, id)
-            }
-            Requisition => check_delete_record_by_id!(ReportRowRepository, con, id),
-            RequisitionLine => check_delete_record_by_id!(ReportRowRepository, con, id),
-            InventoryAdjustmentReason => {
-                check_delete_record_by_id!(InventoryAdjustmentReasonRowRepository, con, id)
-            }
-            #[cfg(all(test, feature = "integration_test"))]
-            Location => check_delete_record_by_id!(LocationRowRepository, con, id),
-            #[cfg(all(test, feature = "integration_test"))]
-            StockLine => check_delete_record_by_id_option!(StockLineRowRepository, con, id),
-            #[cfg(all(test, feature = "integration_test"))]
-            Stocktake => check_delete_record_by_id!(StocktakeRowRepository, con, id),
-            #[cfg(all(test, feature = "integration_test"))]
-            StocktakeLine => check_delete_record_by_id!(StocktakeLineRowRepository, con, id),
-            #[cfg(all(test, feature = "integration_test"))]
-            ActivityLog => check_delete_record_by_id!(ActivityLogRowRepository, con, id),
-        }
-    }
-}
 pub(crate) async fn check_test_records_against_database(
     con: &StorageConnection,
     test_records: Vec<TestSyncPullRecord>,
 ) {
     for test_record in test_records {
-        let translated_record = match test_record.translated_record {
-            Some(translated_record) => translated_record,
-            None => continue,
+        let translated_records = match test_record.translated_record {
+            PullTranslateResult::IntegrationOperations(translated_record) => translated_record,
+            // Should this throw an assertion ?
+            _ => continue,
         };
-        check_records_against_database(con, translated_record).await;
+        check_integrated(con, translated_records)
+    }
+}
+
+pub(crate) fn check_integrated(
+    con: &StorageConnection,
+    integration_records: Vec<IntegrationOperation>,
+) {
+    for record in integration_records {
+        match record {
+            IntegrationOperation::Upsert(upsert) => upsert.assert_upserted(con),
+            IntegrationOperation::Delete(delete) => delete.assert_deleted(con),
+        }
     }
 }

--- a/server/service/src/sync/test/pull_and_push.rs
+++ b/server/service/src/sync/test/pull_and_push.rs
@@ -51,7 +51,10 @@ async fn test_sync_pull_and_push() {
         get_all_pull_upsert_central_test_records(),
         get_all_pull_upsert_remote_test_records(),
     ]
-    .concat();
+    .into_iter()
+    .flatten()
+    .collect();
+
     insert_all_extra_data(&test_records, &connection).await;
     let sync_records: Vec<SyncBufferRow> = extract_sync_buffer_rows(&test_records);
 
@@ -102,7 +105,9 @@ async fn test_sync_pull_and_push() {
         get_all_pull_delete_central_test_records(),
         get_all_pull_delete_remote_test_records(),
     ]
-    .concat();
+    .into_iter()
+    .flatten()
+    .collect();
     insert_all_extra_data(&test_records, &connection).await;
     let sync_records: Vec<SyncBufferRow> = extract_sync_buffer_rows(&test_records);
 

--- a/server/service/src/sync/test/test_data/activity_log.rs
+++ b/server/service/src/sync/test/test_data/activity_log.rs
@@ -1,10 +1,12 @@
 use crate::sync::{
     test::{TestSyncPullRecord, TestSyncPushRecord},
-    translations::{activity_log::LegacyActivityLogRow, LegacyTableName, PullUpsertRecord},
+    translations::activity_log::LegacyActivityLogRow,
 };
 use chrono::NaiveDate;
 use repository::{ActivityLogRow, ActivityLogType};
 use serde_json::json;
+
+const TABLE_NAME: &'static str = "om_activity_log";
 
 const ACTIVITY_LOG_1: (&'static str, &'static str) = (
     "log_d",
@@ -37,9 +39,9 @@ const ACTIVITY_LOG_2: (&'static str, &'static str) = (
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::OM_ACTIVITY_LOG,
+            TABLE_NAME,
             ACTIVITY_LOG_1,
-            PullUpsertRecord::ActivityLog(ActivityLogRow {
+            ActivityLogRow {
                 id: ACTIVITY_LOG_1.0.to_string(),
                 r#type: ActivityLogType::InvoiceCreated,
                 user_id: Some("user_account_a".to_string()),
@@ -51,12 +53,12 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                     .unwrap(),
                 changed_to: None,
                 changed_from: None,
-            }),
+            },
         ),
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::OM_ACTIVITY_LOG,
+            TABLE_NAME,
             ACTIVITY_LOG_2,
-            PullUpsertRecord::ActivityLog(ActivityLogRow {
+            ActivityLogRow {
                 id: ACTIVITY_LOG_2.0.to_string(),
                 r#type: ActivityLogType::InvoiceStatusAllocated,
                 user_id: Some("user_account_a".to_string()),
@@ -68,7 +70,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                     .unwrap(),
                 changed_to: None,
                 changed_from: None,
-            }),
+            },
         ),
     ]
 }
@@ -77,7 +79,7 @@ pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
     vec![
         TestSyncPushRecord {
             record_id: ACTIVITY_LOG_1.0.to_string(),
-            table_name: LegacyTableName::OM_ACTIVITY_LOG.to_string(),
+            table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyActivityLogRow {
                 id: ACTIVITY_LOG_1.0.to_string(),
                 r#type: ActivityLogType::InvoiceCreated,
@@ -94,7 +96,7 @@ pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
         },
         TestSyncPushRecord {
             record_id: ACTIVITY_LOG_2.0.to_string(),
-            table_name: LegacyTableName::OM_ACTIVITY_LOG.to_string(),
+            table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyActivityLogRow {
                 id: ACTIVITY_LOG_2.0.to_string(),
                 r#type: ActivityLogType::InvoiceStatusAllocated,

--- a/server/service/src/sync/test/test_data/barcode.rs
+++ b/server/service/src/sync/test/test_data/barcode.rs
@@ -1,10 +1,12 @@
 use crate::sync::{
     test::{TestSyncPullRecord, TestSyncPushRecord},
-    translations::{barcode::LegacyBarcodeRow, LegacyTableName, PullUpsertRecord},
+    translations::barcode::LegacyBarcodeRow,
 };
 
 use repository::BarcodeRow;
 use serde_json::json;
+
+const TABLE_NAME: &'static str = "barcode";
 
 const BARCODE_1: (&'static str, &'static str) = (
     "barcode_a",
@@ -31,28 +33,28 @@ const BARCODE_2: (&'static str, &'static str) = (
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::BARCODE,
+            TABLE_NAME,
             BARCODE_1,
-            PullUpsertRecord::Barcode(BarcodeRow {
+            BarcodeRow {
                 id: BARCODE_1.0.to_string(),
                 gtin: "0123456789".to_string(),
                 item_id: "item_a".to_string(),
                 manufacturer_id: Some("manufacturer_a".to_string()),
                 pack_size: Some(1),
                 parent_id: None,
-            }),
+            },
         ),
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::BARCODE,
+            TABLE_NAME,
             BARCODE_2,
-            PullUpsertRecord::Barcode(BarcodeRow {
+            BarcodeRow {
                 id: BARCODE_2.0.to_string(),
                 gtin: "9876543210".to_string(),
                 item_id: "item_b".to_string(),
                 manufacturer_id: Some("manufacturer_a".to_string()),
                 pack_size: Some(1),
                 parent_id: None,
-            }),
+            },
         ),
     ]
 }
@@ -61,7 +63,7 @@ pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
     vec![
         TestSyncPushRecord {
             record_id: BARCODE_1.0.to_string(),
-            table_name: LegacyTableName::BARCODE.to_string(),
+            table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyBarcodeRow {
                 id: BARCODE_1.0.to_string(),
                 gtin: "0123456789".to_string(),
@@ -73,7 +75,7 @@ pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
         },
         TestSyncPushRecord {
             record_id: BARCODE_2.0.to_string(),
-            table_name: LegacyTableName::BARCODE.to_string(),
+            table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyBarcodeRow {
                 id: BARCODE_2.0.to_string(),
                 gtin: "9876543210".to_string(),

--- a/server/service/src/sync/test/test_data/inventory_adjustment_reason.rs
+++ b/server/service/src/sync/test/test_data/inventory_adjustment_reason.rs
@@ -1,7 +1,4 @@
-use crate::sync::{
-    test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullUpsertRecord},
-};
+use crate::sync::test::TestSyncPullRecord;
 use repository::{InventoryAdjustmentReasonRow, InventoryAdjustmentReasonType};
 
 const INVENTORY_ADJUSTMENT_REASON_1: (&'static str, &'static str) = (
@@ -16,13 +13,13 @@ const INVENTORY_ADJUSTMENT_REASON_1: (&'static str, &'static str) = (
 
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::INVENTORY_ADJUSTMENT_REASON,
+        "options",
         INVENTORY_ADJUSTMENT_REASON_1,
-        PullUpsertRecord::InventoryAdjustmentReason(InventoryAdjustmentReasonRow {
+        InventoryAdjustmentReasonRow {
             id: INVENTORY_ADJUSTMENT_REASON_1.0.to_string(),
             r#type: InventoryAdjustmentReasonType::Positive,
             is_active: true,
             reason: "Found".to_string(),
-        }),
+        },
     )]
 }

--- a/server/service/src/sync/test/test_data/invoice.rs
+++ b/server/service/src/sync/test/test_data/invoice.rs
@@ -1,16 +1,17 @@
 use crate::sync::{
     test::TestSyncPullRecord,
-    translations::{
-        invoice::{LegacyTransactRow, LegacyTransactStatus, LegacyTransactType, TransactMode},
-        LegacyTableName, PullDeleteRecordTable, PullUpsertRecord,
+    translations::invoice::{
+        LegacyTransactRow, LegacyTransactStatus, LegacyTransactType, TransactMode,
     },
 };
 use chrono::{Duration, NaiveDate, NaiveTime};
-use repository::{InvoiceRow, InvoiceRowStatus, InvoiceRowType};
+use repository::{InvoiceRow, InvoiceRowDelete, InvoiceRowStatus, InvoiceRowType};
 use serde_json::json;
 use util::constants::INVENTORY_ADJUSTMENT_NAME_CODE;
 
 use super::TestSyncPushRecord;
+
+const TABLE_NAME: &'static str = "transact";
 
 const TRANSACT_1: (&'static str, &'static str) = (
     "12e889c0f0d211eb8dddb54df6d741bc",
@@ -97,9 +98,9 @@ const TRANSACT_1: (&'static str, &'static str) = (
 );
 fn transact_1_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::TRANSACT,
+        TABLE_NAME,
         TRANSACT_1,
-        PullUpsertRecord::Invoice(InvoiceRow {
+        InvoiceRow {
             id: TRANSACT_1.0.to_string(),
             user_id: None,
             store_id: "store_b".to_string(),
@@ -133,12 +134,12 @@ fn transact_1_pull_record() -> TestSyncPullRecord {
             linked_invoice_id: None,
             tax: Some(0.0),
             clinician_id: None,
-        }),
+        },
     )
 }
 fn transact_1_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::TRANSACT.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: TRANSACT_1.0.to_string(),
         push_data: json!(LegacyTransactRow {
             ID: TRANSACT_1.0.to_string(),
@@ -266,9 +267,9 @@ const TRANSACT_2: (&'static str, &'static str) = (
 );
 fn transact_2_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::TRANSACT,
+        TABLE_NAME,
         TRANSACT_2,
-        PullUpsertRecord::Invoice(InvoiceRow {
+        InvoiceRow {
             id: TRANSACT_2.0.to_string(),
             user_id: Some("0763E2E3053D4C478E1E6B6B03FEC207".to_string()),
             store_id: "store_b".to_string(),
@@ -296,12 +297,12 @@ fn transact_2_pull_record() -> TestSyncPullRecord {
             linked_invoice_id: None,
             tax: Some(0.0),
             clinician_id: None,
-        }),
+        },
     )
 }
 fn transact_2_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::TRANSACT.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: TRANSACT_2.0.to_string(),
         push_data: json!(LegacyTransactRow {
             ID: TRANSACT_2.0.to_string(),
@@ -434,9 +435,9 @@ const TRANSACT_OM_FIELDS: (&'static str, &'static str) = (
 
 fn transact_om_fields_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::TRANSACT,
+        TABLE_NAME,
         TRANSACT_OM_FIELDS,
-        PullUpsertRecord::Invoice(InvoiceRow {
+        InvoiceRow {
             id: TRANSACT_OM_FIELDS.0.to_string(),
             user_id: Some("0763E2E3053D4C478E1E6B6B03FEC207".to_string()),
             store_id: "store_b".to_string(),
@@ -488,12 +489,12 @@ fn transact_om_fields_pull_record() -> TestSyncPullRecord {
             linked_invoice_id: None,
             tax: Some(0.0),
             clinician_id: None,
-        }),
+        },
     )
 }
 fn transact_om_fields_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::TRANSACT.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: TRANSACT_OM_FIELDS.0.to_string(),
         push_data: json!(LegacyTransactRow {
             ID: TRANSACT_OM_FIELDS.0.to_string(),
@@ -652,9 +653,9 @@ const INVENTORY_ADDITION: (&'static str, &'static str) = (
 
 fn inventory_addition_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::TRANSACT,
+        TABLE_NAME,
         INVENTORY_ADDITION,
-        PullUpsertRecord::Invoice(InvoiceRow {
+        InvoiceRow {
             id: INVENTORY_ADDITION.0.to_string(),
             user_id: Some("0763E2E3053D4C478E1E6B6B03FEC207".to_string()),
             store_id: "store_b".to_string(),
@@ -687,13 +688,13 @@ fn inventory_addition_pull_record() -> TestSyncPullRecord {
             linked_invoice_id: None,
             colour: None,
             clinician_id: None,
-        }),
+        },
     )
 }
 
 fn inventory_addition_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::TRANSACT.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: INVENTORY_ADDITION.0.to_string(),
         push_data: json!(LegacyTransactRow {
             ID: INVENTORY_ADDITION.0.to_string(),
@@ -832,9 +833,9 @@ const INVENTORY_REDUCTION: (&'static str, &'static str) = (
 
 fn inventory_reduction_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::TRANSACT,
+        TABLE_NAME,
         INVENTORY_REDUCTION,
-        PullUpsertRecord::Invoice(InvoiceRow {
+        InvoiceRow {
             id: INVENTORY_REDUCTION.0.to_string(),
             user_id: Some("0763E2E3053D4C478E1E6B6B03FEC207".to_string()),
             store_id: "store_b".to_string(),
@@ -867,13 +868,13 @@ fn inventory_reduction_pull_record() -> TestSyncPullRecord {
             linked_invoice_id: None,
             colour: None,
             clinician_id: None,
-        }),
+        },
     )
 }
 
 fn inventory_reduction_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::TRANSACT.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: INVENTORY_REDUCTION.0.to_string(),
         push_data: json!(LegacyTransactRow {
             ID: INVENTORY_REDUCTION.0.to_string(),
@@ -1007,9 +1008,9 @@ const PRESCRIPTION_1: (&'static str, &'static str) = (
 );
 fn prescription_1_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::TRANSACT,
+        TABLE_NAME,
         PRESCRIPTION_1,
-        PullUpsertRecord::Invoice(InvoiceRow {
+        InvoiceRow {
             id: PRESCRIPTION_1.0.to_string(),
             user_id: None,
             store_id: "store_b".to_string(),
@@ -1043,12 +1044,12 @@ fn prescription_1_pull_record() -> TestSyncPullRecord {
             linked_invoice_id: None,
             tax: Some(0.0),
             clinician_id: None,
-        }),
+        },
     )
 }
 fn prescription_1_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::TRANSACT.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: PRESCRIPTION_1.0.to_string(),
         push_data: json!(LegacyTransactRow {
             ID: PRESCRIPTION_1.0.to_string(),
@@ -1110,9 +1111,9 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
 
 pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_delete(
-        LegacyTableName::TRANSACT,
+        TABLE_NAME,
         TRANSACT_OM_FIELDS.0,
-        PullDeleteRecordTable::Invoice,
+        InvoiceRowDelete(TRANSACT_OM_FIELDS.0.to_string()),
     )]
 }
 

--- a/server/service/src/sync/test/test_data/invoice_line.rs
+++ b/server/service/src/sync/test/test_data/invoice_line.rs
@@ -1,17 +1,15 @@
 use super::TestSyncPushRecord;
 use crate::sync::{
     test::TestSyncPullRecord,
-    translations::{
-        invoice_line::{LegacyTransLineRow, LegacyTransLineType},
-        LegacyTableName, PullDeleteRecordTable, PullUpsertRecord,
-    },
+    translations::invoice_line::{LegacyTransLineRow, LegacyTransLineType},
 };
 use chrono::NaiveDate;
 use repository::{
     mock::{mock_item_a, mock_stock_line_a},
-    InvoiceLineRow, InvoiceLineRowType,
+    InvoiceLineRow, InvoiceLineRowDelete, InvoiceLineRowType,
 };
 use serde_json::json;
+const TABLE_NAME: &'static str = "trans_line";
 
 const TRANS_LINE_1: (&'static str, &'static str) = (
     "12ee2f10f0d211eb8dddb54df6d741bc",
@@ -72,9 +70,9 @@ const TRANS_LINE_1: (&'static str, &'static str) = (
 );
 fn trans_line_1_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::TRANS_LINE,
+        TABLE_NAME,
         TRANS_LINE_1,
-        PullUpsertRecord::InvoiceLine(InvoiceLineRow {
+        InvoiceLineRow {
             id: TRANS_LINE_1.0.to_string(),
             invoice_id: "outbound_shipment_a".to_string(),
             item_id: mock_item_a().id,
@@ -94,13 +92,13 @@ fn trans_line_1_pull_record() -> TestSyncPullRecord {
             number_of_packs: 700.36363636,
             note: None,
             inventory_adjustment_reason_id: None,
-        }),
+        },
     )
 }
 fn trans_line_1_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
         record_id: TRANS_LINE_1.0.to_string(),
-        table_name: LegacyTableName::TRANS_LINE.to_string(),
+        table_name: TABLE_NAME.to_string(),
         push_data: json!(LegacyTransLineRow {
             id: TRANS_LINE_1.0.to_string(),
             invoice_id: "outbound_shipment_a".to_string(),
@@ -184,9 +182,9 @@ const TRANS_LINE_2: (&'static str, &'static str) = (
 );
 fn trans_line_2_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::TRANS_LINE,
+        TABLE_NAME,
         TRANS_LINE_2,
-        PullUpsertRecord::InvoiceLine(InvoiceLineRow {
+        InvoiceLineRow {
             id: TRANS_LINE_2.0.to_string(),
             invoice_id: "outbound_shipment_a".to_string(),
             item_id: mock_item_a().id,
@@ -206,12 +204,12 @@ fn trans_line_2_pull_record() -> TestSyncPullRecord {
             number_of_packs: 1000.9124798,
             note: Some("every FOUR to SIX hours when necessary ".to_string()),
             inventory_adjustment_reason_id: None,
-        }),
+        },
     )
 }
 fn trans_line_2_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::TRANS_LINE.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: TRANS_LINE_2.0.to_string(),
         push_data: json!(LegacyTransLineRow {
             id: TRANS_LINE_2.0.to_string(),
@@ -299,9 +297,9 @@ const TRANS_LINE_OM_FIELDS: (&'static str, &'static str) = (
 );
 fn trans_line_om_fields_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::TRANS_LINE,
+        TABLE_NAME,
         TRANS_LINE_OM_FIELDS,
-        PullUpsertRecord::InvoiceLine(InvoiceLineRow {
+        InvoiceLineRow {
             id: TRANS_LINE_OM_FIELDS.0.to_string(),
             invoice_id: "outbound_shipment_a".to_string(),
             item_id: mock_item_a().id,
@@ -321,12 +319,12 @@ fn trans_line_om_fields_pull_record() -> TestSyncPullRecord {
             number_of_packs: 1000.9124798,
             note: Some("every FOUR to SIX hours when necessary ".to_string()),
             inventory_adjustment_reason_id: None,
-        }),
+        },
     )
 }
 fn trans_line_om_fields_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::TRANS_LINE.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: TRANS_LINE_OM_FIELDS.0.to_string(),
         push_data: json!(LegacyTransLineRow {
             id: TRANS_LINE_OM_FIELDS.0.to_string(),
@@ -414,9 +412,9 @@ const TRANS_LINE_OM_UNSET_TAX_FIELDS: (&'static str, &'static str) = (
 );
 fn trans_line_om_fields_unset_tax_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::TRANS_LINE,
+        TABLE_NAME,
         TRANS_LINE_OM_UNSET_TAX_FIELDS,
-        PullUpsertRecord::InvoiceLine(InvoiceLineRow {
+        InvoiceLineRow {
             id: TRANS_LINE_OM_UNSET_TAX_FIELDS.0.to_string(),
             invoice_id: "outbound_shipment_a".to_string(),
             item_id: mock_item_a().id,
@@ -436,12 +434,12 @@ fn trans_line_om_fields_unset_tax_pull_record() -> TestSyncPullRecord {
             number_of_packs: 1000.9124798,
             note: Some("every FOUR to SIX hours when necessary ".to_string()),
             inventory_adjustment_reason_id: None,
-        }),
+        },
     )
 }
 fn trans_line_om_fields_unset_tax_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::TRANS_LINE.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: TRANS_LINE_OM_UNSET_TAX_FIELDS.0.to_string(),
         push_data: json!(LegacyTransLineRow {
             id: TRANS_LINE_OM_UNSET_TAX_FIELDS.0.to_string(),
@@ -478,9 +476,9 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
 
 pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_delete(
-        LegacyTableName::TRANS_LINE,
+        TABLE_NAME,
         TRANS_LINE_OM_UNSET_TAX_FIELDS.0,
-        PullDeleteRecordTable::InvoiceLine,
+        InvoiceLineRowDelete(TRANS_LINE_OM_UNSET_TAX_FIELDS.0.to_string()),
     )]
 }
 

--- a/server/service/src/sync/test/test_data/item.rs
+++ b/server/service/src/sync/test/test_data/item.rs
@@ -1,10 +1,7 @@
-use crate::sync::{
-    test::TestSyncPullRecord,
-    translations::{
-        item::ordered_simple_json, LegacyTableName, PullDeleteRecordTable, PullUpsertRecord,
-    },
-};
-use repository::{ItemRow, ItemRowType};
+use crate::sync::{test::TestSyncPullRecord, translations::item::ordered_simple_json};
+use repository::{ItemRow, ItemRowDelete, ItemRowType};
+
+const TABLE_NAME: &'static str = "item";
 
 const ITEM_1: (&'static str, &'static str) = (
     "8F252B5884B74888AAB73A0D42C09E7A",
@@ -169,9 +166,9 @@ const ITEM_2: (&'static str, &'static str) = (
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::ITEM,
+            TABLE_NAME,
             (ITEM_1.0, &ordered_simple_json(ITEM_1.1).unwrap()),
-            PullUpsertRecord::Item(ItemRow {
+            ItemRow {
                 id: ITEM_1.0.to_owned(),
                 name: "Non stock items".to_owned(),
                 code: "NSI".to_owned(),
@@ -179,12 +176,12 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 r#type: ItemRowType::NonStock,
                 legacy_record: ordered_simple_json(ITEM_1.1).unwrap(),
                 default_pack_size: 1,
-            }),
+            },
         ),
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::ITEM,
+            TABLE_NAME,
             (ITEM_2.0, &ordered_simple_json(ITEM_2.1).unwrap()),
-            PullUpsertRecord::Item(ItemRow {
+            ItemRow {
                 id: ITEM_2.0.to_owned(),
                 name: "Non stock items 2".to_owned(),
                 code: "NSI".to_owned(),
@@ -192,15 +189,15 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 r#type: ItemRowType::Stock,
                 legacy_record: ordered_simple_json(ITEM_2.1).unwrap(),
                 default_pack_size: 2,
-            }),
+            },
         ),
     ]
 }
 
 pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_delete(
-        LegacyTableName::ITEM,
+        TABLE_NAME,
         ITEM_1.0,
-        PullDeleteRecordTable::Item,
+        ItemRowDelete(ITEM_1.0.to_string()),
     )]
 }

--- a/server/service/src/sync/test/test_data/location.rs
+++ b/server/service/src/sync/test/test_data/location.rs
@@ -1,9 +1,11 @@
-use crate::sync::translations::{location::LegacyLocationRow, LegacyTableName, PullUpsertRecord};
+use crate::sync::translations::location::LegacyLocationRow;
 
 use repository::LocationRow;
 use serde_json::json;
 
 use super::{TestSyncPullRecord, TestSyncPushRecord};
+
+const TABLE_NAME: &'static str = "Location";
 
 const LOCATION_1: (&'static str, &'static str) = (
     "cf5812e0c33911eb9757779d39ae2bdb",
@@ -29,21 +31,21 @@ const LOCATION_1: (&'static str, &'static str) = (
 
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::LOCATION,
+        TABLE_NAME,
         LOCATION_1,
-        PullUpsertRecord::Location(LocationRow {
+        LocationRow {
             id: LOCATION_1.0.to_string(),
             name: "NameRed.02".to_string(),
             code: "Red.02".to_string(),
             on_hold: false,
             store_id: "store_a".to_string(),
-        }),
+        },
     )]
 }
 
 pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
     vec![TestSyncPushRecord {
-        table_name: LegacyTableName::LOCATION.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: LOCATION_1.0.to_string(),
         push_data: json!(LegacyLocationRow {
             id: LOCATION_1.0.to_string(),

--- a/server/service/src/sync/test/test_data/location_movement.rs
+++ b/server/service/src/sync/test/test_data/location_movement.rs
@@ -1,12 +1,12 @@
-use crate::sync::translations::{
-    location_movement::LegacyLocationMovementRow, LegacyTableName, PullUpsertRecord,
-};
+use crate::sync::translations::location_movement::LegacyLocationMovementRow;
 
 use chrono::{NaiveDate, NaiveTime};
 use repository::LocationMovementRow;
 use serde_json::json;
 
 use super::{TestSyncPullRecord, TestSyncPushRecord};
+
+const TABLE_NAME: &'static str = "location_movement";
 
 const LOCATION_MOVEMENT_1: (&'static str, &'static str) = (
     "77829028-8456-4adb-b428-243f67c6cc4f",
@@ -24,9 +24,9 @@ const LOCATION_MOVEMENT_1: (&'static str, &'static str) = (
 
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::LOCATION_MOVEMENT,
+        TABLE_NAME,
         LOCATION_MOVEMENT_1,
-        PullUpsertRecord::LocationMovement(LocationMovementRow {
+        LocationMovementRow {
             id: LOCATION_MOVEMENT_1.0.to_string(),
             store_id: "store_a".to_string(),
             stock_line_id: "item_c_line_a".to_string(),
@@ -37,13 +37,13 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                     .and_time(NaiveTime::from_num_seconds_from_midnight_opt(1000, 0).unwrap()),
             ),
             exit_datetime: None,
-        }),
+        },
     )]
 }
 
 pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
     vec![TestSyncPushRecord {
-        table_name: LegacyTableName::LOCATION_MOVEMENT.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: LOCATION_MOVEMENT_1.0.to_string(),
         push_data: json!(LegacyLocationMovementRow {
             id: LOCATION_MOVEMENT_1.0.to_string(),

--- a/server/service/src/sync/test/test_data/master_list.rs
+++ b/server/service/src/sync/test/test_data/master_list.rs
@@ -1,9 +1,8 @@
 use repository::MasterListRow;
 
-use crate::sync::{
-    test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullUpsertRecord},
-};
+use crate::sync::test::TestSyncPullRecord;
+
+const TABLE_NAME: &'static str = "list_master";
 
 const MASTER_LIST_1: (&'static str, &'static str) = (
     "87027C44835B48E6989376F42A58F7EA",
@@ -21,7 +20,7 @@ const MASTER_LIST_1: (&'static str, &'static str) = (
     "isPatientList": false,
     "is_hiv": false,
     "isSupplierHubCatalog": false,
-    "inactive": false
+    "inactive": true
 }"#,
 );
 
@@ -48,26 +47,26 @@ const MASTER_LIST_2: (&'static str, &'static str) = (
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::LIST_MASTER,
+            TABLE_NAME,
             MASTER_LIST_1,
-            PullUpsertRecord::MasterList(MasterListRow {
+            MasterListRow {
                 id: MASTER_LIST_1.0.to_owned(),
                 name: "District Store".to_owned(),
                 code: "".to_owned(),
                 description: "note 1".to_owned(),
-                is_active: true,
-            }),
+                is_active: false,
+            },
         ),
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::LIST_MASTER,
+            TABLE_NAME,
             MASTER_LIST_2,
-            PullUpsertRecord::MasterList(MasterListRow {
+            MasterListRow {
                 id: MASTER_LIST_2.0.to_owned(),
                 name: "District Store 2".to_owned(),
                 code: "".to_owned(),
                 description: "note 2".to_owned(),
                 is_active: true,
-            }),
+            },
         ),
     ]
 }

--- a/server/service/src/sync/test/test_data/master_list_line.rs
+++ b/server/service/src/sync/test/test_data/master_list_line.rs
@@ -1,9 +1,6 @@
 use repository::MasterListLineRow;
 
-use crate::sync::{
-    test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullUpsertRecord},
-};
+use crate::sync::test::TestSyncPullRecord;
 
 const MASTER_LIST_LINE_1: (&'static str, &'static str) = (
     "9B02D0770B544BD1AC7DB99BB85FCDD5",
@@ -19,12 +16,12 @@ const MASTER_LIST_LINE_1: (&'static str, &'static str) = (
 
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::LIST_MASTER_LINE,
+        "list_master_line",
         MASTER_LIST_LINE_1,
-        PullUpsertRecord::MasterListLine(MasterListLineRow {
+        MasterListLineRow {
             id: "9B02D0770B544BD1AC7DB99BB85FCDD5".to_owned(),
             item_id: "8F252B5884B74888AAB73A0D42C09E7F".to_owned(),
             master_list_id: "87027C44835B48E6989376F42A58F7E3".to_owned(),
-        }),
+        },
     )]
 }

--- a/server/service/src/sync/test/test_data/master_list_name_join.rs
+++ b/server/service/src/sync/test/test_data/master_list_name_join.rs
@@ -1,8 +1,7 @@
-use crate::sync::{
-    test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullDeleteRecordTable, PullUpsertRecord},
-};
-use repository::MasterListNameJoinRow;
+use crate::sync::test::TestSyncPullRecord;
+use repository::{MasterListNameJoinRow, MasterListNameJoinRowDelete};
+
+const TABLE_NAME: &'static str = "list_master_name_join";
 
 const LIST_MASTER_NAME_JOIN_1: (&'static str, &'static str) = (
     "A7A06D78361041448B836857ED4330C4",
@@ -20,20 +19,20 @@ const LIST_MASTER_NAME_JOIN_1: (&'static str, &'static str) = (
 
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::LIST_MASTER_NAME_JOIN,
+        TABLE_NAME,
         LIST_MASTER_NAME_JOIN_1,
-        PullUpsertRecord::MasterListNameJoin(MasterListNameJoinRow {
+        MasterListNameJoinRow {
             id: LIST_MASTER_NAME_JOIN_1.0.to_owned(),
             master_list_id: "87027C44835B48E6989376F42A58F7E3".to_owned(),
             name_id: "1FB32324AF8049248D929CFB35F255BA".to_owned(),
-        }),
+        },
     )]
 }
 
 pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_delete(
-        LegacyTableName::LIST_MASTER_NAME_JOIN,
+        TABLE_NAME,
         LIST_MASTER_NAME_JOIN_1.0,
-        PullDeleteRecordTable::MasterListNameJoin,
+        MasterListNameJoinRowDelete(LIST_MASTER_NAME_JOIN_1.0.to_string()),
     )]
 }

--- a/server/service/src/sync/test/test_data/name.rs
+++ b/server/service/src/sync/test/test_data/name.rs
@@ -1,13 +1,12 @@
 use crate::sync::{
     test::{TestSyncPullRecord, TestSyncPushRecord},
-    translations::{
-        name::{LegacyNameRow, LegacyNameType},
-        LegacyTableName, PullDeleteRecordTable, PullUpsertRecord,
-    },
+    translations::name::{LegacyNameRow, LegacyNameType},
 };
 use chrono::NaiveDate;
-use repository::{Gender, NameRow, NameType};
+use repository::{Gender, NameRow, NameRowDelete, NameType};
 use serde_json::json;
+
+const TABLE_NAME: &'static str = "name";
 
 const NAME_1: (&'static str, &'static str) = (
     "1FB32324AF8049248D929CFB35F255BA",
@@ -109,9 +108,9 @@ const NAME_1: (&'static str, &'static str) = (
 
 fn name_1() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::NAME,
+        TABLE_NAME,
         NAME_1,
-        PullUpsertRecord::Name(NameRow {
+        NameRow {
             id: NAME_1.0.to_owned(),
             name: "General".to_owned(),
             code: "GEN".to_owned(),
@@ -145,7 +144,7 @@ fn name_1() -> TestSyncPullRecord {
             ),
             date_of_death: None,
             custom_data_string: None,
-        }),
+        },
     )
 }
 
@@ -249,9 +248,9 @@ const NAME_2: (&'static str, &'static str) = (
 
 fn name_2() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::NAME,
+        TABLE_NAME,
         NAME_2,
-        PullUpsertRecord::Name(NameRow {
+        NameRow {
             id: NAME_2.0.to_owned(),
             name: "Birch Store".to_owned(),
             code: "SNA".to_owned(),
@@ -279,7 +278,7 @@ fn name_2() -> TestSyncPullRecord {
             national_health_number: None,
             date_of_death: None,
             custom_data_string: None,
-        }),
+        },
     )
 }
 
@@ -383,9 +382,9 @@ const NAME_3: (&'static str, &'static str) = (
 
 fn name_3() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::NAME,
+        TABLE_NAME,
         NAME_3,
-        PullUpsertRecord::Name(NameRow {
+        NameRow {
             id: NAME_3.0.to_owned(),
             name: "Birch Store 2".to_owned(),
             code: "SNA".to_owned(),
@@ -413,7 +412,7 @@ fn name_3() -> TestSyncPullRecord {
             national_health_number: Some("NHN002".to_string()),
             date_of_death: None,
             custom_data_string: Some(r#"{"check":"check"}"#.to_string()),
-        }),
+        },
     )
 }
 
@@ -518,9 +517,9 @@ const NAME_4: (&'static str, &'static str) = (
 
 fn name_4() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::NAME,
+        TABLE_NAME,
         NAME_4,
-        PullUpsertRecord::Name(NameRow {
+        NameRow {
             id: NAME_4.0.to_string(),
             name: "Moemoe, Alex".to_string(),
             code: "00102/19/00".to_string(),
@@ -553,13 +552,13 @@ fn name_4() -> TestSyncPullRecord {
             national_health_number: Some("NHN003".to_string()),
             date_of_death: None,
             custom_data_string: None,
-        }),
+        },
     )
 }
 
 fn name_push_record_1() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::NAME.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: NAME_1.0.to_string(),
         push_data: json!(LegacyNameRow {
             id: NAME_1.0.to_owned(),
@@ -602,7 +601,7 @@ fn name_push_record_1() -> TestSyncPushRecord {
 
 fn name_push_record_2() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::NAME.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: NAME_4.0.to_string(),
         push_data: json!(LegacyNameRow {
             id: NAME_4.0.to_string(),
@@ -649,9 +648,9 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
 
 pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_delete(
-        LegacyTableName::NAME,
+        TABLE_NAME,
         NAME_4.0,
-        PullDeleteRecordTable::Name,
+        NameRowDelete(NAME_4.0.to_string()),
     )]
 }
 

--- a/server/service/src/sync/test/test_data/name_store_join.rs
+++ b/server/service/src/sync/test/test_data/name_store_join.rs
@@ -1,12 +1,11 @@
 use crate::sync::{
     test::{TestSyncPullRecord, TestSyncPushRecord},
-    translations::{
-        name_store_join::LegacyNameStoreJoinRow, LegacyTableName, PullDeleteRecordTable,
-        PullUpsertRecord,
-    },
+    translations::name_store_join::LegacyNameStoreJoinRow,
 };
-use repository::NameStoreJoinRow;
+use repository::{NameStoreJoinRow, NameStoreJoinRowDelete};
 use serde_json::json;
+
+const TABLE_NAME: &'static str = "name_store_join";
 
 const NAME_STORE_JOIN_1: (&'static str, &'static str) = (
     "66607B6E7F2A47E782B8AC6743F71A8A",
@@ -23,15 +22,15 @@ const NAME_STORE_JOIN_1: (&'static str, &'static str) = (
 
 fn name_store_join_1_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::NAME_STORE_JOIN,
+        TABLE_NAME,
         NAME_STORE_JOIN_1,
-        PullUpsertRecord::NameStoreJoin(NameStoreJoinRow {
+        NameStoreJoinRow {
             id: NAME_STORE_JOIN_1.0.to_string(),
             store_id: "store_a".to_string(),
             name_id: "name_store_c".to_string(),
             name_is_customer: false,
             name_is_supplier: true,
-        }),
+        },
     )
 }
 
@@ -61,22 +60,22 @@ const NAME_STORE_JOIN_INACTIVE_2: (&'static str, &'static str) = (
 );
 fn name_store_join_2_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::NAME_STORE_JOIN,
+        TABLE_NAME,
         NAME_STORE_JOIN_2,
-        PullUpsertRecord::NameStoreJoin(NameStoreJoinRow {
+        NameStoreJoinRow {
             id: NAME_STORE_JOIN_2.0.to_string(),
             store_id: "store_b".to_string(),
             name_id: "name_store_a".to_string(),
             name_is_customer: false,
             name_is_supplier: true,
-        }),
+        },
     )
 }
 fn name_store_join_2_delete_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_delete(
-        LegacyTableName::NAME_STORE_JOIN,
+        TABLE_NAME,
         NAME_STORE_JOIN_2.0,
-        PullDeleteRecordTable::NameStoreJoin,
+        NameStoreJoinRowDelete(NAME_STORE_JOIN_2.0.to_string()),
     )
 }
 
@@ -104,15 +103,15 @@ fn name_store_join_2_inactive_pull_record() -> TestSyncPullRecord {
 // );
 // fn name_store_join_3_pull_record() -> TestSyncPullRecord {
 //     TestSyncPullRecord::new_pull_upsert(
-//         LegacyTableName::NAME_STORE_JOIN,
+//         TABLE_NAME,
 //         NAME_STORE_JOIN_3,
-//         PullUpsertRecord::NameStoreJoin(NameStoreJoinRow {
+//         NameStoreJoinRow {
 //             id: NAME_STORE_JOIN_3.0.to_string(),
 //             store_id: "store_b".to_string(),
 //             name_id: "name_store_c".to_string(),
 //             name_is_customer: true,
 //             name_is_supplier: true,
-//         }),
+//         }
 //     )
 // }
 
@@ -136,7 +135,7 @@ pub(crate) fn test_push_upsert() -> Vec<TestSyncPushRecord> {
     vec![
         TestSyncPushRecord {
             record_id: NAME_STORE_JOIN_1.0.to_string(),
-            table_name: LegacyTableName::NAME_STORE_JOIN.to_string(),
+            table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyNameStoreJoinRow {
                 id: NAME_STORE_JOIN_1.0.to_string(),
                 store_id: "store_a".to_string(),
@@ -148,7 +147,7 @@ pub(crate) fn test_push_upsert() -> Vec<TestSyncPushRecord> {
         },
         TestSyncPushRecord {
             record_id: NAME_STORE_JOIN_2.0.to_string(),
-            table_name: LegacyTableName::NAME_STORE_JOIN.to_string(),
+            table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyNameStoreJoinRow {
                 id: NAME_STORE_JOIN_2.0.to_string(),
                 store_id: "store_b".to_string(),

--- a/server/service/src/sync/test/test_data/name_tag.rs
+++ b/server/service/src/sync/test/test_data/name_tag.rs
@@ -1,9 +1,8 @@
-use crate::sync::{
-    test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullUpsertRecord},
-};
+use crate::sync::test::TestSyncPullRecord;
 
 use repository::NameTagRow;
+
+const TABLE_NAME: &'static str = "name_tag";
 
 const NAME_TAG_1: (&'static str, &'static str) = (
     "59F2635D22B346ADA0088D6261926465",
@@ -15,12 +14,12 @@ const NAME_TAG_1: (&'static str, &'static str) = (
 
 fn name_tag_1() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::NAME_TAG,
+        TABLE_NAME,
         NAME_TAG_1,
-        PullUpsertRecord::NameTag(NameTagRow {
+        NameTagRow {
             id: NAME_TAG_1.0.to_owned(),
             name: "a1".to_owned(),
-        }),
+        },
     )
 }
 
@@ -34,12 +33,12 @@ const NAME_TAG_2: (&'static str, &'static str) = (
 
 fn name_tag_2() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::NAME_TAG,
+        TABLE_NAME,
         NAME_TAG_2,
-        PullUpsertRecord::NameTag(NameTagRow {
+        NameTagRow {
             id: NAME_TAG_2.0.to_owned(),
             name: "b2".to_owned(),
-        }),
+        },
     )
 }
 

--- a/server/service/src/sync/test/test_data/name_tag_join.rs
+++ b/server/service/src/sync/test/test_data/name_tag_join.rs
@@ -1,9 +1,8 @@
-use crate::sync::{
-    test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullDeleteRecordTable, PullUpsertRecord},
-};
+use crate::sync::test::TestSyncPullRecord;
 
-use repository::NameTagJoinRow;
+use repository::{NameTagJoinRow, NameTagJoinRowDelete};
+
+const TABLE_NAME: &'static str = "name_tag_join";
 
 const NAME_TAG_JOIN_1: (&'static str, &'static str) = (
     "44F59B35C8FE3C41B779CFF6AC823F57",
@@ -16,13 +15,13 @@ const NAME_TAG_JOIN_1: (&'static str, &'static str) = (
 
 fn name_tag_join_1() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::NAME_TAG_JOIN,
+        TABLE_NAME,
         NAME_TAG_JOIN_1,
-        PullUpsertRecord::NameTagJoin(NameTagJoinRow {
+        NameTagJoinRow {
             id: NAME_TAG_JOIN_1.0.to_owned(),
             name_id: "1FB32324AF8049248D929CFB35F255BA".to_owned(),
             name_tag_id: "59F2635D22B346ADA0088D6261926465".to_owned(),
-        }),
+        },
     )
 }
 
@@ -37,13 +36,13 @@ const NAME_TAG_JOIN_2: (&'static str, &'static str) = (
 
 fn name_tag_join_2() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::NAME_TAG_JOIN,
+        TABLE_NAME,
         NAME_TAG_JOIN_2,
-        PullUpsertRecord::NameTagJoin(NameTagJoinRow {
+        NameTagJoinRow {
             id: NAME_TAG_JOIN_2.0.to_owned(),
             name_id: "1FB32324AF8049248D929CFB35F255BA".to_owned(),
             name_tag_id: "1A3B380E37F741729DAC4761AF3549F9".to_owned(),
-        }),
+        },
     )
 }
 
@@ -53,8 +52,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
 
 pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_delete(
-        LegacyTableName::NAME_TAG_JOIN,
+        TABLE_NAME,
         NAME_TAG_JOIN_2.0,
-        PullDeleteRecordTable::NameTagJoin,
+        NameTagJoinRowDelete(NAME_TAG_JOIN_2.0.to_string()),
     )]
 }

--- a/server/service/src/sync/test/test_data/period.rs
+++ b/server/service/src/sync/test/test_data/period.rs
@@ -1,10 +1,9 @@
 use chrono::NaiveDate;
 use repository::PeriodRow;
 
-use crate::sync::{
-    test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullUpsertRecord},
-};
+use crate::sync::test::TestSyncPullRecord;
+
+const TABLE_NAME: &'static str = "period";
 
 const PERIOD_1: (&'static str, &'static str) = (
     "period_1",
@@ -55,48 +54,48 @@ const PERIOD_4: (&'static str, &'static str) = (
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::PERIOD,
+            TABLE_NAME,
             PERIOD_1,
-            PullUpsertRecord::Period(PeriodRow {
+            PeriodRow {
                 id: "period_1".to_string(),
                 period_schedule_id: "period_schedule_1".to_string(),
                 name: "Jan Wk01 2023".to_string(),
                 start_date: NaiveDate::from_ymd_opt(2023, 01, 01).unwrap(),
                 end_date: NaiveDate::from_ymd_opt(2023, 01, 07).unwrap(),
-            }),
+            },
         ),
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::PERIOD,
+            TABLE_NAME,
             PERIOD_2,
-            PullUpsertRecord::Period(PeriodRow {
+            PeriodRow {
                 id: "period_2".to_string(),
                 period_schedule_id: "period_schedule_2".to_string(),
                 name: "2023".to_string(),
                 start_date: NaiveDate::from_ymd_opt(2023, 01, 01).unwrap(),
                 end_date: NaiveDate::from_ymd_opt(2023, 12, 31).unwrap(),
-            }),
+            },
         ),
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::PERIOD,
+            TABLE_NAME,
             PERIOD_3,
-            PullUpsertRecord::Period(PeriodRow {
+            PeriodRow {
                 id: "641A3560C84A44BC9E6DDC01F3D75923".to_string(),
                 period_schedule_id: "597074CBCCC24166B8C1F82553DACC2F".to_string(),
                 name: "2020_Q2".to_string(),
                 start_date: NaiveDate::from_ymd_opt(2020, 04, 01).unwrap(),
                 end_date: NaiveDate::from_ymd_opt(2020, 06, 30).unwrap(),
-            }),
+            },
         ),
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::PERIOD,
+            TABLE_NAME,
             PERIOD_4,
-            PullUpsertRecord::Period(PeriodRow {
+            PeriodRow {
                 id: "772B3984DBA14A5F941ED0EF857FDB31".to_string(),
                 period_schedule_id: "597074CBCCC24166B8C1F82553DACC2F".to_string(),
                 name: "2020_Q3".to_string(),
                 start_date: NaiveDate::from_ymd_opt(2020, 07, 01).unwrap(),
                 end_date: NaiveDate::from_ymd_opt(2020, 09, 30).unwrap(),
-            }),
+            },
         ),
     ]
 }

--- a/server/service/src/sync/test/test_data/period_schedule.rs
+++ b/server/service/src/sync/test/test_data/period_schedule.rs
@@ -1,9 +1,8 @@
 use repository::PeriodScheduleRow;
 
-use crate::sync::{
-    test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullUpsertRecord},
-};
+use crate::sync::test::TestSyncPullRecord;
+
+const TABLE_NAME: &'static str = "periodSchedule";
 
 const PERIOD_SCHEDULE_1: (&'static str, &'static str) = (
     "period_schedule_1",
@@ -32,28 +31,28 @@ const PERIOD_SCHEDULE_3: (&'static str, &'static str) = (
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::PERIOD_SCHEDULE,
+            TABLE_NAME,
             PERIOD_SCHEDULE_1,
-            PullUpsertRecord::PeriodSchedule(PeriodScheduleRow {
+            PeriodScheduleRow {
                 id: "period_schedule_1".to_string(),
                 name: "Weekly1".to_string(),
-            }),
+            },
         ),
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::PERIOD_SCHEDULE,
+            TABLE_NAME,
             PERIOD_SCHEDULE_2,
-            PullUpsertRecord::PeriodSchedule(PeriodScheduleRow {
+            PeriodScheduleRow {
                 id: "period_schedule_2".to_string(),
                 name: "Yearly2".to_string(),
-            }),
+            },
         ),
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::PERIOD_SCHEDULE,
+            TABLE_NAME,
             PERIOD_SCHEDULE_3,
-            PullUpsertRecord::PeriodSchedule(PeriodScheduleRow {
+            PeriodScheduleRow {
                 id: "597074CBCCC24166B8C1F82553DACC2F".to_string(),
                 name: "Quarterly".to_string(),
-            }),
+            },
         ),
     ]
 }

--- a/server/service/src/sync/test/test_data/program_requisition_settings.rs
+++ b/server/service/src/sync/test/test_data/program_requisition_settings.rs
@@ -4,12 +4,15 @@ use repository::{
         mock_period_schedule_2,
     },
     ContextRow, ProgramRequisitionOrderTypeRow, ProgramRequisitionSettingsRow, ProgramRow,
+    SyncBufferAction, SyncBufferRow,
 };
 
 use crate::sync::{
     test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullUpsertRecord},
+    translations::{IntegrationOperation, PullTranslateResult},
 };
+
+const TABLE_NAME: &'static str = "list_master";
 
 const MASTER_LIST_WITH_PROGRAM_1: (&'static str, &'static str) = (
     "program_test",
@@ -116,27 +119,25 @@ const MASTER_LIST_WITH_PROGRAM_2: (&'static str, &'static str) = (
 
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
-        TestSyncPullRecord::new_pull_upserts(
-            LegacyTableName::LIST_MASTER,
-            MASTER_LIST_WITH_PROGRAM_1,
-            vec![
-                PullUpsertRecord::Context(ContextRow {
+        TestSyncPullRecord {
+            translated_record: PullTranslateResult::IntegrationOperations(vec![
+                IntegrationOperation::upsert(ContextRow {
                     id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
                     name: "Program Test 01".to_owned(),
                 }),
-                PullUpsertRecord::Program(ProgramRow {
+                IntegrationOperation::upsert(ProgramRow {
                     id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
                     name: "Program Test 01".to_owned(),
                     master_list_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
                     context_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
                 }),
-                PullUpsertRecord::ProgramRequisitionSettings(ProgramRequisitionSettingsRow {
+                IntegrationOperation::upsert(ProgramRequisitionSettingsRow {
                     id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned() + &mock_name_tag_1().id,
                     name_tag_id: mock_name_tag_1().id,
                     program_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
                     period_schedule_id: mock_period_schedule_1().id,
                 }),
-                PullUpsertRecord::ProgramRequisitionOrderType(ProgramRequisitionOrderTypeRow {
+                IntegrationOperation::upsert(ProgramRequisitionOrderTypeRow {
                     id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned()
                         + &mock_name_tag_1().id
                         + "New order 1",
@@ -147,7 +148,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                     max_mos: 3.0,
                     max_order_per_period: 1,
                 }),
-                PullUpsertRecord::ProgramRequisitionOrderType(ProgramRequisitionOrderTypeRow {
+                IntegrationOperation::upsert(ProgramRequisitionOrderTypeRow {
                     id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned()
                         + &mock_name_tag_1().id
                         + "New order 2",
@@ -158,13 +159,13 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                     max_mos: 3.0,
                     max_order_per_period: 1,
                 }),
-                PullUpsertRecord::ProgramRequisitionSettings(ProgramRequisitionSettingsRow {
+                IntegrationOperation::upsert(ProgramRequisitionSettingsRow {
                     id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned() + &mock_name_tag_2().id,
                     name_tag_id: mock_name_tag_2().id,
                     program_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
                     period_schedule_id: mock_period_schedule_1().id,
                 }),
-                PullUpsertRecord::ProgramRequisitionOrderType(ProgramRequisitionOrderTypeRow {
+                IntegrationOperation::upsert(ProgramRequisitionOrderTypeRow {
                     id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned()
                         + &mock_name_tag_2().id
                         + "New order 1",
@@ -175,13 +176,13 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                     max_mos: 4.0,
                     max_order_per_period: 1,
                 }),
-                PullUpsertRecord::ProgramRequisitionSettings(ProgramRequisitionSettingsRow {
+                IntegrationOperation::upsert(ProgramRequisitionSettingsRow {
                     id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned() + &mock_name_tag_3().id,
                     name_tag_id: mock_name_tag_3().id,
                     program_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
                     period_schedule_id: mock_period_schedule_2().id,
                 }),
-                PullUpsertRecord::ProgramRequisitionOrderType(ProgramRequisitionOrderTypeRow {
+                IntegrationOperation::upsert(ProgramRequisitionOrderTypeRow {
                     id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned()
                         + &mock_name_tag_3().id
                         + "New order 1",
@@ -192,29 +193,43 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                     max_mos: 2.0,
                     max_order_per_period: 3,
                 }),
-            ],
-        ),
-        TestSyncPullRecord::new_pull_upserts(
-            LegacyTableName::LIST_MASTER,
-            MASTER_LIST_WITH_PROGRAM_2,
-            vec![
-                PullUpsertRecord::Context(ContextRow {
+            ]),
+            sync_buffer_row: SyncBufferRow {
+                table_name: TABLE_NAME.to_string(),
+                record_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
+                data: MASTER_LIST_WITH_PROGRAM_1.1.to_owned(),
+                action: SyncBufferAction::Upsert,
+                ..Default::default()
+            },
+            extra_data: None,
+        },
+        TestSyncPullRecord {
+            translated_record: PullTranslateResult::IntegrationOperations(vec![
+                IntegrationOperation::upsert(ContextRow {
                     id: MASTER_LIST_WITH_PROGRAM_2.0.to_owned(),
                     name: "Program Test 02".to_owned(),
                 }),
-                PullUpsertRecord::Program(ProgramRow {
+                IntegrationOperation::upsert(ProgramRow {
                     id: MASTER_LIST_WITH_PROGRAM_2.0.to_owned(),
                     name: "Program Test 02".to_owned(),
                     master_list_id: MASTER_LIST_WITH_PROGRAM_2.0.to_owned(),
                     context_id: MASTER_LIST_WITH_PROGRAM_2.0.to_owned(),
                 }),
-                PullUpsertRecord::ProgramRequisitionSettings(ProgramRequisitionSettingsRow {
+                IntegrationOperation::upsert(ProgramRequisitionSettingsRow {
                     id: MASTER_LIST_WITH_PROGRAM_2.0.to_owned() + &mock_name_tag_1().id,
                     name_tag_id: mock_name_tag_1().id,
                     program_id: MASTER_LIST_WITH_PROGRAM_2.0.to_owned(),
                     period_schedule_id: mock_period_schedule_1().id,
                 }),
-            ],
-        ),
+            ]),
+            sync_buffer_row: SyncBufferRow {
+                table_name: TABLE_NAME.to_string(),
+                record_id: MASTER_LIST_WITH_PROGRAM_2.0.to_owned(),
+                data: MASTER_LIST_WITH_PROGRAM_2.1.to_owned(),
+                action: SyncBufferAction::Upsert,
+                ..Default::default()
+            },
+            extra_data: None,
+        },
     ]
 }

--- a/server/service/src/sync/test/test_data/report.rs
+++ b/server/service/src/sync/test/test_data/report.rs
@@ -1,8 +1,7 @@
-use crate::sync::{
-    test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullDeleteRecordTable, PullUpsertRecord},
-};
-use repository::{ReportContext, ReportRow, ReportType};
+use crate::sync::test::TestSyncPullRecord;
+use repository::{ReportContext, ReportRow, ReportRowDelete, ReportType};
+
+const TABLE_NAME: &'static str = "report";
 
 const REPORT_1: (&'static str, &'static str) = (
     "76B6C424E1935C4DAF36A7A8F451FE72",
@@ -29,9 +28,9 @@ const REPORT_1: (&'static str, &'static str) = (
 
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::REPORT,
+        TABLE_NAME,
         REPORT_1,
-        PullUpsertRecord::Report(ReportRow {
+        ReportRow {
             id: REPORT_1.0.to_string(),
             name: "Test".to_string(),
             r#type: ReportType::OmSupply,
@@ -40,14 +39,14 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
             comment: Some("Test comment".to_string()),
             sub_context: None,
             argument_schema_id: None,
-        }),
+        },
     )]
 }
 
 pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_delete(
-        LegacyTableName::REPORT,
+        TABLE_NAME,
         REPORT_1.0,
-        PullDeleteRecordTable::Report,
+        ReportRowDelete(REPORT_1.0.to_string()),
     )]
 }

--- a/server/service/src/sync/test/test_data/requisition.rs
+++ b/server/service/src/sync/test/test_data/requisition.rs
@@ -1,17 +1,15 @@
 use super::{TestSyncPullRecord, TestSyncPushRecord};
-use crate::sync::translations::{
-    requisition::{
-        LegacyAuthorisationStatus, LegacyRequisitionRow, LegacyRequisitionStatus,
-        LegacyRequisitionType,
-    },
-    LegacyTableName, PullDeleteRecordTable, PullUpsertRecord,
+use crate::sync::translations::requisition::{
+    LegacyAuthorisationStatus, LegacyRequisitionRow, LegacyRequisitionStatus, LegacyRequisitionType,
 };
 use chrono::NaiveDate;
 use repository::{
     requisition_row::{RequisitionRowStatus, RequisitionRowType},
-    RequisitionRow, RequisitionRowApprovalStatus,
+    RequisitionRow, RequisitionRowApprovalStatus, RequisitionRowDelete,
 };
 use serde_json::json;
+
+const TABLE_NAME: &'static str = "requisition";
 
 const REQUISITION_REQUEST: (&'static str, &'static str) = (
     "B3D3761753DB42A7B3286ACF89FBCA1C",
@@ -54,9 +52,9 @@ const REQUISITION_REQUEST: (&'static str, &'static str) = (
 );
 fn requisition_request_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::REQUISITION,
+        TABLE_NAME,
         REQUISITION_REQUEST,
-        PullUpsertRecord::Requisition(RequisitionRow {
+        RequisitionRow {
             id: REQUISITION_REQUEST.0.to_string(),
             user_id: Some("0763E2E3053D4C478E1E6B6B03FEC207".to_string()),
             requisition_number: 8,
@@ -86,12 +84,12 @@ fn requisition_request_pull_record() -> TestSyncPullRecord {
             program_id: None,
             period_id: None,
             order_type: None,
-        }),
+        },
     )
 }
 fn requisition_request_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::REQUISITION.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: REQUISITION_REQUEST.0.to_string(),
         push_data: json!(LegacyRequisitionRow {
             ID: REQUISITION_REQUEST.0.to_string(),
@@ -167,9 +165,9 @@ const REQUISITION_RESPONSE: (&'static str, &'static str) = (
 );
 fn requisition_response_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::REQUISITION,
+        TABLE_NAME,
         REQUISITION_RESPONSE,
-        PullUpsertRecord::Requisition(RequisitionRow {
+        RequisitionRow {
             id: REQUISITION_RESPONSE.0.to_string(),
             user_id: Some("0763E2E3053D4C478E1E6B6B03FEC207".to_string()),
             requisition_number: 1,
@@ -199,12 +197,12 @@ fn requisition_response_pull_record() -> TestSyncPullRecord {
             program_id: Some("missing_program".to_string()),
             period_id: Some("641A3560C84A44BC9E6DDC01F3D75923".to_string()),
             order_type: Some("Normal".to_string()),
-        }),
+        },
     )
 }
 fn requisition_response_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::REQUISITION.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: REQUISITION_RESPONSE.0.to_string(),
         push_data: json!(LegacyRequisitionRow {
             ID: REQUISITION_RESPONSE.0.to_string(),
@@ -287,9 +285,9 @@ const REQUISITION_OM_FIELDS: (&'static str, &'static str) = (
 );
 fn requisition_om_fields_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::REQUISITION,
+        TABLE_NAME,
         REQUISITION_OM_FIELDS,
-        PullUpsertRecord::Requisition(RequisitionRow {
+        RequisitionRow {
             id: REQUISITION_OM_FIELDS.0.to_string(),
             user_id: Some("0763E2E3053D4C478E1E6B6B03FEC207".to_string()),
             requisition_number: 1,
@@ -324,12 +322,12 @@ fn requisition_om_fields_pull_record() -> TestSyncPullRecord {
             program_id: None,
             period_id: Some("641A3560C84A44BC9E6DDC01F3D75923".to_string()),
             order_type: Some("Normal".to_string()),
-        }),
+        },
     )
 }
 fn requisition_om_fields_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::REQUISITION.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: REQUISITION_OM_FIELDS.0.to_string(),
         push_data: json!(LegacyRequisitionRow {
             ID: REQUISITION_OM_FIELDS.0.to_string(),
@@ -417,9 +415,9 @@ const PROGRAM_REQUISITION_REQUEST: (&'static str, &'static str) = (
 );
 fn program_requisition_request_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::REQUISITION,
+        TABLE_NAME,
         PROGRAM_REQUISITION_REQUEST,
-        PullUpsertRecord::Requisition(RequisitionRow {
+        RequisitionRow {
             id: PROGRAM_REQUISITION_REQUEST.0.to_string(),
             user_id: Some("0763E2E3053D4C478E1E6B6B03FEC207".to_string()),
             requisition_number: 8,
@@ -449,12 +447,12 @@ fn program_requisition_request_pull_record() -> TestSyncPullRecord {
             program_id: Some("missing_program".to_string()),
             period_id: Some("772B3984DBA14A5F941ED0EF857FDB31".to_string()),
             order_type: Some("Normal".to_string()),
-        }),
+        },
     )
 }
 fn program_requisition_request_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::REQUISITION.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: PROGRAM_REQUISITION_REQUEST.0.to_string(),
         push_data: json!(LegacyRequisitionRow {
             ID: PROGRAM_REQUISITION_REQUEST.0.to_string(),
@@ -507,9 +505,9 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
 
 pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_delete(
-        LegacyTableName::REQUISITION,
+        TABLE_NAME,
         REQUISITION_OM_FIELDS.0,
-        PullDeleteRecordTable::Requisition,
+        RequisitionRowDelete(REQUISITION_OM_FIELDS.0.to_string()),
     )]
 }
 

--- a/server/service/src/sync/test/test_data/requisition_line.rs
+++ b/server/service/src/sync/test/test_data/requisition_line.rs
@@ -1,13 +1,12 @@
-use crate::sync::translations::{
-    requisition_line::LegacyRequisitionLineRow, LegacyTableName, PullDeleteRecordTable,
-    PullUpsertRecord,
-};
+use crate::sync::translations::requisition_line::LegacyRequisitionLineRow;
 
 use super::{TestSyncPullRecord, TestSyncPushRecord};
 use chrono::NaiveDate;
-use repository::RequisitionLineRow;
+use repository::{RequisitionLineRow, RequisitionLineRowDelete};
 use serde_json::json;
 use util::constants::NUMBER_OF_DAYS_IN_A_MONTH;
+
+const TABLE_NAME: &'static str = "requisition_line";
 
 const REQUISITION_LINE_1: (&'static str, &'static str) = (
     "66FB0A41C95441ABBBC7905857466089",
@@ -47,9 +46,9 @@ const REQUISITION_LINE_1: (&'static str, &'static str) = (
 );
 fn requisition_line_request_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::REQUISITION_LINE,
+        TABLE_NAME,
         REQUISITION_LINE_1,
-        PullUpsertRecord::RequisitionLine(RequisitionLineRow {
+        RequisitionLineRow {
             id: REQUISITION_LINE_1.0.to_string(),
             requisition_id: "mock_request_draft_requisition3".to_string(),
             item_id: "item_a".to_string(),
@@ -62,12 +61,12 @@ fn requisition_line_request_pull_record() -> TestSyncPullRecord {
             snapshot_datetime: None,
             approved_quantity: 0,
             approval_comment: None,
-        }),
+        },
     )
 }
 fn requisition_line_request_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::REQUISITION_LINE.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: REQUISITION_LINE_1.0.to_string(),
         push_data: json!(LegacyRequisitionLineRow {
             ID: REQUISITION_LINE_1.0.to_string(),
@@ -125,9 +124,9 @@ const REQUISITION_LINE_OM_FIELD: (&'static str, &'static str) = (
 );
 fn requisition_line_om_fields_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::REQUISITION_LINE,
+        TABLE_NAME,
         REQUISITION_LINE_OM_FIELD,
-        PullUpsertRecord::RequisitionLine(RequisitionLineRow {
+        RequisitionLineRow {
             id: REQUISITION_LINE_OM_FIELD.0.to_string(),
             requisition_id: "mock_request_draft_requisition3".to_string(),
             item_id: "item_a".to_string(),
@@ -145,12 +144,12 @@ fn requisition_line_om_fields_pull_record() -> TestSyncPullRecord {
                     .and_hms_opt(14, 48, 11)
                     .unwrap(),
             ),
-        }),
+        },
     )
 }
 fn requisition_line_om_fields_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::REQUISITION_LINE.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: REQUISITION_LINE_OM_FIELD.0.to_string(),
         push_data: json!(LegacyRequisitionLineRow {
             ID: REQUISITION_LINE_OM_FIELD.0.to_string(),
@@ -184,9 +183,9 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
 
 pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_delete(
-        LegacyTableName::REQUISITION_LINE,
+        TABLE_NAME,
         REQUISITION_LINE_OM_FIELD.0,
-        PullDeleteRecordTable::RequisitionLine,
+        RequisitionLineRowDelete(REQUISITION_LINE_OM_FIELD.0.to_string()),
     )]
 }
 

--- a/server/service/src/sync/test/test_data/sensor.rs
+++ b/server/service/src/sync/test/test_data/sensor.rs
@@ -1,10 +1,12 @@
-use crate::sync::translations::{sensor::LegacySensorRow, LegacyTableName, PullUpsertRecord};
+use crate::sync::translations::sensor::LegacySensorRow;
 
 use chrono::{Duration, NaiveDate, NaiveTime};
 use repository::{SensorRow, SensorType};
 use serde_json::json;
 
 use super::{TestSyncPullRecord, TestSyncPushRecord};
+
+const TABLE_NAME: &'static str = "sensor";
 
 const SENSOR_1: (&'static str, &'static str) = (
     "cf5812e0c33911eb9757779d39ae2dbd",
@@ -25,9 +27,9 @@ const SENSOR_1: (&'static str, &'static str) = (
 
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::SENSOR,
+        TABLE_NAME,
         SENSOR_1,
-        PullUpsertRecord::Sensor(SensorRow {
+        SensorRow {
             id: SENSOR_1.0.to_string(),
             name: "NameRed.02".to_string(),
             serial: "SerialRed.02".to_string(),
@@ -44,13 +46,13 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                     + Duration::seconds(47046),
             ),
             r#type: SensorType::BlueMaestro,
-        }),
+        },
     )]
 }
 
 pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
     vec![TestSyncPushRecord {
-        table_name: LegacyTableName::SENSOR.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: SENSOR_1.0.to_string(),
         push_data: json!(LegacySensorRow {
             id: SENSOR_1.0.to_string(),

--- a/server/service/src/sync/test/test_data/special/name_to_name_store_join.rs
+++ b/server/service/src/sync/test/test_data/special/name_to_name_store_join.rs
@@ -4,11 +4,10 @@ use util::{inline_edit, inline_init};
 
 use crate::sync::{
     test::{TestSyncPullRecord, TestSyncPushRecord},
-    translations::{
-        name_store_join::LegacyNameStoreJoinRow, IntegrationRecords, LegacyTableName,
-        PullUpsertRecord,
-    },
+    translations::{name_store_join::LegacyNameStoreJoinRow, PullTranslateResult},
 };
+
+const TABLE_NAME: &'static str = "name_store_join";
 
 const NAME_1: (&'static str, &'static str) = (
     "BEB2D69692C44B32B24BEBD5020BCD14",
@@ -161,20 +160,20 @@ pub fn name_store_join3() -> NameStoreJoinRow {
 
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord {
-        translated_record: Some(IntegrationRecords::from_upserts(vec![
-            PullUpsertRecord::NameStoreJoin(inline_edit(&name_store_join1(), |mut r| {
+        translated_record: PullTranslateResult::upserts(vec![
+            inline_edit(&name_store_join1(), |mut r| {
                 r.name_is_customer = true;
                 r.name_is_supplier = false;
                 r
-            })),
-            PullUpsertRecord::NameStoreJoin(inline_edit(&name_store_join2(), |mut r| {
+            }),
+            inline_edit(&name_store_join2(), |mut r| {
                 r.name_is_customer = true;
                 r.name_is_supplier = false;
                 r
-            })),
-        ])),
+            }),
+        ]),
         sync_buffer_row: inline_init(|r: &mut SyncBufferRow| {
-            r.table_name = LegacyTableName::NAME.to_owned();
+            r.table_name = "name".to_string();
             r.record_id = NAME_1.0.to_owned();
             r.data = NAME_1.1.to_owned();
         }),
@@ -190,19 +189,20 @@ pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
     vec![
         TestSyncPushRecord {
             record_id: name_store_join1().id,
-            table_name: LegacyTableName::NAME_STORE_JOIN.to_string(),
+            table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyNameStoreJoinRow {
                 id: name_store_join1().id,
                 store_id: name_store_join1().store_id,
                 name_id: name_store_join1().name_id,
                 inactive: Some(false),
                 name_is_customer: Some(true),
+
                 name_is_supplier: Some(false),
             }),
         },
         TestSyncPushRecord {
             record_id: name_store_join2().id,
-            table_name: LegacyTableName::NAME_STORE_JOIN.to_string(),
+            table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyNameStoreJoinRow {
                 id: name_store_join2().id,
                 store_id: name_store_join2().store_id,
@@ -214,7 +214,7 @@ pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
         },
         TestSyncPushRecord {
             record_id: name_store_join3().id,
-            table_name: LegacyTableName::NAME_STORE_JOIN.to_string(),
+            table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyNameStoreJoinRow {
                 id: name_store_join3().id,
                 store_id: name_store_join3().store_id,

--- a/server/service/src/sync/test/test_data/stock_line.rs
+++ b/server/service/src/sync/test/test_data/stock_line.rs
@@ -2,12 +2,11 @@ use chrono::NaiveDate;
 use repository::StockLineRow;
 use serde_json::json;
 
-use crate::sync::{
-    test::TestSyncPullRecord,
-    translations::{stock_line::LegacyStockLineRow, LegacyTableName, PullUpsertRecord},
-};
+use crate::sync::{test::TestSyncPullRecord, translations::stock_line::LegacyStockLineRow};
 
 use super::TestSyncPushRecord;
+
+const TABLE_NAME: &'static str = "item_line";
 
 const ITEM_LINE_1: (&'static str, &'static str) = (
     "0a3b02d0f0d211eb8dddb54df6d741bc",
@@ -54,9 +53,9 @@ const ITEM_LINE_1: (&'static str, &'static str) = (
 );
 fn item_line_1_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::ITEM_LINE,
+        TABLE_NAME,
         ITEM_LINE_1,
-        PullUpsertRecord::StockLine(StockLineRow {
+        StockLineRow {
             id: ITEM_LINE_1.0.to_string(),
             store_id: "store_a".to_string(),
             item_id: "item_a".to_string(),
@@ -72,12 +71,12 @@ fn item_line_1_pull_record() -> TestSyncPullRecord {
             note: Some("test note".to_string()),
             supplier_id: Some("name_store_b".to_string()),
             barcode_id: None,
-        }),
+        },
     )
 }
 fn item_line_1_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::ITEM_LINE.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: ITEM_LINE_1.0.to_string(),
         push_data: json!(LegacyStockLineRow {
             ID: ITEM_LINE_1.0.to_string(),
@@ -144,9 +143,9 @@ const ITEM_LINE_2: (&'static str, &'static str) = (
 );
 fn item_line_2_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::ITEM_LINE,
+        TABLE_NAME,
         ITEM_LINE_2,
-        PullUpsertRecord::StockLine(StockLineRow {
+        StockLineRow {
             id: ITEM_LINE_2.0.to_string(),
             store_id: "store_a".to_string(),
             item_id: "item_b".to_string(),
@@ -162,12 +161,12 @@ fn item_line_2_pull_record() -> TestSyncPullRecord {
             note: None,
             supplier_id: None,
             barcode_id: None,
-        }),
+        },
     )
 }
 fn item_line_2_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::ITEM_LINE.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: ITEM_LINE_2.0.to_string(),
         push_data: json!(LegacyStockLineRow {
             ID: ITEM_LINE_2.0.to_string(),

--- a/server/service/src/sync/test/test_data/stocktake.rs
+++ b/server/service/src/sync/test/test_data/stocktake.rs
@@ -1,15 +1,14 @@
 use crate::sync::{
     test::TestSyncPullRecord,
-    translations::{
-        stocktake::{LegacyStocktakeRow, LegacyStocktakeStatus},
-        LegacyTableName, PullUpsertRecord,
-    },
+    translations::stocktake::{LegacyStocktakeRow, LegacyStocktakeStatus},
 };
 use chrono::{NaiveDate, NaiveTime};
 use repository::{StocktakeRow, StocktakeStatus};
 use serde_json::json;
 
 use super::TestSyncPushRecord;
+
+const TABLE_NAME: &'static str = "Stock_take";
 
 const STOCKTAKE_1: (&'static str, &'static str) = (
     "0a375950f0d211eb8dddb54df6d741bc",
@@ -35,9 +34,9 @@ const STOCKTAKE_1: (&'static str, &'static str) = (
 );
 fn stocktake_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::STOCKTAKE,
+        TABLE_NAME,
         STOCKTAKE_1,
-        PullUpsertRecord::Stocktake(StocktakeRow {
+        StocktakeRow {
             id: STOCKTAKE_1.0.to_string(),
             user_id: "".to_string(),
             store_id: "store_a".to_string(),
@@ -53,12 +52,12 @@ fn stocktake_pull_record() -> TestSyncPullRecord {
             inventory_reduction_id: Some("inbound_shipment_b".to_string()),
             is_locked: false,
             stocktake_date: Some(NaiveDate::from_ymd_opt(2021, 07, 30).unwrap()),
-        }),
+        },
     )
 }
 fn stocktake_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::STOCKTAKE.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: STOCKTAKE_1.0.to_string(),
         push_data: json!(LegacyStocktakeRow {
             ID: STOCKTAKE_1.0.to_string(),
@@ -109,9 +108,9 @@ const STOCKTAKE_OM_FIELD: (&'static str, &'static str) = (
 );
 fn stocktake_om_field_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::STOCKTAKE,
+        TABLE_NAME,
         STOCKTAKE_OM_FIELD,
-        PullUpsertRecord::Stocktake(StocktakeRow {
+        StocktakeRow {
             id: STOCKTAKE_OM_FIELD.0.to_string(),
             user_id: "".to_string(),
             store_id: "store_a".to_string(),
@@ -133,12 +132,12 @@ fn stocktake_om_field_pull_record() -> TestSyncPullRecord {
             inventory_reduction_id: None,
             is_locked: false,
             stocktake_date: Some(NaiveDate::from_ymd_opt(2021, 07, 30).unwrap()),
-        }),
+        },
     )
 }
 fn stocktake_om_field_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::STOCKTAKE.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: STOCKTAKE_OM_FIELD.0.to_string(),
         push_data: json!(LegacyStocktakeRow {
             ID: STOCKTAKE_OM_FIELD.0.to_string(),

--- a/server/service/src/sync/test/test_data/stocktake_line.rs
+++ b/server/service/src/sync/test/test_data/stocktake_line.rs
@@ -1,10 +1,9 @@
 use super::TestSyncPushRecord;
-use crate::sync::{
-    test::TestSyncPullRecord,
-    translations::{stocktake_line::LegacyStocktakeLineRow, LegacyTableName, PullUpsertRecord},
-};
+use crate::sync::{test::TestSyncPullRecord, translations::stocktake_line::LegacyStocktakeLineRow};
 use repository::StocktakeLineRow;
 use serde_json::json;
+
+const TABLE_NAME: &'static str = "Stock_take_lines";
 
 const STOCKTAKE_LINE_1: (&'static str, &'static str) = (
     "0a3de900f0d211eb8dddb54df6d741bc",
@@ -33,9 +32,9 @@ const STOCKTAKE_LINE_1: (&'static str, &'static str) = (
 );
 fn stocktake_line_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::STOCKTAKE_LINE,
+        TABLE_NAME,
         STOCKTAKE_LINE_1,
-        PullUpsertRecord::StocktakeLine(StocktakeLineRow {
+        StocktakeLineRow {
             id: STOCKTAKE_LINE_1.0.to_string(),
             stocktake_id: "stocktake_a".to_string(),
             stock_line_id: Some("item_c_line_a".to_string()),
@@ -51,12 +50,12 @@ fn stocktake_line_pull_record() -> TestSyncPullRecord {
             sell_price_per_pack: Some(15.0),
             note: None,
             inventory_adjustment_reason_id: None,
-        }),
+        },
     )
 }
 fn stocktake_line_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::STOCKTAKE_LINE.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: STOCKTAKE_LINE_1.0.to_string(),
         push_data: json!(LegacyStocktakeLineRow {
             ID: STOCKTAKE_LINE_1.0.to_string(),
@@ -107,9 +106,9 @@ const STOCKTAKE_LINE_OM_FIELDS: (&'static str, &'static str) = (
 );
 fn stocktake_line_om_field_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::STOCKTAKE_LINE,
+        TABLE_NAME,
         STOCKTAKE_LINE_OM_FIELDS,
-        PullUpsertRecord::StocktakeLine(StocktakeLineRow {
+        StocktakeLineRow {
             id: STOCKTAKE_LINE_OM_FIELDS.0.to_string(),
             stocktake_id: "stocktake_a".to_string(),
             stock_line_id: Some("item_c_line_a".to_string()),
@@ -125,12 +124,12 @@ fn stocktake_line_om_field_pull_record() -> TestSyncPullRecord {
             sell_price_per_pack: Some(15.0),
             note: Some("om note".to_string()),
             inventory_adjustment_reason_id: None,
-        }),
+        },
     )
 }
 fn stocktake_line_om_field_push_record() -> TestSyncPushRecord {
     TestSyncPushRecord {
-        table_name: LegacyTableName::STOCKTAKE_LINE.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: STOCKTAKE_LINE_OM_FIELDS.0.to_string(),
         push_data: json!(LegacyStocktakeLineRow {
             ID: STOCKTAKE_LINE_OM_FIELDS.0.to_string(),

--- a/server/service/src/sync/test/test_data/store.rs
+++ b/server/service/src/sync/test/test_data/store.rs
@@ -1,12 +1,8 @@
-use crate::sync::{
-    test::TestSyncPullRecord,
-    translations::{
-        IntegrationRecords, LegacyTableName, PullDeleteRecord, PullDeleteRecordTable,
-        PullUpsertRecord,
-    },
-};
-use repository::{StoreRow, SyncBufferRow};
+use crate::sync::{test::TestSyncPullRecord, translations::PullTranslateResult};
+use repository::{StoreRow, StoreRowDelete, SyncBufferRow};
 use util::inline_init;
+
+const TABLE_NAME: &'static str = "store";
 
 const STORE_1: (&'static str, &'static str) = (
     "4E27CEB263354EB7B1B33CEA8F7884D8",
@@ -54,16 +50,16 @@ const STORE_1: (&'static str, &'static str) = (
 );
 
 fn store_1() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upserts(
-        LegacyTableName::STORE,
+    TestSyncPullRecord::new_pull_upsert(
+        TABLE_NAME,
         STORE_1,
-        vec![PullUpsertRecord::Store(inline_init(|s: &mut StoreRow| {
+        inline_init(|s: &mut StoreRow| {
             s.id = STORE_1.0.to_owned();
             s.name_id = "1FB32324AF8049248D929CFB35F255BA".to_string();
             s.code = "GEN".to_string();
             s.site_id = 1;
             s.logo = Some("No logo".to_string());
-        }))],
+        }),
     )
 }
 
@@ -115,9 +111,11 @@ const STORE_2: (&'static str, &'static str) = (
 
 fn store_2() -> TestSyncPullRecord {
     TestSyncPullRecord {
-        translated_record: None,
+        translated_record: PullTranslateResult::Ignored(
+            "Ignoring not implemented system names".to_string(),
+        ),
         sync_buffer_row: inline_init(|r: &mut SyncBufferRow| {
-            r.table_name = LegacyTableName::STORE.to_owned();
+            r.table_name = TABLE_NAME.to_owned();
             r.record_id = STORE_2.0.to_owned();
             r.data = STORE_2.1.to_owned();
         }),
@@ -173,9 +171,11 @@ const STORE_3: (&'static str, &'static str) = (
 
 fn store_3() -> TestSyncPullRecord {
     TestSyncPullRecord {
-        translated_record: None,
+        translated_record: PullTranslateResult::Ignored(
+            "Ignoring not implemented system names".to_string(),
+        ),
         sync_buffer_row: inline_init(|r: &mut SyncBufferRow| {
-            r.table_name = LegacyTableName::STORE.to_owned();
+            r.table_name = TABLE_NAME.to_owned();
             r.record_id = STORE_3.0.to_owned();
             r.data = STORE_3.1.to_owned();
         }),
@@ -231,9 +231,11 @@ const STORE_4: (&'static str, &'static str) = (
 
 fn store_4() -> TestSyncPullRecord {
     TestSyncPullRecord {
-        translated_record: None,
+        translated_record: PullTranslateResult::Ignored(
+            "Ignoring not implemented system names".to_string(),
+        ),
         sync_buffer_row: inline_init(|r: &mut SyncBufferRow| {
-            r.table_name = LegacyTableName::STORE.to_owned();
+            r.table_name = TABLE_NAME.to_owned();
             r.record_id = STORE_4.0.to_owned();
             r.data = STORE_4.1.to_owned();
         }),
@@ -246,15 +248,9 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
 }
 
 pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_deletes(
-        LegacyTableName::STORE,
+    vec![TestSyncPullRecord::new_pull_delete(
+        TABLE_NAME,
         STORE_4.0,
-        IntegrationRecords {
-            upserts: Vec::new(),
-            deletes: vec![PullDeleteRecord {
-                id: STORE_4.0.to_owned(),
-                table: PullDeleteRecordTable::Store,
-            }],
-        },
+        StoreRowDelete(STORE_4.0.to_string()),
     )]
 }

--- a/server/service/src/sync/test/test_data/store_preference.rs
+++ b/server/service/src/sync/test/test_data/store_preference.rs
@@ -1,8 +1,7 @@
-use crate::sync::{
-    test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullUpsertRecord},
-};
+use crate::sync::test::TestSyncPullRecord;
 use repository::{StorePreferenceRow, StorePreferenceType};
+
+const TABLE_NAME: &'static str = "pref";
 
 const STORE_PREFERENCE_1: (&'static str, &'static str) = (
     "store_preference",
@@ -138,9 +137,9 @@ const STORE_PREFERENCE_2: (&'static str, &'static str) = (
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::STORE_PREFERENCE,
+            TABLE_NAME,
             STORE_PREFERENCE_1,
-            PullUpsertRecord::StorePreference(StorePreferenceRow {
+            StorePreferenceRow {
                 id: "store_a".to_string(),
                 r#type: StorePreferenceType::StorePreferences,
                 pack_to_one: true,
@@ -148,12 +147,12 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 request_requisition_requires_authorisation: false,
                 om_program_module: true,
                 vaccine_module: false,
-            }),
+            },
         ),
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::STORE_PREFERENCE,
+            TABLE_NAME,
             STORE_PREFERENCE_2,
-            PullUpsertRecord::StorePreference(StorePreferenceRow {
+            StorePreferenceRow {
                 id: "store_b".to_string(),
                 r#type: StorePreferenceType::StorePreferences,
                 pack_to_one: false,
@@ -162,7 +161,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 // This one is missing, should default to false
                 om_program_module: false,
                 vaccine_module: true,
-            }),
+            },
         ),
     ]
 }

--- a/server/service/src/sync/test/test_data/temperature_breach.rs
+++ b/server/service/src/sync/test/test_data/temperature_breach.rs
@@ -1,6 +1,5 @@
-use crate::sync::translations::{
-    temperature_breach::{LegacyTemperatureBreachRow, LegacyTemperatureBreachType},
-    LegacyTableName, PullUpsertRecord,
+use crate::sync::translations::temperature_breach::{
+    LegacyTemperatureBreachRow, LegacyTemperatureBreachType,
 };
 
 use chrono::{Duration, NaiveDate, NaiveTime};
@@ -8,6 +7,8 @@ use repository::{TemperatureBreachRow, TemperatureBreachRowType};
 use serde_json::json;
 
 use super::{TestSyncPullRecord, TestSyncPushRecord};
+
+const TABLE_NAME: &'static str = "temperature_breach";
 
 const TEMPERATURE_BREACH_1: (&'static str, &'static str) = (
     "996812e0c33911eb9757779d39ae2dbd",
@@ -34,9 +35,9 @@ const TEMPERATURE_BREACH_1: (&'static str, &'static str) = (
 
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::TEMPERATURE_BREACH,
+        TABLE_NAME,
         TEMPERATURE_BREACH_1,
-        PullUpsertRecord::TemperatureBreach(TemperatureBreachRow {
+        TemperatureBreachRow {
             id: TEMPERATURE_BREACH_1.0.to_string(),
             store_id: "store_a".to_string(),
             location_id: None,
@@ -60,13 +61,13 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                     + Duration::seconds(47046),
             ),
             comment: None,
-        }),
+        },
     )]
 }
 
 pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
     vec![TestSyncPushRecord {
-        table_name: LegacyTableName::TEMPERATURE_BREACH.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: TEMPERATURE_BREACH_1.0.to_string(),
         push_data: json!(LegacyTemperatureBreachRow {
             id: TEMPERATURE_BREACH_1.0.to_string(),

--- a/server/service/src/sync/test/test_data/temperature_log.rs
+++ b/server/service/src/sync/test/test_data/temperature_log.rs
@@ -1,12 +1,12 @@
-use crate::sync::translations::{
-    temperature_log::LegacyTemperatureLogRow, LegacyTableName, PullUpsertRecord,
-};
+use crate::sync::translations::temperature_log::LegacyTemperatureLogRow;
 
 use chrono::{Duration, NaiveDate, NaiveTime};
 use repository::TemperatureLogRow;
 use serde_json::json;
 
 use super::{TestSyncPullRecord, TestSyncPushRecord};
+
+const TABLE_NAME: &'static str = "temperature_log";
 
 const TEMPERATURE_LOG_1: (&'static str, &'static str) = (
     "995812e0c33911eb9757779d39ae2dbd",
@@ -25,9 +25,9 @@ const TEMPERATURE_LOG_1: (&'static str, &'static str) = (
 
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_upsert(
-        LegacyTableName::TEMPERATURE_LOG,
+        TABLE_NAME,
         TEMPERATURE_LOG_1,
-        PullUpsertRecord::TemperatureLog(TemperatureLogRow {
+        TemperatureLogRow {
             id: TEMPERATURE_LOG_1.0.to_string(),
             store_id: "store_a".to_string(),
             location_id: None,
@@ -39,13 +39,13 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 .unwrap()
                 + Duration::seconds(47046),
             temperature_breach_id: None,
-        }),
+        },
     )]
 }
 
 pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
     vec![TestSyncPushRecord {
-        table_name: LegacyTableName::TEMPERATURE_LOG.to_string(),
+        table_name: TABLE_NAME.to_string(),
         record_id: TEMPERATURE_LOG_1.0.to_string(),
         push_data: json!(LegacyTemperatureLogRow {
             id: TEMPERATURE_LOG_1.0.to_string(),

--- a/server/service/src/sync/test/test_data/unit.rs
+++ b/server/service/src/sync/test/test_data/unit.rs
@@ -1,9 +1,8 @@
-use repository::UnitRow;
+use repository::{UnitRow, UnitRowDelete};
 
-use crate::sync::{
-    test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullDeleteRecordTable, PullUpsertRecord},
-};
+use crate::sync::test::TestSyncPullRecord;
+
+const TABLE_NAME: &'static str = "unit";
 
 const UNIT_1: (&'static str, &'static str) = (
     "A02C91EB6C77400BA783C4CD7C565F2A",
@@ -38,42 +37,42 @@ const UNIT_3: (&'static str, &'static str) = (
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::UNIT,
+            TABLE_NAME,
             UNIT_1,
-            PullUpsertRecord::Unit(UnitRow {
+            UnitRow {
                 id: UNIT_1.0.to_owned(),
                 name: "Units".to_owned(),
                 description: None,
                 index: 0,
-            }),
+            },
         ),
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::UNIT,
+            TABLE_NAME,
             UNIT_2,
-            PullUpsertRecord::Unit(UnitRow {
+            UnitRow {
                 id: UNIT_2.0.to_owned(),
                 name: "Tab".to_owned(),
                 description: None,
                 index: 1,
-            }),
+            },
         ),
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::UNIT,
+            TABLE_NAME,
             UNIT_3,
-            PullUpsertRecord::Unit(UnitRow {
+            UnitRow {
                 id: UNIT_3.0.to_owned(),
                 name: "Bottle".to_owned(),
                 description: Some("This is a bottle unit type".to_owned()),
                 index: 2,
-            }),
+            },
         ),
     ]
 }
 
 pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_delete(
-        LegacyTableName::UNIT,
+        TABLE_NAME,
         UNIT_1.0,
-        PullDeleteRecordTable::Unit,
+        UnitRowDelete(UNIT_1.0.to_string()),
     )]
 }

--- a/server/service/src/sync/test/test_data/user_permission.rs
+++ b/server/service/src/sync/test/test_data/user_permission.rs
@@ -1,9 +1,8 @@
-use repository::{mock::context_program_a, Permission, UserPermissionRow};
+use repository::{mock::context_program_a, Permission, UserPermissionRow, UserPermissionRowDelete};
 
-use crate::sync::{
-    test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullDeleteRecordTable, PullUpsertRecord},
-};
+use crate::sync::test::TestSyncPullRecord;
+
+const TABLE_NAME: &'static str = "om_user_permission";
 
 const USER_PERMISSION_1: (&'static str, &'static str) = (
     "user_permission_1",
@@ -30,34 +29,34 @@ const USER_PERMISSION_2: (&'static str, &'static str) = (
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::USER_PERMISSION,
+            TABLE_NAME,
             USER_PERMISSION_1,
-            PullUpsertRecord::UserPermission(UserPermissionRow {
+            UserPermissionRow {
                 id: USER_PERMISSION_1.0.to_owned(),
                 user_id: "user_account_a".to_string(),
                 store_id: Some("store_a".to_string()),
                 permission: Permission::DocumentQuery,
                 context_id: Some(context_program_a().id.to_string()),
-            }),
+            },
         ),
         TestSyncPullRecord::new_pull_upsert(
-            LegacyTableName::USER_PERMISSION,
+            TABLE_NAME,
             USER_PERMISSION_2,
-            PullUpsertRecord::UserPermission(UserPermissionRow {
+            UserPermissionRow {
                 id: USER_PERMISSION_2.0.to_owned(),
                 user_id: "user_account_a".to_string(),
                 store_id: Some("store_a".to_string()),
                 permission: Permission::DocumentMutate,
                 context_id: Some(context_program_a().id.to_string()),
-            }),
+            },
         ),
     ]
 }
 
 pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_delete(
-        LegacyTableName::USER_PERMISSION,
+        TABLE_NAME,
         USER_PERMISSION_2.0,
-        PullDeleteRecordTable::UserPermission,
+        UserPermissionRowDelete(USER_PERMISSION_2.0.to_string()),
     )]
 }

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -1,10 +1,6 @@
-use crate::sync::{integrate_document::sync_upsert_document, translations::PullDeleteRecordTable};
-
 use super::{
     sync_buffer::SyncBuffer,
-    translations::{
-        IntegrationRecords, PullDeleteRecord, PullUpsertRecord, SyncTranslation, SyncTranslators,
-    },
+    translations::{IntegrationOperation, PullTranslateResult, SyncTranslation, SyncTranslators},
 };
 use log::warn;
 use repository::*;
@@ -40,10 +36,14 @@ impl<'a> TranslationAndIntegration<'a> {
         &self,
         sync_record: &SyncBufferRow,
         translators: &SyncTranslators,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        let mut translation_results = IntegrationRecords::new();
+    ) -> Result<Option<Vec<IntegrationOperation>>, anyhow::Error> {
+        let mut translation_results = Vec::new();
 
         for translator in translators.iter() {
+            if !translator.match_pull(&sync_record) {
+                continue;
+            }
+
             let translation_result = match sync_record.action {
                 SyncBufferAction::Upsert => {
                     translator.try_translate_pull_upsert(self.connection, &sync_record)?
@@ -54,15 +54,21 @@ impl<'a> TranslationAndIntegration<'a> {
                 SyncBufferAction::Merge => return Err(anyhow::anyhow!("Merge not implemented")),
             };
 
-            if let Some(translation_result) = translation_result {
-                translation_results = translation_results.join(translation_result);
+            match translation_result {
+                PullTranslateResult::IntegrationOperations(records) => {
+                    translation_results.push(records)
+                }
+                PullTranslateResult::Ignored(ignore_message) => {
+                    log::debug!("Ignored record in push translation: {}", ignore_message)
+                }
+                PullTranslateResult::NotMatched => {}
             }
         }
 
         if translation_results.is_empty() {
             Ok(None)
         } else {
-            Ok(Some(translation_results))
+            Ok(Some(translation_results.into_iter().flatten().collect()))
         }
     }
 
@@ -75,7 +81,6 @@ impl<'a> TranslationAndIntegration<'a> {
 
         for sync_record in sync_records {
             // Try translate
-
             let translation_result = match self.translate_sync_record(&sync_record, &translators) {
                 Ok(translation_result) => translation_result,
                 // Record error in sync buffer and in result, continue to next sync_record
@@ -110,7 +115,7 @@ impl<'a> TranslationAndIntegration<'a> {
             };
 
             // Integrate
-            let integration_result = integration_records.integrate(self.connection);
+            let integration_result = integrate(self.connection, &integration_records);
             match integration_result {
                 Ok(_) => {
                     self.sync_buffer
@@ -134,137 +139,35 @@ impl<'a> TranslationAndIntegration<'a> {
     }
 }
 
-impl IntegrationRecords {
-    pub(crate) fn integrate(&self, connection: &StorageConnection) -> Result<(), RepositoryError> {
-        // Only start nested transaction if transaction is already ongoing. See integrate_and_translate_sync_buffer
-        let start_nested_transaction = { connection.transaction_level.get() > 0 };
-
-        for delete in self.deletes.iter() {
-            // Integrate every record in a sub transaction. This is mainly for Postgres where the
-            // whole transaction fails when there is a DB error (not a problem in sqlite).
-            if start_nested_transaction {
-                connection
-                    .transaction_sync_etc(|sub_tx| delete.delete(sub_tx), false)
-                    .map_err(|e| e.to_inner_error())?;
-            } else {
-                delete.delete(&connection)?;
-            }
-        }
-
-        for upsert in self.upserts.iter() {
-            // Integrate every record in a sub transaction. This is mainly for Postgres where the
-            // whole transaction fails when there is a DB error (not a problem in sqlite).
-            if start_nested_transaction {
-                connection
-                    .transaction_sync_etc(|sub_tx| upsert.upsert(sub_tx), false)
-                    .map_err(|e| e.to_inner_error())?;
-            } else {
-                upsert.upsert(&connection)?;
-            }
-        }
-
-        Ok(())
-    }
-}
-
-impl PullUpsertRecord {
-    pub(crate) fn upsert(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
-        use PullUpsertRecord::*;
+impl IntegrationOperation {
+    fn integrate(&self, connection: &StorageConnection) -> Result<(), RepositoryError> {
         match self {
-            UserPermission(record) => UserPermissionRowRepository::new(con).upsert_one(record),
-            Name(record) => NameRowRepository::new(con).sync_upsert_one(record),
-            NameTag(record) => NameTagRowRepository::new(con).upsert_one(record),
-            NameTagJoin(record) => NameTagJoinRepository::new(con).upsert_one(record),
-            Unit(record) => UnitRowRepository::new(con).upsert_one(record),
-            Item(record) => ItemRowRepository::new(con).upsert_one(record),
-            Store(record) => StoreRowRepository::new(con).upsert_one(record),
-            MasterList(record) => MasterListRowRepository::new(con).upsert_one(record),
-            MasterListLine(record) => MasterListLineRowRepository::new(con).upsert_one(record),
-            MasterListNameJoin(record) => MasterListNameJoinRepository::new(con).upsert_one(record),
-            PeriodSchedule(record) => PeriodScheduleRowRepository::new(con).upsert_one(record),
-            Period(record) => PeriodRowRepository::new(con).upsert_one(record),
-            Context(record) => ContextRowRepository::new(con).upsert_one(record),
-            Program(record) => ProgramRowRepository::new(con).upsert_one(record),
-            ProgramRequisitionSettings(record) => {
-                ProgramRequisitionSettingsRowRepository::new(con).upsert_one(record)
-            }
-            ProgramRequisitionOrderType(record) => {
-                ProgramRequisitionOrderTypeRowRepository::new(con).upsert_one(record)
-            }
-            Report(record) => ReportRowRepository::new(con).upsert_one(record),
-            Location(record) => LocationRowRepository::new(con).upsert_one(record),
-            LocationMovement(record) => LocationMovementRowRepository::new(con).upsert_one(record),
-            StockLine(record) => StockLineRowRepository::new(con).upsert_one(record),
-            NameStoreJoin(record) => NameStoreJoinRepository::new(con).sync_upsert_one(record),
-            Invoice(record) => InvoiceRowRepository::new(con).upsert_one(record),
-            InvoiceLine(record) => InvoiceLineRowRepository::new(con).upsert_one(record),
-            Stocktake(record) => StocktakeRowRepository::new(con).upsert_one(record),
-            StocktakeLine(record) => StocktakeLineRowRepository::new(con).upsert_one(record),
-            Requisition(record) => RequisitionRowRepository::new(con).sync_upsert_one(record),
-            RequisitionLine(record) => {
-                RequisitionLineRowRepository::new(con).sync_upsert_one(record)
-            }
-            ActivityLog(record) => ActivityLogRowRepository::new(con).insert_one(record),
-            InventoryAdjustmentReason(record) => {
-                InventoryAdjustmentReasonRowRepository::new(con).upsert_one(record)
-            }
-            StorePreference(record) => StorePreferenceRowRepository::new(con).upsert_one(record),
-            Barcode(record) => BarcodeRowRepository::new(con).sync_upsert_one(record),
-            Sensor(record) => SensorRowRepository::new(con).upsert_one(record),
-            TemperatureLog(record) => TemperatureLogRowRepository::new(con).upsert_one(record),
-            TemperatureBreach(record) => {
-                TemperatureBreachRowRepository::new(con).upsert_one(record)
-            }
-            Clinician(record) => ClinicianRowRepository::new(con).sync_upsert_one(record),
-            ClinicianStoreJoin(record) => {
-                ClinicianStoreJoinRowRepository::new(con).sync_upsert_one(record)
-            }
-            FormSchema(record) => FormSchemaRowRepository::new(con).upsert_one(record),
-            DocumentRegistry(record) => DocumentRegistryRowRepository::new(con).upsert_one(record),
-            Document(record) => sync_upsert_document(con, record),
+            IntegrationOperation::Upsert(upsert) => upsert.upsert_sync(connection),
+            IntegrationOperation::Delete(delete) => delete.delete(connection),
         }
     }
 }
 
-impl PullDeleteRecord {
-    pub(crate) fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
-        use PullDeleteRecordTable::*;
-        let id = &self.id;
-        match self.table {
-            UserPermission => UserPermissionRowRepository::new(con).delete(id),
-            Name => NameRowRepository::new(con).delete(id),
-            NameTagJoin => NameTagJoinRepository::new(con).delete(id),
-            Unit => UnitRowRepository::new(con).delete(id),
-            Item => ItemRowRepository::new(con).delete(id),
-            Store => StoreRowRepository::new(con).delete(id),
-            ProgramRequisitionOrderType => {
-                ProgramRequisitionOrderTypeRowRepository::new(con).delete(id)
-            }
-            ProgramRequisitionSettings => {
-                ProgramRequisitionSettingsRowRepository::new(con).delete(id)
-            }
-            MasterListNameJoin => MasterListNameJoinRepository::new(con).delete(id),
-            Report => ReportRowRepository::new(con).delete(id),
-            NameStoreJoin => NameStoreJoinRepository::new(con).delete(id),
-            Invoice => InvoiceRowRepository::new(con).delete(id),
-            InvoiceLine => InvoiceLineRowRepository::new(con).delete(id),
-            Requisition => RequisitionRowRepository::new(con).delete(id),
-            RequisitionLine => RequisitionLineRowRepository::new(con).delete(id),
-            InventoryAdjustmentReason => {
-                InventoryAdjustmentReasonRowRepository::new(con).delete(id)
-            }
-            #[cfg(all(test, feature = "integration_test"))]
-            Location => LocationRowRepository::new(con).delete(id),
-            #[cfg(all(test, feature = "integration_test"))]
-            StockLine => StockLineRowRepository::new(con).delete(id),
-            #[cfg(all(test, feature = "integration_test"))]
-            Stocktake => StocktakeRowRepository::new(con).delete(id),
-            #[cfg(all(test, feature = "integration_test"))]
-            StocktakeLine => StocktakeLineRowRepository::new(con).delete(id),
-            #[cfg(all(test, feature = "integration_test"))]
-            ActivityLog => Ok(()),
+pub(crate) fn integrate(
+    connection: &StorageConnection,
+    integration_records: &Vec<IntegrationOperation>,
+) -> Result<(), RepositoryError> {
+    // Only start nested transaction if transaction is already ongoing. See integrate_and_translate_sync_buffer
+    let start_nested_transaction = { connection.transaction_level.get() > 0 };
+
+    for integration_record in integration_records.iter() {
+        // Integrate every record in a sub transaction. This is mainly for Postgres where the
+        // whole transaction fails when there is a DB error (not a problem in sqlite).
+        if start_nested_transaction {
+            connection
+                .transaction_sync_etc(|sub_tx| integration_record.integrate(sub_tx), false)
+                .map_err(|e| e.to_inner_error())?;
+        } else {
+            integration_record.integrate(connection)?;
         }
     }
+
+    Ok(())
 }
 
 impl TranslationAndIntegrationResults {
@@ -291,12 +194,13 @@ impl TranslationAndIntegrationResults {
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use repository::{
         mock::MockDataInserts, test_db, ItemRow, ItemRowRepository, UnitRow, UnitRowRepository,
     };
     use util::{assert_matches, inline_init};
 
-    use crate::sync::translations::{IntegrationRecords, PullUpsertRecord};
+    use crate::sync::translations::IntegrationOperation;
 
     #[actix_rt::test]
     async fn test_fall_through_inner_transaction() {
@@ -309,23 +213,27 @@ mod test {
         connection
             .transaction_sync(|connection| {
                 // Doesn't fail
-                let result = IntegrationRecords::from_upsert(PullUpsertRecord::Unit(inline_init(
-                    |r: &mut UnitRow| {
-                        r.id = "unit".to_string();
-                    },
-                )))
-                .integrate(connection);
+                let result = integrate(
+                    connection,
+                    &vec![IntegrationOperation::upsert(inline_init(
+                        |r: &mut UnitRow| {
+                            r.id = "unit".to_string();
+                        },
+                    ))],
+                );
 
                 assert_eq!(result, Ok(()));
 
                 // Fails due to referencial constraint
-                let result = IntegrationRecords::from_upsert(PullUpsertRecord::Item(inline_init(
-                    |r: &mut ItemRow| {
-                        r.id = "item".to_string();
-                        r.unit_id = Some("invalid".to_string());
-                    },
-                )))
-                .integrate(connection);
+                let result = integrate(
+                    connection,
+                    &vec![IntegrationOperation::upsert(inline_init(
+                        |r: &mut ItemRow| {
+                            r.id = "item".to_string();
+                            r.unit_id = Some("invalid".to_string());
+                        },
+                    ))],
+                );
 
                 assert_ne!(result, Ok(()));
 

--- a/server/service/src/sync/translations/activity_log.rs
+++ b/server/service/src/sync/translations/activity_log.rs
@@ -5,20 +5,9 @@ use repository::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::sync::{api::RemoteSyncRecordV5, sync_serde::empty_str_as_option_string};
+use crate::sync::{sync_serde::empty_str_as_option_string, translations::store::StoreTranslation};
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
-};
-
-const LEGACY_TABLE_NAME: &'static str = LegacyTableName::OM_ACTIVITY_LOG;
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LEGACY_TABLE_NAME
-}
-fn match_push_table(changelog: &ChangelogRow) -> bool {
-    changelog.table_name == ChangelogTableName::ActivityLog
-}
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
@@ -40,24 +29,27 @@ pub struct LegacyActivityLogRow {
     pub changed_from: Option<String>,
 }
 
-pub(crate) struct ActivityLogTranslation {}
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(ActivityLogTranslation)
+}
+
+pub(super) struct ActivityLogTranslation;
 impl SyncTranslation for ActivityLogTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::OM_ACTIVITY_LOG,
-            dependencies: vec![LegacyTableName::STORE],
-        }
+    fn table_name(&self) -> &'static str {
+        "om_activity_log"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![StoreTranslation.table_name()]
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let data = serde_json::from_str::<LegacyActivityLogRow>(&sync_record.data)?;
 
         let result = ActivityLogRow {
@@ -71,20 +63,18 @@ impl SyncTranslation for ActivityLogTranslation {
             changed_from: data.changed_from,
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::ActivityLog(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::ActivityLog)
     }
 
     fn try_translate_push_upsert(
         &self,
         connection: &StorageConnection,
         changelog: &ChangelogRow,
-    ) -> Result<Option<Vec<RemoteSyncRecordV5>>, anyhow::Error> {
-        if !match_push_table(changelog) {
-            return Ok(None);
-        }
-
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let ActivityLogRow {
             id,
             r#type,
@@ -101,10 +91,9 @@ impl SyncTranslation for ActivityLogTranslation {
                 changelog.record_id
             )))?;
 
-        let (store_id, record_id, user_id) = match (store_id, record_id, user_id) {
-            (Some(store_id), Some(record_id), Some(user_id)) => (store_id, record_id, user_id),
-            _ => return Ok(Some(Vec::new())),
-        };
+        let (Some(store_id), Some(record_id), Some(user_id)) = (store_id, record_id, user_id) else {
+            return Ok(PushTranslateResult::Ignored("Ignoring activity logs without store, user or record id".to_string())
+        )};
 
         let legacy_row = LegacyActivityLogRow {
             id,
@@ -116,11 +105,12 @@ impl SyncTranslation for ActivityLogTranslation {
             changed_to,
             changed_from,
         };
-        Ok(Some(vec![RemoteSyncRecordV5::new_upsert(
+
+        Ok(PushTranslateResult::upsert(
             changelog,
-            LEGACY_TABLE_NAME,
+            self.table_name(),
             serde_json::to_value(&legacy_row)?,
-        )]))
+        ))
     }
 }
 
@@ -138,6 +128,7 @@ mod tests {
             setup_all("test_activity_log_translation", MockDataInserts::none()).await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/barcode.rs
+++ b/server/service/src/sync/translations/barcode.rs
@@ -4,20 +4,9 @@ use repository::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::sync::api::RemoteSyncRecordV5;
+use crate::sync::translations::item::ItemTranslation;
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
-};
-
-const LEGACY_TABLE_NAME: &'static str = LegacyTableName::BARCODE;
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LEGACY_TABLE_NAME
-}
-fn match_push_table(changelog: &ChangelogRow) -> bool {
-    changelog.table_name == ChangelogTableName::Barcode
-}
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
@@ -36,31 +25,33 @@ pub struct LegacyBarcodeRow {
     pub parent_id: Option<String>,
 }
 
-pub(crate) struct BarcodeTranslation {}
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(BarcodeTranslation)
+}
+
+pub(super) struct BarcodeTranslation;
 impl SyncTranslation for BarcodeTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::BARCODE,
-            dependencies: vec![LegacyTableName::ITEM],
-        }
+    fn table_name(&self) -> &'static str {
+        "barcode"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![ItemTranslation.table_name()]
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::Barcode)
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
+    ) -> Result<PullTranslateResult, anyhow::Error> {
+        let data = serde_json::from_str::<LegacyBarcodeRow>(&sync_record.data)?;
 
-        let deserialised_row = match serde_json::from_str::<LegacyBarcodeRow>(&sync_record.data) {
-            Ok(row) => row,
-            Err(e) => {
-                log::warn!("Failed to deserialise barcode row: {:?}", e);
-                return Ok(None);
-            }
-        };
         let LegacyBarcodeRow {
             id,
             gtin,
@@ -68,7 +59,7 @@ impl SyncTranslation for BarcodeTranslation {
             manufacturer_id,
             pack_size,
             parent_id,
-        } = deserialised_row;
+        } = data;
 
         let result = BarcodeRow {
             id,
@@ -79,20 +70,14 @@ impl SyncTranslation for BarcodeTranslation {
             parent_id,
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::Barcode(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 
     fn try_translate_push_upsert(
         &self,
         connection: &StorageConnection,
         changelog: &ChangelogRow,
-    ) -> Result<Option<Vec<RemoteSyncRecordV5>>, anyhow::Error> {
-        if !match_push_table(changelog) {
-            return Ok(None);
-        }
-
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let BarcodeRow {
             id,
             gtin,
@@ -115,11 +100,11 @@ impl SyncTranslation for BarcodeTranslation {
             pack_size,
             parent_id,
         };
-        Ok(Some(vec![RemoteSyncRecordV5::new_upsert(
+        Ok(PushTranslateResult::upsert(
             changelog,
-            LEGACY_TABLE_NAME,
+            self.table_name(),
             serde_json::to_value(&legacy_row)?,
-        )]))
+        ))
     }
 }
 
@@ -137,6 +122,7 @@ mod tests {
             setup_all("test_barcode_translation", MockDataInserts::none()).await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/clinician.rs
+++ b/server/service/src/sync/translations/clinician.rs
@@ -5,11 +5,9 @@ use repository::{
     StorageConnection, SyncBufferRow,
 };
 
-use crate::sync::{
-    api::RemoteSyncRecordV5, sync_serde::empty_str_as_option_string, translations::LegacyTableName,
-};
+use crate::sync::sync_serde::empty_str_as_option_string;
 
-use super::{IntegrationRecords, PullDependency, PullUpsertRecord, SyncTranslation};
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[derive(Deserialize, Serialize)]
 pub struct LegacyClinicianRow {
@@ -43,30 +41,31 @@ pub struct LegacyClinicianRow {
     pub is_active: bool,
 }
 
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LegacyTableName::CLINICIAN
-}
-fn match_push_table(changelog: &ChangelogRow) -> bool {
-    changelog.table_name == ChangelogTableName::Clinician
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(ClinicianTranslation)
 }
 
-pub(crate) struct ClinicianTranslation {}
+pub(super) struct ClinicianTranslation;
 impl SyncTranslation for ClinicianTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::CLINICIAN,
-            dependencies: vec![],
-        }
+    fn table_name(&self) -> &'static str {
+        "clinician"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![]
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::Clinician)
     }
 
     fn try_translate_pull_upsert(
         &self,
         _connection: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let LegacyClinicianRow {
             id,
             code,
@@ -100,20 +99,14 @@ impl SyncTranslation for ClinicianTranslation {
             },
             is_active,
         };
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::Clinician(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 
     fn try_translate_push_upsert(
         &self,
         connection: &StorageConnection,
         changelog: &ChangelogRow,
-    ) -> Result<Option<Vec<RemoteSyncRecordV5>>, anyhow::Error> {
-        if !match_push_table(changelog) {
-            return Ok(None);
-        }
-
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let ClinicianRow {
             id,
             code,
@@ -155,26 +148,20 @@ impl SyncTranslation for ClinicianTranslation {
             is_female,
             is_active,
         };
-
-        Ok(Some(vec![RemoteSyncRecordV5::new_upsert(
+        Ok(PushTranslateResult::upsert(
             changelog,
-            LegacyTableName::CLINICIAN,
+            self.table_name(),
             serde_json::to_value(&legacy_row)?,
-        )]))
+        ))
     }
 
+    // TODO should not be deleting clinicians
+    // TODO soft delete
     fn try_translate_push_delete(
         &self,
         _: &StorageConnection,
         changelog: &ChangelogRow,
-    ) -> Result<Option<Vec<RemoteSyncRecordV5>>, anyhow::Error> {
-        let result = match_push_table(changelog).then(|| {
-            vec![RemoteSyncRecordV5::new_delete(
-                changelog,
-                LegacyTableName::CLINICIAN,
-            )]
-        });
-
-        Ok(result)
+    ) -> Result<PushTranslateResult, anyhow::Error> {
+        Ok(PushTranslateResult::delete(changelog, self.table_name()))
     }
 }

--- a/server/service/src/sync/translations/clinician_store_join.rs
+++ b/server/service/src/sync/translations/clinician_store_join.rs
@@ -5,9 +5,9 @@ use repository::{
     StorageConnection, SyncBufferRow,
 };
 
-use crate::sync::{api::RemoteSyncRecordV5, translations::LegacyTableName};
+use crate::sync::translations::{clinician::ClinicianTranslation, store::StoreTranslation};
 
-use super::{IntegrationRecords, PullDependency, PullUpsertRecord, SyncTranslation};
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[derive(Deserialize, Serialize)]
 pub struct LegacyClinicianStoreJoinRow {
@@ -19,30 +19,34 @@ pub struct LegacyClinicianStoreJoinRow {
     pub prescriber_id: String,
 }
 
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LegacyTableName::CLINICIAN_STORE_JOIN
-}
-fn match_push_table(changelog: &ChangelogRow) -> bool {
-    changelog.table_name == ChangelogTableName::ClinicianStoreJoin
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(ClinicianStoreJoinTranslation)
 }
 
-pub(crate) struct ClinicianStoreJoinTranslation {}
+pub(super) struct ClinicianStoreJoinTranslation;
 impl SyncTranslation for ClinicianStoreJoinTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::CLINICIAN_STORE_JOIN,
-            dependencies: vec![LegacyTableName::STORE, LegacyTableName::CLINICIAN],
-        }
+    fn table_name(&self) -> &'static str {
+        "clinician_store_join"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![
+            StoreTranslation.table_name(),
+            ClinicianTranslation.table_name(),
+        ]
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::ClinicianStoreJoin)
     }
 
     fn try_translate_pull_upsert(
         &self,
         _connection: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let LegacyClinicianStoreJoinRow {
             id,
             store_id,
@@ -54,20 +58,14 @@ impl SyncTranslation for ClinicianStoreJoinTranslation {
             store_id,
             clinician_id: prescriber_id,
         };
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::ClinicianStoreJoin(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 
     fn try_translate_push_upsert(
         &self,
         connection: &StorageConnection,
         changelog: &ChangelogRow,
-    ) -> Result<Option<Vec<RemoteSyncRecordV5>>, anyhow::Error> {
-        if !match_push_table(changelog) {
-            return Ok(None);
-        }
-
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let ClinicianStoreJoinRow {
             id,
             store_id,
@@ -85,25 +83,18 @@ impl SyncTranslation for ClinicianStoreJoinTranslation {
             prescriber_id: clinician_id,
         };
 
-        Ok(Some(vec![RemoteSyncRecordV5::new_upsert(
+        Ok(PushTranslateResult::upsert(
             changelog,
-            LegacyTableName::CLINICIAN_STORE_JOIN,
+            self.table_name(),
             serde_json::to_value(&legacy_row)?,
-        )]))
+        ))
     }
 
     fn try_translate_push_delete(
         &self,
         _: &StorageConnection,
         changelog: &ChangelogRow,
-    ) -> Result<Option<Vec<RemoteSyncRecordV5>>, anyhow::Error> {
-        let result = match_push_table(changelog).then(|| {
-            vec![RemoteSyncRecordV5::new_delete(
-                changelog,
-                LegacyTableName::CLINICIAN_STORE_JOIN,
-            )]
-        });
-
-        Ok(result)
+    ) -> Result<PushTranslateResult, anyhow::Error> {
+        Ok(PushTranslateResult::delete(changelog, self.table_name()))
     }
 }

--- a/server/service/src/sync/translations/document.rs
+++ b/server/service/src/sync/translations/document.rs
@@ -8,10 +8,15 @@ use repository::{
 use serde_json::Value;
 
 use crate::sync::{
-    api::RemoteSyncRecordV5, sync_serde::empty_str_as_option_string, translations::LegacyTableName,
+    integrate_document::DocumentUpsert,
+    sync_serde::empty_str_as_option_string,
+    translations::{
+        document_registry::DocumentRegistryTranslation, form_schema::FormSchemaTranslation,
+        name::NameTranslation,
+    },
 };
 
-use super::{IntegrationRecords, PullDependency, PullUpsertRecord, SyncTranslation};
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -44,35 +49,35 @@ struct LegacyDocumentRow {
     pub context_id: String,
 }
 
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LegacyTableName::DOCUMENT
-}
-fn match_push_table(changelog: &ChangelogRow) -> bool {
-    changelog.table_name == ChangelogTableName::Document
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(DocumentTranslation)
 }
 
-pub(crate) struct DocumentTranslation {}
+pub(super) struct DocumentTranslation;
 impl SyncTranslation for DocumentTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::DOCUMENT,
-            dependencies: vec![
-                LegacyTableName::NAME,
-                LegacyTableName::FORM_SCHEMA,
-                // DocumentRegistry is needed in `upsert_document()`
-                LegacyTableName::DOCUMENT_REGISTRY,
-            ],
-        }
+    fn table_name(&self) -> &'static str {
+        "om_document"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![
+            NameTranslation.table_name(),
+            FormSchemaTranslation.table_name(),
+            DocumentRegistryTranslation.table_name(),
+        ]
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::Document)
     }
 
     fn try_translate_pull_upsert(
         &self,
         _connection: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let LegacyDocumentRow {
             id,
             name,
@@ -102,20 +107,14 @@ impl SyncTranslation for DocumentTranslation {
             owner_name_id,
             context_id,
         };
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::Document(result),
-        )))
+        Ok(PullTranslateResult::upsert(DocumentUpsert(result)))
     }
 
     fn try_translate_push_upsert(
         &self,
         connection: &StorageConnection,
         changelog: &ChangelogRow,
-    ) -> Result<Option<Vec<RemoteSyncRecordV5>>, anyhow::Error> {
-        if !match_push_table(changelog) {
-            return Ok(None);
-        }
-
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let document = DocumentRepository::new(connection)
             .find_one_by_id(&changelog.record_id)?
             .ok_or(anyhow::Error::msg(format!(
@@ -153,10 +152,10 @@ impl SyncTranslation for DocumentTranslation {
             context_id,
         };
 
-        Ok(Some(vec![RemoteSyncRecordV5::new_upsert(
+        Ok(PushTranslateResult::upsert(
             changelog,
-            LegacyTableName::DOCUMENT,
+            self.table_name(),
             serde_json::to_value(&legacy_row)?,
-        )]))
+        ))
     }
 }

--- a/server/service/src/sync/translations/document_registry.rs
+++ b/server/service/src/sync/translations/document_registry.rs
@@ -1,11 +1,12 @@
-use crate::sync::sync_serde::empty_str_as_option_string;
+use crate::sync::{
+    sync_serde::empty_str_as_option_string,
+    translations::{form_schema::FormSchemaTranslation, master_list::MasterListTranslation},
+};
 use repository::{DocumentRegistryCategory, DocumentRegistryRow, StorageConnection, SyncBufferRow};
 use serde::Deserialize;
 use serde_json::Value;
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
-};
+use super::{PullTranslateResult, SyncTranslation};
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -33,28 +34,31 @@ struct LegacyDocumentRegistryRow {
     pub config: Option<Value>,
 }
 
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LegacyTableName::DOCUMENT_REGISTRY
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(DocumentRegistryTranslation)
 }
 
-pub(crate) struct DocumentRegistryTranslation {}
+pub(super) struct DocumentRegistryTranslation;
 impl SyncTranslation for DocumentRegistryTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::DOCUMENT_REGISTRY,
-            dependencies: vec![LegacyTableName::FORM_SCHEMA, LegacyTableName::LIST_MASTER],
-        }
+    fn table_name(&self) -> &'static str {
+        "om_document_registry"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![
+            FormSchemaTranslation.table_name(),
+            // TODO is this needed ?
+            MasterListTranslation.table_name(),
+        ]
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let LegacyDocumentRegistryRow {
             id,
             document_type,
@@ -69,6 +73,7 @@ impl SyncTranslation for DocumentRegistryTranslation {
             Some(config) => Some(serde_json::to_string(&config)?),
             None => None,
         };
+
         let result = DocumentRegistryRow {
             id,
             document_type,
@@ -87,8 +92,6 @@ impl SyncTranslation for DocumentRegistryTranslation {
             config: config_str,
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::DocumentRegistry(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 }

--- a/server/service/src/sync/translations/document_registry.rs
+++ b/server/service/src/sync/translations/document_registry.rs
@@ -49,7 +49,7 @@ impl SyncTranslation for DocumentRegistryTranslation {
     fn pull_dependencies(&self) -> Vec<&'static str> {
         vec![
             FormSchemaTranslation.table_name(),
-            // TODO is this needed ?
+            // The program context is synced via the program master list
             MasterListTranslation.table_name(),
         ]
     }

--- a/server/service/src/sync/translations/form_schema.rs
+++ b/server/service/src/sync/translations/form_schema.rs
@@ -2,9 +2,7 @@ use repository::{FormSchemaJson, StorageConnection, SyncBufferRow};
 use serde::Deserialize;
 use serde_json::Value;
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
-};
+use super::{PullTranslateResult, SyncTranslation};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize)]
@@ -16,27 +14,27 @@ pub struct LegacyFormSchemaRow {
     ui_schema: Value,
 }
 
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LegacyTableName::FORM_SCHEMA
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(FormSchemaTranslation)
 }
 
-pub(crate) struct FormSchemaTranslation {}
+pub(super) struct FormSchemaTranslation;
 impl SyncTranslation for FormSchemaTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::FORM_SCHEMA,
-            dependencies: vec![],
-        }
+    fn table_name(&self) -> &'static str {
+        "form_schema"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![]
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let LegacyFormSchemaRow {
             id,
             r#type,
@@ -51,8 +49,6 @@ impl SyncTranslation for FormSchemaTranslation {
             ui_schema,
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::FormSchema(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 }

--- a/server/service/src/sync/translations/inventory_adjustment_reason.rs
+++ b/server/service/src/sync/translations/inventory_adjustment_reason.rs
@@ -1,18 +1,10 @@
 use repository::{
-    InventoryAdjustmentReasonRow, InventoryAdjustmentReasonType, StorageConnection, SyncBufferRow,
+    InventoryAdjustmentReasonRow, InventoryAdjustmentReasonRowDelete,
+    InventoryAdjustmentReasonType, StorageConnection, SyncBufferRow,
 };
 use serde::{Deserialize, Serialize};
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullDependency, PullUpsertRecord,
-    SyncTranslation,
-};
-
-const LEGACY_TABLE_NAME: &'static str = LegacyTableName::INVENTORY_ADJUSTMENT_REASON;
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LEGACY_TABLE_NAME
-}
+use super::{PullTranslateResult, SyncTranslation};
 
 #[derive(Deserialize, Serialize, Debug)]
 pub enum LegacyOptionsType {
@@ -35,24 +27,27 @@ pub struct LegacyOptionsRow {
     pub reason: String,
 }
 
-pub(crate) struct InventoryAdjustmentReasonTranslation {}
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(InventoryAdjustmentReasonTranslation)
+}
+
+pub(super) struct InventoryAdjustmentReasonTranslation;
 impl SyncTranslation for InventoryAdjustmentReasonTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::INVENTORY_ADJUSTMENT_REASON,
-            dependencies: vec![],
-        }
+    fn table_name(&self) -> &'static str {
+        "options"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![]
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let data = serde_json::from_str::<LegacyOptionsRow>(&sync_record.data)?;
 
         let r#type = match data.r#type {
@@ -67,24 +62,18 @@ impl SyncTranslation for InventoryAdjustmentReasonTranslation {
             reason: data.reason,
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::InventoryAdjustmentReason(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 
+    // TODO soft delete
     fn try_translate_pull_delete(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        let result = match_pull_table(sync_record).then(|| {
-            IntegrationRecords::from_delete(
-                &sync_record.record_id,
-                PullDeleteRecordTable::InventoryAdjustmentReason,
-            )
-        });
-
-        Ok(result)
+    ) -> Result<PullTranslateResult, anyhow::Error> {
+        Ok(PullTranslateResult::delete(
+            InventoryAdjustmentReasonRowDelete(sync_record.record_id.clone()),
+        ))
     }
 }
 
@@ -96,7 +85,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_inventory_adjustment_reason_translation() {
         use crate::sync::test::test_data::inventory_adjustment_reason as test_data;
-        let translator = InventoryAdjustmentReasonTranslation {};
+        let translator = InventoryAdjustmentReasonTranslation;
 
         let (_, connection, _, _) = setup_all(
             "test_inventory_adjustment_reason_translation",
@@ -105,6 +94,7 @@ mod tests {
         .await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/item.rs
+++ b/server/service/src/sync/translations/item.rs
@@ -1,10 +1,9 @@
-use repository::{ItemRow, ItemRowType, StorageConnection, SyncBufferRow};
+use repository::{ItemRow, ItemRowDelete, ItemRowType, StorageConnection, SyncBufferRow};
 use serde::Deserialize;
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullDependency, PullUpsertRecord,
-    SyncTranslation,
-};
+use crate::sync::translations::unit::UnitTranslation;
+
+use super::{PullTranslateResult, SyncTranslation};
 
 #[allow(non_camel_case_types)]
 #[derive(Deserialize)]
@@ -33,32 +32,32 @@ fn to_item_type(type_of: LegacyItemType) -> ItemRowType {
     }
 }
 
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LegacyTableName::ITEM
-}
-
 pub(crate) fn ordered_simple_json(text: &str) -> Result<String, serde_json::Error> {
     let json: serde_json::Value = serde_json::from_str(&text)?;
     serde_json::to_string(&json)
 }
 
-pub(crate) struct ItemTranslation {}
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(ItemTranslation)
+}
+
+pub(super) struct ItemTranslation;
 impl SyncTranslation for ItemTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::ITEM,
-            dependencies: vec![LegacyTableName::UNIT],
-        }
+    fn table_name(&self) -> &'static str {
+        "item"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![UnitTranslation.table_name()]
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let data = serde_json::from_str::<LegacyItemRow>(&sync_record.data)?;
 
         let mut result = ItemRow {
@@ -75,21 +74,18 @@ impl SyncTranslation for ItemTranslation {
             result.unit_id = Some(data.unit_ID);
         }
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::Item(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 
+    // TODO soft delete
     fn try_translate_pull_delete(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        let result = match_pull_table(sync_record).then(|| {
-            IntegrationRecords::from_delete(&sync_record.record_id, PullDeleteRecordTable::Item)
-        });
-
-        Ok(result)
+    ) -> Result<PullTranslateResult, anyhow::Error> {
+        Ok(PullTranslateResult::delete(ItemRowDelete(
+            sync_record.record_id.clone(),
+        )))
     }
 }
 
@@ -107,6 +103,7 @@ mod tests {
             setup_all("test_item_translation", MockDataInserts::none()).await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();
@@ -115,6 +112,7 @@ mod tests {
         }
 
         for record in test_data::test_pull_delete_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_delete(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/location.rs
+++ b/server/service/src/sync/translations/location.rs
@@ -4,20 +4,9 @@ use repository::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::sync::api::RemoteSyncRecordV5;
+use crate::sync::translations::store::StoreTranslation;
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
-};
-
-const LEGACY_TABLE_NAME: &'static str = LegacyTableName::LOCATION;
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LEGACY_TABLE_NAME
-}
-fn match_push_table(changelog: &ChangelogRow) -> bool {
-    changelog.table_name == ChangelogTableName::Location
-}
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[derive(Deserialize, Serialize)]
 pub struct LegacyLocationRow {
@@ -32,24 +21,31 @@ pub struct LegacyLocationRow {
     pub store_id: String,
 }
 
-pub(crate) struct LocationTranslation {}
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(LocationTranslation)
+}
+
+pub(super) struct LocationTranslation;
 impl SyncTranslation for LocationTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::LOCATION,
-            dependencies: vec![LegacyTableName::STORE],
-        }
+    fn table_name(&self) -> &'static str {
+        "Location"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![StoreTranslation.table_name()]
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::Location)
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let LegacyLocationRow {
             id,
             name,
@@ -66,20 +62,14 @@ impl SyncTranslation for LocationTranslation {
             store_id,
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::Location(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 
     fn try_translate_push_upsert(
         &self,
         connection: &StorageConnection,
         changelog: &ChangelogRow,
-    ) -> Result<Option<Vec<RemoteSyncRecordV5>>, anyhow::Error> {
-        if !match_push_table(changelog) {
-            return Ok(None);
-        }
-
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let LocationRow {
             id,
             name,
@@ -101,22 +91,19 @@ impl SyncTranslation for LocationTranslation {
             store_id: store_id,
         };
 
-        Ok(Some(vec![RemoteSyncRecordV5::new_upsert(
+        Ok(PushTranslateResult::upsert(
             changelog,
-            LEGACY_TABLE_NAME,
+            self.table_name(),
             serde_json::to_value(&legacy_row)?,
-        )]))
+        ))
     }
 
     fn try_translate_push_delete(
         &self,
         _: &StorageConnection,
         changelog: &ChangelogRow,
-    ) -> Result<Option<Vec<RemoteSyncRecordV5>>, anyhow::Error> {
-        let result = match_push_table(changelog)
-            .then(|| vec![RemoteSyncRecordV5::new_delete(changelog, LEGACY_TABLE_NAME)]);
-
-        Ok(result)
+    ) -> Result<PushTranslateResult, anyhow::Error> {
+        Ok(PushTranslateResult::delete(changelog, self.table_name()))
     }
 }
 
@@ -134,6 +121,7 @@ mod tests {
             setup_all("test_location_translation", MockDataInserts::none()).await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/location_movement.rs
+++ b/server/service/src/sync/translations/location_movement.rs
@@ -6,24 +6,15 @@ use repository::{
 use serde::{Deserialize, Serialize};
 
 use crate::sync::{
-    api::RemoteSyncRecordV5,
     sync_serde::{
         date_option_to_isostring, empty_str_as_option_string, naive_time, zero_date_as_option,
     },
+    translations::{
+        location::LocationTranslation, stock_line::StockLineTranslation, store::StoreTranslation,
+    },
 };
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
-};
-
-const LEGACY_TABLE_NAME: &'static str = LegacyTableName::LOCATION_MOVEMENT;
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LEGACY_TABLE_NAME
-}
-fn match_push_table(changelog: &ChangelogRow) -> bool {
-    changelog.table_name == ChangelogTableName::LocationMovement
-}
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[derive(Deserialize, Serialize)]
 pub struct LegacyLocationMovementRow {
@@ -49,29 +40,35 @@ pub struct LegacyLocationMovementRow {
     #[serde(deserialize_with = "naive_time")]
     pub exit_time: NaiveTime,
 }
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(LocationMovementTranslation)
+}
 
-pub(crate) struct LocationMovementTranslation {}
+pub(super) struct LocationMovementTranslation;
 impl SyncTranslation for LocationMovementTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::LOCATION_MOVEMENT,
-            dependencies: vec![
-                LegacyTableName::STORE,
-                LegacyTableName::LOCATION,
-                LegacyTableName::ITEM_LINE,
-            ],
-        }
+    fn table_name(&self) -> &'static str {
+        "location_movement"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![
+            StoreTranslation.table_name(),
+            LocationTranslation.table_name(),
+            StockLineTranslation.table_name(),
+        ]
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::LocationMovement)
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let LegacyLocationMovementRow {
             id,
             store_id,
@@ -92,20 +89,14 @@ impl SyncTranslation for LocationMovementTranslation {
             exit_datetime: exit_date.map(|exit_date| NaiveDateTime::new(exit_date, exit_time)),
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::LocationMovement(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 
     fn try_translate_push_upsert(
         &self,
         connection: &StorageConnection,
         changelog: &ChangelogRow,
-    ) -> Result<Option<Vec<RemoteSyncRecordV5>>, anyhow::Error> {
-        if !match_push_table(changelog) {
-            return Ok(None);
-        }
-
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let LocationMovementRow {
             id,
             store_id,
@@ -135,11 +126,11 @@ impl SyncTranslation for LocationMovementTranslation {
                 .unwrap_or(NaiveTime::from_hms_opt(0, 0, 0).unwrap()),
         };
 
-        Ok(Some(vec![RemoteSyncRecordV5::new_upsert(
+        Ok(PushTranslateResult::upsert(
             changelog,
-            LEGACY_TABLE_NAME,
+            self.table_name(),
             serde_json::to_value(&legacy_row)?,
-        )]))
+        ))
     }
 }
 
@@ -160,6 +151,7 @@ mod tests {
         .await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/master_list.rs
+++ b/server/service/src/sync/translations/master_list.rs
@@ -42,7 +42,8 @@ impl SyncTranslation for MasterListTranslation {
             name: data.description,
             code: data.code,
             description: data.note,
-            is_active: !data.inactive.unwrap_or(false),
+            // By default if inactive = null, or missing, it should mean is_active = true
+            is_active: !data.inactive.unwrap_or(true),
         };
         Ok(PullTranslateResult::upsert(result))
     }

--- a/server/service/src/sync/translations/master_list.rs
+++ b/server/service/src/sync/translations/master_list.rs
@@ -2,9 +2,7 @@ use repository::{MasterListRow, StorageConnection, SyncBufferRow};
 
 use serde::Deserialize;
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
-};
+use super::{PullTranslateResult, SyncTranslation};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize)]
@@ -16,28 +14,27 @@ pub struct LegacyListMasterRow {
     note: String,
     inactive: Option<bool>,
 }
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LegacyTableName::LIST_MASTER
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(MasterListTranslation)
 }
-pub(crate) struct MasterListTranslation {}
+
+pub(super) struct MasterListTranslation;
 impl SyncTranslation for MasterListTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::LIST_MASTER,
-            dependencies: vec![],
-        }
+    fn table_name(&self) -> &'static str {
+        "list_master"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![]
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let data = serde_json::from_str::<LegacyListMasterRow>(&sync_record.data)?;
 
         let result = MasterListRow {
@@ -47,9 +44,7 @@ impl SyncTranslation for MasterListTranslation {
             description: data.note,
             is_active: !data.inactive.unwrap_or(false),
         };
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::MasterList(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 }
 
@@ -61,12 +56,13 @@ mod tests {
     #[actix_rt::test]
     async fn test_master_list_translation() {
         use crate::sync::test::test_data::master_list as test_data;
-        let translator = MasterListTranslation {};
+        let translator = MasterListTranslation;
 
         let (_, connection, _, _) =
             setup_all("test_master_list_translation", MockDataInserts::none()).await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/master_list_line.rs
+++ b/server/service/src/sync/translations/master_list_line.rs
@@ -2,9 +2,9 @@ use repository::{MasterListLineRow, StorageConnection, SyncBufferRow};
 
 use serde::Deserialize;
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
-};
+use crate::sync::translations::{item::ItemTranslation, master_list::MasterListTranslation};
+
+use super::{PullTranslateResult, SyncTranslation};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize)]
@@ -14,27 +14,30 @@ pub struct LegacyListMasterLineRow {
     item_ID: String,
 }
 
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LegacyTableName::LIST_MASTER_LINE
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(MasterListLineTranslation)
 }
-pub(crate) struct MasterListLineTranslation {}
+
+pub(super) struct MasterListLineTranslation;
 impl SyncTranslation for MasterListLineTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::LIST_MASTER_LINE,
-            dependencies: vec![LegacyTableName::ITEM, LegacyTableName::LIST_MASTER],
-        }
+    fn table_name(&self) -> &'static str {
+        "list_master_line"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![
+            MasterListTranslation.table_name(),
+            ItemTranslation.table_name(),
+        ]
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let data = serde_json::from_str::<LegacyListMasterLineRow>(&sync_record.data)?;
         let result = MasterListLineRow {
             id: data.ID,
@@ -42,9 +45,7 @@ impl SyncTranslation for MasterListLineTranslation {
             master_list_id: data.item_master_ID,
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::MasterListLine(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 }
 
@@ -62,6 +63,7 @@ mod tests {
             setup_all("test_master_list_line_translation", MockDataInserts::none()).await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/master_list_name_join.rs
+++ b/server/service/src/sync/translations/master_list_name_join.rs
@@ -1,11 +1,12 @@
-use repository::{MasterListNameJoinRow, StorageConnection, SyncBufferRow};
+use repository::{
+    MasterListNameJoinRow, MasterListNameJoinRowDelete, StorageConnection, SyncBufferRow,
+};
 
 use serde::Deserialize;
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullDependency, PullUpsertRecord,
-    SyncTranslation,
-};
+use crate::sync::translations::{master_list::MasterListTranslation, name::NameTranslation};
+
+use super::{PullTranslateResult, SyncTranslation};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize)]
@@ -14,32 +15,33 @@ pub struct LegacyListMasterNameJoinRow {
     name_ID: String,
     list_master_ID: String,
 }
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LegacyTableName::LIST_MASTER_NAME_JOIN
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(MasterListNameJoinTranslation)
 }
 
-pub(crate) struct MasterListNameJoinTranslation {}
+pub(super) struct MasterListNameJoinTranslation;
 impl SyncTranslation for MasterListNameJoinTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::LIST_MASTER_NAME_JOIN,
-            dependencies: vec![LegacyTableName::NAME, LegacyTableName::LIST_MASTER],
-        }
+    fn table_name(&self) -> &'static str {
+        "list_master_name_join"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![
+            NameTranslation.table_name(),
+            MasterListTranslation.table_name(),
+        ]
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let data = serde_json::from_str::<LegacyListMasterNameJoinRow>(&sync_record.data)?;
         if data.name_ID == "" {
-            return Ok(None);
+            return Ok(PullTranslateResult::Ignored("Missing name_id".to_string()));
         }
 
         let result = MasterListNameJoinRow {
@@ -48,24 +50,17 @@ impl SyncTranslation for MasterListNameJoinTranslation {
             name_id: data.name_ID,
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::MasterListNameJoin(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 
     fn try_translate_pull_delete(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        let result = match_pull_table(sync_record).then(|| {
-            IntegrationRecords::from_delete(
-                &sync_record.record_id,
-                PullDeleteRecordTable::MasterListNameJoin,
-            )
-        });
-
-        Ok(result)
+    ) -> Result<PullTranslateResult, anyhow::Error> {
+        Ok(PullTranslateResult::delete(MasterListNameJoinRowDelete(
+            sync_record.record_id.clone(),
+        )))
     }
 }
 
@@ -86,6 +81,7 @@ mod tests {
         .await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();
@@ -94,6 +90,7 @@ mod tests {
         }
 
         for record in test_data::test_pull_delete_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_delete(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/mod.rs
+++ b/server/service/src/sync/translations/mod.rs
@@ -148,7 +148,10 @@ impl IntegrationOperation {
 #[derive(Debug)]
 pub(crate) enum PullTranslateResult {
     IntegrationOperations(Vec<IntegrationOperation>),
+    // Translator was found for a record, but ignored because of unexpected data or error
+    // For example if store is a system store, or report context not found
     Ignored(String),
+    // Translator doesn't translates this record
     NotMatched,
 }
 

--- a/server/service/src/sync/translations/name_tag.rs
+++ b/server/service/src/sync/translations/name_tag.rs
@@ -2,9 +2,7 @@ use repository::{NameTagRow, StorageConnection, SyncBufferRow};
 
 use serde::{Deserialize, Serialize};
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
-};
+use super::{PullTranslateResult, SyncTranslation};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
@@ -12,29 +10,27 @@ pub struct LegacyNameTagRow {
     pub ID: String,
     pub description: String,
 }
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LegacyTableName::NAME_TAG
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(NameTagTranslation)
 }
 
-pub(crate) struct NameTagTranslation {}
+pub(super) struct NameTagTranslation;
 impl SyncTranslation for NameTagTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::NAME_TAG,
-            dependencies: vec![],
-        }
+    fn table_name(&self) -> &'static str {
+        "name_tag"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![]
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let LegacyNameTagRow { ID, description } =
             serde_json::from_str::<LegacyNameTagRow>(&sync_record.data)?;
 
@@ -43,19 +39,7 @@ impl SyncTranslation for NameTagTranslation {
             name: description,
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::NameTag(result),
-        )))
-    }
-
-    fn try_translate_pull_delete(
-        &self,
-        _: &StorageConnection,
-        _sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        // Name tags are not deleted in mSupply.
-
-        Ok(None)
+        Ok(PullTranslateResult::upsert(result))
     }
 }
 
@@ -67,12 +51,13 @@ mod tests {
     #[actix_rt::test]
     async fn test_name_tag_translation() {
         use crate::sync::test::test_data::name_tag as test_data;
-        let translator = NameTagTranslation {};
+        let translator = NameTagTranslation;
 
         let (_, connection, _, _) =
             setup_all("test_name_tag_translation", MockDataInserts::none()).await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/name_tag_join.rs
+++ b/server/service/src/sync/translations/name_tag_join.rs
@@ -1,11 +1,10 @@
-use repository::{NameTagJoinRow, StorageConnection, SyncBufferRow};
+use repository::{NameTagJoinRow, NameTagJoinRowDelete, StorageConnection, SyncBufferRow};
 
 use serde::Deserialize;
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullDependency, PullUpsertRecord,
-    SyncTranslation,
-};
+use crate::sync::translations::{name::NameTranslation, name_tag::NameTagTranslation};
+
+use super::{PullTranslateResult, SyncTranslation};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize)]
@@ -14,36 +13,37 @@ pub struct LegacyNameTagJoinRow {
     name_ID: String,
     name_tag_ID: String,
 }
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LegacyTableName::NAME_TAG_JOIN
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(NameTagJoinTranslation)
 }
 
-pub(crate) struct NameTagJoinTranslation {}
+pub(super) struct NameTagJoinTranslation;
 impl SyncTranslation for NameTagJoinTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::NAME_TAG_JOIN,
-            dependencies: vec![LegacyTableName::NAME, LegacyTableName::NAME_TAG],
-        }
+    fn table_name(&self) -> &'static str {
+        "name_tag_join"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![
+            NameTranslation.table_name(),
+            NameTagTranslation.table_name(),
+        ]
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let LegacyNameTagJoinRow {
             ID,
             name_ID,
             name_tag_ID,
         } = serde_json::from_str::<LegacyNameTagJoinRow>(&sync_record.data)?;
         if name_ID == "" {
-            return Ok(None);
+            return Ok(PullTranslateResult::Ignored("Name id is empty".to_string()));
         }
 
         let result = NameTagJoinRow {
@@ -52,24 +52,17 @@ impl SyncTranslation for NameTagJoinTranslation {
             name_tag_id: name_tag_ID,
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::NameTagJoin(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 
     fn try_translate_pull_delete(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        let result = match_pull_table(sync_record).then(|| {
-            IntegrationRecords::from_delete(
-                &sync_record.record_id,
-                PullDeleteRecordTable::NameTagJoin,
-            )
-        });
-
-        Ok(result)
+    ) -> Result<PullTranslateResult, anyhow::Error> {
+        Ok(PullTranslateResult::delete(NameTagJoinRowDelete(
+            sync_record.record_id.clone(),
+        )))
     }
 }
 
@@ -87,6 +80,7 @@ mod tests {
             setup_all("test_name_tag_join_translation", MockDataInserts::none()).await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();
@@ -95,6 +89,7 @@ mod tests {
         }
 
         for record in test_data::test_pull_delete_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_delete(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/period.rs
+++ b/server/service/src/sync/translations/period.rs
@@ -2,15 +2,9 @@ use chrono::NaiveDate;
 use repository::{PeriodRow, StorageConnection, SyncBufferRow};
 use serde::{Deserialize, Serialize};
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
-};
+use crate::sync::translations::period_schedule::PeriodScheduleTranslation;
 
-const LEGACY_TABLE_NAME: &'static str = LegacyTableName::PERIOD;
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LEGACY_TABLE_NAME
-}
+use super::{PullTranslateResult, SyncTranslation};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
@@ -25,25 +19,27 @@ pub struct LegacyPeriodRow {
     pub end_date: NaiveDate,
     pub name: String,
 }
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(PeriodTranslation)
+}
 
-pub(crate) struct PeriodTranslation {}
+pub(super) struct PeriodTranslation;
 impl SyncTranslation for PeriodTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::PERIOD,
-            dependencies: vec![LegacyTableName::PERIOD_SCHEDULE],
-        }
+    fn table_name(&self) -> &'static str {
+        "period"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![PeriodScheduleTranslation.table_name()]
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let LegacyPeriodRow {
             id,
             period_schedule_id,
@@ -60,9 +56,7 @@ impl SyncTranslation for PeriodTranslation {
             name,
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::Period(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 }
 
@@ -80,6 +74,7 @@ mod tests {
             setup_all("test_period_translation", MockDataInserts::none()).await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/period_schedule.rs
+++ b/server/service/src/sync/translations/period_schedule.rs
@@ -1,15 +1,7 @@
 use repository::{PeriodScheduleRow, StorageConnection, SyncBufferRow};
 use serde::{Deserialize, Serialize};
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
-};
-
-const LEGACY_TABLE_NAME: &'static str = LegacyTableName::PERIOD_SCHEDULE;
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LEGACY_TABLE_NAME
-}
+use super::{PullTranslateResult, SyncTranslation};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
@@ -19,32 +11,33 @@ pub struct LegacyPeriodScheduleRow {
     pub name: String,
 }
 
-pub(crate) struct PeriodScheduleTranslation {}
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(PeriodScheduleTranslation)
+}
+
+pub(super) struct PeriodScheduleTranslation;
 impl SyncTranslation for PeriodScheduleTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::PERIOD_SCHEDULE,
-            dependencies: vec![],
-        }
+    fn table_name(&self) -> &'static str {
+        "periodSchedule"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![]
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let LegacyPeriodScheduleRow { id, name } =
             serde_json::from_str::<LegacyPeriodScheduleRow>(&sync_record.data)?;
 
         let result = PeriodScheduleRow { id, name };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::PeriodSchedule(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 }
 
@@ -62,6 +55,7 @@ mod tests {
             setup_all("test_period_schedule_translation", MockDataInserts::none()).await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/program_requisition_settings.rs
+++ b/server/service/src/sync/translations/program_requisition_settings.rs
@@ -1,15 +1,19 @@
 use repository::{
     ContextRow, NameTagRowRepository, PeriodScheduleRowRepository, ProgramRequisitionOrderTypeRow,
-    ProgramRequisitionOrderTypeRowRepository, ProgramRequisitionSettingsRow,
+    ProgramRequisitionOrderTypeRowDelete, ProgramRequisitionOrderTypeRowRepository,
+    ProgramRequisitionSettingsRow, ProgramRequisitionSettingsRowDelete,
     ProgramRequisitionSettingsRowRepository, ProgramRow, StorageConnection, SyncBufferRow,
 };
 
 use serde::Deserialize;
 use std::collections::HashMap;
 
+use crate::sync::translations::{
+    name_tag::NameTagTranslation, period_schedule::PeriodScheduleTranslation,
+};
+
 use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecord, PullDeleteRecordTable, PullDependency,
-    PullUpsertRecord, SyncTranslation,
+    master_list::MasterListTranslation, IntegrationOperation, PullTranslateResult, SyncTranslation,
 };
 
 #[allow(non_snake_case)]
@@ -47,82 +51,75 @@ struct LegacyOrderType {
     #[serde(rename = "maxOrdersPerPeriod")]
     max_order_per_period: i32,
 }
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LegacyTableName::LIST_MASTER
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(ProgramRequisitionSettingsTranslation)
 }
-pub(crate) struct ProgramRequisitionSettingsTranslation {}
+
+pub(super) struct ProgramRequisitionSettingsTranslation;
 impl SyncTranslation for ProgramRequisitionSettingsTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::LIST_MASTER,
-            dependencies: vec![LegacyTableName::NAME_TAG, LegacyTableName::PERIOD_SCHEDULE],
-        }
+    fn table_name(&self) -> &'static str {
+        MasterListTranslation.table_name()
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![
+            NameTagTranslation.table_name(),
+            PeriodScheduleTranslation.table_name(),
+        ]
     }
 
     fn try_translate_pull_upsert(
         &self,
         connection: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let data = serde_json::from_str::<LegacyListMasterRow>(&sync_record.data)?;
 
-        let Some(generate) = generate_requisition_program(connection, data.clone())? else {
-            return Ok(None);
-        };
-        let Some(delete) = delete_requisition_program(connection, data)? else {
-            return Ok(None);
-        };
+        if data.is_program == false {
+            return Ok(PullTranslateResult::NotMatched);
+        }
 
-        let mut upserts = Vec::new();
-        let mut deletes = Vec::new();
+        let upserts = generate_requisition_program(connection, data.clone())?;
+        let deletes = delete_requisition_program(connection, data)?;
 
-        delete
+        let mut integration_operations = Vec::new();
+
+        deletes
             .program_requisition_order_type_ids
             .into_iter()
             .for_each(|order_type_id| {
-                deletes.push(PullDeleteRecord {
-                    id: order_type_id,
-                    table: PullDeleteRecordTable::ProgramRequisitionOrderType,
-                })
+                integration_operations.push(IntegrationOperation::delete(
+                    ProgramRequisitionOrderTypeRowDelete(order_type_id),
+                ))
             });
 
-        delete
+        deletes
             .program_requisition_settings_ids
             .into_iter()
             .for_each(|settings_id| {
-                deletes.push(PullDeleteRecord {
-                    id: settings_id,
-                    table: PullDeleteRecordTable::ProgramRequisitionSettings,
-                })
+                integration_operations.push(IntegrationOperation::delete(
+                    ProgramRequisitionSettingsRowDelete(settings_id),
+                ))
             });
 
-        upserts.push(PullUpsertRecord::Context(generate.context_row));
-        upserts.push(PullUpsertRecord::Program(generate.program_row));
+        integration_operations.push(IntegrationOperation::upsert(upserts.context_row));
+        integration_operations.push(IntegrationOperation::upsert(upserts.program_row));
 
-        generate
+        upserts
             .program_requisition_settings_rows
             .into_iter()
-            .for_each(|program_requisition_setting| {
-                upserts.push(PullUpsertRecord::ProgramRequisitionSettings(
-                    program_requisition_setting,
-                ))
-            });
+            .for_each(|u| integration_operations.push(IntegrationOperation::upsert(u)));
 
-        generate
+        upserts
             .program_requisition_order_type_rows
             .into_iter()
-            .for_each(|program_requisition_order_type| {
-                upserts.push(PullUpsertRecord::ProgramRequisitionOrderType(
-                    program_requisition_order_type,
-                ))
-            });
+            .for_each(|u| integration_operations.push(IntegrationOperation::upsert(u)));
 
-        Ok(Some(IntegrationRecords { upserts, deletes }))
+        Ok(PullTranslateResult::IntegrationOperations(
+            integration_operations,
+        ))
     }
 }
 
@@ -135,11 +132,7 @@ struct DeleteRequisitionProgram {
 fn delete_requisition_program(
     connection: &StorageConnection,
     master_list: LegacyListMasterRow,
-) -> Result<Option<DeleteRequisitionProgram>, anyhow::Error> {
-    if master_list.is_program == false {
-        return Ok(None);
-    }
-
+) -> Result<DeleteRequisitionProgram, anyhow::Error> {
     let mut program_requisition_settings_ids = Vec::new();
     let mut program_requisition_order_type_ids = Vec::new();
 
@@ -155,10 +148,10 @@ fn delete_requisition_program(
         .iter()
         .for_each(|order_type| program_requisition_order_type_ids.push(order_type.id.clone()));
 
-    Ok(Some(DeleteRequisitionProgram {
+    Ok(DeleteRequisitionProgram {
         program_requisition_settings_ids,
         program_requisition_order_type_ids,
-    }))
+    })
 }
 
 #[derive(Clone)]
@@ -172,11 +165,7 @@ struct GenerateRequisitionProgram {
 fn generate_requisition_program(
     connection: &StorageConnection,
     master_list: LegacyListMasterRow,
-) -> Result<Option<GenerateRequisitionProgram>, anyhow::Error> {
-    if master_list.is_program == false {
-        return Ok(None);
-    }
-
+) -> Result<GenerateRequisitionProgram, anyhow::Error> {
     let program_settings = master_list.program_settings.clone().ok_or(anyhow::anyhow!(
         "Program settings not found for program {}",
         master_list.id
@@ -247,35 +236,18 @@ fn generate_requisition_program(
         }
     }
 
-    Ok(Some(GenerateRequisitionProgram {
+    Ok(GenerateRequisitionProgram {
         context_row,
         program_row,
         program_requisition_settings_rows,
         program_requisition_order_type_rows,
-    }))
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use repository::{mock::MockDataInserts, test_db::setup_all};
-
-    fn sort_results(unsorted: Option<IntegrationRecords>) -> Option<IntegrationRecords> {
-        unsorted.map(|mut unsorted| {
-            use PullUpsertRecord::*;
-            unsorted.upserts.sort_by(|a, b| match (a, b) {
-                (Program(a), Program(b)) => a.id.cmp(&b.id),
-                (Program(_), _) => std::cmp::Ordering::Greater,
-                (_, Program(_)) => std::cmp::Ordering::Less,
-                (ProgramRequisitionSettings(a), ProgramRequisitionSettings(b)) => a.id.cmp(&b.id),
-                (ProgramRequisitionSettings(_), _) => std::cmp::Ordering::Greater,
-                (_, ProgramRequisitionSettings(_)) => std::cmp::Ordering::Less,
-                (ProgramRequisitionOrderType(a), ProgramRequisitionOrderType(b)) => a.id.cmp(&b.id),
-                _ => std::cmp::Ordering::Equal,
-            });
-            unsorted
-        })
-    }
 
     #[actix_rt::test]
     async fn test_program_requisition_translation() {
@@ -289,6 +261,7 @@ mod tests {
         .await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();
@@ -298,5 +271,21 @@ mod tests {
                 sort_results(record.translated_record)
             );
         }
+    }
+
+    // Since storeTags in programSettings is an a json object, order is not guaranteed
+    // and sometimes different order of integraiton records will be returned by translator
+    // thus we need to sort by type and by id, this is quite easily done just by sorting by
+    // debug output
+    fn sort_results(unsorted: PullTranslateResult) -> PullTranslateResult {
+        let mut to_be_sorted = match unsorted {
+            PullTranslateResult::IntegrationOperations(u) => u,
+            PullTranslateResult::Ignored(i) => return PullTranslateResult::Ignored(i),
+            PullTranslateResult::NotMatched => return PullTranslateResult::NotMatched,
+        };
+
+        to_be_sorted.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
+
+        PullTranslateResult::IntegrationOperations(to_be_sorted)
     }
 }

--- a/server/service/src/sync/translations/report.rs
+++ b/server/service/src/sync/translations/report.rs
@@ -1,12 +1,13 @@
-use crate::sync::sync_serde::empty_str_as_option_string;
-use repository::{ReportContext, ReportRow, ReportType, StorageConnection, SyncBufferRow};
+use crate::sync::{
+    sync_serde::empty_str_as_option_string, translations::form_schema::FormSchemaTranslation,
+};
+use repository::{
+    ReportContext, ReportRow, ReportRowDelete, ReportType, StorageConnection, SyncBufferRow,
+};
 
 use serde::{Deserialize, Serialize};
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullDependency, PullUpsertRecord,
-    SyncTranslation,
-};
+use super::{PullTranslateResult, SyncTranslation};
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 pub enum LegacyReportEditor {
@@ -37,6 +38,7 @@ pub enum LegacyReportContext {
     #[serde(other)]
     Others,
 }
+// https://github.com/msupply-foundation/open-msupply/pull/2152
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
@@ -58,28 +60,27 @@ pub struct LegacyReportRow {
     pub argument_schema_id: Option<String>,
 }
 
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LegacyTableName::REPORT
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(ReportTranslation)
 }
 
-pub(crate) struct ReportTranslation {}
+pub(super) struct ReportTranslation;
 impl SyncTranslation for ReportTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::REPORT,
-            dependencies: vec![LegacyTableName::FORM_SCHEMA],
-        }
+    fn table_name(&self) -> &'static str {
+        "report"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![FormSchemaTranslation.table_name()]
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let LegacyReportRow {
             id,
             report_name,
@@ -93,7 +94,7 @@ impl SyncTranslation for ReportTranslation {
 
         let r#type = match editor {
             LegacyReportEditor::OmSupply => ReportType::OmSupply,
-            LegacyReportEditor::Others => return Ok(None),
+            LegacyReportEditor::Others => return Ok(PullTranslateResult::NotMatched),
         };
         let context = match context {
             LegacyReportContext::CustomerInvoice => ReportContext::OutboundShipment,
@@ -103,7 +104,11 @@ impl SyncTranslation for ReportTranslation {
             LegacyReportContext::Patient => ReportContext::Patient,
             LegacyReportContext::Dispensary => ReportContext::Dispensary,
             LegacyReportContext::Repack => ReportContext::Repack,
-            LegacyReportContext::Others => return Ok(None),
+            LegacyReportContext::Others => {
+                return Ok(PullTranslateResult::Ignored(
+                    "Unknown report context".to_string(),
+                ))
+            }
         };
 
         let result = ReportRow {
@@ -117,21 +122,17 @@ impl SyncTranslation for ReportTranslation {
             argument_schema_id,
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::Report(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 
     fn try_translate_pull_delete(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        let result = match_pull_table(sync_record).then(|| {
-            IntegrationRecords::from_delete(&sync_record.record_id, PullDeleteRecordTable::Report)
-        });
-
-        Ok(result)
+    ) -> Result<PullTranslateResult, anyhow::Error> {
+        Ok(PullTranslateResult::delete(ReportRowDelete(
+            sync_record.record_id.clone(),
+        )))
     }
 }
 
@@ -149,6 +150,7 @@ mod tests {
             setup_all("test_report_translation", MockDataInserts::none()).await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();
@@ -157,6 +159,7 @@ mod tests {
         }
 
         for record in test_data::test_pull_delete_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_delete(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/report.rs
+++ b/server/service/src/sync/translations/report.rs
@@ -38,7 +38,6 @@ pub enum LegacyReportContext {
     #[serde(other)]
     Others,
 }
-// https://github.com/msupply-foundation/open-msupply/pull/2152
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]

--- a/server/service/src/sync/translations/sensor.rs
+++ b/server/service/src/sync/translations/sensor.rs
@@ -1,9 +1,9 @@
 use crate::sync::{
-    api::RemoteSyncRecordV5,
     sync_serde::{
         date_option_to_isostring, empty_str_as_option, empty_str_as_option_string, naive_time,
         zero_date_as_option,
     },
+    translations::{location::LocationTranslation, store::StoreTranslation},
 };
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 
@@ -13,19 +13,7 @@ use repository::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
-};
-
-const LEGACY_TABLE_NAME: &'static str = LegacyTableName::SENSOR;
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LEGACY_TABLE_NAME
-}
-fn match_push_table(changelog: &ChangelogRow) -> bool {
-    changelog.table_name == ChangelogTableName::Sensor
-}
-
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
 pub struct LegacySensorRow {
@@ -57,24 +45,34 @@ pub struct LegacySensorRow {
     pub last_connection_datetime: Option<NaiveDateTime>,
 }
 
-pub(crate) struct SensorTranslation {}
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(SensorTranslation)
+}
+
+pub(crate) struct SensorTranslation;
 impl SyncTranslation for SensorTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::SENSOR,
-            dependencies: vec![LegacyTableName::LOCATION, LegacyTableName::STORE],
-        }
+    fn table_name(&self) -> &'static str {
+        "sensor"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![
+            LocationTranslation.table_name(),
+            StoreTranslation.table_name(),
+        ]
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::Sensor)
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let data = serde_json::from_str::<LegacySensorRow>(&sync_record.data)?;
 
         let LegacySensorRow {
@@ -110,20 +108,14 @@ impl SyncTranslation for SensorTranslation {
             r#type,
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::Sensor(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 
     fn try_translate_push_upsert(
         &self,
         connection: &StorageConnection,
         changelog: &ChangelogRow,
-    ) -> Result<Option<Vec<RemoteSyncRecordV5>>, anyhow::Error> {
-        if !match_push_table(changelog) {
-            return Ok(None);
-        }
-
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let SensorRow {
             id,
             name,
@@ -170,11 +162,12 @@ impl SyncTranslation for SensorTranslation {
             last_connection_time,
             last_connection_datetime,
         };
-        Ok(Some(vec![RemoteSyncRecordV5::new_upsert(
+
+        Ok(PushTranslateResult::upsert(
             changelog,
-            LEGACY_TABLE_NAME,
+            self.table_name(),
             serde_json::to_value(&legacy_row)?,
-        )]))
+        ))
     }
 }
 
@@ -192,6 +185,7 @@ mod tests {
             setup_all("test_sensor_translation", MockDataInserts::none()).await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/special/mod.rs
+++ b/server/service/src/sync/translations/special/mod.rs
@@ -1,2 +1,1 @@
-mod name_to_name_store_join;
-pub(crate) use name_to_name_store_join::*;
+pub(crate) mod name_to_name_store_join;

--- a/server/service/src/sync/translations/special/name_to_name_store_join.rs
+++ b/server/service/src/sync/translations/special/name_to_name_store_join.rs
@@ -1,12 +1,11 @@
 use repository::{
-    EqualFilter, NameStoreJoinFilter, NameStoreJoinRepository, StorageConnection, SyncBufferRow,
+    EqualFilter, NameStoreJoinFilter, NameStoreJoinRepository, NameStoreJoinRow, StorageConnection,
+    SyncBufferRow,
 };
 
 use serde::Deserialize;
 
-use crate::sync::translations::{
-    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
-};
+use crate::sync::translations::{name::NameTranslation, PullTranslateResult, SyncTranslation};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize)]
@@ -18,47 +17,52 @@ pub struct PartialLegacyNameRow {
     pub name_is_supplier: bool,
 }
 
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(NameToNameStoreJoinTranslation)
+}
 // In omSupply, is_customer and is_supplier relationship between store and name is stored
 // in name_store_join, in mSupply it's stored on name. This translator updates all name_store_joins
 // for name when name is pulled (setting is_customer and is_supplier appropriatly)
 // NOTE Translator should be removed when central server configures these properties on name_store_join
-pub(crate) struct NameToNameStoreJoinTranslation {}
+pub(super) struct NameToNameStoreJoinTranslation;
 impl SyncTranslation for NameToNameStoreJoinTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::NAME,
-            dependencies: vec![],
-        }
+    // TODO would this even work ? (would it not have a dependnecy to ?)
+    fn table_name(&self) -> &'static str {
+        NameTranslation.table_name()
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![]
     }
 
     fn try_translate_pull_upsert(
         &self,
         connection: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if sync_record.table_name != LegacyTableName::NAME {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let data = serde_json::from_str::<PartialLegacyNameRow>(&sync_record.data)?;
 
         let name_store_joins = NameStoreJoinRepository::new(connection)
             .query_by_filter(NameStoreJoinFilter::new().name_id(EqualFilter::equal_to(&data.ID)))?;
 
         if name_store_joins.len() == 0 {
-            return Ok(None);
+            return Ok(PullTranslateResult::Ignored(
+                "Name store joins now found for name".to_string(),
+            ));
         }
 
-        let upserts: Vec<PullUpsertRecord> = name_store_joins
+        let upserts = name_store_joins
             .into_iter()
-            .map(|mut r| {
-                r.name_is_customer = data.name_is_customer;
-                r.name_is_supplier = data.name_is_supplier;
-                PullUpsertRecord::NameStoreJoin(r)
+            .map(|r| NameStoreJoinRow {
+                name_is_customer: data.name_is_customer,
+                name_is_supplier: data.name_is_supplier,
+                ..r
             })
             .collect();
 
-        Ok(Some(IntegrationRecords::from_upserts(upserts)))
+        Ok(PullTranslateResult::upserts(upserts))
     }
 }
 
@@ -81,6 +85,7 @@ mod tests {
         for record in test_data::test_pull_upsert_records() {
             record.insert_extra_data(&connection).await;
 
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/special/name_to_name_store_join.rs
+++ b/server/service/src/sync/translations/special/name_to_name_store_join.rs
@@ -28,11 +28,14 @@ pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
 // NOTE Translator should be removed when central server configures these properties on name_store_join
 pub(super) struct NameToNameStoreJoinTranslation;
 impl SyncTranslation for NameToNameStoreJoinTranslation {
-    // TODO would this even work ? (would it not have a dependnecy to ?)
     fn table_name(&self) -> &'static str {
         NameTranslation.table_name()
     }
 
+    // Even though we are making changes to name_store_joins, no dependencies required
+    // this translator is special translator to update existing names_store_joins when
+    // name.is_customer or name.is_supplier are toggled
+    // Btw, when name_store_joins are upserted, we check name for is_customer,is_supplier
     fn pull_dependencies(&self) -> Vec<&'static str> {
         vec![]
     }

--- a/server/service/src/sync/translations/stocktake.rs
+++ b/server/service/src/sync/translations/stocktake.rs
@@ -1,9 +1,9 @@
 use crate::sync::{
-    api::RemoteSyncRecordV5,
     sync_serde::{
         date_from_date_time, date_option_to_isostring, date_to_isostring, empty_str_as_option,
         empty_str_as_option_string, naive_time, zero_date_as_option,
     },
+    translations::{invoice::InvoiceTranslation, store::StoreTranslation},
 };
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use repository::{
@@ -12,18 +12,7 @@ use repository::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
-};
-
-const LEGACY_TABLE_NAME: &'static str = LegacyTableName::STOCKTAKE;
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LEGACY_TABLE_NAME
-}
-fn match_push_table(changelog: &ChangelogRow) -> bool {
-    changelog.table_name == ChangelogTableName::Stocktake
-}
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum LegacyStocktakeStatus {
@@ -86,24 +75,34 @@ pub struct LegacyStocktakeRow {
     pub finalised_datetime: Option<NaiveDateTime>,
 }
 
-pub(crate) struct StocktakeTranslation {}
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(StocktakeTranslation)
+}
+
+pub(super) struct StocktakeTranslation;
 impl SyncTranslation for StocktakeTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::STOCKTAKE,
-            dependencies: vec![LegacyTableName::STORE, LegacyTableName::TRANSACT],
-        }
+    fn table_name(&self) -> &'static str {
+        "Stock_take"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![
+            InvoiceTranslation.table_name(),
+            StoreTranslation.table_name(),
+        ]
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::Stocktake)
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let data = serde_json::from_str::<LegacyStocktakeRow>(&sync_record.data)?;
         let (created_datetime, finalised_datetime) = match data.created_datetime {
             Some(created_datetime) => {
@@ -135,20 +134,14 @@ impl SyncTranslation for StocktakeTranslation {
             is_locked: data.is_locked,
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::Stocktake(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 
     fn try_translate_push_upsert(
         &self,
         connection: &StorageConnection,
         changelog: &ChangelogRow,
-    ) -> Result<Option<Vec<RemoteSyncRecordV5>>, anyhow::Error> {
-        if !match_push_table(changelog) {
-            return Ok(None);
-        }
-
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let StocktakeRow {
             id,
             user_id,
@@ -185,22 +178,19 @@ impl SyncTranslation for StocktakeTranslation {
             finalised_datetime,
         };
 
-        Ok(Some(vec![RemoteSyncRecordV5::new_upsert(
+        Ok(PushTranslateResult::upsert(
             changelog,
-            LEGACY_TABLE_NAME,
+            self.table_name(),
             serde_json::to_value(&legacy_row)?,
-        )]))
+        ))
     }
 
     fn try_translate_push_delete(
         &self,
         _: &StorageConnection,
         changelog: &ChangelogRow,
-    ) -> Result<Option<Vec<RemoteSyncRecordV5>>, anyhow::Error> {
-        let result = match_push_table(changelog)
-            .then(|| vec![RemoteSyncRecordV5::new_delete(changelog, LEGACY_TABLE_NAME)]);
-
-        Ok(result)
+    ) -> Result<PushTranslateResult, anyhow::Error> {
+        Ok(PushTranslateResult::delete(changelog, self.table_name()))
     }
 }
 
@@ -234,6 +224,7 @@ mod tests {
             setup_all("test_stocktake_translation", MockDataInserts::none()).await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/stocktake_line.rs
+++ b/server/service/src/sync/translations/stocktake_line.rs
@@ -1,6 +1,10 @@
 use crate::sync::{
-    api::RemoteSyncRecordV5,
     sync_serde::{date_option_to_isostring, empty_str_as_option_string, zero_date_as_option},
+    translations::{
+        inventory_adjustment_reason::InventoryAdjustmentReasonTranslation, item::ItemTranslation,
+        location::LocationTranslation, stock_line::StockLineTranslation,
+        stocktake::StocktakeTranslation,
+    },
 };
 use chrono::NaiveDate;
 use repository::{
@@ -9,18 +13,7 @@ use repository::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
-};
-
-const LEGACY_TABLE_NAME: &'static str = LegacyTableName::STOCKTAKE_LINE;
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LEGACY_TABLE_NAME
-}
-fn match_push_table(changelog: &ChangelogRow) -> bool {
-    changelog.table_name == ChangelogTableName::StocktakeLine
-}
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
@@ -53,31 +46,37 @@ pub struct LegacyStocktakeLineRow {
     #[serde(deserialize_with = "empty_str_as_option_string")]
     pub inventory_adjustment_reason_id: Option<String>,
 }
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(StocktakeLineTranslation)
+}
 
-pub(crate) struct StocktakeLineTranslation {}
+pub(super) struct StocktakeLineTranslation;
 impl SyncTranslation for StocktakeLineTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::STOCKTAKE_LINE,
-            dependencies: vec![
-                LegacyTableName::STOCKTAKE,
-                LegacyTableName::ITEM_LINE,
-                LegacyTableName::LOCATION,
-                LegacyTableName::ITEM,
-                LegacyTableName::INVENTORY_ADJUSTMENT_REASON,
-            ],
-        }
+    fn table_name(&self) -> &'static str {
+        "Stock_take_lines"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![
+            StocktakeTranslation.table_name(),
+            StockLineTranslation.table_name(),
+            ItemTranslation.table_name(),
+            LocationTranslation.table_name(),
+            InventoryAdjustmentReasonTranslation.table_name(),
+        ]
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::StocktakeLine)
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let data = serde_json::from_str::<LegacyStocktakeLineRow>(&sync_record.data)?;
 
         // TODO is this correct?
@@ -104,20 +103,14 @@ impl SyncTranslation for StocktakeLineTranslation {
             inventory_adjustment_reason_id: data.inventory_adjustment_reason_id,
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::StocktakeLine(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 
     fn try_translate_push_upsert(
         &self,
         connection: &StorageConnection,
         changelog: &ChangelogRow,
-    ) -> Result<Option<Vec<RemoteSyncRecordV5>>, anyhow::Error> {
-        if !match_push_table(changelog) {
-            return Ok(None);
-        }
-
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let StocktakeLineRow {
             id,
             stocktake_id,
@@ -164,22 +157,19 @@ impl SyncTranslation for StocktakeLineTranslation {
             inventory_adjustment_reason_id,
         };
 
-        Ok(Some(vec![RemoteSyncRecordV5::new_upsert(
+        Ok(PushTranslateResult::upsert(
             changelog,
-            LEGACY_TABLE_NAME,
+            self.table_name(),
             serde_json::to_value(&legacy_row)?,
-        )]))
+        ))
     }
 
     fn try_translate_push_delete(
         &self,
         _: &StorageConnection,
         changelog: &ChangelogRow,
-    ) -> Result<Option<Vec<RemoteSyncRecordV5>>, anyhow::Error> {
-        let result = match_push_table(changelog)
-            .then(|| vec![RemoteSyncRecordV5::new_delete(changelog, LEGACY_TABLE_NAME)]);
-
-        Ok(result)
+    ) -> Result<PushTranslateResult, anyhow::Error> {
+        Ok(PushTranslateResult::delete(changelog, self.table_name()))
     }
 }
 
@@ -197,6 +187,7 @@ mod tests {
             setup_all("test_stock_take_line_translation", MockDataInserts::none()).await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/store.rs
+++ b/server/service/src/sync/translations/store.rs
@@ -1,12 +1,9 @@
-use repository::{StorageConnection, StoreMode, StoreRow, SyncBufferRow};
+use repository::{StorageConnection, StoreMode, StoreRow, StoreRowDelete, SyncBufferRow};
 
-use crate::sync::sync_serde::empty_str_as_option_string;
+use crate::sync::{sync_serde::empty_str_as_option_string, translations::name::NameTranslation};
 use serde::{Deserialize, Serialize};
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullDependency, PullUpsertRecord,
-    SyncTranslation,
-};
+use super::{PullTranslateResult, SyncTranslation};
 
 #[derive(Deserialize, Serialize, Debug)]
 pub enum LegacyStoreMode {
@@ -30,28 +27,27 @@ pub struct LegacyStoreRow {
     logo: Option<String>,
     store_mode: LegacyStoreMode,
 }
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LegacyTableName::STORE
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(StoreTranslation)
 }
-pub(crate) struct StoreTranslation {}
+
+pub(super) struct StoreTranslation;
 impl SyncTranslation for StoreTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::STORE,
-            dependencies: vec![LegacyTableName::NAME],
-        }
+    fn table_name(&self) -> &'static str {
+        "store"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![NameTranslation.table_name()]
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let data = serde_json::from_str::<LegacyStoreRow>(&sync_record.data)?;
 
         // Ignore the following stores as they are system stores with some properties that prevent them from being integrated
@@ -61,12 +57,15 @@ impl SyncTranslation for StoreTranslation {
         // TODO: Ideally we want another state, `Ignored`
         // (i.e. return type) Translation Not Matches, Translation Ignored (with message ?) and Translated records
         if let "HIS" | "DRG" | "SM" = &data.code[..] {
-            return Ok(None);
+            return Ok(PullTranslateResult::Ignored(
+                "Ignoring not implemented system names".to_string(),
+            ));
         }
 
-        // ignore stores without name
         if data.name_id == "" {
-            return Ok(None);
+            return Ok(PullTranslateResult::Ignored(
+                "Ignore stores without name".to_string(),
+            ));
         }
 
         let store_mode = match data.store_mode {
@@ -83,21 +82,17 @@ impl SyncTranslation for StoreTranslation {
             store_mode,
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::Store(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
-
+    // TODO soft delete
     fn try_translate_pull_delete(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        let result = match_pull_table(sync_record).then(|| {
-            IntegrationRecords::from_delete(&sync_record.record_id, PullDeleteRecordTable::Store)
-        });
-
-        Ok(result)
+    ) -> Result<PullTranslateResult, anyhow::Error> {
+        Ok(PullTranslateResult::delete(StoreRowDelete(
+            sync_record.record_id.clone(),
+        )))
     }
 }
 
@@ -115,6 +110,7 @@ mod tests {
             setup_all("test_store_translation", MockDataInserts::none()).await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();
@@ -123,6 +119,7 @@ mod tests {
         }
 
         for record in test_data::test_pull_delete_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_delete(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/store_preference.rs
+++ b/server/service/src/sync/translations/store_preference.rs
@@ -1,15 +1,7 @@
 use repository::{StorageConnection, StorePreferenceRow, StorePreferenceType, SyncBufferRow};
 use serde::{Deserialize, Serialize};
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
-};
-
-const LEGACY_TABLE_NAME: &'static str = LegacyTableName::STORE_PREFERENCE;
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LEGACY_TABLE_NAME
-}
+use super::{PullTranslateResult, SyncTranslation};
 
 #[derive(Deserialize, Serialize, Debug)]
 pub enum LegacyOptionsType {
@@ -41,24 +33,27 @@ pub struct LegacyPrefData {
     pub vaccine_module: bool,
 }
 
-pub(crate) struct StorePreferenceTranslation {}
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(StorePreferenceTranslation)
+}
+
+pub(super) struct StorePreferenceTranslation;
 impl SyncTranslation for StorePreferenceTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::STORE_PREFERENCE,
-            dependencies: vec![],
-        }
+    fn table_name(&self) -> &'static str {
+        "pref"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![]
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let data = serde_json::from_str::<LegacyPrefRow>(&sync_record.data)?;
 
         let LegacyPrefRow { id, r#type, data } = data;
@@ -85,9 +80,7 @@ impl SyncTranslation for StorePreferenceTranslation {
             vaccine_module,
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::StorePreference(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 }
 
@@ -105,6 +98,7 @@ mod tests {
             setup_all("test_store_preference_translation", MockDataInserts::none()).await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/temperature_breach.rs
+++ b/server/service/src/sync/translations/temperature_breach.rs
@@ -1,8 +1,10 @@
 use crate::sync::{
-    api::RemoteSyncRecordV5,
     sync_serde::{
         date_from_date_time, date_option_to_isostring, empty_str_as_option,
         empty_str_as_option_string, naive_time, zero_date_as_option,
+    },
+    translations::{
+        location::LocationTranslation, sensor::SensorTranslation, store::StoreTranslation,
     },
 };
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
@@ -13,18 +15,7 @@ use repository::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
-};
-
-const LEGACY_TABLE_NAME: &'static str = LegacyTableName::TEMPERATURE_BREACH;
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LEGACY_TABLE_NAME
-}
-fn match_push_table(changelog: &ChangelogRow) -> bool {
-    changelog.table_name == ChangelogTableName::TemperatureBreach
-}
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -80,28 +71,35 @@ pub struct LegacyTemperatureBreachRow {
     pub comment: Option<String>,
 }
 
-pub(crate) struct TemperatureBreachTranslation {}
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(TemperatureBreachTranslation)
+}
+
+pub(crate) struct TemperatureBreachTranslation;
 impl SyncTranslation for TemperatureBreachTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::TEMPERATURE_BREACH,
-            dependencies: vec![
-                LegacyTableName::STORE,
-                LegacyTableName::LOCATION,
-                LegacyTableName::SENSOR,
-            ],
-        }
+    fn table_name(&self) -> &'static str {
+        "temperature_breach"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![
+            SensorTranslation.table_name(),
+            StoreTranslation.table_name(),
+            LocationTranslation.table_name(),
+        ]
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::TemperatureBreach)
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let data = serde_json::from_str::<LegacyTemperatureBreachRow>(&sync_record.data)?;
         let LegacyTemperatureBreachRow {
             id,
@@ -142,20 +140,14 @@ impl SyncTranslation for TemperatureBreachTranslation {
             comment,
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::TemperatureBreach(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 
     fn try_translate_push_upsert(
         &self,
         connection: &StorageConnection,
         changelog: &ChangelogRow,
-    ) -> Result<Option<Vec<RemoteSyncRecordV5>>, anyhow::Error> {
-        if !match_push_table(changelog) {
-            return Ok(None);
-        }
-
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let TemperatureBreachRow {
             id,
             duration_milliseconds,
@@ -200,11 +192,12 @@ impl SyncTranslation for TemperatureBreachTranslation {
             end_datetime,
             comment,
         };
-        Ok(Some(vec![RemoteSyncRecordV5::new_upsert(
+
+        Ok(PushTranslateResult::upsert(
             changelog,
-            LEGACY_TABLE_NAME,
+            self.table_name(),
             serde_json::to_value(&legacy_row)?,
-        )]))
+        ))
     }
 }
 
@@ -245,6 +238,7 @@ mod tests {
         .await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/temperature_log.rs
+++ b/server/service/src/sync/translations/temperature_log.rs
@@ -1,8 +1,11 @@
 use crate::sync::{
-    api::RemoteSyncRecordV5,
     sync_serde::{
         date_option_to_isostring, empty_str_as_option, empty_str_as_option_string, naive_time,
         zero_date_as_option,
+    },
+    translations::{
+        location::LocationTranslation, sensor::SensorTranslation, store::StoreTranslation,
+        temperature_breach::TemperatureBreachTranslation,
     },
 };
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
@@ -13,18 +16,7 @@ use repository::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
-};
-
-const LEGACY_TABLE_NAME: &'static str = LegacyTableName::TEMPERATURE_LOG;
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LEGACY_TABLE_NAME
-}
-fn match_push_table(changelog: &ChangelogRow) -> bool {
-    changelog.table_name == ChangelogTableName::TemperatureLog
-}
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
@@ -52,29 +44,36 @@ pub struct LegacyTemperatureLogRow {
     pub datetime: Option<NaiveDateTime>,
 }
 
-pub(crate) struct TemperatureLogTranslation {}
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(TemperatureLogTranslation)
+}
+
+pub(crate) struct TemperatureLogTranslation;
 impl SyncTranslation for TemperatureLogTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::TEMPERATURE_LOG,
-            dependencies: vec![
-                LegacyTableName::STORE,
-                LegacyTableName::LOCATION,
-                LegacyTableName::SENSOR,
-                LegacyTableName::TEMPERATURE_BREACH,
-            ],
-        }
+    fn table_name(&self) -> &'static str {
+        "temperature_log"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![
+            StoreTranslation.table_name(),
+            LocationTranslation.table_name(),
+            SensorTranslation.table_name(),
+            TemperatureBreachTranslation.table_name(),
+        ]
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::TemperatureLog)
     }
 
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
-
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let data = serde_json::from_str::<LegacyTemperatureLogRow>(&sync_record.data)?;
 
         let LegacyTemperatureLogRow {
@@ -101,20 +100,14 @@ impl SyncTranslation for TemperatureLogTranslation {
             temperature_breach_id,
         };
 
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::TemperatureLog(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 
     fn try_translate_push_upsert(
         &self,
         connection: &StorageConnection,
         changelog: &ChangelogRow,
-    ) -> Result<Option<Vec<RemoteSyncRecordV5>>, anyhow::Error> {
-        if !match_push_table(changelog) {
-            return Ok(None);
-        }
-
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let TemperatureLogRow {
             id,
             temperature,
@@ -141,11 +134,11 @@ impl SyncTranslation for TemperatureLogTranslation {
             temperature_breach_id,
             datetime: Some(datetime),
         };
-        Ok(Some(vec![RemoteSyncRecordV5::new_upsert(
+        Ok(PushTranslateResult::upsert(
             changelog,
-            LEGACY_TABLE_NAME,
+            self.table_name(),
             serde_json::to_value(&legacy_row)?,
-        )]))
+        ))
     }
 }
 
@@ -163,6 +156,7 @@ mod tests {
             setup_all("test_temperature_log_translation", MockDataInserts::none()).await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();

--- a/server/service/src/sync/translations/user_permission.rs
+++ b/server/service/src/sync/translations/user_permission.rs
@@ -1,12 +1,15 @@
 use serde::{Deserialize, Serialize};
 
-use repository::{Permission, StorageConnection, SyncBufferRow, UserPermissionRow};
-
-use crate::sync::{sync_serde::empty_str_as_option_string, translations::LegacyTableName};
-
-use super::{
-    IntegrationRecords, PullDeleteRecordTable, PullDependency, PullUpsertRecord, SyncTranslation,
+use repository::{
+    Permission, StorageConnection, SyncBufferRow, UserPermissionRow, UserPermissionRowDelete,
 };
+
+use crate::sync::{
+    sync_serde::empty_str_as_option_string,
+    translations::{master_list::MasterListTranslation, store::StoreTranslation},
+};
+
+use super::{PullTranslateResult, SyncTranslation};
 
 #[derive(Deserialize, Serialize, Debug)]
 pub enum LegacyPermission {
@@ -28,29 +31,31 @@ pub struct LegacyUserPermissionTable {
     #[serde(deserialize_with = "empty_str_as_option_string")]
     pub context: Option<String>,
 }
-
-fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
-    sync_record.table_name == LegacyTableName::USER_PERMISSION
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(UserPermissionTranslation)
 }
 
-pub(crate) struct UserPermissionTranslation {}
+pub(super) struct UserPermissionTranslation;
 impl SyncTranslation for UserPermissionTranslation {
-    fn pull_dependencies(&self) -> PullDependency {
-        PullDependency {
-            table: LegacyTableName::USER_PERMISSION,
-            // include LIST_MASTER to populate context entries, e.g. program contexts
-            dependencies: vec![LegacyTableName::STORE, LegacyTableName::LIST_MASTER],
-        }
+    fn table_name(&self) -> &'static str {
+        "om_user_permission"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![
+            StoreTranslation.table_name(),
+            // include Master List to populate context entries, e.g. program contexts
+            MasterListTranslation.table_name(),
+        ]
     }
 
     fn try_translate_pull_upsert(
         &self,
         _connection: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        if !match_pull_table(sync_record) {
-            return Ok(None);
-        }
+    ) -> Result<PullTranslateResult, anyhow::Error> {
         let LegacyUserPermissionTable {
             id,
             user_id,
@@ -71,24 +76,17 @@ impl SyncTranslation for UserPermissionTranslation {
             permission: user_permission,
             context_id: context,
         };
-        Ok(Some(IntegrationRecords::from_upsert(
-            PullUpsertRecord::UserPermission(result),
-        )))
+        Ok(PullTranslateResult::upsert(result))
     }
 
     fn try_translate_pull_delete(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        let result = match_pull_table(sync_record).then(|| {
-            IntegrationRecords::from_delete(
-                &sync_record.record_id,
-                PullDeleteRecordTable::UserPermission,
-            )
-        });
-
-        Ok(result)
+    ) -> Result<PullTranslateResult, anyhow::Error> {
+        Ok(PullTranslateResult::delete(UserPermissionRowDelete(
+            sync_record.record_id.clone(),
+        )))
     }
 }
 
@@ -106,6 +104,7 @@ mod tests {
             setup_all("test_user_permission_translation", MockDataInserts::none()).await;
 
         for record in test_data::test_pull_upsert_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();
@@ -114,6 +113,7 @@ mod tests {
         }
 
         for record in test_data::test_pull_delete_records() {
+            assert!(translator.match_pull(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_pull_delete(&connection, &record.sync_buffer_row)
                 .unwrap();


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Links to #2062-1 (sync refactor before central config server changes)

The idea was to combine requests from various new experiences implementing sync. And the end goal was to reduce number of files that need to be changed. The end product is the difference between these two examples:

Adding new table and sync it [previous way](https://github.com/msupply-foundation/open-msupply/commit/112a5093ace80808bee77837c1de47cda6a70c68), and the [new way](https://github.com/msupply-foundation/open-msupply/commit/806174acbc8b058e1c637172f21d9d55deb6c5d8#diff-4ea3869b5556eae226feee1d4771959d25b7978673b6eb0c9d25eaf3744b4b4a). Btw the new way is included as an example in the follow up PR for sync docs. (there is slightly more changes in repo but less changes in translations, and less files touched)

On the hindsight, this refactor was not essential to omSupply Central Config server implementation, and should have been postponed until we have the time for it. And team should have been consulted before I did the work on it.

Most of the changes here are repeats, the first commit 6f9abf2b8b1f87dca4cbefa53037f4a3a23db289 shows how they apply for one records type (requisition_line), the rest is basically applying this pattern to other record types.

# 👩🏻‍💻 What does this PR do? 

Adds Upsert/Delete trait instead of `IntegrationOperation` and `PullDeleteRecord` enums, this reduces number of different files that need to be touched when adding new sync translation. 

Default implementation of SyncTranslator does a bit more work now, rather then checking table names in each translator, match_pull uses new _required_ table_name method. (also don't have to add table names another file, it's added directly in translator). This also lead to changing pull_dependency to use table_name from translators.

Added boxed() method to translators (to be used to add translators to all_translator method), this was requested, since a number of times implementers forgot to add to all_translators, causing a bit of time waste debugging (I also did this at least once)

Also updated integration tests to use this new pattern (all tests seem to pass, after some tweaks)

Since the records are boxed now, can't really use PartialEq to compare in tests, thus it's implemented manually by just comparing debug output. Btw this also helped in program requisition tests (where sorting is done by debug output comparision)

# 🧪 How has/should this change been tested? 

Can run full test, including integrations. I think as part of full central server test, can do a sync regression test

## 💌 Any notes for the reviewer?

Well, first of all sorry about the mass changes, and thanks for your patience : ). I've made docs with diagram in the follow up PR, maybe worth checking out first. Also I think the examples commits of the difference between before and after are worth checking out first
