### PR TITLE
2912 add timezone agnostic date time for picker

### DIFF
--- a/client/packages/common/package.json
+++ b/client/packages/common/package.json
@@ -24,7 +24,7 @@
     "autosuggest-highlight": "^3.3.4",
     "currency.js": "^2.0.4",
     "date-fns": "^2.27.0",
-    "date-fns-tz": "^2.2.0",
+    "date-fns-tz": "^2.0.0",
     "dompurify": "^3.0.1",
     "graphql-import-node": "^0.0.5",
     "graphql-request": "^6.1.0",

--- a/client/packages/common/package.json
+++ b/client/packages/common/package.json
@@ -24,6 +24,7 @@
     "autosuggest-highlight": "^3.3.4",
     "currency.js": "^2.0.4",
     "date-fns": "^2.27.0",
+    "date-fns-tz": "^2.2.0",
     "dompurify": "^3.0.1",
     "graphql-import-node": "^0.0.5",
     "graphql-request": "^6.1.0",

--- a/client/packages/common/src/intl/utils/DateUtils.test.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.test.ts
@@ -1,0 +1,25 @@
+import { renderHookWithProvider } from '../../utils/testing';
+import { useFormatDateTime } from './DateUtils';
+
+describe('useFormatDateTime', () => {
+  it('to be truthy', () => {
+    const truthy = true;
+    expect(truthy).toBe(true);
+  });
+  it('getLocalDateTime returns start of day for local timezone regardless of time zone', () => {
+    const { result } = renderHookWithProvider(useFormatDateTime);
+    const timeZone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const date = '2024-02-07';
+    const options = {
+      locale: {
+        code: timeZone,
+      },
+    };
+    expect(
+      result.current
+        .getLocalDate(date, undefined, options)
+        ?.toString()
+        .slice(0, 24)
+    ).toBe('Wed Feb 07 2024 00:00:00');
+  });
+});

--- a/client/packages/common/src/intl/utils/DateUtils.test.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.test.ts
@@ -2,10 +2,6 @@ import { renderHookWithProvider } from '../../utils/testing';
 import { useFormatDateTime } from './DateUtils';
 
 describe('useFormatDateTime', () => {
-  it('to be truthy', () => {
-    const truthy = true;
-    expect(truthy).toBe(true);
-  });
   it('getLocalDateTime returns start of day for local timezone regardless of time zone', () => {
     const { result } = renderHookWithProvider(useFormatDateTime);
     const timeZone = new Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -212,7 +212,10 @@ export const useFormatDateTime = () => {
     format?: string,
     options?: Parameters<typeof parse>[3]
   ): Date | null => {
-    const tz = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+    // tz passed as props options for testing purposes
+    const tz =
+      options?.locale?.code ??
+      new Intl.DateTimeFormat().resolvedOptions().timeZone;
     const UTCDateWithoutTime = DateUtils.getDateOrNull(date, format, options);
     const offset = UTCDateWithoutTime
       ? getTimezoneOffset(tz, UTCDateWithoutTime)

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -197,9 +197,17 @@ export const useFormatDateTime = () => {
       : '';
   };
 
-  // this function acts in the same way as getDateOrNull, but will also convert date to start of the
-  // local datetime rather than local utc.
-  const getLocalStartOfDayFromDateOrNull = (
+  /**
+   * While getDateOrNull is naive to the timezone, the timezone will still change.
+   * When converting from the assumed naive zone of GMT to the local timezone, the
+   * dateTime will be wrong if the timezone is behind GMT. This function acts in
+   * the same way as getDateOrNull, but will create a datetime of start of day local
+   * time rather than start of day GMT.
+   * You can use this function anytime you need a datetime for mui date picker to
+   * be created from a date only string. This includes date of birth, date of death
+   * or any other date which is time and timezone agnostic.
+   */
+  const getLocalDate = (
     date?: Date | string | null,
     format?: string,
     options?: Parameters<typeof parse>[3]
@@ -226,6 +234,6 @@ export const useFormatDateTime = () => {
     localisedDistanceToNow,
     localisedTime,
     relativeDateTime,
-    getLocalStartOfDayFromDateOrNull,
+    getLocalDate,
   };
 };

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -200,9 +200,12 @@ export const useFormatDateTime = () => {
   /**
    * While getDateOrNull is naive to the timezone, the timezone will still change.
    * When converting from the assumed naive zone of GMT to the local timezone, the
-   * dateTime will be wrong if the timezone is behind GMT. This function acts in
-   * the same way as getDateOrNull, but will create a datetime of start of day local
-   * time rather than start of day GMT.
+   * dateTime will be wrong if the timezone is behind GMT.
+   * For example: for a user in -10 timezone, a date of 24-02-2024 will become
+   * 2024-02-23T13:00:00.000Z when rendered for mui datepicker.
+   * This function acts in the same way as getDateOrNull, but will create a datetime
+   * of start of day local time rather than start of day GMT by subtracting the local
+   * timezone offset.
    * You can use this function anytime you need a datetime for mui date picker to
    * be created from a date only string. This includes date of birth, date of death
    * or any other date which is time and timezone agnostic.

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -204,8 +204,7 @@ export const useFormatDateTime = () => {
     format?: string,
     options?: Parameters<typeof parse>[3]
   ): Date | null => {
-    // eslint-disable-next-line new-cap
-    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const tz = new Intl.DateTimeFormat().resolvedOptions().timeZone;
     const UTCDateWithoutTime = DateUtils.getDateOrNull(date, format, options);
     const offset = UTCDateWithoutTime
       ? getTimezoneOffset(tz, UTCDateWithoutTime)

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -40,10 +40,8 @@ import { getTimezoneOffset } from 'date-fns-tz';
 export const MINIMUM_EXPIRY_MONTHS = 3;
 
 const dateInputHandler = (date: Date | string | number): Date => {
-  // console.log('date input handler', date);
-  // TODO this is being called for every patient in list (it shouldn't)
   // Assume a string is an ISO date-time string
-  if (typeof date === 'string') parseISO(date);
+  if (typeof date === 'string') return parseISO(date);
   // Assume a number is a UNIX timestamp
   if (typeof date === 'number') return fromUnixTime(date);
   return date as Date;
@@ -99,7 +97,6 @@ export const DateUtils = {
         : new Date(date);
     return isValid(maybeDate) ? maybeDate : null;
   },
-
   minDate: (...dates: (Date | null)[]) => {
     const maybeDate = fromUnixTime(
       Math.min(
@@ -213,7 +210,6 @@ export const useFormatDateTime = () => {
     const offset = UTCDateWithoutTime
       ? getTimezoneOffset(tz, UTCDateWithoutTime)
       : 0;
-    // return UTCDate;
     return UTCDateWithoutTime
       ? addMilliseconds(UTCDateWithoutTime, -offset)
       : null;

--- a/client/packages/common/src/utils/formatters/formatters.test.ts
+++ b/client/packages/common/src/utils/formatters/formatters.test.ts
@@ -59,23 +59,13 @@ describe('Formatter', () => {
     expect(Formatter.toIsoString(utcStartOfDay)).toBe(
       '1984-03-13T00:00:00.000Z'
     );
-    expect(Formatter.toIsoString(null)).toBe(null);
-
-    const offsetInHours =
-      dateFnsTz.getTimezoneOffset(timeZone, new Date()) / 1000 / 60 / 60;
-    let dateString =
-      offsetInHours > 0
-        ? `1984-03-12T${24 - offsetInHours}:00:00.000Z`
-        : `1984-03-13T${-offsetInHours}:00:00.000Z`;
-    expect(Formatter.toIsoString(new Date('1984/3/13'))).toBe(dateString);
-    // note there are +13 and +14 hour timezones, but nothing below -11;
-    dateString =
-      offsetInHours > 11
-        ? `1984-03-12T${24 - offsetInHours + 11}:12:13.000Z`
-        : `1984-03-13T${11 - offsetInHours}:12:13.000Z`;
-    expect(Formatter.toIsoString(new Date('1984/3/13 11:12:13'))).toBe(
-      dateString
+    const localisedNewDate = new Date('1984/3/13 11:12:13');
+    const utcNewDate = df.addMilliseconds(
+      localisedNewDate,
+      dateFnsTz.getTimezoneOffset(timeZone, localisedNewDate)
     );
+    expect(Formatter.toIsoString(utcNewDate)).toBe('1984-03-13T11:12:13.000Z');
+    expect(Formatter.toIsoString(null)).toBe(null);
   });
 
   it('tax', () => {

--- a/client/packages/common/src/utils/formatters/formatters.test.ts
+++ b/client/packages/common/src/utils/formatters/formatters.test.ts
@@ -50,16 +50,8 @@ describe('Formatter', () => {
   });
 
   it('naiveDateTime', () => {
-    // While toIsoString is naive to the timezone, the timezone will still change.
-    // so when converting to GMT from the local timezone, the reference string will
-    // be wrong depending on the timezone.
-    // I've refactored to subtract timezone from naive string for. This will test both
-    // the naive interpretation and the timezone modification in the same test.
-
-    // eslint-disable-next-line new-cap
-    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const timeZone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
     const localalisedStartOfDay = new Date('1984/3/13');
-    // now subtract timezone which is daylight saving dependent
     const utcStartOfDay = df.addMilliseconds(
       localalisedStartOfDay,
       dateFnsTz.getTimezoneOffset(timeZone, localalisedStartOfDay)
@@ -76,7 +68,6 @@ describe('Formatter', () => {
         ? `1984-03-12T${24 - offsetInHours}:00:00.000Z`
         : `1984-03-13T${-offsetInHours}:00:00.000Z`;
     expect(Formatter.toIsoString(new Date('1984/3/13'))).toBe(dateString);
-
     // note there are +13 and +14 hour timezones, but nothing below -11;
     dateString =
       offsetInHours > 11

--- a/client/packages/common/src/utils/formatters/formatters.test.ts
+++ b/client/packages/common/src/utils/formatters/formatters.test.ts
@@ -1,6 +1,6 @@
 import { Formatter } from './formatters';
-import * as df from 'date-fns';
-import * as dateFnsTz from 'date-fns-tz';
+import { addMilliseconds } from 'date-fns';
+import { getTimezoneOffset } from 'date-fns-tz';
 
 describe('Formatter', () => {
   it('is defined', () => {
@@ -52,17 +52,17 @@ describe('Formatter', () => {
   it('naiveDateTime', () => {
     const timeZone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
     const localalisedStartOfDay = new Date('1984/3/13');
-    const utcStartOfDay = df.addMilliseconds(
+    const utcStartOfDay = addMilliseconds(
       localalisedStartOfDay,
-      dateFnsTz.getTimezoneOffset(timeZone, localalisedStartOfDay)
+      getTimezoneOffset(timeZone, localalisedStartOfDay)
     );
     expect(Formatter.toIsoString(utcStartOfDay)).toBe(
       '1984-03-13T00:00:00.000Z'
     );
     const localisedNewDate = new Date('1984/3/13 11:12:13');
-    const utcNewDate = df.addMilliseconds(
+    const utcNewDate = addMilliseconds(
       localisedNewDate,
-      dateFnsTz.getTimezoneOffset(timeZone, localisedNewDate)
+      getTimezoneOffset(timeZone, localisedNewDate)
     );
     expect(Formatter.toIsoString(utcNewDate)).toBe('1984-03-13T11:12:13.000Z');
     expect(Formatter.toIsoString(null)).toBe(null);

--- a/client/packages/programs/src/JsonForms/common/components/Date.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Date.tsx
@@ -50,7 +50,7 @@ const UIComponent = (props: ControlProps) => {
       Input={
         <BaseDatePickerInput
           // undefined is displayed as "now" and null as unset
-          value={formatDateTime.getLocalStartOfDayFromDateOrNull(data)}
+          value={formatDateTime.getLocalDate(data)}
           onChange={e => {
             handleChange(
               path,

--- a/client/packages/programs/src/JsonForms/common/components/Date.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Date.tsx
@@ -5,7 +5,6 @@ import {
   DetailInputWithLabelRow,
   useFormatDateTime,
   BaseDatePickerInput,
-  DateUtils,
 } from '@openmsupply-client/common';
 import { FORM_LABEL_WIDTH } from '../styleConstants';
 import { z } from 'zod';
@@ -25,7 +24,7 @@ export const dateTester = rankWith(5, isDateControl);
 
 const UIComponent = (props: ControlProps) => {
   const { data, handleChange, label, path, uischema } = props;
-  const dateFormatter = useFormatDateTime().customDate;
+  const formatDateTime = useFormatDateTime();
   const { errors: zErrors, options } = useZodOptionsValidation(
     Options,
     uischema.options
@@ -36,6 +35,7 @@ const UIComponent = (props: ControlProps) => {
   if (!props.visible) {
     return null;
   }
+
   return (
     <DetailInputWithLabelRow
       sx={{
@@ -50,9 +50,12 @@ const UIComponent = (props: ControlProps) => {
       Input={
         <BaseDatePickerInput
           // undefined is displayed as "now" and null as unset
-          value={DateUtils.getDateOrNull(data)}
+          value={formatDateTime.getLocalStartOfDayFromDateOrNull(data)}
           onChange={e => {
-            handleChange(path, !e ? undefined : dateFormatter(e, 'yyyy-MM-dd'));
+            handleChange(
+              path,
+              !e ? undefined : formatDateTime.customDate(e, 'yyyy-MM-dd')
+            );
             if (customError) setCustomError(undefined);
           }}
           format="P"

--- a/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
+++ b/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
@@ -31,7 +31,7 @@ const UIComponent = (props: ControlProps) => {
   const [age, setAge] = React.useState<number | string>('');
   const [dob, setDoB] = React.useState<Date | null>(null);
   const t = useTranslation('common');
-  const dateFormatter = useFormatDateTime().customDate;
+  const formatDateTime = useFormatDateTime();
   const { customError, setCustomError } = useJSONFormsCustomError(
     path,
     'Date of Birth'
@@ -50,14 +50,14 @@ const UIComponent = (props: ControlProps) => {
     setCustomError(undefined);
     setAge(DateUtils.age(dateOfBirth));
     setDoB(dateOfBirth);
-    handleChange(dobPath, dateFormatter(dateOfBirth, 'yyyy-MM-dd'));
+    handleChange(dobPath, formatDateTime.customDate(dateOfBirth, 'yyyy-MM-dd'));
     handleChange(estimatedPath, false);
   };
 
   const onChangeAge = (newAge: number) => {
     const dob = DateUtils.startOfYear(DateUtils.addYears(new Date(), -newAge));
     setDoB(dob);
-    handleChange(dobPath, dateFormatter(dob, 'yyyy-MM-dd'));
+    handleChange(dobPath, formatDateTime.customDate(dob, 'yyyy-MM-dd'));
     handleChange(estimatedPath, true);
     setCustomError(undefined);
     setAge(newAge);
@@ -87,7 +87,7 @@ const UIComponent = (props: ControlProps) => {
         <Box display="flex" alignItems="center" gap={FORM_GAP} width="100%">
           <BaseDatePickerInput
             // undefined is displayed as "now" and null as unset
-            value={dob ?? null}
+            value={formatDateTime.getLocalStartOfDayFromDateOrNull(dob)}
             onChange={onChangeDoB}
             format="P"
             width={135}

--- a/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
+++ b/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
@@ -87,7 +87,7 @@ const UIComponent = (props: ControlProps) => {
         <Box display="flex" alignItems="center" gap={FORM_GAP} width="100%">
           <BaseDatePickerInput
             // undefined is displayed as "now" and null as unset
-            value={formatDateTime.getLocalStartOfDayFromDateOrNull(dob)}
+            value={formatDateTime.getLocalDate(dob)}
             onChange={onChangeDoB}
             format="P"
             width={135}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8156,6 +8156,11 @@ dataloader@^2.2.2:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.2.2.tgz#216dc509b5abe39d43a9b9d97e6e5e473dfbe3e0"
   integrity sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==
 
+date-fns-tz@^2.2.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-2.0.0.tgz#1b14c386cb8bc16fc56fe333d4fc34ae1d1099d5"
+  integrity sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==
+
 date-fns@^2.27.0:
   version "2.30.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8156,7 +8156,7 @@ dataloader@^2.2.2:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.2.2.tgz#216dc509b5abe39d43a9b9d97e6e5e473dfbe3e0"
   integrity sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==
 
-date-fns-tz@^2.2.0:
+date-fns-tz@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-2.0.0.tgz#1b14c386cb8bc16fc56fe333d4fc34ae1d1099d5"
   integrity sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==


### PR DESCRIPTION
Add timezone agnostic function for datetime picker


Fixes #2912 

# 👩🏻‍💻 What does this PR do? 
Adds a function to convert date only strings to a ISO date for the start of day in users' local time rather than UTC local time.
Using normal naive date time functions caused issue when timezones behind UTC were used, which caused the date to be displayed as the previous day.

# 🧪 How has/should this change been tested? 
Go to patients -> open patient create modal or patient detail view
Change the DOB of a patient and see it show as the correct day in the modal / detail view.

## 💌 Any notes for the reviewer?
Still in draft - other use cases for date input to be added.
