### PR TITLE
Fix stocktake detail cache invalidation

### DIFF
--- a/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeLines.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeLines.ts
@@ -8,9 +8,7 @@ export const useStocktakeLines = (id: string) => {
   });
   const api = useStocktakeApi();
 
-  return {
-    ...useQuery(api.keys.lines(id, queryParams), () =>
-      api.get.lines(id, queryParams)
-    ),
-  };
+  return useQuery(api.keys.lines(id, queryParams), () =>
+    api.get.lines(id, queryParams)
+  );
 };

--- a/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeLines.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeLines.ts
@@ -1,5 +1,6 @@
 import { useQuery, useUrlQueryParams } from '@openmsupply-client/common';
 import { useStocktakeApi } from '../utils/useStocktakeApi';
+import { useStocktakeNumber } from '../document/useStocktake';
 
 export const useStocktakeLines = (id: string) => {
   const { queryParams } = useUrlQueryParams({
@@ -7,8 +8,9 @@ export const useStocktakeLines = (id: string) => {
     filters: [{ key: 'itemCodeOrName' }],
   });
   const api = useStocktakeApi();
+  const stocktakeNumber = useStocktakeNumber();
 
-  return useQuery(api.keys.lines(id, queryParams), () =>
+  return useQuery(api.keys.lines(stocktakeNumber, queryParams), () =>
     api.get.lines(id, queryParams)
   );
 };

--- a/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeSaveLines.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeSaveLines.ts
@@ -1,14 +1,14 @@
 import { useQueryClient, useMutation } from '@openmsupply-client/common';
-import { useStocktakeNumber } from '../document/useStocktake';
+import { useStocktake } from '../document/useStocktake';
 import { useStocktakeApi } from '../utils/useStocktakeApi';
 
 export const useSaveStocktakeLines = () => {
-  const stocktakeNumber = useStocktakeNumber();
+  const { data: stocktake } = useStocktake();
   const queryClient = useQueryClient();
   const api = useStocktakeApi();
 
   return useMutation(api.updateLines, {
     onSuccess: () =>
-      queryClient.invalidateQueries(api.keys.detail(stocktakeNumber)),
+      queryClient.invalidateQueries(api.keys.detail(stocktake?.id ?? '')),
   });
 };

--- a/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeSaveLines.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeSaveLines.ts
@@ -1,14 +1,14 @@
 import { useQueryClient, useMutation } from '@openmsupply-client/common';
-import { useStocktake } from '../document/useStocktake';
+import { useStocktakeNumber } from '../document/useStocktake';
 import { useStocktakeApi } from '../utils/useStocktakeApi';
 
 export const useSaveStocktakeLines = () => {
-  const { data: stocktake } = useStocktake();
+  const stocktakeNumber = useStocktakeNumber();
   const queryClient = useQueryClient();
   const api = useStocktakeApi();
 
   return useMutation(api.updateLines, {
     onSuccess: () =>
-      queryClient.invalidateQueries(api.keys.detail(stocktake?.id ?? '')),
+      queryClient.invalidateQueries(api.keys.detail(stocktakeNumber)),
   });
 };

--- a/client/packages/inventory/src/Stocktake/api/hooks/utils/useStocktakeApi.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/utils/useStocktakeApi.ts
@@ -5,9 +5,9 @@ import { getSdk, StocktakeRowFragment } from '../../operations.generated';
 export const useStocktakeApi = () => {
   const keys = {
     base: () => ['stocktake'] as const,
-    detail: (id: string) => [...keys.base(), storeId, id] as const,
-    lines: (id: string, params: LinesParams) =>
-      [...keys.detail(id), 'lines', params] as const,
+    detail: (number: string) => [...keys.base(), storeId, number] as const,
+    lines: (number: string, params: LinesParams) =>
+      [...keys.detail(number), 'lines', params] as const,
     list: () => [...keys.base(), storeId, 'list'] as const,
     paramList: (params: ListParams) => [...keys.list(), params] as const,
     sortedList: (sortBy: SortBy<StocktakeRowFragment>) =>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3048

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The cache invalidation which is called when the stocktake is updated is using the stocktake number in the cache key
However the hook `useStocktakeLines` was using the stocktake id in the cache key, so wasn't seeing the update after the stocktake was saved.

There are more usages of number, so have renamed the cache parameter to number and updated the `useStocktakeLines` hook.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Open a stocktake, and add an item. This should show on clicking OK.
Edit a line, and update the counted number of packs - check that the value is updated in the table on clicking OK.



## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
