### PR TITLE
Update the "Add" SplitButton dependent on the active tab

### DIFF
--- a/client/packages/system/src/Patient/PatientView/AddButton.tsx
+++ b/client/packages/system/src/Patient/PatientView/AddButton.tsx
@@ -1,14 +1,16 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   useTranslation,
   SplitButton,
   SplitButtonOption,
   PlusCircleIcon,
+  useUrlQuery,
 } from '@openmsupply-client/common';
 import {
   PatientModal,
   usePatientModalStore,
 } from '@openmsupply-client/programs';
+import { PatientTabValue } from './PatientView';
 
 interface AddButtonProps {
   /** Disable the whole control */
@@ -21,27 +23,52 @@ export const AddButton: React.FC<AddButtonProps> = ({
   disableEncounterButton,
 }) => {
   const t = useTranslation('dispensary');
+  const { urlQuery } = useUrlQuery();
+  const currentUrlTab = urlQuery['tab'];
   const { setModal: selectModal, reset } = usePatientModalStore();
-  const options = [
-    {
-      value: PatientModal.ProgramSearch,
-      label: t('button.add-program'),
-      isDisabled: false,
-    },
-    {
-      value: PatientModal.Encounter,
-      label: t('button.add-encounter'),
-      isDisabled: disableEncounterButton,
-    },
-    {
-      value: PatientModal.ContactTraceSearch,
-      label: t('button.add-contact-trace'),
-    },
-  ];
+
+  const options: [
+    SplitButtonOption<PatientModal>,
+    SplitButtonOption<PatientModal>,
+    SplitButtonOption<PatientModal>,
+  ] = useMemo(
+    () => [
+      {
+        value: PatientModal.ProgramSearch,
+        label: t('button.add-program'),
+        isDisabled: false,
+      },
+      {
+        value: PatientModal.Encounter,
+        label: t('button.add-encounter'),
+        isDisabled: disableEncounterButton,
+      },
+      {
+        value: PatientModal.ContactTraceSearch,
+        label: t('button.add-contact-trace'),
+      },
+    ],
+    [disableEncounterButton, t]
+  );
+  const [programOption, encounterOption, contactTraceOption] = options;
 
   const [selectedOption, setSelectedOption] = useState<
     SplitButtonOption<PatientModal>
-  >(options[0] as SplitButtonOption<PatientModal>);
+  >(options[0]);
+
+  useEffect(() => {
+    switch (currentUrlTab) {
+      case PatientTabValue.Programs:
+        setSelectedOption(programOption);
+        break;
+      case PatientTabValue.Encounters:
+        setSelectedOption(encounterOption);
+        break;
+      case PatientTabValue.ContactTracing:
+        setSelectedOption(contactTraceOption);
+        break;
+    }
+  }, [contactTraceOption, currentUrlTab, encounterOption, programOption]);
 
   const onSelectOption = (option: SplitButtonOption<PatientModal>) => {
     setSelectedOption(option);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #653 

# 👩🏻‍💻 What does this PR do? 
Set the selected SplitButton option depending on the active patient program tab.

# Testing
Change between different tabs while being on the patient page. The "Add" button at the top should update.