### PR TITLE
Central config server transition integration tests

### DIFF
--- a/server/service/src/sync/test/integration/README.md
+++ b/server/service/src/sync/test/integration/README.md
@@ -43,8 +43,8 @@ Only data that needs to be present on central server site is a new sync site:
 
 ## 4 `Open mSupply central server`
 
-* Open mSupply central server for should have a port + 2 of mSupply original central server port.
-* IS_CENTRAL_SERVER env variable should be set as `true``
+* The open mSupply central server should have a port offset of `+2` relative to the mSupply central server port.
+* IS_CENTRAL_SERVER env variable should be set to `true`
 * And graphql API should be 'open' (without token), thus 'APP_SERVER__DEBUG_NO_ACCESS_CONTROL' env variable should be set to `true`
 
 In case you are wondering, the APP env variables translate to settings in [configuration .yaml](https://github.com/msupply-foundation/open-msupply/blob/1b8b9237863eef1a764be3973d563e6d84358827/server/configuration/example.yaml#L7) files, and override them

--- a/server/service/src/sync/test/integration/README.md
+++ b/server/service/src/sync/test/integration/README.md
@@ -118,3 +118,15 @@ Full test including integration can be run with:
 ```bash
 SYNC_SITE_PASSWORD="pass" SYNC_SITE_NAME="demo" SYNC_URL="http://localhost:2048" cargo test  --features integration_test && SYNC_SITE_PASSWORD="pass" SYNC_SITE_NAME="demo" SYNC_URL="http://localhost:2048" cargo test --features integration_test,postgres 
 ```
+
+
+APP_SERVER__PORT=9000
+APP_DATABASE__DATABASE_NAME="central_test"
+APP_SYNC__URL="http://loclahost:2048"
+APP_SYNC__PASSWORD_SHA256="d74ff0ee8da3b9806b18c877dbf29bbde50b5bd8e4dad7a3a725000feb82e8f1"
+APP_SYNC__USERNAME="test"
+cargo run 
+
+
+
+IS_CENTRAL_SERVER=true APP_SERVER__PORT=2050 APP_DATABASE__DATABASE_NAME="central_test" APP_SYNC__URL="http://localhost:2048" APP_SYNC__INTERVAL_SECONDS=30 APP_SERVER__DEBUG_NO_ACCESS_CONTROL=TRUE APP_SYNC__PASSWORD_SHA256="d74ff0ee8da3b9806b18c877dbf29bbde50b5bd8e4dad7a3a725000feb82e8f1" APP_SYNC__USERNAME="test" cargo run 

--- a/server/service/src/sync/test/integration/central/document_registry.rs
+++ b/server/service/src/sync/test/integration/central/document_registry.rs
@@ -64,11 +64,11 @@ impl SyncRecordTester for DocumentRegistryTester {
                 "form_schema": [form_json1],
                 "om_document_registry": [doc_registry_json1],
             }),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(form_row1),
                 IntegrationOperation::upsert(doc_registry1),
             ],
+            ..Default::default()
         });
 
         result

--- a/server/service/src/sync/test/integration/central/form_schema.rs
+++ b/server/service/src/sync/test/integration/central/form_schema.rs
@@ -31,8 +31,8 @@ impl SyncRecordTester for FormSchemaTester {
             central_upsert: json!({
                 "form_schema": [json1],
             }),
-            central_delete: json!({}),
             integration_records: vec![IntegrationOperation::upsert(row1)],
+            ..Default::default()
         });
 
         result

--- a/server/service/src/sync/test/integration/central/inventory_adjustment_reason.rs
+++ b/server/service/src/sync/test/integration/central/inventory_adjustment_reason.rs
@@ -67,13 +67,13 @@ impl SyncRecordTester for InventoryAdjustmentReasonTester {
                     "type": "negativeInventoryAdjustment"
                   }],
             }),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(pos_1),
                 IntegrationOperation::upsert(pos_2),
                 IntegrationOperation::upsert(neg_1),
                 IntegrationOperation::upsert(neg_2),
             ],
+            ..Default::default()
         });
         // STEP 2 - deletes
         // TODO should be soft deleted

--- a/server/service/src/sync/test/integration/central/master_list.rs
+++ b/server/service/src/sync/test/integration/central/master_list.rs
@@ -85,7 +85,6 @@ impl SyncRecordTester for MasterListTester {
                 "list_master_line": [master_list_line_json],
                 "item": [{"ID": item_id, "type_of": "general"}]
             }),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(master_list_row1),
                 IntegrationOperation::upsert(master_list_row2),
@@ -93,6 +92,7 @@ impl SyncRecordTester for MasterListTester {
                 IntegrationOperation::upsert(master_list_name_join_row2),
                 IntegrationOperation::upsert(master_list_line_row),
             ],
+            ..Default::default()
         });
 
         result

--- a/server/service/src/sync/test/integration/central/name_and_store_and_name_store_join.rs
+++ b/server/service/src/sync/test/integration/central/name_and_store_and_name_store_join.rs
@@ -113,12 +113,13 @@ impl SyncRecordTester for NameAndStoreAndNameStoreJoinTester {
                 "name": [name_json1, name_json2.clone()],
                 "store": [store_json]
             }),
-            central_delete: json!({}),
+
             integration_records: vec![
                 IntegrationOperation::upsert(name_row1),
                 IntegrationOperation::upsert(name_row2.clone()),
                 IntegrationOperation::upsert(store_row.clone()),
             ],
+            ..Default::default()
         });
         // STEP 2 name store joins need to be inserted after store (for them to be inserted in sync queue)
         let mut name_store_join_row1 = NameStoreJoinRow {
@@ -152,12 +153,11 @@ impl SyncRecordTester for NameAndStoreAndNameStoreJoinTester {
             central_upsert: json!({
                 "name_store_join": [name_store_join_json1, name_store_join_json2],
             }),
-            central_delete: json!({}),
-
             integration_records: vec![
                 IntegrationOperation::upsert(name_store_join_row1.clone()),
                 IntegrationOperation::upsert(name_store_join_row2.clone()),
             ],
+            ..Default::default()
         });
         // STEP 3 update name and make sure name_store_joins update
         merge_json(
@@ -177,23 +177,22 @@ impl SyncRecordTester for NameAndStoreAndNameStoreJoinTester {
         result.push(TestStepData {
             central_upsert: json!({
                 "name": [name_json2],
-
             }),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(name_store_join_row1.clone()),
                 IntegrationOperation::upsert(name_store_join_row2),
             ],
+            ..Default::default()
         });
 
         // STEP 4 - deletes
         // TODO should we check for name and store deletes ?
         result.push(TestStepData {
-            central_upsert: json!({}),
             central_delete: json!({ "name_store_join": [name_store_join_row1.id] }),
             integration_records: vec![IntegrationOperation::delete(NameStoreJoinRowDelete(
                 name_store_join_row1.id,
             ))],
+            ..Default::default()
         });
         result
     }

--- a/server/service/src/sync/test/integration/central/period_schedule_and_period.rs
+++ b/server/service/src/sync/test/integration/central/period_schedule_and_period.rs
@@ -73,13 +73,13 @@ impl SyncRecordTester for PeriodScheduleAndPeriodTester {
                 "periodSchedule": [period_schedule_1_json, period_schedule_2_json],
                 "period": [period_1_json, period_2_json]
             }),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(period_schedule_1),
                 IntegrationOperation::upsert(period_schedule_2),
                 IntegrationOperation::upsert(period_1),
                 IntegrationOperation::upsert(period_2),
             ],
+            ..Default::default()
         });
 
         result

--- a/server/service/src/sync/test/integration/central/report.rs
+++ b/server/service/src/sync/test/integration/central/report.rs
@@ -68,22 +68,22 @@ impl SyncRecordTester for ReportTester {
             central_upsert: json!({
                 "report": [report_json1,report_json2,report_json3,report_json4],
             }),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(report_row1.clone()),
                 IntegrationOperation::upsert(report_row2),
                 IntegrationOperation::upsert(report_row3),
                 IntegrationOperation::upsert(report_row4),
             ],
+            ..Default::default()
         });
 
         // STEP 2 - deletes
         result.push(TestStepData {
-            central_upsert: json!({}),
             central_delete: json!({ "report": [report_row1.id] }),
             integration_records: vec![IntegrationOperation::delete(ReportRowDelete(
                 report_row1.id,
             ))],
+            ..Default::default()
         });
         result
     }

--- a/server/service/src/sync/test/integration/central/unit_and_item.rs
+++ b/server/service/src/sync/test/integration/central/unit_and_item.rs
@@ -103,7 +103,6 @@ impl SyncRecordTester for UnitAndItemTester {
                 "item": [item_json1, item_json2, item_json3],
                 "unit": [unit_json1, unit_json2]
             }),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(unit_row1.clone()),
                 IntegrationOperation::upsert(unit_row2),
@@ -111,15 +110,16 @@ impl SyncRecordTester for UnitAndItemTester {
                 IntegrationOperation::upsert(item_row2.clone()),
                 IntegrationOperation::upsert(item_row3),
             ],
+            ..Default::default()
         });
         // STEP 2 - deletes
         result.push(TestStepData {
-            central_upsert: json!({}),
             central_delete: json!({ "item": [item_row2.id], "unit": [unit_row1.id] }),
             integration_records: vec![
                 IntegrationOperation::delete(UnitRowDelete(unit_row1.id)),
                 IntegrationOperation::delete(ItemRowDelete(item_row2.id)),
             ],
+            ..Default::default()
         });
         result
     }

--- a/server/service/src/sync/test/integration/central_server_configurations.rs
+++ b/server/service/src/sync/test/integration/central_server_configurations.rs
@@ -1,10 +1,13 @@
 use serde::{Deserialize, Serialize};
 use std::env;
 
-use crate::sync::{
-    api::{to_json, SyncApiError, SyncApiV5},
-    settings::SyncSettings,
-    sync_api_credentials::SyncCredentials,
+use crate::{
+    app_data::{AppDataService, AppDataServiceTrait},
+    sync::{
+        api::{to_json, SyncApiError, SyncApiV5},
+        settings::SyncSettings,
+        SyncApiSettings,
+    },
 };
 
 use super::with_retry;
@@ -61,6 +64,7 @@ impl SyncApiV5 {
         visible_name_ids: Vec<String>,
     ) -> Result<CreateSyncSiteResponse, SyncApiError> {
         let route = "/sync/v5/test/create_site";
+
         let response = self
             .do_post(route, &CreateSyncSiteInput { visible_name_ids })
             .await?;
@@ -70,9 +74,10 @@ impl SyncApiV5 {
             .map_err(|error| self.api_error(route, error.into()))?;
 
         let check_site_api = SyncApiV5 {
-            credentials: SyncCredentials {
+            settings: SyncApiSettings {
                 username: site_response.site.name.clone(),
                 password_sha256: site_response.site.password_sha256.clone(),
+                ..self.settings.clone()
             },
             ..self.clone()
         };
@@ -100,8 +105,12 @@ impl ConfigureCentralServer {
         let site_name = env::var("SYNC_SITE_NAME").expect("SYNC_SITE_NAME env variable missing");
         let url = env::var("SYNC_URL").expect("SYNC_URL env variable missing");
 
+        let hardware_id = AppDataService::new("../app_data")
+            .get_hardware_id()
+            .unwrap();
+
         ConfigureCentralServer {
-            api: SyncApiV5::new_test(&url, &site_name, &password, ""),
+            api: SyncApiV5::new_test(&url, &site_name, &password, &hardware_id),
             server_url: url,
         }
     }

--- a/server/service/src/sync/test/integration/errors.rs
+++ b/server/service/src/sync/test/integration/errors.rs
@@ -9,7 +9,7 @@ mod tests {
         app_data::{AppData, AppDataServiceTrait},
         service_provider::ServiceProvider,
         sync::{
-            api::{ParsedError, SyncApiError, SyncApiErrorVariant, SyncErrorCodeV5},
+            api::{ParsedError, SyncApiError, SyncApiErrorVariantV5, SyncErrorCodeV5},
             remote_data_synchroniser::{PostInitialisationError, RemotePushError},
             settings::SyncSettings,
             sync_status::SyncLogError,
@@ -94,7 +94,7 @@ mod tests {
         assert_matches!(
             error,
             SyncError::RemotePushError(RemotePushError::SyncApiError(SyncApiError {
-                source: SyncApiErrorVariant::ParsedError {
+                source: SyncApiErrorVariantV5::ParsedError {
                     status: StatusCode::UNAUTHORIZED,
                     ..
                 },
@@ -153,7 +153,7 @@ mod tests {
             error,
             SyncError::PostInitialisationError(PostInitialisationError::SyncApiError(
                 SyncApiError {
-                    source: SyncApiErrorVariant::ParsedError {
+                    source: SyncApiErrorVariantV5::ParsedError {
                         status: StatusCode::CONFLICT,
                         source: ParsedError {
                             code: SyncErrorCodeV5::ApiVersionIncompatible,

--- a/server/service/src/sync/test/integration/mod.rs
+++ b/server/service/src/sync/test/integration/mod.rs
@@ -1,6 +1,7 @@
 mod central;
 mod central_server_configurations;
 mod errors;
+mod omsupply_central;
 mod remote;
 mod site_info;
 mod transfer;
@@ -14,6 +15,8 @@ use crate::{
     test_helpers::{setup_all_and_service_provider, ServiceTestContext},
 };
 use repository::{mock::MockDataInserts, StorageConnection};
+use serde::Serialize;
+use serde_json::json;
 use std::{error::Error, future::Future, sync::Arc};
 use tokio::task::JoinHandle;
 
@@ -61,10 +64,27 @@ async fn init_test_context(
     }
 }
 
+#[derive(Default, Serialize)]
+pub(crate) struct GraphqlRequest {
+    query: String,
+    variables: serde_json::Value,
+}
 struct TestStepData {
     central_upsert: serde_json::Value,
     central_delete: serde_json::Value,
     integration_records: Vec<IntegrationOperation>,
+    om_supply_central_graphql_operations: Vec<GraphqlRequest>,
+}
+
+impl Default for TestStepData {
+    fn default() -> Self {
+        Self {
+            central_upsert: json!({}),
+            central_delete: json!({}),
+            integration_records: Default::default(),
+            om_supply_central_graphql_operations: Default::default(),
+        }
+    }
 }
 
 trait SyncRecordTester {

--- a/server/service/src/sync/test/integration/omsupply_central/mod.rs
+++ b/server/service/src/sync/test/integration/omsupply_central/mod.rs
@@ -1,0 +1,135 @@
+mod pack_variant;
+mod test;
+
+use std::time::Duration;
+
+use reqwest::Client;
+
+use crate::sync::{
+    api_v6::get_omsupply_central_url,
+    settings::SyncSettings,
+    test::{
+        check_integrated,
+        integration::{
+            central_server_configurations::{ConfigureCentralServer, SiteConfiguration},
+            init_test_context, SyncIntegrationContext,
+        },
+    },
+};
+
+use super::{GraphqlRequest, SyncRecordTester};
+
+async fn test_omsupply_central_records(identifier: &str, tester: &dyn SyncRecordTester) {
+    // util::init_logger(util::LogLevel::Info);
+    // Without re-initialisation
+    println!("test_omsupply_central_records{}_init", identifier);
+
+    let central_server_configurations = ConfigureCentralServer::from_env();
+    let SiteConfiguration {
+        new_site_properties,
+        sync_settings,
+    } = central_server_configurations
+        .create_sync_site(vec![])
+        .await
+        .expect("Problem creating sync site");
+
+    let SyncIntegrationContext {
+        connection,
+        synchroniser,
+        ..
+    } = init_test_context(&sync_settings, &identifier).await;
+
+    let steps_data = tester.test_step_data(&new_site_properties);
+
+    for (index, step_data) in steps_data.into_iter().enumerate() {
+        println!(
+            "test_omsupply_central_records_{}_step{}",
+            identifier,
+            index + 1
+        );
+
+        central_server_configurations
+            .upsert_records(step_data.central_upsert)
+            .await
+            .expect("Problem inserting central data");
+
+        // Sync omSupply central server first
+        sync_omsupply_central(&sync_settings).await;
+        // Integrate omSupply central server records via graphql
+        for graphql_operation in step_data.om_supply_central_graphql_operations {
+            graphql(&sync_settings, graphql_operation).await;
+        }
+
+        synchroniser.sync().await.unwrap();
+        check_integrated(&connection, step_data.integration_records)
+    }
+}
+
+// Helper for graphql queries
+async fn graphql(sync_settings: &SyncSettings, graphql: GraphqlRequest) -> serde_json::Value {
+    let mut url = get_omsupply_central_url(&sync_settings.url).unwrap();
+    url = url.join("graphql").unwrap();
+
+    let result = Client::new()
+        .post(url.clone())
+        .body(serde_json::to_string(&graphql).unwrap())
+        .send()
+        .await;
+
+    let response_text = result.unwrap().text().await.unwrap();
+
+    let response_json: serde_json::Value = serde_json::from_str(&response_text).unwrap();
+
+    assert_eq!(
+        response_json.get("errors").is_some(),
+        false,
+        "graphql responded with error {}",
+        serde_json::to_string_pretty(&response_json).unwrap()
+    );
+
+    response_json.get("data").unwrap().to_owned()
+}
+
+// Call manual sync mutation and then wait for synchronisation
+async fn sync_omsupply_central(sync_settings: &SyncSettings) {
+    graphql(
+        sync_settings,
+        GraphqlRequest {
+            query: "mutation { manualSync }".to_string(),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    loop {
+        // TODO max timeout ?
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        let result = graphql(
+            sync_settings,
+            GraphqlRequest {
+                query: r#" 
+                    query {
+                        latestSyncStatus {
+                            isSyncing
+                            error {
+                                fullError
+                            }
+                        }
+                    }
+                "#
+                .to_string(),
+
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let status = result.get("latestSyncStatus").unwrap();
+        // Make sure there are not errors
+        assert_eq!(status.get("error"), Some(&serde_json::Value::Null));
+
+        if let Some(serde_json::Value::Bool(false)) = status.get("isSyncing") {
+            break;
+        }
+    }
+}

--- a/server/service/src/sync/test/integration/omsupply_central/mod.rs
+++ b/server/service/src/sync/test/integration/omsupply_central/mod.rs
@@ -102,7 +102,7 @@ async fn sync_omsupply_central(sync_settings: &SyncSettings) {
     .await;
 
     loop {
-        // TODO max timeout ?
+        // TODO max timeout ? or log output every X seconds
         tokio::time::sleep(Duration::from_secs(1)).await;
         let result = graphql(
             sync_settings,

--- a/server/service/src/sync/test/integration/omsupply_central/pack_variant.rs
+++ b/server/service/src/sync/test/integration/omsupply_central/pack_variant.rs
@@ -1,15 +1,11 @@
-use crate::{
-    sync::{
-        test::integration::{
-            central_server_configurations::NewSiteProperties, GraphqlRequest, SyncRecordTester,
-            TestStepData,
-        },
-        translations::IntegrationOperation,
+use crate::sync::{
+    test::integration::{
+        central_server_configurations::NewSiteProperties, GraphqlRequest, SyncRecordTester,
+        TestStepData,
     },
-    u32_to_i32,
+    translations::IntegrationOperation,
 };
 
-use rand::Rng;
 use repository::PackVariantRow;
 use serde_json::json;
 use util::uuid::uuid;
@@ -27,15 +23,13 @@ impl SyncRecordTester for PackVariantTester {
             "type_of": "general",
 
         });
-        let mut rng = rand::thread_rng();
-        let pack_size: u32 = rng.gen();
 
         let pack_variant = PackVariantRow {
             id: uuid(),
             item_id: item_id.clone(),
             short_name: uuid(),
             long_name: uuid(),
-            pack_size: u32_to_i32(pack_size / 2),
+            pack_size: 20,
             is_active: true,
         };
 

--- a/server/service/src/sync/test/integration/omsupply_central/pack_variant.rs
+++ b/server/service/src/sync/test/integration/omsupply_central/pack_variant.rs
@@ -1,0 +1,108 @@
+use crate::{
+    sync::{
+        test::integration::{
+            central_server_configurations::NewSiteProperties, GraphqlRequest, SyncRecordTester,
+            TestStepData,
+        },
+        translations::IntegrationOperation,
+    },
+    u32_to_i32,
+};
+
+use rand::Rng;
+use repository::PackVariantRow;
+use serde_json::json;
+use util::uuid::uuid;
+
+pub(crate) struct PackVariantTester;
+
+impl SyncRecordTester for PackVariantTester {
+    fn test_step_data(&self, site_properties: &NewSiteProperties) -> Vec<TestStepData> {
+        let mut result = Vec::new();
+
+        let item_id = uuid();
+        // STEP 1 - insert
+        let item_json = json!({
+            "ID": item_id.clone(),
+            "type_of": "general",
+
+        });
+        let mut rng = rand::thread_rng();
+        let pack_size: u32 = rng.gen();
+
+        let pack_variant = PackVariantRow {
+            id: uuid(),
+            item_id: item_id.clone(),
+            short_name: uuid(),
+            long_name: uuid(),
+            pack_size: u32_to_i32(pack_size / 2),
+            is_active: true,
+        };
+
+        let pack_variant_mutation = GraphqlRequest {
+            query: r#"
+            mutation insert($storeId: String!, $input: InsertPackVariantInput!) {
+                insertPackVariant(storeId: $storeId, input: $input) {
+                    ... on VariantNode {
+                        id
+                    }
+                }
+            }"#
+            .to_string(),
+            variables: json!({
+                "input": {
+                    "id": pack_variant.id,
+                    "itemId": pack_variant.item_id,
+                    "longName": pack_variant.long_name,
+                    "packSize": pack_variant.pack_size,
+                    "shortName": pack_variant.short_name,
+                },
+                "storeId": site_properties.store_id
+            }),
+        };
+
+        result.push(TestStepData {
+            central_upsert: json!({
+                "item": [item_json],
+            }),
+            integration_records: vec![IntegrationOperation::upsert(pack_variant.clone())],
+            om_supply_central_graphql_operations: vec![pack_variant_mutation],
+            ..Default::default()
+        });
+
+        // STEP 2 - upsert
+        let pack_variant = PackVariantRow {
+            long_name: uuid(),
+            short_name: uuid(),
+            ..pack_variant
+        };
+
+        let pack_variant_mutation = GraphqlRequest {
+            query: r#"
+            mutation update($storeId: String!, $input: UpdatePackVariantInput!) {
+                updatePackVariant(storeId: $storeId, input: $input) {
+                    ... on VariantNode {
+                        id
+                    }
+                }
+            }"#
+            .to_string(),
+            variables: json!({
+                "input": {
+                    "id": pack_variant.id,
+                    "longName": pack_variant.long_name,
+                     "shortName": pack_variant.short_name,
+                },
+                "storeId": site_properties.store_id
+            }),
+        };
+
+        result.push(TestStepData {
+            integration_records: vec![IntegrationOperation::upsert(pack_variant.clone())],
+            om_supply_central_graphql_operations: vec![pack_variant_mutation],
+            ..Default::default()
+        });
+
+        result
+    }
+}

--- a/server/service/src/sync/test/integration/omsupply_central/test.rs
+++ b/server/service/src/sync/test/integration/omsupply_central/test.rs
@@ -1,0 +1,11 @@
+#[cfg(test)]
+mod tests {
+    use crate::sync::test::integration::omsupply_central::{
+        pack_variant::PackVariantTester, test_omsupply_central_records,
+    };
+
+    #[actix_rt::test]
+    async fn omsupply_central_sync_pack_variant() {
+        test_omsupply_central_records("pack_variant", &PackVariantTester).await;
+    }
+}

--- a/server/service/src/sync/test/integration/omsupply_central/test.rs
+++ b/server/service/src/sync/test/integration/omsupply_central/test.rs
@@ -5,7 +5,7 @@ mod tests {
     };
 
     #[actix_rt::test]
-    async fn omsupply_central_sync_pack_variant() {
+    async fn integration_sync_omsupply_central_sync_pack_variant() {
         test_omsupply_central_records("pack_variant", &PackVariantTester).await;
     }
 }

--- a/server/service/src/sync/test/integration/remote/activity_log.rs
+++ b/server/service/src/sync/test/integration/remote/activity_log.rs
@@ -6,7 +6,6 @@ use crate::sync::{
 };
 use chrono::NaiveDate;
 use repository::{ActivityLogRow, ActivityLogRowDelete, ActivityLogType};
-use serde_json::json;
 use util::{inline_edit, uuid::uuid};
 
 pub struct ActivityLogRecordTester;
@@ -48,14 +47,13 @@ impl SyncRecordTester for ActivityLogRecordTester {
         });
 
         result.push(TestStepData {
-            central_upsert: json!({}),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(log_1),
                 IntegrationOperation::upsert(log_2),
                 // Should not sync out thus need to check if it's missing after re-initialisation
                 IntegrationOperation::delete(ActivityLogRowDelete(log_3.id)),
             ],
+            ..Default::default()
         });
         result
     }

--- a/server/service/src/sync/test/integration/remote/clinician.rs
+++ b/server/service/src/sync/test/integration/remote/clinician.rs
@@ -74,12 +74,12 @@ impl SyncRecordTester for ClinicianRecordTester {
                 "clinician": [clinician_json],
                 "clinician_store_join": [join_json],
             }),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(store_row),
                 IntegrationOperation::upsert(clinician_row.clone()),
                 IntegrationOperation::upsert(join_row),
             ],
+            ..Default::default()
         });
 
         // STEP 2 - mutate
@@ -98,9 +98,8 @@ impl SyncRecordTester for ClinicianRecordTester {
         });
 
         result.push(TestStepData {
-            central_upsert: json!({}),
-            central_delete: json!({}),
             integration_records: vec![IntegrationOperation::upsert(row)],
+            ..Default::default()
         });
         result
     }

--- a/server/service/src/sync/test/integration/remote/document.rs
+++ b/server/service/src/sync/test/integration/remote/document.rs
@@ -72,8 +72,8 @@ impl SyncRecordTester for DocumentRecordTester {
                 "name_store_join": [patient_name_store_join_json],
                 "form_schema": [schema_json],
             }),
-            central_delete: json!({}),
             integration_records: vec![IntegrationOperation::upsert(DocumentUpsert(row))],
+            ..Default::default()
         });
 
         result

--- a/server/service/src/sync/test/integration/remote/invoice.rs
+++ b/server/service/src/sync/test/integration/remote/invoice.rs
@@ -161,7 +161,6 @@ impl SyncRecordTester for InvoiceRecordTester {
                     "type": "positiveInventoryAdjustment"
                 }]
             }),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(location_row),
                 IntegrationOperation::upsert(invoice_row_1.clone()),
@@ -176,6 +175,7 @@ impl SyncRecordTester for InvoiceRecordTester {
                 IntegrationOperation::upsert(invoice_line_row_4),
                 IntegrationOperation::upsert(invoice_line_row_5),
             ],
+            ..Default::default()
         });
         // STEP 2 - mutate
         let stock_line_row = inline_init(|r: &mut StockLineRow| {
@@ -247,8 +247,6 @@ impl SyncRecordTester for InvoiceRecordTester {
         });
 
         result.push(TestStepData {
-            central_upsert: json!({}),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(stock_line_row),
                 IntegrationOperation::upsert(requisition_row),
@@ -256,6 +254,7 @@ impl SyncRecordTester for InvoiceRecordTester {
                 IntegrationOperation::upsert(invoice_row_2.clone()),
                 IntegrationOperation::upsert(invoice_line_row_1.clone()),
             ],
+            ..Default::default()
         });
         // STEP 3 - delete
         let invoice_row_2 = inline_edit(&invoice_row_2, |mut d| {
@@ -263,13 +262,12 @@ impl SyncRecordTester for InvoiceRecordTester {
             d
         });
         result.push(TestStepData {
-            central_upsert: json!({}),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(invoice_row_2),
                 IntegrationOperation::delete(InvoiceLineRowDelete(invoice_line_row_1.id.clone())),
                 IntegrationOperation::delete(InvoiceRowDelete(invoice_row_1.id.clone())),
             ],
+            ..Default::default()
         });
         result
     }

--- a/server/service/src/sync/test/integration/remote/location.rs
+++ b/server/service/src/sync/test/integration/remote/location.rs
@@ -5,7 +5,6 @@ use crate::sync::{
     translations::IntegrationOperation,
 };
 use repository::{LocationRow, LocationRowDelete};
-use serde_json::json;
 use util::{inline_edit, uuid::uuid};
 
 pub struct LocationRecordTester;
@@ -23,9 +22,8 @@ impl SyncRecordTester for LocationRecordTester {
         };
 
         result.push(TestStepData {
-            central_upsert: json!({}),
-            central_delete: json!({}),
             integration_records: vec![IntegrationOperation::upsert(row.clone())],
+            ..Default::default()
         });
         // STEP 2 - mutate
         let row = inline_edit(&row, |mut d| {
@@ -35,15 +33,13 @@ impl SyncRecordTester for LocationRecordTester {
             d
         });
         result.push(TestStepData {
-            central_upsert: json!({}),
-            central_delete: json!({}),
             integration_records: vec![IntegrationOperation::upsert(row.clone())],
+            ..Default::default()
         });
         // STEP 3 - delete
         result.push(TestStepData {
-            central_upsert: json!({}),
-            central_delete: json!({}),
             integration_records: vec![IntegrationOperation::delete(LocationRowDelete(row.id))],
+            ..Default::default()
         });
         result
     }

--- a/server/service/src/sync/test/integration/remote/location_movement.rs
+++ b/server/service/src/sync/test/integration/remote/location_movement.rs
@@ -54,12 +54,12 @@ impl SyncRecordTester for LocationMovementRecordTester {
                 "ID": stock_line_row.item_id,
                 "type_of": "general"
             }]}),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(location_row.clone()),
                 IntegrationOperation::upsert(stock_line_row.clone()),
                 IntegrationOperation::upsert(location_movement_row.clone()),
             ],
+            ..Default::default()
         });
 
         // STEP 2 - mutate
@@ -80,9 +80,8 @@ impl SyncRecordTester for LocationMovementRecordTester {
             d
         });
         result.push(TestStepData {
-            central_upsert: json!({}),
-            central_delete: json!({}),
             integration_records: vec![IntegrationOperation::upsert(location_movement.clone())],
+            ..Default::default()
         });
 
         result

--- a/server/service/src/sync/test/integration/remote/patient_name_and_store_and_name_store_join.rs
+++ b/server/service/src/sync/test/integration/remote/patient_name_and_store_and_name_store_join.rs
@@ -85,17 +85,17 @@ impl SyncRecordTester for PatientNameAndStoreAndNameStoreJoinTester {
 
         result.push(TestStepData {
             central_upsert: json!({
-                "store": [store_json ],
+                "store": [store_json],
                 "name": [patient_name_json, facility_name_json],
                 "name_store_join": [patient_name_store_join_json],
             }),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(patient_name_row.clone()),
                 IntegrationOperation::upsert(facility_name_row),
                 IntegrationOperation::upsert(patient_name_store_join_row),
                 IntegrationOperation::upsert(store_row),
             ],
+            ..Default::default()
         });
 
         // STEP 2 - update patient name
@@ -107,9 +107,8 @@ impl SyncRecordTester for PatientNameAndStoreAndNameStoreJoinTester {
         });
 
         result.push(TestStepData {
-            central_upsert: json!({}),
-            central_delete: json!({}),
             integration_records: vec![IntegrationOperation::upsert(patient_row)],
+            ..Default::default()
         });
 
         result

--- a/server/service/src/sync/test/integration/remote/program_requisition.rs
+++ b/server/service/src/sync/test/integration/remote/program_requisition.rs
@@ -226,7 +226,6 @@ impl SyncRecordTester for ProgramRequisitionTester {
                 "list_master": [master_list_json, master_list_json2],
                 "list_master_name_join": [master_list_name_join_json, master_list_name_join_json2],
             }),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(period_schedule1.clone()),
                 IntegrationOperation::upsert(period_schedule2),
@@ -245,6 +244,7 @@ impl SyncRecordTester for ProgramRequisitionTester {
                 IntegrationOperation::upsert(order_type2.clone()),
                 IntegrationOperation::upsert(order_type3.clone()),
             ],
+            ..Default::default()
         });
 
         // STEP 2 - mutate from central
@@ -303,7 +303,6 @@ impl SyncRecordTester for ProgramRequisitionTester {
                 "name_tag": [upsert_name_tag_json],
                 "list_master": [upsert_master_list_json],
             }),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(upsert_name_tag),
                 IntegrationOperation::upsert(upsert_program_requisition_settings),
@@ -318,6 +317,7 @@ impl SyncRecordTester for ProgramRequisitionTester {
                     program_requisition_settings2.id,
                 )),
             ],
+            ..Default::default()
         });
 
         result

--- a/server/service/src/sync/test/integration/remote/requisition.rs
+++ b/server/service/src/sync/test/integration/remote/requisition.rs
@@ -89,7 +89,6 @@ impl SyncRecordTester for RequisitionRecordTester {
                     "type": "store"
                 }],
             }),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(requisition_row_1.clone()),
                 IntegrationOperation::upsert(requisition_row_2.clone()),
@@ -97,6 +96,7 @@ impl SyncRecordTester for RequisitionRecordTester {
                 IntegrationOperation::upsert(requisition_row_4),
                 IntegrationOperation::upsert(requisition_line_row_1.clone()),
             ],
+            ..Default::default()
         });
 
         // STEP 2 - mutate
@@ -139,13 +139,12 @@ impl SyncRecordTester for RequisitionRecordTester {
         });
 
         result.push(TestStepData {
-            central_upsert: json!({}),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(requisition_row_1.clone()),
                 IntegrationOperation::upsert(requisition_row_2.clone()),
                 IntegrationOperation::upsert(requisition_line_row_1.clone()),
             ],
+            ..Default::default()
         });
         // STEP 3 - delete
         let requisition_row_2 = inline_edit(&requisition_row_2, |mut d| {
@@ -153,8 +152,6 @@ impl SyncRecordTester for RequisitionRecordTester {
             d
         });
         result.push(TestStepData {
-            central_upsert: json!({}),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(requisition_row_2),
                 IntegrationOperation::delete(RequisitionLineRowDelete(
@@ -162,6 +159,7 @@ impl SyncRecordTester for RequisitionRecordTester {
                 )),
                 IntegrationOperation::delete(RequisitionRowDelete(requisition_row_1.id.clone())),
             ],
+            ..Default::default()
         });
         result
     }

--- a/server/service/src/sync/test/integration/remote/stock_line.rs
+++ b/server/service/src/sync/test/integration/remote/stock_line.rs
@@ -46,11 +46,11 @@ impl SyncRecordTester for StockLineRecordTester {
                 "ID": stock_line_row.item_id,
                 "type_of": "general"
             }]}),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(location_row),
                 IntegrationOperation::upsert(stock_line_row.clone()),
             ],
+            ..Default::default()
         });
         // STEP 2 - mutate
         let stock_line_row = inline_edit(&stock_line_row, |mut d| {
@@ -73,16 +73,15 @@ impl SyncRecordTester for StockLineRecordTester {
                 "ID": stock_line_row.item_id,
                 "type_of": "general"
             }]}),
-            central_delete: json!({}),
             integration_records: vec![IntegrationOperation::upsert(stock_line_row.clone())],
+            ..Default::default()
         });
         // STEP 3 - delete
         result.push(TestStepData {
-            central_upsert: json!({}),
-            central_delete: json!({}),
             integration_records: vec![IntegrationOperation::delete(StockLineRowDelete(
                 stock_line_row.id,
             ))],
+            ..Default::default()
         });
         result
     }

--- a/server/service/src/sync/test/integration/remote/stocktake.rs
+++ b/server/service/src/sync/test/integration/remote/stocktake.rs
@@ -67,12 +67,12 @@ impl SyncRecordTester for StocktakeRecordTester {
                 "ID": stocktake_line_row.item_id,
                 "type_of": "general"
             }]}),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(location_row),
                 IntegrationOperation::upsert(stocktake_row.clone()),
                 IntegrationOperation::upsert(stocktake_line_row.clone()),
             ],
+            ..Default::default()
         });
         // STEP 2 - mutate
         let invoice_row = inline_init(|r: &mut InvoiceRow| {
@@ -126,22 +126,21 @@ impl SyncRecordTester for StocktakeRecordTester {
                 "ID": stock_line_row.item_id,
                 "type_of": "general"
             }]}),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(invoice_row),
                 IntegrationOperation::upsert(stock_line_row.clone()),
                 IntegrationOperation::upsert(stocktake_row.clone()),
                 IntegrationOperation::upsert(stocktake_line_row.clone()),
             ],
+            ..Default::default()
         });
         // STEP 3 - delete
         result.push(TestStepData {
-            central_upsert: json!({}),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::delete(StocktakeLineRowDelete(stocktake_line_row.id.clone())),
                 IntegrationOperation::delete(StocktakeRowDelete(stocktake_row.id.clone())),
             ],
+            ..Default::default()
         });
         result
     }

--- a/server/service/src/sync/test/integration/remote/user_permission.rs
+++ b/server/service/src/sync/test/integration/remote/user_permission.rs
@@ -64,22 +64,22 @@ impl SyncRecordTester for UserPermissionTester {
                 "list_master": [context_json],
                 "om_user_permission": [user_permission_row_1_json, user_permission_row_2_json],
             }),
-            central_delete: json!({}),
             integration_records: vec![
                 IntegrationOperation::upsert(user_permission_row_1.clone()),
                 IntegrationOperation::upsert(user_permission_row_2),
             ],
+            ..Default::default()
         });
 
         // STEP 2 - deletes
         result.push(TestStepData {
-            central_upsert: json!({}),
             central_delete: json!({
                 "om_user_permission": [user_permission_row_1.id],
             }),
             integration_records: vec![IntegrationOperation::delete(UserPermissionRowDelete(
                 user_permission_row_1.id,
             ))],
+            ..Default::default()
         });
         result
     }

--- a/server/service/src/test_helpers.rs
+++ b/server/service/src/test_helpers.rs
@@ -39,7 +39,7 @@ pub(crate) async fn setup_all_with_data_and_service_provider(
 
     let service_provider = Arc::new(ServiceProvider::new_with_triggers(
         connection_manager.clone(),
-        "",
+        "../app_data",
         processors_trigger,
         sync_trigger,
         site_is_initialise_trigger,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Links to #2062-3 (integration tests for omSupply central)

# 👩🏻‍💻 What does this PR do? 

The updated docs should explain what this PR achieves.

* Add om_supply_central_graphql_operations to integration TestData struct, which also required adding Default spread on existing tests. This field allows mutating data in omSupply central (which needs to be started in `APP_SERVER__DEBUG_NO_ACCESS_CONTROL` mode, thank you @clemens-msupply for this field, made this functionality so much simpler (otherwise would need to create user, login etc..)
* Creates TestData for pack variant
* Adds omSupply central config test driver, which has a helper for running graphql query and for asking omSupply central to sync. 

# 🧪 How has/should this change been tested? 

Running integration tests as per integration test doc

## 💌 Any notes for the reviewer?

See PR with docs for further explanation of omSupply central server https://github.com/msupply-foundation/open-msupply/pull/2820
