### PR TITLE
Android issues when running offline

### DIFF
--- a/client/packages/android/app/src/main/assets/capacitor.config.json
+++ b/client/packages/android/app/src/main/assets/capacitor.config.json
@@ -1,6 +1,6 @@
 {
 	"appId": "org.openmsupply.client",
-	"appName": "openmsupply-client",
+	"appName": "Open mSupply",
 	"webDir": "../host/dist/",
 	"bundledWebRuntime": false,
 	"android": {

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
@@ -366,7 +366,12 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
         } catch (Exception ex) {
             Log.e(OM_SUPPLY, ex.toString());
         }
-        return serviceInfo.getHost().getHostAddress();
+        InetAddress host = serviceInfo.getHost();
+        // this will happen if there is no network interface available
+        if (host == null) {
+            return "127.0.0.1";
+        }
+        return host.getHostAddress();
     }
 
     private JSObject serviceInfoToObject(NsdServiceInfo serviceInfo) {
@@ -513,7 +518,8 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
          * e.g. https://127.0.0.1:8000
          */
         public String getUrl() {
-            return data.getString("protocol") + "://" + data.getString("ip") + ":" + data.getString("port");
+            String host = data.getBool("isLocal") ? "localhost" : data.getString("ip");
+            return data.getString("protocol") + "://" + host + ":" + data.getString("port");
         }
 
         /**

--- a/client/packages/android/app/src/main/res/values/strings.xml
+++ b/client/packages/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
-    <string name="app_name">openmsupply-client</string>
-    <string name="title_activity_main">openmsupply-client</string>
+    <string name="app_name">Open mSupply</string>
+    <string name="title_activity_main">Open mSupply</string>
     <string name="package_name">org.openmsupply.client</string>
     <string name="custom_url_scheme">org.openmsupply.client</string>
 </resources>

--- a/client/packages/android/capacitor.config.ts
+++ b/client/packages/android/capacitor.config.ts
@@ -5,7 +5,7 @@ import { CapacitorConfig } from '@capacitor/cli';
 
 const config: CapacitorConfig = {
   appId: 'org.openmsupply.client',
-  appName: 'openmsupply-client',
+  appName: 'Open mSupply',
   // This is only needed for `npx cap copy` to work, and it does have to point to actual bundle
   // bundle is server by remote server (local or discovered) or through webpack if debugging (see comment below)
   webDir: '../host/dist/',

--- a/client/packages/host/src/components/Android.tsx
+++ b/client/packages/host/src/components/Android.tsx
@@ -126,7 +126,7 @@ export const Android = () => {
     // this page is not for web users! begone!
     if (!getNativeAPI()) navigate(RouteBuilder.create(AppRoute.Login).build());
     getPreference('mode', '"none"').then(setLocalMode);
-  }, []);
+  }, [navigate]);
 
   useEffect(() => {
     if (mode === NativeMode.Server) {
@@ -145,7 +145,7 @@ export const Android = () => {
           .build()
       );
     }
-  }, [mode, previousServer, connectToPreviousFailed]);
+  }, [mode, previousServer, connectToPreviousFailed, navigate]);
 
   if (mode === NativeMode.None)
     return (

--- a/client/packages/host/src/components/Login/LoginLayout.tsx
+++ b/client/packages/host/src/components/Login/LoginLayout.tsx
@@ -40,7 +40,7 @@ export const LoginLayout = ({
         flex="1 0 50%"
         sx={{
           backgroundImage: (theme: Theme) => theme.mixins.gradient.primary,
-          padding: '0 80px 7% 80px',
+          padding: '0 5% 7%',
         }}
         display="flex"
         alignItems="flex-start"
@@ -52,8 +52,8 @@ export const LoginLayout = ({
             sx={{
               color: (theme: Theme) => theme.typography.login.color,
               fontSize: {
-                xs: '38px',
-                sm: '38px',
+                xs: '28px',
+                sm: '30px',
                 md: '48px',
                 lg: '64px',
                 xl: '64px',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "1.6.00",
+  "version": "1.6.01",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2867 
Fixes #2793 
Fixes #2784

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The primary issue is that when there is no network, the call to `serviceInfo.getHost()` returns null. We then try to call `getHostAddress()` on the result which crashes the app.

I also noticed that the login screen looks squashed in portrait orientation, so have tweaked that:
From this

![Screenshot 2024-02-01 at 10 56 06 AM](https://github.com/msupply-foundation/open-msupply/assets/9192912/cceadc65-b9ed-4ffe-b130-b7c6ace68620)

to this:
 
![Screenshot 2024-02-01 at 10 42 53 AM](https://github.com/msupply-foundation/open-msupply/assets/9192912/46c784ee-dd12-4523-9b4b-cd685a91a187)

And while I was at it, did the change for #2793 too.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
A couple of scenarios:
**One**
- enable network
- start the app and select server mode
- initialise the tablet
- login
- disable network
- try to do something

**Two**
- Close the app
- disable the network
- open the app

Check that, when the network is enabled, you can see the local IP as the server info - but the API calls are made to `localhost`:

![Screenshot 2024-02-01 at 10 43 58 AM](https://github.com/msupply-foundation/open-msupply/assets/9192912/275ee7fb-2f4a-4f3b-9233-5706ffcebf1a)

When the network is not enabled, the IP resolution cannot happen and so you'll see `127.0.0.1` as the server IP address

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

There is a debug apk file (open-msupply-1.6.01-debug.apk) in the [google drive](https://drive.google.com/open?id=1Ax4J-x4-ZXbyOzpM_VixVGQ9WxW4jn2Q&usp=drive_fs)

This is built off the branch in this PR and could be used for testing.

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
