### PR TITLE
3005 Remove constraint on barcode manufacturer link id

### DIFF
--- a/server/repository/src/migrations/v1_07_00/barcode_add_manufacturer_link_id.rs
+++ b/server/repository/src/migrations/v1_07_00/barcode_add_manufacturer_link_id.rs
@@ -11,6 +11,8 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
         
         UPDATE barcode
         SET manufacturer_link_id = manufacturer_id;
+        UPDATE barcode SET manufacturer_link_id = null WHERE manufacturer_link_id = '';
+        UPDATE barcode SET parent_id = null WHERE parent_id = '';
 
         ALTER TABLE barcode ADD CONSTRAINT barcode_manufacturer_link_id_fkey FOREIGN KEY (manufacturer_link_id) REFERENCES name_link(id);
         "#,
@@ -24,6 +26,8 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
         PRAGMA foreign_keys = OFF;
         ALTER TABLE barcode
         ADD COLUMN manufacturer_link_id TEXT REFERENCES name_link(id);
+        UPDATE barcode SET manufacturer_link_id = null WHERE manufacturer_link_id = '';
+        UPDATE barcode SET parent_id = null WHERE parent_id = '';
         
         UPDATE barcode
         SET manufacturer_link_id = manufacturer_id;

--- a/server/repository/src/migrations/v1_07_00/barcode_add_manufacturer_link_id.rs
+++ b/server/repository/src/migrations/v1_07_00/barcode_add_manufacturer_link_id.rs
@@ -1,6 +1,14 @@
 use crate::{migrations::sql, StorageConnection};
 
 pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
+    sql!(
+        connection,
+        r#"
+        UPDATE barcode SET manufacturer_link_id = null WHERE manufacturer_link_id = '';
+        UPDATE barcode SET parent_id = null WHERE parent_id = '';
+        "#,
+    )?;
+
     #[cfg(feature = "postgres")]
     sql!(
         connection,
@@ -11,8 +19,6 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
         
         UPDATE barcode
         SET manufacturer_link_id = manufacturer_id;
-
-        UPDATE barcode SET manufacturer_link_id = null WHERE manufacturer_link_id = '';
 
         ALTER TABLE barcode ADD CONSTRAINT barcode_manufacturer_link_id_fkey FOREIGN KEY (manufacturer_link_id) REFERENCES name_link(id);
         "#,

--- a/server/repository/src/migrations/v1_07_00/barcode_add_manufacturer_link_id.rs
+++ b/server/repository/src/migrations/v1_07_00/barcode_add_manufacturer_link_id.rs
@@ -11,8 +11,6 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
         
         UPDATE barcode
         SET manufacturer_link_id = manufacturer_id;
-        
-        ALTER TABLE barcode ADD CONSTRAINT barcode_manufacturer_link_id_fkey FOREIGN KEY (manufacturer_link_id) REFERENCES name_link(id);
         "#,
     )?;
 

--- a/server/repository/src/migrations/v1_07_00/barcode_add_manufacturer_link_id.rs
+++ b/server/repository/src/migrations/v1_07_00/barcode_add_manufacturer_link_id.rs
@@ -1,14 +1,6 @@
 use crate::{migrations::sql, StorageConnection};
 
 pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
-    sql!(
-        connection,
-        r#"
-        UPDATE barcode SET manufacturer_link_id = null WHERE manufacturer_link_id = '';
-        UPDATE barcode SET parent_id = null WHERE parent_id = '';
-        "#,
-    )?;
-
     #[cfg(feature = "postgres")]
     sql!(
         connection,

--- a/server/repository/src/migrations/v1_07_00/barcode_add_manufacturer_link_id.rs
+++ b/server/repository/src/migrations/v1_07_00/barcode_add_manufacturer_link_id.rs
@@ -11,6 +11,10 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
         
         UPDATE barcode
         SET manufacturer_link_id = manufacturer_id;
+
+        UPDATE barcode SET manufacturer_link_id = null WHERE manufacturer_link_id = '';
+
+        ALTER TABLE barcode ADD CONSTRAINT barcode_manufacturer_link_id_fkey FOREIGN KEY (manufacturer_link_id) REFERENCES name_link(id);
         "#,
     )?;
 

--- a/server/service/src/sync/translations/barcode.rs
+++ b/server/service/src/sync/translations/barcode.rs
@@ -4,7 +4,7 @@ use repository::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::sync::api::RemoteSyncRecordV5;
+use crate::sync::{api::RemoteSyncRecordV5, sync_serde::empty_str_as_option_string};
 
 use super::{
     IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
@@ -28,10 +28,12 @@ pub struct LegacyBarcodeRow {
     pub gtin: String,
     #[serde(rename = "itemID")]
     pub item_id: String,
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     #[serde(rename = "manufacturerID")]
     pub manufacturer_id: Option<String>,
     #[serde(rename = "packSize")]
     pub pack_size: Option<i32>,
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     #[serde(rename = "parentID")]
     pub parent_id: Option<String>,
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3005

# 👩🏻‍💻 What does this PR do? 
Ignore the typo in the branch... Removed the postgres constraint on barcode manufacturer link id... This constraint expects the column to be NOT NULL, and if this field is often missing in the barcode then safe to remove. Not sure why it doesn't bug for other FK's that are nullable though.... but they seem to be migrating fine so far?

# 🧪 How has/should this change been tested? 
- [ ] Initialise main with a datafile that has some barcodes with no manufacturer link id
- [ ] Then go to this branch and test upgrade