### PR TITLE
Wait a little longer for sync push timeout

### DIFF
--- a/client/packages/common/src/intl/locales/en/app.json
+++ b/client/packages/common/src/intl/locales/en/app.json
@@ -42,7 +42,7 @@
   "error.sync-api-incompatible": "Sync api version is not compatible",
   "error.authentication-error": "The server has returned an error",
   "error.connection-error": "Unable to connect to server",
-  "error.integration-timeout-reached": "Central server integration timeout reached",
+  "error.integration-timeout-reached": "The central server took too long integrating pushed records. Please retry later.",
   "error.invalid-url": "Invalid url",
   "error.login": "Invalid username or password",
   "error.account-blocked": "Account is blocked until the lockout period has expired",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -418,7 +418,7 @@
   "messages.no-scanners-found": "No scanners found",
   "messages.not-applicable": "N/A",
   "messages.not-initialised": "[ Not configured ]",
-  "messages.over-allocated": "Due to the pack sizes available a total quantity of {{allocatedQuantity}} has been allocated rather than {{requestedQuantity}}",
+  "messages.over-allocated": "Due to the pack sizes available a total quantity of {{quantity}} has been allocated rather than {{issueQuantity}}",
   "messages.placeholder-allocated": "Not enough stock is available to allocate the requested quantity. A placeholder has been added for  {{placeholderQuantity}} units.",
   "messages.saved": "Saved",
   "messages.scanner-connected": "Connected",

--- a/server/repository/src/database_settings.rs
+++ b/server/repository/src/database_settings.rs
@@ -1,3 +1,4 @@
+#[cfg(all(not(feature = "postgres"), not(feature = "memory")))]
 use std::path::Path;
 
 use crate::db_diesel::{DBBackendConnection, StorageConnectionManager};

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -23,7 +23,7 @@ use super::{
 };
 
 const INTEGRATION_POLL_PERIOD_SECONDS: u64 = 1;
-const INTEGRATION_TIMEOUT_SECONDS: u64 = 15;
+const INTEGRATION_TIMEOUT_SECONDS: u64 = 30;
 
 pub struct Synchroniser {
     settings: SyncSettings,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1786

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Wait a little longer for the time out (30s rather than 15s) and update the error message to 

`The central server took too long integrating pushed records. Please retry later.`

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
I had to force the issue in code - by preventing the early return, adding a delay to the mSupply API and reducing the timeout value.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->
I think it's ok to glance at this and approve without testing, which is problematic. Perhaps @clemens-msupply has a dataset which causes the issue, if you want to test?

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
