### PR TITLE
3008 create outbound return from list view

### DIFF
--- a/client/packages/common/src/intl/locales/en/replenishment.json
+++ b/client/packages/common/src/intl/locales/en/replenishment.json
@@ -5,6 +5,7 @@
   "button.return-lines": "Return selected lines",
   "button.requested-to-suggested": "Use Suggested Quantities",
   "error.amc-is-zero": "No Average Monthly Consumption value",
+  "error.failed-to-create-return": "Failed to create return!",
   "error.no-inbound-items": "No items have been added to this shipment.",
   "error.no-inbound-shipments": "There are no Inbound Shipments to display.",
   "error.no-internal-orders": "No internal orders to display.",

--- a/client/packages/invoices/src/Returns/OutboundListView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/Returns/OutboundListView/AppBarButtons.tsx
@@ -12,6 +12,7 @@ import {
   Platform,
   useNotification,
   FileUtils,
+  FnUtils,
 } from '@openmsupply-client/common';
 import { SupplierSearchModal } from '@openmsupply-client/system';
 import { useReturns } from '../api';
@@ -22,7 +23,7 @@ export const AppBarButtonsComponent: FC<{
 }> = ({ modalController }) => {
   const t = useTranslation('replenishment');
   const { success, error } = useNotification();
-  // const { mutate: onCreate } = useReturns.document.insertOutbound();
+  const { mutateAsync: onCreate } = useReturns.document.insertSupplierReturn();
   const { fetchAsync, isLoading } = useReturns.document.listAllOutbound({
     key: 'createdDateTime',
     direction: 'desc',
@@ -47,18 +48,18 @@ export const AppBarButtonsComponent: FC<{
         onClose={modalController.toggleOff}
         onChange={async name => {
           modalController.toggleOff();
-          console.log('TODO: create. Selected supplier:', name);
-          // try {
-          //   await onCreate({
-          //     id: FnUtils.generateUUID(),
-          //     otherPartyId: name?.id,
-          //   });
-          // } catch (e) {
-          //   const errorSnack = error(
-          //     'Failed to create return! ' + (e as Error).message
-          //   );
-          //   errorSnack();
-          // }
+          try {
+            await onCreate({
+              id: FnUtils.generateUUID(),
+              supplierId: name?.id,
+              supplierReturnLines: [],
+            });
+          } catch (e) {
+            const errorSnack = error(
+              `${t('error.failed-to-create-return')} ${(e as Error).message}`
+            );
+            errorSnack();
+          }
         }}
       />
       <Grid container gap={1}>

--- a/client/packages/invoices/src/Returns/api/api.ts
+++ b/client/packages/invoices/src/Returns/api/api.ts
@@ -178,7 +178,13 @@ export const getReturnsQueries = (sdk: Sdk, storeId: string) => ({
       input,
     });
 
-    return result.insertSupplierReturn;
+    const { insertSupplierReturn } = result;
+
+    if (insertSupplierReturn.__typename === 'InvoiceNode') {
+      return insertSupplierReturn.invoiceNumber;
+    }
+
+    throw new Error('Could not insert supplier return');
   },
   deleteOutbound: async (
     returns: OutboundReturnRowFragment[]

--- a/client/packages/invoices/src/Returns/api/hooks/document/useInsertSupplierReturn.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/document/useInsertSupplierReturn.ts
@@ -1,19 +1,23 @@
-import { useQueryClient, useMutation } from '@openmsupply-client/common';
+import {
+  useQueryClient,
+  useMutation,
+  useNavigate,
+  RouteBuilder,
+} from '@openmsupply-client/common';
 import { useReturnsApi } from '../utils/useReturnsApi';
+import { AppRoute } from 'packages/config/src';
 
 export const useInsertSupplierReturn = () => {
   const queryClient = useQueryClient();
-  // const navigate = useNavigate();
+  const navigate = useNavigate();
   const api = useReturnsApi();
   return useMutation(api.insertSupplierReturn, {
-    onSuccess: () => {
-      // TODO: redirect to details page
-      // onSuccess: invoiceNumber => {
-      // const route = RouteBuilder.create(AppRoute.Replenishment)
-      //   .addPart(AppRoute.InboundShipment)
-      //   .addPart(String(invoiceNumber))
-      //   .build();
-      // navigate(route, { replace: true });
+    onSuccess: invoiceNumber => {
+      const route = RouteBuilder.create(AppRoute.Replenishment)
+        .addPart(AppRoute.OutboundReturn)
+        .addPart(String(invoiceNumber))
+        .build();
+      navigate(route, { replace: true });
       return queryClient.invalidateQueries(api.keys.base());
     },
   });


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3008 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

All this was already in the list view, but now connects the insert mutation on supplier selection and redirects to the resulting details view:
![Screenshot 2024-02-19 at 12 28 31 PM](https://github.com/msupply-foundation/open-msupply/assets/55115239/253f71ce-be69-4b35-947c-37fd5cee52a5)


# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

- On the outbound return list view, click `New Return`
- Supplier selection modal appears
- When you select a supplier, the mutation is called, and you are redirected to the detail page