### PR TITLE
2972 create asset tables

### DIFF
--- a/server/repository/src/db_diesel/assets/asset.rs
+++ b/server/repository/src/db_diesel/assets/asset.rs
@@ -1,0 +1,264 @@
+use super::asset_row::{
+    asset::{self, dsl as asset_dsl},
+    AssetRow,
+};
+
+use diesel::{dsl::IntoBoxed, prelude::*};
+
+use crate::{
+    diesel_macros::{
+        apply_date_filter, apply_equal_filter, apply_sort, apply_sort_no_case, apply_string_filter,
+    },
+    repository_error::RepositoryError,
+    DBType, DateFilter, DatetimeFilter, EqualFilter, Pagination, Sort, StorageConnection,
+    StringFilter,
+};
+
+type Asset = AssetRow;
+
+pub enum AssetSortField {
+    SerialNumber,
+    InstallationDate,
+    ReplacementDate,
+}
+
+pub type AssetSort = Sort<AssetSortField>;
+
+#[derive(Clone)]
+pub struct AssetFilter {
+    pub id: Option<EqualFilter<String>>,
+    pub serial_number: Option<StringFilter>,
+    pub category_id: Option<EqualFilter<String>>,
+    pub type_id: Option<EqualFilter<String>>,
+    pub catalogue_item_id: Option<EqualFilter<String>>,
+    pub installation_date: Option<DateFilter>,
+    pub replacement_date: Option<DateFilter>,
+}
+
+impl AssetFilter {
+    pub fn new() -> AssetFilter {
+        AssetFilter {
+            id: None,
+            serial_number: None,
+            category_id: None,
+            type_id: None,
+            catalogue_item_id: None,
+            installation_date: None,
+            replacement_date: None,
+        }
+    }
+
+    pub fn id(mut self, filter: EqualFilter<String>) -> Self {
+        self.id = Some(filter);
+        self
+    }
+
+    pub fn serial_number(mut self, filter: StringFilter) -> Self {
+        self.serial_number = Some(filter);
+        self
+    }
+
+    pub fn category_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.category_id = Some(filter);
+        self
+    }
+
+    pub fn type_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.type_id = Some(filter);
+        self
+    }
+
+    pub fn catalogue_item_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.catalogue_item_id = Some(filter);
+        self
+    }
+
+    pub fn installation_date(mut self, filter: DateFilter) -> Self {
+        self.installation_date = Some(filter);
+        self
+    }
+
+    pub fn replacement_date(mut self, filter: DateFilter) -> Self {
+        self.replacement_date = Some(filter);
+        self
+    }
+}
+
+pub struct AssetRepository<'a> {
+    connection: &'a StorageConnection,
+}
+
+impl<'a> AssetRepository<'a> {
+    pub fn new(connection: &'a StorageConnection) -> Self {
+        AssetRepository { connection }
+    }
+
+    pub fn count(&self, filter: Option<AssetFilter>) -> Result<i64, RepositoryError> {
+        let query = create_filtered_query(filter);
+
+        Ok(query.count().get_result(&self.connection.connection)?)
+    }
+
+    pub fn query_one(&self, filter: AssetFilter) -> Result<Option<Asset>, RepositoryError> {
+        Ok(self.query_by_filter(filter)?.pop())
+    }
+
+    pub fn query_by_filter(&self, filter: AssetFilter) -> Result<Vec<Asset>, RepositoryError> {
+        self.query(Pagination::all(), Some(filter), None)
+    }
+
+    pub fn query(
+        &self,
+        pagination: Pagination,
+        filter: Option<AssetFilter>,
+        sort: Option<AssetSort>,
+    ) -> Result<Vec<Asset>, RepositoryError> {
+        let mut query = create_filtered_query(filter);
+
+        if let Some(sort) = sort {
+            match sort.key {
+                AssetSortField::SerialNumber => {
+                    apply_sort_no_case!(query, sort, asset_dsl::serial_number);
+                }
+                AssetSortField::InstallationDate => {
+                    apply_sort!(query, sort, asset_dsl::installation_date)
+                }
+                AssetSortField::ReplacementDate => {
+                    apply_sort!(query, sort, asset_dsl::replacement_date)
+                }
+            }
+        } else {
+            query = query.order(asset_dsl::id.asc())
+        }
+
+        let final_query = query
+            .offset(pagination.offset as i64)
+            .limit(pagination.limit as i64);
+
+        // Debug diesel query
+        // println!(
+        //    "{}",
+        //     diesel::debug_query::<DBType, _>(&final_query).to_string()
+        // );
+
+        let result = final_query.load::<Asset>(&self.connection.connection)?;
+
+        Ok(result.into_iter().map(to_domain).collect())
+    }
+}
+
+fn to_domain(asset_row: AssetRow) -> Asset {
+    asset_row
+}
+
+type BoxedAssetQuery = IntoBoxed<'static, asset::table, DBType>;
+
+fn create_filtered_query(filter: Option<AssetFilter>) -> BoxedAssetQuery {
+    let mut query = asset_dsl::asset.into_boxed();
+
+    if let Some(f) = filter {
+        let AssetFilter {
+            id,
+            serial_number,
+            category_id,
+            type_id,
+            catalogue_item_id,
+            installation_date,
+            replacement_date,
+        } = f;
+
+        apply_equal_filter!(query, id, asset_dsl::id);
+        apply_string_filter!(query, serial_number, asset_dsl::serial_number);
+        apply_equal_filter!(query, category_id, asset_dsl::asset_category_id);
+        apply_equal_filter!(query, type_id, asset_dsl::asset_type_id);
+        apply_equal_filter!(query, catalogue_item_id, asset_dsl::catalogue_item_id);
+        apply_date_filter!(query, installation_date, asset_dsl::installation_date);
+        apply_date_filter!(query, replacement_date, asset_dsl::replacement_date);
+    }
+    query
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        assets::{
+            asset::AssetRepository,
+            asset_category_row::{AssetCategoryRow, AssetCategoryRowRepository},
+            asset_class_row::{AssetClassRow, AssetClassRowRepository},
+            asset_row::{AssetRow, AssetRowRepository},
+            asset_type_row::{AssetTypeRow, AssetTypeRowRepository},
+        },
+        mock::MockDataInserts,
+        test_db, EqualFilter,
+    };
+
+    use super::AssetFilter;
+
+    #[actix_rt::test]
+    async fn test_asset_query_repository() {
+        // Prepare
+        let (_, storage_connection, _, _) =
+            test_db::setup_all("test_asset_query_repository", MockDataInserts::none()).await;
+
+        // TODO: Replace this reference data with mock data, or inserted data from https://github.com/msupply-foundation/open-msupply/issues/3035
+
+        // Create a class row
+        let class_id = "test_class_id".to_string();
+        let class_name = "test_class_name".to_string();
+        let class_row = AssetClassRow {
+            id: class_id.clone(),
+            name: class_name.clone(),
+        };
+        let class_row_repo = AssetClassRowRepository::new(&storage_connection);
+        class_row_repo.insert_one(&class_row).unwrap();
+
+        // Create a category
+        let category_id = "test_category_id".to_string();
+        let category_name = "test_category_name".to_string();
+        let category_row = AssetCategoryRow {
+            id: category_id.clone(),
+            name: category_name.clone(),
+            class_id: class_id.clone(),
+        };
+        let category_row_repo = AssetCategoryRowRepository::new(&storage_connection);
+        category_row_repo.insert_one(&category_row).unwrap();
+
+        // Create the type
+        let type_id = "test_type_id".to_string();
+        let type_name = "test_type_name".to_string();
+
+        // Insert a row
+        let type_row_repository = AssetTypeRowRepository::new(&storage_connection);
+        type_row_repository
+            .insert_one(&AssetTypeRow {
+                id: type_id.clone(),
+                name: type_name.clone(),
+                category_id: category_id.clone(),
+            })
+            .unwrap();
+
+        // Create an asset
+        let asset_repository = AssetRepository::new(&storage_connection);
+        let asset_row_repository = AssetRowRepository::new(&storage_connection);
+
+        let asset_id = "test_asset_id".to_string();
+        let serial_number = "test_serial_number".to_string();
+        let asset = AssetRow {
+            id: asset_id.clone(),
+            serial_number: serial_number.clone(),
+            category_id: category_id.clone(),
+            type_id: type_id.clone(),
+            ..Default::default()
+        };
+
+        let _result = asset_row_repository.insert_one(&asset).unwrap();
+
+        // Query by id
+        let result = asset_repository
+            .query_one(AssetFilter::new().id(EqualFilter::equal_to(&asset_id)))
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.id, asset_id);
+        assert_eq!(result.serial_number, serial_number);
+    }
+}

--- a/server/repository/src/db_diesel/assets/asset.rs
+++ b/server/repository/src/db_diesel/assets/asset.rs
@@ -191,7 +191,7 @@ mod tests {
             asset_row::{AssetRow, AssetRowRepository},
             asset_type_row::{AssetTypeRow, AssetTypeRowRepository},
         },
-        mock::MockDataInserts,
+        mock::{mock_name_store_a, mock_store_a, MockDataInserts},
         test_db, EqualFilter,
     };
 
@@ -200,8 +200,11 @@ mod tests {
     #[actix_rt::test]
     async fn test_asset_query_repository() {
         // Prepare
-        let (_, storage_connection, _, _) =
-            test_db::setup_all("test_asset_query_repository", MockDataInserts::none()).await;
+        let (_, storage_connection, _, _) = test_db::setup_all(
+            "test_asset_query_repository",
+            MockDataInserts::none().stores(),
+        )
+        .await;
 
         // TODO: Replace this reference data with mock data, or inserted data from https://github.com/msupply-foundation/open-msupply/issues/3035
 
@@ -248,6 +251,7 @@ mod tests {
         let serial_number = "test_serial_number".to_string();
         let asset = AssetRow {
             id: asset_id.clone(),
+            store_id: mock_store_a().id,
             serial_number: serial_number.clone(),
             category_id: category_id.clone(),
             type_id: type_id.clone(),

--- a/server/repository/src/db_diesel/assets/asset.rs
+++ b/server/repository/src/db_diesel/assets/asset.rs
@@ -30,6 +30,7 @@ pub type AssetSort = Sort<AssetSortField>;
 pub struct AssetFilter {
     pub id: Option<EqualFilter<String>>,
     pub name: Option<StringFilter>,
+    pub code: Option<StringFilter>,
     pub serial_number: Option<StringFilter>,
     pub class_id: Option<EqualFilter<String>>,
     pub category_id: Option<EqualFilter<String>>,
@@ -44,6 +45,7 @@ impl AssetFilter {
         AssetFilter {
             id: None,
             name: None,
+            code: None,
             serial_number: None,
             class_id: None,
             category_id: None,
@@ -61,6 +63,11 @@ impl AssetFilter {
 
     pub fn name(mut self, filter: StringFilter) -> Self {
         self.name = Some(filter);
+        self
+    }
+
+    pub fn code(mut self, filter: StringFilter) -> Self {
+        self.code = Some(filter);
         self
     }
 
@@ -182,6 +189,7 @@ fn create_filtered_query(filter: Option<AssetFilter>) -> BoxedAssetQuery {
         let AssetFilter {
             id,
             name,
+            code,
             serial_number,
             class_id,
             category_id,
@@ -193,6 +201,7 @@ fn create_filtered_query(filter: Option<AssetFilter>) -> BoxedAssetQuery {
 
         apply_equal_filter!(query, id, asset_dsl::id);
         apply_string_filter!(query, name, asset_dsl::name);
+        apply_string_filter!(query, code, asset_dsl::code);
         apply_string_filter!(query, serial_number, asset_dsl::serial_number);
 
         apply_equal_filter!(query, catalogue_item_id, asset_dsl::asset_catalogue_item_id);

--- a/server/repository/src/db_diesel/assets/asset.rs
+++ b/server/repository/src/db_diesel/assets/asset.rs
@@ -6,6 +6,7 @@ use super::asset_row::{
 use diesel::{dsl::IntoBoxed, prelude::*};
 
 use crate::{
+    assets::asset_catalogue_item_row::asset_catalogue_item::dsl as asset_catalogue_item_dsl,
     diesel_macros::{
         apply_date_filter, apply_equal_filter, apply_sort, apply_sort_no_case, apply_string_filter,
     },
@@ -16,6 +17,7 @@ use crate::{
 type Asset = AssetRow;
 
 pub enum AssetSortField {
+    Name,
     SerialNumber,
     InstallationDate,
     ReplacementDate,
@@ -27,7 +29,9 @@ pub type AssetSort = Sort<AssetSortField>;
 #[derive(Clone)]
 pub struct AssetFilter {
     pub id: Option<EqualFilter<String>>,
+    pub name: Option<StringFilter>,
     pub serial_number: Option<StringFilter>,
+    pub class_id: Option<EqualFilter<String>>,
     pub category_id: Option<EqualFilter<String>>,
     pub type_id: Option<EqualFilter<String>>,
     pub catalogue_item_id: Option<EqualFilter<String>>,
@@ -39,7 +43,9 @@ impl AssetFilter {
     pub fn new() -> AssetFilter {
         AssetFilter {
             id: None,
+            name: None,
             serial_number: None,
+            class_id: None,
             category_id: None,
             type_id: None,
             catalogue_item_id: None,
@@ -53,8 +59,18 @@ impl AssetFilter {
         self
     }
 
+    pub fn name(mut self, filter: StringFilter) -> Self {
+        self.name = Some(filter);
+        self
+    }
+
     pub fn serial_number(mut self, filter: StringFilter) -> Self {
         self.serial_number = Some(filter);
+        self
+    }
+
+    pub fn class_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.class_id = Some(filter);
         self
     }
 
@@ -117,6 +133,9 @@ impl<'a> AssetRepository<'a> {
 
         if let Some(sort) = sort {
             match sort.key {
+                AssetSortField::Name => {
+                    apply_sort_no_case!(query, sort, asset_dsl::name);
+                }
                 AssetSortField::SerialNumber => {
                     apply_sort_no_case!(query, sort, asset_dsl::serial_number);
                 }
@@ -162,7 +181,9 @@ fn create_filtered_query(filter: Option<AssetFilter>) -> BoxedAssetQuery {
     if let Some(f) = filter {
         let AssetFilter {
             id,
+            name,
             serial_number,
+            class_id,
             category_id,
             type_id,
             catalogue_item_id,
@@ -171,12 +192,48 @@ fn create_filtered_query(filter: Option<AssetFilter>) -> BoxedAssetQuery {
         } = f;
 
         apply_equal_filter!(query, id, asset_dsl::id);
+        apply_string_filter!(query, name, asset_dsl::name);
         apply_string_filter!(query, serial_number, asset_dsl::serial_number);
-        apply_equal_filter!(query, category_id, asset_dsl::asset_category_id);
-        apply_equal_filter!(query, type_id, asset_dsl::asset_type_id);
+
         apply_equal_filter!(query, catalogue_item_id, asset_dsl::asset_catalogue_item_id);
         apply_date_filter!(query, installation_date, asset_dsl::installation_date);
         apply_date_filter!(query, replacement_date, asset_dsl::replacement_date);
+
+        if let Some(category_id) = category_id {
+            let mut sub_query = asset_catalogue_item_dsl::asset_catalogue_item
+                .select(asset_catalogue_item_dsl::id.nullable())
+                .into_boxed();
+            apply_equal_filter!(
+                sub_query,
+                Some(category_id),
+                asset_catalogue_item_dsl::asset_category_id
+            );
+            query = query.filter(asset_dsl::asset_catalogue_item_id.eq_any(sub_query));
+        }
+
+        if let Some(class_id) = class_id {
+            let mut sub_query = asset_catalogue_item_dsl::asset_catalogue_item
+                .select(asset_catalogue_item_dsl::id.nullable())
+                .into_boxed();
+            apply_equal_filter!(
+                sub_query,
+                Some(class_id),
+                asset_catalogue_item_dsl::asset_class_id
+            );
+            query = query.filter(asset_dsl::asset_catalogue_item_id.eq_any(sub_query));
+        }
+
+        if let Some(type_id) = type_id {
+            let mut sub_query = asset_catalogue_item_dsl::asset_catalogue_item
+                .select(asset_catalogue_item_dsl::id.nullable())
+                .into_boxed();
+            apply_equal_filter!(
+                sub_query,
+                Some(type_id),
+                asset_catalogue_item_dsl::asset_type_id
+            );
+            query = query.filter(asset_dsl::asset_catalogue_item_id.eq_any(sub_query));
+        }
     }
     query.filter(asset_dsl::deleted_datetime.is_null()) // Don't include any deleted items
 }
@@ -186,10 +243,7 @@ mod tests {
     use crate::{
         assets::{
             asset::AssetRepository,
-            asset_category_row::{AssetCategoryRow, AssetCategoryRowRepository},
-            asset_class_row::{AssetClassRow, AssetClassRowRepository},
             asset_row::{AssetRow, AssetRowRepository},
-            asset_type_row::{AssetTypeRow, AssetTypeRowRepository},
         },
         mock::{mock_store_a, MockDataInserts},
         test_db, EqualFilter,
@@ -206,44 +260,7 @@ mod tests {
         )
         .await;
 
-        // TODO: Replace this reference data with mock data, or inserted data from https://github.com/msupply-foundation/open-msupply/issues/3035
-
-        // Create a class row
-        let class_id = "test_class_id".to_string();
-        let class_name = "test_class_name".to_string();
-        let class_row = AssetClassRow {
-            id: class_id.clone(),
-            name: class_name.clone(),
-        };
-        let class_row_repo = AssetClassRowRepository::new(&storage_connection);
-        class_row_repo.insert_one(&class_row).unwrap();
-
-        // Create a category
-        let category_id = "test_category_id".to_string();
-        let category_name = "test_category_name".to_string();
-        let category_row = AssetCategoryRow {
-            id: category_id.clone(),
-            name: category_name.clone(),
-            class_id: class_id.clone(),
-        };
-        let category_row_repo = AssetCategoryRowRepository::new(&storage_connection);
-        category_row_repo.insert_one(&category_row).unwrap();
-
-        // Create the type
-        let type_id = "test_type_id".to_string();
-        let type_name = "test_type_name".to_string();
-
-        // Insert a row
-        let type_row_repository = AssetTypeRowRepository::new(&storage_connection);
-        type_row_repository
-            .insert_one(&AssetTypeRow {
-                id: type_id.clone(),
-                name: type_name.clone(),
-                category_id: category_id.clone(),
-            })
-            .unwrap();
-
-        // Create an asset
+        // Create an asset without catalogue item
         let asset_repository = AssetRepository::new(&storage_connection);
         let asset_row_repository = AssetRowRepository::new(&storage_connection);
 
@@ -251,10 +268,9 @@ mod tests {
         let serial_number = "test_serial_number".to_string();
         let asset = AssetRow {
             id: asset_id.clone(),
-            store_id: mock_store_a().id,
-            serial_number: serial_number.clone(),
-            category_id: category_id.clone(),
-            type_id: type_id.clone(),
+            name: "test_name".to_string(),
+            store_id: Some(mock_store_a().id),
+            serial_number: Some(serial_number.clone()),
             ..Default::default()
         };
 
@@ -266,6 +282,6 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(result.id, asset_id);
-        assert_eq!(result.serial_number, serial_number);
+        assert_eq!(result.serial_number, Some(serial_number));
     }
 }

--- a/server/repository/src/db_diesel/assets/asset.rs
+++ b/server/repository/src/db_diesel/assets/asset.rs
@@ -10,8 +10,7 @@ use crate::{
         apply_date_filter, apply_equal_filter, apply_sort, apply_sort_no_case, apply_string_filter,
     },
     repository_error::RepositoryError,
-    DBType, DateFilter, DatetimeFilter, EqualFilter, Pagination, Sort, StorageConnection,
-    StringFilter,
+    DBType, DateFilter, EqualFilter, Pagination, Sort, StorageConnection, StringFilter,
 };
 
 type Asset = AssetRow;
@@ -20,6 +19,7 @@ pub enum AssetSortField {
     SerialNumber,
     InstallationDate,
     ReplacementDate,
+    ModifiedDatetime,
 }
 
 pub type AssetSort = Sort<AssetSortField>;
@@ -125,6 +125,9 @@ impl<'a> AssetRepository<'a> {
                 }
                 AssetSortField::ReplacementDate => {
                     apply_sort!(query, sort, asset_dsl::replacement_date)
+                }
+                AssetSortField::ModifiedDatetime => {
+                    apply_sort!(query, sort, asset_dsl::modified_datetime)
                 }
             }
         } else {

--- a/server/repository/src/db_diesel/assets/asset_catalogue_item.rs
+++ b/server/repository/src/db_diesel/assets/asset_catalogue_item.rs
@@ -154,13 +154,25 @@ fn create_filtered_query(filter: Option<AssetCatalogueItemFilter>) -> BoxedAsset
             code,
             manufacturer,
             model,
-            ..
+            category: _, // Handled in query() function
+            category_id,
+            class: _, // Handled in query() function
+            class_id,
+            r#type: _, // Handled in query() function
+            type_id,
         } = f;
 
         apply_equal_filter!(query, id, asset_catalogue_item_dsl::id);
         apply_string_filter!(query, code, asset_catalogue_item_dsl::code);
         apply_string_filter!(query, manufacturer, asset_catalogue_item_dsl::manufacturer);
         apply_string_filter!(query, model, asset_catalogue_item_dsl::model);
+        apply_equal_filter!(
+            query,
+            category_id,
+            asset_catalogue_item_dsl::asset_category_id
+        );
+        apply_equal_filter!(query, class_id, asset_catalogue_item_dsl::asset_class_id);
+        apply_equal_filter!(query, type_id, asset_catalogue_item_dsl::asset_type_id);
     }
     query
 }

--- a/server/repository/src/db_diesel/assets/asset_internal_location_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_internal_location_row.rs
@@ -1,4 +1,4 @@
-use super::asset_location_row::asset_location::dsl::*;
+use super::asset_internal_location_row::asset_internal_location::dsl::*;
 
 use crate::RepositoryError;
 use crate::StorageConnection;
@@ -7,7 +7,7 @@ use chrono::NaiveDateTime;
 use diesel::prelude::*;
 
 table! {
-    asset_location (id) {
+    asset_internal_location (id) {
         id -> Text,
         asset_id -> Text,
         location_id -> Text,
@@ -17,8 +17,8 @@ table! {
 }
 
 #[derive(Clone, Insertable, Queryable, Debug, PartialEq, AsChangeset, Eq)]
-#[table_name = "asset_location"]
-pub struct AssetLocationRow {
+#[table_name = "asset_internal_location"]
+pub struct AssetInternalLocationRow {
     pub id: String,
     pub asset_id: String,
     pub location_id: String,
@@ -36,27 +36,36 @@ impl<'a> AssetLocationRowRepository<'a> {
     }
 
     #[cfg(feature = "postgres")]
-    pub fn upsert_one(&self, asset_location_row: &AssetLocationRow) -> Result<(), RepositoryError> {
-        diesel::insert_into(asset_location)
-            .values(asset_location_row)
+    pub fn upsert_one(
+        &self,
+        asset_internal_location_row: &AssetInternalLocationRow,
+    ) -> Result<(), RepositoryError> {
+        diesel::insert_into(asset_internal_location)
+            .values(asset_internal_location_row)
             .on_conflict(id)
             .do_update()
-            .set(asset_location_row)
+            .set(asset_internal_location_row)
             .execute(&self.connection.connection)?;
         Ok(())
     }
 
     #[cfg(not(feature = "postgres"))]
-    pub fn upsert_one(&self, asset_location_row: &AssetLocationRow) -> Result<(), RepositoryError> {
-        diesel::replace_into(asset_location)
-            .values(asset_location_row)
+    pub fn upsert_one(
+        &self,
+        asset_internal_location_row: &AssetInternalLocationRow,
+    ) -> Result<(), RepositoryError> {
+        diesel::replace_into(asset_internal_location)
+            .values(asset_internal_location_row)
             .execute(&self.connection.connection)?;
         Ok(())
     }
 
-    pub fn insert_one(&self, asset_location_row: &AssetLocationRow) -> Result<(), RepositoryError> {
-        diesel::insert_into(asset_location)
-            .values(asset_location_row)
+    pub fn insert_one(
+        &self,
+        asset_internal_location_row: &AssetInternalLocationRow,
+    ) -> Result<(), RepositoryError> {
+        diesel::insert_into(asset_internal_location)
+            .values(asset_internal_location_row)
             .execute(&self.connection.connection)?;
         Ok(())
     }
@@ -64,8 +73,8 @@ impl<'a> AssetLocationRowRepository<'a> {
     pub fn find_all_by_location(
         &self,
         some_location_id: String,
-    ) -> Result<Vec<AssetLocationRow>, RepositoryError> {
-        let result = asset_location
+    ) -> Result<Vec<AssetInternalLocationRow>, RepositoryError> {
+        let result = asset_internal_location
             .filter(location_id.eq(some_location_id))
             .load(&self.connection.connection);
         Ok(result?)
@@ -74,8 +83,8 @@ impl<'a> AssetLocationRowRepository<'a> {
     pub fn find_all_by_asset(
         &self,
         some_asset_id: String,
-    ) -> Result<Vec<AssetLocationRow>, RepositoryError> {
-        let result = asset_location
+    ) -> Result<Vec<AssetInternalLocationRow>, RepositoryError> {
+        let result = asset_internal_location
             .filter(asset_id.eq(some_asset_id))
             .load(&self.connection.connection);
         Ok(result?)
@@ -83,18 +92,18 @@ impl<'a> AssetLocationRowRepository<'a> {
 
     pub fn find_one_by_id(
         &self,
-        asset_location_id: &str,
-    ) -> Result<Option<AssetLocationRow>, RepositoryError> {
-        let result = asset_location
-            .filter(id.eq(asset_location_id))
+        asset_internal_location_id: &str,
+    ) -> Result<Option<AssetInternalLocationRow>, RepositoryError> {
+        let result = asset_internal_location
+            .filter(id.eq(asset_internal_location_id))
             .first(&self.connection.connection)
             .optional()?;
         Ok(result)
     }
 
-    pub fn delete(&self, asset_location_id: &str) -> Result<(), RepositoryError> {
-        diesel::delete(asset_location)
-            .filter(id.eq(asset_location_id))
+    pub fn delete(&self, asset_internal_location_id: &str) -> Result<(), RepositoryError> {
+        diesel::delete(asset_internal_location)
+            .filter(id.eq(asset_internal_location_id))
             .execute(&self.connection.connection)?;
         Ok(())
     }

--- a/server/repository/src/db_diesel/assets/asset_location_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_location_row.rs
@@ -1,0 +1,96 @@
+use super::asset_location_row::asset_location::dsl::*;
+
+use crate::RepositoryError;
+use crate::StorageConnection;
+
+use diesel::prelude::*;
+
+table! {
+    asset_location (id) {
+        id -> Text,
+        asset_id -> Text,
+        location_id -> Text,
+    }
+}
+
+#[derive(Clone, Insertable, Queryable, Debug, PartialEq, AsChangeset, Eq)]
+#[table_name = "asset_location"]
+pub struct AssetLocationRow {
+    pub id: String,
+    pub asset_id: String,
+    pub location_id: String,
+}
+
+pub struct AssetLocationRowRepository<'a> {
+    connection: &'a StorageConnection,
+}
+
+impl<'a> AssetLocationRowRepository<'a> {
+    pub fn new(connection: &'a StorageConnection) -> Self {
+        AssetLocationRowRepository { connection }
+    }
+
+    #[cfg(feature = "postgres")]
+    pub fn upsert_one(&self, asset_location_row: &AssetLocationRow) -> Result<(), RepositoryError> {
+        diesel::insert_into(asset_location)
+            .values(asset_location_row)
+            .on_conflict(id)
+            .do_update()
+            .set(asset_location_row)
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "postgres"))]
+    pub fn upsert_one(&self, asset_location_row: &AssetLocationRow) -> Result<(), RepositoryError> {
+        diesel::replace_into(asset_location)
+            .values(asset_location_row)
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
+
+    pub fn insert_one(&self, asset_location_row: &AssetLocationRow) -> Result<(), RepositoryError> {
+        diesel::insert_into(asset_location)
+            .values(asset_location_row)
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
+
+    pub fn find_all_by_location(
+        &self,
+        some_location_id: String,
+    ) -> Result<Vec<AssetLocationRow>, RepositoryError> {
+        let result = asset_location
+            .filter(location_id.eq(some_location_id))
+            .load(&self.connection.connection);
+        Ok(result?)
+    }
+
+    pub fn find_all_by_asset(
+        &self,
+        some_asset_id: String,
+    ) -> Result<Vec<AssetLocationRow>, RepositoryError> {
+        let result = asset_location
+            .filter(asset_id.eq(some_asset_id))
+            .load(&self.connection.connection);
+        Ok(result?)
+    }
+
+    pub fn find_one_by_id(
+        &self,
+        asset_location_id: &str,
+    ) -> Result<Option<AssetLocationRow>, RepositoryError> {
+        let result = asset_location
+            .filter(id.eq(asset_location_id))
+            .first(&self.connection.connection)
+            .optional()?;
+        Ok(result)
+    }
+
+    pub fn delete(&self, asset_location_id: &str) -> Result<(), RepositoryError> {
+        diesel::delete(asset_location)
+            .filter(id.eq(asset_location_id))
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
+}

--- a/server/repository/src/db_diesel/assets/asset_location_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_location_row.rs
@@ -3,6 +3,7 @@ use super::asset_location_row::asset_location::dsl::*;
 use crate::RepositoryError;
 use crate::StorageConnection;
 
+use chrono::NaiveDateTime;
 use diesel::prelude::*;
 
 table! {
@@ -10,6 +11,8 @@ table! {
         id -> Text,
         asset_id -> Text,
         location_id -> Text,
+        created_datetime -> Timestamp,
+        modified_datetime -> Timestamp,
     }
 }
 
@@ -19,6 +22,8 @@ pub struct AssetLocationRow {
     pub id: String,
     pub asset_id: String,
     pub location_id: String,
+    pub created_datetime: NaiveDateTime,
+    pub modified_datetime: NaiveDateTime,
 }
 
 pub struct AssetLocationRowRepository<'a> {

--- a/server/repository/src/db_diesel/assets/asset_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_row.rs
@@ -16,6 +16,8 @@ table! {
         catalogue_item_id -> Nullable<Text>,
         installation_date -> Nullable<Date>,
         replacement_date -> Nullable<Date>,
+        created_datetime -> Timestamp,
+        modified_datetime -> Timestamp,
         deleted_datetime -> Nullable<Timestamp>,
     }
 }
@@ -32,6 +34,8 @@ pub struct AssetRow {
     pub catalogue_item_id: Option<String>,
     pub installation_date: Option<NaiveDate>,
     pub replacement_date: Option<NaiveDate>,
+    pub created_datetime: NaiveDateTime,
+    pub modified_datetime: NaiveDateTime,
     pub deleted_datetime: Option<NaiveDateTime>,
 }
 

--- a/server/repository/src/db_diesel/assets/asset_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_row.rs
@@ -11,6 +11,7 @@ table! {
     asset (id) {
         id -> Text,
         name -> Text,
+        code -> Text,
         store_id -> Nullable<Text>,
         serial_number -> Nullable<Text>,
         asset_catalogue_item_id -> Nullable<Text>,
@@ -27,6 +28,7 @@ table! {
 pub struct AssetRow {
     pub id: String,
     pub name: String,
+    pub code: String,
     pub store_id: Option<String>,
     pub serial_number: Option<String>,
     #[column_name = "asset_catalogue_item_id"]

--- a/server/repository/src/db_diesel/assets/asset_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_row.rs
@@ -1,0 +1,94 @@
+use super::asset_row::asset::dsl::*;
+
+use crate::RepositoryError;
+use crate::StorageConnection;
+
+use chrono::NaiveDate;
+use chrono::NaiveDateTime;
+use diesel::prelude::*;
+
+table! {
+    asset (id) {
+        id -> Text,
+        serial_number -> Text,
+        asset_category_id -> Text,
+        asset_type_id -> Text,
+        catalogue_item_id -> Nullable<Text>,
+        installation_date -> Nullable<Date>,
+        replacement_date -> Nullable<Date>,
+        deleted_datetime -> Nullable<Timestamp>,
+    }
+}
+
+#[derive(Clone, Insertable, Queryable, Debug, PartialEq, AsChangeset, Eq, Default)]
+#[table_name = "asset"]
+pub struct AssetRow {
+    pub id: String,
+    pub serial_number: String,
+    #[column_name = "asset_category_id"]
+    pub category_id: String,
+    #[column_name = "asset_type_id"]
+    pub type_id: String,
+    pub catalogue_item_id: Option<String>,
+    pub installation_date: Option<NaiveDate>,
+    pub replacement_date: Option<NaiveDate>,
+    pub deleted_datetime: Option<NaiveDateTime>,
+}
+
+pub struct AssetRowRepository<'a> {
+    connection: &'a StorageConnection,
+}
+
+impl<'a> AssetRowRepository<'a> {
+    pub fn new(connection: &'a StorageConnection) -> Self {
+        AssetRowRepository { connection }
+    }
+
+    #[cfg(feature = "postgres")]
+    pub fn upsert_one(&self, asset_row: &AssetRow) -> Result<(), RepositoryError> {
+        diesel::insert_into(asset)
+            .values(asset_row)
+            .on_conflict(id)
+            .do_update()
+            .set(asset_row)
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "postgres"))]
+    pub fn upsert_one(&self, asset_row: &AssetRow) -> Result<(), RepositoryError> {
+        diesel::replace_into(asset)
+            .values(asset_row)
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
+
+    pub fn insert_one(&self, asset_row: &AssetRow) -> Result<(), RepositoryError> {
+        diesel::insert_into(asset)
+            .values(asset_row)
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
+
+    pub fn find_all(&self) -> Result<Vec<AssetRow>, RepositoryError> {
+        let result = asset
+            .filter(deleted_datetime.is_null())
+            .load(&self.connection.connection);
+        Ok(result?)
+    }
+
+    pub fn find_one_by_id(&self, asset_id: &str) -> Result<Option<AssetRow>, RepositoryError> {
+        let result = asset
+            .filter(id.eq(asset_id))
+            .first(&self.connection.connection)
+            .optional()?;
+        Ok(result)
+    }
+
+    pub fn delete(&self, asset_id: &str) -> Result<(), RepositoryError> {
+        diesel::update(asset.filter(id.eq(asset_id)))
+            .set(deleted_datetime.eq(Some(chrono::Utc::now().naive_utc())))
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
+}

--- a/server/repository/src/db_diesel/assets/asset_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_row.rs
@@ -10,10 +10,9 @@ use diesel::prelude::*;
 table! {
     asset (id) {
         id -> Text,
-        store_id -> Text,
-        serial_number -> Text,
-        asset_category_id -> Text,
-        asset_type_id -> Text,
+        name -> Text,
+        store_id -> Nullable<Text>,
+        serial_number -> Nullable<Text>,
         asset_catalogue_item_id -> Nullable<Text>,
         installation_date -> Nullable<Date>,
         replacement_date -> Nullable<Date>,
@@ -27,12 +26,9 @@ table! {
 #[table_name = "asset"]
 pub struct AssetRow {
     pub id: String,
-    pub store_id: String,
-    pub serial_number: String,
-    #[column_name = "asset_category_id"]
-    pub category_id: String,
-    #[column_name = "asset_type_id"]
-    pub type_id: String,
+    pub name: String,
+    pub store_id: Option<String>,
+    pub serial_number: Option<String>,
     #[column_name = "asset_catalogue_item_id"]
     pub catalogue_item_id: Option<String>,
     pub installation_date: Option<NaiveDate>,

--- a/server/repository/src/db_diesel/assets/asset_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_row.rs
@@ -10,6 +10,7 @@ use diesel::prelude::*;
 table! {
     asset (id) {
         id -> Text,
+        store_id -> Text,
         serial_number -> Text,
         asset_category_id -> Text,
         asset_type_id -> Text,
@@ -26,6 +27,7 @@ table! {
 #[table_name = "asset"]
 pub struct AssetRow {
     pub id: String,
+    pub store_id: String,
     pub serial_number: String,
     #[column_name = "asset_category_id"]
     pub category_id: String,

--- a/server/repository/src/db_diesel/assets/mod.rs
+++ b/server/repository/src/db_diesel/assets/mod.rs
@@ -1,6 +1,8 @@
+pub mod asset;
 pub mod asset_category;
 pub mod asset_category_row;
 pub mod asset_class;
 pub mod asset_class_row;
+pub mod asset_row;
 pub mod asset_type;
 pub mod asset_type_row;

--- a/server/repository/src/db_diesel/assets/mod.rs
+++ b/server/repository/src/db_diesel/assets/mod.rs
@@ -3,7 +3,7 @@ pub mod asset_category;
 pub mod asset_category_row;
 pub mod asset_class;
 pub mod asset_class_row;
-pub mod asset_location_row;
+pub mod asset_internal_location_row;
 pub mod asset_row;
 pub mod asset_type;
 pub mod asset_type_row;

--- a/server/repository/src/db_diesel/assets/mod.rs
+++ b/server/repository/src/db_diesel/assets/mod.rs
@@ -3,6 +3,7 @@ pub mod asset_category;
 pub mod asset_category_row;
 pub mod asset_class;
 pub mod asset_class_row;
+pub mod asset_location_row;
 pub mod asset_row;
 pub mod asset_type;
 pub mod asset_type_row;

--- a/server/repository/src/migrations/v1_08_00/assets/asset.rs
+++ b/server/repository/src/migrations/v1_08_00/assets/asset.rs
@@ -1,0 +1,42 @@
+use crate::migrations::DATE;
+use crate::migrations::DATETIME;
+use crate::{migrations::sql, StorageConnection};
+
+pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
+    sql!(
+        connection,
+        r#"
+        CREATE TABLE asset (
+            id TEXT NOT NULL PRIMARY KEY,
+            serial_number TEXT NOT NULL, 
+            asset_category_id TEXT REFERENCES asset_category (id),
+            asset_type_id TEXT REFERENCES asset_type (id),
+            catalogue_item_id, -- TODO: after merge https://github.com/msupply-foundation/open-msupply/pull/3036 TEXT REFERENCES catalogue_item (id)
+            installation_date {DATE},
+            replacement_date {DATE},
+            deleted_datetime {DATETIME},
+            UNIQUE (serial_number, deleted_datetime) --If something doesn't have a serial number, one can be generated?
+        );
+        CREATE INDEX asset_category_id ON asset (asset_category_id);
+        CREATE INDEX asset_type_id ON asset (asset_type_id);
+        CREATE INDEX asset_catalogue_item_id ON asset (catalogue_item_id);
+        CREATE INDEX asset_serial_number ON asset (serial_number);
+        CREATE INDEX asset_deleted_datetime ON asset (deleted_datetime);
+        "#,
+    )?;
+
+    sql!(
+        connection,
+        r#"
+        CREATE TABLE asset_location (
+            id TEXT NOT NULL PRIMARY KEY,
+            asset_id TEXT NOT NULL REFERENCES asset (id),
+            location_id TEXT NOT NULL REFERENCES location (id),
+            UNIQUE (asset_id, location_id)
+        );
+        CREATE INDEX asset_location_asset_id ON asset_location (asset_id);
+        "#,
+    )?;
+
+    Ok(())
+}

--- a/server/repository/src/migrations/v1_08_00/assets/asset.rs
+++ b/server/repository/src/migrations/v1_08_00/assets/asset.rs
@@ -8,8 +8,9 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
         r#"
         CREATE TABLE asset (
             id TEXT NOT NULL PRIMARY KEY,
-            store_id TEXT NOT NULL REFERENCES store (id), -- This serves as the location of the asset at least for now
-            serial_number TEXT NOT NULL, 
+            store_id TEXT REFERENCES store (id), -- This serves as the location of the asset at least for now
+            name TEXT NOT NULL,
+            serial_number TEXT, 
             asset_category_id TEXT REFERENCES asset_category (id),
             asset_type_id TEXT REFERENCES asset_type (id),
             asset_catalogue_item_id TEXT REFERENCES asset_catalogue_item (id),
@@ -18,7 +19,6 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
             deleted_datetime {DATETIME},
             created_datetime {DATETIME} NOT NULL,
             modified_datetime {DATETIME} NOT NULL,
-            UNIQUE (serial_number, deleted_datetime) --If something doesn't have a serial number, one can be generated?
         );
         CREATE INDEX asset_category_id ON asset (asset_category_id);
         CREATE INDEX asset_type_id ON asset (asset_type_id);

--- a/server/repository/src/migrations/v1_08_00/assets/asset.rs
+++ b/server/repository/src/migrations/v1_08_00/assets/asset.rs
@@ -10,6 +10,7 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
             id TEXT NOT NULL PRIMARY KEY,
             store_id TEXT REFERENCES store (id), -- This serves as the location of the asset at least for now
             name TEXT NOT NULL,
+            code TEXT NOT NULL,
             serial_number TEXT, 
             asset_category_id TEXT REFERENCES asset_category (id),
             asset_type_id TEXT REFERENCES asset_type (id),
@@ -18,7 +19,8 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
             replacement_date {DATE},
             deleted_datetime {DATETIME},
             created_datetime {DATETIME} NOT NULL,
-            modified_datetime {DATETIME} NOT NULL
+            modified_datetime {DATETIME} NOT NULL,
+            UNIQUE (code) -- Asset codes must be unique, they'll be used in the barcode
         );
         CREATE INDEX asset_category_id ON asset (asset_category_id);
         CREATE INDEX asset_type_id ON asset (asset_type_id);

--- a/server/repository/src/migrations/v1_08_00/assets/asset.rs
+++ b/server/repository/src/migrations/v1_08_00/assets/asset.rs
@@ -8,6 +8,7 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
         r#"
         CREATE TABLE asset (
             id TEXT NOT NULL PRIMARY KEY,
+            store_id TEXT NOT NULL REFERENCES store (id), -- This serves as the location of the asset at least for now
             serial_number TEXT NOT NULL, 
             asset_category_id TEXT REFERENCES asset_category (id),
             asset_type_id TEXT REFERENCES asset_type (id),
@@ -30,15 +31,15 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
     sql!(
         connection,
         r#"
-        CREATE TABLE asset_location (
+        CREATE TABLE asset_internal_location (
             id TEXT NOT NULL PRIMARY KEY,
             asset_id TEXT NOT NULL REFERENCES asset (id),
             location_id TEXT NOT NULL REFERENCES location (id),
             created_datetime {DATETIME} NOT NULL,
-            modified_datetime {DATETIME} NOT NULL,
-            UNIQUE (asset_id, location_id)
+            modified_datetime {DATETIME} NOT NULL, 
+            UNIQUE (location_id) -- Locations can only be assigned to be inside a single asset, this isn't tracking where the asset is, just what locations exist within it
         );
-        CREATE INDEX asset_location_asset_id ON asset_location (asset_id);
+        CREATE INDEX asset_internal_location_asset_id ON asset_internal_location (asset_id);
         "#,
     )?;
 

--- a/server/repository/src/migrations/v1_08_00/assets/asset.rs
+++ b/server/repository/src/migrations/v1_08_00/assets/asset.rs
@@ -15,6 +15,8 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
             installation_date {DATE},
             replacement_date {DATE},
             deleted_datetime {DATETIME},
+            created_datetime {DATETIME} NOT NULL,
+            modified_datetime {DATETIME} NOT NULL,
             UNIQUE (serial_number, deleted_datetime) --If something doesn't have a serial number, one can be generated?
         );
         CREATE INDEX asset_category_id ON asset (asset_category_id);
@@ -32,6 +34,8 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
             id TEXT NOT NULL PRIMARY KEY,
             asset_id TEXT NOT NULL REFERENCES asset (id),
             location_id TEXT NOT NULL REFERENCES location (id),
+            created_datetime {DATETIME} NOT NULL,
+            modified_datetime {DATETIME} NOT NULL,
             UNIQUE (asset_id, location_id)
         );
         CREATE INDEX asset_location_asset_id ON asset_location (asset_id);

--- a/server/repository/src/migrations/v1_08_00/assets/asset.rs
+++ b/server/repository/src/migrations/v1_08_00/assets/asset.rs
@@ -18,7 +18,7 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
             replacement_date {DATE},
             deleted_datetime {DATETIME},
             created_datetime {DATETIME} NOT NULL,
-            modified_datetime {DATETIME} NOT NULL,
+            modified_datetime {DATETIME} NOT NULL
         );
         CREATE INDEX asset_category_id ON asset (asset_category_id);
         CREATE INDEX asset_type_id ON asset (asset_type_id);

--- a/server/repository/src/migrations/v1_08_00/assets/mod.rs
+++ b/server/repository/src/migrations/v1_08_00/assets/mod.rs
@@ -1,8 +1,10 @@
 use crate::StorageConnection;
 
+pub mod asset;
 pub mod reference_data;
 
 pub(crate) fn migrate_assets(connection: &StorageConnection) -> anyhow::Result<()> {
     reference_data::migrate(connection)?;
+    asset::migrate(connection)?;
     Ok(())
 }

--- a/server/repository/src/mock/mod.rs
+++ b/server/repository/src/mock/mod.rs
@@ -340,6 +340,7 @@ impl MockDataInserts {
     }
 
     pub fn stores(mut self) -> Self {
+        self.names = true;
         self.stores = true;
         self
     }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2972 

# 👩🏻‍💻 What does this PR do? 
Adds the `asset` and `asset_internal_location` tables.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

## 💌 Any notes for the reviewer?
For MVP, we're considering leaving out locations but that would compromise MVP Goal #1
>Provide real-time visibility of functional storage capacity (used vs unused volume) of CCE at a national level with granularity down to the Service Delivery Points.
We could have a single location associated with the asset if we allowed hierarchical locations, which does exist, however I assume that's more work to bring in to the MVP than what I've currently done...

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_