### PR TITLE
2857 program event clean up

### DIFF
--- a/server/graphql/types/src/types/program/encounter.rs
+++ b/server/graphql/types/src/types/program/encounter.rs
@@ -412,6 +412,7 @@ impl EncounterNode {
                     key: ProgramEventSortField::Datetime,
                     desc: Some(true),
                 })),
+                Some(&self.allowed_ctx),
             )
             .map_err(StandardGraphqlError::from_list_error)?;
 
@@ -455,6 +456,7 @@ impl EncounterNode {
                 page.map(PaginationOption::from),
                 Some(program_filter),
                 sort.map(ProgramEventSortInput::to_domain),
+                Some(&self.allowed_ctx),
             )
             .map_err(StandardGraphqlError::from_list_error)?;
 

--- a/server/graphql/types/src/types/program/program_enrolment.rs
+++ b/server/graphql/types/src/types/program/program_enrolment.rs
@@ -301,6 +301,7 @@ impl ProgramEnrolmentNode {
                     key: ProgramEventSortField::Datetime,
                     desc: Some(true),
                 })),
+                Some(&self.allowed_ctx),
             )
             .map_err(StandardGraphqlError::from_list_error)?;
         Ok(ProgramEventResponse::Response(ProgramEventConnector {

--- a/server/service/src/programs/encounter/encounter_updated.rs
+++ b/server/service/src/programs/encounter/encounter_updated.rs
@@ -195,6 +195,7 @@ mod encounter_document_updated_test {
                 None,
                 Some(ProgramEventFilter::new().patient_id(EqualFilter::equal_to(&patient.id))),
                 None,
+                None,
             )
             .unwrap();
         assert_eq!(events.count, 1);
@@ -237,6 +238,7 @@ mod encounter_document_updated_test {
                 &context,
                 None,
                 Some(ProgramEventFilter::new().patient_id(EqualFilter::equal_to(&patient.id))),
+                None,
                 None,
             )
             .unwrap();

--- a/server/service/src/programs/encounter/suggested_next_encounter.rs
+++ b/server/service/src/programs/encounter/suggested_next_encounter.rs
@@ -49,6 +49,7 @@ pub fn suggested_next_encounter(
             }),
             Some(program_filter),
             None,
+            Some(allowed_ctx),
         )
         .map_err(|err| match err {
             ListError::DatabaseError(err) => err,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Not directly part of #2857

# 👩🏻‍💻 What does this PR do? 
Some small refactoring that I noticed while working on #2357. In other places the allowed_ctx permission check is done in the service, so I did the same for program events. Previously, it made it hard to validate that permissions are taken into account correctly.