### PR TITLE
3076 coldchain breach comment overflow

### DIFF
--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureBreach/TempereatureBreachCells.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureBreach/TempereatureBreachCells.tsx
@@ -79,7 +79,10 @@ export const IconCell = ({
       <PaperHoverPopover
         width={400}
         Content={
-          <PaperPopoverSection label={t('label.comment')}>
+          <PaperPopoverSection
+            label={t('label.comment')}
+            sx={{ wordBreak: 'break-word' }}
+          >
             {String(rowData?.comment)}
           </PaperPopoverSection>
         }

--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureBreach/TempereatureBreachCells.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureBreach/TempereatureBreachCells.tsx
@@ -79,10 +79,7 @@ export const IconCell = ({
       <PaperHoverPopover
         width={400}
         Content={
-          <PaperPopoverSection
-            label={t('label.comment')}
-            sx={{ wordBreak: 'break-word' }}
-          >
+          <PaperPopoverSection label={t('label.comment')}>
             {String(rowData?.comment)}
           </PaperPopoverSection>
         }

--- a/client/packages/common/src/ui/components/popover/PaperPopover/PaperPopoverSection.tsx
+++ b/client/packages/common/src/ui/components/popover/PaperPopover/PaperPopoverSection.tsx
@@ -1,22 +1,25 @@
 import React, { FC, PropsWithChildren } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import { SxProps, Theme } from '@mui/material';
 
 export interface PaperPopoverSectionProps {
   label?: string;
   labelStyle?: React.CSSProperties;
   alignItems?: 'center' | 'flex-start' | 'flex-end' | 'stretch';
+  sx?: SxProps<Theme>;
 }
 
 export const PaperPopoverSection: FC<
   PropsWithChildren<PaperPopoverSectionProps>
-> = ({ children, label, labelStyle, alignItems }) => (
+> = ({ children, label, labelStyle, alignItems, sx }) => (
   <Box
     gap={2}
     p={3}
     flexDirection="column"
     display="flex"
     alignItems={alignItems}
+    sx={sx}
   >
     <Typography fontWeight="700" style={labelStyle}>
       {label}

--- a/client/packages/common/src/ui/components/popover/PaperPopover/PaperPopoverSection.tsx
+++ b/client/packages/common/src/ui/components/popover/PaperPopover/PaperPopoverSection.tsx
@@ -1,25 +1,23 @@
 import React, { FC, PropsWithChildren } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import { SxProps, Theme } from '@mui/material';
 
 export interface PaperPopoverSectionProps {
   label?: string;
   labelStyle?: React.CSSProperties;
   alignItems?: 'center' | 'flex-start' | 'flex-end' | 'stretch';
-  sx?: SxProps<Theme>;
 }
 
 export const PaperPopoverSection: FC<
   PropsWithChildren<PaperPopoverSectionProps>
-> = ({ children, label, labelStyle, alignItems, sx }) => (
+> = ({ children, label, labelStyle, alignItems }) => (
   <Box
     gap={2}
     p={3}
     flexDirection="column"
     display="flex"
     alignItems={alignItems}
-    sx={sx}
+    sx={{ wordBreak: 'break-word' }}
   >
     <Typography fontWeight="700" style={labelStyle}>
       {label}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3076 

# 👩🏻‍💻 What does this PR do? 
Stops comment from overflowing in cold chain pop over
![Screenshot 2024-03-05 at 17 12 15](https://github.com/msupply-foundation/open-msupply/assets/61820074/388bb82d-2f93-4fa4-8947-74c8b1218250)

# 🧪 How has/should this change been tested? 
- [ ] Have cold chain set up with some breaches
- [ ] Acknowledge a breach and make the comment a long word (Something more than 30 letters long?)
- [ ] Click the Acknowledge icon and see that comment isn't overflowing anymore