### PR TITLE
Add sensor type to sensor form

### DIFF
--- a/client/packages/coldchain/src/Sensor/Components/SensorLineForm.tsx
+++ b/client/packages/coldchain/src/Sensor/Components/SensorLineForm.tsx
@@ -71,6 +71,12 @@ export const SensorLineForm: FC<UseDraftSensorControl> = ({
           draft.latestTemperatureLog?.nodes[0]?.datetime
         )}
       />
+      <TextWithLabelRow
+        sx={textSx}
+        labelProps={labelWrap}
+        label={t('label.sensor-type')}
+        text={draft.type ?? ''}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
Fixes #2861 

# 👩🏻‍💻 What does this PR do? 
Adds sensor type to sensor detail modal

# 🧪 How has/should this change been tested? 
Open sensor detail modal.
See that sensor type is not available.