### PR TITLE
3052 Cannot choose the time correctly in date-time picker

### DIFF
--- a/client/packages/common/src/intl/utils/IntlUtils.ts
+++ b/client/packages/common/src/intl/utils/IntlUtils.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { EnvUtils } from '@common/utils';
 import { LanguageType } from '../../types/schema';
 import { LocalStorage } from '../../localStorage';
@@ -63,13 +63,16 @@ export const useIntlUtils = () => {
   const { language: i18nLanguage } = i18n;
   const [language, setLanguage] = React.useState<string>(i18nLanguage);
 
-  const changeLanguage = (languageCode?: string) => {
-    if (!languageCode) return;
-    if (!locales.some(locale => languageCode === locale)) return;
+  const changeLanguage = useCallback(
+    (languageCode?: string) => {
+      if (!languageCode) return;
+      if (!locales.some(locale => languageCode === locale)) return;
 
-    i18n.changeLanguage(languageCode);
-    setLanguage(languageCode);
-  };
+      i18n.changeLanguage(languageCode);
+      setLanguage(languageCode);
+    },
+    [i18n]
+  );
 
   const isRtl = rtlLocales.includes(language);
 
@@ -95,23 +98,11 @@ export const useIntlUtils = () => {
     option => option.value === language
   )?.label;
 
-  const getLocaleCode = (language: LanguageType) => parseLanguage(language);
-
-  const getUserLocale = (username: string) => {
-    const locales = LocalStorage.getItem('/localisation/locale');
-    return !!locales ? locales[username] : undefined;
-  };
-
-  const setUserLocale = (username: string, locale: SupportedLocales) => {
-    const locales = LocalStorage.getItem('/localisation/locale') ?? {};
-    locales[username] = locale;
-    LocalStorage.setItem('/localisation/locale', locales);
-  };
-
-  const getLocalisedFullName = (
-    firstName: StringOrEmpty,
-    lastName: StringOrEmpty
-  ) => getFullName(language, firstName, lastName);
+  const getLocalisedFullName = useCallback(
+    (firstName: StringOrEmpty, lastName: StringOrEmpty) =>
+      getFullName(language, firstName, lastName),
+    [language]
+  );
 
   return {
     currentLanguage,
@@ -125,6 +116,19 @@ export const useIntlUtils = () => {
     setUserLocale,
     getLocalisedFullName,
   };
+};
+
+const getLocaleCode = (language: LanguageType) => parseLanguage(language);
+
+const getUserLocale = (username: string) => {
+  const locales = LocalStorage.getItem('/localisation/locale');
+  return !!locales ? locales[username] : undefined;
+};
+
+const setUserLocale = (username: string, locale: SupportedLocales) => {
+  const locales = LocalStorage.getItem('/localisation/locale') ?? {};
+  locales[username] = locale;
+  LocalStorage.setItem('/localisation/locale', locales);
 };
 
 const parseLanguage = (language?: string) => {

--- a/client/packages/common/src/ui/components/inputs/DatePickers/DateTimePickerInput/DateTimePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/DateTimePickerInput/DateTimePickerInput.tsx
@@ -31,7 +31,6 @@ export const DateTimePickerInput: FC<
   width,
   label,
   textFieldProps,
-  format = 'P p',
   minDate,
   maxDate,
   showTime,
@@ -43,6 +42,7 @@ export const DateTimePickerInput: FC<
   const t = useTranslation();
   const { getLocale } = useIntlUtils();
   const dateParseOptions = { locale: getLocale() };
+  const format = props.format ?? showTime ? 'P p' : 'P';
 
   // Max/Min should be restricted by the UI, but it's not restricting TIME input
   // (only Date component). So this function will enforce the max/min after
@@ -61,7 +61,7 @@ export const DateTimePickerInput: FC<
 
   return (
     <DateTimePicker
-      format={showTime ? 'P p' : 'P'}
+      format={format}
       slots={{
         textField: TextField,
       }}

--- a/client/packages/programs/src/JsonForms/common/components/DateTime.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/DateTime.tsx
@@ -85,7 +85,7 @@ const UIComponent = (props: ControlProps) => {
 
   const dateOnly = options?.dateOnly ?? false;
 
-  const inputFormat = !dateOnly ? 'dd/MM/yyyy hh:mm' : 'dd/MM/yyyy';
+  const inputFormat = !dateOnly ? 'P p' : 'P';
 
   const onChange = (e: Date | null) => {
     if (!e) return;
@@ -100,7 +100,7 @@ const UIComponent = (props: ControlProps) => {
   };
 
   const sharedComponentProps = {
-    value: DateUtils.getDateOrNull(data),
+    value: DateUtils.getDateOrNull(data, inputFormat),
     onChange: (e: Date | null) => onChange(e),
     inputFormat,
     readOnly: !!props.uischema.options?.['readonly'],

--- a/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
@@ -278,7 +278,7 @@ export const Toolbar: FC<ToolbarProps> = ({
                         : undefined;
                       if (endDatetime) {
                         setEndDatetime(endDatetime);
-                        onChange({ startDatetime, endDatetime });
+                        onChange({ endDatetime });
                       }
                     }}
                   />

--- a/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
@@ -117,7 +117,7 @@ export const Toolbar: FC<ToolbarProps> = ({
       ),
       value: encounter.clinician as Clinician,
     });
-  }, [encounter]);
+  }, [encounter, getLocalisedFullName]);
 
   const getDeleteConfirmation = useConfirmationModal({
     message: t('message.confirm-delete-encounter'),

--- a/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
@@ -286,6 +286,9 @@ export const Toolbar: FC<ToolbarProps> = ({
                 labelWidth="60px"
                 Input={
                   <TimePickerInput
+                    minTime={
+                      startDatetime ? new Date(startDatetime) : undefined
+                    }
                     value={DateUtils.getDateOrNull(endDatetime ?? null)}
                     onChange={date => {
                       const endDatetime = date

--- a/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
@@ -230,9 +230,19 @@ export const Toolbar: FC<ToolbarProps> = ({
                     onChange={date => {
                       const startDatetime = DateUtils.formatRFC3339(date);
                       setStartDatetime(startDatetime);
+                      const endDt = DateUtils.getDateOrNull(endDatetime);
                       onChange({
                         startDatetime,
-                        endDatetime: endDatetime ?? undefined,
+                        endDatetime: endDatetime
+                          ? DateUtils.formatRFC3339(
+                              new Date(
+                                new Date(startDatetime ?? '').setHours(
+                                  endDt?.getHours() ?? 0,
+                                  endDt?.getMinutes() ?? 0
+                                )
+                              )
+                            )
+                          : undefined,
                       });
                     }}
                   />

--- a/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
@@ -59,6 +59,25 @@ const Row = ({
 }) => (
   <InputWithLabelRow labelWidth="90px" label={label} Input={Input} sx={sx} />
 );
+
+/**
+ * Updates the date component of the endDate to match the date of the startDatetime.
+ * If the startDatetime is not provided the current date is used.
+ */
+const updateEndDatetimeFromStartDate = (
+  endDate: Date,
+  startDatetime: string | undefined
+) => {
+  return DateUtils.formatRFC3339(
+    new Date(
+      new Date(startDatetime ?? '').setHours(
+        endDate.getHours(),
+        endDate.getMinutes()
+      )
+    )
+  );
+};
+
 interface ToolbarProps {
   onChange: (patch: Partial<EncounterFragment>) => void;
   onDelete: () => void;
@@ -233,15 +252,8 @@ export const Toolbar: FC<ToolbarProps> = ({
                       const endDt = DateUtils.getDateOrNull(endDatetime);
                       onChange({
                         startDatetime,
-                        endDatetime: endDatetime
-                          ? DateUtils.formatRFC3339(
-                              new Date(
-                                new Date(startDatetime ?? '').setHours(
-                                  endDt?.getHours() ?? 0,
-                                  endDt?.getMinutes() ?? 0
-                                )
-                              )
-                            )
+                        endDatetime: endDt
+                          ? updateEndDatetimeFromStartDate(endDt, startDatetime)
                           : undefined,
                       });
                     }}
@@ -277,14 +289,7 @@ export const Toolbar: FC<ToolbarProps> = ({
                     value={DateUtils.getDateOrNull(endDatetime ?? null)}
                     onChange={date => {
                       const endDatetime = date
-                        ? DateUtils.formatRFC3339(
-                            new Date(
-                              new Date(startDatetime ?? '').setHours(
-                                date.getHours(),
-                                date.getMinutes()
-                              )
-                            )
-                          )
+                        ? updateEndDatetimeFromStartDate(date, startDatetime)
                         : undefined;
                       if (endDatetime) {
                         setEndDatetime(endDatetime);

--- a/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
@@ -267,11 +267,18 @@ export const Toolbar: FC<ToolbarProps> = ({
                     value={DateUtils.getDateOrNull(endDatetime ?? null)}
                     onChange={date => {
                       const endDatetime = date
-                        ? DateUtils.formatRFC3339(date)
+                        ? DateUtils.formatRFC3339(
+                            new Date(
+                              new Date(startDatetime ?? '').setHours(
+                                date.getHours(),
+                                date.getMinutes()
+                              )
+                            )
+                          )
                         : undefined;
                       if (endDatetime) {
                         setEndDatetime(endDatetime);
-                        onChange({ endDatetime });
+                        onChange({ startDatetime, endDatetime });
                       }
                     }}
                   />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3052

# 👩🏻‍💻 What does this PR do? 
Make sure that the end time for encounters

# 🧪 How has/should this change been tested? 
- [ ] Set up programs
- [ ] Enrol a patient in a program
- [ ] Create an encounter from that program
- [ ] Change date to the past
- [ ] Try change end time
- [ ] The date shouldn't change to today

## 💌 Any notes for the reviewer?
Didn't do it in this PR since this is just a bug fix, but I think there should be some validations in place for end time so that the user doesn't choose a time that is before the start time.