### PR TITLE
3084 Currency display should be dependant on language

### DIFF
--- a/client/packages/common/src/intl/currency/currency.test.tsx
+++ b/client/packages/common/src/intl/currency/currency.test.tsx
@@ -41,19 +41,19 @@ describe('currency formatting - en', () => {
   });
 });
 
-describe('currency formatting - fr', () => {
+describe('currency formatting - eur for en', () => {
   it('formats a string with up to the precision number of decimal places, dropping decimal places where needed', () => {
     const { result } = renderHookWithProvider(() => useCurrency('EUR'));
 
     const f1 = result.current.c(1.11111111111).format();
-    expect(f1).toBe('1,11 €');
+    expect(f1).toBe('1.11 €');
   });
 
   it('formats a string with up to the precision number of decimal places, dropping decimal places where needed even with large numbers', () => {
     const { result } = renderHookWithProvider(() => useCurrency('EUR'));
 
     const f1 = result.current.c(111_111.11111111111).format();
-    expect(f1).toBe('111.111,11 €');
+    expect(f1).toBe('111,111.11 €');
   });
 
   it('does drop trailing zeroes', () => {
@@ -61,19 +61,19 @@ describe('currency formatting - fr', () => {
 
     // Note: Using a string to pass into c as formatters will generally
     // auto clear trailing zeroes when literal numbers.
-    const f1 = result.current.c('111,11000').format();
-    expect(f1).toBe('111,11 €');
+    const f1 = result.current.c('111.11000').format();
+    expect(f1).toBe('111.11 €');
   });
   it('has a minimum of two trailing zeroes, adding one if needed', () => {
     const { result } = renderHookWithProvider(() => useCurrency('EUR'));
 
-    const f1 = result.current.c('111,1000').format();
-    expect(f1).toBe('111,10 €');
+    const f1 = result.current.c('111.100').format();
+    expect(f1).toBe('111.10 €');
   });
   it('has a minimum of two trailing zeroes, adding two if needed', () => {
     const { result } = renderHookWithProvider(() => useCurrency('EUR'));
 
     const f1 = result.current.c(111).format();
-    expect(f1).toBe('111,00 €');
+    expect(f1).toBe('111.00 €');
   });
 });

--- a/client/packages/common/src/intl/currency/currency.ts
+++ b/client/packages/common/src/intl/currency/currency.ts
@@ -80,6 +80,17 @@ const getSeparatorAndDecimal = (locale: string) => {
   return { separator, decimal };
 };
 
+const getPatterns = (locale: string) => {
+  switch (locale) {
+    case 'fr-DJ':
+    case 'fr':
+    case 'ru':
+      return { pattern: '# !', negativePattern: '-# !' };
+    default:
+      return { pattern: '!#', negativePattern: '-!#' };
+  }
+};
+
 export type Currencies =
   | 'USD'
   | 'EUR'
@@ -99,10 +110,9 @@ export const currencyOptions = (locale: string, code?: Currencies) => {
         // eslint-disable-next-line no-irregular-whitespace
         // separator: " " decimal = ","
         ...getSeparatorAndDecimal(locale),
+        ...getPatterns(locale),
         symbol: '€',
         precision: 2,
-        pattern: '# !',
-        negativePattern: '-# !',
         format,
       };
     case 'DJF':
@@ -110,39 +120,35 @@ export const currencyOptions = (locale: string, code?: Currencies) => {
         // eslint-disable-next-line no-irregular-whitespace
         // separator: " " decimal = ","
         ...getSeparatorAndDecimal(locale),
+        ...getPatterns(locale),
         symbol: 'DJF',
         precision: 0,
-        pattern: '# !',
-        negativePattern: '-# !',
         format,
       };
     case 'QAR':
       return {
         // separator: "," decimal = "."
         ...getSeparatorAndDecimal(locale),
+        ...getPatterns(locale),
         symbol: 'ر.ق.',
         precision: 2,
-        pattern: '!#',
-        negativePattern: '-!#',
         format,
       };
     case 'RUB':
       return {
         // separator: "." decimal = ","
         ...getSeparatorAndDecimal(locale),
+        ...getPatterns(locale),
         symbol: '₽',
         precision: 2,
-        pattern: '# !',
-        negativePattern: '-# !',
         format,
       };
     case 'SSP': {
       return {
         // separator: "," decimal = "."
         ...getSeparatorAndDecimal(locale),
+        ...getPatterns(locale),
         symbol: 'SSP',
-        pattern: '# !',
-        negativePattern: '-# !',
         precision: 2,
         format,
       };
@@ -151,10 +157,9 @@ export const currencyOptions = (locale: string, code?: Currencies) => {
       return {
         // separator: "." decimal = ","
         ...getSeparatorAndDecimal(locale),
+        ...getPatterns(locale),
         symbol: 'K',
         precision: 2,
-        pattern: '# !',
-        negativePattern: '-# !',
         format,
       };
     }
@@ -162,9 +167,8 @@ export const currencyOptions = (locale: string, code?: Currencies) => {
       return {
         // separator: "." decimal = ","
         ...getSeparatorAndDecimal(locale),
+        ...getPatterns(locale),
         symbol: '$',
-        pattern: '# !',
-        negativePattern: '-# !',
         precision: 2,
         format,
       };
@@ -173,9 +177,8 @@ export const currencyOptions = (locale: string, code?: Currencies) => {
       return {
         // separator: "," decimal = "."
         ...getSeparatorAndDecimal(locale),
+        ...getPatterns(locale),
         symbol: 'SI$',
-        pattern: '# !',
-        negativePattern: '-# !',
         precision: 2,
         format,
       };
@@ -186,10 +189,9 @@ export const currencyOptions = (locale: string, code?: Currencies) => {
       return {
         // separator: "," decimal = "."
         ...getSeparatorAndDecimal(locale),
+        ...getPatterns(locale),
         symbol: '$',
         precision: 2,
-        pattern: '!#',
-        negativePattern: '-!#',
         format,
       };
   }

--- a/client/packages/common/src/intl/currency/currency.ts
+++ b/client/packages/common/src/intl/currency/currency.ts
@@ -1,5 +1,6 @@
 import currency from 'currency.js';
 import { useAuthContext } from '../../authentication';
+import { useIntlUtils } from '../utils';
 
 const trimCents = (centsString: string) => {
   const trimmed = Number(`.${centsString}`);
@@ -91,12 +92,13 @@ export type Currencies =
   | 'COP'
   | 'SBD';
 
-export const currencyOptions = (code?: Currencies) => {
+export const currencyOptions = (locale: string, code?: Currencies) => {
   switch (code) {
     case 'EUR':
       return {
+        // eslint-disable-next-line no-irregular-whitespace
         // separator: " " decimal = ","
-        ...getSeparatorAndDecimal('fr'),
+        ...getSeparatorAndDecimal(locale),
         symbol: '€',
         precision: 2,
         pattern: '# !',
@@ -105,8 +107,9 @@ export const currencyOptions = (code?: Currencies) => {
       };
     case 'DJF':
       return {
+        // eslint-disable-next-line no-irregular-whitespace
         // separator: " " decimal = ","
-        ...getSeparatorAndDecimal('fr-DJ'),
+        ...getSeparatorAndDecimal(locale),
         symbol: 'DJF',
         precision: 0,
         pattern: '# !',
@@ -116,7 +119,7 @@ export const currencyOptions = (code?: Currencies) => {
     case 'QAR':
       return {
         // separator: "," decimal = "."
-        ...getSeparatorAndDecimal('ar'),
+        ...getSeparatorAndDecimal(locale),
         symbol: 'ر.ق.',
         precision: 2,
         pattern: '!#',
@@ -126,7 +129,7 @@ export const currencyOptions = (code?: Currencies) => {
     case 'RUB':
       return {
         // separator: "." decimal = ","
-        ...getSeparatorAndDecimal('ru'),
+        ...getSeparatorAndDecimal(locale),
         symbol: '₽',
         precision: 2,
         pattern: '# !',
@@ -136,7 +139,7 @@ export const currencyOptions = (code?: Currencies) => {
     case 'SSP': {
       return {
         // separator: "," decimal = "."
-        ...getSeparatorAndDecimal('en-ss'),
+        ...getSeparatorAndDecimal(locale),
         symbol: 'SSP',
         pattern: '# !',
         negativePattern: '-# !',
@@ -147,7 +150,7 @@ export const currencyOptions = (code?: Currencies) => {
     case 'PGK': {
       return {
         // separator: "." decimal = ","
-        ...getSeparatorAndDecimal('pg'),
+        ...getSeparatorAndDecimal(locale),
         symbol: 'K',
         precision: 2,
         pattern: '# !',
@@ -158,7 +161,7 @@ export const currencyOptions = (code?: Currencies) => {
     case 'COP': {
       return {
         // separator: "." decimal = ","
-        ...getSeparatorAndDecimal('co'),
+        ...getSeparatorAndDecimal(locale),
         symbol: '$',
         pattern: '# !',
         negativePattern: '-# !',
@@ -169,7 +172,7 @@ export const currencyOptions = (code?: Currencies) => {
     case 'SBD': {
       return {
         // separator: "," decimal = "."
-        ...getSeparatorAndDecimal('sb'),
+        ...getSeparatorAndDecimal(locale),
         symbol: 'SI$',
         pattern: '# !',
         negativePattern: '-# !',
@@ -182,7 +185,7 @@ export const currencyOptions = (code?: Currencies) => {
     default:
       return {
         // separator: "," decimal = "."
-        ...getSeparatorAndDecimal('en'),
+        ...getSeparatorAndDecimal(locale),
         symbol: '$',
         precision: 2,
         pattern: '!#',
@@ -194,9 +197,10 @@ export const currencyOptions = (code?: Currencies) => {
 
 export const useCurrency = (code?: Currencies) => {
   const { store } = useAuthContext();
+  const { currentLanguage: language } = useIntlUtils();
   const currencyCode = code ? code : (store?.homeCurrencyCode as Currencies);
 
-  const options = currencyOptions(currencyCode);
+  const options = currencyOptions(language, currencyCode);
   const precision = options.precision;
   return {
     c: (value: currency.Any) => currency(value, { ...options, precision }),

--- a/server/graphql/general/src/queries/mod.rs
+++ b/server/graphql/general/src/queries/mod.rs
@@ -48,7 +48,6 @@ pub use self::plugin::*;
 pub mod temperature_chart;
 pub use self::temperature_chart::*;
 pub mod currency;
-pub use self::currency::*;
 
 #[cfg(test)]
 mod tests;

--- a/server/repository/src/db_diesel/mod.rs
+++ b/server/repository/src/db_diesel/mod.rs
@@ -12,7 +12,7 @@ pub mod consumption;
 pub mod contact_trace;
 pub mod contact_trace_row;
 mod context_row;
-mod currency;
+pub mod currency;
 mod currency_row;
 pub mod diesel_schema;
 pub mod document;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3084

# 👩🏻‍💻 What does this PR do? 
Displays currency in locale format. 
![Screenshot 2024-02-28 at 10 35 23](https://github.com/msupply-foundation/open-msupply/assets/61820074/02faa071-7cf1-4cac-b2e5-45d68f854da7)
![Screenshot 2024-02-28 at 10 35 42](https://github.com/msupply-foundation/open-msupply/assets/61820074/747b54bd-429b-4a7c-809c-992e9ad19965)


# 🧪 How has/should this change been tested? 
- mSupply
- [ ] Go to Currencies 
- [ ] Add some and update rates
- [ ] Go to Stores -> Preferences
- [ ] Enable `Store: Able to issue in foreign currency`
- om
- [ ] Go to Inbound Shipment
- [ ] Create an invoice with external Supplier
- [ ] Add some lines with prices
- [ ] Click on pen next to `Foreign Currency` in `More` panel
- [ ] Change to a currency that uses a different format from Eng e.g. `EUR`
- [ ] See that the format is still in one that Eng uses instead of the one Europe uses
- [ ] Change language to `French`
- [ ] See format change
