### PR TITLE
3038 map to stock line ids

### DIFF
--- a/client/packages/common/src/intl/locales/en/distribution.json
+++ b/client/packages/common/src/intl/locales/en/distribution.json
@@ -94,6 +94,7 @@
   "messages.on-hold-confirmation": "This will prevent any further status changes until the hold is removed",
   "messages.no-stock-available": "There is no stock available",
   "messages.cant-delete-requisitions": "Can only delete requisitions with a status of 'Draft'",
+  "messages.cant-return-shipment": "Cannot process return of lines until the status is 'Delivered'",
   "messages.click-to-return-to-requisitions": "Unable to find a requisition with that ID. Click OK to return to the requisition list",
   "messages.click-to-return-to-shipments": "Unable to find a shipment with that ID. Click OK to return to the shipment list",
   "messages.confirm-add-from-master-list": "Do you want to add all of the items from this master list?",

--- a/client/packages/common/src/intl/locales/en/distribution.json
+++ b/client/packages/common/src/intl/locales/en/distribution.json
@@ -67,6 +67,7 @@
   "label.select-rows-to-allocate-them": "Select rows to allocate them",
   "label.supply-quantity": "Quantity to supply",
   "message.placeholder-line": "A placeholder line has been created for additional requested quantity",
+  "message.placeholder-lines-cannot-be-returned": "Placeholder lines cannot be returned",
   "messages.allocated-lines_one": "Allocated {{count}} line",
   "messages.allocated-lines_few": "Allocated {{count}} lines",
   "messages.allocated-lines_many": "Allocated {{count}} lines",

--- a/client/packages/common/src/intl/locales/en/replenishment.json
+++ b/client/packages/common/src/intl/locales/en/replenishment.json
@@ -82,6 +82,7 @@
   "messages.off-hold-confirmation": "This will re-enable status changes",
   "messages.on-hold-confirmation": "This will prevent any further status changes until the hold is removed",
   "messages.cant-delete-requisitions": "Can only delete requisitions with a status of 'Draft'",
+  "messages.cant-return-new-shipment": "Cannot return lines from an Inbound Shipment with a status of 'New'",
   "messages.changing-max-mos": "This will change the target months of stock.",
   "messages.changing-min-mos": "This will change the reorder threshold months of stock.",
   "messages.unassign-min-mos": "This will remove the stock reorder threshold. Reorder threshold will now default to be the same as target months of stock.",

--- a/client/packages/common/src/intl/locales/en/replenishment.json
+++ b/client/packages/common/src/intl/locales/en/replenishment.json
@@ -82,7 +82,7 @@
   "messages.off-hold-confirmation": "This will re-enable status changes",
   "messages.on-hold-confirmation": "This will prevent any further status changes until the hold is removed",
   "messages.cant-delete-requisitions": "Can only delete requisitions with a status of 'Draft'",
-  "messages.cant-return-new-shipment": "Cannot return lines from an Inbound Shipment with a status of 'New'",
+  "messages.cant-return-shipment": "Cannot return lines from an Inbound Shipment until the status is 'Delivered'",
   "messages.changing-max-mos": "This will change the target months of stock.",
   "messages.changing-min-mos": "This will change the reorder threshold months of stock.",
   "messages.unassign-min-mos": "This will remove the stock reorder threshold. Reorder threshold will now default to be the same as target months of stock.",

--- a/client/packages/common/src/intl/locales/en/replenishment.json
+++ b/client/packages/common/src/intl/locales/en/replenishment.json
@@ -82,7 +82,7 @@
   "messages.off-hold-confirmation": "This will re-enable status changes",
   "messages.on-hold-confirmation": "This will prevent any further status changes until the hold is removed",
   "messages.cant-delete-requisitions": "Can only delete requisitions with a status of 'Draft'",
-  "messages.cant-return-shipment": "Cannot return lines from an Inbound Shipment until the status is 'Delivered'",
+  "messages.cant-return-shipment": "Cannot return lines until the status is 'Delivered'",
   "messages.changing-max-mos": "This will change the target months of stock.",
   "messages.changing-min-mos": "This will change the reorder threshold months of stock.",
   "messages.unassign-min-mos": "This will remove the stock reorder threshold. Reorder threshold will now default to be the same as target months of stock.",

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -1431,11 +1431,11 @@ export enum GenderType {
 }
 
 export type GenerateInboundReturnInput = {
-  outboundShipmentLineIds: Array<Scalars['String']['input']>;
+  stockLineIds: Array<Scalars['String']['input']>;
 };
 
 export type GenerateOutboundReturnLinesInput = {
-  inboundShipmentLineIds: Array<Scalars['String']['input']>;
+  stockLineIds: Array<Scalars['String']['input']>;
 };
 
 export type InboundInvoiceCounts = {

--- a/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -38,7 +38,7 @@ export const DetailView: FC = () => {
     onOpen: onOpenReturns,
     onClose: onCloseReturns,
     isOpen: returnsIsOpen,
-    entity: selectedInboundShipmentLineIds,
+    entity: stockLineIds,
   } = useEditModal<string[]>();
   const navigate = useNavigate();
   const t = useTranslation('replenishment');
@@ -51,11 +51,11 @@ export const DetailView: FC = () => {
     [onOpen]
   );
 
-  const onReturn = async (inboundShipmentLineIds: string[]) => {
-    if (!inboundShipmentLineIds.length) {
+  const onReturn = async (selectedStockLineIds: string[]) => {
+    if (!selectedStockLineIds.length) {
       const selectLinesSnack = info(t('messages.select-rows-to-return'));
       selectLinesSnack();
-    } else onOpenReturns(inboundShipmentLineIds);
+    } else onOpenReturns(selectedStockLineIds);
   };
 
   if (isLoading) return <DetailViewSkeleton hasGroupBy={true} hasHold={true} />;
@@ -113,7 +113,7 @@ export const DetailView: FC = () => {
             <OutboundReturnEditModal
               isOpen={returnsIsOpen}
               onClose={onCloseReturns}
-              stockLineIds={selectedInboundShipmentLineIds || []}
+              stockLineIds={stockLineIds || []}
               supplierId={data.otherParty.id}
             />
           )}

--- a/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -54,8 +54,8 @@ export const DetailView: FC = () => {
 
   const onReturn = async (selectedStockLineIds: string[]) => {
     if (!data || !canReturnInboundLines(data)) {
-      const selectLinesSnack = info(t('messages.cant-return-shipment'));
-      selectLinesSnack();
+      const cantReturnSnack = info(t('messages.cant-return-shipment'));
+      cantReturnSnack();
     } else if (!selectedStockLineIds.length) {
       const selectLinesSnack = info(t('messages.select-rows-to-return'));
       selectLinesSnack();

--- a/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -11,7 +11,6 @@ import {
   createQueryParamsStore,
   DetailTabs,
   useNotification,
-  InvoiceNodeStatus,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import {
@@ -27,6 +26,7 @@ import { InboundLineEdit } from './modals/InboundLineEdit';
 import { InboundItem } from '../../types';
 import { useInbound, InboundLineFragment } from '../api';
 import { OutboundReturnEditModal } from '../../Returns';
+import { canReturnInboundLines } from '../../utils';
 
 type InboundLineItem = InboundLineFragment['item'];
 
@@ -53,8 +53,8 @@ export const DetailView: FC = () => {
   );
 
   const onReturn = async (selectedStockLineIds: string[]) => {
-    if (data?.status === InvoiceNodeStatus.New) {
-      const selectLinesSnack = info(t('messages.cant-return-new-shipment'));
+    if (!data || !canReturnInboundLines(data)) {
+      const selectLinesSnack = info(t('messages.cant-return-shipment'));
       selectLinesSnack();
     } else if (!selectedStockLineIds.length) {
       const selectLinesSnack = info(t('messages.select-rows-to-return'));

--- a/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -11,6 +11,7 @@ import {
   createQueryParamsStore,
   DetailTabs,
   useNotification,
+  InvoiceNodeStatus,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import {
@@ -52,7 +53,10 @@ export const DetailView: FC = () => {
   );
 
   const onReturn = async (selectedStockLineIds: string[]) => {
-    if (!selectedStockLineIds.length) {
+    if (data?.status === InvoiceNodeStatus.New) {
+      const selectLinesSnack = info(t('messages.cant-return-new-shipment'));
+      selectLinesSnack();
+    } else if (!selectedStockLineIds.length) {
       const selectLinesSnack = info(t('messages.select-rows-to-return'));
       selectLinesSnack();
     } else onOpenReturns(selectedStockLineIds);

--- a/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
@@ -119,7 +119,6 @@ export const Toolbar: FC<{
           </Box>
           <DropdownMenu label={t('label.actions')}>
             <DropdownMenuItem
-              disabled={shipment?.status === InvoiceNodeStatus.New}
               IconComponent={ArrowLeftIcon}
               onClick={() => onReturnLines(selectedStockLineIds)}
             >

--- a/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
@@ -13,28 +13,9 @@ import {
   InvoiceNodeStatus,
   Alert,
   ArrowLeftIcon,
-  useTableStore,
 } from '@openmsupply-client/common';
 import { SupplierSearchInput } from '@openmsupply-client/system';
 import { InboundRowFragment, useInbound } from '../api';
-
-const useSelectedIds = () => {
-  const { items, lines } = useInbound.lines.rows();
-
-  const selectedIds =
-    useTableStore(state => {
-      const { isGrouped } = state;
-
-      return isGrouped
-        ? items
-            ?.filter(({ id }) => state.rowState[id]?.isSelected)
-            .map(({ lines }) => lines.flat())
-            .flat()
-        : lines?.filter(({ id }) => state.rowState[id]?.isSelected);
-    })?.map(({ id }) => id) || [];
-
-  return selectedIds;
-};
 
 const InboundInfoPanel = ({
   shipment,
@@ -72,7 +53,7 @@ export const Toolbar: FC<{
   const { isGrouped, toggleIsGrouped } = useInbound.lines.rows();
   const t = useTranslation('replenishment');
 
-  const selectedIds = useSelectedIds();
+  const selectedStockLineIds = useInbound.utils.selectedStockLineIds();
 
   const isTransfer = !!shipment?.linkedShipment?.id;
 
@@ -139,7 +120,7 @@ export const Toolbar: FC<{
           <DropdownMenu label={t('label.actions')}>
             <DropdownMenuItem
               IconComponent={ArrowLeftIcon}
-              onClick={() => onReturnLines(selectedIds)}
+              onClick={() => onReturnLines(selectedStockLineIds)}
             >
               {t('button.return-lines')}
             </DropdownMenuItem>

--- a/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
@@ -119,6 +119,7 @@ export const Toolbar: FC<{
           </Box>
           <DropdownMenu label={t('label.actions')}>
             <DropdownMenuItem
+              disabled={shipment?.status === InvoiceNodeStatus.New}
               IconComponent={ArrowLeftIcon}
               onClick={() => onReturnLines(selectedStockLineIds)}
             >

--- a/client/packages/invoices/src/InboundShipment/api/hooks/index.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/index.ts
@@ -32,5 +32,6 @@ export const useInbound = {
     api: Utils.useInboundApi,
     isDisabled: Utils.useIsInboundDisabled,
     isStatusChangeDisabled: Utils.useIsStatusChangeDisabled,
+    selectedStockLineIds: Utils.useSelectedStockLineIds,
   },
 };

--- a/client/packages/invoices/src/InboundShipment/api/hooks/utils/index.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/utils/index.ts
@@ -2,10 +2,12 @@ import { useInboundApi } from './useInboundApi';
 import { useIsInboundDisabled } from './useIsInboundDisabled';
 import { useIsStatusChangeDisabled } from './useIsStatusChangeDisabled';
 import { useAddFromMasterList } from './useAddFromMasterList';
+import { useSelectedStockLineIds } from './useSelectedStockLineIds';
 
 export const Utils = {
   useInboundApi,
   useIsInboundDisabled,
   useIsStatusChangeDisabled,
   useAddFromMasterList,
+  useSelectedStockLineIds,
 };

--- a/client/packages/invoices/src/InboundShipment/api/hooks/utils/useSelectedStockLineIds.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/utils/useSelectedStockLineIds.ts
@@ -1,0 +1,23 @@
+import { useTableStore } from 'packages/common/src';
+import { useInboundRows } from '../line/useInboundRows';
+import { isString } from 'lodash';
+
+export const useSelectedStockLineIds = () => {
+  const { items, lines } = useInboundRows();
+
+  const selectedIds =
+    useTableStore(state => {
+      const { isGrouped } = state;
+
+      return isGrouped
+        ? items
+            ?.filter(({ id }) => state.rowState[id]?.isSelected)
+            .map(({ lines }) => lines.flat())
+            .flat()
+        : lines?.filter(({ id }) => state.rowState[id]?.isSelected);
+    })
+      ?.map(({ stockLine }) => stockLine?.id)
+      .filter(isString) || [];
+
+  return selectedIds;
+};

--- a/client/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
@@ -26,6 +26,7 @@ import { Draft } from '../..';
 import { StockOutLineFragment } from '../../StockOut';
 import { OutboundLineEdit } from './OutboundLineEdit';
 import { InboundReturnEditModal } from '../../Returns';
+import { canReturnOutboundLines } from '../../utils';
 
 export const DetailView: FC = () => {
   const { info } = useNotification();
@@ -54,7 +55,10 @@ export const DetailView: FC = () => {
   };
 
   const onReturn = async (selectedStockLineIds: string[]) => {
-    if (!selectedStockLineIds.length) {
+    if (!data || !canReturnOutboundLines(data)) {
+      const cantReturnSnack = info(t('messages.cant-return-shipment'));
+      cantReturnSnack();
+    } else if (!selectedStockLineIds.length) {
       const selectLinesSnack = info(t('messages.select-rows-to-return'));
       selectLinesSnack();
     } else onOpenReturns(selectedStockLineIds);

--- a/client/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
@@ -36,7 +36,7 @@ export const DetailView: FC = () => {
     onOpen: onOpenReturns,
     onClose: onCloseReturns,
     isOpen: returnsIsOpen,
-    entity: selectedOutboundShipmentLineIds,
+    entity: stockLineIds,
   } = useEditModal<string[]>();
 
   const { data, isLoading } = useOutbound.document.get();
@@ -53,11 +53,11 @@ export const DetailView: FC = () => {
     setMode(ModalMode.Create);
   };
 
-  const onReturn = async (outboundShipmentLineIds: string[]) => {
-    if (!outboundShipmentLineIds.length) {
+  const onReturn = async (selectedStockLineIds: string[]) => {
+    if (!selectedStockLineIds.length) {
       const selectLinesSnack = info(t('messages.select-rows-to-return'));
       selectLinesSnack();
-    } else onOpenReturns(outboundShipmentLineIds);
+    } else onOpenReturns(selectedStockLineIds);
   };
 
   if (isLoading) return <DetailViewSkeleton hasGroupBy={true} hasHold={true} />;
@@ -107,7 +107,7 @@ export const DetailView: FC = () => {
             <InboundReturnEditModal
               isOpen={returnsIsOpen}
               onClose={onCloseReturns}
-              stockLineIds={selectedOutboundShipmentLineIds || []}
+              stockLineIds={stockLineIds || []}
               customerId={data.otherPartyId}
             />
           )}

--- a/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
@@ -14,7 +14,6 @@ import {
   Switch,
   useIsGrouped,
   ArrowLeftIcon,
-  Tooltip,
 } from '@openmsupply-client/common';
 import { CustomerSearchInput } from '@openmsupply-client/system';
 import { useOutbound } from '../api';
@@ -108,23 +107,12 @@ export const Toolbar: FC<{
               {t('button.allocate-lines')}
             </DropdownMenuItem>
 
-            <Tooltip
-              title={
-                !selectedStockLineIds.length
-                  ? t('message.placeholder-lines-cannot-be-returned')
-                  : ''
-              }
+            <DropdownMenuItem
+              IconComponent={ArrowLeftIcon}
+              onClick={() => onReturnLines(selectedStockLineIds)}
             >
-              <span>
-                <DropdownMenuItem
-                  disabled={!selectedStockLineIds.length}
-                  IconComponent={ArrowLeftIcon}
-                  onClick={() => onReturnLines(selectedStockLineIds)}
-                >
-                  {t('button.return-lines')}
-                </DropdownMenuItem>
-              </span>
-            </Tooltip>
+              {t('button.return-lines')}
+            </DropdownMenuItem>
           </DropdownMenu>
         </Grid>
       </Grid>

--- a/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
@@ -14,6 +14,7 @@ import {
   Switch,
   useIsGrouped,
   ArrowLeftIcon,
+  Tooltip,
 } from '@openmsupply-client/common';
 import { CustomerSearchInput } from '@openmsupply-client/system';
 import { useOutbound } from '../api';
@@ -106,12 +107,24 @@ export const Toolbar: FC<{
             <DropdownMenuItem IconComponent={ZapIcon} onClick={onAllocate}>
               {t('button.allocate-lines')}
             </DropdownMenuItem>
-            <DropdownMenuItem
-              IconComponent={ArrowLeftIcon}
-              onClick={() => onReturnLines(selectedStockLineIds)}
+
+            <Tooltip
+              title={
+                !selectedStockLineIds.length
+                  ? t('message.placeholder-lines-cannot-be-returned')
+                  : ''
+              }
             >
-              {t('button.return-lines')}
-            </DropdownMenuItem>
+              <span>
+                <DropdownMenuItem
+                  disabled={!selectedStockLineIds.length}
+                  IconComponent={ArrowLeftIcon}
+                  onClick={() => onReturnLines(selectedStockLineIds)}
+                >
+                  {t('button.return-lines')}
+                </DropdownMenuItem>
+              </span>
+            </Tooltip>
           </DropdownMenu>
         </Grid>
       </Grid>

--- a/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
@@ -38,7 +38,8 @@ export const Toolbar: FC<{
 
   const isDisabled = useOutbound.utils.isDisabled();
 
-  const selectedIds: string[] = useOutbound.utils.selectedIds();
+  const selectedStockLineIds: string[] =
+    useOutbound.utils.selectedStockLineIds();
 
   return (
     <AppBarContentPortal sx={{ display: 'flex', flex: 1, marginBottom: 1 }}>
@@ -107,7 +108,7 @@ export const Toolbar: FC<{
             </DropdownMenuItem>
             <DropdownMenuItem
               IconComponent={ArrowLeftIcon}
-              onClick={() => onReturnLines(selectedIds)}
+              onClick={() => onReturnLines(selectedStockLineIds)}
             >
               {t('button.return-lines')}
             </DropdownMenuItem>

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/index.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/index.ts
@@ -10,7 +10,7 @@ export const useOutbound = {
     barcodeInsert: Utils.useBarcodeInsert,
     isDisabled: Utils.useOutboundIsDisabled,
     number: Utils.useOutboundNumber,
-    selectedIds: Utils.useSelectedIds,
+    selectedStockLineIds: Utils.useSelectedStockLineIds,
   },
 
   document: {

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/utils/index.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/utils/index.ts
@@ -4,7 +4,7 @@ import { useOutboundApi } from './useOutboundApi';
 import { useAddFromMasterList } from './useAddFromMasterList';
 import { useBarcode } from './useBarcode';
 import { useBarcodeInsert } from './useBarcodeInsert';
-import { useSelectedIds } from './useSelectedIds';
+import { useSelectedStockLineIds } from './useSelectedStockLineIds';
 
 export const Utils = {
   useAddFromMasterList,
@@ -13,5 +13,5 @@ export const Utils = {
   useOutboundApi,
   useBarcode,
   useBarcodeInsert,
-  useSelectedIds,
+  useSelectedStockLineIds,
 };

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/utils/useSelectedStockLineIds.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/utils/useSelectedStockLineIds.ts
@@ -1,7 +1,8 @@
 import { useTableStore } from 'packages/common/src';
 import { useOutboundRows } from '../line/useOutboundRows';
+import { isString } from 'lodash';
 
-export const useSelectedIds = () => {
+export const useSelectedStockLineIds = () => {
   const { items, lines } = useOutboundRows();
 
   const selectedIds =
@@ -13,7 +14,9 @@ export const useSelectedIds = () => {
             ?.filter(({ id }) => state.rowState[id]?.isSelected)
             .flatMap(({ lines }) => lines.flat())
         : lines?.filter(({ id }) => state.rowState[id]?.isSelected);
-    })?.map(({ id }) => id) || [];
+    })
+      ?.map(({ stockLine }) => stockLine?.id)
+      .filter(isString) || [];
 
   return selectedIds;
 };

--- a/client/packages/invoices/src/Returns/api/api.ts
+++ b/client/packages/invoices/src/Returns/api/api.ts
@@ -149,17 +149,17 @@ export const getReturnsQueries = (sdk: Sdk, storeId: string) => ({
       });
       return result?.invoices;
     },
-    outboundReturnLines: async (inboundShipmentLineIds: string[]) => {
+    outboundReturnLines: async (stockLineIds: string[]) => {
       const result = await sdk.generateOutboundReturnLines({
-        inboundShipmentLineIds,
+        stockLineIds,
         storeId,
       });
 
       return result?.generateOutboundReturnLines;
     },
-    inboundReturnLines: async (outboundShipmentLineIds: string[]) => {
+    inboundReturnLines: async (stockLineIds: string[]) => {
       const result = await sdk.generateInboundReturnLines({
-        outboundShipmentLineIds,
+        stockLineIds,
         storeId,
       });
 

--- a/client/packages/invoices/src/Returns/api/hooks/line/useInboundReturnLines.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/line/useInboundReturnLines.ts
@@ -1,11 +1,11 @@
 import { useQuery } from '@openmsupply-client/common';
 import { useReturnsApi } from '../utils/useReturnsApi';
 
-export const useInboundReturnLines = (outboundShipmentLineIds: string[]) => {
+export const useInboundReturnLines = (stockLineIds: string[]) => {
   const api = useReturnsApi();
 
   const { data } = useQuery(api.keys.newReturns(), () =>
-    api.get.inboundReturnLines(outboundShipmentLineIds)
+    api.get.inboundReturnLines(stockLineIds)
   );
 
   return data;

--- a/client/packages/invoices/src/Returns/api/operations.generated.ts
+++ b/client/packages/invoices/src/Returns/api/operations.generated.ts
@@ -33,7 +33,7 @@ export type InboundReturnsQueryVariables = Types.Exact<{
 export type InboundReturnsQuery = { __typename: 'Queries', invoices: { __typename: 'InvoiceConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceNode', id: string, otherPartyName: string, status: Types.InvoiceNodeStatus, invoiceNumber: number, colour?: string | null, createdDatetime: string, deliveredDatetime?: string | null }> } };
 
 export type GenerateOutboundReturnLinesQueryVariables = Types.Exact<{
-  inboundShipmentLineIds?: Types.InputMaybe<Array<Types.Scalars['String']['input']> | Types.Scalars['String']['input']>;
+  stockLineIds?: Types.InputMaybe<Array<Types.Scalars['String']['input']> | Types.Scalars['String']['input']>;
   storeId: Types.Scalars['String']['input'];
 }>;
 
@@ -41,7 +41,7 @@ export type GenerateOutboundReturnLinesQueryVariables = Types.Exact<{
 export type GenerateOutboundReturnLinesQuery = { __typename: 'Queries', generateOutboundReturnLines: Array<{ __typename: 'OutboundReturnLine', availableNumberOfPacks: number, batch?: string | null, expiryDate?: string | null, id: string, itemCode: string, itemName: string, numberOfPacksToReturn: number, packSize: number, stockLineId: string, comment: string, reasonId?: string | null }> };
 
 export type GenerateInboundReturnLinesQueryVariables = Types.Exact<{
-  outboundShipmentLineIds?: Types.InputMaybe<Array<Types.Scalars['String']['input']> | Types.Scalars['String']['input']>;
+  stockLineIds?: Types.InputMaybe<Array<Types.Scalars['String']['input']> | Types.Scalars['String']['input']>;
   storeId: Types.Scalars['String']['input'];
 }>;
 
@@ -147,9 +147,9 @@ export const InboundReturnsDocument = gql`
 }
     ${InboundReturnRowFragmentDoc}`;
 export const GenerateOutboundReturnLinesDocument = gql`
-    query generateOutboundReturnLines($inboundShipmentLineIds: [String!], $storeId: String!) {
+    query generateOutboundReturnLines($stockLineIds: [String!], $storeId: String!) {
   generateOutboundReturnLines(
-    input: {inboundShipmentLineIds: $inboundShipmentLineIds}
+    input: {stockLineIds: $stockLineIds}
     storeId: $storeId
   ) {
     availableNumberOfPacks
@@ -167,9 +167,9 @@ export const GenerateOutboundReturnLinesDocument = gql`
 }
     `;
 export const GenerateInboundReturnLinesDocument = gql`
-    query generateInboundReturnLines($outboundShipmentLineIds: [String!], $storeId: String!) {
+    query generateInboundReturnLines($stockLineIds: [String!], $storeId: String!) {
   generateInboundReturnLines(
-    input: {outboundShipmentLineIds: $outboundShipmentLineIds}
+    input: {stockLineIds: $stockLineIds}
     storeId: $storeId
   ) {
     batch
@@ -329,7 +329,7 @@ export const mockInboundReturnsQuery = (resolver: ResponseResolver<GraphQLReques
  * @see https://mswjs.io/docs/basics/response-resolver
  * @example
  * mockGenerateOutboundReturnLinesQuery((req, res, ctx) => {
- *   const { inboundShipmentLineIds, storeId } = req.variables;
+ *   const { stockLineIds, storeId } = req.variables;
  *   return res(
  *     ctx.data({ generateOutboundReturnLines })
  *   )
@@ -346,7 +346,7 @@ export const mockGenerateOutboundReturnLinesQuery = (resolver: ResponseResolver<
  * @see https://mswjs.io/docs/basics/response-resolver
  * @example
  * mockGenerateInboundReturnLinesQuery((req, res, ctx) => {
- *   const { outboundShipmentLineIds, storeId } = req.variables;
+ *   const { stockLineIds, storeId } = req.variables;
  *   return res(
  *     ctx.data({ generateInboundReturnLines })
  *   )

--- a/client/packages/invoices/src/Returns/api/operations.graphql
+++ b/client/packages/invoices/src/Returns/api/operations.graphql
@@ -66,12 +66,9 @@ query inboundReturns(
   }
 }
 
-query generateOutboundReturnLines(
-  $inboundShipmentLineIds: [String!]
-  $storeId: String!
-) {
+query generateOutboundReturnLines($stockLineIds: [String!], $storeId: String!) {
   generateOutboundReturnLines(
-    input: { inboundShipmentLineIds: $inboundShipmentLineIds }
+    input: { stockLineIds: $stockLineIds }
     storeId: $storeId
   ) {
     availableNumberOfPacks
@@ -88,12 +85,9 @@ query generateOutboundReturnLines(
   }
 }
 
-query generateInboundReturnLines(
-  $outboundShipmentLineIds: [String!]
-  $storeId: String!
-) {
+query generateInboundReturnLines($stockLineIds: [String!], $storeId: String!) {
   generateInboundReturnLines(
-    input: { outboundShipmentLineIds: $outboundShipmentLineIds }
+    input: { stockLineIds: $stockLineIds }
     storeId: $storeId
   ) {
     batch

--- a/client/packages/invoices/src/utils.ts
+++ b/client/packages/invoices/src/utils.ts
@@ -11,7 +11,7 @@ import {
   Formatter,
   TypedTFunction,
 } from '@openmsupply-client/common';
-import { OutboundRowFragment } from './OutboundShipment/api';
+import { OutboundFragment, OutboundRowFragment } from './OutboundShipment/api';
 import { InboundLineFragment } from './InboundShipment/api';
 import { DraftStockOutLine, InboundItem } from './types';
 import { PrescriptionRowFragment } from './Prescriptions/api';
@@ -206,6 +206,10 @@ export const canDeletePrescription = (
 export const canReturnInboundLines = (inbound: InboundFragment): boolean =>
   inbound.status === InvoiceNodeStatus.Delivered ||
   inbound.status === InvoiceNodeStatus.Verified;
+
+export const canReturnOutboundLines = (outbound: OutboundFragment): boolean =>
+  outbound.status === InvoiceNodeStatus.Delivered ||
+  outbound.status === InvoiceNodeStatus.Verified;
 
 export const isA = {
   stockOutLine: (line: { type: InvoiceLineNodeType }) =>

--- a/client/packages/invoices/src/utils.ts
+++ b/client/packages/invoices/src/utils.ts
@@ -203,6 +203,10 @@ export const canDeletePrescription = (
   invoice.status === InvoiceNodeStatus.New ||
   invoice.status === InvoiceNodeStatus.Picked;
 
+export const canReturnInboundLines = (inbound: InboundFragment): boolean =>
+  inbound.status === InvoiceNodeStatus.Delivered ||
+  inbound.status === InvoiceNodeStatus.Verified;
+
 export const isA = {
   stockOutLine: (line: { type: InvoiceLineNodeType }) =>
     line.type === InvoiceLineNodeType.StockOut,

--- a/server/graphql/general/src/queries/generate_inbound_return_lines.rs
+++ b/server/graphql/general/src/queries/generate_inbound_return_lines.rs
@@ -3,7 +3,7 @@ use chrono::NaiveDate;
 
 #[derive(InputObject, Clone)]
 pub struct GenerateInboundReturnInput {
-    pub outbound_shipment_line_ids: Vec<String>,
+    pub stock_line_ids: Vec<String>,
 }
 
 #[derive(SimpleObject, Clone)]

--- a/server/graphql/general/src/queries/generate_outbound_return_lines.rs
+++ b/server/graphql/general/src/queries/generate_outbound_return_lines.rs
@@ -3,7 +3,7 @@ use chrono::NaiveDate;
 
 #[derive(InputObject, Clone)]
 pub struct GenerateOutboundReturnLinesInput {
-    pub inbound_shipment_line_ids: Vec<String>,
+    pub stock_line_ids: Vec<String>,
 }
 
 #[derive(SimpleObject, Clone)]


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3038

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

In previous PRs I had conflated inbound/outbound shipment line ids and stock line ids. This PR corrects that, mapping to the selected stock line ids to be passed to the generate return line queries!

It felt easiest/cleanest to do this mapping in the useSelectedIds hooks - just return the stockLinesId of each selected line, rather than the selected line ids, and then having to map at a later point. Does the code read/flow ok to you?


# 🧪 How has/should this change been tested? 
It all still compiles/runs 🎉 