### PR TITLE
Make final column auto-width

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
@@ -118,7 +118,6 @@ export const useRequestColumns = () => {
       label: 'label.requested-packs',
       description: 'label.requested-number-packs',
       align: ColumnAlign.Right,
-      // width: 150,
       accessor: ({ rowData }) =>
         formatNumber.round(
           rowData.requestedQuantity / rowData.item.defaultPackSize,

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
@@ -88,7 +88,6 @@ export const useResponseColumns = () => {
     label: 'label.remaining-to-supply',
     description: 'description.remaining-to-supply',
     key: 'remainingToSupply',
-    width: 100,
     align: ColumnAlign.Right,
     accessor: ({ rowData }) => rowData.remainingQuantityToSupply,
     getSortValue: rowData => rowData.remainingQuantityToSupply,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2823

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Fixes the overlapping column header/checkbox for Requisition detail view.

Very tiny fix, just disabled the width and let it determine it automatically. I could just set a bigger width (change from 100 to 150, say), but I'm just copying what has been done for Internal orders.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

@roxy-dao I think the scroll bar is a bit of a red herring -- I get the horizontal scroll bar fine when I narrow the window (in all browsers)
