### PR TITLE
3051 Doesn't select the searched entry from list in program enrolment form

### DIFF
--- a/client/packages/programs/src/JsonForms/components/Search/SearchWithUserSource.tsx
+++ b/client/packages/programs/src/JsonForms/components/Search/SearchWithUserSource.tsx
@@ -53,10 +53,10 @@ export const SearchWithUserSource = (
   const getOptionLabel = (data: PatientSchema) =>
     options?.optionString
       ? formatTemplateString(options?.optionString, data)
-      : `${data['code']} - ${data['firstName']} ${data['lastName']}`;
+      : `${data['code'] ?? ''} - ${data['firstName']} ${data['lastName']}`;
 
   const handlePatientSelect = (patientId: string) => {
-    const patient = results.find(p => (p.id = patientId));
+    const patient = results.find(p => p.id === patientId);
     if (!patient) return;
     if (!options?.saveFields) {
       handleChange(path, patient);

--- a/client/packages/programs/src/JsonForms/components/Search/SearchWithUserSource.tsx
+++ b/client/packages/programs/src/JsonForms/components/Search/SearchWithUserSource.tsx
@@ -53,7 +53,9 @@ export const SearchWithUserSource = (
   const getOptionLabel = (data: PatientSchema) =>
     options?.optionString
       ? formatTemplateString(options?.optionString, data)
-      : `${data['code'] ?? ''} - ${data['firstName']} ${data['lastName']}`;
+      : `${data['code'] ? data['code'] + '-' : ''} ${data['firstName']} ${
+          data['lastName']
+        }`;
 
   const handlePatientSelect = (patientId: string) => {
     const patient = results.find(p => p.id === patientId);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3051

# 👩🏻‍💻 What does this PR do? 
Fix the patient check.

# 🧪 How has/should this change been tested? 
- [ ] Have programs set up
- [ ] Create two patients that have the same first name `e.g. Mimi` and a third with whatever name you want
- [ ] Enrol the third patient into `HIV Care and Treatment` program
- [ ] Go to the mother field and type `Mimi` or whatever name you have chosen
- [ ] Select the 2nd `Mimi` on the list
- [ ] Should load correctly