### PR TITLE
3014 add new inbound return from list view

### DIFF
--- a/client/packages/common/src/intl/locales/en/distribution.json
+++ b/client/packages/common/src/intl/locales/en/distribution.json
@@ -11,6 +11,7 @@
   "button.new-shipment": "New Shipment",
   "button.select-a-color": "Select a colour",
   "button.stop": "Stop",
+  "error.failed-to-create-return": "Failed to create return!",
   "error.failed-to-create-outbound": "Failed to create Outbound Shipment",
   "error.failed-to-save-service-charges": "Failed to save service charges",
   "error.no-inbound-returns": "There are no Inbound Returns to display.",

--- a/client/packages/invoices/src/Returns/InboundListView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/Returns/InboundListView/AppBarButtons.tsx
@@ -12,6 +12,7 @@ import {
   Platform,
   useNotification,
   FileUtils,
+  FnUtils,
 } from '@openmsupply-client/common';
 import { CustomerSearchModal } from '@openmsupply-client/system';
 import { useReturns } from '../api';
@@ -22,7 +23,7 @@ export const AppBarButtonsComponent: FC<{
 }> = ({ modalController }) => {
   const t = useTranslation('distribution');
   const { success, error } = useNotification();
-  // const { mutate: onCreate } = useReturns.document.insertInbound();
+  const { mutateAsync: onCreate } = useReturns.document.insertInboundReturn();
   const { fetchAsync, isLoading } = useReturns.document.listAllInbound({
     key: 'createdDateTime',
     direction: 'desc',
@@ -47,18 +48,18 @@ export const AppBarButtonsComponent: FC<{
         onClose={modalController.toggleOff}
         onChange={async name => {
           modalController.toggleOff();
-          console.log('TODO: create. Selected customer:', name);
-          // try {
-          //   await onCreate({
-          //     id: FnUtils.generateUUID(),
-          //     otherPartyId: name?.id,
-          //   });
-          // } catch (e) {
-          //   const errorSnack = error(
-          //     'Failed to create return! ' + (e as Error).message
-          //   );
-          //   errorSnack();
-          // }
+          try {
+            await onCreate({
+              id: FnUtils.generateUUID(),
+              customerId: name?.id,
+              inboundReturnLines: [],
+            });
+          } catch (e) {
+            const errorSnack = error(
+              `${t('error.failed-to-create-return')} ${(e as Error).message}`
+            );
+            errorSnack();
+          }
         }}
       />
       <Grid container gap={1}>

--- a/client/packages/invoices/src/Returns/api/api.ts
+++ b/client/packages/invoices/src/Returns/api/api.ts
@@ -185,7 +185,7 @@ export const getReturnsQueries = (sdk: Sdk, storeId: string) => ({
       return insertOutboundReturn.invoiceNumber;
     }
 
-    throw new Error('Could not insert supplier return');
+    throw new Error('Could not insert outbound return');
   },
   insertInboundReturn: async (input: InboundReturnInput) => {
     const result = await sdk.insertInboundReturn({
@@ -193,7 +193,13 @@ export const getReturnsQueries = (sdk: Sdk, storeId: string) => ({
       storeId,
     });
 
-    return result.insertInboundReturn;
+    const { insertInboundReturn } = result;
+
+    if (insertInboundReturn.__typename === 'InvoiceNode') {
+      return insertInboundReturn.invoiceNumber;
+    }
+
+    throw new Error('Could not insert inbound return');
   },
   deleteOutbound: async (
     returns: OutboundReturnRowFragment[]

--- a/client/packages/invoices/src/Returns/api/hooks/document/useInsertInboundReturn.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/document/useInsertInboundReturn.ts
@@ -1,19 +1,23 @@
-import { useQueryClient, useMutation } from '@openmsupply-client/common';
+import {
+  useQueryClient,
+  useMutation,
+  useNavigate,
+  RouteBuilder,
+} from '@openmsupply-client/common';
 import { useReturnsApi } from '../utils/useReturnsApi';
+import { AppRoute } from 'packages/config/src';
 
 export const useInsertInboundReturn = () => {
   const queryClient = useQueryClient();
-  // const navigate = useNavigate();
+  const navigate = useNavigate();
   const api = useReturnsApi();
   return useMutation(api.insertInboundReturn, {
-    onSuccess: () => {
-      // TODO: redirect to details page
-      // onSuccess: invoiceNumber => {
-      // const route = RouteBuilder.create(AppRoute.Replenishment)
-      //   .addPart(AppRoute.InboundShipment)
-      //   .addPart(String(invoiceNumber))
-      //   .build();
-      // navigate(route, { replace: true });
+    onSuccess: invoiceNumber => {
+      const route = RouteBuilder.create(AppRoute.Distribution)
+        .addPart(AppRoute.InboundReturn)
+        .addPart(String(invoiceNumber))
+        .build();
+      navigate(route);
       return queryClient.invalidateQueries(api.keys.base());
     },
   });


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3014 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Selecting a customer here now calls the insertInboundReturn mutation and redirects to the detail URL (page incoming lol)
![Screenshot 2024-02-21 at 1 43 12 PM](https://github.com/msupply-foundation/open-msupply/assets/55115239/05c4a4ef-2205-4b3b-b265-e787142b2e7f)


# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

- On the inbound returns list view, click `New Return`
- Customer selection modal appears
- When you select a customer, the insert mutation is called, and you are redirected to the detail page

