### PR TITLE
2895 add set up steps for msupply remote site

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -22,7 +22,7 @@ To see it in action, check out the [demo server](https://demo-open.msupply.org/)
 
 `yarn start` (using demo server as API)
 
-`yarn start-local` (using localhost:8000 as API)
+`yarn start-local` (using localhost:8000 as API - ensure you have already gone through the `server` setup instructions)
 
 `cd packages/host && yarn start -- --env API_HOST='http://localhost:8001'` (using custom API url, see [config.ts for more info](./packages/config/src/config.ts))
 

--- a/server/README.md
+++ b/server/README.md
@@ -53,21 +53,21 @@ sudo apt install make gcc pkg-config libavahi-compat-libdnssd-dev libpq-dev
 
 Remote server data is configured through mSupply central server, when the app first starts it's expected to initialise from mSupply.
 
-### Set up omSupply remote site in mSupply
+### Set up Open mSupply remote site in mSupply
 
 - Ensure you have mSupply set up locally
 - In Admin > Preferences > General, ensure `Synchronisation is active` is selected
 - In Special > Synchronisation
   - Open (or create) the site for our Open mSupply instance
   - Does it have a hardware ID already? If so, refresh the hardware ID so it doesn't have one.
-- Initialise your omSupply instance - you can do this two ways:
+- Initialise your Open mSupply instance - you can do this two ways:
   - Via the UI (this may be the easier option when you are switching between different APIs):
     - After starting the server & client, you should see an initialisation screen
     - Enter the site details from mSupply
   - Via YAML configuration:
     - In your Open mSupply repo, under `server/configuration` copy the `example.yaml` to `local.yaml`, and uncomment the contents of the file. Under the `sync` config, ensure the `username` is set to the site name from mSupply (i.e. `remote`)
-    - Your omSupply instance should sync with mSupply automatically when you start the server
-- After the initial sync, you generally shouldn't need mSupply running to run omSupply
+    - Your Open mSupply instance should sync with mSupply automatically when you start the server
+- After the initial sync, you generally shouldn't need mSupply running to run Open mSupply
 
 ### OR: Run without mSupply central
 
@@ -241,7 +241,7 @@ By default remote-server limits Cross-Origin Resource Sharing to the origins con
 This is a security mechanism to reduce the risk of a malicious site accessing an authenticated connection with mSupply.
 Rust enforces the allowed origins in requests, even if the browser doesn't, by returning a 400 error when the Origin isn't specified in a request, or if doesn't match one of origins configured in cors_origins.
 
-Set the cors_origins section of the yaml to include any URLs you want to access omSupply's GraphQL API from this includes the url for the omsupply-client you are using.
+Set the cors_origins section of the yaml to include any URLs you want to access Open mSupply's GraphQL API from this includes the url for the omsupply-client you are using.
 e.g. local.yaml
 
 ```

--- a/server/README.md
+++ b/server/README.md
@@ -60,9 +60,17 @@ Remote server data is configured through mSupply central server, when the app fi
 - In Special > Synchronisation
   - Open (or create) the site for our Open mSupply instance
   - Does it have a hardware ID already? If so, refresh the hardware ID so it doesn't have one.
-- In your Open mSupply repo, under `server/configuration` copy the `example.yaml` to `local.yaml`, and uncomment the contents of the file. Under the `sync` config, ensure the `username` is set to the site name from mSupply (i.e. `remote`)
-- From the `server` root, run `cargo run`
-- This should sync with your mSupply instance, and make the omSupply server available for local use
+- Initialise your omSupply instance - you can do this two ways:
+
+  - Via YAML configuration:
+    - In your Open mSupply repo, under `server/configuration` copy the `example.yaml` to `local.yaml`, and uncomment the contents of the file. Under the `sync` config, ensure the `username` is set to the site name from mSupply (i.e. `remote`)
+    - Start the server: from the `server` root, run `cargo run`
+    - This should sync with your mSupply instance, and make the omSupply server available for local use
+  - Via the UI (this may be the easier option when you are switching between different APIs):
+    - Start the server: from the `server` root, run `cargo run`
+    - Start the UI: from the `client` root, run `yarn start-local`
+    - You should see an initialisation screen - enter the site details from mSupply
+
 - After this initial sync, you generally shouldn't need mSupply running to run omSupply
 
 ### OR: Run without mSupply central

--- a/server/README.md
+++ b/server/README.md
@@ -61,17 +61,13 @@ Remote server data is configured through mSupply central server, when the app fi
   - Open (or create) the site for our Open mSupply instance
   - Does it have a hardware ID already? If so, refresh the hardware ID so it doesn't have one.
 - Initialise your omSupply instance - you can do this two ways:
-
+  - Via the UI (this may be the easier option when you are switching between different APIs):
+    - After starting the server & client, you should see an initialisation screen
+    - Enter the site details from mSupply
   - Via YAML configuration:
     - In your Open mSupply repo, under `server/configuration` copy the `example.yaml` to `local.yaml`, and uncomment the contents of the file. Under the `sync` config, ensure the `username` is set to the site name from mSupply (i.e. `remote`)
-    - Start the server: from the `server` root, run `cargo run`
-    - This should sync with your mSupply instance, and make the omSupply server available for local use
-  - Via the UI (this may be the easier option when you are switching between different APIs):
-    - Start the server: from the `server` root, run `cargo run`
-    - Start the UI: from the `client` root, run `yarn start-local`
-    - You should see an initialisation screen - enter the site details from mSupply
-
-- After this initial sync, you generally shouldn't need mSupply running to run omSupply
+    - Your omSupply instance should sync with mSupply automatically when you start the server
+- After the initial sync, you generally shouldn't need mSupply running to run omSupply
 
 ### OR: Run without mSupply central
 
@@ -90,13 +86,15 @@ cargo run --bin remote_server_cli -- initialise-from-export -n reference1
 
 Above will create sqlite database in root folder with the name specified in `configuration/*.yaml` and will populate it with data. Towards the end of console output of the cli command user:password list is presented (those users can be used to log in vi client/api)
 
+## Start the server
+
 Now we can start server with
 
 ```
 cargo run
 ```
 
-`NOTE` make sure that sync configurations in configuration/\*.yaml file is commented out, otherwise may get an error that database and yaml sync configurations differ (in which case remote server will try to contact central server)
+> NOTE: make sure that sync configurations in `configuration/*.yaml` files are commented out if running without mSupply Central, otherwise you may get an error stating that the database and yaml sync configurations differ (in which case, the remote server will try to contact central server)
 
 Explore API available on `http://localhost:8000/graphql` with build in playground or try [online graphiql explorer](https://graphiql-online.com/)
 


### PR DESCRIPTION
#Fixes #2895

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Adds instructions around setting up a remote site for omSupply in your local mSupply instance for initial sync.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

N/A

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
