### PR TITLE
2917 Cannot allocate expiry message not clear enough

### DIFF
--- a/client/packages/common/src/intl/locales/en/dispensary.json
+++ b/client/packages/common/src/intl/locales/en/dispensary.json
@@ -88,7 +88,7 @@
   "messages.results-found": "{{totalCount}} results found",
   "messages.results-over-limit": "Showing the first {{limit}} results only - please refine your search",
   "messages.save-encounter-as-visited": "Save encounter as Visited?",
-  "messages.stock-expired": "Some stock lines are expired and cannot be allocated.",
+  "messages.stock-expired": "Some stock lines are expired and will not be auto-allocated.",
   "messages.stock-on-hold": "Some stock lines are hold and cannot be allocated.",
   "placeholder.search-by-first-name": "Search by first name",
   "placeholder.search-by-identifier": "Search by ID",

--- a/client/packages/common/src/intl/locales/en/distribution.json
+++ b/client/packages/common/src/intl/locales/en/distribution.json
@@ -118,7 +118,7 @@
   "messages.shipment-saved": "Shipment saved 🥳",
   "messages.confirm-not-fully-supplied": "Not all items in this requisition have been supplied to the customer.  If you finalise you will not be able to supply any more items to the customer from this requisition. Would you still like to continue?",
   "messages.stock-on-hold": "Some stock lines are hold and cannot be allocated.",
-  "messages.stock-expired": "Some stock lines are expired and cannot be allocated.",
+  "messages.stock-expired": "Some stock lines are expired and will not be auto-allocated.",
   "stocktake.description-template": "Created by {{username}} on {{date}}",
   "warning.nothing-to-supply": "Nothing left to supply!",
   "info.no-shipment": "Finalising this requisition will prevent you from creating a shipment for it."


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2917

# 👩🏻‍💻 What does this PR do? 
Quick fix to change the stock expired allocation message

## 📃 Documentation
Update docs screenshot
![Screenshot 2024-03-01 at 08 36 10](https://github.com/msupply-foundation/open-msupply/assets/61820074/46bdb902-26e3-4c24-b2d8-be75db13f278)
