### PR TITLE
2502 restrict pack variant editing to central server

### DIFF
--- a/client/packages/common/src/authentication/api/api.ts
+++ b/client/packages/common/src/authentication/api/api.ts
@@ -83,6 +83,10 @@ export const getAuthQueries = (sdk: Sdk, t: TypedTFunction<LocaleKey>) => ({
       const result = await sdk.refreshToken();
       return refreshTokenGuard(result);
     },
+    isCentralServer: async () => {
+      const result = await sdk.isCentralServer();
+      return result.isCentralServer;
+    },
     me: async (token?: string) => {
       try {
         const result = await sdk.me(

--- a/client/packages/common/src/authentication/api/hooks/index.ts
+++ b/client/packages/common/src/authentication/api/hooks/index.ts
@@ -4,3 +4,4 @@ export * from './useUserDetails';
 export * from './useRefreshToken';
 export * from './useLogin';
 export * from './useGetUserPermissions';
+export * from './useIsCentralServer';

--- a/client/packages/common/src/authentication/api/hooks/useAuthApi.ts
+++ b/client/packages/common/src/authentication/api/hooks/useAuthApi.ts
@@ -10,6 +10,7 @@ export const useAuthApi = () => {
 
   const keys = {
     me: (token: string) => ['me', token] as const,
+    isCentralServer: ['isCentralServer'] as const,
     refresh: (token: string) => ['refresh', token] as const,
   };
 

--- a/client/packages/common/src/authentication/api/hooks/useIsCentralServer.ts
+++ b/client/packages/common/src/authentication/api/hooks/useIsCentralServer.ts
@@ -5,10 +5,13 @@ import { useTranslation } from '@common/intl';
 
 export const useIsCentralServerApi = () => {
   const api = useAuthApi();
-  // api.keys.isCentralServer should guarantee that this is called just once
-  // on page load
-  const { data } = useQuery(api.keys.isCentralServer, () =>
-    api.get.isCentralServer()
+  // api.keys.isCentralServer and "refetchOnMount: false" should guarantee that this is called just once, on page load
+  const { data } = useQuery(
+    api.keys.isCentralServer,
+    () => api.get.isCentralServer(),
+    {
+      refetchOnMount: false,
+    }
   );
   return !!data;
 };

--- a/client/packages/common/src/authentication/api/hooks/useIsCentralServer.ts
+++ b/client/packages/common/src/authentication/api/hooks/useIsCentralServer.ts
@@ -16,18 +16,20 @@ export const useIsCentralServerApi = () => {
   return !!data;
 };
 
-const isCentralServerOrWarning =
-  (isCentralServer: Boolean, orDo: () => void) =>
+const returnOrFallback =
+  (isCentralServer: boolean, fallback: () => void) =>
   <T>(f: T | (() => void)) =>
-    isCentralServer ? f : orDo;
+    isCentralServer ? f : fallback;
 
-export const useIsCentralServerOrWarning = () => {
+export const useCentralServerCallback = () => {
   const { warning } = useNotification();
   const isCentralServer = useIsCentralServerApi();
   const t = useTranslation('common');
 
-  return isCentralServerOrWarning(
-    isCentralServer,
-    warning(t('auth.not-a-central-server'))
-  );
+  return {
+    executeIfCentralOrShowWarning: returnOrFallback(
+      isCentralServer,
+      warning(t('auth.not-a-central-server'))
+    ),
+  };
 };

--- a/client/packages/common/src/authentication/api/hooks/useIsCentralServer.ts
+++ b/client/packages/common/src/authentication/api/hooks/useIsCentralServer.ts
@@ -1,0 +1,30 @@
+import { useQuery } from 'react-query';
+import { useAuthApi } from './useAuthApi';
+import { useNotification } from '@common/hooks';
+import { useTranslation } from '@common/intl';
+
+export const useIsCentralServerApi = () => {
+  const api = useAuthApi();
+  // api.keys.isCentralServer should guarantee that this is called just once
+  // on page load
+  const { data } = useQuery(api.keys.isCentralServer, () =>
+    api.get.isCentralServer()
+  );
+  return !!data;
+};
+
+const isCentralServerOrWarning =
+  (isCentralServer: Boolean, orDo: () => void) =>
+  <T>(f: T | (() => void)) =>
+    isCentralServer ? f : orDo;
+
+export const useIsCentralServerOrWarning = () => {
+  const { warning } = useNotification();
+  const isCentralServer = useIsCentralServerApi();
+  const t = useTranslation('common');
+
+  return isCentralServerOrWarning(
+    isCentralServer,
+    warning(t('auth.not-a-central-server'))
+  );
+};

--- a/client/packages/common/src/authentication/api/operations.generated.ts
+++ b/client/packages/common/src/authentication/api/operations.generated.ts
@@ -19,6 +19,11 @@ export type MeQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 export type MeQuery = { __typename: 'Queries', me: { __typename: 'UserNode', email?: string | null, language: Types.LanguageType, username: string, userId: string, firstName?: string | null, lastName?: string | null, phoneNumber?: string | null, jobTitle?: string | null, defaultStore?: { __typename: 'UserStoreNode', code: string, id: string, name: string, storeMode: Types.StoreModeNodeType, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean, omProgramModule: boolean, vaccineModule: boolean } } | null, stores: { __typename: 'UserStoreConnector', totalCount: number, nodes: Array<{ __typename: 'UserStoreNode', code: string, id: string, name: string, storeMode: Types.StoreModeNodeType, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean, omProgramModule: boolean, vaccineModule: boolean } }> } } };
 
+export type IsCentralServerQueryVariables = Types.Exact<{ [key: string]: never; }>;
+
+
+export type IsCentralServerQuery = { __typename: 'Queries', isCentralServer: boolean };
+
 export type RefreshTokenQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
@@ -101,6 +106,11 @@ export const MeDocument = gql`
   }
 }
     ${UserStoreNodeFragmentDoc}`;
+export const IsCentralServerDocument = gql`
+    query isCentralServer {
+  isCentralServer
+}
+    `;
 export const RefreshTokenDocument = gql`
     query refreshToken {
   refreshToken {
@@ -184,6 +194,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     me(variables?: MeQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<MeQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<MeQuery>(MeDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'me', 'query');
     },
+    isCentralServer(variables?: IsCentralServerQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<IsCentralServerQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<IsCentralServerQuery>(IsCentralServerDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'isCentralServer', 'query');
+    },
     refreshToken(variables?: RefreshTokenQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<RefreshTokenQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<RefreshTokenQuery>(RefreshTokenDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'refreshToken', 'query');
     },
@@ -227,6 +240,22 @@ export const mockAuthTokenQuery = (resolver: ResponseResolver<GraphQLRequest<Aut
 export const mockMeQuery = (resolver: ResponseResolver<GraphQLRequest<MeQueryVariables>, GraphQLContext<MeQuery>, any>) =>
   graphql.query<MeQuery, MeQueryVariables>(
     'me',
+    resolver
+  )
+
+/**
+ * @param resolver a function that accepts a captured request and may return a mocked response.
+ * @see https://mswjs.io/docs/basics/response-resolver
+ * @example
+ * mockIsCentralServerQuery((req, res, ctx) => {
+ *   return res(
+ *     ctx.data({ isCentralServer })
+ *   )
+ * })
+ */
+export const mockIsCentralServerQuery = (resolver: ResponseResolver<GraphQLRequest<IsCentralServerQueryVariables>, GraphQLContext<IsCentralServerQuery>, any>) =>
+  graphql.query<IsCentralServerQuery, IsCentralServerQueryVariables>(
+    'isCentralServer',
     resolver
   )
 

--- a/client/packages/common/src/authentication/api/operations.graphql
+++ b/client/packages/common/src/authentication/api/operations.graphql
@@ -58,6 +58,10 @@ query me {
   }
 }
 
+query isCentralServer {
+  isCentralServer
+}
+
 query refreshToken {
   refreshToken {
     ... on RefreshToken {

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -6,6 +6,7 @@
   "approval-status.none": "None",
   "approval-status.pending": "Pending",
   "auth.permission-denied": "Permission denied",
+  "auth.not-a-central-server": "Operation is only permitted on central server",
   "breadcrumb.item": "#{{id}}",
   "button.add-item": "Add Item",
   "button.allocate": "Allocate",

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -459,6 +459,11 @@ export type CentralPatientSearchInput = {
 
 export type CentralPatientSearchResponse = CentralPatientSearchConnector | CentralPatientSearchError;
 
+export type CentralServerMutationNode = {
+  __typename: 'CentralServerMutationNode';
+  packVariant: PackVariantMutations;
+};
+
 export type ClinicianConnector = {
   __typename: 'ClinicianConnector';
   nodes: Array<ClinicianNode>;
@@ -1374,6 +1379,7 @@ export type FullSyncStatusNode = {
   prepareInitial?: Maybe<SyncStatusNode>;
   pullCentral?: Maybe<SyncStatusWithProgressNode>;
   pullRemote?: Maybe<SyncStatusWithProgressNode>;
+  pullV6?: Maybe<SyncStatusWithProgressNode>;
   push?: Maybe<SyncStatusWithProgressNode>;
   summary: SyncStatusNode;
 };
@@ -2550,6 +2556,7 @@ export type Mutations = {
   batchPrescription: BatchPrescriptionResponse;
   batchRequestRequisition: BatchRequestRequisitionResponse;
   batchStocktake: BatchStocktakeResponse;
+  centralServer: CentralServerMutationNode;
   /**
    * Create shipment for response requisition
    * Will create Outbound Shipment with placeholder lines for each requisition line
@@ -2565,7 +2572,6 @@ export type Mutations = {
   deleteOutboundShipmentLine: DeleteOutboundShipmentLineResponse;
   deleteOutboundShipmentServiceLine: DeleteOutboundShipmentServiceLineResponse;
   deleteOutboundShipmentUnallocatedLine: DeleteOutboundShipmentUnallocatedLineResponse;
-  deletePackVariant: DeletePackVariantResponse;
   deletePrescription: DeletePrescriptionResponse;
   deletePrescriptionLine: DeletePrescriptionLineResponse;
   deleteRequestRequisition: DeleteRequestRequisitionResponse;
@@ -2586,7 +2592,6 @@ export type Mutations = {
   insertOutboundShipmentLine: InsertOutboundShipmentLineResponse;
   insertOutboundShipmentServiceLine: InsertOutboundShipmentServiceLineResponse;
   insertOutboundShipmentUnallocatedLine: InsertOutboundShipmentUnallocatedLineResponse;
-  insertPackVariant: InsertPackVariantResponse;
   /** Inserts a new patient (without document data) */
   insertPatient: InsertPatientResponse;
   insertPluginData: InsertPluginDataResponse;
@@ -2627,7 +2632,6 @@ export type Mutations = {
   updateOutboundShipmentName: UpdateOutboundShipmentNameResponse;
   updateOutboundShipmentServiceLine: UpdateOutboundShipmentServiceLineResponse;
   updateOutboundShipmentUnallocatedLine: UpdateOutboundShipmentUnallocatedLineResponse;
-  updatePackVariant: UpdatePackVariantResponse;
   /** Updates a new patient (without document data) */
   updatePatient: UpdatePatientResponse;
   updatePluginData: UpdatePluginDataResponse;
@@ -2770,12 +2774,6 @@ export type MutationsDeleteOutboundShipmentUnallocatedLineArgs = {
 };
 
 
-export type MutationsDeletePackVariantArgs = {
-  input: DeletePackVariantInput;
-  storeId: Scalars['String']['input'];
-};
-
-
 export type MutationsDeletePrescriptionArgs = {
   id: Scalars['String']['input'];
   storeId: Scalars['String']['input'];
@@ -2889,12 +2887,6 @@ export type MutationsInsertOutboundShipmentServiceLineArgs = {
 
 export type MutationsInsertOutboundShipmentUnallocatedLineArgs = {
   input: InsertOutboundShipmentUnallocatedLineInput;
-  storeId: Scalars['String']['input'];
-};
-
-
-export type MutationsInsertPackVariantArgs = {
-  input: InsertPackVariantInput;
   storeId: Scalars['String']['input'];
 };
 
@@ -3062,12 +3054,6 @@ export type MutationsUpdateOutboundShipmentServiceLineArgs = {
 
 export type MutationsUpdateOutboundShipmentUnallocatedLineArgs = {
   input: UpdateOutboundShipmentUnallocatedLineInput;
-  storeId: Scalars['String']['input'];
-};
-
-
-export type MutationsUpdatePackVariantArgs = {
-  input: UpdatePackVariantInput;
   storeId: Scalars['String']['input'];
 };
 
@@ -3361,6 +3347,31 @@ export type OutboundInvoiceCounts = {
   created: InvoiceCountsSummary;
   /** Number of outbound shipments not shipped yet */
   notShipped: Scalars['Int']['output'];
+};
+
+export type PackVariantMutations = {
+  __typename: 'PackVariantMutations';
+  deletePackVariant: DeletePackVariantResponse;
+  insertPackVariant: InsertPackVariantResponse;
+  updatePackVariant: UpdatePackVariantResponse;
+};
+
+
+export type PackVariantMutationsDeletePackVariantArgs = {
+  input: DeletePackVariantInput;
+  storeId: Scalars['String']['input'];
+};
+
+
+export type PackVariantMutationsInsertPackVariantArgs = {
+  input: InsertPackVariantInput;
+  storeId: Scalars['String']['input'];
+};
+
+
+export type PackVariantMutationsUpdatePackVariantArgs = {
+  input: UpdatePackVariantInput;
+  storeId: Scalars['String']['input'];
 };
 
 /**
@@ -3785,6 +3796,7 @@ export type Queries = {
   invoiceCounts: InvoiceCounts;
   invoiceLines: InvoiceLinesResponse;
   invoices: InvoicesResponse;
+  isCentralServer: Scalars['Boolean']['output'];
   itemCounts: ItemCounts;
   /** Query omSupply "item" entries */
   items: ItemsResponse;

--- a/client/packages/host/src/Host.tsx
+++ b/client/packages/host/src/Host.tsx
@@ -65,7 +65,7 @@ const skipRequest = () =>
  */
 const Init = () => {
   // Fetch pack units at startup. Note, the units are cached, i.e. they are not fetched repeatedly.
-  // They will be refetched on page reload or when store is changed based on cache usePackUnits api keys
+  // They will be refetched on page reload or when store is changed based on cache usePackVariants cache keys
   useRefreshPackVariant();
   useInitPlugins();
   return <></>;
@@ -81,8 +81,8 @@ const Host = () => (
               url={Environment.GRAPHQL_URL}
               skipRequest={skipRequest}
             >
-              <Init />
               <AuthProvider>
+                <Init />
                 <AppThemeProvider>
                   <ConfirmationModalProvider>
                     <AlertModalProvider>

--- a/client/packages/system/src/Item/DetailView/Tabs/PackVariants.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/PackVariants.tsx
@@ -18,7 +18,7 @@ import {
   DropdownMenu,
   DropdownMenuItem,
   DeleteIcon,
-  useIsCentralServerOrWarning,
+  useCentralServerCallback,
 } from '@openmsupply-client/common';
 import { usePackVariant } from '../../context';
 import { PackVariantEditModal } from '../../Components/PackVariantEditModal';
@@ -37,7 +37,7 @@ const PackVariantTable: FC<{ itemId: string }> = ({ itemId }) => {
   );
   const variants = variantsControl?.variants ?? [];
   const onDelete = usePackVariantDeleteSelected(variants);
-  const isCentralServerOrWarning = useIsCentralServerOrWarning();
+  const { executeIfCentralOrShowWarning } = useCentralServerCallback();
 
   const columns = useColumns<VariantFragment>([
     'packSize',
@@ -56,6 +56,9 @@ const PackVariantTable: FC<{ itemId: string }> = ({ itemId }) => {
     'selection',
   ]);
 
+  // TODO hide drop down
+  const isEmpty = false;
+
   return (
     <>
       {isOpen && (
@@ -67,34 +70,40 @@ const PackVariantTable: FC<{ itemId: string }> = ({ itemId }) => {
           itemId={itemId ?? ''}
         />
       )}
-      <Box display="flex" justifyContent="space-between" paddingBottom={2}>
-        <DropdownMenu label="Select">
-          <DropdownMenuItem
-            IconComponent={DeleteIcon}
-            onClick={
-              hasPermission ? isCentralServerOrWarning(onDelete) : warningSnack
-            }
-          >
-            {t('button.delete-lines')}
-          </DropdownMenuItem>
-        </DropdownMenu>
+      <Box display="flex" justifyContent="flex-end" gap={2} paddingBottom={2}>
         <ButtonWithIcon
           Icon={<PlusCircleIcon />}
           label={t('label.new-pack-variant')}
           onClick={
             hasPermission
-              ? isCentralServerOrWarning(() => onOpen())
+              ? executeIfCentralOrShowWarning(() => onOpen())
               : warningSnack
           }
         />
+        <DropdownMenu
+          label="Select"
+          sx={{ visibility: isEmpty ? 'hidden' : 'visible' }}
+        >
+          <DropdownMenuItem
+            IconComponent={DeleteIcon}
+            onClick={
+              hasPermission
+                ? executeIfCentralOrShowWarning(onDelete)
+                : warningSnack
+            }
+          >
+            {t('button.delete-lines')}
+          </DropdownMenuItem>
+        </DropdownMenu>
       </Box>
+
       <DataTable
         id="item-variants-detail"
         data={variants}
         columns={columns}
         noDataElement={<NothingHere body={t('error.no-pack-variants')} />}
         onRowClick={
-          hasPermission ? isCentralServerOrWarning(onOpen) : warningSnack
+          hasPermission ? executeIfCentralOrShowWarning(onOpen) : warningSnack
         }
       />
     </>

--- a/client/packages/system/src/Item/DetailView/Tabs/PackVariants.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/PackVariants.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenu,
   DropdownMenuItem,
   DeleteIcon,
+  useIsCentralServerOrWarning,
 } from '@openmsupply-client/common';
 import { usePackVariant } from '../../context';
 import { PackVariantEditModal } from '../../Components/PackVariantEditModal';
@@ -36,6 +37,7 @@ const PackVariantTable: FC<{ itemId: string }> = ({ itemId }) => {
   );
   const variants = variantsControl?.variants ?? [];
   const onDelete = usePackVariantDeleteSelected(variants);
+  const isCentralServerOrWarning = useIsCentralServerOrWarning();
 
   const columns = useColumns<VariantFragment>([
     'packSize',
@@ -67,14 +69,23 @@ const PackVariantTable: FC<{ itemId: string }> = ({ itemId }) => {
       )}
       <Box display="flex" justifyContent="space-between" paddingBottom={2}>
         <DropdownMenu label="Select">
-          <DropdownMenuItem IconComponent={DeleteIcon} onClick={onDelete}>
+          <DropdownMenuItem
+            IconComponent={DeleteIcon}
+            onClick={
+              hasPermission ? isCentralServerOrWarning(onDelete) : warningSnack
+            }
+          >
             {t('button.delete-lines')}
           </DropdownMenuItem>
         </DropdownMenu>
         <ButtonWithIcon
           Icon={<PlusCircleIcon />}
           label={t('label.new-pack-variant')}
-          onClick={hasPermission ? () => onOpen() : () => warningSnack()}
+          onClick={
+            hasPermission
+              ? isCentralServerOrWarning(() => onOpen())
+              : warningSnack
+          }
         />
       </Box>
       <DataTable
@@ -82,7 +93,9 @@ const PackVariantTable: FC<{ itemId: string }> = ({ itemId }) => {
         data={variants}
         columns={columns}
         noDataElement={<NothingHere body={t('error.no-pack-variants')} />}
-        onRowClick={hasPermission ? onOpen : warningSnack}
+        onRowClick={
+          hasPermission ? isCentralServerOrWarning(onOpen) : warningSnack
+        }
       />
     </>
   );

--- a/client/packages/system/src/Item/api/api.ts
+++ b/client/packages/system/src/Item/api/api.ts
@@ -193,7 +193,7 @@ export const getItemQueries = (sdk: Sdk, storeId: string) => ({
       input: packVariantParsers.toInsert(input),
     });
 
-    return result.insertPackVariant;
+    return result.centralServer.packVariant.insertPackVariant;
   },
   updatePackVariant: async (input: VariantFragment) => {
     const result = await sdk.updatePackVariant({
@@ -201,7 +201,7 @@ export const getItemQueries = (sdk: Sdk, storeId: string) => ({
       input: packVariantParsers.toUpdate(input),
     });
 
-    return result.updatePackVariant;
+    return result.centralServer.packVariant.updatePackVariant;
   },
   deletePackVariant: async (input: VariantFragment) =>
     await sdk.deletePackVariant({

--- a/client/packages/system/src/Item/api/operations.generated.ts
+++ b/client/packages/system/src/Item/api/operations.generated.ts
@@ -93,7 +93,7 @@ export type InsertPackVariantMutationVariables = Types.Exact<{
 }>;
 
 
-export type InsertPackVariantMutation = { __typename: 'Mutations', insertPackVariant: { __typename: 'InsertPackVariantError', error: { __typename: 'CannotAddPackSizeOfZero', description: string } | { __typename: 'CannotAddWithNoAbbreviationAndName', description: string } | { __typename: 'VariantWithPackSizeAlreadyExists', description: string } } | { __typename: 'VariantNode', id: string, itemId: string, longName: string, packSize: number, shortName: string } };
+export type InsertPackVariantMutation = { __typename: 'Mutations', centralServer: { __typename: 'CentralServerMutationNode', packVariant: { __typename: 'PackVariantMutations', insertPackVariant: { __typename: 'InsertPackVariantError', error: { __typename: 'CannotAddPackSizeOfZero', description: string } | { __typename: 'CannotAddWithNoAbbreviationAndName', description: string } | { __typename: 'VariantWithPackSizeAlreadyExists', description: string } } | { __typename: 'VariantNode', id: string, itemId: string, longName: string, packSize: number, shortName: string } } } };
 
 export type UpdatePackVariantMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -101,7 +101,7 @@ export type UpdatePackVariantMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdatePackVariantMutation = { __typename: 'Mutations', updatePackVariant: { __typename: 'UpdatePackVariantError', error: { __typename: 'CannotAddWithNoAbbreviationAndName', description: string } } | { __typename: 'VariantNode', id: string, itemId: string, longName: string, packSize: number, shortName: string } };
+export type UpdatePackVariantMutation = { __typename: 'Mutations', centralServer: { __typename: 'CentralServerMutationNode', packVariant: { __typename: 'PackVariantMutations', updatePackVariant: { __typename: 'UpdatePackVariantError', error: { __typename: 'CannotAddWithNoAbbreviationAndName', description: string } } | { __typename: 'VariantNode', id: string, itemId: string, longName: string, packSize: number, shortName: string } } } };
 
 export type DeletePackVariantMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -109,7 +109,7 @@ export type DeletePackVariantMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeletePackVariantMutation = { __typename: 'Mutations', deletePackVariant: { __typename: 'DeleteResponse', id: string } };
+export type DeletePackVariantMutation = { __typename: 'Mutations', centralServer: { __typename: 'CentralServerMutationNode', packVariant: { __typename: 'PackVariantMutations', deletePackVariant: { __typename: 'DeleteResponse', id: string } } } };
 
 export const ServiceItemRowFragmentDoc = gql`
     fragment ServiceItemRow on ItemNode {
@@ -365,15 +365,19 @@ export const PackVariantsDocument = gql`
     ${PackVariantFragmentDoc}`;
 export const InsertPackVariantDocument = gql`
     mutation insertPackVariant($storeId: String!, $input: InsertPackVariantInput!) {
-  insertPackVariant(storeId: $storeId, input: $input) {
-    __typename
-    ... on VariantNode {
-      ...Variant
-    }
-    ... on InsertPackVariantError {
-      error {
+  centralServer {
+    packVariant {
+      insertPackVariant(storeId: $storeId, input: $input) {
         __typename
-        description
+        ... on VariantNode {
+          ...Variant
+        }
+        ... on InsertPackVariantError {
+          error {
+            __typename
+            description
+          }
+        }
       }
     }
   }
@@ -381,15 +385,19 @@ export const InsertPackVariantDocument = gql`
     ${VariantFragmentDoc}`;
 export const UpdatePackVariantDocument = gql`
     mutation updatePackVariant($storeId: String!, $input: UpdatePackVariantInput!) {
-  updatePackVariant(storeId: $storeId, input: $input) {
-    __typename
-    ... on VariantNode {
-      ...Variant
-    }
-    ... on UpdatePackVariantError {
-      error {
+  centralServer {
+    packVariant {
+      updatePackVariant(storeId: $storeId, input: $input) {
         __typename
-        description
+        ... on VariantNode {
+          ...Variant
+        }
+        ... on UpdatePackVariantError {
+          error {
+            __typename
+            description
+          }
+        }
       }
     }
   }
@@ -397,10 +405,14 @@ export const UpdatePackVariantDocument = gql`
     ${VariantFragmentDoc}`;
 export const DeletePackVariantDocument = gql`
     mutation deletePackVariant($storeId: String!, $input: DeletePackVariantInput!) {
-  deletePackVariant(storeId: $storeId, input: $input) {
-    ... on DeleteResponse {
-      __typename
-      id
+  centralServer {
+    packVariant {
+      deletePackVariant(storeId: $storeId, input: $input) {
+        ... on DeleteResponse {
+          __typename
+          id
+        }
+      }
     }
   }
 }
@@ -553,7 +565,7 @@ export const mockPackVariantsQuery = (resolver: ResponseResolver<GraphQLRequest<
  * mockInsertPackVariantMutation((req, res, ctx) => {
  *   const { storeId, input } = req.variables;
  *   return res(
- *     ctx.data({ insertPackVariant })
+ *     ctx.data({ centralServer })
  *   )
  * })
  */
@@ -570,7 +582,7 @@ export const mockInsertPackVariantMutation = (resolver: ResponseResolver<GraphQL
  * mockUpdatePackVariantMutation((req, res, ctx) => {
  *   const { storeId, input } = req.variables;
  *   return res(
- *     ctx.data({ updatePackVariant })
+ *     ctx.data({ centralServer })
  *   )
  * })
  */
@@ -587,7 +599,7 @@ export const mockUpdatePackVariantMutation = (resolver: ResponseResolver<GraphQL
  * mockDeletePackVariantMutation((req, res, ctx) => {
  *   const { storeId, input } = req.variables;
  *   return res(
- *     ctx.data({ deletePackVariant })
+ *     ctx.data({ centralServer })
  *   )
  * })
  */

--- a/client/packages/system/src/Item/api/operations.graphql
+++ b/client/packages/system/src/Item/api/operations.graphql
@@ -260,40 +260,52 @@ query packVariants($storeId: String!) {
 }
 
 mutation insertPackVariant($storeId: String!, $input: InsertPackVariantInput!) {
-  insertPackVariant(storeId: $storeId, input: $input) {
-    __typename
-    ... on VariantNode {
-      ...Variant
-    }
-    ... on InsertPackVariantError {
-      error {
+  centralServer {
+    packVariant {
+      insertPackVariant(storeId: $storeId, input: $input) {
         __typename
-        description
+        ... on VariantNode {
+          ...Variant
+        }
+        ... on InsertPackVariantError {
+          error {
+            __typename
+            description
+          }
+        }
       }
     }
   }
 }
 
 mutation updatePackVariant($storeId: String!, $input: UpdatePackVariantInput!) {
-  updatePackVariant(storeId: $storeId, input: $input) {
-    __typename
-    ... on VariantNode {
-      ...Variant
-    }
-    ... on UpdatePackVariantError {
-      error {
+  centralServer {
+    packVariant {
+      updatePackVariant(storeId: $storeId, input: $input) {
         __typename
-        description
+        ... on VariantNode {
+          ...Variant
+        }
+        ... on UpdatePackVariantError {
+          error {
+            __typename
+            description
+          }
+        }
       }
     }
   }
 }
 
 mutation deletePackVariant($storeId: String!, $input: DeletePackVariantInput!) {
-  deletePackVariant(storeId: $storeId, input: $input) {
+  centralServer {
+    packVariant {
+      deletePackVariant(storeId: $storeId, input: $input) {
         ... on DeleteResponse {
-      __typename
-      id
+          __typename
+          id
+        }
+      }
     }
   }
 }

--- a/client/packages/system/src/Item/context/usePackVariant.ts
+++ b/client/packages/system/src/Item/context/usePackVariant.ts
@@ -57,7 +57,7 @@ export interface VariantControl {
 }
 
 // Will call API to refresh pack variant if cache is expired
-// or if store is change (based on cache keys)
+// or if store is changed (based on cache keys)
 export const useRefreshPackVariant = () => {
   const { setItems } = usePackVariantStore();
 

--- a/client/packages/system/src/Item/context/usePackVariant.ts
+++ b/client/packages/system/src/Item/context/usePackVariant.ts
@@ -57,7 +57,7 @@ export interface VariantControl {
 }
 
 // Will call API to refresh pack variant if cache is expired
-// or if store is change (based on api keys)
+// or if store is change (based on cache keys)
 export const useRefreshPackVariant = () => {
   const { setItems } = usePackVariantStore();
 

--- a/server/graphql/general/src/lib.rs
+++ b/server/graphql/general/src/lib.rs
@@ -7,6 +7,7 @@ use self::queries::*;
 
 use chrono::{DateTime, Utc};
 use graphql_core::pagination::PaginationInput;
+use util::is_central_server;
 
 use crate::store_preference::store_preferences;
 use graphql_types::types::{StorePreferenceNode, TemperatureLogFilterInput};
@@ -62,6 +63,10 @@ impl GeneralQueries {
 
     pub async fn me(&self, ctx: &Context<'_>) -> Result<UserResponse> {
         me(ctx)
+    }
+
+    pub async fn is_central_server(&self) -> bool {
+        is_central_server()
     }
 
     /// Query omSupply "name" entries

--- a/server/graphql/tests/permissions.rs
+++ b/server/graphql/tests/permissions.rs
@@ -16,7 +16,7 @@ mod permission_tests {
     use graphql_invoice::{InvoiceMutations, InvoiceQueries};
     use graphql_invoice_line::InvoiceLineMutations;
     use graphql_location::{LocationMutations, LocationQueries};
-    use graphql_pack_variant::{PackVariantMutations, PackVariantQueries};
+    use graphql_pack_variant::PackVariantQueries;
     use graphql_reports::ReportQueries;
     use graphql_requisition::{RequisitionMutations, RequisitionQueries};
     use graphql_requisition_line::RequisitionLineMutations;
@@ -57,7 +57,6 @@ mod permission_tests {
         pub RequisitionMutations,
         pub RequisitionLineMutations,
         pub GeneralMutations,
-        pub PackVariantMutations,
     );
 
     pub fn full_query() -> FullQuery {
@@ -89,7 +88,6 @@ mod permission_tests {
             RequisitionMutations,
             RequisitionLineMutations,
             GeneralMutations,
-            PackVariantMutations,
         )
     }
 

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -197,7 +197,10 @@ impl Synchroniser {
         // PULL V6
         if !is_central_server() {
             logger.start_step(SyncStep::PullCentralV6)?;
-            self.central_v6.pull(&ctx.connection, 20, logger).await?;
+            if let Err(error) = self.central_v6.pull(&ctx.connection, 20, logger).await {
+                // Log but ignore error for now, to allow omSupply to run without omSupply server
+                let _ = logger.error(&error.into());
+            }
             logger.done_step(SyncStep::PullCentralV6)?;
         }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2502 

# 👩🏻‍💻 What does this PR do? 

* add isCentralServer graphql query (no permission check, should it have ?)
* move central server graphql mutations behind centralServer endpoint (idea is to have one place where isCentralServer is checked)
* add isCentralServer api query to front end, and useIsCentralServerOrWarning hook to help with central server checks
* disallow deleting of pack variant when user doesn't have permission (this was done for editing and for creating pack variants but not for delete)
* Silently ignore sync error to omSupply central server, this is just temporary, this point is in carry over issue, we can discuss this tomorrow as it's in the [carry over issue](https://github.com/msupply-foundation/open-msupply/issues/2821)

# 🧪 How has/should this change been tested? 

Start server in central server mode:
IS_CENTRAL_SERVER=true cargo run
make sure user has this permission (if not tick enable it and re-login):
![Screenshot 2024-01-31 at 5 01 16 PM](https://github.com/msupply-foundation/open-msupply/assets/26194949/1fa01208-d739-4806-b777-316052eed72b)
- [ ] go to item and pack_variant tab, try adding a pack variant (should be able to add)
Remove above permission from user (and re-login)
- [ ] go to item and pack_variant tab, try selecting pack variant deleting it (should get permission error).
Stop server and start in remote site mode
`cargo run`
- [ ]  go to item and pack_variant tab, try deleting, adding new pack variant or editing existing one, should get an error saying this operation is only allowed on central server

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

or

- [ ] Functional change 1
- [ ] Functional change 2