### PR TITLE
Bug fix for sqlite download on old android installs with old database…

### DIFF
--- a/client/packages/android/app/src/main/java/org/openmsupply/client/FileManager.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/FileManager.java
@@ -74,6 +74,17 @@ public class FileManager {
             Uri uri = data.getData();
             Context context = activity.getApplicationContext();
 
+            // The db file name can be either `omsupply-database` or
+            // `omsupply-database.sqlite`
+            // The rust code automatically appends .sqlite to the file name if it doesn't
+            // already exist but uses the old file name it is is still present.
+            // We need to repeat the same logic here for older databases that don't have the
+            // .sqlite extension
+
+            if (!dbFile.isFile()) {
+                dbFile = new File(dbFile + ".sqlite");
+            }
+
             InputStream inputStream = null;
             OutputStream outputStream = null;
             ZipOutputStream zipStream = null;

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
@@ -42,7 +42,11 @@ import javax.net.ssl.SSLHandshakeException;
 @CapacitorPlugin(name = "NativeApi")
 public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
     private static final String LOG_FILE_NAME = "remote_server.log";
-    private static final String DB_FILE_NAME = "omsupply-database.sqlite";
+
+    // This comes from Java_org_openmsupply_client_RemoteServer_startServer - if
+    // it's changed there, it will need to be changed here too...
+    private static final String DB_FILE_NAME = "omsupply-database";
+
     public static final String OM_SUPPLY = "omSupply";
     private static final Integer DEFAULT_PORT = DiscoveryConstants.PORT;
     private static final String DEFAULT_URL = "https://localhost:" + DEFAULT_PORT + "/";


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3172 

# 👩🏻‍💻 What does this PR do? 
Checks is the dbname `omsupply-database` exists, if not uses `omsupply-database.sqlite`
This is consistent with the rust code.

# 🧪 How has/should this change been tested? 
Issue was found in testing, needs to be tested on a newly `initialised` install and an upgrade from old version.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_