### PR TITLE
Add page titles and placeholder docs links

### DIFF
--- a/client/packages/common/src/utils/environment/EnvUtils.ts
+++ b/client/packages/common/src/utils/environment/EnvUtils.ts
@@ -34,6 +34,10 @@ const mapRoute = (route: string): RouteMapping => {
         title: 'inbound-shipments',
         docs: '/replenishment/inbound-shipments/',
       };
+    case inRoute('outbound-return'):
+      return { title: 'outbound-return', docs: '/introduction/' };
+    case inRoute('inbound-return'):
+      return { title: 'inbound-return', docs: '/introduction/' };
     case inRoute('internal-order'):
       return {
         title: 'internal-order',


### PR DESCRIPTION
Fixes #3160 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Adds the new returns routes to EnvUtils so we get page titles in the browser tabs, and adds a placeholder for links to docs.

i.e:
![Screenshot 2024-03-05 at 11 24 21 AM](https://github.com/msupply-foundation/open-msupply/assets/55115239/434d31e5-e52a-40fc-a23c-c6a1846159a8)


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->

We don't have any public docs for returns yet, but when we do, we should update the docs link to point to them!