### PR TITLE
#2932 Number fixes

### DIFF
--- a/client/packages/common/src/intl/currency/currency.test.tsx
+++ b/client/packages/common/src/intl/currency/currency.test.tsx
@@ -65,7 +65,7 @@ describe('currency formatting - fr', () => {
     });
 
     const f1 = result.current.c(111_111.11111111111).format();
-    expect(f1).toBe('111.111,11 €');
+    expect(f1).toBe('111 111,11 €');
   });
 
   it('does drop trailing zeroes', () => {

--- a/client/packages/common/src/intl/number/IntlNumber.ts
+++ b/client/packages/common/src/intl/number/IntlNumber.ts
@@ -16,7 +16,6 @@ export const useFormatNumber = () => {
       if (value === undefined) return '';
       const locale = options?.locale ?? currentLanguage;
       return new Intl.NumberFormat(locale, {
-        // Don't round here, as most use cases have their own internal rounding
         maximumFractionDigits: 21, // maximum allowed
         ...options,
       }).format(value);

--- a/client/packages/common/src/intl/number/IntlNumber.ts
+++ b/client/packages/common/src/intl/number/IntlNumber.ts
@@ -15,7 +15,11 @@ export const useFormatNumber = () => {
     ) => {
       if (value === undefined) return '';
       const locale = options?.locale ?? currentLanguage;
-      return new Intl.NumberFormat(locale, options).format(value);
+      return new Intl.NumberFormat(locale, {
+        // Don't round here, as most use cases have their own internal rounding
+        maximumFractionDigits: 21, // maximum allowed
+        ...options,
+      }).format(value);
     },
     round: (value?: number, dp?: number): string => {
       const intl = new Intl.NumberFormat(currentLanguage, {

--- a/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
@@ -14,7 +14,9 @@ export const NumberInputCell = <T extends RecordWithId>({
   rowIndex,
   columnIndex,
   isDisabled = false,
-  min,
+  // Make the default min=1 as this is the typical implementation
+  // in Data Tables
+  min = 1,
   max,
   decimalLimit,
   step,
@@ -44,13 +46,11 @@ export const NumberInputCell = <T extends RecordWithId>({
         ...TextInputProps?.InputProps,
       }}
       onChange={num => {
-        const newValue = num === undefined ? 0 : num;
+        const newValue = num === undefined ? min : num;
         setBuffer(newValue);
         updater({ ...rowData, [column.key]: Number(newValue) });
       }}
-      // Make the default min=1 as this is the typical implementation
-      // in Data Tables
-      min={min ?? 1}
+      min={min}
       max={max}
       decimalLimit={decimalLimit}
       step={step}

--- a/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
@@ -44,7 +44,7 @@ export const NumberInputCell = <T extends RecordWithId>({
         ...TextInputProps?.InputProps,
       }}
       onChange={num => {
-        const newValue = num;
+        const newValue = num === undefined ? 0 : num;
         setBuffer(newValue);
         updater({ ...rowData, [column.key]: Number(newValue) });
       }}

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   getRowExpandColumn,
   GenericColumnKey,
@@ -9,7 +8,6 @@ import {
   useCurrency,
   useUrlQueryParams,
   ColumnAlign,
-  NumberInputCell,
   TooltipTextCell,
   useColumnUtils,
 } from '@openmsupply-client/common';
@@ -205,7 +203,6 @@ export const useInboundShipmentColumns = () => {
       [
         'numberOfPacks',
         {
-          Cell: props => <NumberInputCell {...props} min={1} />,
           accessor: ({ rowData }) => {
             if ('lines' in rowData) {
               const { lines } = rowData;

--- a/client/packages/programs/src/JsonForms/components/EncounterLineChart.tsx
+++ b/client/packages/programs/src/JsonForms/components/EncounterLineChart.tsx
@@ -143,7 +143,10 @@ const UIComponent = (props: ControlProps) => {
   }
 
   // with no valid data, the y-axis label cannot be shown, so we provide some defaults
-  const domain = (data.every(value => value.y === null) || data.length === 0) ? [0, 100] : undefined;
+  const domain =
+    data.every(value => value.y === null) || data.length === 0
+      ? [0, 100]
+      : undefined;
 
   return (
     <Box
@@ -164,7 +167,6 @@ const UIComponent = (props: ControlProps) => {
         <XAxis
           dataKey="time"
           scale="time"
-          type="number"
           tickFormatter={dayMonthShort}
           domain={['auto', 'auto']}
         />

--- a/client/packages/programs/src/JsonForms/components/QuantityDispensed.tsx
+++ b/client/packages/programs/src/JsonForms/components/QuantityDispensed.tsx
@@ -161,7 +161,6 @@ const UIComponent = (props: ControlProps) => {
         inputAlignment={'start'}
         Input={
           <NumericTextInput
-            type="number"
             InputProps={{
               sx: { '& .MuiInput-input': { textAlign: 'right' } },
             }}
@@ -188,7 +187,6 @@ const UIComponent = (props: ControlProps) => {
         Input={
           <Box flexBasis="100%" display="flex" alignItems="center" gap={2}>
             <NumericTextInput
-              type="number"
               InputProps={{
                 sx: { '& .MuiInput-input': { textAlign: 'right' } },
               }}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2932 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

This fixes the items listed in #2932, except for two of them (unticked), but they're covered by [this issue's suggested solution](https://github.com/msupply-foundation/open-msupply/issues/2918#issuecomment-1965489335).

The main problem I discovered is that the `format` method (in NumUtils), which uses `Intl.NumberFormat`, defaults to 3 dp. So I've just made set that to default to the maximum allowed (21 dp) and we can continue using our `.round()` method to handle precision.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Tested the main cases listed in the issue. However I haven't properly tested the two Programs components affected. All I did there was remove the `type="number"` attribute, so I think it should be fine but if anyone has Programs set up on their system and can confirm it's okay, that'd be great.