### PR TITLE
Consolidate prescription mutations

### DIFF
--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
@@ -60,21 +60,20 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
     'id',
   ]);
   const { mutateAsync } = usePrescription.line.save();
-  const { mutateAsync: mutateStatus } = usePrescription.document.update();
   const isDisabled = usePrescription.utils.isDisabled();
   const {
-    draftStockOutLines,
+    draftStockOutLines: draftPrescriptionLines,
     updateQuantity,
     setDraftStockOutLines,
     isLoading,
     updateNotes,
   } = useDraftPrescriptionLines(currentItem);
-  const packSizeController = usePackSizeController(draftStockOutLines);
+  const packSizeController = usePackSizeController(draftPrescriptionLines);
   const { next, disabled: nextDisabled } = useNextItem(currentItem?.id);
   const { isDirty, setIsDirty } = useDirtyCheck();
   const height = useKeyboardHeightAdjustment(700);
 
-  const placeholder = draftStockOutLines?.find(
+  const placeholder = draftPrescriptionLines?.find(
     ({ type, numberOfPacks }) =>
       type === InvoiceLineNodeType.UnallocatedStock && numberOfPacks !== 0
   );
@@ -93,21 +92,21 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
     if (!isDirty) return;
 
     // needed since placeholders aren't being created for prescriptions yet, but still adding to array
-    const isOnHold = draftStockOutLines.some(
+    const isOnHold = draftPrescriptionLines.some(
       ({ stockLine, location }) => stockLine?.onHold || location?.onHold
     );
 
-    if (
+    const patch =
       status !== InvoiceNodeStatus.Picked &&
-      draftStockOutLines.length >= 1 &&
+      draftPrescriptionLines.length >= 1 &&
       !isOnHold
-    ) {
-      await mutateStatus({
-        id: invoiceId,
-        status: InvoiceNodeStatus.Picked,
-      });
-    }
-    await mutateAsync(draftStockOutLines);
+        ? {
+            id: invoiceId,
+            status: InvoiceNodeStatus.Picked,
+          }
+        : undefined;
+
+    await mutateAsync({ draftPrescriptionLines, patch });
 
     if (!draft) return;
   };
@@ -119,10 +118,10 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
   ) => {
     const newAllocateQuantities = allocateQuantities(
       status,
-      draftStockOutLines
+      draftPrescriptionLines
     )(newVal, packSize);
     setIsDirty(true);
-    setDraftStockOutLines(newAllocateQuantities ?? draftStockOutLines);
+    setDraftStockOutLines(newAllocateQuantities ?? draftPrescriptionLines);
     setIsAutoAllocated(autoAllocated);
     if (showZeroQuantityConfirmation && newVal !== 0)
       setShowZeroQuantityConfirmation(false);
@@ -130,13 +129,13 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
     return newAllocateQuantities;
   };
 
-  const canAutoAllocate = !!(currentItem && draftStockOutLines.length);
+  const canAutoAllocate = !!(currentItem && draftPrescriptionLines.length);
   const okNextDisabled =
     (mode === ModalMode.Update && nextDisabled) || !currentItem;
 
   const handleSave = async (onSaved: () => boolean | void) => {
     if (
-      getAllocatedQuantity(draftStockOutLines) === 0 &&
+      getAllocatedQuantity(draftPrescriptionLines) === 0 &&
       !showZeroQuantityConfirmation
     ) {
       setShowZeroQuantityConfirmation(true);
@@ -173,11 +172,11 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
     return await handleSave(onSaved);
   };
 
-  const hasOnHold = draftStockOutLines.some(
+  const hasOnHold = draftPrescriptionLines.some(
     ({ stockLine }) =>
       (stockLine?.availableNumberOfPacks ?? 0) > 0 && !!stockLine?.onHold
   );
-  const hasExpired = draftStockOutLines.some(
+  const hasExpired = draftPrescriptionLines.some(
     ({ stockLine }) =>
       (stockLine?.availableNumberOfPacks ?? 0) > 0 &&
       !!stockLine?.expiryDate &&
@@ -216,13 +215,13 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
             setCurrentItem(item);
           }}
           item={currentItem}
-          allocatedQuantity={getAllocatedQuantity(draftStockOutLines)}
-          availableQuantity={sumAvailableQuantity(draftStockOutLines)}
+          allocatedQuantity={getAllocatedQuantity(draftPrescriptionLines)}
+          availableQuantity={sumAvailableQuantity(draftPrescriptionLines)}
           onChangeQuantity={onAllocate}
           canAutoAllocate={canAutoAllocate}
           isAutoAllocated={isAutoAllocated}
           updateNotes={onUpdateNotes}
-          draftPrescriptionLines={draftStockOutLines}
+          draftPrescriptionLines={draftPrescriptionLines}
           showZeroQuantityConfirmation={showZeroQuantityConfirmation}
           hasOnHold={hasOnHold}
           hasExpired={hasExpired}
@@ -234,8 +233,8 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
           isLoading={isLoading}
           packSizeController={packSizeController}
           updateQuantity={onUpdateQuantity}
-          draftPrescriptionLines={draftStockOutLines}
-          allocatedQuantity={getAllocatedQuantity(draftStockOutLines)}
+          draftPrescriptionLines={draftPrescriptionLines}
+          allocatedQuantity={getAllocatedQuantity(draftPrescriptionLines)}
         />
       </Grid>
     </Modal>

--- a/client/packages/invoices/src/Prescriptions/api/api.ts
+++ b/client/packages/invoices/src/Prescriptions/api/api.ts
@@ -189,9 +189,15 @@ export const getPrescriptionQueries = (sdk: Sdk, storeId: string) => ({
 
     throw new Error('Could not delete invoices');
   },
-  updateLines: async (draftPrescriptionLine: DraftStockOutLine[]) => {
+  updateLines: async ({
+    draftPrescriptionLines,
+    patch,
+  }: {
+    draftPrescriptionLines: DraftStockOutLine[];
+    patch?: RecordPatch<PrescriptionRowFragment>;
+  }) => {
     const input = {
-      insertPrescriptionLines: draftPrescriptionLine
+      insertPrescriptionLines: draftPrescriptionLines
         .filter(
           ({ type, isCreated, numberOfPacks }) =>
             isCreated &&
@@ -199,7 +205,7 @@ export const getPrescriptionQueries = (sdk: Sdk, storeId: string) => ({
             numberOfPacks > 0
         )
         .map(prescriptionParsers.toInsertLine),
-      updatePrescriptionLines: draftPrescriptionLine
+      updatePrescriptionLines: draftPrescriptionLines
         .filter(
           ({ type, isCreated, isUpdated, numberOfPacks }) =>
             !isCreated &&
@@ -208,7 +214,7 @@ export const getPrescriptionQueries = (sdk: Sdk, storeId: string) => ({
             numberOfPacks > 0
         )
         .map(prescriptionParsers.toUpdateLine),
-      deletePrescriptionLines: draftPrescriptionLine
+      deletePrescriptionLines: draftPrescriptionLines
         .filter(
           ({ type, isCreated, isUpdated, numberOfPacks }) =>
             !isCreated &&
@@ -217,7 +223,11 @@ export const getPrescriptionQueries = (sdk: Sdk, storeId: string) => ({
             numberOfPacks === 0
         )
         .map(prescriptionParsers.toDeleteLine),
+      updatePrescriptions: !!patch
+        ? [prescriptionParsers.toUpdate(patch)]
+        : undefined,
     };
+
     const result = await sdk.upsertPrescription({ storeId, input });
 
     return result;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2996

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The prescription mutation behaves differently for the new status / first item added, in that the status is also updated.
This has been changed, I've put the status update into the same batch mutation that inserts the new prescription line and testing this version I've been unable to reproduce the issue.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Tested using the debug build in [this folder](https://drive.google.com/open?id=1Ax4J-x4-ZXbyOzpM_VixVGQ9WxW4jn2Q&usp=drive_fs). The apk is `open-msupply-1.6.02-debug.apk` and is signed with the release key, so that you can update over a release version without uninstalling.

Have run in server mode, sync'd with a datafile with 50k+ patients ([this datafile](https://drive.google.com/file/d/1fdoYKhSzlEZz645DJGiZvB0B05JJAGkB/view?usp=drive_link)) and created a prescription. Closed app, restarted and tested again then repeated process.



## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
