### PR TITLE
Backspace too quickly and the query is incorrect

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Filters/TextFilter.tsx
+++ b/client/packages/common/src/ui/components/inputs/Filters/TextFilter.tsx
@@ -29,8 +29,7 @@ export const TextFilter: FC<{
 
   const handleChange = (newValue: string) => {
     setValue(newValue);
-    if (newValue === '') updateQuery({ [filterDefinition.urlParameter]: '' });
-    else debouncedOnChange(newValue);
+    debouncedOnChange(newValue);
   };
 
   return (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2822

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
If you enter a value into a text filter and then slowly press backspace, deleting each character in turn, then the filter works correctly.

If you do what I think is more normal, and mash backspace repeatedly until the text is cleared, then the first letter of the query remains.

This is because the url query is cleared immediately and then the debounced call fires and sets the query to be the final character in the search text. I've removed the inconsistent behaviour.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
As above, try clearing search text quickly using backspace and see what happens.


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
