### PR TITLE
 2994 New program enrolment name is breaking build

### DIFF
--- a/server/repository/src/db_diesel/patient.rs
+++ b/server/repository/src/db_diesel/patient.rs
@@ -223,7 +223,7 @@ impl<'a> PatientRepository<'a> {
                         ..Default::default()
                     },
                 ))
-                .select(program_enrolment_dsl::patient_id);
+                .select(name_dsl::id);
 
                 query = query.filter(name_dsl::id.eq_any(sub_query))
             }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2994

# 👩🏻‍💻 What does this PR do? 
Use name_dsl instead of program_enrolment_dsl since program enrolment doesn't have patient id anymore.

# 🧪 How has/should this change been tested? 
1. Make sure program enrolment name filter is still working
- [ ] Set up programs
- [ ] Go to patients 
- [ ] Enrol a few in different programs
- [ ] Add the `program enrolment` filter 
- [ ] Try using it
2. Make sure it builds
- [ ] run `yarn build`
