### PR TITLE
Rename item_link_id for MasterListLineRow

### DIFF
--- a/server/graphql/general/src/queries/tests/master_lists.rs
+++ b/server/graphql/general/src/queries/tests/master_lists.rs
@@ -108,7 +108,7 @@ mod graphql {
                 json!({
                     "id": line.id,
                     "item": {
-                        "id": line.item_id
+                        "id": line.item_link_id
                     }
                 })
             })

--- a/server/repository/src/db_diesel/item.rs
+++ b/server/repository/src/db_diesel/item.rs
@@ -514,22 +514,22 @@ mod tests {
         let master_list_line_rows = vec![
             MasterListLineRow {
                 id: "id1".to_owned(),
-                item_id: "item1".to_owned(),
+                item_link_id: "item1".to_owned(),
                 master_list_id: "master_list1".to_owned(),
             },
             MasterListLineRow {
                 id: "id2".to_owned(),
-                item_id: "item2".to_owned(),
+                item_link_id: "item2".to_owned(),
                 master_list_id: "master_list1".to_owned(),
             },
             MasterListLineRow {
                 id: "id3".to_owned(),
-                item_id: "item3".to_owned(),
+                item_link_id: "item3".to_owned(),
                 master_list_id: "master_list2".to_owned(),
             },
             MasterListLineRow {
                 id: "id4".to_owned(),
-                item_id: "item4".to_owned(),
+                item_link_id: "item4".to_owned(),
                 master_list_id: "master_list2".to_owned(),
             },
         ];

--- a/server/repository/src/db_diesel/master_list_line.rs
+++ b/server/repository/src/db_diesel/master_list_line.rs
@@ -15,7 +15,12 @@ use diesel::{
     prelude::*,
 };
 
-pub type MasterListLine = MasterListLineRow;
+#[derive(Clone, Debug, PartialEq)]
+pub struct MasterListLine {
+    pub id: String,
+    pub item_id: String,
+    pub master_list_id: String,
+}
 
 type MasterListLineJoin = (MasterListLineRow, (ItemLinkRow, ItemRow));
 
@@ -45,7 +50,7 @@ impl<'a> MasterListLineRepository<'a> {
     pub fn query_by_filter(
         &self,
         filter: MasterListLineFilter,
-    ) -> Result<Vec<MasterListLineRow>, RepositoryError> {
+    ) -> Result<Vec<MasterListLine>, RepositoryError> {
         // TODO (beyond M1), check that store_id matches current store
         let mut query = create_filtered_query(Some(filter))?;
 
@@ -60,7 +65,7 @@ impl<'a> MasterListLineRepository<'a> {
         &self,
         pagination: Pagination,
         filter: Option<MasterListLineFilter>,
-    ) -> Result<Vec<MasterListLineRow>, RepositoryError> {
+    ) -> Result<Vec<MasterListLine>, RepositoryError> {
         // TODO (beyond M1), check that store_id matches current store
         let mut query = create_filtered_query(filter)?;
 
@@ -101,8 +106,8 @@ fn create_filtered_query(
     Ok(query)
 }
 
-fn to_domain((master_list_line_row, (_, item_row)): MasterListLineJoin) -> MasterListLineRow {
-    MasterListLineRow {
+fn to_domain((master_list_line_row, (_, item_row)): MasterListLineJoin) -> MasterListLine {
+    MasterListLine {
         id: master_list_line_row.id,
         master_list_id: master_list_line_row.master_list_id,
         item_id: item_row.id,

--- a/server/repository/src/db_diesel/master_list_line_row.rs
+++ b/server/repository/src/db_diesel/master_list_line_row.rs
@@ -24,8 +24,7 @@ allow_tables_to_appear_in_same_query!(master_list_line, name_link);
 #[table_name = "master_list_line"]
 pub struct MasterListLineRow {
     pub id: String,
-    #[column_name = "item_link_id"]
-    pub item_id: String,
+    pub item_link_id: String,
     pub master_list_id: String,
 }
 

--- a/server/repository/src/mock/full_master_list.rs
+++ b/server/repository/src/mock/full_master_list.rs
@@ -26,7 +26,7 @@ pub fn mock_master_list_item_query_test1() -> FullMockMasterList {
         }],
         lines: vec![MasterListLineRow {
             id: "item_query_test1".to_owned(),
-            item_id: "item_query_test1".to_owned(),
+            item_link_id: "item_query_test1".to_owned(),
             master_list_id: "item_query_test1".to_owned(),
         }],
     }
@@ -73,7 +73,7 @@ pub fn mock_master_list_program() -> FullMockMasterList {
         ],
         lines: vec![MasterListLineRow {
             id: "program_item".to_owned(),
-            item_id: "item_query_test1".to_owned(),
+            item_link_id: "item_query_test1".to_owned(),
             master_list_id: "master_list_program".to_owned(),
         }],
     }
@@ -92,12 +92,12 @@ pub fn mock_master_list_master_list_line_filter_test() -> FullMockMasterList {
         lines: vec![
             MasterListLineRow {
                 id: "master_list_line_filter_test_1".to_owned(),
-                item_id: "item_a".to_owned(),
+                item_link_id: "item_a".to_owned(),
                 master_list_id: "master_list_master_list_line_filter_test".to_owned(),
             },
             MasterListLineRow {
                 id: "master_list_line_filter_test_2".to_owned(),
-                item_id: "item_b".to_owned(),
+                item_link_id: "item_b".to_owned(),
                 master_list_id: "master_list_master_list_line_filter_test".to_owned(),
             },
         ],

--- a/server/repository/src/tests.rs
+++ b/server/repository/src/tests.rs
@@ -92,7 +92,7 @@ mod repository_test {
         pub fn master_list_line_1() -> MasterListLineRow {
             MasterListLineRow {
                 id: "masterlistline1".to_string(),
-                item_id: item_1().id.to_string(),
+                item_link_id: item_1().id.to_string(),
                 master_list_id: master_list_1().id.to_string(),
             }
         }
@@ -100,7 +100,7 @@ mod repository_test {
         pub fn master_list_line_upsert_1() -> MasterListLineRow {
             MasterListLineRow {
                 id: "masterlistline1".to_string(),
-                item_id: item_2().id.to_string(),
+                item_link_id: item_2().id.to_string(),
                 master_list_id: master_list_1().id.to_string(),
             }
         }

--- a/server/service/src/dashboard/item_count.rs
+++ b/server/service/src/dashboard/item_count.rs
@@ -147,17 +147,17 @@ mod item_count_service_test {
                     lines: vec![
                         MasterListLineRow {
                             id: "listline1".to_string(),
-                            item_id: "item1".to_string(),
+                            item_link_id: "item1".to_string(),
                             master_list_id: "list1".to_string(),
                         },
                         MasterListLineRow {
                             id: "listline2".to_string(),
-                            item_id: "item2".to_string(),
+                            item_link_id: "item2".to_string(),
                             master_list_id: "list1".to_string(),
                         },
                         MasterListLineRow {
                             id: "listline3".to_string(),
-                            item_id: "item3".to_string(),
+                            item_link_id: "item3".to_string(),
                             master_list_id: "list1".to_string(),
                         },
                     ],
@@ -228,17 +228,17 @@ mod item_count_service_test {
                     lines: vec![
                         MasterListLineRow {
                             id: "listline1".to_string(),
-                            item_id: "item1".to_string(),
+                            item_link_id: "item1".to_string(),
                             master_list_id: "list1".to_string(),
                         },
                         MasterListLineRow {
                             id: "listline2".to_string(),
-                            item_id: "item2".to_string(),
+                            item_link_id: "item2".to_string(),
                             master_list_id: "list1".to_string(),
                         },
                         MasterListLineRow {
                             id: "listline3".to_string(),
-                            item_id: "item3".to_string(),
+                            item_link_id: "item3".to_string(),
                             master_list_id: "list1".to_string(),
                         },
                     ],
@@ -376,17 +376,17 @@ mod item_count_service_test {
                     lines: vec![
                         MasterListLineRow {
                             id: "listline1".to_string(),
-                            item_id: "item1".to_string(),
+                            item_link_id: "item1".to_string(),
                             master_list_id: "list1".to_string(),
                         },
                         MasterListLineRow {
                             id: "listline2".to_string(),
-                            item_id: "item2".to_string(),
+                            item_link_id: "item2".to_string(),
                             master_list_id: "list1".to_string(),
                         },
                         MasterListLineRow {
                             id: "listline3".to_string(),
-                            item_id: "item3".to_string(),
+                            item_link_id: "item3".to_string(),
                             master_list_id: "list1".to_string(),
                         },
                     ],

--- a/server/service/src/invoice/inbound_shipment/add_from_master_list.rs
+++ b/server/service/src/invoice/inbound_shipment/add_from_master_list.rs
@@ -229,22 +229,22 @@ mod test {
                 lines: vec![
                     MasterListLineRow {
                         id: line1.clone(),
-                        item_id: mock_item_a().id,
+                        item_link_id: mock_item_a().id,
                         master_list_id: id.clone(),
                     },
                     MasterListLineRow {
                         id: line2.clone(),
-                        item_id: mock_item_b().id,
+                        item_link_id: mock_item_b().id,
                         master_list_id: id.clone(),
                     },
                     MasterListLineRow {
                         id: line3.clone(),
-                        item_id: mock_item_c().id,
+                        item_link_id: mock_item_c().id,
                         master_list_id: id.clone(),
                     },
                     MasterListLineRow {
                         id: line4.clone(),
-                        item_id: mock_item_d().id,
+                        item_link_id: mock_item_d().id,
                         master_list_id: id.clone(),
                     },
                 ],

--- a/server/service/src/invoice/outbound_shipment/add_from_master_list.rs
+++ b/server/service/src/invoice/outbound_shipment/add_from_master_list.rs
@@ -239,22 +239,22 @@ mod test {
                 lines: vec![
                     MasterListLineRow {
                         id: line1.clone(),
-                        item_id: mock_item_a().id,
+                        item_link_id: mock_item_a().id,
                         master_list_id: id.clone(),
                     },
                     MasterListLineRow {
                         id: line2.clone(),
-                        item_id: mock_item_b().id,
+                        item_link_id: mock_item_b().id,
                         master_list_id: id.clone(),
                     },
                     MasterListLineRow {
                         id: line3.clone(),
-                        item_id: mock_item_c().id,
+                        item_link_id: mock_item_c().id,
                         master_list_id: id.clone(),
                     },
                     MasterListLineRow {
                         id: line4.clone(),
-                        item_id: mock_item_d().id,
+                        item_link_id: mock_item_d().id,
                         master_list_id: id.clone(),
                     },
                 ],

--- a/server/service/src/requisition/request_requisition/add_from_master_list.rs
+++ b/server/service/src/requisition/request_requisition/add_from_master_list.rs
@@ -264,17 +264,17 @@ mod test {
                 lines: vec![
                     MasterListLineRow {
                         id: line1.clone(),
-                        item_id: mock_item_a().id,
+                        item_link_id: mock_item_a().id,
                         master_list_id: id.clone(),
                     },
                     MasterListLineRow {
                         id: line2.clone(),
-                        item_id: test_item_stats::item().id,
+                        item_link_id: test_item_stats::item().id,
                         master_list_id: id.clone(),
                     },
                     MasterListLineRow {
                         id: line3.clone(),
-                        item_id: test_item_stats::item2().id,
+                        item_link_id: test_item_stats::item2().id,
                         master_list_id: id.clone(),
                     },
                 ],

--- a/server/service/src/stocktake/insert.rs
+++ b/server/service/src/stocktake/insert.rs
@@ -576,7 +576,7 @@ mod test {
         let _ = MasterListLineRowRepository::new(&connection).upsert_one(&MasterListLineRow {
             id: "master_list_line_b".to_string(),
             master_list_id: master_list_id.clone(),
-            item_id: "item_d".to_string(),
+            item_link_id: "item_d".to_string(),
         });
 
         service

--- a/server/service/src/sync/test/test_data/master_list_line.rs
+++ b/server/service/src/sync/test/test_data/master_list_line.rs
@@ -23,7 +23,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
         MASTER_LIST_LINE_1,
         PullUpsertRecord::MasterListLine(MasterListLineRow {
             id: "9B02D0770B544BD1AC7DB99BB85FCDD5".to_owned(),
-            item_id: "8F252B5884B74888AAB73A0D42C09E7F".to_owned(),
+            item_link_id: "8F252B5884B74888AAB73A0D42C09E7F".to_owned(),
             master_list_id: "87027C44835B48E6989376F42A58F7E3".to_owned(),
         }),
     )]

--- a/server/service/src/sync/translations/master_list_line.rs
+++ b/server/service/src/sync/translations/master_list_line.rs
@@ -38,7 +38,7 @@ impl SyncTranslation for MasterListLineTranslation {
         let data = serde_json::from_str::<LegacyListMasterLineRow>(&sync_record.data)?;
         let result = MasterListLineRow {
             id: data.ID,
-            item_id: data.item_ID,
+            item_link_id: data.item_ID,
             master_list_id: data.item_master_ID,
         };
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Part of #2759

This one introduces a proper MasterListLine domain object. This actually follows the idea of a repository more closely to make the DB layer independent of the rest of the system. Maybe we should have done this for other repos as well?

We could even make MasterListLineRow private to the repo and change all usages to MasterListLine...