### PR TITLE
Update layout to cope with bitwarden #2615

### DIFF
--- a/client/packages/common/src/hooks/useDeleteConfirmation/useDeleteConfirmation.ts
+++ b/client/packages/common/src/hooks/useDeleteConfirmation/useDeleteConfirmation.ts
@@ -30,7 +30,7 @@ export const useDeleteConfirmation = <T>({
     cantDelete,
     selectRows,
   } = messages;
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { success, info } = useNotification();
   const cannotDeleteSnack = info(
     cantDelete || t('messages.cant-delete-generic')

--- a/client/packages/common/src/hooks/useDetailPanel/useDetailPanel.tsx
+++ b/client/packages/common/src/hooks/useDetailPanel/useDetailPanel.tsx
@@ -42,7 +42,7 @@ interface DetailPanel {
   close: () => void;
 }
 export const useDetailPanel = (): DetailPanel => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { isOpen, open, close } = useDetailPanelStore();
   const OpenButton = isOpen ? null : (
     <ButtonWithIcon

--- a/client/packages/common/src/ui/components/buttons/ColorSelectButton/ColorSelectButton.tsx
+++ b/client/packages/common/src/ui/components/buttons/ColorSelectButton/ColorSelectButton.tsx
@@ -18,7 +18,7 @@ export const ColorSelectButton: FC<ColorSelectButtonProps> = ({
   disabled = false,
 }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
-  const t = useTranslation('common');
+  const t = useTranslation();
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
   };

--- a/client/packages/common/src/ui/components/buttons/standard/DialogButton.tsx
+++ b/client/packages/common/src/ui/components/buttons/standard/DialogButton.tsx
@@ -73,7 +73,7 @@ export const DialogButton: React.FC<DialogButtonProps> = ({
   color,
   type,
 }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { variant: buttonVariant, icon, labelKey } = getButtonProps(variant);
 
   return (

--- a/client/packages/common/src/ui/components/domain/Dashboard/StatsPanel.stories.tsx
+++ b/client/packages/common/src/ui/components/domain/Dashboard/StatsPanel.stories.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from '@common/intl';
 
 const Template: ComponentStory<typeof StatsPanel> = () => {
   const [isLoading, setIsLoading] = React.useState(true);
-  const t = useTranslation('common');
+  const t = useTranslation();
   const stats: Stat[] = [
     { label: t('label.expired'), value: '8' },
     {

--- a/client/packages/common/src/ui/components/domain/StatusCrumbs/StatusCrumbs.stories.tsx
+++ b/client/packages/common/src/ui/components/domain/StatusCrumbs/StatusCrumbs.stories.tsx
@@ -46,7 +46,7 @@ const Template: ComponentStory<typeof StatusCrumbs> = () => {
   const [currentStatus, setCurrentStatus] = useState(statuses[4]);
   const [statusLog, setStatusLog] = useState(defaultStatusLog);
 
-  const t = useTranslation('common');
+  const t = useTranslation();
 
   return (
     <Stack gap={2}>

--- a/client/packages/common/src/ui/components/domain/StatusCrumbs/StatusCrumbs.tsx
+++ b/client/packages/common/src/ui/components/domain/StatusCrumbs/StatusCrumbs.tsx
@@ -38,7 +38,7 @@ export const StatusCrumbs = <StatusType extends string>(
   props: StatusCrumbsProps<StatusType>
 ): JSX.Element | null => {
   const { statuses, statusLog, statusFormatter } = props;
-  const t = useTranslation('common');
+  const t = useTranslation();
   const isSmallScreen = useIsSmallScreen();
 
   const steps = useSteps(props);

--- a/client/packages/common/src/ui/components/errors/GenericErrorFallback.tsx
+++ b/client/packages/common/src/ui/components/errors/GenericErrorFallback.tsx
@@ -8,7 +8,7 @@ import { BaseButton } from '../buttons';
 export const GenericErrorFallback: FC<ErrorBoundaryFallbackProps> = ({
   onClearError,
 }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
 
   return (
     <Box

--- a/client/packages/common/src/ui/components/errors/NothingHere.tsx
+++ b/client/packages/common/src/ui/components/errors/NothingHere.tsx
@@ -17,7 +17,7 @@ export const NothingHere: React.FC<NothingHereProps> = ({
   title,
   onCreate,
 }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const heading = title || t('error.no-results');
   const createButtonText = buttonText || t('button.create-a-new-one');
 

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteMultiList.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteMultiList.tsx
@@ -61,7 +61,7 @@ export const AutocompleteMultiList = <T extends { id: string }>({
 
   const ItemInput: FC<AutocompleteRenderInputParams> = props => {
     const { InputProps, ...rest } = props;
-    const t = useTranslation('common');
+    const t = useTranslation();
     const filtered = options.filter(option =>
       RegexUtils.matchObjectProperties(inputValue, option, filterProperties)
     );

--- a/client/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
@@ -55,7 +55,7 @@ export const BaseDatePickerInput: FC<
   const theme = useAppTheme();
   const [internalError, setInternalError] = useState<string | null>(null);
   const [isInitialEntry, setIsInitialEntry] = useState(true);
-  const t = useTranslation('common');
+  const t = useTranslation();
 
   return (
     <DatePicker

--- a/client/packages/common/src/ui/components/navigation/Tabs/ModalTabs.tsx
+++ b/client/packages/common/src/ui/components/navigation/Tabs/ModalTabs.tsx
@@ -18,7 +18,7 @@ interface DetailTabsProps {
  **/
 export const ModalTabs: FC<DetailTabsProps> = ({ sx, tabs }) => {
   const [currentTab, setCurrentTab] = useState<string>(tabs[0]?.value ?? '');
-  const t = useTranslation('common');
+  const t = useTranslation();
 
   return (
     <TabContext value={currentTab}>

--- a/client/packages/common/src/ui/components/portals/DetailPanel/DetailPanel.tsx
+++ b/client/packages/common/src/ui/components/portals/DetailPanel/DetailPanel.tsx
@@ -65,7 +65,7 @@ export const DetailPanel: FC = () => {
 export const DetailPanelPortal: FC<
   PropsWithChildren<DetailPanelPortalProps>
 > = ({ Actions, children }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { detailPanelRef } = useHostContext();
   const { hasUserSet, isOpen, close } = useDetailPanelStore();
   const isLargeScreen = useIsLargeScreen();

--- a/client/packages/common/src/ui/layout/tables/columns/CommentPopoverColumn/CommentPopoverColumn.tsx
+++ b/client/packages/common/src/ui/layout/tables/columns/CommentPopoverColumn/CommentPopoverColumn.tsx
@@ -17,7 +17,7 @@ export const getCommentPopoverColumn = <T extends RecordWithId>(
   },
 
   Cell: ({ column, rowData }) => {
-    const t = useTranslation('common');
+    const t = useTranslation();
     const value = column.accessor({ rowData });
 
     return value ? (

--- a/client/packages/common/src/ui/layout/tables/columns/LineLabel/LineLabel.tsx
+++ b/client/packages/common/src/ui/layout/tables/columns/LineLabel/LineLabel.tsx
@@ -4,7 +4,7 @@ import { ColumnAlign, ColumnDefinition } from '../types';
 import { useTranslation } from '@common/intl';
 
 export const getLineLabelColumn = <
-  T extends RecordWithId
+  T extends RecordWithId,
 >(): ColumnDefinition<T> => ({
   key: 'lineLabel',
   sortable: false,
@@ -15,7 +15,7 @@ export const getLineLabelColumn = <
   },
 
   Cell: ({ rowIndex }) => {
-    const t = useTranslation('common');
+    const t = useTranslation();
     const label = t('label.line', { line: rowIndex + 1 });
 
     return <>{label}</>;

--- a/client/packages/common/src/ui/layout/tables/columns/NotePopoverColumn/NotePopoverColumn.tsx
+++ b/client/packages/common/src/ui/layout/tables/columns/NotePopoverColumn/NotePopoverColumn.tsx
@@ -62,7 +62,7 @@ export const getNotePopoverColumn = <T extends RecordWithId>(
   },
 
   Cell: ({ column, rowData }) => {
-    const t = useTranslation('common');
+    const t = useTranslation();
     const value = column.accessor({ rowData });
 
     let content: NoteObject[] = value as NoteObject[];

--- a/client/packages/common/src/ui/layout/tables/columns/PaginationRow/PaginationRow.tsx
+++ b/client/packages/common/src/ui/layout/tables/columns/PaginationRow/PaginationRow.tsx
@@ -51,7 +51,7 @@ export const PaginationRow: FC<PaginationRowProps> = ({
     onChangePage(event, 0);
   };
 
-  const t = useTranslation('common');
+  const t = useTranslation();
   const getNumberSelectedLabel = () =>
     !!numberSelected && `(${numberSelected} ${t('label.selected')})`;
 

--- a/client/packages/common/src/ui/layout/tables/columns/RowExpand/RowExpand.tsx
+++ b/client/packages/common/src/ui/layout/tables/columns/RowExpand/RowExpand.tsx
@@ -22,7 +22,7 @@ export const getRowExpandColumn = <
   align: ColumnAlign.Right,
   width: 60,
   Header: () => {
-    const t = useTranslation('common');
+    const t = useTranslation();
     const { isGrouped, numberExpanded, toggleAllExpanded } = useTableStore();
 
     return isGrouped ? (
@@ -50,7 +50,7 @@ export const getRowExpandColumn = <
     ) : null;
   },
   Cell: ({ rowData }) => {
-    const t = useTranslation('common');
+    const t = useTranslation();
     const { toggleExpanded, isExpanded } = useExpanded(rowData.id);
 
     if (!rowData.canExpand && !((rowData?.lines?.length ?? 0) > 1)) return null;

--- a/client/packages/common/src/ui/layout/tables/components/Header/ColumnPicker.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Header/ColumnPicker.tsx
@@ -27,7 +27,7 @@ export const ColumnPicker = <T extends RecordWithId>({
   columns,
   onChange,
 }: ColumnPickerProps<T>) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const [hiddenColumnsConfig, setHiddenColumnsConfig] =
     useLocalStorage('/columns/hidden');
   const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(

--- a/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -41,7 +41,7 @@ export const HeaderCell = <T extends RecordWithId>({
   } = column;
 
   const { direction, key: currentSortKey } = sortBy ?? {};
-  const t = useTranslation('common');
+  const t = useTranslation();
   const isSorted = key === currentSortKey;
 
   const onSort = useDebounceCallback(

--- a/client/packages/common/src/utils/BarcodeScannerContext.tsx
+++ b/client/packages/common/src/utils/BarcodeScannerContext.tsx
@@ -83,7 +83,7 @@ export const parseResult = (content?: string): ScanResult => {
 export const BarcodeScannerProvider: FC<PropsWithChildrenOnly> = ({
   children,
 }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const [isScanning, setIsScanning] = useState(false);
   const { error } = useNotification();
   const { electronNativeAPI } = window;

--- a/client/packages/host/public/index.html
+++ b/client/packages/host/public/index.html
@@ -1,6 +1,9 @@
-<html>
-  <head> </head>
-  <body>
-    <div id="root"></div>
+<body>
+    <div id="content-row">
+      <div id="outer-wrapper">
+        <div id="inner-wrapper">
+          <div id="root"></div>
+        </div>
+      </div>
+    </div>
   </body>
-</html>

--- a/client/packages/host/src/Admin/AndroidLogFileModal.tsx
+++ b/client/packages/host/src/Admin/AndroidLogFileModal.tsx
@@ -12,7 +12,7 @@ export const AndroidLogFileModal = ({
   isOpen: boolean;
   onClose: () => void;
 }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { Modal } = useDialog({ isOpen });
   const { readLog, saveFile } = useNativeClient();
   const [logText, setLogText] = useState('');

--- a/client/packages/host/src/Admin/ElectronSettings.tsx
+++ b/client/packages/host/src/Admin/ElectronSettings.tsx
@@ -65,7 +65,7 @@ const Scanner = ({ scanner }: { scanner: BarcodeScanner | null }) => {
 
 export const ElectronSettings = () => {
   const { electronNativeAPI } = window;
-  const t = useTranslation('common');
+  const t = useTranslation();
   const [scanner, setScanner] = useState<BarcodeScanner | null>(null);
   const [isScanning, setIsScanning] = useState(false);
   const { error, success } = useNotification();

--- a/client/packages/host/src/Admin/ServerSettings.tsx
+++ b/client/packages/host/src/Admin/ServerSettings.tsx
@@ -32,7 +32,7 @@ export const ServerSettings = () => {
   const { saveDatabase } = useNativeClient();
   const { data: databaseSettings } = useDatabaseSettings();
   const [isDownloading, setIsDownloading] = useState(false);
-  const t = useTranslation('common');
+  const t = useTranslation();
   const {
     isOn: isLogShown,
     toggleOn: showLog,

--- a/client/packages/host/src/Admin/SettingTextArea.tsx
+++ b/client/packages/host/src/Admin/SettingTextArea.tsx
@@ -32,7 +32,7 @@ export const SettingTextArea: React.FC<SettingTextAreaProps> = ({
   infoText,
   title,
 }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const [value, setValue] = React.useState(defaultValue);
 
   const changeText = (event: ChangeEvent<HTMLTextAreaElement>) =>

--- a/client/packages/host/src/Admin/Settings.tsx
+++ b/client/packages/host/src/Admin/Settings.tsx
@@ -25,7 +25,7 @@ import { ServerSettings } from './ServerSettings';
 import { ElectronSettings } from './ElectronSettings';
 
 export const Settings: React.FC = () => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { error } = useNotification();
   const navigate = useNavigate();
   const [customTheme, setCustomTheme] = useLocalStorage('/theme/custom');

--- a/client/packages/host/src/Admin/SyncSettings.tsx
+++ b/client/packages/host/src/Admin/SyncSettings.tsx
@@ -43,7 +43,7 @@ const SyncSettingsForm = ({
   onSave: () => void;
   setSyncSettings: (syncSettings: SyncSettingsInput) => void;
 }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const setSettings = (
     property: keyof SyncSettingsInput,
     value: number | string

--- a/client/packages/host/src/components/AppVersion.tsx
+++ b/client/packages/host/src/components/AppVersion.tsx
@@ -9,7 +9,7 @@ interface AppVersionProps {
 }
 
 export const AppVersion: FC<AppVersionProps> = ({ SiteInfo, style }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   return (
     <Grid
       style={{

--- a/client/packages/host/src/components/NotFound.tsx
+++ b/client/packages/host/src/components/NotFound.tsx
@@ -9,7 +9,7 @@ import {
 } from '@openmsupply-client/common';
 
 export const NotFound: React.FC = () => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   return (
     <Grid
       container

--- a/client/packages/host/src/components/Sync/Sync.tsx
+++ b/client/packages/host/src/components/Sync/Sync.tsx
@@ -188,7 +188,7 @@ const Row: React.FC<PropsWithChildren<RowProps>> = ({ title, children }) => (
 );
 
 const FormattedSyncDate = ({ date }: { date: Date | null }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { localisedDistanceToNow, relativeDateTime } = useFormatDateTime();
 
   if (!date) return null;

--- a/client/packages/host/src/components/Viewport.tsx
+++ b/client/packages/host/src/components/Viewport.tsx
@@ -1,32 +1,43 @@
-import React, { useEffect, useState } from 'react';
-import {
-  GlobalStyles,
-  CssBaseline,
-  EnvUtils,
-  Platform,
-} from '@openmsupply-client/common';
+import React from 'react';
+import { GlobalStyles, CssBaseline } from '@openmsupply-client/common';
 import { PropsWithChildrenOnly } from '@common/types';
 
-// there is an issue on mobile devices when using viewport units (e.g. vh)
-// "Using vh will size the element as if the URL bar is always hidden while using % will size the element as if the URL bar were always showing."
-// the result is that using `100vh` on mobile devices will give you a greater height than is visible, and the bottom of the page will be cut off
-const getHeight = () =>
-  EnvUtils.platform === Platform.Android ? `${window.innerHeight}px` : '100vh';
-
 export const Viewport: React.FC<PropsWithChildrenOnly> = props => {
-  const [height, setHeight] = useState(getHeight());
-  const handleResize = () => setHeight(getHeight());
-
   const globalStyles = {
     '*:-webkit-full-screen': {
       height: '100%',
       width: '100%',
     },
     '#root': {
-      height,
       width: '100vw',
       display: 'flex',
       flexDirection: 'column',
+      position: 'absolute',
+      top: '0',
+      bottom: '0',
+      left: '0',
+      right: '0',
+    },
+    body: {
+      // displaying as table (and introducing the below wrappers around #root)
+      // makes page responsive to injected popups like the Bitwarden one
+      display: 'table',
+      height: '100vh',
+      width: '100%',
+    },
+    '#content-row': {
+      display: 'table-row',
+      height: '100%',
+    },
+    '#outer-wrapper': {
+      display: 'table-cell',
+      height: '100%',
+    },
+    '#inner-wrapper': {
+      height: '100%',
+      width: '100vw',
+      position: 'relative',
+      overflow: 'auto',
     },
     html: { position: 'fixed' },
     'html, body': {
@@ -34,11 +45,6 @@ export const Viewport: React.FC<PropsWithChildrenOnly> = props => {
       width: '100%',
     },
   } as const;
-
-  useEffect(() => {
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
 
   return (
     <React.Fragment>

--- a/client/packages/inventory/src/Stocktake/DetailView/AppBarButtons.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/AppBarButtons.tsx
@@ -28,7 +28,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   onAddItem,
 }) => {
   const { OpenButton } = useDetailPanel();
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { print, isPrinting } = useReport.utils.print();
   const { data } = useStocktake.document.get();
   const isDisabled = !data || isStocktakeDisabled(data);

--- a/client/packages/inventory/src/Stocktake/DetailView/SidePanel.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/SidePanel.tsx
@@ -20,7 +20,7 @@ import { useStocktake } from '../api';
 import { canDeleteStocktake } from '../../utils';
 
 const AdditionalInfoSection: FC = () => {
-  const t = useTranslation('common');
+  const t = useTranslation();
 
   const { comment, user, update } = useStocktake.document.fields([
     'comment',

--- a/client/packages/invoices/src/InboundShipment/DetailView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/AppBarButtons.tsx
@@ -31,7 +31,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   const isDisabled = useInbound.utils.isDisabled();
   const { data } = useInbound.document.get();
   const { OpenButton } = useDetailPanel();
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { print, isPrinting } = useReport.utils.print();
   const {
     queryParams: { sortBy },

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
@@ -25,7 +25,7 @@ export const InboundLineEditForm: FC<InboundLineEditProps> = ({
   disabled,
   onChangeItem,
 }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { data: items } = useInbound.lines.items();
 
   return (

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -157,6 +157,7 @@ export const PricingTableComponent: FC<TableProps> = ({
       description: 'description.fc-sell-price',
       width: 100,
       align: ColumnAlign.Right,
+      // eslint-disable-next-line new-cap
       Cell: CurrencyCell({ currency: currency?.code }),
       accessor: ({ rowData }) => {
         if (currency) {
@@ -183,6 +184,7 @@ export const PricingTableComponent: FC<TableProps> = ({
       description: 'description.fc-cost-price',
       width: 100,
       align: ColumnAlign.Right,
+      // eslint-disable-next-line new-cap
       Cell: CurrencyCell({ currency: currency?.code }),
       accessor: ({ rowData }) => {
         if (currency) {
@@ -215,6 +217,7 @@ export const PricingTableComponent: FC<TableProps> = ({
       label: 'label.fc-line-total',
       description: 'description.fc-line-total',
       width: 100,
+      // eslint-disable-next-line new-cap
       Cell: CurrencyCell({ currency: currency?.code }),
       align: ColumnAlign.Right,
       accessor: ({ rowData }) => {

--- a/client/packages/invoices/src/OutboundShipment/DetailView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/AppBarButtons.tsx
@@ -32,7 +32,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   const isDisabled = useOutbound.utils.isDisabled();
   const { data } = useOutbound.document.get();
   const { OpenButton } = useDetailPanel();
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { print, isPrinting } = useReport.utils.print();
   const {
     queryParams: { sortBy },

--- a/client/packages/programs/src/JsonForms/common/JsonForm.tsx
+++ b/client/packages/programs/src/JsonForms/common/JsonForm.tsx
@@ -211,7 +211,7 @@ export const JsonForm: FC<PropsWithChildren<JsonFormProps>> = ({
   additionalRenderers,
   config,
 }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
 
   if (isError)
     return (

--- a/client/packages/programs/src/JsonForms/common/components/Array/EnumArray.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Array/EnumArray.tsx
@@ -101,7 +101,7 @@ export const EnumArrayComponent: FC<EnumArrayControlCustomProps> = ({
   addItem,
   removeItems,
 }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const [removeIndex, setRemoveIndex] = useState<number | undefined>();
 
   if (!visible) {

--- a/client/packages/programs/src/JsonForms/common/components/Array/Notes.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Array/Notes.tsx
@@ -226,7 +226,7 @@ const NoteComponent = (props: ControlProps) => {
   );
   const [editMode, setEditMode] = useState(!text);
 
-  const t = useTranslation('common');
+  const t = useTranslation();
 
   if (!props.visible) {
     return null;

--- a/client/packages/programs/src/JsonForms/common/components/Array/common.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Array/common.tsx
@@ -80,7 +80,7 @@ const isStringEnum = (
 };
 
 export const ArrayCommonComponent = (props: ArrayControlCustomProps) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const [removeIndex, setRemoveIndex] = useState<number | undefined>();
   const {
     uischema,

--- a/client/packages/programs/src/JsonForms/common/components/CategorizationTabLayout.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/CategorizationTabLayout.tsx
@@ -161,7 +161,7 @@ const ErrorStringComponent: FC<{
   category: Category;
   errorPaths: string[];
 }> = ({ category, errorPaths }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
 
   if (errorPaths.length === 0) {
     return null;

--- a/client/packages/programs/src/JsonForms/common/components/Text.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Text.tsx
@@ -100,7 +100,7 @@ const UIComponent = (props: ControlProps) => {
     data,
     (value: string | undefined) => handleChange(path, value)
   );
-  const t = useTranslation('common');
+  const t = useTranslation();
 
   const examples =
     (props.schema as Record<string, string[]>)['examples'] ??

--- a/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
+++ b/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
@@ -30,7 +30,7 @@ const UIComponent = (props: ControlProps) => {
   const { data, handleChange, label, path } = props;
   const [age, setAge] = React.useState<number | undefined>();
   const [dob, setDoB] = React.useState<Date | null>(null);
-  const t = useTranslation('common');
+  const t = useTranslation();
   const formatDateTime = useFormatDateTime();
   const { customError, setCustomError } = useJSONFormsCustomError(
     path,

--- a/client/packages/programs/src/JsonForms/useJsonForms.tsx
+++ b/client/packages/programs/src/JsonForms/useJsonForms.tsx
@@ -123,7 +123,7 @@ export const useJsonForms = <R,>(
   const [data, setData] = useState<JsonData | undefined>();
   const [isSaving, setSaving] = useState(false);
   const [isDirty, setIsDirty] = useState<boolean>();
-  const t = useTranslation('common');
+  const t = useTranslation();
   const [validationError, setValidationError] = useState<string | false>(false);
   const { success, error: errorNotification } = useNotification();
 

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/SidePanel.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/SidePanel.tsx
@@ -35,7 +35,7 @@ const AdditionalInfoSection: FC = () => {
       'user',
     ]);
   const [bufferedColor, setBufferedColor] = useBufferState(colour);
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { localisedDate } = useFormatDateTime();
 
   return (

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
@@ -13,7 +13,7 @@ import {
 import { useRequest } from '../api';
 
 export const useRequestColumns = () => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { maxMonthsOfStock } = useRequest.document.fields('maxMonthsOfStock');
   const {
     updateSortQuery,

--- a/client/packages/requisitions/src/RequestRequisition/ListView/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/ListView/AppBarButtons.tsx
@@ -26,7 +26,7 @@ export const AppBarButtons: FC<{
   const { mutate: onCreate } = useRequest.document.insert();
   const { mutate: onProgramCreate } = useRequest.document.insertProgram();
   const { success, error } = useNotification();
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { isLoading, fetchAsync } = useRequest.document.listAll({
     key: 'createdDatetime',
     direction: 'desc',

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
@@ -22,7 +22,7 @@ export const AppBarButtonsComponent = () => {
   const { OpenButton } = useDetailPanel();
   const { data } = useResponse.document.get();
   const { print, isPrinting } = useReport.utils.print();
-  const t = useTranslation('common');
+  const t = useTranslation();
 
   const printReport = (
     report: ReportRowFragment,

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ReponseStats/RequestStoreStats.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ReponseStats/RequestStoreStats.tsx
@@ -28,7 +28,7 @@ const MonthlyConsumption = ({
   averageMonthlyConsumption: number;
   showText: boolean;
 }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const formatNumber = useFormatNumber();
   const text = ` (${month} ${t('label.months', {
     count: month,

--- a/client/packages/requisitions/src/ResponseRequisition/ListView/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/ListView/AppBarButtons.tsx
@@ -15,7 +15,7 @@ import { responsesToCsv } from '../../utils';
 
 export const AppBarButtons = () => {
   const { success, error } = useNotification();
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { mutateAsync, isLoading } = useResponse.document.listAll({
     key: 'createdDatetime',
     direction: 'desc',

--- a/client/packages/system/src/ContactTrace/DetailView/Footer.tsx
+++ b/client/packages/system/src/ContactTrace/DetailView/Footer.tsx
@@ -35,7 +35,7 @@ export const Footer: FC<FooterProps> = ({
   onCancel,
   onSave,
 }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const navigate = useNavigate();
   const { Modal, showDialog, hideDialog } = useDialog();
   return (

--- a/client/packages/system/src/Encounter/DetailView/Footer.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Footer.tsx
@@ -34,7 +34,7 @@ interface FooterProps {
 const EncounterStatusCrumbs: FC<{ encounter: EncounterFragment }> = ({
   encounter,
 }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   // TODO StatusCrumbs shows "Order History" in the logs pop up -> make this configurable
   return (
     <StatusCrumbs
@@ -69,7 +69,7 @@ export const Footer: FC<FooterProps> = ({
   onSave,
   encounter,
 }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const navigate = useNavigate();
   const { Modal, showDialog, hideDialog } = useDialog();
   return (

--- a/client/packages/system/src/Item/Components/ServiceItemSearchInput/ServiceItemSearchInput.tsx
+++ b/client/packages/system/src/Item/Components/ServiceItemSearchInput/ServiceItemSearchInput.tsx
@@ -49,7 +49,7 @@ const ServiceItemSearchComponent: FC<ItemSearchInputProps> = ({
   refetchOnMount = true,
 }) => {
   const { data, isLoading } = useServiceItems({ refetchOnMount });
-  const t = useTranslation('common');
+  const t = useTranslation();
   const selectControl = useToggle();
 
   const value =

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
@@ -42,7 +42,7 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
   // then the current item may not be in the available list of items due to pagination batching
   const { data: currentItem } = useItemById(currentItemId ?? undefined);
 
-  const t = useTranslation('common');
+  const t = useTranslation();
   const formatNumber = useFormatNumber();
 
   const selectControl = useToggle();

--- a/client/packages/system/src/Item/Components/StockItemSearchInputWithStats/StockItemSearchInputWithStats.tsx
+++ b/client/packages/system/src/Item/Components/StockItemSearchInputWithStats/StockItemSearchInputWithStats.tsx
@@ -26,7 +26,7 @@ export const StockItemSearchInputWithStats: FC<
   openOnFocus,
 }) => {
   const { data, isLoading } = useStockItemsWithStats();
-  const t = useTranslation('common');
+  const t = useTranslation();
   const formatNumber = useFormatNumber();
 
   const value = data?.nodes.find(({ id }) => id === currentItemId) ?? null;

--- a/client/packages/system/src/MasterList/DetailView/ContentArea.tsx
+++ b/client/packages/system/src/MasterList/DetailView/ContentArea.tsx
@@ -3,7 +3,7 @@ import { DataTable, useTranslation } from '@openmsupply-client/common';
 import { useMasterList } from '../api';
 
 export const ContentArea = () => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { lines, columns } = useMasterList.line.rows();
   return (
     <DataTable

--- a/client/packages/system/src/MasterList/ListView/Toolbar.tsx
+++ b/client/packages/system/src/MasterList/ListView/Toolbar.tsx
@@ -11,7 +11,7 @@ import { MasterListRow } from '../types';
 export const Toolbar: FC<{
   filter: FilterController;
 }> = ({ filter }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
 
   const key = 'name' as keyof MasterListRow;
   const filterString =

--- a/client/packages/system/src/Name/DetailModal/DetailModal.tsx
+++ b/client/packages/system/src/Name/DetailModal/DetailModal.tsx
@@ -21,7 +21,7 @@ interface DetailModalProps {
 
 export const DetailModal: FC<DetailModalProps> = ({ nameId }) => {
   const { data, isLoading } = useName.document.get(nameId);
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { setSuffix } = useBreadcrumbs();
   const isDisabled = true;
   const { localisedDate } = useFormatDateTime();

--- a/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
@@ -245,7 +245,7 @@ const RenderForm = ({
   isLoading: boolean;
   isProgram: boolean;
 }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   if (!isProgram) return null;
   if (isError)
     return (

--- a/client/packages/system/src/Patient/PatientView/AppBarButtons.tsx
+++ b/client/packages/system/src/Patient/PatientView/AppBarButtons.tsx
@@ -17,7 +17,7 @@ export const AppBarButtons: FC<{
   disabled: boolean;
   store?: UserStoreNodeFragment;
 }> = ({ disabled, store }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { print, isPrinting } = useReport.utils.print();
   const patientId = usePatient.utils.id();
   const printReport = (

--- a/client/packages/system/src/Patient/PatientView/Footer.tsx
+++ b/client/packages/system/src/Patient/PatientView/Footer.tsx
@@ -33,7 +33,7 @@ export const Footer: FC<FooterProps> = ({
   inputData,
   showSaveConfirmation,
 }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { Modal, showDialog, hideDialog } = useDialog();
   const navigate = useNavigate();
   const { userHasPermission } = useAuthContext();

--- a/client/packages/system/src/Patient/ProgramEnrolment/Components/DetailModal.tsx
+++ b/client/packages/system/src/Patient/ProgramEnrolment/Components/DetailModal.tsx
@@ -49,7 +49,7 @@ const useUpsertProgramEnrolment = (
 };
 
 export const ProgramDetailModal: FC = () => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const patientId = usePatient.utils.id();
 
   const { current, document, reset } = usePatientModalStore();

--- a/client/packages/system/src/Report/ListView/ListView.tsx
+++ b/client/packages/system/src/Report/ListView/ListView.tsx
@@ -79,7 +79,7 @@ const ReportListComponent = ({ context }: { context: ReportContext }) => {
     queryParams,
   });
   const pagination = { page, first, offset };
-  const t = useTranslation('common');
+  const t = useTranslation();
   const [reportWithArgs, setReportWithArgs] = useState<
     ReportRowFragment | undefined
   >();

--- a/client/packages/system/src/Report/ListView/Toolbar.tsx
+++ b/client/packages/system/src/Report/ListView/Toolbar.tsx
@@ -12,7 +12,7 @@ interface ToolbarProps {
 }
 
 export const Toolbar: FC<ToolbarProps> = ({ filter }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const filterString =
     ((filter.filterBy?.['name'] as FilterRule)?.like as string) || '';
 

--- a/client/packages/system/src/Report/components/ReportSelector.tsx
+++ b/client/packages/system/src/Report/components/ReportSelector.tsx
@@ -20,7 +20,7 @@ interface ReportSelectorProps {
 }
 
 const NoReports = ({ hasPermission }: { hasPermission: boolean }) => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   return (
     <Box display="flex" alignItems="center" gap={1} padding={2}>
       <Box flex={0}>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2615

# 👩🏻‍💻 What does this PR do? 
Updates layout to cope with Bitwarden

# 🧪 How has/should this change been tested? 
- [ ] Have Bitwarden plugin installed for Firefox or Chrome
- [ ] Login and keep the Bitwarden popup at the top
- [ ] See that logout button is still there
- [ ] Can try in different views with explorer's developer tool