### PR TITLE
Remove store_id from catalogue queries

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -30,6 +30,14 @@ export type Scalars = {
    * * `2000-02-24`
    */
   NaiveDate: { input: string; output: string; }
+  /**
+   * ISO 8601 combined date and time without timezone.
+   *
+   * # Examples
+   *
+   * * `2015-07-01T08:59:60.123`,
+   */
+  NaiveDateTime: { input: string; output: string; }
 };
 
 export type AccountBlocked = AuthTokenErrorInterface & {
@@ -229,14 +237,17 @@ export type AssetCatalogueItemFilterInput = {
   id?: InputMaybe<EqualFilterStringInput>;
   manufacturer?: InputMaybe<StringFilterInput>;
   model?: InputMaybe<StringFilterInput>;
-  type?: InputMaybe<EqualFilterStringInput>;
+  type?: InputMaybe<StringFilterInput>;
   typeId?: InputMaybe<EqualFilterStringInput>;
 };
 
 export type AssetCatalogueItemNode = {
   __typename: 'AssetCatalogueItemNode';
+  assetCategory?: Maybe<AssetCategoryNode>;
   assetCategoryId: Scalars['String']['output'];
+  assetClass?: Maybe<AssetClassNode>;
   assetClassId: Scalars['String']['output'];
+  assetType?: Maybe<AssetTypeNode>;
   assetTypeId: Scalars['String']['output'];
   code: Scalars['String']['output'];
   id: Scalars['String']['output'];
@@ -322,6 +333,59 @@ export type AssetClassSortInput = {
 
 export type AssetClassesResponse = AssetClassConnector;
 
+export type AssetConnector = {
+  __typename: 'AssetConnector';
+  nodes: Array<AssetNode>;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type AssetFilterInput = {
+  catalogueItemId?: InputMaybe<EqualFilterStringInput>;
+  categoryId?: InputMaybe<EqualFilterStringInput>;
+  classId?: InputMaybe<EqualFilterStringInput>;
+  code?: InputMaybe<StringFilterInput>;
+  id?: InputMaybe<EqualFilterStringInput>;
+  installationDate?: InputMaybe<DateFilterInput>;
+  name?: InputMaybe<StringFilterInput>;
+  replacementDate?: InputMaybe<DateFilterInput>;
+  serialNumber?: InputMaybe<StringFilterInput>;
+  typeId?: InputMaybe<EqualFilterStringInput>;
+};
+
+export type AssetNode = {
+  __typename: 'AssetNode';
+  catalogueItem?: Maybe<AssetCatalogueItemNode>;
+  catalogueItemId?: Maybe<Scalars['String']['output']>;
+  code: Scalars['String']['output'];
+  createdDatetime: Scalars['NaiveDateTime']['output'];
+  id: Scalars['String']['output'];
+  installationDate?: Maybe<Scalars['NaiveDate']['output']>;
+  modifiedDatetime: Scalars['NaiveDateTime']['output'];
+  name: Scalars['String']['output'];
+  replacementDate?: Maybe<Scalars['NaiveDate']['output']>;
+  serialNumber?: Maybe<Scalars['String']['output']>;
+  store?: Maybe<StoreNode>;
+  storeId?: Maybe<Scalars['String']['output']>;
+};
+
+export enum AssetSortFieldInput {
+  InstallationDate = 'installationDate',
+  ModifiedDatetime = 'modifiedDatetime',
+  Name = 'name',
+  ReplacementDate = 'replacementDate',
+  SerialNumber = 'serialNumber'
+}
+
+export type AssetSortInput = {
+  /**
+   * 	Sort query result is sorted descending or ascending (if not provided the default is
+   * ascending)
+   */
+  desc?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Sort query result by `key` */
+  key: AssetSortFieldInput;
+};
+
 export type AssetTypeConnector = {
   __typename: 'AssetTypeConnector';
   nodes: Array<AssetTypeNode>;
@@ -331,7 +395,7 @@ export type AssetTypeConnector = {
 export type AssetTypeFilterInput = {
   categoryId?: InputMaybe<EqualFilterStringInput>;
   id?: InputMaybe<EqualFilterStringInput>;
-  name?: InputMaybe<EqualFilterStringInput>;
+  name?: InputMaybe<StringFilterInput>;
 };
 
 export type AssetTypeNode = {
@@ -353,6 +417,8 @@ export type AssetTypeSortInput = {
 };
 
 export type AssetTypesResponse = AssetTypeConnector;
+
+export type AssetsResponse = AssetConnector;
 
 export type AuthToken = {
   __typename: 'AuthToken';
@@ -765,7 +831,7 @@ export type CreateRequisitionShipmentInput = {
 
 export type CreateRequisitionShipmentResponse = CreateRequisitionShipmentError | InvoiceNode;
 
-export type DatabaseError = DeleteLocationErrorInterface & InsertLocationErrorInterface & NodeErrorInterface & RefreshTokenErrorInterface & UpdateLocationErrorInterface & UpdateSensorErrorInterface & {
+export type DatabaseError = DeleteAssetErrorInterface & DeleteLocationErrorInterface & InsertAssetErrorInterface & InsertLocationErrorInterface & NodeErrorInterface & RefreshTokenErrorInterface & UpdateAssetErrorInterface & UpdateLocationErrorInterface & UpdateSensorErrorInterface & {
   __typename: 'DatabaseError';
   description: Scalars['String']['output'];
   fullError: Scalars['String']['output'];
@@ -792,6 +858,17 @@ export type DatetimeFilterInput = {
   beforeOrEqualTo?: InputMaybe<Scalars['DateTime']['input']>;
   equalTo?: InputMaybe<Scalars['DateTime']['input']>;
 };
+
+export type DeleteAssetError = {
+  __typename: 'DeleteAssetError';
+  error: DeleteAssetErrorInterface;
+};
+
+export type DeleteAssetErrorInterface = {
+  description: Scalars['String']['output'];
+};
+
+export type DeleteAssetResponse = DeleteAssetError | DeleteResponse;
 
 export type DeleteErrorInterface = {
   description: Scalars['String']['output'];
@@ -1565,6 +1642,28 @@ export enum InitialisationStatusType {
 
 export type InitialiseSiteResponse = SyncErrorNode | SyncSettingsNode;
 
+export type InsertAssetError = {
+  __typename: 'InsertAssetError';
+  error: InsertAssetErrorInterface;
+};
+
+export type InsertAssetErrorInterface = {
+  description: Scalars['String']['output'];
+};
+
+export type InsertAssetInput = {
+  catalogueItemId?: InputMaybe<Scalars['String']['input']>;
+  code: Scalars['String']['input'];
+  id: Scalars['String']['input'];
+  installationDate?: InputMaybe<Scalars['NaiveDate']['input']>;
+  name: Scalars['String']['input'];
+  replacementDate?: InputMaybe<Scalars['NaiveDate']['input']>;
+  serialNumber?: InputMaybe<Scalars['String']['input']>;
+  storeId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type InsertAssetResponse = AssetNode | InsertAssetError;
+
 export type InsertBarcodeInput = {
   gtin: Scalars['String']['input'];
   itemId: Scalars['String']['input'];
@@ -2070,7 +2169,7 @@ export type InsertStocktakeResponseWithId = {
   response: InsertStocktakeResponse;
 };
 
-export type InternalError = InsertLocationErrorInterface & RefreshTokenErrorInterface & UpdateLocationErrorInterface & UpdateSensorErrorInterface & {
+export type InternalError = InsertAssetErrorInterface & InsertLocationErrorInterface & RefreshTokenErrorInterface & UpdateAssetErrorInterface & UpdateLocationErrorInterface & UpdateSensorErrorInterface & {
   __typename: 'InternalError';
   description: Scalars['String']['output'];
   fullError: Scalars['String']['output'];
@@ -2666,6 +2765,7 @@ export type Mutations = {
    * lines quantity (placeholder and filled) for requisitionLine.item
    */
   createRequisitionShipment: CreateRequisitionShipmentResponse;
+  deleteAsset: DeleteAssetResponse;
   deleteInboundShipment: DeleteInboundShipmentResponse;
   deleteInboundShipmentLine: DeleteInboundShipmentLineResponse;
   deleteInboundShipmentServiceLine: DeleteInboundShipmentServiceLineResponse;
@@ -2681,6 +2781,7 @@ export type Mutations = {
   deleteStocktake: DeleteStocktakeResponse;
   deleteStocktakeLine: DeleteStocktakeLineResponse;
   initialiseSite: InitialiseSiteResponse;
+  insertAsset: InsertAssetResponse;
   insertBarcode: InsertBarcodeResponse;
   insertContactTrace: InsertContactTraceResponse;
   insertDocumentRegistry: InsertDocumentResponse;
@@ -2720,6 +2821,7 @@ export type Mutations = {
   manualSync: Scalars['String']['output'];
   /** Set supply quantity to requested quantity */
   supplyRequestedQuantity: SupplyRequestedQuantityResponse;
+  updateAsset: UpdateAssetResponse;
   updateContactTrace: UpdateContactTraceResponse;
   updateDisplaySettings: UpdateDisplaySettingsResponse;
   updateDocument: UpdateDocumentResponse;
@@ -2828,6 +2930,12 @@ export type MutationsCreateRequisitionShipmentArgs = {
 };
 
 
+export type MutationsDeleteAssetArgs = {
+  assetId: Scalars['String']['input'];
+  storeId: Scalars['String']['input'];
+};
+
+
 export type MutationsDeleteInboundShipmentArgs = {
   input: DeleteInboundShipmentInput;
   storeId: Scalars['String']['input'];
@@ -2914,6 +3022,12 @@ export type MutationsDeleteStocktakeLineArgs = {
 
 export type MutationsInitialiseSiteArgs = {
   input: SyncSettingsInput;
+};
+
+
+export type MutationsInsertAssetArgs = {
+  input: InsertAssetInput;
+  storeId: Scalars['String']['input'];
 };
 
 
@@ -3073,6 +3187,12 @@ export type MutationsLinkPatientToStoreArgs = {
 
 export type MutationsSupplyRequestedQuantityArgs = {
   input: SupplyRequestedQuantityInput;
+  storeId: Scalars['String']['input'];
+};
+
+
+export type MutationsUpdateAssetArgs = {
+  input: UpdateAssetInput;
   storeId: Scalars['String']['input'];
 };
 
@@ -3402,6 +3522,21 @@ export type NotEnoughStockForReduction = InsertOutboundShipmentLineErrorInterfac
 export type NothingRemainingToSupply = CreateRequisitionShipmentErrorInterface & {
   __typename: 'NothingRemainingToSupply';
   description: Scalars['String']['output'];
+};
+
+/**
+ * Update a nullable value
+ *
+ * This struct is usually used as an optional value.
+ * For example, in an API update input object like `mutableValue:  NullableUpdate | null | undefined`.
+ * This is done to encode the following cases (using `mutableValue` from previous example):
+ * 1) if `mutableValue` is `null | undefined`, nothing is updated
+ * 2) if `mutableValue` object is set:
+ * a) if `NullableUpdate.value` is `undefined | null`, the `mutableValue` is set to `null`
+ * b) if `NullableUpdate.value` is set, the `mutableValue` is set to the provided `NullableUpdate.value`
+ */
+export type NullableDateUpdate = {
+  value?: InputMaybe<Scalars['NaiveDate']['input']>;
 };
 
 /**
@@ -3856,6 +3991,8 @@ export type Queries = {
   assetClasses: AssetClassesResponse;
   assetType: AssetTypeResponse;
   assetTypes: AssetTypesResponse;
+  /** Query omSupply "assets" entries */
+  assets: AssetsResponse;
   /**
    * Retrieves a new auth bearer and refresh token
    * The refresh token is returned as a cookie
@@ -3973,7 +4110,6 @@ export type QueriesActivityLogsArgs = {
 
 export type QueriesAssetCatalogueItemArgs = {
   id: Scalars['String']['input'];
-  storeId: Scalars['String']['input'];
 };
 
 
@@ -3981,7 +4117,6 @@ export type QueriesAssetCatalogueItemsArgs = {
   filter?: InputMaybe<AssetCatalogueItemFilterInput>;
   page?: InputMaybe<PaginationInput>;
   sort?: InputMaybe<Array<AssetCatalogueItemSortInput>>;
-  storeId: Scalars['String']['input'];
 };
 
 
@@ -3989,19 +4124,16 @@ export type QueriesAssetCategoriesArgs = {
   filter?: InputMaybe<AssetCategoryFilterInput>;
   page?: InputMaybe<PaginationInput>;
   sort?: InputMaybe<Array<AssetCategorySortInput>>;
-  storeId: Scalars['String']['input'];
 };
 
 
 export type QueriesAssetCategoryArgs = {
   id: Scalars['String']['input'];
-  storeId: Scalars['String']['input'];
 };
 
 
 export type QueriesAssetClassArgs = {
   id: Scalars['String']['input'];
-  storeId: Scalars['String']['input'];
 };
 
 
@@ -4009,13 +4141,11 @@ export type QueriesAssetClassesArgs = {
   filter?: InputMaybe<AssetClassFilterInput>;
   page?: InputMaybe<PaginationInput>;
   sort?: InputMaybe<Array<AssetClassSortInput>>;
-  storeId: Scalars['String']['input'];
 };
 
 
 export type QueriesAssetTypeArgs = {
   id: Scalars['String']['input'];
-  storeId: Scalars['String']['input'];
 };
 
 
@@ -4023,6 +4153,13 @@ export type QueriesAssetTypesArgs = {
   filter?: InputMaybe<AssetTypeFilterInput>;
   page?: InputMaybe<PaginationInput>;
   sort?: InputMaybe<Array<AssetTypeSortInput>>;
+};
+
+
+export type QueriesAssetsArgs = {
+  filter?: InputMaybe<AssetFilterInput>;
+  page?: InputMaybe<PaginationInput>;
+  sort?: InputMaybe<Array<AssetSortInput>>;
   storeId: Scalars['String']['input'];
 };
 
@@ -4448,17 +4585,17 @@ export type RawDocumentNode = {
   type: Scalars['String']['output'];
 };
 
-export type RecordAlreadyExist = InsertLocationErrorInterface & {
+export type RecordAlreadyExist = InsertAssetErrorInterface & InsertLocationErrorInterface & {
   __typename: 'RecordAlreadyExist';
   description: Scalars['String']['output'];
 };
 
-export type RecordBelongsToAnotherStore = DeleteLocationErrorInterface & UpdateLocationErrorInterface & UpdateSensorErrorInterface & {
+export type RecordBelongsToAnotherStore = DeleteAssetErrorInterface & DeleteLocationErrorInterface & UpdateAssetErrorInterface & UpdateLocationErrorInterface & UpdateSensorErrorInterface & {
   __typename: 'RecordBelongsToAnotherStore';
   description: Scalars['String']['output'];
 };
 
-export type RecordNotFound = AddFromMasterListErrorInterface & AddToInboundShipmentFromMasterListErrorInterface & AddToOutboundShipmentFromMasterListErrorInterface & AllocateOutboundShipmentUnallocatedLineErrorInterface & CreateRequisitionShipmentErrorInterface & DeleteErrorInterface & DeleteInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteInboundShipmentServiceLineErrorInterface & DeleteLocationErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & DeleteOutboundShipmentUnallocatedLineErrorInterface & DeletePrescriptionErrorInterface & DeletePrescriptionLineErrorInterface & DeleteRequestRequisitionErrorInterface & DeleteRequestRequisitionLineErrorInterface & NodeErrorInterface & RequisitionLineChartErrorInterface & RequisitionLineStatsErrorInterface & SupplyRequestedQuantityErrorInterface & UpdateErrorInterface & UpdateInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateInboundShipmentServiceLineErrorInterface & UpdateLocationErrorInterface & UpdateNameErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentUnallocatedLineErrorInterface & UpdatePrescriptionErrorInterface & UpdatePrescriptionLineErrorInterface & UpdateRequestRequisitionErrorInterface & UpdateRequestRequisitionLineErrorInterface & UpdateResponseRequisitionErrorInterface & UpdateResponseRequisitionLineErrorInterface & UpdateSensorErrorInterface & UpdateStockLineErrorInterface & UseSuggestedQuantityErrorInterface & {
+export type RecordNotFound = AddFromMasterListErrorInterface & AddToInboundShipmentFromMasterListErrorInterface & AddToOutboundShipmentFromMasterListErrorInterface & AllocateOutboundShipmentUnallocatedLineErrorInterface & CreateRequisitionShipmentErrorInterface & DeleteAssetErrorInterface & DeleteErrorInterface & DeleteInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteInboundShipmentServiceLineErrorInterface & DeleteLocationErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & DeleteOutboundShipmentUnallocatedLineErrorInterface & DeletePrescriptionErrorInterface & DeletePrescriptionLineErrorInterface & DeleteRequestRequisitionErrorInterface & DeleteRequestRequisitionLineErrorInterface & NodeErrorInterface & RequisitionLineChartErrorInterface & RequisitionLineStatsErrorInterface & SupplyRequestedQuantityErrorInterface & UpdateAssetErrorInterface & UpdateErrorInterface & UpdateInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateInboundShipmentServiceLineErrorInterface & UpdateLocationErrorInterface & UpdateNameErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentUnallocatedLineErrorInterface & UpdatePrescriptionErrorInterface & UpdatePrescriptionLineErrorInterface & UpdateRequestRequisitionErrorInterface & UpdateRequestRequisitionLineErrorInterface & UpdateResponseRequisitionErrorInterface & UpdateResponseRequisitionLineErrorInterface & UpdateSensorErrorInterface & UpdateStockLineErrorInterface & UseSuggestedQuantityErrorInterface & {
   __typename: 'RecordNotFound';
   description: Scalars['String']['output'];
 };
@@ -5424,11 +5561,33 @@ export enum UniqueValueKey {
   Serial = 'serial'
 }
 
-export type UniqueValueViolation = InsertLocationErrorInterface & UpdateLocationErrorInterface & UpdateSensorErrorInterface & {
+export type UniqueValueViolation = InsertAssetErrorInterface & InsertLocationErrorInterface & UpdateAssetErrorInterface & UpdateLocationErrorInterface & UpdateSensorErrorInterface & {
   __typename: 'UniqueValueViolation';
   description: Scalars['String']['output'];
   field: UniqueValueKey;
 };
+
+export type UpdateAssetError = {
+  __typename: 'UpdateAssetError';
+  error: UpdateAssetErrorInterface;
+};
+
+export type UpdateAssetErrorInterface = {
+  description: Scalars['String']['output'];
+};
+
+export type UpdateAssetInput = {
+  catalogueItemId?: InputMaybe<NullableStringUpdate>;
+  code?: InputMaybe<Scalars['String']['input']>;
+  id: Scalars['String']['input'];
+  installationDate?: InputMaybe<NullableDateUpdate>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  replacementDate?: InputMaybe<NullableDateUpdate>;
+  serialNumber?: InputMaybe<NullableStringUpdate>;
+  storeId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateAssetResponse = AssetNode | UpdateAssetError;
 
 export type UpdateContactTraceInput = {
   /** Contact trace document data */

--- a/client/packages/system/src/Asset/api/api.ts
+++ b/client/packages/system/src/Asset/api/api.ts
@@ -55,7 +55,6 @@ export const getAssetQueries = (sdk: Sdk, storeId: string) => ({
         offset,
         key: itemParsers.toSortField(sortBy),
         desc: sortBy.isDesc,
-        storeId,
         filter: filterBy,
       });
 
@@ -67,7 +66,6 @@ export const getAssetQueries = (sdk: Sdk, storeId: string) => ({
       const result = await sdk.assetCatalogueItems({
         key: itemParsers.toSortField(sortBy),
         desc: sortBy.isDesc,
-        storeId,
       });
 
       const items = result?.assetCatalogueItems;
@@ -76,7 +74,6 @@ export const getAssetQueries = (sdk: Sdk, storeId: string) => ({
     },
     categories: async () => {
       const result = await sdk.assetCategories({
-        storeId,
         sort: { key: AssetCategorySortFieldInput.Name, desc: false },
       });
       const categories = result?.assetCategories;
@@ -85,7 +82,6 @@ export const getAssetQueries = (sdk: Sdk, storeId: string) => ({
     },
     classes: async () => {
       const result = await sdk.assetClasses({
-        storeId,
         sort: { key: AssetClassSortFieldInput.Name, desc: false },
       });
       const classes = result?.assetClasses;
@@ -94,7 +90,6 @@ export const getAssetQueries = (sdk: Sdk, storeId: string) => ({
     },
     types: async () => {
       const result = await sdk.assetTypes({
-        storeId,
         sort: { key: AssetTypeSortFieldInput.Name, desc: false },
       });
       const types = result?.assetTypes;

--- a/client/packages/system/src/Asset/api/operations.generated.ts
+++ b/client/packages/system/src/Asset/api/operations.generated.ts
@@ -12,7 +12,6 @@ export type AssetCatalogueItemsQueryVariables = Types.Exact<{
   key: Types.AssetCatalogueItemSortFieldInput;
   desc?: Types.InputMaybe<Types.Scalars['Boolean']['input']>;
   filter?: Types.InputMaybe<Types.ItemFilterInput>;
-  storeId: Types.Scalars['String']['input'];
 }>;
 
 
@@ -27,15 +26,13 @@ export type AssetCatalogueItemByIdQueryVariables = Types.Exact<{
 export type AssetCatalogueItemByIdQuery = { __typename: 'Queries', assetCatalogueItems: { __typename: 'AssetCatalogueItemConnector', totalCount: number, nodes: Array<{ __typename: 'AssetCatalogueItemNode', assetCategoryId: string, assetClassId: string, assetTypeId: string, code: string, id: string, manufacturer?: string | null, model: string }> } };
 
 export type AssetClassesQueryVariables = Types.Exact<{
-  storeId: Types.Scalars['String']['input'];
   sort?: Types.InputMaybe<Types.AssetClassSortInput>;
 }>;
 
 
-export type AssetClassesQuery = { __typename: 'Queries', assetClasses: { __typename: 'AssetClassConnector', totalCount: number, nodes: Array<{ __typename: 'AssetClassNode', name: string, id: string }> } };
+export type AssetClassesQuery = { __typename: 'Queries', assetClasses: { __typename: 'AssetClassConnector', totalCount: number, nodes: Array<{ __typename: 'AssetClassNode', id: string, name: string }> } };
 
 export type AssetTypesQueryVariables = Types.Exact<{
-  storeId: Types.Scalars['String']['input'];
   sort?: Types.InputMaybe<Types.AssetTypeSortInput>;
 }>;
 
@@ -43,12 +40,11 @@ export type AssetTypesQueryVariables = Types.Exact<{
 export type AssetTypesQuery = { __typename: 'Queries', assetTypes: { __typename: 'AssetTypeConnector', totalCount: number, nodes: Array<{ __typename: 'AssetTypeNode', id: string, name: string, categoryId: string }> } };
 
 export type AssetCategoriesQueryVariables = Types.Exact<{
-  storeId: Types.Scalars['String']['input'];
   sort?: Types.InputMaybe<Types.AssetCategorySortInput>;
 }>;
 
 
-export type AssetCategoriesQuery = { __typename: 'Queries', assetCategories: { __typename: 'AssetCategoryConnector', totalCount: number, nodes: Array<{ __typename: 'AssetCategoryNode', classId: string, id: string, name: string }> } };
+export type AssetCategoriesQuery = { __typename: 'Queries', assetCategories: { __typename: 'AssetCategoryConnector', totalCount: number, nodes: Array<{ __typename: 'AssetCategoryNode', id: string, name: string, classId: string }> } };
 
 export const AssetCatalogueItemFragmentDoc = gql`
     fragment AssetCatalogueItem on AssetCatalogueItemNode {
@@ -63,12 +59,11 @@ export const AssetCatalogueItemFragmentDoc = gql`
 }
     `;
 export const AssetCatalogueItemsDocument = gql`
-    query assetCatalogueItems($first: Int, $offset: Int, $key: AssetCatalogueItemSortFieldInput!, $desc: Boolean, $filter: ItemFilterInput, $storeId: String!) {
+    query assetCatalogueItems($first: Int, $offset: Int, $key: AssetCatalogueItemSortFieldInput!, $desc: Boolean, $filter: ItemFilterInput) {
   assetCatalogueItems(
     page: {first: $first, offset: $offset}
     sort: {key: $key, desc: $desc}
     filter: $filter
-    storeId: $storeId
   ) {
     ... on AssetCatalogueItemConnector {
       __typename
@@ -82,10 +77,7 @@ export const AssetCatalogueItemsDocument = gql`
     ${AssetCatalogueItemFragmentDoc}`;
 export const AssetCatalogueItemByIdDocument = gql`
     query assetCatalogueItemById($storeId: String!, $assetCatalogueItemId: String!) {
-  assetCatalogueItems(
-    storeId: $storeId
-    filter: {id: {equalTo: $assetCatalogueItemId}}
-  ) {
+  assetCatalogueItems(filter: {id: {equalTo: $assetCatalogueItemId}}) {
     ... on AssetCatalogueItemConnector {
       __typename
       nodes {
@@ -98,12 +90,12 @@ export const AssetCatalogueItemByIdDocument = gql`
 }
     ${AssetCatalogueItemFragmentDoc}`;
 export const AssetClassesDocument = gql`
-    query assetClasses($storeId: String!, $sort: AssetClassSortInput) {
+    query assetClasses($sort: AssetClassSortInput) {
   assetClasses(storeId: $storeId, sort: $sort) {
     ... on AssetClassConnector {
       nodes {
-        name
         id
+        name
       }
       totalCount
     }
@@ -111,8 +103,8 @@ export const AssetClassesDocument = gql`
 }
     `;
 export const AssetTypesDocument = gql`
-    query assetTypes($storeId: String!, $sort: AssetTypeSortInput) {
-  assetTypes(storeId: $storeId, sort: $sort) {
+    query assetTypes($sort: AssetTypeSortInput) {
+  assetTypes(sort: $sort) {
     ... on AssetTypeConnector {
       nodes {
         id
@@ -125,13 +117,13 @@ export const AssetTypesDocument = gql`
 }
     `;
 export const AssetCategoriesDocument = gql`
-    query assetCategories($storeId: String!, $sort: AssetCategorySortInput) {
-  assetCategories(storeId: $storeId, sort: $sort) {
+    query assetCategories($sort: AssetCategorySortInput) {
+  assetCategories(sort: $sort) {
     ... on AssetCategoryConnector {
       nodes {
-        classId
         id
         name
+        classId
       }
       totalCount
     }
@@ -152,13 +144,13 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     assetCatalogueItemById(variables: AssetCatalogueItemByIdQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AssetCatalogueItemByIdQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<AssetCatalogueItemByIdQuery>(AssetCatalogueItemByIdDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'assetCatalogueItemById', 'query');
     },
-    assetClasses(variables: AssetClassesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AssetClassesQuery> {
+    assetClasses(variables?: AssetClassesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AssetClassesQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<AssetClassesQuery>(AssetClassesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'assetClasses', 'query');
     },
-    assetTypes(variables: AssetTypesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AssetTypesQuery> {
+    assetTypes(variables?: AssetTypesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AssetTypesQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<AssetTypesQuery>(AssetTypesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'assetTypes', 'query');
     },
-    assetCategories(variables: AssetCategoriesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AssetCategoriesQuery> {
+    assetCategories(variables?: AssetCategoriesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AssetCategoriesQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<AssetCategoriesQuery>(AssetCategoriesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'assetCategories', 'query');
     }
   };
@@ -170,7 +162,7 @@ export type Sdk = ReturnType<typeof getSdk>;
  * @see https://mswjs.io/docs/basics/response-resolver
  * @example
  * mockAssetCatalogueItemsQuery((req, res, ctx) => {
- *   const { first, offset, key, desc, filter, storeId } = req.variables;
+ *   const { first, offset, key, desc, filter } = req.variables;
  *   return res(
  *     ctx.data({ assetCatalogueItems })
  *   )
@@ -204,7 +196,7 @@ export const mockAssetCatalogueItemByIdQuery = (resolver: ResponseResolver<Graph
  * @see https://mswjs.io/docs/basics/response-resolver
  * @example
  * mockAssetClassesQuery((req, res, ctx) => {
- *   const { storeId, sort } = req.variables;
+ *   const { sort } = req.variables;
  *   return res(
  *     ctx.data({ assetClasses })
  *   )
@@ -221,7 +213,7 @@ export const mockAssetClassesQuery = (resolver: ResponseResolver<GraphQLRequest<
  * @see https://mswjs.io/docs/basics/response-resolver
  * @example
  * mockAssetTypesQuery((req, res, ctx) => {
- *   const { storeId, sort } = req.variables;
+ *   const { sort } = req.variables;
  *   return res(
  *     ctx.data({ assetTypes })
  *   )
@@ -238,7 +230,7 @@ export const mockAssetTypesQuery = (resolver: ResponseResolver<GraphQLRequest<As
  * @see https://mswjs.io/docs/basics/response-resolver
  * @example
  * mockAssetCategoriesQuery((req, res, ctx) => {
- *   const { storeId, sort } = req.variables;
+ *   const { sort } = req.variables;
  *   return res(
  *     ctx.data({ assetCategories })
  *   )

--- a/client/packages/system/src/Asset/api/operations.graphql
+++ b/client/packages/system/src/Asset/api/operations.graphql
@@ -15,13 +15,11 @@ query assetCatalogueItems(
   $key: AssetCatalogueItemSortFieldInput!
   $desc: Boolean
   $filter: ItemFilterInput
-  $storeId: String!
 ) {
   assetCatalogueItems(
     page: { first: $first, offset: $offset }
     sort: { key: $key, desc: $desc }
     filter: $filter
-    storeId: $storeId
   ) {
     ... on AssetCatalogueItemConnector {
       __typename
@@ -37,10 +35,7 @@ query assetCatalogueItemById(
   $storeId: String!
   $assetCatalogueItemId: String!
 ) {
-  assetCatalogueItems(
-    storeId: $storeId
-    filter: { id: { equalTo: $assetCatalogueItemId } }
-  ) {
+  assetCatalogueItems(filter: { id: { equalTo: $assetCatalogueItemId } }) {
     ... on AssetCatalogueItemConnector {
       __typename
       nodes {
@@ -52,7 +47,7 @@ query assetCatalogueItemById(
   }
 }
 
-query assetClasses($storeId: String!, $sort: AssetClassSortInput) {
+query assetClasses($sort: AssetClassSortInput) {
   assetClasses(storeId: $storeId, sort: $sort) {
     ... on AssetClassConnector {
       nodes {
@@ -64,8 +59,8 @@ query assetClasses($storeId: String!, $sort: AssetClassSortInput) {
   }
 }
 
-query assetTypes($storeId: String!, $sort: AssetTypeSortInput) {
-  assetTypes(storeId: $storeId, sort: $sort) {
+query assetTypes($sort: AssetTypeSortInput) {
+  assetTypes(sort: $sort) {
     ... on AssetTypeConnector {
       nodes {
         id
@@ -77,8 +72,8 @@ query assetTypes($storeId: String!, $sort: AssetTypeSortInput) {
   }
 }
 
-query assetCategories($storeId: String!, $sort: AssetCategorySortInput) {
-  assetCategories(storeId: $storeId, sort: $sort) {
+query assetCategories($sort: AssetCategorySortInput) {
+  assetCategories(sort: $sort) {
     ... on AssetCategoryConnector {
       nodes {
         id


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes a bug where asset queries are trying to use a store_id which doesn't exist in graphql