### PR TITLE
3055 & 3030 cold chain display

### DIFF
--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureBreach/TemperatureBreachList.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureBreach/TemperatureBreachList.tsx
@@ -6,7 +6,6 @@ import {
   DataTable,
   Formatter,
   NothingHere,
-  NumUtils,
   TableProvider,
   createTableStore,
   useColumns,
@@ -134,9 +133,7 @@ const ListView: FC = () => {
         width: 125,
         accessor: ({ rowData }) => {
           return !!rowData.maxOrMinTemperature
-            ? `${formatTemperature(
-                NumUtils.round(rowData.maxOrMinTemperature, 2)
-              )}`
+            ? `${formatTemperature(rowData.maxOrMinTemperature)}`
             : null;
         },
         sortable: false,

--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureBreach/TemperatureBreachList.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureBreach/TemperatureBreachList.tsx
@@ -6,6 +6,7 @@ import {
   DataTable,
   Formatter,
   NothingHere,
+  NumUtils,
   TableProvider,
   createTableStore,
   useColumns,
@@ -18,6 +19,7 @@ import { BreachTypeCell } from '../../../common';
 import { Toolbar } from './Toolbar';
 import { useAcknowledgeBreachModal } from './useAcknowledgeBreachModal';
 import { DurationCell, IconCell } from './TempereatureBreachCells';
+import { useFormatTemperature } from '../../../common/utils';
 
 const ListView: FC = () => {
   const {
@@ -58,6 +60,7 @@ const ListView: FC = () => {
 
   const pagination = { page, first, offset };
   const t = useTranslation('coldchain');
+  const formatTemperature = useFormatTemperature;
 
   const columns = useColumns<TemperatureBreachFragment>(
     [
@@ -131,7 +134,9 @@ const ListView: FC = () => {
         width: 125,
         accessor: ({ rowData }) => {
           return !!rowData.maxOrMinTemperature
-            ? `${rowData.maxOrMinTemperature} ${t('label.temperature-unit')}`
+            ? `${formatTemperature(
+                NumUtils.round(rowData.maxOrMinTemperature, 2)
+              )}`
             : null;
         },
         sortable: false,

--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/TemperatureChart.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/TemperatureChart.tsx
@@ -10,7 +10,6 @@ import {
   Legend,
   Line,
   NothingHere,
-  NumUtils,
   ResponsiveContainer,
   TooltipProps,
   Typography,
@@ -55,7 +54,7 @@ const Chart = ({
   const formatTemp = useFormatTemperature;
 
   const formatTemperature = (value: number | null) =>
-    !!value ? `${formatTemp(NumUtils.round(value, 2))}` : '-';
+    !!value ? `${formatTemp(value)}` : '-';
 
   const TemperatureTooltip = ({
     active,

--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/TemperatureChart.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/TemperatureChart.tsx
@@ -55,7 +55,7 @@ const Chart = ({
   const formatTemp = useFormatTemperature;
 
   const formatTemperature = (value: number | null) =>
-    value ? `${formatTemp(NumUtils.round(value, 2))}` : '-';
+    !!value ? `${formatTemp(NumUtils.round(value, 2))}` : '-';
 
   const TemperatureTooltip = ({
     active,

--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/TemperatureChart.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/TemperatureChart.tsx
@@ -25,6 +25,7 @@ import { BreachPopover } from './BreachPopover';
 import { BreachConfig, BreachDot, DotProps, Sensor } from './types';
 import { BreachIndicator } from './BreachIndicator';
 import { Toolbar } from '../TemperatureLog/Toolbar';
+import { useFormatTemperature } from '../../../common';
 
 const NUMBER_OF_HORIZONTAL_LINES = 4;
 const LOWER_THRESHOLD = 2;
@@ -51,11 +52,10 @@ const Chart = ({
     null
   );
   const { urlQuery, updateQuery } = useUrlQuery();
+  const formatTemp = useFormatTemperature;
 
   const formatTemperature = (value: number | null) =>
-    value === null
-      ? '-'
-      : `${NumUtils.round(value, 2)} ${t('label.temperature-unit')}`;
+    value ? `${formatTemp(NumUtils.round(value, 2))}` : '-';
 
   const TemperatureTooltip = ({
     active,

--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureLog/TemperatureLogList.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureLog/TemperatureLogList.tsx
@@ -14,7 +14,7 @@ import {
   createTableStore,
   useColumns,
 } from '@openmsupply-client/common';
-import { BreachTypeCell } from '../../../common';
+import { BreachTypeCell, useFormatTemperature } from '../../../common';
 import { Toolbar } from './Toolbar';
 
 const temperatureLogFilterAndSort = {
@@ -52,6 +52,7 @@ const ListView: FC = () => {
     useTemperatureLog.document.list(queryParams);
   const pagination = { page, first, offset };
   const t = useTranslation('coldchain');
+  const formatTemperature = useFormatTemperature;
 
   const columns = useColumns<TemperatureLogFragment>(
     [
@@ -83,9 +84,7 @@ const ListView: FC = () => {
         key: 'temperature',
         label: 'label.temperature',
         accessor: ({ rowData }) => {
-          return `${NumUtils.round(rowData.temperature, 2)} ${t(
-            'label.temperature-unit'
-          )}`;
+          return `${formatTemperature(NumUtils.round(rowData.temperature, 2))}`;
         },
       },
       {

--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureLog/TemperatureLogList.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureLog/TemperatureLogList.tsx
@@ -9,7 +9,6 @@ import {
   DataTable,
   Formatter,
   NothingHere,
-  NumUtils,
   TableProvider,
   createTableStore,
   useColumns,
@@ -84,7 +83,7 @@ const ListView: FC = () => {
         key: 'temperature',
         label: 'label.temperature',
         accessor: ({ rowData }) => {
-          return `${formatTemperature(NumUtils.round(rowData.temperature, 2))}`;
+          return `${formatTemperature(rowData.temperature)}`;
         },
       },
       {

--- a/client/packages/coldchain/src/Sensor/Components/SensorLineForm.tsx
+++ b/client/packages/coldchain/src/Sensor/Components/SensorLineForm.tsx
@@ -7,9 +7,11 @@ import {
   Formatter,
   TextWithLabelRow,
   SensorNodeType,
+  NumUtils,
 } from '@openmsupply-client/common';
 import { UseDraftSensorControl } from './SensorEditModal';
 import { isSensorNameEditDisabled } from '../utils';
+import { useFormatTemperature } from '../../common';
 
 export const SensorLineForm: FC<UseDraftSensorControl> = ({
   draft,
@@ -19,6 +21,7 @@ export const SensorLineForm: FC<UseDraftSensorControl> = ({
   const textSx = { paddingLeft: 2 };
   const labelWrap = { sx: { whiteSpace: 'pre-wrap' } };
   const inputTextAlign = { sx: { textAlign: 'end' } };
+  const formatTemperature = useFormatTemperature;
 
   return (
     <Box display="flex" flexDirection="column" gap={2}>
@@ -58,14 +61,21 @@ export const SensorLineForm: FC<UseDraftSensorControl> = ({
       <TextWithLabelRow
         sx={textSx}
         label={t('label.battery-level')}
-        text={`${draft.batteryLevel?.toString()}%` ?? ''}
+        text={draft.batteryLevel ? `${draft.batteryLevel}%` : '-'}
       />
       <TextWithLabelRow
         sx={textSx}
         labelProps={labelWrap}
         label={t('label.last-reading')}
         text={
-          draft.latestTemperatureLog?.nodes[0]?.temperature.toString() ?? ''
+          draft.latestTemperatureLog?.nodes[0]?.temperature
+            ? `${formatTemperature(
+                NumUtils.round(
+                  draft.latestTemperatureLog?.nodes[0]?.temperature,
+                  2
+                )
+              )}`
+            : '-'
         }
       />
       <TextWithLabelRow

--- a/client/packages/coldchain/src/Sensor/Components/SensorLineForm.tsx
+++ b/client/packages/coldchain/src/Sensor/Components/SensorLineForm.tsx
@@ -68,7 +68,7 @@ export const SensorLineForm: FC<UseDraftSensorControl> = ({
         labelProps={labelWrap}
         label={t('label.last-reading')}
         text={
-          draft.latestTemperatureLog?.nodes[0]?.temperature
+          !!draft.latestTemperatureLog?.nodes[0]?.temperature
             ? `${formatTemperature(
                 NumUtils.round(
                   draft.latestTemperatureLog?.nodes[0]?.temperature,

--- a/client/packages/coldchain/src/Sensor/Components/SensorLineForm.tsx
+++ b/client/packages/coldchain/src/Sensor/Components/SensorLineForm.tsx
@@ -7,7 +7,6 @@ import {
   Formatter,
   TextWithLabelRow,
   SensorNodeType,
-  NumUtils,
 } from '@openmsupply-client/common';
 import { UseDraftSensorControl } from './SensorEditModal';
 import { isSensorNameEditDisabled } from '../utils';
@@ -70,10 +69,7 @@ export const SensorLineForm: FC<UseDraftSensorControl> = ({
         text={
           !!draft.latestTemperatureLog?.nodes[0]?.temperature
             ? `${formatTemperature(
-                NumUtils.round(
-                  draft.latestTemperatureLog?.nodes[0]?.temperature,
-                  2
-                )
+                draft.latestTemperatureLog?.nodes[0]?.temperature
               )}`
             : '-'
         }

--- a/client/packages/coldchain/src/Sensor/ListView/ListView.tsx
+++ b/client/packages/coldchain/src/Sensor/ListView/ListView.tsx
@@ -64,7 +64,7 @@ export const SensorListView: FC = () => {
         key: 'lastReading',
         label: 'label.last-reading',
         accessor: ({ rowData }) => {
-          return rowData.latestTemperatureLog?.nodes[0]?.temperature
+          return !!rowData.latestTemperatureLog?.nodes[0]?.temperature
             ? `${formatTemperature(
                 NumUtils.round(
                   rowData.latestTemperatureLog?.nodes[0]?.temperature,

--- a/client/packages/coldchain/src/Sensor/ListView/ListView.tsx
+++ b/client/packages/coldchain/src/Sensor/ListView/ListView.tsx
@@ -11,10 +11,11 @@ import {
   useEditModal,
   useUrlQuery,
   SensorNodeType,
+  NumUtils,
 } from '@openmsupply-client/common';
 import { useSensor, SensorFragment } from '../api';
 import { SensorEditModal } from '../Components';
-import { BreachTypeCell } from '../../common';
+import { BreachTypeCell, useFormatTemperature } from '../../common';
 
 export const SensorListView: FC = () => {
   const {
@@ -28,6 +29,7 @@ export const SensorListView: FC = () => {
   const pagination = { page, first, offset };
   const t = useTranslation('coldchain');
   const { urlQuery, updateQuery } = useUrlQuery();
+  const formatTemperature = useFormatTemperature;
 
   const columns = useColumns<SensorFragment>(
     [
@@ -54,9 +56,7 @@ export const SensorListView: FC = () => {
         accessor: ({ rowData }) => {
           const batteryLevel = rowData.batteryLevel;
 
-          return batteryLevel
-            ? `${batteryLevel}%`
-            : t('messages.not-initialised');
+          return batteryLevel ? `${batteryLevel}%` : '-';
         },
         sortable: false,
       },
@@ -64,9 +64,14 @@ export const SensorListView: FC = () => {
         key: 'lastReading',
         label: 'label.last-reading',
         accessor: ({ rowData }) => {
-          return `${rowData.latestTemperatureLog?.nodes[0]?.temperature}${t(
-            'label.temperature-unit'
-          )}`;
+          return rowData.latestTemperatureLog?.nodes[0]?.temperature
+            ? `${formatTemperature(
+                NumUtils.round(
+                  rowData.latestTemperatureLog?.nodes[0]?.temperature,
+                  2
+                )
+              )}`
+            : '-';
         },
         sortable: false,
       },

--- a/client/packages/coldchain/src/Sensor/ListView/ListView.tsx
+++ b/client/packages/coldchain/src/Sensor/ListView/ListView.tsx
@@ -11,7 +11,6 @@ import {
   useEditModal,
   useUrlQuery,
   SensorNodeType,
-  NumUtils,
 } from '@openmsupply-client/common';
 import { useSensor, SensorFragment } from '../api';
 import { SensorEditModal } from '../Components';
@@ -66,10 +65,7 @@ export const SensorListView: FC = () => {
         accessor: ({ rowData }) => {
           return !!rowData.latestTemperatureLog?.nodes[0]?.temperature
             ? `${formatTemperature(
-                NumUtils.round(
-                  rowData.latestTemperatureLog?.nodes[0]?.temperature,
-                  2
-                )
+                rowData.latestTemperatureLog?.nodes[0]?.temperature
               )}`
             : '-';
         },

--- a/client/packages/coldchain/src/common/utils.ts
+++ b/client/packages/coldchain/src/common/utils.ts
@@ -1,3 +1,4 @@
+import { useIntlUtils } from '@common/intl';
 import { TemperatureBreachNodeType } from '@common/types';
 
 export const parseBreachType = (
@@ -7,4 +8,13 @@ export const parseBreachType = (
   const type = breachType?.split('_')[1];
 
   return { temperature, type };
+};
+
+export const useFormatTemperature = (temperature: number) => {
+  const { currentLanguage: language } = useIntlUtils();
+  return new Intl.NumberFormat(language, {
+    style: 'unit',
+    unit: 'celsius',
+    unitDisplay: 'short',
+  }).format(temperature);
 };

--- a/client/packages/coldchain/src/common/utils.ts
+++ b/client/packages/coldchain/src/common/utils.ts
@@ -1,5 +1,6 @@
 import { useIntlUtils } from '@common/intl';
 import { TemperatureBreachNodeType } from '@common/types';
+import { NumUtils } from '@common/utils';
 
 export const parseBreachType = (
   breachType: TemperatureBreachNodeType | null
@@ -16,5 +17,5 @@ export const useFormatTemperature = (temperature: number) => {
     style: 'unit',
     unit: 'celsius',
     unitDisplay: 'short',
-  }).format(temperature);
+  }).format(NumUtils.round(temperature, 2));
 };

--- a/client/packages/common/src/intl/locales/en/coldchain.json
+++ b/client/packages/common/src/intl/locales/en/coldchain.json
@@ -28,7 +28,6 @@
   "label.last-record": "Last recording date / time",
   "label.last-recording-value": "Last temperature recording value",
   "label.rtmd": "mSupply RTMD",
-  "label.temperature-unit": "°C",
   "label.unacknowledged": "Unacknowledged",
   "message.acknowledge-breach-helptext": "Enter a comment and click OK to acknowledge the breach.",
   "message.breach-ongoing": "This breach is ongoing and cannot be acknowledged until it has ended.",


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3055 & #3030

# 👩🏻‍💻 What does this PR do? 
Updates the temperature formats to use `Intl.NumberFormat` and handle the undefined values that were being returned in sensor modal

# 🧪 How has/should this change been tested? 
- [ ] Check temperatures are still being formatted as `X°C`
- [ ] Go to a sensor without a battery level and see that it now says '-' instead of undefined%