### PR TITLE
2800 foreign currency store pref

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "1.6.00",
+  "version": "1.7.00",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/graphql/types/src/types/store_preference.rs
+++ b/server/graphql/types/src/types/store_preference.rs
@@ -34,6 +34,10 @@ impl StorePreferenceNode {
     pub async fn vaccine_module(&self) -> &bool {
         &self.store_preference.vaccine_module
     }
+
+    pub async fn issue_in_foreign_currency(&self) -> &bool {
+        &self.store_preference.issue_in_foreign_currency
+    }
 }
 
 impl StorePreferenceNode {

--- a/server/repository/src/db_diesel/store_preference_row.rs
+++ b/server/repository/src/db_diesel/store_preference_row.rs
@@ -19,6 +19,7 @@ table! {
         request_requisition_requires_authorisation -> Bool,
         om_program_module -> Bool,
         vaccine_module -> Bool,
+        issue_in_foreign_currency -> Bool,
     }
 }
 
@@ -45,6 +46,7 @@ pub struct StorePreferenceRow {
     pub request_requisition_requires_authorisation: bool,
     pub om_program_module: bool,
     pub vaccine_module: bool,
+    pub issue_in_foreign_currency: bool,
 }
 
 impl Default for StorePreferenceRow {
@@ -57,6 +59,7 @@ impl Default for StorePreferenceRow {
             request_requisition_requires_authorisation: Default::default(),
             om_program_module: Default::default(),
             vaccine_module: Default::default(),
+            issue_in_foreign_currency: Default::default(),
         }
     }
 }

--- a/server/repository/src/migrations/mod.rs
+++ b/server/repository/src/migrations/mod.rs
@@ -16,6 +16,7 @@ mod v1_04_00;
 mod v1_05_00;
 mod v1_05_04;
 mod v1_06_00;
+mod v1_07_00;
 mod version;
 
 pub(crate) use self::types::*;
@@ -89,6 +90,7 @@ pub fn migrate(
         Box::new(v1_05_00::V1_05_00),
         Box::new(v1_05_04::V1_05_04),
         Box::new(v1_06_00::V1_06_00),
+        Box::new(v1_07_00::V1_07_00),
     ];
 
     // Historic diesel migrations

--- a/server/repository/src/migrations/v1_07_00/mod.rs
+++ b/server/repository/src/migrations/v1_07_00/mod.rs
@@ -1,0 +1,38 @@
+use super::{version::Version, Migration};
+
+use crate::StorageConnection;
+
+mod store_preference_add_issue_in_foreign_currency;
+
+pub(crate) struct V1_07_00;
+
+impl Migration for V1_07_00 {
+    fn version(&self) -> Version {
+        Version::from_str("1.7.0")
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        store_preference_add_issue_in_foreign_currency::migrate(connection)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[actix_rt::test]
+async fn migration_1_07_00() {
+    use crate::migrations::*;
+    use crate::test_db::*;
+
+    let version = V1_07_00.version();
+
+    // This test allows checking sql syntax
+    let SetupResult { connection, .. } = setup_test(SetupOption {
+        db_name: &format!("migration_{version}"),
+        version: Some(version.clone()),
+        ..Default::default()
+    })
+    .await;
+
+    assert_eq!(get_database_version(&connection), version);
+}

--- a/server/repository/src/migrations/v1_07_00/store_preference_add_issue_in_foreign_currency.rs
+++ b/server/repository/src/migrations/v1_07_00/store_preference_add_issue_in_foreign_currency.rs
@@ -1,0 +1,14 @@
+use crate::StorageConnection;
+
+pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
+    use crate::migrations::sql;
+
+    sql!(
+        connection,
+        r#"
+            ALTER TABLE store_preference ADD COLUMN issue_in_foreign_currency bool NOT NULL DEFAULT false;
+        "#
+    )?;
+
+    Ok(())
+}

--- a/server/service/src/sync/test/test_data/store_preference.rs
+++ b/server/service/src/sync/test/test_data/store_preference.rs
@@ -19,7 +19,7 @@ const STORE_PREFERENCE_1: (&'static str, &'static str) = (
         "can_enter_total_distribution_quantities": false,
         "round_up_distribute_quantities": false,
         "can_pack_items_into_multiple_boxes": false,
-        "can_issue_in_foreign_currency": false,
+        "can_issue_in_foreign_currency": true,
         "edit_sell_price_on_customer_invoice_lines": false,
         "purchase_order_must_be_authorised": false,
         "finalise_customer_invoices_automatically": false,
@@ -148,6 +148,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 request_requisition_requires_authorisation: false,
                 om_program_module: true,
                 vaccine_module: false,
+                issue_in_foreign_currency: true,
             }),
         ),
         TestSyncPullRecord::new_pull_upsert(
@@ -162,6 +163,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 // This one is missing, should default to false
                 om_program_module: false,
                 vaccine_module: true,
+                issue_in_foreign_currency: false,
             }),
         ),
     ]

--- a/server/service/src/sync/translations/store_preference.rs
+++ b/server/service/src/sync/translations/store_preference.rs
@@ -39,6 +39,8 @@ pub struct LegacyPrefData {
     pub om_program_module: bool,
     #[serde(rename = "usesVaccineModule")]
     pub vaccine_module: bool,
+    #[serde(rename = "can_issue_in_foreign_currency")]
+    pub issue_in_foreign_currency: bool,
 }
 
 pub(crate) struct StorePreferenceTranslation {}
@@ -73,6 +75,7 @@ impl SyncTranslation for StorePreferenceTranslation {
             request_requisition_requires_authorisation,
             om_program_module,
             vaccine_module,
+            issue_in_foreign_currency,
         } = data;
 
         let result = StorePreferenceRow {
@@ -83,6 +86,7 @@ impl SyncTranslation for StorePreferenceTranslation {
             request_requisition_requires_authorisation,
             om_program_module,
             vaccine_module,
+            issue_in_foreign_currency,
         };
 
         Ok(Some(IntegrationRecords::from_upsert(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2800

# 👩🏻‍💻 What does this PR do? 
- Adds `issue_in_foreign_currency` to store pref
- Sync `issue_in_foreign_currency`
- Add to `StorePreferenceNode`

# 🧪 How has/should this change been tested? 
- [ ] Run tests