### PR TITLE
3134 Save currency in invoice on default

### DIFF
--- a/server/graphql/types/src/types/invoice_query.rs
+++ b/server/graphql/types/src/types/invoice_query.rs
@@ -339,7 +339,7 @@ impl InvoiceNode {
         Ok(Some(CurrencyNode::from_domain(currency)))
     }
 
-    pub async fn currency_rate(&self) -> &Option<f64> {
+    pub async fn currency_rate(&self) -> &f64 {
         &self.row().currency_rate
     }
 }

--- a/server/repository/src/db_diesel/currency_row.rs
+++ b/server/repository/src/db_diesel/currency_row.rs
@@ -15,7 +15,7 @@ table! {
     }
 }
 
-#[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq)]
+#[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq, Default)]
 #[changeset_options(treat_none_as_null = "true")]
 #[table_name = "currency"]
 pub struct CurrencyRow {

--- a/server/repository/src/db_diesel/invoice_row.rs
+++ b/server/repository/src/db_diesel/invoice_row.rs
@@ -38,7 +38,7 @@ table! {
         linked_invoice_id -> Nullable<Text>,
         tax -> Nullable<Double>,
         currency_id -> Nullable<Text>,
-        currency_rate -> Nullable<Double>,
+        currency_rate -> Double,
         clinician_link_id -> Nullable<Text>,
     }
 }
@@ -106,7 +106,7 @@ pub struct InvoiceRow {
     pub linked_invoice_id: Option<String>,
     pub tax: Option<f64>,
     pub currency_id: Option<String>,
-    pub currency_rate: Option<f64>,
+    pub currency_rate: f64,
     pub clinician_link_id: Option<String>,
 }
 

--- a/server/repository/src/db_diesel/mod.rs
+++ b/server/repository/src/db_diesel/mod.rs
@@ -12,7 +12,7 @@ pub mod consumption;
 pub mod contact_trace;
 pub mod contact_trace_row;
 mod context_row;
-mod currency;
+pub mod currency;
 mod currency_row;
 pub mod diesel_schema;
 pub mod document;

--- a/server/repository/src/migrations/v1_07_00/invoice_add_currency_fields.rs
+++ b/server/repository/src/migrations/v1_07_00/invoice_add_currency_fields.rs
@@ -8,7 +8,7 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
         connection,
         r#"
         ALTER TABLE invoice ADD COLUMN currency_id TEXT REFERENCES currency(id);
-        ALTER TABLE invoice ADD COLUMN currency_rate {DOUBLE};
+        ALTER TABLE invoice ADD COLUMN currency_rate {DOUBLE} NOT NULL DEFAULT 1.0;
         "#,
     )?;
     Ok(())

--- a/server/repository/src/mock/currency.rs
+++ b/server/repository/src/mock/currency.rs
@@ -1,0 +1,25 @@
+use crate::CurrencyRow;
+
+pub fn currency_a() -> CurrencyRow {
+    CurrencyRow {
+        id: String::from("currency_a"),
+        code: String::from("USD"),
+        rate: 1.0,
+        is_home_currency: true,
+        date_updated: None,
+    }
+}
+
+pub fn currency_b() -> CurrencyRow {
+    CurrencyRow {
+        id: String::from("currency_b"),
+        code: String::from("EUR"),
+        rate: 0.9,
+        is_home_currency: false,
+        date_updated: None,
+    }
+}
+
+pub fn mock_currencies() -> Vec<CurrencyRow> {
+    vec![currency_a(), currency_b()]
+}

--- a/server/service/src/invoice/common.rs
+++ b/server/service/src/invoice/common.rs
@@ -1,7 +1,7 @@
 use repository::{
-    EqualFilter, InvoiceLine, InvoiceLineFilter, InvoiceLineRepository, InvoiceLineRowType,
-    InvoiceRow, MasterList, MasterListFilter, MasterListRepository, NameLinkRowRepository,
-    RepositoryError, StockLineRow, StorageConnection,
+    CurrencyFilter, CurrencyRepository, EqualFilter, InvoiceLine, InvoiceLineFilter,
+    InvoiceLineRepository, InvoiceLineRowType, InvoiceRow, MasterList, MasterListFilter,
+    MasterListRepository, NameLinkRowRepository, RepositoryError, StockLineRow, StorageConnection,
 };
 use util::inline_edit;
 
@@ -38,10 +38,21 @@ pub fn calculate_total_after_tax(total_before_tax: f64, tax: Option<f64>) -> f64
     }
 }
 
-pub fn calculate_foreign_currency_total(total: f64, currency_rate: Option<f64>) -> Option<f64> {
-    match currency_rate {
-        Some(currency_rate) => Some(total / currency_rate),
-        None => None,
+pub fn calculate_foreign_currency_total(
+    connection: &StorageConnection,
+    total: f64,
+    currency_id: Option<String>,
+    currency_rate: &f64,
+) -> Result<Option<f64>, RepositoryError> {
+    let currency = CurrencyRepository::new(connection)
+        .query_by_filter(CurrencyFilter::new().is_home_currency(true))?
+        .pop()
+        .ok_or(RepositoryError::NotFound)?;
+
+    if currency_id.is_none() && currency.currency_row.id != currency_id.unwrap_or_default() {
+        Ok(None)
+    } else {
+        Ok(Some(total / currency_rate))
     }
 }
 

--- a/server/service/src/invoice/inbound_shipment/insert/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/insert/generate.rs
@@ -1,8 +1,8 @@
 use chrono::Utc;
 
 use repository::{
-    InvoiceRow, InvoiceRowStatus, InvoiceRowType, Name, NumberRowType, RepositoryError,
-    StorageConnection,
+    CurrencyFilter, CurrencyRepository, InvoiceRow, InvoiceRowStatus, InvoiceRowType, Name,
+    NumberRowType, RepositoryError, StorageConnection,
 };
 
 use crate::number::next_number;
@@ -24,6 +24,10 @@ pub fn generate(
     other_party: Name,
 ) -> Result<InvoiceRow, RepositoryError> {
     let current_datetime = Utc::now().naive_utc();
+    let currency = CurrencyRepository::new(connection)
+        .query_by_filter(CurrencyFilter::new().is_home_currency(true))?
+        .pop()
+        .ok_or(RepositoryError::NotFound)?;
 
     let result = InvoiceRow {
         id,
@@ -40,6 +44,8 @@ pub fn generate(
         on_hold: on_hold.unwrap_or(false),
         colour,
         // Default
+        currency_id: Some(currency.currency_row.id),
+        currency_rate: 1.0,
         tax: None,
         transport_reference: None,
         allocated_datetime: None,
@@ -49,8 +55,6 @@ pub fn generate(
         verified_datetime: None,
         linked_invoice_id: None,
         requisition_id: None,
-        currency_id: None,
-        currency_rate: None,
         clinician_link_id: None,
     };
 

--- a/server/service/src/invoice/inbound_shipment/update/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/update/generate.rs
@@ -60,7 +60,7 @@ pub(crate) fn generate(
     }
 
     update_invoice.currency_id = patch.currency_id.or(update_invoice.currency_id);
-    update_invoice.currency_rate = patch.currency_rate.or(update_invoice.currency_rate);
+    update_invoice.currency_rate = patch.currency_rate.unwrap_or(update_invoice.currency_rate);
 
     let batches_to_update = if should_create_batches {
         Some(generate_lines_and_stock_lines(
@@ -69,7 +69,8 @@ pub(crate) fn generate(
             &update_invoice.id,
             update_invoice.tax,
             &update_invoice.name_link_id,
-            update_invoice.currency_rate,
+            update_invoice.currency_id.clone(),
+            &update_invoice.currency_rate,
         )?)
     } else {
         None
@@ -89,12 +90,13 @@ pub(crate) fn generate(
         None
     };
 
-    let update_lines = if update_invoice.tax.is_some() || update_invoice.currency_id.is_some() {
+    let update_lines = if update_invoice.tax.is_some() || patch.currency_rate.is_some() {
         Some(generate_update_for_lines(
             connection,
             &update_invoice.id,
             update_invoice.tax,
-            update_invoice.currency_rate,
+            update_invoice.currency_id.clone(),
+            &update_invoice.currency_rate,
         )?)
     } else {
         None
@@ -125,7 +127,8 @@ fn generate_update_for_lines(
     connection: &StorageConnection,
     invoice_id: &str,
     tax: Option<f64>,
-    currency_rate: Option<f64>,
+    currency_id: Option<String>,
+    currency_rate: &f64,
 ) -> Result<Vec<InvoiceLineRow>, UpdateInboundShipmentError> {
     let invoice_lines = InvoiceLineRepository::new(connection).query_by_filter(
         InvoiceLineFilter::new()
@@ -139,8 +142,12 @@ fn generate_update_for_lines(
         invoice_line_row.tax = tax;
         invoice_line_row.total_after_tax =
             calculate_total_after_tax(invoice_line_row.total_before_tax, tax);
-        invoice_line_row.foreign_currency_price_before_tax =
-            calculate_foreign_currency_total(invoice_line_row.total_before_tax, currency_rate);
+        invoice_line_row.foreign_currency_price_before_tax = calculate_foreign_currency_total(
+            connection,
+            invoice_line_row.total_before_tax,
+            currency_id.clone(),
+            currency_rate,
+        )?;
         result.push(invoice_line_row);
     }
 
@@ -212,7 +219,8 @@ pub fn generate_lines_and_stock_lines(
     id: &str,
     tax: Option<f64>,
     supplier_id: &str,
-    currency_rate: Option<f64>,
+    currency_id: Option<String>,
+    currency_rate: &f64,
 ) -> Result<Vec<LineAndStockLine>, UpdateInboundShipmentError> {
     let lines = InvoiceLineRowRepository::new(connection).find_many_by_invoice_id(id)?;
     let mut result = Vec::new();
@@ -225,8 +233,12 @@ pub fn generate_lines_and_stock_lines(
             line.tax = tax;
             line.total_after_tax = calculate_total_after_tax(line.total_before_tax, tax);
         }
-        line.foreign_currency_price_before_tax =
-            calculate_foreign_currency_total(line.total_before_tax, currency_rate);
+        line.foreign_currency_price_before_tax = calculate_foreign_currency_total(
+            connection,
+            line.total_before_tax,
+            currency_id.clone(),
+            currency_rate,
+        )?;
 
         let InvoiceLineRow {
             id: _,

--- a/server/service/src/invoice/outbound_shipment/insert/generate.rs
+++ b/server/service/src/invoice/outbound_shipment/insert/generate.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 
-use repository::Name;
+use repository::{CurrencyFilter, CurrencyRepository, Name};
 use repository::{
     InvoiceRow, InvoiceRowStatus, InvoiceRowType, NumberRowType, RepositoryError, StorageConnection,
 };
@@ -17,6 +17,10 @@ pub fn generate(
     other_party: Name,
 ) -> Result<InvoiceRow, RepositoryError> {
     let current_datetime = Utc::now().naive_utc();
+    let currency = CurrencyRepository::new(connection)
+        .query_by_filter(CurrencyFilter::new().is_home_currency(true))?
+        .pop()
+        .ok_or(RepositoryError::NotFound)?;
 
     let result = InvoiceRow {
         id: input.id,
@@ -33,6 +37,8 @@ pub fn generate(
         on_hold: input.on_hold.unwrap_or(false),
         colour: input.colour,
         // Default
+        currency_id: Some(currency.currency_row.id),
+        currency_rate: 1.0,
         tax: None,
         transport_reference: None,
         allocated_datetime: None,
@@ -42,8 +48,6 @@ pub fn generate(
         verified_datetime: None,
         linked_invoice_id: None,
         requisition_id: None,
-        currency_id: None,
-        currency_rate: None,
         clinician_link_id: None,
     };
 

--- a/server/service/src/invoice_line/inbound_shipment_line/update/generate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_line/update/generate.rs
@@ -37,11 +37,13 @@ pub fn generate(
     let batch_to_delete_id = get_batch_to_delete_id(&current_line, &new_item_option);
 
     let update_line = generate_line(
+        connection,
         input,
         current_line.invoice_line_row,
         new_item_option,
-        existing_invoice_row.currency_rate,
-    );
+        existing_invoice_row.currency_id.clone(),
+        &existing_invoice_row.currency_rate,
+    )?;
 
     let mut update_line = match store_preferences.pack_to_one {
         true => convert_invoice_line_to_single_pack(update_line),
@@ -85,6 +87,7 @@ fn get_batch_to_delete_id(
 }
 
 fn generate_line(
+    connection: &StorageConnection,
     UpdateInboundShipmentLine {
         pack_size,
         batch,
@@ -100,8 +103,9 @@ fn generate_line(
     }: UpdateInboundShipmentLine,
     current_line: InvoiceLineRow,
     new_item_option: Option<ItemRow>,
-    currency_rate: Option<f64>,
-) -> InvoiceLineRow {
+    currency_id: Option<String>,
+    currency_rate: &f64,
+) -> Result<InvoiceLineRow, RepositoryError> {
     let mut update_line = current_line;
 
     update_line.pack_size = pack_size.map(u32_to_i32).unwrap_or(update_line.pack_size);
@@ -114,8 +118,12 @@ fn generate_line(
         cost_price_per_pack.unwrap_or(update_line.cost_price_per_pack);
     update_line.number_of_packs = number_of_packs.unwrap_or(update_line.number_of_packs);
     update_line.tax = tax.map(|tax| tax.percentage).unwrap_or(update_line.tax);
-    update_line.foreign_currency_price_before_tax =
-        calculate_foreign_currency_total(update_line.total_before_tax, currency_rate);
+    update_line.foreign_currency_price_before_tax = calculate_foreign_currency_total(
+        connection,
+        update_line.total_before_tax,
+        currency_id,
+        currency_rate,
+    )?;
 
     if let Some(item) = new_item_option {
         update_line.item_link_id = item.id;
@@ -134,5 +142,5 @@ fn generate_line(
     update_line.total_after_tax =
         calculate_total_after_tax(update_line.total_before_tax, update_line.tax);
 
-    update_line
+    Ok(update_line)
 }

--- a/server/service/src/invoice_line/inbound_shipment_service_line/insert/generate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_service_line/insert/generate.rs
@@ -1,10 +1,11 @@
-use repository::{InvoiceLineRow, InvoiceLineRowType, ItemRow};
+use repository::{InvoiceLineRow, InvoiceLineRowType, ItemRow, RepositoryError, StorageConnection};
 
 use crate::invoice::common::{calculate_foreign_currency_total, calculate_total_after_tax};
 
-use super::{InsertInboundShipmentServiceLine, InsertInboundShipmentServiceLineError};
+use super::InsertInboundShipmentServiceLine;
 
 pub fn generate(
+    connection: &StorageConnection,
     InsertInboundShipmentServiceLine {
         id,
         invoice_id,
@@ -15,8 +16,9 @@ pub fn generate(
         note,
     }: InsertInboundShipmentServiceLine,
     item: ItemRow,
-    currency_rate: Option<f64>,
-) -> Result<InvoiceLineRow, InsertInboundShipmentServiceLineError> {
+    currency_id: Option<String>,
+    currency_rate: &f64,
+) -> Result<InvoiceLineRow, RepositoryError> {
     Ok(InvoiceLineRow {
         id,
         invoice_id,
@@ -29,9 +31,11 @@ pub fn generate(
         item_name: name.unwrap_or(item.name),
         r#type: InvoiceLineRowType::Service,
         foreign_currency_price_before_tax: calculate_foreign_currency_total(
+            connection,
             total_before_tax,
+            currency_id,
             currency_rate,
-        ),
+        )?,
         // Default
         stock_line_id: None,
         location_id: None,

--- a/server/service/src/invoice_line/inbound_shipment_service_line/insert/mod.rs
+++ b/server/service/src/invoice_line/inbound_shipment_service_line/insert/mod.rs
@@ -28,7 +28,13 @@ pub fn insert_inbound_shipment_service_line(
         .connection
         .transaction_sync(|connection| {
             let (item_row, invoice_row) = validate(&input, &ctx.store_id, &connection)?;
-            let new_line = generate(input, item_row, invoice_row.currency_rate)?;
+            let new_line = generate(
+                connection,
+                input,
+                item_row,
+                invoice_row.currency_id,
+                &invoice_row.currency_rate,
+            )?;
             InvoiceLineRowRepository::new(&connection).upsert_one(&new_line)?;
             get_invoice_line(ctx, &new_line.id)
                 .map_err(|error| OutError::DatabaseError(error))?

--- a/server/service/src/invoice_line/inbound_shipment_service_line/update/mod.rs
+++ b/server/service/src/invoice_line/inbound_shipment_service_line/update/mod.rs
@@ -27,7 +27,14 @@ pub fn update_inbound_shipment_service_line(
         .connection
         .transaction_sync(|connection| {
             let (existing_line, invoice_row, item) = validate(&input, &ctx.store_id, &connection)?;
-            let updated_line = generate(input, existing_line, item, invoice_row.currency_rate)?;
+            let updated_line = generate(
+                &connection,
+                input,
+                existing_line,
+                item,
+                invoice_row.currency_id,
+                &invoice_row.currency_rate,
+            )?;
             InvoiceLineRowRepository::new(&connection).upsert_one(&updated_line)?;
 
             get_invoice_line(ctx, &updated_line.id)

--- a/server/service/src/invoice_line/outbound_shipment_service_line/insert/generate.rs
+++ b/server/service/src/invoice_line/outbound_shipment_service_line/insert/generate.rs
@@ -1,10 +1,11 @@
-use repository::{InvoiceLineRow, InvoiceLineRowType, ItemRow};
+use repository::{InvoiceLineRow, InvoiceLineRowType, ItemRow, StorageConnection};
 
 use crate::invoice::common::{calculate_foreign_currency_total, calculate_total_after_tax};
 
 use super::{InsertOutboundShipmentServiceLine, InsertOutboundShipmentServiceLineError};
 
 pub fn generate(
+    connection: &StorageConnection,
     InsertOutboundShipmentServiceLine {
         id,
         invoice_id,
@@ -15,7 +16,8 @@ pub fn generate(
         note,
     }: InsertOutboundShipmentServiceLine,
     item: ItemRow,
-    currency_rate: Option<f64>,
+    currency_id: Option<String>,
+    currency_rate: &f64,
 ) -> Result<InvoiceLineRow, InsertOutboundShipmentServiceLineError> {
     Ok(InvoiceLineRow {
         id,
@@ -29,9 +31,11 @@ pub fn generate(
         item_name: name.unwrap_or(item.name),
         r#type: InvoiceLineRowType::Service,
         foreign_currency_price_before_tax: calculate_foreign_currency_total(
+            connection,
             total_before_tax,
+            currency_id,
             currency_rate,
-        ),
+        )?,
         // Default
         stock_line_id: None,
         location_id: None,

--- a/server/service/src/invoice_line/outbound_shipment_service_line/insert/mod.rs
+++ b/server/service/src/invoice_line/outbound_shipment_service_line/insert/mod.rs
@@ -28,7 +28,13 @@ pub fn insert_outbound_shipment_service_line(
         .connection
         .transaction_sync(|connection| {
             let (item_row, invoice_row) = validate(&input, &ctx.store_id, &connection)?;
-            let new_line = generate(input, item_row, invoice_row.currency_rate)?;
+            let new_line = generate(
+                connection,
+                input,
+                item_row,
+                invoice_row.currency_id,
+                &invoice_row.currency_rate,
+            )?;
             InvoiceLineRowRepository::new(&connection).upsert_one(&new_line)?;
             get_invoice_line(ctx, &new_line.id)
                 .map_err(|error| OutError::DatabaseError(error))?

--- a/server/service/src/invoice_line/outbound_shipment_service_line/update/generate.rs
+++ b/server/service/src/invoice_line/outbound_shipment_service_line/update/generate.rs
@@ -1,10 +1,11 @@
-use repository::{InvoiceLine, InvoiceLineRow, ItemRow};
+use repository::{InvoiceLine, InvoiceLineRow, ItemRow, StorageConnection};
 
 use crate::invoice::common::{calculate_foreign_currency_total, calculate_total_after_tax};
 
 use super::{UpdateOutboundShipmentServiceLine, UpdateOutboundShipmentServiceLineError};
 
 pub fn generate(
+    connection: &StorageConnection,
     UpdateOutboundShipmentServiceLine {
         id: _,
         item_id: input_item_id,
@@ -20,7 +21,8 @@ pub fn generate(
         code: item_code,
         ..
     }: ItemRow,
-    currency_rate: Option<f64>,
+    currency_id: Option<String>,
+    currency_rate: &f64,
 ) -> Result<InvoiceLineRow, UpdateOutboundShipmentServiceLineError> {
     // 1) Use name from input (if specified)
     // 2) else: if item has been updated use name from the updated item name
@@ -59,22 +61,36 @@ pub fn generate(
     update_line.total_after_tax =
         calculate_total_after_tax(update_line.total_before_tax, update_line.tax);
 
-    update_line.foreign_currency_price_before_tax =
-        calculate_foreign_currency_total(update_line.total_before_tax, currency_rate);
+    update_line.foreign_currency_price_before_tax = calculate_foreign_currency_total(
+        connection,
+        update_line.total_before_tax,
+        currency_id,
+        currency_rate,
+    )?;
 
     Ok(update_line)
 }
 
 #[cfg(test)]
 mod outbound_shipment_service_line_update_test {
-    use repository::mock::{
-        mock_items, mock_outbound_shipment_a, mock_outbound_shipment_invoice_lines,
+    use repository::{
+        mock::{
+            mock_items, mock_outbound_shipment_a, mock_outbound_shipment_invoice_lines,
+            MockDataInserts,
+        },
+        test_db::setup_all,
     };
 
     use super::*;
 
-    #[test]
-    fn test_name_update() {
+    #[actix_rt::test]
+    async fn test_name_update() {
+        let (_, connection, _, _) = setup_all(
+            "test_outbound_shipment_service_line_generation",
+            MockDataInserts::none().currencies(),
+        )
+        .await;
+
         let items = mock_items();
         let item1 = items.get(0).unwrap().clone();
         let item2 = items.get(1).unwrap().clone();
@@ -94,6 +110,7 @@ mod outbound_shipment_service_line_update_test {
 
         // no name change
         let result = generate(
+            &connection,
             UpdateOutboundShipmentServiceLine {
                 id: "".to_string(),
                 item_id: None,
@@ -104,13 +121,15 @@ mod outbound_shipment_service_line_update_test {
             },
             line.clone(),
             item1.clone(),
-            None,
+            Some("currency_a".to_string()),
+            &1.0,
         )
         .unwrap();
         assert_eq!(result.item_name, item1.name);
 
         // change name in input
         let result = generate(
+            &connection,
             UpdateOutboundShipmentServiceLine {
                 id: "".to_string(),
                 item_id: None,
@@ -121,13 +140,15 @@ mod outbound_shipment_service_line_update_test {
             },
             line.clone(),
             item1,
-            None,
+            Some("currency_a".to_string()),
+            &1.0,
         )
         .unwrap();
         assert_eq!(result.item_name, "input name");
 
         // change item id to item2 but still specify input name
         let result = generate(
+            &connection,
             UpdateOutboundShipmentServiceLine {
                 id: "".to_string(),
                 item_id: Some(item2.id.to_owned()),
@@ -138,13 +159,15 @@ mod outbound_shipment_service_line_update_test {
             },
             line.clone(),
             item2.clone(),
-            None,
+            Some("currency_a".to_string()),
+            &1.0,
         )
         .unwrap();
         assert_eq!(result.item_name, "input name 2");
 
         // change item id to item2 and no name in the input
         let result = generate(
+            &connection,
             UpdateOutboundShipmentServiceLine {
                 id: "".to_string(),
                 item_id: Some(item2.id.to_owned()),
@@ -155,7 +178,8 @@ mod outbound_shipment_service_line_update_test {
             },
             line.clone(),
             item2.clone(),
-            None,
+            Some("currency_a".to_string()),
+            &1.0,
         )
         .unwrap();
         assert_eq!(result.item_name, item2.name);

--- a/server/service/src/invoice_line/outbound_shipment_service_line/update/mod.rs
+++ b/server/service/src/invoice_line/outbound_shipment_service_line/update/mod.rs
@@ -30,7 +30,14 @@ pub fn update_outbound_shipment_service_line(
         .connection
         .transaction_sync(|connection| {
             let (existing_line, invoice_row, item) = validate(&input, &ctx.store_id, &connection)?;
-            let updated_line = generate(input, existing_line, item, invoice_row.currency_rate)?;
+            let updated_line = generate(
+                &connection,
+                input,
+                existing_line,
+                item,
+                invoice_row.currency_id,
+                &invoice_row.currency_rate,
+            )?;
             InvoiceLineRowRepository::new(&connection).upsert_one(&updated_line)?;
 
             get_invoice_line(ctx, &updated_line.id)

--- a/server/service/src/invoice_line/outbound_shipment_unallocated_line/allocate/test.rs
+++ b/server/service/src/invoice_line/outbound_shipment_unallocated_line/allocate/test.rs
@@ -104,7 +104,12 @@ mod test {
 
         let (_, connection, connection_manager, _) = setup_all_with_data(
             "allocate_unallocated_line_basic_success",
-            MockDataInserts::none().stores().items().names().units(),
+            MockDataInserts::none()
+                .stores()
+                .items()
+                .names()
+                .units()
+                .currencies(),
             inline_init(|r: &mut MockData| {
                 r.invoices = vec![invoice()];
                 r.invoice_lines = vec![line()];
@@ -205,7 +210,12 @@ mod test {
 
         let (_, connection, connection_manager, _) = setup_all_with_data(
             "allocate_unallocated_line_partial_allocate_and_fefo",
-            MockDataInserts::none().stores().items().names().units(),
+            MockDataInserts::none()
+                .stores()
+                .items()
+                .names()
+                .units()
+                .currencies(),
             inline_init(|r: &mut MockData| {
                 r.invoices = vec![invoice()];
                 r.invoice_lines = vec![line()];
@@ -357,7 +367,12 @@ mod test {
 
         let (_, _, connection_manager, _) = setup_all_with_data(
             "allocate_unallocated_line_partial_allocate",
-            MockDataInserts::none().stores().items().names().units(),
+            MockDataInserts::none()
+                .stores()
+                .items()
+                .names()
+                .units()
+                .currencies(),
             inline_init(|r: &mut MockData| {
                 r.invoices = vec![invoice()];
                 r.invoice_lines = vec![line()];
@@ -510,7 +525,12 @@ mod test {
 
         let (_, _, connection_manager, _) = setup_all_with_data(
             "allocate_unallocated_line_add_to_existing_lines",
-            MockDataInserts::none().stores().items().names().units(),
+            MockDataInserts::none()
+                .stores()
+                .items()
+                .names()
+                .units()
+                .currencies(),
             inline_init(|r: &mut MockData| {
                 r.invoices = vec![invoice()];
                 r.invoice_lines = vec![line(), allocated_line(), allocated_line2()];
@@ -597,7 +617,12 @@ mod test {
 
         let (_, connection, connection_manager, _) = setup_all_with_data(
             "allocate_unallocated_line_round_up",
-            MockDataInserts::none().stores().items().names().units(),
+            MockDataInserts::none()
+                .stores()
+                .items()
+                .names()
+                .units()
+                .currencies(),
             inline_init(|r: &mut MockData| {
                 r.invoices = vec![invoice()];
                 r.invoice_lines = vec![line()];

--- a/server/service/src/invoice_line/stock_out_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_out_line/insert/mod.rs
@@ -70,7 +70,7 @@ pub fn insert_stock_out_line(
         .connection
         .transaction_sync(|connection| {
             let (item, invoice, batch) = validate(&input, &ctx.store_id, &connection)?;
-            let (new_line, update_batch) = generate(input, item, batch, invoice)?;
+            let (new_line, update_batch) = generate(connection, input, item, batch, invoice)?;
             InvoiceLineRowRepository::new(&connection).upsert_one(&new_line)?;
             StockLineRowRepository::new(&connection).upsert_one(&update_batch)?;
             get_invoice_line(ctx, &new_line.id)

--- a/server/service/src/processors/transfer/shipment/test.rs
+++ b/server/service/src/processors/transfer/shipment/test.rs
@@ -69,7 +69,12 @@ async fn invoice_transfers() {
         ..
     } = setup_all_with_data_and_service_provider(
         "invoice_transfers",
-        MockDataInserts::none().stores().names().items().units(),
+        MockDataInserts::none()
+            .stores()
+            .names()
+            .items()
+            .units()
+            .currencies(),
         inline_init(|r: &mut MockData| {
             r.names = vec![inbound_store_name.clone(), outbound_store_name.clone()];
             r.stores = vec![inbound_store.clone(), outbound_store.clone()];
@@ -219,7 +224,12 @@ async fn invoice_transfers_with_merged_name() {
         ..
     } = setup_all_with_data_and_service_provider(
         "invoice_transfers_with_merged_name",
-        MockDataInserts::none().stores().names().items().units(),
+        MockDataInserts::none()
+            .stores()
+            .names()
+            .items()
+            .units()
+            .currencies(),
         inline_init(|r: &mut MockData| {
             r.names = vec![
                 inbound_store_name.clone(),

--- a/server/service/src/requisition/response_requisition/create_requisition_shipment/generate.rs
+++ b/server/service/src/requisition/response_requisition/create_requisition_shipment/generate.rs
@@ -5,8 +5,9 @@ use crate::{
 };
 use chrono::Utc;
 use repository::{
-    InvoiceLineRow, InvoiceLineRowType, InvoiceRow, InvoiceRowStatus, InvoiceRowType,
-    ItemRowRepository, NumberRowType, Requisition, StorageConnection,
+    CurrencyFilter, CurrencyRepository, InvoiceLineRow, InvoiceLineRowType, InvoiceRow,
+    InvoiceRowStatus, InvoiceRowType, ItemRowRepository, NumberRowType, Requisition,
+    StorageConnection,
 };
 use util::uuid::uuid;
 
@@ -20,6 +21,13 @@ pub fn generate(
     let other_party = get_other_party(connection, store_id, &requisition.name_row.id)?
         .ok_or(OutError::ProblemGettingOtherParty)?;
     let requisition_row = requisition.requisition_row;
+    let currency = CurrencyRepository::new(connection)
+        .query_by_filter(CurrencyFilter::new().is_home_currency(true))?
+        .pop()
+        .ok_or(OutError::DatabaseError(
+            repository::RepositoryError::NotFound,
+        ))?;
+
     let new_invoice = InvoiceRow {
         id: uuid(),
         user_id: Some(user_id.to_string()),
@@ -33,6 +41,8 @@ pub fn generate(
         requisition_id: Some(requisition_row.id),
 
         // Default
+        currency_id: Some(currency.currency_row.id),
+        currency_rate: 1.0,
         on_hold: false,
         comment: None,
         their_reference: None,
@@ -45,8 +55,6 @@ pub fn generate(
         colour: None,
         linked_invoice_id: None,
         tax: None,
-        currency_id: None,
-        currency_rate: None,
         clinician_link_id: None,
     };
 

--- a/server/service/src/stocktake/update.rs
+++ b/server/service/src/stocktake/update.rs
@@ -1,14 +1,14 @@
 use chrono::{NaiveDate, Utc};
 use repository::{
     location_movement::{LocationMovementFilter, LocationMovementRepository},
-    ActivityLogType, DatetimeFilter, EqualFilter, InvoiceLineRow, InvoiceLineRowRepository,
-    InvoiceLineRowType, InvoiceRow, InvoiceRowRepository, InvoiceRowStatus, InvoiceRowType,
-    ItemLinkRowRepository, ItemRowRepository, LocationMovementRow, LocationMovementRowRepository,
-    NameLinkRowRepository, NameRowRepository, NumberRowType, RepositoryError, StockLine,
-    StockLineFilter, StockLineRepository, StockLineRow, StockLineRowRepository, Stocktake,
-    StocktakeLine, StocktakeLineFilter, StocktakeLineRepository, StocktakeLineRow,
-    StocktakeLineRowRepository, StocktakeRow, StocktakeRowRepository, StocktakeStatus,
-    StorageConnection,
+    ActivityLogType, CurrencyFilter, CurrencyRepository, DatetimeFilter, EqualFilter,
+    InvoiceLineRow, InvoiceLineRowRepository, InvoiceLineRowType, InvoiceRow, InvoiceRowRepository,
+    InvoiceRowStatus, InvoiceRowType, ItemLinkRowRepository, ItemRowRepository,
+    LocationMovementRow, LocationMovementRowRepository, NameLinkRowRepository, NameRowRepository,
+    NumberRowType, RepositoryError, StockLine, StockLineFilter, StockLineRepository, StockLineRow,
+    StockLineRowRepository, Stocktake, StocktakeLine, StocktakeLineFilter, StocktakeLineRepository,
+    StocktakeLineRow, StocktakeLineRowRepository, StocktakeRow, StocktakeRowRepository,
+    StocktakeStatus, StorageConnection,
 };
 use util::{constants::INVENTORY_ADJUSTMENT_NAME_CODE, inline_edit, uuid::uuid};
 
@@ -538,6 +538,12 @@ fn generate(
         user_id,
         ..
     } = ctx;
+    let currency = CurrencyRepository::new(connection)
+        .query_by_filter(CurrencyFilter::new().is_home_currency(true))?
+        .pop()
+        .ok_or(UpdateStocktakeError::DatabaseError(
+            RepositoryError::NotFound,
+        ))?;
 
     let stocktake = inline_edit(&existing, |mut u: StocktakeRow| {
         u.description = input_description.or(u.description);
@@ -627,6 +633,8 @@ fn generate(
         status: InvoiceRowStatus::Verified,
         verified_datetime: Some(now),
         // Default
+        currency_id: Some(currency.currency_row.id),
+        currency_rate: 1.0,
         name_store_id: None,
         transport_reference: None,
         on_hold: false,
@@ -641,8 +649,6 @@ fn generate(
         requisition_id: None,
         linked_invoice_id: None,
         tax: None,
-        currency_id: None,
-        currency_rate: None,
         clinician_link_id: None,
     };
 

--- a/server/service/src/sync/test/test_data/invoice.rs
+++ b/server/service/src/sync/test/test_data/invoice.rs
@@ -133,7 +133,7 @@ fn transact_1_pull_record() -> TestSyncPullRecord {
             linked_invoice_id: None,
             tax: Some(0.0),
             currency_id: Some("NEW_ZEALAND_DOLLARS".to_string()),
-            currency_rate: Some(1.32),
+            currency_rate: 1.32,
             clinician_link_id: None,
         }),
     )
@@ -186,7 +186,7 @@ fn transact_1_push_record() -> TestSyncPushRecord {
             tax: Some(0.0),
             clinician_id: None,
             currency_id: Some("NEW_ZEALAND_DOLLARS".to_string()),
-            currency_rate: Some(1.32)
+            currency_rate: 1.32
         }),
     }
 }
@@ -300,7 +300,7 @@ fn transact_2_pull_record() -> TestSyncPullRecord {
             linked_invoice_id: None,
             tax: Some(0.0),
             currency_id: Some("AUSTRALIAN_DOLLARS".to_string()),
-            currency_rate: Some(1.0),
+            currency_rate: 1.0,
             clinician_link_id: None,
         }),
     )
@@ -348,7 +348,7 @@ fn transact_2_push_record() -> TestSyncPushRecord {
             tax: Some(0.0),
             clinician_id: None,
             currency_id: Some("AUSTRALIAN_DOLLARS".to_string()),
-            currency_rate: Some(1.0),
+            currency_rate: 1.0,
         }),
     }
 }
@@ -496,7 +496,7 @@ fn transact_om_fields_pull_record() -> TestSyncPullRecord {
             linked_invoice_id: None,
             tax: Some(0.0),
             currency_id: None,
-            currency_rate: Some(1.0),
+            currency_rate: 1.0,
             clinician_link_id: None,
         }),
     )
@@ -569,7 +569,7 @@ fn transact_om_fields_push_record() -> TestSyncPushRecord {
             tax: Some(0.0),
             clinician_id: None,
             currency_id: None,
-            currency_rate: Some(1.0),
+            currency_rate: 1.0,
         }),
     }
 }
@@ -699,7 +699,7 @@ fn inventory_addition_pull_record() -> TestSyncPullRecord {
             linked_invoice_id: None,
             colour: None,
             currency_id: None,
-            currency_rate: Some(1.0),
+            currency_rate: 1.0,
             clinician_link_id: None,
         }),
     )
@@ -753,7 +753,7 @@ fn inventory_addition_push_record() -> TestSyncPushRecord {
             linked_transaction_id: None,
             clinician_id: None,
             currency_id: None,
-            currency_rate: Some(1.0)
+            currency_rate: 1.0
         }),
     }
 }
@@ -883,7 +883,7 @@ fn inventory_reduction_pull_record() -> TestSyncPullRecord {
             linked_invoice_id: None,
             colour: None,
             currency_id: None,
-            currency_rate: Some(1.0),
+            currency_rate: 1.0,
             clinician_link_id: None,
         }),
     )
@@ -937,7 +937,7 @@ fn inventory_reduction_push_record() -> TestSyncPushRecord {
             linked_transaction_id: None,
             clinician_id: None,
             currency_id: None,
-            currency_rate: Some(1.0),
+            currency_rate: 1.0,
         }),
     }
 }
@@ -1063,7 +1063,7 @@ fn prescription_1_pull_record() -> TestSyncPullRecord {
             linked_invoice_id: None,
             tax: Some(0.0),
             currency_id: None,
-            currency_rate: Some(1.0),
+            currency_rate: 1.0,
             clinician_link_id: None,
         }),
     )
@@ -1116,7 +1116,7 @@ fn prescription_1_push_record() -> TestSyncPushRecord {
             tax: Some(0.0),
             clinician_id: None,
             currency_id: None,
-            currency_rate: Some(1.0),
+            currency_rate: 1.0,
         }),
     }
 }

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -105,7 +105,7 @@ pub struct LegacyTransactRow {
     #[serde(rename = "currency_ID")]
     #[serde(deserialize_with = "empty_str_as_option_string")]
     pub currency_id: Option<String>,
-    pub currency_rate: Option<f64>,
+    pub currency_rate: f64,
 
     #[serde(default)]
     #[serde(rename = "om_transport_reference")]

--- a/server/service/src/sync/translations/invoice_line.rs
+++ b/server/service/src/sync/translations/invoice_line.rs
@@ -99,6 +99,7 @@ impl SyncTranslation for InvoiceLineTranslation {
                 LegacyTableName::ITEM_LINE,
                 LegacyTableName::LOCATION,
                 LegacyTableName::INVENTORY_ADJUSTMENT_REASON,
+                LegacyTableName::CURRENCY,
             ],
         }
     }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3134

# 👩🏻‍💻 What does this PR do? 
- Have kept `currency_id` as optional in invoice since creating a trigger/inserting mock data wasn't getting the home currency from the `currency` table to set the `currency_id` as home currency by default... 
This PR saves the home currency id on invoices during insert and/or update. 

# 🧪 How has/should this change been tested? 
- [ ] Run test
- [ ] Or manually create an invoice and check if the currency id is home currency id