### PR TITLE
Startup log message now shows central/remote and port number

### DIFF
--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -63,11 +63,16 @@ pub async fn start_server(
     mut off_switch: tokio::sync::mpsc::Receiver<()>,
 ) -> std::io::Result<()> {
     info!(
-        "Server starting in {} mode",
+        "{} server starting in {} mode on port {}",
+        match is_central_server() {
+            true => "Central",
+            false => "Remote",
+        },
         match is_develop() {
             true => "Development",
             false => "Production",
-        }
+        },
+        settings.server.port
     );
 
     // INITIALISE DATABASE AND CONNECTION


### PR DESCRIPTION
Starting OMS should show Central or Remote Server
`<server:65>:Remote server starting in Development mode on port 8082`
or
`<server:65>:Central server starting in Development mode on port 8082`