### PR TITLE
Inbound shipments: long references not visible when status is "shipped" #3079

### DIFF
--- a/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
@@ -50,6 +50,9 @@ export const BasicTextInput: FC<BasicTextInputProps> = React.forwardRef(
             ...InputProps?.sx,
           },
         }}
+        inputProps={
+          props.disabled ? { style: { textOverflow: 'ellipsis' } } : {}
+        }
         {...props}
       />
       <Box width={2}>

--- a/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
@@ -12,6 +12,7 @@ import {
   Switch,
   InvoiceNodeStatus,
   Alert,
+  Tooltip,
 } from '@openmsupply-client/common';
 import { SupplierSearchInput } from '@openmsupply-client/system';
 import { InboundRowFragment, useInbound } from '../api';
@@ -81,15 +82,17 @@ export const Toolbar: FC = () => {
             <InputWithLabelRow
               label={t('label.supplier-ref')}
               Input={
-                <BufferedTextInput
-                  disabled={isDisabled}
-                  size="small"
-                  sx={{ width: 250 }}
-                  value={theirReference ?? ''}
-                  onChange={event => {
-                    update({ theirReference: event.target.value });
-                  }}
-                />
+                <Tooltip title={theirReference} placement="bottom-start">
+                  <BufferedTextInput
+                    disabled={isDisabled}
+                    size="small"
+                    sx={{ width: 250 }}
+                    value={theirReference ?? ''}
+                    onChange={event => {
+                      update({ theirReference: event.target.value });
+                    }}
+                  />
+                </Tooltip>
               }
             />
             <InboundInfoPanel shipment={shipment} />

--- a/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
@@ -12,6 +12,7 @@ import {
   NothingHere,
   useToggle,
   useUrlQueryParams,
+  TooltipTextCell,
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
@@ -69,8 +70,13 @@ export const InboundListView: FC = () => {
       ['invoiceNumber', { maxWidth: 80 }],
       'createdDatetime',
       'deliveredDatetime',
-      ['comment', { width: '100%' }],
-      'theirReference',
+      ['comment', { width: '100%', Cell: TooltipTextCell }],
+      [
+        'theirReference',
+        {
+          Cell: TooltipTextCell,
+        },
+      ],
       [
         'totalAfterTax',
         {

--- a/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
@@ -70,7 +70,7 @@ export const InboundListView: FC = () => {
       ['invoiceNumber', { maxWidth: 80 }],
       'createdDatetime',
       'deliveredDatetime',
-      ['comment', { width: '100%', Cell: TooltipTextCell }],
+      ['comment', { width: 125, Cell: TooltipTextCell }],
       [
         'theirReference',
         {

--- a/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
@@ -13,6 +13,7 @@ import {
   ZapIcon,
   Switch,
   useIsGrouped,
+  Tooltip,
 } from '@openmsupply-client/common';
 import { CustomerSearchInput } from '@openmsupply-client/system';
 import { useOutbound } from '../api';
@@ -63,16 +64,18 @@ export const Toolbar: FC = () => {
             <InputWithLabelRow
               label={t('label.customer-ref')}
               Input={
-                <BasicTextInput
-                  disabled={isDisabled}
-                  size="small"
-                  sx={{ width: 250 }}
-                  value={theirReferenceBuffer ?? ''}
-                  onChange={event => {
-                    setTheirReferenceBuffer(event.target.value);
-                    update({ theirReference: event.target.value });
-                  }}
-                />
+                <Tooltip title={theirReferenceBuffer} placement="bottom-start">
+                  <BasicTextInput
+                    disabled={isDisabled}
+                    size="small"
+                    sx={{ width: 250 }}
+                    value={theirReferenceBuffer ?? ''}
+                    onChange={event => {
+                      setTheirReferenceBuffer(event.target.value);
+                      update({ theirReference: event.target.value });
+                    }}
+                  />
+                </Tooltip>
               }
             />
           </Box>

--- a/client/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/client/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -12,6 +12,7 @@ import {
   NothingHere,
   useToggle,
   useUrlQueryParams,
+  TooltipTextCell,
 } from '@openmsupply-client/common';
 import { getStatusTranslator, isOutboundDisabled } from '../../utils';
 import { Toolbar } from './Toolbar';
@@ -69,8 +70,14 @@ const OutboundShipmentListViewComponent: FC = () => {
         description: 'description.customer-reference',
         key: 'theirReference',
         label: 'label.reference',
+        Cell: TooltipTextCell,
       },
-      ['comment'],
+      [
+        'comment',
+        {
+          Cell: TooltipTextCell,
+        },
+      ],
       [
         'totalAfterTax',
         {

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
   Box,
   Alert,
+  Tooltip,
 } from '@openmsupply-client/common';
 import { InternalSupplierSearchInput } from '@openmsupply-client/system';
 import { useRequest } from '../../api';
@@ -65,13 +66,15 @@ export const Toolbar: FC = () => {
           <InputWithLabelRow
             label={t('label.supplier-ref')}
             Input={
-              <BufferedTextInput
-                disabled={isDisabled}
-                size="small"
-                sx={{ width: 250 }}
-                value={theirReference ?? null}
-                onChange={e => update({ theirReference: e.target.value })}
-              />
+              <Tooltip title={theirReference} placement="bottom-start">
+                <BufferedTextInput
+                  disabled={isDisabled}
+                  size="small"
+                  sx={{ width: 250 }}
+                  value={theirReference ?? null}
+                  onChange={e => update({ theirReference: e.target.value })}
+                />
+              </Tooltip>
             }
           />
           {usesRemoteAuthorisation && (

--- a/client/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
@@ -13,6 +13,7 @@ import {
   useToggle,
   useUrlQueryParams,
   ColumnDescription,
+  TooltipTextCell,
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
@@ -99,7 +100,7 @@ export const RequestRequisitionListView: FC = () => {
           getRequisitionTranslator(t)(currentStatus as RequisitionNodeStatus),
       },
     ],
-    ['comment', { width: '100%' }],
+    ['comment', { width: '100%', Cell: TooltipTextCell }],
   ];
 
   if (requireSupplierAuthorisation) {

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Toolbar.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Toolbar.tsx
@@ -12,6 +12,7 @@ import {
   Typography,
   BufferedTextInput,
   Alert,
+  Tooltip,
 } from '@openmsupply-client/common';
 import { CustomerSearchInput } from '@openmsupply-client/system';
 
@@ -76,13 +77,15 @@ export const Toolbar: FC = () => {
               <InputWithLabelRow
                 label={t('label.customer-ref')}
                 Input={
-                  <BufferedTextInput
-                    disabled={isDisabled}
-                    size="small"
-                    sx={{ width: 250 }}
-                    value={theirReference}
-                    onChange={e => update({ theirReference: e.target.value })}
-                  />
+                  <Tooltip title={theirReference} placement="bottom-start">
+                    <BufferedTextInput
+                      disabled={isDisabled}
+                      size="small"
+                      sx={{ width: 250 }}
+                      value={theirReference}
+                      onChange={e => update({ theirReference: e.target.value })}
+                    />
+                  </Tooltip>
                 }
               />
               {isRemoteAuthorisation && (

--- a/client/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
@@ -12,6 +12,7 @@ import {
   NothingHere,
   useUrlQueryParams,
   ColumnDescription,
+  TooltipTextCell,
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
@@ -112,7 +113,7 @@ export const ResponseRequisitionListView: FC = () => {
         t(getApprovalStatusKey(rowData.approvalStatus)),
     });
   }
-  columnDefinitions.push(['comment', { minWidth: 400 }]);
+  columnDefinitions.push(['comment', { minWidth: 400, Cell: TooltipTextCell }]);
 
   const columns = useColumns<ResponseRowFragment>(
     columnDefinitions,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3079

# 👩🏻‍💻 What does this PR do? 
** Ignore branch name was created for another bug and forgot to change 🙄 and renaming will close PR again **
Adds tooltip to invoice/requisition list views and detail header for comments/references since long references/comments get cut off.

# 🧪 How has/should this change been tested? 
- [ ] Have an invoice/requisition with a long comment/reference... maybe do a transfer? 
- [ ] Hover over to see tooltip