### PR TITLE
Fix end of supply display

### DIFF
--- a/client/packages/programs/src/JsonForms/components/QuantityDispensed.tsx
+++ b/client/packages/programs/src/JsonForms/components/QuantityDispensed.tsx
@@ -76,7 +76,9 @@ const getEndOfSupply = (
 const UIComponent = (props: ControlProps) => {
   const { data, handleChange, label, path, uischema } = props;
   const [localData, setLocalData] = useState<number | undefined>(data);
-  const [remainingQuantity, setRemainingQuantity] = useState(0);
+  const [remainingQuantity, setRemainingQuantity] = useState<
+    number | undefined
+  >(undefined);
   const [baseTime, setBaseTime] = useState<string | undefined>();
   const { errors, options } = useZodOptionsValidation(
     Options,
@@ -96,7 +98,7 @@ const UIComponent = (props: ControlProps) => {
       core.data,
       options?.remainingQuantityField ?? ''
     );
-    setRemainingQuantity(remainingQuantity ?? 0);
+    setRemainingQuantity(remainingQuantity);
   }, [core?.data, options]);
 
   const onChange = useDebounceCallback(
@@ -122,13 +124,13 @@ const UIComponent = (props: ControlProps) => {
       if (options.quantityPrescribedField) {
         handleChange(
           options.quantityPrescribedField,
-          remainingQuantity + value
+          (remainingQuantity ?? 0) + value
         );
       }
       if (options.endOfSupplyField) {
         const scheduleStartTime =
           value > 0
-            ? getEndOfSupply(baseTime, remainingQuantity, value, options)
+            ? getEndOfSupply(baseTime, remainingQuantity ?? 0, value, options)
             : undefined;
         handleChange(
           options.endOfSupplyField,
@@ -140,14 +142,18 @@ const UIComponent = (props: ControlProps) => {
   );
   const error = !!errors;
 
-  const endOfSupplySec = baseTime
-    ? getEndOfSupply(
-        baseTime,
-        remainingQuantity,
-        localData ?? 0,
-        options
-      ).getTime() / 1000
-    : undefined;
+  // Only show end of supply if either remainingQuantity or pillsDispensed have been entered
+  const endOfSupplyString =
+    baseTime && (localData !== undefined || remainingQuantity !== undefined)
+      ? dateFormat.localisedDate(
+          getEndOfSupply(
+            baseTime,
+            remainingQuantity ?? 0,
+            localData ?? 0,
+            options
+          ).getTime() / 1000
+        )
+      : '';
 
   if (!props.visible) {
     return null;
@@ -199,7 +205,7 @@ const UIComponent = (props: ControlProps) => {
               disabled={true}
               error={error}
               helperText={errors}
-              value={remainingQuantity + (localData ?? 0)}
+              value={(remainingQuantity ?? 0) + (localData ?? 0)}
             />
 
             <Box
@@ -211,11 +217,7 @@ const UIComponent = (props: ControlProps) => {
                 {t('label.end-of-supply')}:
               </FormLabel>
             </Box>
-            <FormLabel>
-              {endOfSupplySec
-                ? `${dateFormat.localisedDate(endOfSupplySec)}`
-                : ''}
-            </FormLabel>
+            <FormLabel>{endOfSupplyString}</FormLabel>
           </Box>
         }
       />

--- a/client/packages/programs/src/JsonForms/components/QuantityDispensed.tsx
+++ b/client/packages/programs/src/JsonForms/components/QuantityDispensed.tsx
@@ -153,7 +153,7 @@ const UIComponent = (props: ControlProps) => {
             options
           ).getTime() / 1000
         )
-      : '';
+      : 'N/A';
 
   if (!props.visible) {
     return null;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3142 

# 👩🏻‍💻 What does this PR do? 
Don't show the end of supply date when no data has been entered yet.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

- Create new encounter
- end of supply should not show until the "Pill count (at start)" and/or "Quantity of pills dispensed" has been entered.
- end of supply should show when entering 0
