### PR TITLE
Rename Mobile

### DIFF
--- a/server/service/src/sync/api/core.rs
+++ b/server/service/src/sync/api/core.rs
@@ -35,7 +35,7 @@ fn generate_headers(hardware_id: &str, sync_version: u32) -> HeaderMap {
     #[cfg(target_os = "android")]
     headers.insert(
         HeaderName::from_static("app-name"),
-        "Open mSupply Mobile".parse().unwrap(),
+        "Open mSupply Android".parse().unwrap(),
     );
     #[cfg(not(target_os = "android"))]
     headers.insert(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2785 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Change the name of the app to something that doesn't include `Mobile` as if the `app-name` header includes Mobile, the mSupply server won't allow syncing to multiple stores.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
This is only an issue when running on android; to replicate you will have to run an android build.
If you do want to test - there is an apk (open-msupply-1.6.00-debug-2785.apk) on the [google drive](https://drive.google.com/open?id=1Ax4J-x4-ZXbyOzpM_VixVGQ9WxW4jn2Q&usp=drive_fs)


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
