### PR TITLE
Outbound shipment allocation - unable to type multi digit quantities

### DIFF
--- a/client/packages/common/src/hooks/useDebounce/useDebouncedValueCallback.ts
+++ b/client/packages/common/src/hooks/useDebounce/useDebouncedValueCallback.ts
@@ -9,10 +9,17 @@ import { FnUtils } from '@common/utils';
 export const useDebouncedValueCallback = <T extends (...args: any[]) => any>(
   callback: T,
   depsArray: DependencyList,
-  wait = 500
+  wait = 500,
+  callbackDepsArray: DependencyList = []
 ): ((...args: Parameters<T>) => Promise<ReturnType<T>>) => {
-  const memoizedCallback = useCallback(FnUtils.debounce(callback, wait), []);
-  const debounced = useCallback(memoizedCallback, depsArray);
+  const memoizedCallback = useCallback(
+    FnUtils.debounce(callback, wait),
+    callbackDepsArray
+  );
+  const debounced = useCallback(memoizedCallback, [
+    ...depsArray,
+    memoizedCallback,
+  ]);
 
   return debounced;
 };

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
@@ -68,6 +68,7 @@ export const OutboundLineEdit: React.FC<ItemDetailsModalProps> = ({
   const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
   const [currentItem, setCurrentItem] = useBufferState(item);
   const [isAutoAllocated, setIsAutoAllocated] = useState(false);
+  const [okDisabled, setOkDisabled] = useState(false);
 
   const { mutateAsync: insertBarcode } = useOutbound.utils.barcodeInsert();
   const { status } = useOutbound.document.fields('status');
@@ -219,7 +220,7 @@ export const OutboundLineEdit: React.FC<ItemDetailsModalProps> = ({
       }
       okButton={
         <DialogButton
-          disabled={!currentItem}
+          disabled={!currentItem || okDisabled}
           variant="ok"
           onClick={() => handleSave(onClose)}
         />
@@ -244,6 +245,7 @@ export const OutboundLineEdit: React.FC<ItemDetailsModalProps> = ({
           showZeroQuantityConfirmation={showZeroQuantityConfirmation}
           hasOnHold={hasOnHold}
           hasExpired={hasExpired}
+          setOkDisabled={setOkDisabled}
         />
 
         <TableWrapper

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
@@ -246,6 +246,7 @@ export const OutboundLineEdit: React.FC<ItemDetailsModalProps> = ({
           hasOnHold={hasOnHold}
           hasExpired={hasExpired}
           setOkDisabled={setOkDisabled}
+          draftStockOutLines={draftStockOutLines}
         />
 
         <TableWrapper

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -13,7 +13,7 @@ import {
   Typography,
   useFormatNumber,
   useDebounceCallback,
-  FnUtils,
+  useDebouncedValueCallback,
 } from '@openmsupply-client/common';
 import {
   ItemStockOnHandFragment,
@@ -125,14 +125,15 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
     updateIssueQuantity(allocatedQuantity);
   };
 
-  const memoizedCallback = useCallback(
-    FnUtils.debounce((quantity, packSize) => {
+  const debouncedAllocate = useDebouncedValueCallback(
+    (quantity, packSize) => {
       allocate(quantity, packSize);
       setOkDisabled(false);
-    }, 500),
+    },
+    [],
+    500,
     [draftStockOutLines]
   );
-  const debouncedAllocate = useCallback(memoizedCallback, [memoizedCallback]);
 
   const handleIssueQuantityChange = (quantity: number) => {
     setIssueQuantity(quantity);

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -125,6 +125,11 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
     updateIssueQuantity(allocatedQuantity);
   };
 
+  // using a debounced value for the allocation. In the scenario where
+  // you have only pack sizes > 1 available, and try to type a quantity which starts with 1
+  // e.g. 10, 12, 100.. then the allocation rounds the 1 up immediately to the available
+  // pack size which stops you entering the required quantity.
+  // See https://github.com/msupply-foundation/open-msupply/issues/2727
   const debouncedAllocate = useDebouncedValueCallback(
     (quantity, packSize) => {
       allocate(quantity, packSize);
@@ -132,7 +137,7 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
     },
     [],
     500,
-    [draftStockOutLines]
+    [draftStockOutLines] // this is needed to prevent a captured enclosure of onChangeQuantity
   );
 
   const handleIssueQuantityChange = (quantity: number) => {

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -13,6 +13,7 @@ import {
   Typography,
   useFormatNumber,
   useDebounceCallback,
+  useDebouncedValueCallback,
 } from '@openmsupply-client/common';
 import {
   ItemStockOnHandFragment,
@@ -46,6 +47,7 @@ interface OutboundLineEditFormProps {
   showZeroQuantityConfirmation: boolean;
   hasOnHold: boolean;
   hasExpired: boolean;
+  setOkDisabled: (disabled: boolean) => void;
 }
 
 export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
@@ -61,6 +63,7 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
   showZeroQuantityConfirmation,
   hasOnHold,
   hasExpired,
+  setOkDisabled,
 }) => {
   const t = useTranslation('distribution');
   const [allocationAlerts, setAllocationAlerts] = useState<StockOutAlert[]>([]);
@@ -117,9 +120,18 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
     updateIssueQuantity(allocatedQuantity);
   };
 
+  const debouncedAllocate = useDebouncedValueCallback(
+    (quantity, packSize) => {
+      allocate(quantity, packSize);
+      setOkDisabled(false);
+    },
+    [issueQuantity],
+    500
+  );
   const handleIssueQuantityChange = (quantity: number) => {
     setIssueQuantity(quantity);
-    allocate(quantity, Number(packSizeController.selected?.value));
+    setOkDisabled(true);
+    debouncedAllocate(quantity, Number(packSizeController.selected?.value));
   };
 
   useEffect(() => {

--- a/client/packages/invoices/src/StockOut/utils.tsx
+++ b/client/packages/invoices/src/StockOut/utils.tsx
@@ -377,8 +377,8 @@ export const getAllocationAlerts = (
   if (allocatedQuantity !== requestedQuantity && allocatedQuantity > 0) {
     alerts.push({
       message: t('messages.over-allocated', {
-        allocatedQuantity: format(allocatedQuantity),
-        requestedQuantity: format(requestedQuantity),
+        quantity: format(allocatedQuantity),
+        issueQuantity: format(requestedQuantity),
       }),
       severity: 'warning',
     });

--- a/client/packages/invoices/src/StockOut/utils.tsx
+++ b/client/packages/invoices/src/StockOut/utils.tsx
@@ -377,8 +377,8 @@ export const getAllocationAlerts = (
   if (allocatedQuantity !== requestedQuantity && allocatedQuantity > 0) {
     alerts.push({
       message: t('messages.over-allocated', {
-        quantity: format(allocatedQuantity),
-        issueQuantity: format(requestedQuantity),
+        allocatedQuantity: format(allocatedQuantity),
+        requestedQuantity: format(requestedQuantity),
       }),
       severity: 'warning',
     });


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2727

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Debounces the issue quantity change to allow entry of multi-digit values.
currently, if you have a range of unhelpful pack sizes available, then the allocation logic will round up your quantity, overwriting the entered digits and preventing you from entering in the desired quantity.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
* Have some stock for an item, which has pack sizes other than `1`
* Create an outbound shipment, add that item
* Issue a quantity for a number which contains multiple digits and starts with `1` e.g. `10` or `105` etc.


## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
