### PR TITLE
Rename name_link_id and clinician_link_id for the InvoiceRow

### DIFF
--- a/server/cli/src/refresh_dates.rs
+++ b/server/cli/src/refresh_dates.rs
@@ -363,7 +363,7 @@ mod tests {
         fn invoice1() -> InvoiceRow {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = "invoice1".to_string();
-                r.name_id = mock_name_a().id;
+                r.name_link_id = mock_name_a().id;
                 r.store_id = mock_store_a().id;
                 r.created_datetime = NaiveDate::from_ymd_opt(2021, 01, 01)
                     .unwrap()
@@ -375,7 +375,7 @@ mod tests {
         fn invoice2() -> InvoiceRow {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = "invoice2".to_string();
-                r.name_id = mock_name_a().id;
+                r.name_link_id = mock_name_a().id;
                 r.store_id = mock_store_a().id;
                 r.created_datetime = NaiveDate::from_ymd_opt(2021, 02, 01)
                     .unwrap()

--- a/server/graphql/invoice/src/mutations/outbound_shipment/delete.rs
+++ b/server/graphql/invoice/src/mutations/outbound_shipment/delete.rs
@@ -117,7 +117,7 @@ mod graphql {
         fn shipped_outbound_shipment() -> InvoiceRow {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = "shipped_outbound_shipment".to_string();
-                r.name_id = String::from("name_store_a");
+                r.name_link_id = String::from("name_store_a");
                 r.store_id = String::from("store_a");
                 r.invoice_number = 3;
                 r.r#type = InvoiceRowType::OutboundShipment;
@@ -140,7 +140,7 @@ mod graphql {
         fn outbound_shipment_no_lines() -> InvoiceRow {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = String::from("outbound_shipment_no_lines_test");
-                r.name_id = String::from("name_store_a");
+                r.name_link_id = String::from("name_store_a");
                 r.store_id = String::from("store_a");
                 r.r#type = InvoiceRowType::OutboundShipment;
                 r.status = InvoiceRowStatus::Picked;

--- a/server/repository/src/db_diesel/changelog/test.rs
+++ b/server/repository/src/db_diesel/changelog/test.rs
@@ -348,7 +348,7 @@ async fn test_changelog_name_and_store_id_in_trigger() {
     fn invoice() -> InvoiceRow {
         inline_init(|r: &mut InvoiceRow| {
             r.id = "invoice".to_string();
-            r.name_id = name().id;
+            r.name_link_id = name().id;
             r.store_id = store().id;
         })
     }
@@ -398,7 +398,7 @@ async fn test_changelog_name_and_store_id_in_trigger() {
         TestRecord {
             record: invoice_line(),
             record_id: invoice_line().id,
-            name_id: invoice().name_id,
+            name_id: invoice().name_link_id,
             store_id: invoice().store_id,
         },
         ChangelogAction::Upsert,
@@ -414,7 +414,7 @@ async fn test_changelog_name_and_store_id_in_trigger() {
         TestRecord {
             record: invoice_line(),
             record_id: invoice_line().id,
-            name_id: invoice().name_id,
+            name_id: invoice().name_link_id,
             store_id: invoice().store_id,
         },
         ChangelogAction::Upsert,
@@ -432,7 +432,7 @@ async fn test_changelog_name_and_store_id_in_trigger() {
         TestRecord {
             record: invoice_line(),
             record_id: invoice_line().id,
-            name_id: invoice().name_id,
+            name_id: invoice().name_link_id,
             store_id: invoice().store_id,
         },
         ChangelogAction::Delete,
@@ -450,7 +450,7 @@ async fn test_changelog_name_and_store_id_in_trigger() {
         TestRecord {
             record: invoice(),
             record_id: invoice().id,
-            name_id: invoice().name_id,
+            name_id: invoice().name_link_id,
             store_id: invoice().store_id,
         },
         ChangelogAction::Upsert,
@@ -466,7 +466,7 @@ async fn test_changelog_name_and_store_id_in_trigger() {
         TestRecord {
             record: invoice(),
             record_id: invoice().id,
-            name_id: invoice().name_id,
+            name_id: invoice().name_link_id,
             store_id: invoice().store_id,
         },
         ChangelogAction::Upsert,
@@ -480,7 +480,7 @@ async fn test_changelog_name_and_store_id_in_trigger() {
         TestRecord {
             record: invoice(),
             record_id: invoice().id,
-            name_id: invoice().name_id,
+            name_id: invoice().name_link_id,
             store_id: invoice().store_id,
         },
         ChangelogAction::Delete,

--- a/server/repository/src/db_diesel/filter_restriction.rs
+++ b/server/repository/src/db_diesel/filter_restriction.rs
@@ -30,7 +30,7 @@ mod tests {
     fn mock_invoice_a() -> InvoiceRow {
         inline_init(|r: &mut InvoiceRow| {
             r.id = "invoice1".to_string();
-            r.name_id = mock_name_a().id;
+            r.name_link_id = mock_name_a().id;
             r.store_id = "store_a".to_string();
             r.user_id = Some("A".to_string());
         })
@@ -39,7 +39,7 @@ mod tests {
     fn mock_invoice_b() -> InvoiceRow {
         inline_init(|r: &mut InvoiceRow| {
             r.id = "invoice2".to_string();
-            r.name_id = mock_name_a().id;
+            r.name_link_id = mock_name_a().id;
             r.store_id = "store_a".to_string();
             r.user_id = Some("B".to_string());
         })
@@ -48,7 +48,7 @@ mod tests {
     fn mock_invoice_excluded() -> InvoiceRow {
         inline_init(|r: &mut InvoiceRow| {
             r.id = "invoice3".to_string();
-            r.name_id = mock_name_a().id;
+            r.name_link_id = mock_name_a().id;
             r.store_id = "store_a".to_string();
             r.user_id = Some("Excluded".to_string());
         })
@@ -57,7 +57,7 @@ mod tests {
     fn mock_invoice_none() -> InvoiceRow {
         inline_init(|r: &mut InvoiceRow| {
             r.id = "invoice4".to_string();
-            r.name_id = mock_name_a().id;
+            r.name_link_id = mock_name_a().id;
             r.store_id = "store_a".to_string();
             r.user_id = None;
         })

--- a/server/repository/src/db_diesel/invoice.rs
+++ b/server/repository/src/db_diesel/invoice.rs
@@ -202,7 +202,7 @@ type BoxedInvoiceQuery = IntoBoxed<
     DBType,
 >;
 
-fn create_filtered_query<'a>(filter: Option<InvoiceFilter>) -> BoxedInvoiceQuery {
+fn create_filtered_query(filter: Option<InvoiceFilter>) -> BoxedInvoiceQuery {
     let mut query = invoice_dsl::invoice
         .inner_join(name_link_dsl::name_link.inner_join(name_dsl::name))
         .inner_join(store_dsl::store)
@@ -438,7 +438,7 @@ impl Invoice {
         &self.name_row.name
     }
     pub fn other_party_id(&self) -> &str {
-        &self.invoice_row.name_id
+        &self.name_row.id
     }
     pub fn other_party_store_id(&self) -> &Option<String> {
         &self.invoice_row.name_store_id

--- a/server/repository/src/db_diesel/invoice_row.rs
+++ b/server/repository/src/db_diesel/invoice_row.rs
@@ -79,8 +79,7 @@ pub enum InvoiceRowStatus {
 #[table_name = "invoice"]
 pub struct InvoiceRow {
     pub id: String,
-    #[column_name = "name_link_id"]
-    pub name_id: String,
+    pub name_link_id: String,
     pub name_store_id: Option<String>,
     pub store_id: String,
     pub user_id: Option<String>,
@@ -102,8 +101,7 @@ pub struct InvoiceRow {
     pub requisition_id: Option<String>,
     pub linked_invoice_id: Option<String>,
     pub tax: Option<f64>,
-    #[column_name = "clinician_link_id"]
-    pub clinician_id: Option<String>,
+    pub clinician_link_id: Option<String>,
 }
 
 impl Default for InvoiceRow {
@@ -115,7 +113,7 @@ impl Default for InvoiceRow {
             // Defaults
             id: Default::default(),
             user_id: Default::default(),
-            name_id: Default::default(),
+            name_link_id: Default::default(),
             name_store_id: Default::default(),
             store_id: Default::default(),
             invoice_number: Default::default(),
@@ -132,7 +130,7 @@ impl Default for InvoiceRow {
             requisition_id: Default::default(),
             linked_invoice_id: Default::default(),
             tax: Default::default(),
-            clinician_id: Default::default(),
+            clinician_link_id: Default::default(),
         }
     }
 }

--- a/server/repository/src/db_diesel/stock_movement.rs
+++ b/server/repository/src/db_diesel/stock_movement.rs
@@ -149,7 +149,7 @@ mod test {
                 r.invoices = vec![inline_init(|r: &mut InvoiceRow| {
                     r.id = invoice_id.clone();
                     r.store_id = store().id;
-                    r.name_id = mock_name_a().id;
+                    r.name_link_id = mock_name_a().id;
                     r.r#type = InvoiceRowType::OutboundShipment;
                 })];
                 r.invoice_lines = vec![inline_init(|r: &mut InvoiceLineRow| {

--- a/server/repository/src/mock/full_invoice.rs
+++ b/server/repository/src/mock/full_invoice.rs
@@ -19,7 +19,7 @@ pub fn mock_full_draft_outbound_shipment_a() -> FullMockInvoice {
     FullMockInvoice {
         invoice: inline_init(|r: &mut InvoiceRow| {
             r.id = invoice_id.clone();
-            r.name_id = String::from("name_store_b");
+            r.name_link_id = String::from("name_store_b");
             r.store_id = String::from("store_c");
             r.invoice_number = 10;
             r.r#type = InvoiceRowType::OutboundShipment;
@@ -95,7 +95,7 @@ pub fn mock_full_draft_inbound_shipment_on_hold() -> FullMockInvoice {
     FullMockInvoice {
         invoice: inline_init(|r: &mut InvoiceRow| {
             r.id = invoice_id.clone();
-            r.name_id = String::from("name_store_a");
+            r.name_link_id = String::from("name_store_a");
             r.store_id = String::from("store_a");
             r.invoice_number = 11;
             r.r#type = InvoiceRowType::InboundShipment;
@@ -116,7 +116,7 @@ pub fn mock_full_draft_outbound_shipment_on_hold() -> FullMockInvoice {
     FullMockInvoice {
         invoice: inline_init(|r: &mut InvoiceRow| {
             r.id = invoice_id.clone();
-            r.name_id = String::from("name_store_a");
+            r.name_link_id = String::from("name_store_a");
             r.store_id = String::from("store_c");
             r.invoice_number = 11;
             r.r#type = InvoiceRowType::OutboundShipment;

--- a/server/repository/src/mock/invoice.rs
+++ b/server/repository/src/mock/invoice.rs
@@ -6,7 +6,7 @@ use crate::{InvoiceLineRow, InvoiceLineRowType, InvoiceRow, InvoiceRowStatus, In
 pub fn mock_outbound_shipment_a() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("outbound_shipment_a");
-        r.name_id = String::from("name_store_a");
+        r.name_link_id = String::from("name_store_a");
         r.store_id = String::from("store_b");
         r.invoice_number = 1;
         r.r#type = InvoiceRowType::OutboundShipment;
@@ -24,7 +24,7 @@ pub fn mock_outbound_shipment_a() -> InvoiceRow {
 pub fn mock_outbound_shipment_b() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("outbound_shipment_b");
-        r.name_id = String::from("name_store_a");
+        r.name_link_id = String::from("name_store_a");
         r.store_id = String::from("store_c");
         r.invoice_number = 2;
         r.r#type = InvoiceRowType::OutboundShipment;
@@ -49,7 +49,7 @@ pub fn mock_outbound_shipment_b() -> InvoiceRow {
 pub fn mock_outbound_shipment_c() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("outbound_shipment_c");
-        r.name_id = String::from("name_store_a");
+        r.name_link_id = String::from("name_store_a");
         r.store_id = String::from("store_c");
         r.invoice_number = 3;
         r.r#type = InvoiceRowType::OutboundShipment;
@@ -66,7 +66,7 @@ pub fn mock_outbound_shipment_c() -> InvoiceRow {
 pub fn mock_outbound_shipment_d() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("outbound_shipment_d");
-        r.name_id = String::from("name_store_a");
+        r.name_link_id = String::from("name_store_a");
         r.store_id = String::from("store_c");
         r.invoice_number = 9;
         r.r#type = InvoiceRowType::OutboundShipment;
@@ -95,7 +95,7 @@ pub fn mock_outbound_shipment_d() -> InvoiceRow {
 pub fn mock_outbound_shipment_e() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("outbound_shipment_e");
-        r.name_id = String::from("name_store_a");
+        r.name_link_id = String::from("name_store_a");
         r.store_id = String::from("store_a");
         r.invoice_number = 3;
         r.r#type = InvoiceRowType::OutboundShipment;
@@ -113,7 +113,7 @@ pub fn mock_outbound_shipment_e() -> InvoiceRow {
 pub fn mock_outbound_shipment_picked() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("outbound_shipment_picked");
-        r.name_id = String::from("name_store_a");
+        r.name_link_id = String::from("name_store_a");
         r.store_id = String::from("store_c");
         r.invoice_number = 3;
         r.r#type = InvoiceRowType::OutboundShipment;
@@ -137,7 +137,7 @@ pub fn mock_outbound_shipment_picked() -> InvoiceRow {
 pub fn mock_outbound_shipment_shipped() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("outbound_shipment_shipped");
-        r.name_id = String::from("name_store_a");
+        r.name_link_id = String::from("name_store_a");
         r.store_id = String::from("store_c");
         r.invoice_number = 3;
         r.r#type = InvoiceRowType::OutboundShipment;
@@ -163,7 +163,7 @@ pub fn mock_outbound_shipment_shipped() -> InvoiceRow {
 pub fn mock_outbound_shipment_no_lines() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("outbound_shipment_no_lines");
-        r.name_id = String::from("name_store_a");
+        r.name_link_id = String::from("name_store_a");
         r.store_id = String::from("store_c");
         r.invoice_number = 3;
         r.r#type = InvoiceRowType::OutboundShipment;
@@ -187,7 +187,7 @@ pub fn mock_outbound_shipment_no_lines() -> InvoiceRow {
 pub fn mock_new_outbound_shipment_no_lines() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("new_outbound_shipment_no_lines");
-        r.name_id = String::from("name_store_a");
+        r.name_link_id = String::from("name_store_a");
         r.store_id = String::from("store_c");
         r.r#type = InvoiceRowType::OutboundShipment;
         r.status = InvoiceRowStatus::New;
@@ -197,7 +197,7 @@ pub fn mock_new_outbound_shipment_no_lines() -> InvoiceRow {
 pub fn mock_new_outbound_shipment_no_stockline() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("mock_new_outbound_shipment_no_stockline");
-        r.name_id = String::from("name_store_a");
+        r.name_link_id = String::from("name_store_a");
         r.store_id = String::from("store_c");
         r.r#type = InvoiceRowType::OutboundShipment;
         r.status = InvoiceRowStatus::New;
@@ -211,7 +211,7 @@ pub fn mock_new_outbound_shipment_no_stockline() -> InvoiceRow {
 pub fn mock_outbound_shipment_on_hold() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("outbound_shipment_on_hold");
-        r.name_id = String::from("name_store_a");
+        r.name_link_id = String::from("name_store_a");
         r.store_id = String::from("store_a");
         r.invoice_number = 10;
         r.on_hold = true;
@@ -235,7 +235,7 @@ pub fn mock_outbound_shipment_on_hold() -> InvoiceRow {
 pub fn mock_inbound_shipment_a() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("inbound_shipment_a");
-        r.name_id = String::from("name_store_b");
+        r.name_link_id = String::from("name_store_b");
         r.store_id = String::from("store_a");
         r.invoice_number = 4;
         r.r#type = InvoiceRowType::InboundShipment;
@@ -253,7 +253,7 @@ pub fn mock_inbound_shipment_a() -> InvoiceRow {
 pub fn mock_inbound_shipment_b() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("inbound_shipment_b");
-        r.name_id = String::from("name_store_c");
+        r.name_link_id = String::from("name_store_c");
         r.store_id = String::from("store_a");
         r.invoice_number = 5;
         r.r#type = InvoiceRowType::InboundShipment;
@@ -278,7 +278,7 @@ pub fn mock_inbound_shipment_b() -> InvoiceRow {
 pub fn mock_inbound_shipment_c() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("inbound_shipment_c");
-        r.name_id = String::from("name_store_c");
+        r.name_link_id = String::from("name_store_c");
         r.store_id = String::from("store_a");
         r.invoice_number = 6;
         r.r#type = InvoiceRowType::InboundShipment;
@@ -295,7 +295,7 @@ pub fn mock_inbound_shipment_c() -> InvoiceRow {
 pub fn mock_inbound_shipment_d() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("inbound_shipment_d");
-        r.name_id = String::from("name_store_c");
+        r.name_link_id = String::from("name_store_c");
         r.store_id = String::from("store_a");
         r.invoice_number = 7;
         r.r#type = InvoiceRowType::InboundShipment;
@@ -318,7 +318,7 @@ pub fn mock_inbound_shipment_d() -> InvoiceRow {
 pub fn mock_inbound_shipment_e() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("inbound_shipment_e");
-        r.name_id = String::from("name_store_c");
+        r.name_link_id = String::from("name_store_c");
         r.store_id = String::from("store_a");
         r.invoice_number = 7;
         r.r#type = InvoiceRowType::InboundShipment;
@@ -336,7 +336,7 @@ pub fn mock_inbound_shipment_e() -> InvoiceRow {
 pub fn mock_empty_draft_inbound_shipment() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("empty_draft_inbound_shipment");
-        r.name_id = String::from("name_store_c");
+        r.name_link_id = String::from("name_store_c");
         r.store_id = String::from("store_a");
         r.invoice_number = 8;
         r.r#type = InvoiceRowType::InboundShipment;
@@ -353,7 +353,7 @@ pub fn mock_empty_draft_inbound_shipment() -> InvoiceRow {
 pub fn mock_unique_number_inbound_shipment() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("mock_unique_number_inbound_shipment");
-        r.name_id = String::from("name_store_c");
+        r.name_link_id = String::from("name_store_c");
         r.store_id = String::from("store_a");
         r.name_store_id = Some(String::from("store_a"));
         r.invoice_number = 9999999;
@@ -386,7 +386,7 @@ pub fn mock_outbound_shipment_line_a() -> InvoiceLineRow {
 pub fn mock_prescription_a() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("prescription_a");
-        r.name_id = String::from("testId");
+        r.name_link_id = String::from("testId");
         r.store_id = String::from("store_a");
         r.invoice_number = 1;
         r.r#type = InvoiceRowType::Prescription;
@@ -401,7 +401,7 @@ pub fn mock_prescription_a() -> InvoiceRow {
 pub fn mock_prescription_picked() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("prescription_picked");
-        r.name_id = String::from("testId");
+        r.name_link_id = String::from("testId");
         r.store_id = String::from("store_a");
         r.invoice_number = 1;
         r.r#type = InvoiceRowType::Prescription;
@@ -416,7 +416,7 @@ pub fn mock_prescription_picked() -> InvoiceRow {
 pub fn mock_prescription_verified() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("prescription_verified");
-        r.name_id = String::from("testId");
+        r.name_link_id = String::from("testId");
         r.store_id = String::from("store_a");
         r.invoice_number = 1;
         r.r#type = InvoiceRowType::Prescription;

--- a/server/repository/src/mock/test_invoice_count_service.rs
+++ b/server/repository/src/mock/test_invoice_count_service.rs
@@ -8,7 +8,7 @@ use super::MockData;
 pub fn mock_inbound_shipment_invoice_count_service_a() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("inbound_shipment_invoice_count_a");
-        r.name_id = String::from("name_store_b");
+        r.name_link_id = String::from("name_store_b");
         r.store_id = String::from("store_a");
         r.invoice_number = 4;
         r.r#type = InvoiceRowType::InboundShipment;
@@ -25,7 +25,7 @@ pub fn mock_inbound_shipment_invoice_count_service_a() -> InvoiceRow {
 pub fn mock_inbound_shipment_invoice_count_service_b() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("inbound_shipment_invoice_count_b");
-        r.name_id = String::from("name_store_b");
+        r.name_link_id = String::from("name_store_b");
         r.store_id = String::from("store_a");
         r.invoice_number = 4;
         r.r#type = InvoiceRowType::InboundShipment;

--- a/server/repository/src/mock/test_invoice_loaders.rs
+++ b/server/repository/src/mock/test_invoice_loaders.rs
@@ -36,7 +36,7 @@ pub fn mock_invoice_loader_requisition1() -> RequisitionRow {
 pub fn mock_invoice_loader_invoice1() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = "mock_invoice_loader_invoice1".to_string();
-        r.name_id = mock_name_store_b().id;
+        r.name_link_id = mock_name_store_b().id;
         r.store_id = mock_store_a().id;
         r.invoice_number = 1;
         r.requisition_id = Some(mock_invoice_loader_requisition1().id);
@@ -52,7 +52,7 @@ pub fn mock_invoice_loader_invoice1() -> InvoiceRow {
 pub fn mock_invoice_loader_invoice2() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = "mock_invoice_loader_invoice2".to_string();
-        r.name_id = mock_name_store_b().id;
+        r.name_link_id = mock_name_store_b().id;
         r.store_id = mock_store_a().id;
         r.invoice_number = 1;
         r.r#type = InvoiceRowType::OutboundShipment;

--- a/server/repository/src/mock/test_item_stats.rs
+++ b/server/repository/src/mock/test_item_stats.rs
@@ -17,7 +17,7 @@ fn consumption_points() -> MockData {
         r.invoices = vec![inline_init(|r: &mut InvoiceRow| {
             r.id = invoice_id.clone();
             r.store_id = mock_store_a().id;
-            r.name_id = mock_name_a().id;
+            r.name_link_id = mock_name_a().id;
             r.r#type = InvoiceRowType::OutboundShipment;
         })];
         r.invoice_lines = vec![

--- a/server/repository/src/mock/test_outbound_shipment_update.rs
+++ b/server/repository/src/mock/test_outbound_shipment_update.rs
@@ -45,7 +45,7 @@ fn mock_item_with_no_stock_line() -> ItemRow {
 fn mock_outbound_shipment_invalid_stock_line() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = String::from("outbound_shipment_invalid_stock_line");
-        r.name_id = String::from("name_store_a");
+        r.name_link_id = String::from("name_store_a");
         r.store_id = String::from("store_c");
         r.invoice_number = 3;
         r.r#type = InvoiceRowType::OutboundShipment;

--- a/server/repository/src/mock/test_remaining_to_supply.rs
+++ b/server/repository/src/mock/test_remaining_to_supply.rs
@@ -21,7 +21,7 @@ pub fn linked_invoice_1() -> InvoiceRow {
         r.id = "lined_invoice_1".to_string();
         r.r#type = InvoiceRowType::OutboundShipment;
         r.requisition_id = Some(requisition().id);
-        r.name_id = mock_name_a().id;
+        r.name_link_id = mock_name_a().id;
         r.store_id = mock_store_a().id;
     })
 }
@@ -31,7 +31,7 @@ pub fn linked_invoice_2() -> InvoiceRow {
         r.r#type = InvoiceRowType::OutboundShipment;
         r.status = InvoiceRowStatus::Picked;
         r.requisition_id = Some(requisition().id);
-        r.name_id = mock_name_a().id;
+        r.name_link_id = mock_name_a().id;
         r.store_id = mock_store_a().id;
     })
 }

--- a/server/repository/src/mock/test_requisition_queries.rs
+++ b/server/repository/src/mock/test_requisition_queries.rs
@@ -164,7 +164,7 @@ pub fn mock_invoice1_linked_to_requisition() -> FullMockInvoice {
     FullMockInvoice {
         invoice: inline_init(|r: &mut InvoiceRow| {
             r.id = invoice_id.clone();
-            r.name_id = mock_name_a().id;
+            r.name_link_id = mock_name_a().id;
             r.store_id = "store_a".to_owned();
             r.invoice_number = 20;
             r.r#type = InvoiceRowType::InboundShipment;
@@ -267,7 +267,7 @@ pub fn mock_invoice2_linked_to_requisition() -> FullMockInvoice {
     FullMockInvoice {
         invoice: inline_init(|r: &mut InvoiceRow| {
             r.id = invoice_id.clone();
-            r.name_id = mock_name_a().id;
+            r.name_link_id = mock_name_a().id;
             r.store_id = "store_a".to_owned();
             r.invoice_number = 20;
             r.r#type = InvoiceRowType::InboundShipment;
@@ -328,7 +328,7 @@ pub fn mock_invoice3_linked_to_requisition() -> FullMockInvoice {
     FullMockInvoice {
         invoice: inline_init(|r: &mut InvoiceRow| {
             r.id = invoice_id.clone();
-            r.name_id = mock_name_a().id;
+            r.name_link_id = mock_name_a().id;
             r.store_id = "store_a".to_owned();
             r.invoice_number = 20;
             r.r#type = InvoiceRowType::OutboundShipment;

--- a/server/repository/src/mock/test_requisition_service.rs
+++ b/server/repository/src/mock/test_requisition_service.rs
@@ -357,7 +357,7 @@ pub fn mock_new_response_requisition_test_invoice() -> FullMockInvoice {
     FullMockInvoice {
         invoice: inline_init(|r: &mut InvoiceRow| {
             r.id = invoice_id.clone();
-            r.name_id = mock_name_a().id;
+            r.name_link_id = mock_name_a().id;
             r.store_id = "store_a".to_owned();
             r.invoice_number = 20;
             r.requisition_id = Some(mock_new_response_requisition_test().requisition.id);

--- a/server/repository/src/mock/test_service_lines.rs
+++ b/server/repository/src/mock/test_service_lines.rs
@@ -26,7 +26,7 @@ pub fn mock_test_service_item() -> MockData {
 pub fn mock_draft_outbound_with_service_lines() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = "mock_draft_outbound_with_service_lines".to_string();
-        r.name_id = mock_name_a().id;
+        r.name_link_id = mock_name_a().id;
         r.store_id = "store_a".to_owned();
         r.r#type = InvoiceRowType::OutboundShipment;
         r.status = InvoiceRowStatus::New;
@@ -44,7 +44,7 @@ pub fn mock_draft_outbound_service_line() -> InvoiceLineRow {
 pub fn mock_draft_outbound_shipped_with_service_lines() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = "mock_draft_outbound_shipped_with_service_lines".to_string();
-        r.name_id = mock_name_a().id;
+        r.name_link_id = mock_name_a().id;
         r.store_id = "store_a".to_owned();
         r.r#type = InvoiceRowType::OutboundShipment;
         r.status = InvoiceRowStatus::Shipped;
@@ -64,7 +64,7 @@ pub fn mock_draft_outbound_shipped_service_line() -> InvoiceLineRow {
 pub fn mock_draft_inbound_shipment_with_service_lines() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = "mock_draft_inbound_shipment_with_service_lines".to_string();
-        r.name_id = mock_name_a().id;
+        r.name_link_id = mock_name_a().id;
         r.store_id = "store_a".to_owned();
         r.r#type = InvoiceRowType::InboundShipment;
         r.status = InvoiceRowStatus::New;
@@ -82,7 +82,7 @@ pub fn mock_draft_inbound_service_line() -> InvoiceLineRow {
 pub fn mock_draft_inbound_shipment_no_lines() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = "mock_draft_inbound_shipment_no_lines".to_string();
-        r.name_id = mock_name_a().id;
+        r.name_link_id = mock_name_a().id;
         r.store_id = "store_a".to_owned();
         r.r#type = InvoiceRowType::InboundShipment;
         r.status = InvoiceRowStatus::New;
@@ -92,7 +92,7 @@ pub fn mock_draft_inbound_shipment_no_lines() -> InvoiceRow {
 pub fn mock_draft_inbound_verified_with_service_lines() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = "mock_draft_inbound_shipped_with_service_lines".to_string();
-        r.name_id = mock_name_a().id;
+        r.name_link_id = mock_name_a().id;
         r.store_id = "store_a".to_owned();
         r.r#type = InvoiceRowType::InboundShipment;
         r.status = InvoiceRowStatus::Verified;

--- a/server/repository/src/mock/test_unallocated_line.rs
+++ b/server/repository/src/mock/test_unallocated_line.rs
@@ -22,7 +22,7 @@ pub fn mock_test_unallocated_line() -> MockData {
 pub fn mock_new_invoice_with_unallocated_line() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = "unallocated_line_new_invoice".to_owned();
-        r.name_id = "name_store_a".to_owned();
+        r.name_link_id = "name_store_a".to_owned();
         r.store_id = "store_c".to_owned();
         r.invoice_number = 1;
         r.r#type = InvoiceRowType::OutboundShipment;
@@ -63,7 +63,7 @@ pub fn mock_unallocated_line() -> InvoiceLineRow {
 pub fn mock_new_invoice_with_unallocated_line2() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = "unallocated_line_new_invoice2".to_owned();
-        r.name_id = "name_store_a".to_owned();
+        r.name_link_id = "name_store_a".to_owned();
         r.store_id = "store_a".to_owned();
         r.invoice_number = 2;
         r.r#type = InvoiceRowType::OutboundShipment;
@@ -102,7 +102,7 @@ pub fn mock_unallocated_line2() -> InvoiceLineRow {
 pub fn mock_allocated_invoice() -> InvoiceRow {
     inline_init(|r: &mut InvoiceRow| {
         r.id = "unallocated_line_allocated_invoice".to_owned();
-        r.name_id = "name_store_a".to_owned();
+        r.name_link_id = "name_store_a".to_owned();
         r.store_id = "store_a".to_owned();
         r.invoice_number = 1;
         r.r#type = InvoiceRowType::OutboundShipment;

--- a/server/repository/src/tests.rs
+++ b/server/repository/src/tests.rs
@@ -116,7 +116,7 @@ mod repository_test {
         pub fn invoice_1() -> InvoiceRow {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = "invoice1".to_string();
-                r.name_id = name_1().id.to_string();
+                r.name_link_id = name_1().id.to_string();
                 r.store_id = store_1().id.to_string();
                 r.invoice_number = 12;
                 r.r#type = InvoiceRowType::InboundShipment;
@@ -131,7 +131,7 @@ mod repository_test {
         pub fn invoice_2() -> InvoiceRow {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = "invoice2".to_string();
-                r.name_id = name_1().id.to_string();
+                r.name_link_id = name_1().id.to_string();
                 r.store_id = store_1().id.to_string();
                 r.invoice_number = 12;
                 r.r#type = InvoiceRowType::OutboundShipment;
@@ -615,7 +615,7 @@ mod repository_test {
             .query_by_filter(
                 InvoiceFilter::new()
                     .r#type(InvoiceRowType::OutboundShipment.equal_to())
-                    .name_id(EqualFilter::equal_to(&item1.name_id)),
+                    .name_id(EqualFilter::equal_to(&item1.name_link_id)),
             )
             .unwrap();
         assert_eq!(1, loaded_item.len());

--- a/server/service/src/activity_log.rs
+++ b/server/service/src/activity_log.rs
@@ -127,7 +127,7 @@ mod test {
             inline_init(|r: &mut MockData| {
                 r.invoices = vec![inline_init(|r: &mut InvoiceRow| {
                     r.id = "test".to_string();
-                    r.name_id = mock_name_a().id;
+                    r.name_link_id = mock_name_a().id;
                     r.store_id = mock_store_a().id;
                     r.r#type = InvoiceRowType::OutboundShipment;
                     r.status = InvoiceRowStatus::Allocated;

--- a/server/service/src/dashboard/item_count.rs
+++ b/server/service/src/dashboard/item_count.rs
@@ -411,7 +411,7 @@ mod item_count_service_test {
                 ],
                 invoices: vec![InvoiceRow {
                     id: "invoice1".to_string(),
-                    name_id: "name_store_a".to_string(),
+                    name_link_id: "name_store_a".to_string(),
                     name_store_id: Some("store_a".to_string()),
                     store_id: mock_store_b().id,
                     picked_datetime: Some(Utc::now().naive_utc() - Duration::days(10)),
@@ -445,7 +445,7 @@ mod item_count_service_test {
         invoice_repository
             .upsert_one(&inline_init(|r: &mut InvoiceRow| {
                 r.id = "invoice2".to_string();
-                r.name_id = "name_store_a".to_string();
+                r.name_link_id = "name_store_a".to_string();
                 r.name_store_id = Some("store_a".to_string());
                 r.store_id = "store_b".to_string();
                 r.picked_datetime = Some(Utc::now().naive_utc() - Duration::days(10));

--- a/server/service/src/invoice/common.rs
+++ b/server/service/src/invoice/common.rs
@@ -1,7 +1,7 @@
 use repository::{
     EqualFilter, InvoiceLine, InvoiceLineFilter, InvoiceLineRepository, InvoiceLineRowType,
-    InvoiceRow, MasterList, MasterListFilter, MasterListRepository, RepositoryError, StockLineRow,
-    StorageConnection,
+    InvoiceRow, MasterList, MasterListFilter, MasterListRepository, NameLinkRowRepository,
+    RepositoryError, StockLineRow, StorageConnection,
 };
 use util::inline_edit;
 
@@ -42,15 +42,19 @@ pub struct AddToShipmentFromMasterListInput {
     pub master_list_id: String,
 }
 
-pub fn check_master_list_for_name(
+pub fn check_master_list_for_name_link_id(
     connection: &StorageConnection,
-    name_id: &str,
+    name_link_id: &str,
     master_list_id: &str,
 ) -> Result<Option<MasterList>, RepositoryError> {
+    let Some(name_link) = NameLinkRowRepository::new(connection).find_one_by_id(name_link_id)?
+    else {
+        return Ok(None);
+    };
     let mut rows = MasterListRepository::new(connection).query_by_filter(
         MasterListFilter::new()
             .id(EqualFilter::equal_to(master_list_id))
-            .exists_for_name_id(EqualFilter::equal_to(name_id)),
+            .exists_for_name_id(EqualFilter::equal_to(&name_link.name_id)),
     )?;
     Ok(rows.pop())
 }

--- a/server/service/src/invoice/inbound_shipment/insert/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/insert/generate.rs
@@ -28,7 +28,7 @@ pub fn generate(
     let result = InvoiceRow {
         id,
         user_id: Some(user_id.to_string()),
-        name_id: other_party_id,
+        name_link_id: other_party_id,
         name_store_id: other_party.store_id().map(|id| id.to_string()),
         r#type: InvoiceRowType::InboundShipment,
         comment,
@@ -49,7 +49,7 @@ pub fn generate(
         verified_datetime: None,
         linked_invoice_id: None,
         requisition_id: None,
-        clinician_id: None,
+        clinician_link_id: None,
     };
 
     Ok(result)

--- a/server/service/src/invoice/inbound_shipment/insert/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/insert/mod.rs
@@ -241,7 +241,7 @@ mod test {
         assert_eq!(
             invoice,
             inline_edit(&invoice, |mut u| {
-                u.name_id = supplier().id;
+                u.name_link_id = supplier().id;
                 u.user_id = Some(mock_user_account_a().id);
                 u
             })
@@ -266,7 +266,7 @@ mod test {
         assert_eq!(
             invoice,
             inline_edit(&invoice, |mut u| {
-                u.name_id = supplier().id;
+                u.name_link_id = supplier().id;
                 u.on_hold = true;
                 u
             })

--- a/server/service/src/invoice/inbound_shipment/update/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/update/generate.rs
@@ -56,7 +56,7 @@ pub(crate) fn generate(
 
     if let Some(other_party) = other_party_option {
         update_invoice.name_store_id = other_party.store_id().map(|id| id.to_string());
-        update_invoice.name_id = other_party.name_row.id;
+        update_invoice.name_link_id = other_party.name_row.id;
     }
 
     let batches_to_update = if should_create_batches {
@@ -65,7 +65,7 @@ pub(crate) fn generate(
             &update_invoice.store_id,
             &update_invoice.id,
             update_invoice.tax,
-            &update_invoice.name_id,
+            &update_invoice.name_link_id,
         )?)
     } else {
         None

--- a/server/service/src/invoice/inbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/update/mod.rs
@@ -346,7 +346,7 @@ mod test {
         fn invoice_tax_test() -> InvoiceRow {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = "invoice_tax_test".to_string();
-                r.name_id = "name_store_b".to_string();
+                r.name_link_id = "name_store_b".to_string();
                 r.store_id = "store_a".to_string();
                 r.invoice_number = 123;
                 r.r#type = InvoiceRowType::InboundShipment;
@@ -406,7 +406,7 @@ mod test {
         assert_eq!(
             invoice,
             inline_edit(&invoice, |mut u| {
-                u.name_id = supplier().id;
+                u.name_link_id = supplier().id;
                 u.user_id = Some(mock_user_account_a().id);
                 u
             })
@@ -691,6 +691,6 @@ mod test {
             })
         );
         assert_eq!(log.r#type, ActivityLogType::InvoiceStatusVerified);
-        assert_eq!(Some(invoice.name_id), stock_line.supplier_id);
+        assert_eq!(Some(invoice.name_link_id), stock_line.supplier_id);
     }
 }

--- a/server/service/src/invoice/outbound_shipment/add_from_master_list.rs
+++ b/server/service/src/invoice/outbound_shipment/add_from_master_list.rs
@@ -1,4 +1,4 @@
-use crate::invoice::common::check_master_list_for_name;
+use crate::invoice::common::check_master_list_for_name_link_id;
 use crate::invoice::common::get_lines_for_invoice;
 use crate::invoice::common::AddToShipmentFromMasterListInput as ServiceInput;
 use crate::{invoice::check_invoice_exists, service_provider::ServiceContext};
@@ -78,8 +78,12 @@ fn validate(
         return Err(OutError::NotAnOutboundShipment);
     }
 
-    check_master_list_for_name(connection, &invoice_row.name_id, &input.master_list_id)?
-        .ok_or(OutError::MasterListNotFoundForThisName)?;
+    check_master_list_for_name_link_id(
+        connection,
+        &invoice_row.name_link_id,
+        &input.master_list_id,
+    )?
+    .ok_or(OutError::MasterListNotFoundForThisName)?;
 
     Ok(invoice_row)
 }
@@ -230,7 +234,7 @@ mod test {
                 joins: vec![MasterListNameJoinRow {
                     id: join1,
                     master_list_id: id.clone(),
-                    name_id: mock_new_outbound_shipment_no_lines().name_id,
+                    name_id: mock_new_outbound_shipment_no_lines().name_link_id,
                 }],
                 lines: vec![
                     MasterListLineRow {

--- a/server/service/src/invoice/outbound_shipment/insert/generate.rs
+++ b/server/service/src/invoice/outbound_shipment/insert/generate.rs
@@ -21,7 +21,7 @@ pub fn generate(
     let result = InvoiceRow {
         id: input.id,
         user_id: Some(user_id.to_string()),
-        name_id: input.other_party_id,
+        name_link_id: input.other_party_id,
         r#type: InvoiceRowType::OutboundShipment,
         comment: input.comment,
         their_reference: input.their_reference,
@@ -42,7 +42,7 @@ pub fn generate(
         verified_datetime: None,
         linked_invoice_id: None,
         requisition_id: None,
-        clinician_id: None,
+        clinician_link_id: None,
     };
 
     Ok(result)

--- a/server/service/src/invoice/outbound_shipment/insert/mod.rs
+++ b/server/service/src/invoice/outbound_shipment/insert/mod.rs
@@ -245,7 +245,7 @@ mod test {
         assert_eq!(
             invoice,
             inline_edit(&invoice, |mut u| {
-                u.name_id = customer().id;
+                u.name_link_id = customer().id;
                 u.user_id = Some(mock_user_account_a().id);
                 u
             })
@@ -270,7 +270,7 @@ mod test {
         assert_eq!(
             invoice,
             inline_edit(&invoice, |mut u| {
-                u.name_id = customer().id;
+                u.name_link_id = customer().id;
                 u.on_hold = true;
                 u
             })

--- a/server/service/src/invoice/outbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/outbound_shipment/update/mod.rs
@@ -199,7 +199,7 @@ mod test {
         fn outbound_shipment_no_stock() -> InvoiceRow {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = String::from("outbound_shipment_no_stock");
-                r.name_id = String::from("name_store_a");
+                r.name_link_id = String::from("name_store_a");
                 r.store_id = String::from("store_a");
                 r.r#type = InvoiceRowType::OutboundShipment;
                 r.status = InvoiceRowStatus::Allocated;
@@ -330,7 +330,7 @@ mod test {
         fn invoice() -> InvoiceRow {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = "invoice".to_string();
-                r.name_id = mock_name_a().id;
+                r.name_link_id = mock_name_a().id;
                 r.store_id = mock_store_a().id;
                 r.r#type = InvoiceRowType::OutboundShipment;
             })
@@ -387,7 +387,7 @@ mod test {
         fn invoice() -> InvoiceRow {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = "test_invoice_pricing".to_string();
-                r.name_id = mock_name_a().id;
+                r.name_link_id = mock_name_a().id;
                 r.store_id = mock_store_a().id;
                 r.r#type = InvoiceRowType::OutboundShipment;
             })
@@ -541,7 +541,7 @@ mod test {
         fn invoice() -> InvoiceRow {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = "invoice".to_string();
-                r.name_id = mock_name_a().id;
+                r.name_link_id = mock_name_a().id;
                 r.store_id = mock_store_a().id;
                 r.r#type = InvoiceRowType::OutboundShipment;
             })

--- a/server/service/src/invoice/outbound_shipment/update_name/generate.rs
+++ b/server/service/src/invoice/outbound_shipment/update_name/generate.rs
@@ -32,7 +32,7 @@ pub fn generate(
 
     let mut new_invoice = InvoiceRow {
         id: uuid(),
-        name_id: input_other_party_id.unwrap_or(existing_invoice.name_id.clone()),
+        name_link_id: input_other_party_id.unwrap_or(existing_invoice.name_link_id.clone()),
         linked_invoice_id: None,
         ..old_invoice.clone()
     };
@@ -57,7 +57,7 @@ pub fn generate(
 
     if let Some(other_party) = other_party_option {
         new_invoice.name_store_id = other_party.store_id().map(|id| id.to_string());
-        new_invoice.name_id = other_party.name_row.id;
+        new_invoice.name_link_id = other_party.name_row.id;
     }
 
     let new_activity_log = ActivityLogRepository::new(connection)

--- a/server/service/src/invoice/outbound_shipment/update_name/mod.rs
+++ b/server/service/src/invoice/outbound_shipment/update_name/mod.rs
@@ -226,7 +226,7 @@ mod test {
         fn invoice() -> InvoiceRow {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = "test_invoice_pricing".to_string();
-                r.name_id = mock_name_a().id;
+                r.name_link_id = mock_name_a().id;
                 r.store_id = mock_store_c().id;
                 r.r#type = InvoiceRowType::OutboundShipment;
                 r.status = InvoiceRowStatus::Picked;
@@ -322,7 +322,10 @@ mod test {
                 .unwrap(),
             updated_invoice.invoice_row
         );
-        assert_ne!(updated_invoice.invoice_row.name_id, invoice().name_id);
+        assert_ne!(
+            updated_invoice.invoice_row.name_link_id,
+            invoice().name_link_id
+        );
         assert_eq!(
             updated_lines,
             vec![

--- a/server/service/src/invoice/prescription/insert/generate.rs
+++ b/server/service/src/invoice/prescription/insert/generate.rs
@@ -19,7 +19,7 @@ pub fn generate(
     let result = InvoiceRow {
         id,
         user_id: Some(user_id.to_string()),
-        name_id: patient_id,
+        name_link_id: patient_id,
         name_store_id: None,
         r#type: InvoiceRowType::Prescription,
         invoice_number: next_number(connection, &NumberRowType::Prescription, store_id)?,
@@ -40,7 +40,7 @@ pub fn generate(
         verified_datetime: None,
         linked_invoice_id: None,
         requisition_id: None,
-        clinician_id: None,
+        clinician_link_id: None,
     };
 
     Ok(result)

--- a/server/service/src/invoice/prescription/insert/mod.rs
+++ b/server/service/src/invoice/prescription/insert/mod.rs
@@ -232,7 +232,7 @@ mod test {
         assert_eq!(
             invoice,
             inline_edit(&invoice, |mut u| {
-                u.name_id = patient().id;
+                u.name_link_id = patient().id;
                 u.user_id = Some(mock_user_account_a().id);
                 u
             })

--- a/server/service/src/invoice/prescription/update/generate.rs
+++ b/server/service/src/invoice/prescription/update/generate.rs
@@ -35,8 +35,8 @@ pub(crate) fn generate(
 
     set_new_status_datetime(&mut update_invoice, &input_status);
 
-    update_invoice.name_id = input_patient_id.unwrap_or(update_invoice.name_id);
-    update_invoice.clinician_id = input_clinician_id.or(update_invoice.clinician_id);
+    update_invoice.name_link_id = input_patient_id.unwrap_or(update_invoice.name_link_id);
+    update_invoice.clinician_link_id = input_clinician_id.or(update_invoice.clinician_link_id);
     update_invoice.comment = input_comment.or(update_invoice.comment);
     update_invoice.colour = input_colour.or(update_invoice.colour);
 

--- a/server/service/src/invoice/prescription/update/mod.rs
+++ b/server/service/src/invoice/prescription/update/mod.rs
@@ -164,7 +164,7 @@ mod test {
         fn prescription_no_stock() -> InvoiceRow {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = String::from("prescription_no_stock");
-                r.name_id = String::from("name_store_a");
+                r.name_link_id = String::from("name_store_a");
                 r.store_id = String::from("store_a");
                 r.r#type = InvoiceRowType::Prescription;
                 r.status = InvoiceRowStatus::New;
@@ -282,7 +282,7 @@ mod test {
         fn prescription() -> InvoiceRow {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = "test_prescription_pricing".to_string();
-                r.name_id = mock_patient().id;
+                r.name_link_id = mock_patient().id;
                 r.store_id = mock_store_a().id;
                 r.r#type = InvoiceRowType::Prescription;
             })
@@ -352,8 +352,8 @@ mod test {
                     comment,
                     colour,
                 } = get_update();
-                u.name_id = patient_id.unwrap();
-                u.clinician_id = clinician_id;
+                u.name_link_id = patient_id.unwrap();
+                u.clinician_link_id = clinician_id;
                 u.comment = comment;
                 u.colour = colour;
                 u

--- a/server/service/src/invoice_line/inbound_shipment_line/generate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_line/generate.rs
@@ -39,7 +39,7 @@ pub fn generate_batch(
         ..
     }: InvoiceLineRow,
     keep_existing_batch: bool,
-    supplier_id: &str,
+    supplier_link_id: &str,
 ) -> StockLineRow {
     // Generate new id if requested via parameter or if stock_line_id is not already set on line
     let stock_line_id = match (stock_line_id, keep_existing_batch) {
@@ -61,7 +61,7 @@ pub fn generate_batch(
         expiry_date,
         on_hold: false,
         note,
-        supplier_id: Some(supplier_id.to_string()),
+        supplier_id: Some(supplier_link_id.to_string()),
         barcode_id: None,
     }
 }

--- a/server/service/src/invoice_line/inbound_shipment_line/insert/generate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_line/insert/generate.rs
@@ -37,7 +37,7 @@ pub fn generate(
             &existing_invoice_row.store_id,
             new_line.clone(),
             false,
-            &existing_invoice_row.name_id,
+            &existing_invoice_row.name_link_id,
         );
         new_line.stock_line_id = Some(new_batch.id.clone());
 

--- a/server/service/src/invoice_line/inbound_shipment_line/update/generate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_line/update/generate.rs
@@ -45,7 +45,7 @@ pub fn generate(
             &existing_invoice_row.store_id,
             update_line.clone(),
             batch_to_delete_id.is_none(),
-            &existing_invoice_row.name_id,
+            &existing_invoice_row.name_link_id,
         );
         update_line.stock_line_id = Some(new_batch.id.clone());
         Some(new_batch)

--- a/server/service/src/invoice_line/outbound_shipment_unallocated_line/allocate/test.rs
+++ b/server/service/src/invoice_line/outbound_shipment_unallocated_line/allocate/test.rs
@@ -54,7 +54,7 @@ mod test {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = "invoice".to_string();
                 r.store_id = mock_store_a().id;
-                r.name_id = mock_name_a().id;
+                r.name_link_id = mock_name_a().id;
                 r.r#type = InvoiceRowType::OutboundShipment;
             })
         }
@@ -154,7 +154,7 @@ mod test {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = "invoice".to_string();
                 r.store_id = mock_store_a().id;
-                r.name_id = mock_name_a().id;
+                r.name_link_id = mock_name_a().id;
                 r.r#type = InvoiceRowType::OutboundShipment;
             })
         }
@@ -177,7 +177,7 @@ mod test {
                 r.item_id = mock_item_a().id;
                 r.pack_size = 3;
                 r.available_number_of_packs = 10.0;
-                r.expiry_date = Some(NaiveDate::from_ymd_opt(3021, 01, 01).unwrap());
+                r.expiry_date = Some(NaiveDate::from_ymd_opt(3021, 1, 1).unwrap());
             })
         }
 
@@ -188,7 +188,7 @@ mod test {
                 r.item_id = mock_item_a().id;
                 r.pack_size = 3;
                 r.available_number_of_packs = 2.0;
-                r.expiry_date = Some(NaiveDate::from_ymd_opt(3021, 02, 01).unwrap());
+                r.expiry_date = Some(NaiveDate::from_ymd_opt(3021, 2, 1).unwrap());
             })
         }
 
@@ -289,7 +289,7 @@ mod test {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = "invoice".to_string();
                 r.store_id = mock_store_a().id;
-                r.name_id = mock_name_a().id;
+                r.name_link_id = mock_name_a().id;
                 r.r#type = InvoiceRowType::OutboundShipment;
             })
         }
@@ -317,7 +317,7 @@ mod test {
 
         fn stock_line_expired() -> StockLineRow {
             inline_edit(&base_stock_line("stock_line_expired"), |mut u| {
-                u.expiry_date = Some(NaiveDate::from_ymd_opt(2021, 01, 01).unwrap());
+                u.expiry_date = Some(NaiveDate::from_ymd_opt(2021, 1, 1).unwrap());
                 u
             })
         }
@@ -437,7 +437,7 @@ mod test {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = "invoice".to_string();
                 r.store_id = mock_store_a().id;
-                r.name_id = mock_name_a().id;
+                r.name_link_id = mock_name_a().id;
                 r.r#type = InvoiceRowType::OutboundShipment;
             })
         }
@@ -460,7 +460,7 @@ mod test {
                 r.item_id = mock_item_a().id;
                 r.pack_size = 1;
                 r.available_number_of_packs = 30.0;
-                r.expiry_date = Some(NaiveDate::from_ymd_opt(3021, 02, 01).unwrap());
+                r.expiry_date = Some(NaiveDate::from_ymd_opt(3021, 2, 1).unwrap());
             })
         }
 
@@ -569,7 +569,7 @@ mod test {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = "invoice".to_string();
                 r.store_id = mock_store_a().id;
-                r.name_id = mock_name_a().id;
+                r.name_link_id = mock_name_a().id;
                 r.r#type = InvoiceRowType::OutboundShipment;
             })
         }

--- a/server/service/src/number.rs
+++ b/server/service/src/number.rs
@@ -81,7 +81,7 @@ mod test {
         fn invoice1() -> InvoiceRow {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = "invoice1".to_string();
-                r.name_id = mock_name_c().id;
+                r.name_link_id = mock_name_c().id;
                 r.store_id = mock_store_c().id;
                 r.r#type = InvoiceRowType::OutboundShipment;
                 r.invoice_number = 100;

--- a/server/service/src/processors/transfer/shipment/create_inbound_shipment.rs
+++ b/server/service/src/processors/transfer/shipment/create_inbound_shipment.rs
@@ -16,7 +16,7 @@ use super::{
     Operation, ShipmentTransferProcessor, ShipmentTransferProcessorRecord,
 };
 
-const DESCRIPTION: &'static str = "Create inbound shipment from outbound shipment";
+const DESCRIPTION: &str = "Create inbound shipment from outbound shipment";
 
 pub(crate) struct CreateInboundShipmentProcessor;
 
@@ -122,7 +122,7 @@ fn generate_inbound_shipment(
     request_requisition: &Option<Requisition>,
 ) -> Result<InvoiceRow, RepositoryError> {
     let store_id = record_for_processing.other_party_store_id.clone();
-    let name_id = outbound_shipment.store_row.name_id.clone();
+    let name_link_id = outbound_shipment.store_row.name_id.clone();
 
     let outbound_shipment_row = &outbound_shipment.invoice_row;
 
@@ -156,7 +156,7 @@ fn generate_inbound_shipment(
         id: uuid(),
         invoice_number: next_number(connection, &NumberRowType::InboundShipment, &store_id)?,
         r#type: InvoiceRowType::InboundShipment,
-        name_id,
+        name_link_id,
         store_id,
         status,
         requisition_id: request_requisition_id,
@@ -177,7 +177,7 @@ fn generate_inbound_shipment(
         allocated_datetime: None,
         delivered_datetime: None,
         verified_datetime: None,
-        clinician_id: None,
+        clinician_link_id: None,
     };
 
     Ok(result)

--- a/server/service/src/processors/transfer/shipment/test.rs
+++ b/server/service/src/processors/transfer/shipment/test.rs
@@ -181,7 +181,7 @@ impl ShipmentTransferTester {
 
         let outbound_shipment = inline_init(|r: &mut InvoiceRow| {
             r.id = uuid();
-            r.name_id = inbound_store.name_id.clone();
+            r.name_link_id = inbound_store.name_id.clone();
             r.store_id = outbound_store.id.clone();
             r.invoice_number = 20;
             r.r#type = InvoiceRowType::OutboundShipment;
@@ -388,7 +388,7 @@ impl ShipmentTransferTester {
 
         assert_eq!(inbound_shipment.r#type, InvoiceRowType::InboundShipment);
         assert_eq!(inbound_shipment.store_id, self.inbound_store.id);
-        assert_eq!(inbound_shipment.name_id, self.outbound_store.name_id);
+        assert_eq!(inbound_shipment.name_link_id, self.outbound_store.name_id);
         assert_eq!(
             inbound_shipment.name_store_id,
             Some(self.outbound_store.id.clone())

--- a/server/service/src/repack/generate.rs
+++ b/server/service/src/repack/generate.rs
@@ -77,7 +77,7 @@ fn generate_invoice_and_lines(
 
     let invoice = InvoiceRow {
         id: uuid(),
-        name_id: repack_name.id,
+        name_link_id: repack_name.id,
         store_id: ctx.store_id.clone(),
         user_id: Some(ctx.user_id.clone()),
         invoice_number: next_number(connection, &NumberRowType::Repack, &ctx.store_id)?,

--- a/server/service/src/repack/query.rs
+++ b/server/service/src/repack/query.rs
@@ -129,7 +129,7 @@ mod test {
     async fn query_repacks() {
         let invoice = InvoiceRow {
             id: "repack_invoice_a".to_string(),
-            name_id: "name_store_a".to_string(),
+            name_link_id: "name_store_a".to_string(),
             store_id: "store_a".to_string(),
             invoice_number: 10,
             r#type: InvoiceRowType::Repack,

--- a/server/service/src/requisition/response_requisition/create_requisition_shipment/generate.rs
+++ b/server/service/src/requisition/response_requisition/create_requisition_shipment/generate.rs
@@ -23,7 +23,7 @@ pub fn generate(
     let new_invoice = InvoiceRow {
         id: uuid(),
         user_id: Some(user_id.to_string()),
-        name_id: requisition_row.name_id,
+        name_link_id: requisition_row.name_id,
         name_store_id: other_party.store_id().map(|id| id.to_string()),
         store_id: store_id.to_owned(),
         invoice_number: next_number(connection, &NumberRowType::OutboundShipment, &store_id)?,
@@ -45,7 +45,7 @@ pub fn generate(
         colour: None,
         linked_invoice_id: None,
         tax: None,
-        clinician_id: None,
+        clinician_link_id: None,
     };
 
     let invoice_line_rows = generate_invoice_lines(connection, &new_invoice.id, fullfilments)?;

--- a/server/service/src/requisition_line/chart/mod.rs
+++ b/server/service/src/requisition_line/chart/mod.rs
@@ -281,7 +281,7 @@ mod test {
                 r.invoices = vec![inline_init(|r: &mut InvoiceRow| {
                     r.id = invoice_id.clone();
                     r.store_id = store().id;
-                    r.name_id = mock_name_a().id;
+                    r.name_link_id = mock_name_a().id;
                     r.r#type = InvoiceRowType::OutboundShipment;
                 })];
                 r.invoice_lines = vec![inline_init(|r: &mut InvoiceLineRow| {
@@ -527,7 +527,7 @@ mod test {
                 r.invoices = vec![inline_init(|r: &mut InvoiceRow| {
                     r.id = invoice_id.clone();
                     r.store_id = store().id;
-                    r.name_id = mock_name_a().id;
+                    r.name_link_id = mock_name_a().id;
                     r.r#type = InvoiceRowType::OutboundShipment;
                 })];
                 r.invoice_lines = vec![inline_init(|r: &mut InvoiceLineRow| {

--- a/server/service/src/stocktake/update.rs
+++ b/server/service/src/stocktake/update.rs
@@ -580,7 +580,7 @@ fn generate(
         r#type: InvoiceRowType::InventoryAddition,
         // Same for addition and reduction
         user_id: Some(user_id.to_string()),
-        name_id: inventory_adjustment_name.id,
+        name_link_id: inventory_adjustment_name.id,
         store_id: store_id.to_string(),
         status: InvoiceRowStatus::Verified,
         verified_datetime: Some(now),
@@ -599,7 +599,7 @@ fn generate(
         requisition_id: None,
         linked_invoice_id: None,
         tax: None,
-        clinician_id: None,
+        clinician_link_id: None,
     };
 
     let inventory_addition = if !inventory_addition_lines.is_empty() {

--- a/server/service/src/stocktake_line/insert.rs
+++ b/server/service/src/stocktake_line/insert.rs
@@ -358,7 +358,7 @@ mod stocktake_line_test {
         fn outbound_shipment() -> InvoiceRow {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = "reduced_stock_outbound_shipment".to_string();
-                r.name_id = "name_store_b".to_string();
+                r.name_link_id = "name_store_b".to_string();
                 r.store_id = "store_a".to_string();
                 r.invoice_number = 15;
                 r.r#type = InvoiceRowType::OutboundShipment;

--- a/server/service/src/stocktake_line/update.rs
+++ b/server/service/src/stocktake_line/update.rs
@@ -243,7 +243,7 @@ mod stocktake_line_test {
         fn outbound_shipment() -> InvoiceRow {
             inline_init(|r: &mut InvoiceRow| {
                 r.id = "reduced_stock_outbound_shipment".to_string();
-                r.name_id = "name_store_b".to_string();
+                r.name_link_id = "name_store_b".to_string();
                 r.store_id = "store_a".to_string();
                 r.invoice_number = 15;
                 r.r#type = InvoiceRowType::OutboundShipment;

--- a/server/service/src/sync/test/test_data/invoice.rs
+++ b/server/service/src/sync/test/test_data/invoice.rs
@@ -12,7 +12,7 @@ use util::constants::INVENTORY_ADJUSTMENT_NAME_CODE;
 
 use super::TestSyncPushRecord;
 
-const TRANSACT_1: (&'static str, &'static str) = (
+const TRANSACT_1: (&str, &str) = (
     "12e889c0f0d211eb8dddb54df6d741bc",
     r#"{
       "Colour": 0,
@@ -103,7 +103,7 @@ fn transact_1_pull_record() -> TestSyncPullRecord {
             id: TRANSACT_1.0.to_string(),
             user_id: None,
             store_id: "store_b".to_string(),
-            name_id: "name_store_a".to_string(),
+            name_link_id: "name_store_a".to_string(),
             name_store_id: Some("store_a".to_string()),
             invoice_number: 1,
             r#type: InvoiceRowType::InboundShipment,
@@ -132,7 +132,7 @@ fn transact_1_pull_record() -> TestSyncPullRecord {
             requisition_id: None,
             linked_invoice_id: None,
             tax: Some(0.0),
-            clinician_id: None,
+            clinician_link_id: None,
         }),
     )
 }
@@ -187,7 +187,7 @@ fn transact_1_push_record() -> TestSyncPushRecord {
     }
 }
 
-const TRANSACT_2: (&'static str, &'static str) = (
+const TRANSACT_2: (&str, &str) = (
     "7c860d40f3f111eb9647790fe8518386",
     r#"{
         "Colour": 1710361,
@@ -272,7 +272,7 @@ fn transact_2_pull_record() -> TestSyncPullRecord {
             id: TRANSACT_2.0.to_string(),
             user_id: Some("0763E2E3053D4C478E1E6B6B03FEC207".to_string()),
             store_id: "store_b".to_string(),
-            name_id: "name_store_b".to_string(),
+            name_link_id: "name_store_b".to_string(),
             name_store_id: Some("store_b".to_string()),
             invoice_number: 4,
             r#type: InvoiceRowType::OutboundShipment,
@@ -295,7 +295,7 @@ fn transact_2_pull_record() -> TestSyncPullRecord {
             requisition_id: None,
             linked_invoice_id: None,
             tax: Some(0.0),
-            clinician_id: None,
+            clinician_link_id: None,
         }),
     )
 }
@@ -345,7 +345,7 @@ fn transact_2_push_record() -> TestSyncPushRecord {
     }
 }
 
-const TRANSACT_OM_FIELDS: (&'static str, &'static str) = (
+const TRANSACT_OM_FIELDS: (&str, &str) = (
     "Ac860d40f3f111eb9647790fe8518386",
     r#"{
         "Colour": 1710361,
@@ -440,7 +440,7 @@ fn transact_om_fields_pull_record() -> TestSyncPullRecord {
             id: TRANSACT_OM_FIELDS.0.to_string(),
             user_id: Some("0763E2E3053D4C478E1E6B6B03FEC207".to_string()),
             store_id: "store_b".to_string(),
-            name_id: "name_store_b".to_string(),
+            name_link_id: "name_store_b".to_string(),
             name_store_id: Some("store_b".to_string()),
             invoice_number: 4,
             r#type: InvoiceRowType::InventoryAddition,
@@ -487,7 +487,7 @@ fn transact_om_fields_pull_record() -> TestSyncPullRecord {
             requisition_id: None,
             linked_invoice_id: None,
             tax: Some(0.0),
-            clinician_id: None,
+            clinician_link_id: None,
         }),
     )
 }
@@ -562,7 +562,7 @@ fn transact_om_fields_push_record() -> TestSyncPushRecord {
     }
 }
 
-const INVENTORY_ADDITION: (&'static str, &'static str) = (
+const INVENTORY_ADDITION: (&str, &str) = (
     "065AEF4C9C214C9AB4ED7BA0A1EC72C0",
     r#"{
         "name_ID": "invad",
@@ -658,16 +658,16 @@ fn inventory_addition_pull_record() -> TestSyncPullRecord {
             id: INVENTORY_ADDITION.0.to_string(),
             user_id: Some("0763E2E3053D4C478E1E6B6B03FEC207".to_string()),
             store_id: "store_b".to_string(),
-            name_id: INVENTORY_ADJUSTMENT_NAME_CODE.to_string(),
+            name_link_id: INVENTORY_ADJUSTMENT_NAME_CODE.to_string(),
             invoice_number: 1,
             r#type: InvoiceRowType::InventoryAddition,
             status: InvoiceRowStatus::Verified,
-            created_datetime: NaiveDate::from_ymd_opt(2023, 01, 16)
+            created_datetime: NaiveDate::from_ymd_opt(2023, 1, 16)
                 .unwrap()
                 .and_hms_opt(0, 0, 0)
                 .unwrap(),
             verified_datetime: Some(
-                NaiveDate::from_ymd_opt(2023, 01, 16)
+                NaiveDate::from_ymd_opt(2023, 1, 16)
                     .unwrap()
                     .and_hms_opt(0, 0, 0)
                     .unwrap(),
@@ -686,7 +686,7 @@ fn inventory_addition_pull_record() -> TestSyncPullRecord {
             requisition_id: None,
             linked_invoice_id: None,
             colour: None,
-            clinician_id: None,
+            clinician_link_id: None,
         }),
     )
 }
@@ -706,18 +706,18 @@ fn inventory_addition_push_record() -> TestSyncPushRecord {
             tax: Some(0.0),
             om_status: Some(InvoiceRowStatus::Verified),
             om_type: Some(InvoiceRowType::InventoryAddition),
-            entry_date: NaiveDate::from_ymd_opt(2023, 01, 16).unwrap(),
+            entry_date: NaiveDate::from_ymd_opt(2023, 1, 16).unwrap(),
             entry_time: NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
-            confirm_date: Some(NaiveDate::from_ymd_opt(2023, 01, 16).unwrap(),),
+            confirm_date: Some(NaiveDate::from_ymd_opt(2023, 1, 16).unwrap(),),
             confirm_time: NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
             created_datetime: Some(
-                NaiveDate::from_ymd_opt(2023, 01, 16)
+                NaiveDate::from_ymd_opt(2023, 1, 16)
                     .unwrap()
                     .and_hms_opt(0, 0, 0)
                     .unwrap()
             ),
             verified_datetime: Some(
-                NaiveDate::from_ymd_opt(2023, 01, 16)
+                NaiveDate::from_ymd_opt(2023, 1, 16)
                     .unwrap()
                     .and_hms_opt(0, 0, 0)
                     .unwrap()
@@ -742,7 +742,7 @@ fn inventory_addition_push_record() -> TestSyncPushRecord {
     }
 }
 
-const INVENTORY_REDUCTION: (&'static str, &'static str) = (
+const INVENTORY_REDUCTION: (&str, &str) = (
     "EE2EBC187C62453AADE221779FCFDABC",
     r#"{
         "name_ID": "invad",
@@ -838,16 +838,16 @@ fn inventory_reduction_pull_record() -> TestSyncPullRecord {
             id: INVENTORY_REDUCTION.0.to_string(),
             user_id: Some("0763E2E3053D4C478E1E6B6B03FEC207".to_string()),
             store_id: "store_b".to_string(),
-            name_id: INVENTORY_ADJUSTMENT_NAME_CODE.to_string(),
+            name_link_id: INVENTORY_ADJUSTMENT_NAME_CODE.to_string(),
             invoice_number: 2,
             r#type: InvoiceRowType::InventoryReduction,
             status: InvoiceRowStatus::Verified,
-            created_datetime: NaiveDate::from_ymd_opt(2023, 01, 16)
+            created_datetime: NaiveDate::from_ymd_opt(2023, 1, 16)
                 .unwrap()
                 .and_hms_opt(0, 0, 0)
                 .unwrap(),
             verified_datetime: Some(
-                NaiveDate::from_ymd_opt(2023, 01, 16)
+                NaiveDate::from_ymd_opt(2023, 1, 16)
                     .unwrap()
                     .and_hms_opt(0, 0, 0)
                     .unwrap(),
@@ -866,7 +866,7 @@ fn inventory_reduction_pull_record() -> TestSyncPullRecord {
             requisition_id: None,
             linked_invoice_id: None,
             colour: None,
-            clinician_id: None,
+            clinician_link_id: None,
         }),
     )
 }
@@ -886,18 +886,18 @@ fn inventory_reduction_push_record() -> TestSyncPushRecord {
             tax: Some(0.0),
             om_status: Some(InvoiceRowStatus::Verified),
             om_type: Some(InvoiceRowType::InventoryReduction),
-            entry_date: NaiveDate::from_ymd_opt(2023, 01, 16).unwrap(),
+            entry_date: NaiveDate::from_ymd_opt(2023, 1, 16).unwrap(),
             entry_time: NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
-            confirm_date: Some(NaiveDate::from_ymd_opt(2023, 01, 16).unwrap(),),
+            confirm_date: Some(NaiveDate::from_ymd_opt(2023, 1, 16).unwrap(),),
             confirm_time: NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
             created_datetime: Some(
-                NaiveDate::from_ymd_opt(2023, 01, 16)
+                NaiveDate::from_ymd_opt(2023, 1, 16)
                     .unwrap()
                     .and_hms_opt(0, 0, 0)
                     .unwrap()
             ),
             verified_datetime: Some(
-                NaiveDate::from_ymd_opt(2023, 01, 16)
+                NaiveDate::from_ymd_opt(2023, 1, 16)
                     .unwrap()
                     .and_hms_opt(0, 0, 0)
                     .unwrap()
@@ -922,7 +922,7 @@ fn inventory_reduction_push_record() -> TestSyncPushRecord {
     }
 }
 
-const PRESCRIPTION_1: (&'static str, &'static str) = (
+const PRESCRIPTION_1: (&str, &str) = (
     "prescription_1",
     r#"{
       "Colour": 0,
@@ -1013,7 +1013,7 @@ fn prescription_1_pull_record() -> TestSyncPullRecord {
             id: PRESCRIPTION_1.0.to_string(),
             user_id: None,
             store_id: "store_b".to_string(),
-            name_id: "name_store_a".to_string(),
+            name_link_id: "name_store_a".to_string(),
             name_store_id: Some("store_a".to_string()),
             invoice_number: 1,
             r#type: InvoiceRowType::Prescription,
@@ -1042,7 +1042,7 @@ fn prescription_1_pull_record() -> TestSyncPullRecord {
             requisition_id: None,
             linked_invoice_id: None,
             tax: Some(0.0),
-            clinician_id: None,
+            clinician_link_id: None,
         }),
     )
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Part of #2759

Mostly testing files where I just initialized the name_link_id column with the proper name.id.

I sometimes also just passed on existing link_id where I thought it's safe to do so, because otherwise I would have to do another DB call... Please review carefully.

Fixed some clippy warnings along the way...