### PR TITLE
Remove all om_* fields from transfered generated in mSupply

### DIFF
--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -28,7 +28,7 @@ fn match_push_table(changelog: &ChangelogRow) -> bool {
     changelog.table_name == ChangelogTableName::Invoice
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
 pub enum LegacyTransactType {
     /// Supplier invoice
     #[serde(rename = "si")]
@@ -178,6 +178,36 @@ pub struct LegacyTransactRow {
     pub om_colour: Option<String>,
 }
 
+/// The mSupply central server will map outbound invoices from omSupply to "si" invoices for the
+/// receiving store.
+/// In the current version of mSupply all om_ fields get copied though.
+/// When receiving the transferred invoice on the omSupply store the "si" get translated to
+/// outbound shipments because the om_type will override to legacy type field.
+/// In other word, the inbound shipment will have an outbound type!
+/// This function detect this case and removes all om_* fields from the incoming record.
+fn sanitize_legacy_record(mut data: serde_json::Value) -> serde_json::Value {
+    let Some(Ok(om_type)) = data
+        .get("om_type")
+        .map(|value| serde_json::from_value::<InvoiceRowType>(value.clone()))
+    else {
+        return data;
+    };
+    let Some(Ok(legacy_type)) = data
+        .get("type")
+        .map(|value| serde_json::from_value::<LegacyTransactType>(value.clone()))
+    else {
+        return data;
+    };
+    if legacy_type == LegacyTransactType::Si && om_type == InvoiceRowType::OutboundShipment {
+        let Some(obj) = data.as_object_mut() else {
+            return data;
+        };
+        obj.retain(|key, _| !key.starts_with("om_"));
+    }
+
+    data
+}
+
 pub(crate) struct InvoiceTranslation {}
 impl SyncTranslation for InvoiceTranslation {
     fn pull_dependencies(&self) -> PullDependency {
@@ -196,7 +226,9 @@ impl SyncTranslation for InvoiceTranslation {
             return Ok(None);
         }
 
-        let data = serde_json::from_str::<LegacyTransactRow>(&sync_record.data)?;
+        let data = serde_json::from_str::<serde_json::Value>(&sync_record.data)?;
+        let data = sanitize_legacy_record(data);
+        let data = serde_json::from_value::<LegacyTransactRow>(data)?;
 
         let name = NameRowRepository::new(connection)
             .find_one_by_id(&data.name_ID)


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2728 

How to reproduce:
1) setup a mobile site, e.g Huff and sync with the central server (think this is needed otherwise the central server doesn't transfer invoices if the site is not old mSupply?)
2) setup an omSupply site e.g. Ravenclaw
3) send an outbound shipment from Ravenclaw to Huff (choose a unique reference to easily identify the shipment later). Set status to shipped. Sync.
4) stop the mobile site and "migrate" the Huff site to open mSupply (open it in omSupply)

Central should have a `transact` record now with type="si" and om_type="OUTBOUNT_SHIPMENT". This is because mSupply just copied the full outbound shipment for the transfer from Ravenclaw to Huff. This is a problem when integrating this record in omSupply because `om_type` is preferred over `type`, i.e. the incoming shipment get outbound status from the original outbound shipment!

# 👩🏻‍💻 What does this PR do? 

This PR detects this mismatch and removes all `om_*` from the incoming record. mSupply created the transfer and thus should not add any om_* columns

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Follow steps above and then check that the Huff site shows the shipment as incoming.
