### PR TITLE
2827 separate currency from language

### DIFF
--- a/client/packages/common/src/authentication/api/operations.generated.ts
+++ b/client/packages/common/src/authentication/api/operations.generated.ts
@@ -4,7 +4,7 @@ import { GraphQLClient } from 'graphql-request';
 import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types';
 import gql from 'graphql-tag';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
-export type UserStoreNodeFragment = { __typename: 'UserStoreNode', code: string, id: string, name: string, storeMode: Types.StoreModeNodeType, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean, omProgramModule: boolean, vaccineModule: boolean } };
+export type UserStoreNodeFragment = { __typename: 'UserStoreNode', code: string, id: string, name: string, storeMode: Types.StoreModeNodeType, homeCurrencyCode?: string | null, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean, omProgramModule: boolean, vaccineModule: boolean, issueInForeignCurrency: boolean } };
 
 export type AuthTokenQueryVariables = Types.Exact<{
   username: Types.Scalars['String']['input'];
@@ -17,7 +17,7 @@ export type AuthTokenQuery = { __typename: 'Queries', authToken: { __typename: '
 export type MeQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type MeQuery = { __typename: 'Queries', me: { __typename: 'UserNode', email?: string | null, language: Types.LanguageType, username: string, userId: string, firstName?: string | null, lastName?: string | null, phoneNumber?: string | null, jobTitle?: string | null, defaultStore?: { __typename: 'UserStoreNode', code: string, id: string, name: string, storeMode: Types.StoreModeNodeType, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean, omProgramModule: boolean, vaccineModule: boolean } } | null, stores: { __typename: 'UserStoreConnector', totalCount: number, nodes: Array<{ __typename: 'UserStoreNode', code: string, id: string, name: string, storeMode: Types.StoreModeNodeType, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean, omProgramModule: boolean, vaccineModule: boolean } }> } } };
+export type MeQuery = { __typename: 'Queries', me: { __typename: 'UserNode', email?: string | null, language: Types.LanguageType, username: string, userId: string, firstName?: string | null, lastName?: string | null, phoneNumber?: string | null, jobTitle?: string | null, defaultStore?: { __typename: 'UserStoreNode', code: string, id: string, name: string, storeMode: Types.StoreModeNodeType, homeCurrencyCode?: string | null, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean, omProgramModule: boolean, vaccineModule: boolean, issueInForeignCurrency: boolean } } | null, stores: { __typename: 'UserStoreConnector', totalCount: number, nodes: Array<{ __typename: 'UserStoreNode', code: string, id: string, name: string, storeMode: Types.StoreModeNodeType, homeCurrencyCode?: string | null, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean, omProgramModule: boolean, vaccineModule: boolean, issueInForeignCurrency: boolean } }> } } };
 
 export type RefreshTokenQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
@@ -51,7 +51,9 @@ export const UserStoreNodeFragmentDoc = gql`
     packToOne
     omProgramModule
     vaccineModule
+    issueInForeignCurrency
   }
+  homeCurrencyCode
 }
     `;
 export const AuthTokenDocument = gql`

--- a/client/packages/common/src/authentication/api/operations.graphql
+++ b/client/packages/common/src/authentication/api/operations.graphql
@@ -10,7 +10,9 @@ fragment UserStoreNode on UserStoreNode {
     packToOne
     omProgramModule
     vaccineModule
+    issueInForeignCurrency
   }
+  homeCurrencyCode
 }
 
 query authToken($username: String!, $password: String!) {

--- a/client/packages/common/src/intl/currency/currency.test.tsx
+++ b/client/packages/common/src/intl/currency/currency.test.tsx
@@ -43,27 +43,21 @@ describe('currency formatting - en', () => {
 
 describe('currency formatting - fr', () => {
   it('formats a string with up to the precision number of decimal places, dropping decimal places where needed', () => {
-    const { result } = renderHookWithProvider(() =>
-      useCurrency(undefined, 'EUR')
-    );
+    const { result } = renderHookWithProvider(() => useCurrency('EUR'));
 
     const f1 = result.current.c(1.11111111111).format();
     expect(f1).toBe('1,11 €');
   });
 
   it('formats a string with up to the precision number of decimal places, dropping decimal places where needed even with large numbers', () => {
-    const { result } = renderHookWithProvider(() =>
-      useCurrency(undefined, 'EUR')
-    );
+    const { result } = renderHookWithProvider(() => useCurrency('EUR'));
 
     const f1 = result.current.c(111_111.11111111111).format();
     expect(f1).toBe('111.111,11 €');
   });
 
   it('does drop trailing zeroes', () => {
-    const { result } = renderHookWithProvider(() =>
-      useCurrency(undefined, 'EUR')
-    );
+    const { result } = renderHookWithProvider(() => useCurrency('EUR'));
 
     // Note: Using a string to pass into c as formatters will generally
     // auto clear trailing zeroes when literal numbers.
@@ -71,17 +65,13 @@ describe('currency formatting - fr', () => {
     expect(f1).toBe('111,11 €');
   });
   it('has a minimum of two trailing zeroes, adding one if needed', () => {
-    const { result } = renderHookWithProvider(() =>
-      useCurrency(undefined, 'EUR')
-    );
+    const { result } = renderHookWithProvider(() => useCurrency('EUR'));
 
     const f1 = result.current.c('111,1000').format();
     expect(f1).toBe('111,10 €');
   });
   it('has a minimum of two trailing zeroes, adding two if needed', () => {
-    const { result } = renderHookWithProvider(() =>
-      useCurrency(undefined, 'EUR')
-    );
+    const { result } = renderHookWithProvider(() => useCurrency('EUR'));
 
     const f1 = result.current.c(111).format();
     expect(f1).toBe('111,00 €');

--- a/client/packages/common/src/intl/currency/currency.test.tsx
+++ b/client/packages/common/src/intl/currency/currency.test.tsx
@@ -1,7 +1,5 @@
 import { renderHookWithProvider } from '@common/utils';
 import { useCurrency } from './currency';
-import { useIntlUtils } from '../utils';
-import { act } from 'react-dom/test-utils';
 
 describe('currency formatting - en', () => {
   it('formats a string with up to the precision number of decimal places, dropping decimal places where needed', () => {
@@ -44,34 +42,28 @@ describe('currency formatting - en', () => {
 });
 
 describe('currency formatting - fr', () => {
-  beforeAll(() => {
-    const { result: intlUtils } = renderHookWithProvider(useIntlUtils);
-    act(() => {
-      intlUtils.current.changeLanguage('fr');
-    });
-  });
-
   it('formats a string with up to the precision number of decimal places, dropping decimal places where needed', () => {
-    const { result } = renderHookWithProvider(useCurrency, {
-      providerProps: { locale: 'fr' },
-    });
+    const { result } = renderHookWithProvider(() =>
+      useCurrency(undefined, 'EUR')
+    );
 
-    const f2 = result.current.c(1.11111111111).format();
-    expect(f2).toBe('1,11 €');
+    const f1 = result.current.c(1.11111111111).format();
+    expect(f1).toBe('1,11 €');
   });
+
   it('formats a string with up to the precision number of decimal places, dropping decimal places where needed even with large numbers', () => {
-    const { result } = renderHookWithProvider(useCurrency, {
-      providerProps: { locale: 'fr' },
-    });
+    const { result } = renderHookWithProvider(() =>
+      useCurrency(undefined, 'EUR')
+    );
 
     const f1 = result.current.c(111_111.11111111111).format();
     expect(f1).toBe('111.111,11 €');
   });
 
   it('does drop trailing zeroes', () => {
-    const { result } = renderHookWithProvider(useCurrency, {
-      providerProps: { locale: 'fr' },
-    });
+    const { result } = renderHookWithProvider(() =>
+      useCurrency(undefined, 'EUR')
+    );
 
     // Note: Using a string to pass into c as formatters will generally
     // auto clear trailing zeroes when literal numbers.
@@ -79,17 +71,17 @@ describe('currency formatting - fr', () => {
     expect(f1).toBe('111,11 €');
   });
   it('has a minimum of two trailing zeroes, adding one if needed', () => {
-    const { result } = renderHookWithProvider(useCurrency, {
-      providerProps: { locale: 'fr' },
-    });
+    const { result } = renderHookWithProvider(() =>
+      useCurrency(undefined, 'EUR')
+    );
 
     const f1 = result.current.c('111,1000').format();
     expect(f1).toBe('111,10 €');
   });
   it('has a minimum of two trailing zeroes, adding two if needed', () => {
-    const { result } = renderHookWithProvider(useCurrency, {
-      providerProps: { locale: 'fr' },
-    });
+    const { result } = renderHookWithProvider(() =>
+      useCurrency(undefined, 'EUR')
+    );
 
     const f1 = result.current.c(111).format();
     expect(f1).toBe('111,00 €');

--- a/client/packages/common/src/intl/currency/currency.ts
+++ b/client/packages/common/src/intl/currency/currency.ts
@@ -1,5 +1,5 @@
 import currency from 'currency.js';
-import { useIntlUtils } from '../utils';
+import { useAuthContext } from '../../authentication';
 
 const trimCents = (centsString: string) => {
   const trimmed = Number(`.${centsString}`);
@@ -67,80 +67,121 @@ export const format: currency.Format = (
   return replacePattern.replace('!', symbol).replace('#', moneyString);
 };
 
-const currencyOptions = {
-  en: {
-    symbol: '$',
-    separator: ',',
-    decimal: '.',
-    precision: 2,
-    pattern: '!#',
-    negativePattern: '-!#',
-    format,
-  },
-  fr: {
-    symbol: '€',
-    separator: '.',
-    decimal: ',',
-    precision: 2,
-    pattern: '# !',
-    negativePattern: '-# !',
-    format,
-  },
-  'fr-DJ': {
-    symbol: 'DJF',
-    separator: '.',
-    decimal: ',',
-    precision: 2,
-    pattern: '# !',
-    negativePattern: '-# !',
-    format,
-  },
-  ar: {
-    symbol: 'ر.ق.',
-    separator: ',',
-    decimal: '.',
-    precision: 2,
-    pattern: '!#',
-    negativePattern: '-!#',
-    format,
-  },
-  es: {
-    symbol: '$',
-    separator: ',',
-    decimal: '.',
-    precision: 2,
-    pattern: '!#',
-    negativePattern: '-!#',
-    format,
-  },
-  tet: {
-    symbol: '$',
-    separator: ',',
-    decimal: '.',
-    precision: 2,
-    pattern: '!#',
-    negativePattern: '-!#',
-    format,
-  },
-  ru: {
-    symbol: '₽',
-    separator: '.',
-    decimal: ',',
-    precision: 2,
-    pattern: '# !',
-    negativePattern: '-# !',
-    format,
-  },
+export type Currencies =
+  | 'USD'
+  | 'EUR'
+  | 'NZD'
+  | 'AUD'
+  | 'DJF'
+  | 'QAR'
+  | 'RUB'
+  | 'SSP'
+  | 'PGK'
+  | 'COP';
+
+export const currencyOptions = (code?: Currencies) => {
+  switch (code) {
+    case 'USD':
+    case 'NZD':
+      return {
+        symbol: '$',
+        separator: ',',
+        decimal: '.',
+        precision: 2,
+        pattern: '!#',
+        negativePattern: '-!#',
+        format,
+      };
+    case 'EUR':
+      return {
+        symbol: '€',
+        separator: '.',
+        decimal: ',',
+        precision: 2,
+        pattern: '# !',
+        negativePattern: '-# !',
+        format,
+      };
+    case 'DJF':
+      return {
+        symbol: 'DJF',
+        separator: ',',
+        decimal: '.',
+        precision: 2,
+        pattern: '# !',
+        negativePattern: '-# !',
+        format,
+      };
+    case 'QAR':
+      return {
+        symbol: 'ر.ق.',
+        separator: ',',
+        decimal: '.',
+        precision: 2,
+        pattern: '!#',
+        negativePattern: '-!#',
+        format,
+      };
+    case 'RUB':
+      return {
+        symbol: '₽',
+        separator: '.',
+        decimal: ',',
+        precision: 2,
+        pattern: '# !',
+        negativePattern: '-# !',
+        format,
+      };
+    case 'SSP': {
+      return {
+        symbol: 'SSP',
+        pattern: '# !',
+        negativePattern: '-# !',
+        format,
+      };
+    }
+    case 'PGK': {
+      return {
+        symbol: 'K',
+        separator: '.',
+        decimal: ',',
+        precision: 2,
+        pattern: '# !',
+        negativePattern: '-# !',
+        format,
+      };
+    }
+    case 'COP': {
+      return {
+        symbol: '$',
+        pattern: '# !',
+        negativePattern: '-# !',
+        format,
+      };
+    }
+    default:
+      return {
+        symbol: '$',
+        separator: ',',
+        decimal: '.',
+        precision: 2,
+        pattern: '!#',
+        negativePattern: '-!#',
+        format,
+      };
+  }
 };
 
-export const useCurrency = (dp?: number) => {
-  const { currentLanguage: language } = useIntlUtils();
-  const options = currencyOptions[language];
+export const useCurrency = (dp?: number, code?: Currencies) => {
+  const { store } = useAuthContext();
+  const currencyCode = code ? code : (store?.homeCurrencyCode as Currencies);
+
+  const options = currencyOptions(currencyCode);
   const precision = dp ?? options.precision;
   return {
     c: (value: currency.Any) => currency(value, { ...options, precision }),
     options,
-    language,
+    currencyCode,
   };
 };
 

--- a/client/packages/common/src/intl/currency/currency.ts
+++ b/client/packages/common/src/intl/currency/currency.ts
@@ -71,7 +71,6 @@ export type Currencies =
   | 'USD'
   | 'EUR'
   | 'NZD'
-  | 'AUD'
   | 'DJF'
   | 'QAR'
   | 'RUB'

--- a/client/packages/common/src/intl/currency/currency.ts
+++ b/client/packages/common/src/intl/currency/currency.ts
@@ -76,7 +76,8 @@ export type Currencies =
   | 'RUB'
   | 'SSP'
   | 'PGK'
-  | 'COP';
+  | 'COP'
+  | 'SBD';
 
 export const currencyOptions = (code?: Currencies) => {
   switch (code) {
@@ -124,6 +125,7 @@ export const currencyOptions = (code?: Currencies) => {
       return {
         symbol: 'SSP',
         pattern: '# !',
+        separator: ',',
         negativePattern: '-# !',
         format,
       };
@@ -144,7 +146,19 @@ export const currencyOptions = (code?: Currencies) => {
         symbol: '$',
         pattern: '# !',
         negativePattern: '-# !',
+        separator: ',',
         format,
+      };
+    }
+    case 'SBD': {
+      return {
+        symbol: 'SI$',
+        pattern: '# !',
+        negativePattern: '-# !',
+        format,
+        separator: ',',
+        decimal: '.',
+        precision: 2,
       };
     }
     case 'USD':

--- a/client/packages/common/src/intl/currency/currency.ts
+++ b/client/packages/common/src/intl/currency/currency.ts
@@ -80,17 +80,6 @@ export type Currencies =
 
 export const currencyOptions = (code?: Currencies) => {
   switch (code) {
-    case 'USD':
-    case 'NZD':
-      return {
-        symbol: '$',
-        separator: ',',
-        decimal: '.',
-        precision: 2,
-        pattern: '!#',
-        negativePattern: '-!#',
-        format,
-      };
     case 'EUR':
       return {
         symbol: '€',
@@ -158,6 +147,8 @@ export const currencyOptions = (code?: Currencies) => {
         format,
       };
     }
+    case 'USD':
+    case 'NZD':
     default:
       return {
         symbol: '$',
@@ -171,12 +162,12 @@ export const currencyOptions = (code?: Currencies) => {
   }
 };
 
-export const useCurrency = (dp?: number, code?: Currencies) => {
+export const useCurrency = (code?: Currencies) => {
   const { store } = useAuthContext();
   const currencyCode = code ? code : (store?.homeCurrencyCode as Currencies);
 
   const options = currencyOptions(currencyCode);
-  const precision = dp ?? options.precision;
+  const precision = options.precision;
   return {
     c: (value: currency.Any) => currency(value, { ...options, precision }),
     options,
@@ -184,7 +175,7 @@ export const useCurrency = (dp?: number, code?: Currencies) => {
   };
 };
 
-export const useFormatCurrency = (dp?: number) => {
-  const { c } = useCurrency(dp);
+export const useFormatCurrency = () => {
+  const { c } = useCurrency();
   return (value: currency.Any) => c(value).format();
 };

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -619,6 +619,44 @@ export type CreateRequisitionShipmentInput = {
 
 export type CreateRequisitionShipmentResponse = CreateRequisitionShipmentError | InvoiceNode;
 
+export type CurrenciesResponse = CurrencyConnector;
+
+export type CurrencyConnector = {
+  __typename: 'CurrencyConnector';
+  nodes: Array<CurrencyNode>;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type CurrencyFilterInput = {
+  id?: InputMaybe<EqualFilterStringInput>;
+  isHomeCurrency?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type CurrencyNode = {
+  __typename: 'CurrencyNode';
+  code: Scalars['String']['output'];
+  dateUpdated?: Maybe<Scalars['NaiveDate']['output']>;
+  id: Scalars['String']['output'];
+  isHomeCurrency: Scalars['Boolean']['output'];
+  rate: Scalars['Float']['output'];
+};
+
+export enum CurrencySortFieldInput {
+  CurrencyCode = 'currencyCode',
+  Id = 'id',
+  IsHomeCurrency = 'isHomeCurrency'
+}
+
+export type CurrencySortInput = {
+  /**
+   * 	Sort query result is sorted descending or ascending (if not provided the default is
+   * ascending)
+   */
+  desc?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Sort query result by `key` */
+  key: CurrencySortFieldInput;
+};
+
 export type DatabaseError = DeleteLocationErrorInterface & InsertLocationErrorInterface & NodeErrorInterface & RefreshTokenErrorInterface & UpdateLocationErrorInterface & UpdateSensorErrorInterface & {
   __typename: 'DatabaseError';
   description: Scalars['String']['output'];
@@ -3699,6 +3737,7 @@ export type Queries = {
   centralPatientSearch: CentralPatientSearchResponse;
   clinicians: CliniciansResponse;
   contactTraces: ContactTraceResponse;
+  currencies: CurrenciesResponse;
   displaySettings: DisplaySettingsNode;
   document?: Maybe<DocumentNode>;
   documentHistory: DocumentHistoryResponse;
@@ -3835,6 +3874,12 @@ export type QueriesContactTracesArgs = {
   page?: InputMaybe<PaginationInput>;
   sort?: InputMaybe<ContactTraceSortInput>;
   storeId: Scalars['String']['input'];
+};
+
+
+export type QueriesCurrenciesArgs = {
+  filter?: InputMaybe<CurrencyFilterInput>;
+  sort?: InputMaybe<Array<CurrencySortInput>>;
 };
 
 
@@ -4929,6 +4974,7 @@ export type StoreNodeNameArgs = {
 export type StorePreferenceNode = {
   __typename: 'StorePreferenceNode';
   id: Scalars['String']['output'];
+  issueInForeignCurrency: Scalars['Boolean']['output'];
   omProgramModule: Scalars['Boolean']['output'];
   packToOne: Scalars['Boolean']['output'];
   requestRequisitionRequiresAuthorisation: Scalars['Boolean']['output'];
@@ -5922,6 +5968,7 @@ export type UserStoreConnector = {
 export type UserStoreNode = {
   __typename: 'UserStoreNode';
   code: Scalars['String']['output'];
+  homeCurrencyCode?: Maybe<Scalars['String']['output']>;
   id: Scalars['String']['output'];
   name: Scalars['String']['output'];
   preferences: StorePreferenceNode;

--- a/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -40,9 +40,9 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
   value,
   ...restOfProps
 }) => {
-  const { c, options, language } = useCurrency();
-  const prefix = language !== 'fr' ? options.symbol : '';
-  const suffix = language === 'fr' ? options.symbol : '';
+  const { c, options, currencyCode } = useCurrency();
+  const prefix = currencyCode !== 'EUR' ? options.symbol : '';
+  const suffix = currencyCode === 'EUR' ? options.symbol : '';
   const valueAsNumber = Number.isNaN(value) ? 0 : Number(value);
 
   return (

--- a/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -40,9 +40,10 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
   value,
   ...restOfProps
 }) => {
-  const { c, options, currencyCode } = useCurrency();
-  const prefix = currencyCode !== 'EUR' ? options.symbol : '';
-  const suffix = currencyCode === 'EUR' ? options.symbol : '';
+  const { c, options } = useCurrency();
+  const isSymbolLast = options.pattern.endsWith('!');
+  const prefix = !isSymbolLast ? options.symbol : '';
+  const suffix = isSymbolLast ? options.symbol : '';
   const valueAsNumber = Number.isNaN(value) ? 0 : Number(value);
 
   return (

--- a/server/graphql/general/src/queries/currency.rs
+++ b/server/graphql/general/src/queries/currency.rs
@@ -16,6 +16,7 @@ use service::{usize_to_u32, ListResult};
 pub enum CurrencySortFieldInput {
     Id,
     CurrencyCode,
+    IsHomeCurrency,
 }
 #[derive(InputObject)]
 pub struct CurrencySortInput {
@@ -30,7 +31,6 @@ pub struct CurrencySortInput {
 pub struct CurrencyFilterInput {
     pub id: Option<EqualFilterStringInput>,
     pub is_home_currency: Option<bool>,
-    pub is_active: Option<bool>,
 }
 
 impl CurrencyFilterInput {
@@ -38,13 +38,11 @@ impl CurrencyFilterInput {
         let CurrencyFilterInput {
             id,
             is_home_currency,
-            is_active,
         } = self;
 
         CurrencyFilter {
             id: id.map(EqualFilter::from),
             is_home_currency,
-            is_active,
         }
     }
 }
@@ -80,10 +78,6 @@ impl CurrencyNode {
 
     pub async fn date_updated(&self) -> Option<NaiveDate> {
         self.row().date_updated
-    }
-
-    pub async fn is_active(&self) -> bool {
-        self.row().is_active
     }
 }
 
@@ -138,6 +132,7 @@ impl CurrencySortInput {
         let key = match self.key {
             from::Id => to::Id,
             from::CurrencyCode => to::CurrencyCode,
+            from::IsHomeCurrency => to::IsHomeCurrency,
         };
 
         CurrencySort {

--- a/server/graphql/types/src/types/user.rs
+++ b/server/graphql/types/src/types/user.rs
@@ -5,7 +5,7 @@ use async_graphql::{
 use graphql_core::{
     loader::NameRowLoader, standard_graphql_error::StandardGraphqlError, ContextExt,
 };
-use repository::{Language, StoreMode, User, UserStore};
+use repository::{CurrencyFilter, Language, StoreMode, User, UserStore};
 use service::permission::permissions;
 
 pub struct UserStoreNode {
@@ -51,6 +51,27 @@ impl UserStoreNode {
 
     pub async fn store_mode(&self) -> StoreModeNodeType {
         StoreModeNodeType::from_domain(&self.user_store.store_row.store_mode)
+    }
+
+    pub async fn home_currency_code(&self, ctx: &Context<'_>) -> Result<Option<String>> {
+        let service_provider = ctx.service_provider();
+        let currency_provider = &service_provider.currency_service;
+        let service_context = service_provider.basic_context()?;
+
+        let home_currency = currency_provider
+            .get_currencies(
+                &service_context,
+                Some(CurrencyFilter::new().is_home_currency(true)),
+                None,
+            )
+            .map_err(StandardGraphqlError::from_list_error)?
+            .rows
+            .pop();
+
+        match home_currency {
+            Some(home_currency) => Ok(Some(home_currency.currency_row.code)),
+            None => Ok(None),
+        }
     }
 }
 

--- a/server/repository/src/db_diesel/currency.rs
+++ b/server/repository/src/db_diesel/currency.rs
@@ -20,12 +20,12 @@ pub struct Currency {
 pub struct CurrencyFilter {
     pub id: Option<EqualFilter<String>>,
     pub is_home_currency: Option<bool>,
-    pub is_active: Option<bool>,
 }
 
 pub enum CurrencySortField {
     Id,
     CurrencyCode,
+    IsHomeCurrency,
 }
 
 pub type CurrencySort = Sort<CurrencySortField>;
@@ -65,6 +65,9 @@ impl<'a> CurrencyRepository<'a> {
                 CurrencySortField::CurrencyCode => {
                     apply_sort_no_case!(query, sort, currency_dsl::code)
                 }
+                CurrencySortField::IsHomeCurrency => {
+                    apply_sort_no_case!(query, sort, currency_dsl::is_home_currency)
+                }
             }
         } else {
             query = query.order(currency_dsl::code.asc())
@@ -89,12 +92,6 @@ fn create_filtered_query(filter: Option<CurrencyFilter>) -> BoxedLogQuery {
             Some(false) => query.filter(currency_dsl::is_home_currency.eq(false)),
             None => query,
         };
-
-        query = match filter.is_active {
-            Some(true) => query.filter(currency_dsl::is_active.eq(true)),
-            Some(false) => query.filter(currency_dsl::is_active.eq(false)),
-            None => query,
-        };
     }
     query
 }
@@ -108,7 +105,6 @@ impl CurrencyFilter {
         CurrencyFilter {
             id: None,
             is_home_currency: None,
-            is_active: None,
         }
     }
 
@@ -119,11 +115,6 @@ impl CurrencyFilter {
 
     pub fn is_home_currency(mut self, filter: bool) -> Self {
         self.is_home_currency = Some(filter);
-        self
-    }
-
-    pub fn is_active(mut self, filter: bool) -> Self {
-        self.is_active = Some(filter);
         self
     }
 }

--- a/server/repository/src/db_diesel/currency_row.rs
+++ b/server/repository/src/db_diesel/currency_row.rs
@@ -12,7 +12,6 @@ table! {
         code -> Text,
         is_home_currency -> Bool,
         date_updated -> Nullable<Date>,
-        is_active -> Bool,
     }
 }
 
@@ -25,7 +24,6 @@ pub struct CurrencyRow {
     pub code: String,
     pub is_home_currency: bool,
     pub date_updated: Option<NaiveDate>,
-    pub is_active: bool,
 }
 
 pub struct CurrencyRowRepository<'a> {

--- a/server/repository/src/migrations/v1_07_00/currency.rs
+++ b/server/repository/src/migrations/v1_07_00/currency.rs
@@ -12,8 +12,7 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
             rate {DOUBLE} NOT NULL,
             code TEXT NOT NULL,
             is_home_currency BOOLEAN NOT NULL DEFAULT FALSE,
-            date_updated {DATE},
-            is_active BOOLEAN NOT NULL DEFAULT TRUE
+            date_updated {DATE}
         );
 
         "#,

--- a/server/service/src/sync/test/test_data/currency.rs
+++ b/server/service/src/sync/test/test_data/currency.rs
@@ -41,7 +41,6 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 code: "NZD".to_string(),
                 is_home_currency: true,
                 date_updated: Some(NaiveDate::from_ymd_opt(2020, 1, 1).unwrap()),
-                is_active: true,
             }),
         ),
         TestSyncPullRecord::new_pull_upsert(
@@ -53,7 +52,6 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 code: "AUD".to_string(),
                 is_home_currency: false,
                 date_updated: Some(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap()),
-                is_active: true,
             }),
         ),
     ]
@@ -70,7 +68,6 @@ pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
                 code: "NZD".to_string(),
                 is_home_currency: true,
                 date_updated: NaiveDate::from_ymd_opt(2020, 1, 1),
-                is_active: true,
             }),
         },
         TestSyncPushRecord {
@@ -82,7 +79,6 @@ pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
                 code: "AUD".to_string(),
                 is_home_currency: false,
                 date_updated: NaiveDate::from_ymd_opt(2022, 1, 1),
-                is_active: true,
             }),
         },
     ]

--- a/server/service/src/sync/translations/currency.rs
+++ b/server/service/src/sync/translations/currency.rs
@@ -35,7 +35,6 @@ pub struct LegacyCurrencyRow {
     #[serde(deserialize_with = "zero_date_as_option")]
     #[serde(serialize_with = "date_option_to_isostring")]
     pub date_updated: Option<NaiveDate>,
-    pub is_active: bool,
 }
 
 pub(crate) struct CurrencyTranslation {}
@@ -64,7 +63,6 @@ impl SyncTranslation for CurrencyTranslation {
             code: data.code,
             is_home_currency: data.is_home_currency,
             date_updated: data.date_updated,
-            is_active: data.is_active,
         };
 
         Ok(Some(IntegrationRecords::from_upsert(
@@ -87,7 +85,6 @@ impl SyncTranslation for CurrencyTranslation {
             code,
             is_home_currency,
             date_updated,
-            is_active,
         } = CurrencyRowRepository::new(connection)
             .find_one_by_id(&changelog.record_id)?
             .ok_or(anyhow::Error::msg(format!(
@@ -101,7 +98,6 @@ impl SyncTranslation for CurrencyTranslation {
             code,
             is_home_currency,
             date_updated,
-            is_active,
         };
         Ok(Some(vec![RemoteSyncRecordV5::new_upsert(
             changelog,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2827

# 👩🏻‍💻 What does this PR do? 
Removes `is_active` from currency... add sort by `is_home_currency` and store's `currency_code` to `UserNode` and finally separate currency from language.

Default currency: `USD/NZD`

# 🧪 How has/should this change been tested? 
- Run frontend tests with `yarn test`