### PR TITLE
Add logging on Temperature Logs and Temperature Breaches API Errors

### DIFF
--- a/server/server/src/cold_chain/sensor.rs
+++ b/server/server/src/cold_chain/sensor.rs
@@ -58,6 +58,13 @@ pub async fn put_sensors(
         Err(error) => return HttpResponse::InternalServerError().body(format!("{:#?}", error)),
     };
 
+    for result in &results {
+        if let Err(e) = result {
+            error!("Error upserting sensors {:#?}", e);
+            // TODO: Should we return an HTTP error here?
+        }
+    }
+
     HttpResponse::Ok()
         .append_header(header::ContentType(mime::APPLICATION_JSON))
         .json(&results)

--- a/server/server/src/cold_chain/sensor.rs
+++ b/server/server/src/cold_chain/sensor.rs
@@ -61,7 +61,7 @@ pub async fn put_sensors(
     for result in &results {
         if let Err(e) = result {
             error!("Error upserting sensors {:#?}", e);
-            // TODO: Should we return an HTTP error here?
+            return HttpResponse::InternalServerError().body(format!("{:#?}", e));
         }
     }
 

--- a/server/server/src/cold_chain/temperature_breach.rs
+++ b/server/server/src/cold_chain/temperature_breach.rs
@@ -66,7 +66,7 @@ pub async fn put_breaches(
 
     for result in &results {
         if let Err(e) = result {
-            error!("Error inserting temperature breach {:#?}", e);
+            error!("Error inserting temperature breaches {:#?}", e);
             return HttpResponse::InternalServerError().body(format!("{:#?}", e));
         }
     }

--- a/server/server/src/cold_chain/temperature_breach.rs
+++ b/server/server/src/cold_chain/temperature_breach.rs
@@ -64,6 +64,13 @@ pub async fn put_breaches(
         Err(error) => return HttpResponse::InternalServerError().body(format!("{:#?}", error)),
     };
 
+    for result in &results {
+        if let Err(e) = result {
+            error!("Error inserting temperature breach {:#?}", e);
+            // TODO: Should we return an HTTP error here?
+        }
+    }
+
     HttpResponse::Ok()
         .append_header(header::ContentType(mime::APPLICATION_JSON))
         .json(&results)

--- a/server/server/src/cold_chain/temperature_breach.rs
+++ b/server/server/src/cold_chain/temperature_breach.rs
@@ -67,7 +67,7 @@ pub async fn put_breaches(
     for result in &results {
         if let Err(e) = result {
             error!("Error inserting temperature breach {:#?}", e);
-            // TODO: Should we return an HTTP error here?
+            return HttpResponse::InternalServerError().body(format!("{:#?}", e));
         }
     }
 

--- a/server/server/src/cold_chain/temperature_log.rs
+++ b/server/server/src/cold_chain/temperature_log.rs
@@ -61,7 +61,7 @@ pub async fn put_logs(
     for result in &results {
         if let Err(e) = result {
             error!("Error inserting temperature log {:#?}", e);
-            // TODO: Should we return an HTTP error here?
+            return HttpResponse::InternalServerError().body(format!("{:#?}", e));
         }
     }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

 #2720 

# 👩🏻‍💻 What does this PR do? 
Adds `error!` log messages on errors saving data from the API.
Returns an http error status when there's an error for a single row.

The cold chain app logic seems to only retry sending if there's an API error, so if a single record fails and it gets a 200 reponse from open-mSupply it might not re-send.

```typescript
function* syncSensors({
  payload: { sensorUrl },
}: PayloadAction<SyncSensorsActionPayload>): SagaIterator {
  const syncQueueManager: SyncQueueManager = yield call(getDependency, 'syncQueueManager');
  const syncOutManager: SyncOutManager = yield call(getDependency, 'syncOutManager');

  try {
    const totalRecordsToSend: number = yield call(syncQueueManager.lengthSensors);
    let iter = totalRecordsToSend;

    do {
      const syncLogs: Sensor[] = yield call(syncQueueManager.nextSensors);
      yield call(syncOutManager.syncSensors, sensorUrl, syncLogs);
      yield call(syncQueueManager.dropLogs, syncLogs);
      iter -= syncLogs.length;
    } while (iter > 0);
    yield put(SyncAction.syncSensorsSuccess(totalRecordsToSend));
  } catch (e) {
    yield put(SyncAction.syncSensorsFailure((e as Error).message));
  }
}
```

# 🧪 How has/should this change been tested? 
Test with cold chain app locally. Found an issue where temperature log records fail to sync if they have a temperature breach associated with them on the first sync.
Issue raised here: https://github.com/msupply-foundation/msupply-cold-chain/issues/290

Discussed possible fixes for this in open-mSupply with @andreievg 
1. Drop foreign key constraint
2. Create a temporary records for a breach if it doesn't exist yet and we're accepting a temperature log (would be updated afterwards)
3. Send all the api requests into the sync logic (as though it's synced down from central server) then the sync logic will correctly order the data (and we don't end up loosing any data)
4. Require all open-mSupply clients to be on an updated version with a fix sync order

For now we think option 4 is acceptible least code to change and we have no active open-mSupply Cold Chain deployments currently.

## 💌 Any notes for the reviewer?
Doesn't completely solve the missing data issue, but helps track down if there are api errors, and hopefully helps CCA retry if there are errors in future.

There's potential for some kind of broken record to continuously resend for ever from CCA, not sure if there's a nice fix for that...

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_