### PR TITLE
2776 cannot select and delete internal orders

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/document/useDeleteSelectedRequisitions.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/document/useDeleteSelectedRequisitions.ts
@@ -13,9 +13,7 @@ export const useDeleteSelectedRequisitions = () => {
   const { queryParams } = useUrlQueryParams({
     initialSort: { key: 'createdDatetime', dir: 'desc' },
   });
-  const { data: rows } = useRequests(queryParams, {
-    enabled: false,
-  });
+  const { data: rows } = useRequests(queryParams);
   const { mutateAsync } = useDeleteRequests();
   const t = useTranslation('replenishment');
   const { selectedRows } = useTableStore(state => ({


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2776 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Enables the query for requests, so we have some data to match the selected lines to.

https://github.com/msupply-foundation/open-msupply/assets/55115239/f5f4218f-e619-4165-8e6c-15125e0cc5e3


# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

1. Go to 'Internal Orders'
2. Select any order/s with status = 'Draft'
3. Select dropdown > ' Delete lines'
4. See delete confirmation modal, select Ok
5. Line is deleted


## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

Unsure if the request was disabled for any reason? Wondered if the automatic query was being disabled to reduce the load time, with the intention of calling it manually at the time it was actually needed, but I don't see that pattern anywhere else in the code...

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_