### PR TITLE
2871 fix label sync action for non default branch PRs

### DIFF
--- a/.github/workflows/pr-issue-label-sync.yaml
+++ b/.github/workflows/pr-issue-label-sync.yaml
@@ -1,8 +1,6 @@
 name: Sync labels from linked issue to PR
 on:
-  pull_request:
-    branches: 
-      - '**'
+  pull_request_target:
     types: [opened, reopened, edited]
 jobs:
   build:


### PR DESCRIPTION
Fixes #2871

# 👩🏻‍💻 What does this PR do? 

I had to test in a separate repo to refine this...

[`pull_request`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) seems to strictly work for only the default branch no matter what I do.

[`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) describes allowing running actions from different forks. But IDK, it seems to allow for branches other than the default. I'd have thought branches within the same repo wouldn't be considered a fork (pretty sure fork is a github term for essentially cloning a whole repository into a different org/user's repos, not a git term).

That said, `pull_request_target` has security warnings:

> Warning: For workflows that are triggered by the pull_request_target event, the GITHUB_TOKEN is granted read/write repository permission unless the permissions key is specified and the workflow can access secrets, even when it is triggered from a fork. Although the workflow runs in the context of the base of the pull request, you should make sure that you do not check out, build, or run untrusted code from the pull request with this event. Additionally, any caches share the same scope as the base branch. To help prevent cache poisoning, you should not save the cache if there is a possibility that the cache contents were altered. For more information, see "[Keeping your GitHub Actions and workflows secure: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests)" on the GitHub Security Lab website.

I think we are safe from this though - the action doesn't checkout any branches or run any builds. It simply uses the github API to query labels/milestone from the linked issue and uses the API to add them to the PR setting off the action.

# 🧪 How has/should this change been tested? 
In a private github repo

## 💌 Any notes for the reviewer?

- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore