### PR TITLE
3198 fix rust warnings

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
  "actix-service",
  "actix-tls",
  "actix-utils",
- "ahash 0.8.7",
+ "ahash 0.8.11",
  "base64 0.21.7",
  "bitflags 2.4.2",
  "brotli",
@@ -114,7 +114,7 @@ dependencies = [
  "flate2",
  "futures-core",
  "h2",
- "http 0.2.11",
+ "http 0.2.12",
  "httparse",
  "httpdate",
  "itoa",
@@ -139,7 +139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -160,7 +160,7 @@ dependencies = [
  "log",
  "memchr",
  "mime",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "serde_plain",
  "tempfile",
@@ -173,11 +173,11 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a0a77f836d869f700e5b47ac7c3c8b9c8bc82e4aec861954c6198abee3ebd4d"
 dependencies = [
- "darling 0.20.5",
+ "darling 0.20.8",
  "parse-size",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -187,9 +187,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22475596539443685426b6bdadb926ad0ecaefdfc5fb05e5e3441f15463c511"
 dependencies = [
  "bytestring",
- "http 0.2.11",
+ "http 0.2.12",
  "regex",
- "serde 1.0.196",
+ "serde 1.0.197",
  "tracing",
 ]
 
@@ -216,7 +216,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2 0.5.5",
+ "socket2 0.5.6",
  "tokio",
  "tracing",
 ]
@@ -277,7 +277,7 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "actix-web-codegen",
- "ahash 0.8.7",
+ "ahash 0.8.11",
  "bytes",
  "bytestring",
  "cfg-if",
@@ -293,11 +293,11 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "regex",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.5.5",
+ "socket2 0.5.6",
  "time",
  "url",
 ]
@@ -329,7 +329,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -340,7 +340,7 @@ checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -360,9 +360,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -371,14 +371,14 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
- "serde 1.0.196",
+ "serde 1.0.197",
  "version_check",
  "zerocopy",
 ]
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -509,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "anymap"
@@ -591,7 +591,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
 ]
 
@@ -627,7 +627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
 dependencies = [
  "concurrent-queue",
- "event-listener 5.0.0",
+ "event-listener 5.2.0",
  "event-listener-strategy 0.5.0",
  "futures-core",
  "pin-project-lite",
@@ -680,7 +680,7 @@ dependencies = [
  "futures-channel",
  "futures-timer",
  "futures-util",
- "http 0.2.11",
+ "http 0.2.12",
  "indexmap 1.9.3",
  "lru",
  "mime",
@@ -689,7 +689,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "regex",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "static_assertions",
  "tempfile",
@@ -740,7 +740,7 @@ dependencies = [
  "async-graphql-value",
  "pest",
  "pest_derive",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
 ]
 
@@ -752,7 +752,7 @@ checksum = "ba2e19876bcd2068f597fd0182f4ba602ce3c89cb04c4b8810d7c36f44724e92"
 dependencies = [
  "bytes",
  "indexmap 1.9.3",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
 ]
 
@@ -788,7 +788,7 @@ dependencies = [
  "futures-io",
  "futures-lite 2.2.0",
  "parking",
- "polling 3.4.0",
+ "polling 3.5.0",
  "rustix 0.38.31",
  "slab",
  "tracing",
@@ -905,7 +905,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -922,7 +922,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -951,7 +951,7 @@ dependencies = [
  "convert_case 0.4.0",
  "proc-macro2",
  "quote",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "ureq",
 ]
@@ -1114,19 +1114,19 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "bytecount"
@@ -1146,7 +1146,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 dependencies = [
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
@@ -1166,9 +1166,9 @@ checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
 dependencies = [
  "jobserver",
  "libc",
@@ -1188,24 +1188,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits 0.2.18",
- "serde 1.0.196",
+ "serde 1.0.197",
  "wasm-bindgen",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d7b79e99bfaa0d47da0687c43aa3b7381938a62ad3a6498599039321f660b7"
+checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -1252,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.0"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
+checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
 dependencies = [
  "clap_builder",
  "clap_derive 4.5.0",
@@ -1262,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.0"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
+checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1294,7 +1294,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1326,7 +1326,7 @@ dependencies = [
  "log",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "server",
  "service",
@@ -1369,7 +1369,7 @@ dependencies = [
  "lazy_static",
  "nom 5.1.3",
  "rust-ini",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -1432,18 +1432,18 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1491,24 +1491,24 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
+checksum = "1e2161dd6eba090ff1594084e95fd67aeccf04382ffea77999ea94ed42ec67b6"
 dependencies = [
  "curl-sys",
  "libc",
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2 0.4.10",
- "winapi",
+ "socket2 0.5.6",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "curl-sys"
-version = "0.4.71+curl-8.6.0"
+version = "0.4.72+curl-8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b12a7ab780395666cb576203dc3ed6e01513754939a600b85196ccf5356bc5"
+checksum = "29cbdc8314c447d11e8fd156dcdd031d9e02a7a976163e396b548c03153bc9ea"
 dependencies = [
  "cc",
  "libc",
@@ -1517,7 +1517,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1542,12 +1542,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.5"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc5d6b04b3fd0ba9926f945895de7d806260a2d7431ba82e7edaecb043c4c6b8"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
 dependencies = [
- "darling_core 0.20.5",
- "darling_macro 0.20.5",
+ "darling_core 0.20.8",
+ "darling_macro 0.20.8",
 ]
 
 [[package]]
@@ -1580,16 +1580,16 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.5"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e48a959bcd5c761246f5d090ebc2fbf7b9cd527a492b07a67510c108f1e7e3"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1616,13 +1616,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.5"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
- "darling_core 0.20.5",
+ "darling_core 0.20.8",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1722,9 +1722,9 @@ dependencies = [
 
 [[package]]
 name = "deunicode"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae2a35373c5c74340b79ae6780b498b2b183915ec5dacf263aac5a099bf485a"
+checksum = "b6e854126756c496b8c81dec88f9a706b15b875c5849d4097a3854476b9fdf94"
 
 [[package]]
 name = "diesel"
@@ -1824,14 +1824,14 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "ena"
@@ -1934,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.0.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72557800024fabbaa2449dd4bf24e37b93702d457a4d4f2b0dd1f0f039f20c1"
+checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1959,7 +1959,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
 dependencies = [
- "event-listener 5.0.0",
+ "event-listener 5.2.0",
  "pin-project-lite",
 ]
 
@@ -2136,7 +2136,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2153,9 +2153,9 @@ checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -2218,7 +2218,7 @@ dependencies = [
  "bstr",
  "log",
  "regex-automata",
- "regex-syntax 0.8.2",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2280,7 +2280,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2310,7 +2310,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2333,7 +2333,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2353,7 +2353,7 @@ dependencies = [
  "chrono",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "strum 0.25.0",
@@ -2379,7 +2379,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2402,7 +2402,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2426,7 +2426,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2450,7 +2450,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "strum 0.25.0",
@@ -2474,7 +2474,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2499,7 +2499,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2523,7 +2523,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2547,7 +2547,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2571,7 +2571,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2595,7 +2595,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2618,7 +2618,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2641,7 +2641,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2664,7 +2664,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2687,7 +2687,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2710,7 +2710,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "strum 0.25.0",
@@ -2734,7 +2734,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2757,7 +2757,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2780,7 +2780,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2803,7 +2803,7 @@ dependencies = [
  "regex",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",
@@ -2821,8 +2821,8 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.11",
- "indexmap 2.2.2",
+ "http 0.2.12",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -2835,7 +2835,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -2857,7 +2857,7 @@ dependencies = [
  "log",
  "rand",
  "regex",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "tempfile",
  "thiserror",
@@ -2884,9 +2884,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -2905,9 +2905,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -2916,9 +2916,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -2932,7 +2932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http 0.2.11",
+ "http 0.2.12",
  "pin-project-lite",
 ]
 
@@ -2974,7 +2974,7 @@ dependencies = [
  "levenshtein",
  "log",
  "regex",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "serde_regex",
  "similar",
@@ -3017,13 +3017,13 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2 0.5.6",
  "tokio",
  "tower-service",
  "tracing",
@@ -3037,7 +3037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http 0.2.11",
+ "http 0.2.12",
  "hyper",
  "rustls 0.21.10",
  "tokio",
@@ -3113,14 +3113,14 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -3150,7 +3150,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.5",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -3160,17 +3160,6 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe8f25ce1159c7740ff0b9b2f5cdf4a8428742ba7c112b9f20f22cd5219c7dab"
-dependencies = [
- "hermit-abi 0.3.5",
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "is_debug"
@@ -3192,7 +3181,7 @@ dependencies = [
  "encoding_rs",
  "event-listener 2.5.3",
  "futures-lite 1.13.0",
- "http 0.2.11",
+ "http 0.2.12",
  "log",
  "mime",
  "once_cell",
@@ -3216,9 +3205,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -3260,9 +3249,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3279,11 +3268,11 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ca9e2b45609132ae2214d50482c03aeee78826cd6fd53a8940915b81acedf16"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.11",
  "anyhow",
  "base64 0.13.1",
  "bytecount",
- "clap 4.5.0",
+ "clap 4.5.1",
  "fancy-regex",
  "fraction",
  "iso8601",
@@ -3295,7 +3284,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "time",
  "url",
@@ -3311,7 +3300,7 @@ dependencies = [
  "base64 0.21.7",
  "pem 1.1.1",
  "ring 0.16.20",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "simple_asn1",
 ]
@@ -3327,34 +3316,33 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4081d44f4611b66c6dd725e6de3169f9f63905421e8626fcb86b6a898998b8"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
 dependencies = [
  "ascii-canvas",
  "bit-set",
- "diff",
  "ena",
- "is-terminal",
  "itertools",
  "lalrpop-util",
  "petgraph",
  "pico-args",
  "regex",
- "regex-syntax 0.7.5",
+ "regex-syntax",
  "string_cache",
  "term",
  "tiny-keccak",
  "unicode-xid",
+ "walkdir",
 ]
 
 [[package]]
 name = "lalrpop-util"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f35c735096c0293d313e8f2a641627472b83d01b937177fe76e5e2708d31e0d"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex",
+ "regex-automata",
 ]
 
 [[package]]
@@ -3494,11 +3482,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 dependencies = [
- "serde 1.0.196",
+ "serde 1.0.197",
  "value-bag",
 ]
 
@@ -3533,7 +3521,7 @@ dependencies = [
  "log",
  "log-mdc",
  "parking_lot 0.11.2",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde-value",
  "serde_derive",
  "serde_json",
@@ -3620,9 +3608,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
@@ -3639,7 +3627,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 0.2.11",
+ "http 0.2.12",
  "httparse",
  "log",
  "memchr",
@@ -3806,7 +3794,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.5",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -3856,9 +3844,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.99"
+version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",
@@ -3972,7 +3960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
 dependencies = [
  "base64 0.21.7",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
@@ -3992,9 +3980,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.7"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c0dcc30b6a27553f9cc242972b67f75b60eb0db71f0b5462f38b058c41546"
+checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -4003,9 +3991,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.7"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1288dbd7786462961e69bfd4df7848c1e37e8b74303dbdab82c3a9cdd2809"
+checksum = "b0d24f72393fd16ab6ac5738bc33cdb6a9aa73f8b902e8fe29cf4e67d7dd1026"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4013,22 +4001,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.7"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1381c29a877c6d34b8c176e734f35d7f7f5b3adaefe940cb4d1bb7af94678e2e"
+checksum = "fdc17e2a6c7d0a492f0158d7a4bd66cc17280308bbaff78d5bef566dca35ab80"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.7"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0934d6907f148c22a3acbda520c7eed243ad7487a30f51f6ce52b58b7077a8a"
+checksum = "934cd7631c050f4674352a6e835d5f6711ffbfb9345c2fc0107155ac495ae293"
 dependencies = [
  "once_cell",
  "pest",
@@ -4042,7 +4030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.2",
+ "indexmap 2.2.5",
 ]
 
 [[package]]
@@ -4100,22 +4088,22 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4164,9 +4152,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "polling"
@@ -4186,9 +4174,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30054e72317ab98eddd8561db0f6524df3367636884b7b21b703e4b280a84a14"
+checksum = "24f040dee2588b4963afb4e420540439d126f73fdacf4a9c486a96d840bac3c9"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
@@ -4390,25 +4378,19 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.2",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -4438,7 +4420,7 @@ dependencies = [
  "log",
  "regex",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "serde_yaml",
  "service",
@@ -4461,7 +4443,7 @@ dependencies = [
  "pretty_assertions",
  "rand",
  "rust-embed",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "strum 0.24.1",
  "thiserror",
@@ -4482,7 +4464,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -4495,7 +4477,7 @@ dependencies = [
  "pin-project-lite",
  "rustls 0.21.10",
  "rustls-pemfile",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
@@ -4528,16 +4510,17 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4594,7 +4577,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.48",
+ "syn 2.0.52",
  "walkdir",
 ]
 
@@ -4684,9 +4667,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
- "ring 0.17.7",
- "rustls-webpki",
+ "ring 0.17.8",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4699,12 +4696,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.7",
+ "ring 0.17.8",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -4716,9 +4730,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "same-file"
@@ -4756,7 +4770,7 @@ dependencies = [
  "Inflector",
  "schemafy_core",
  "schemafy_lib",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_derive",
  "serde_json",
  "serde_repr",
@@ -4769,7 +4783,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bec29dddcfe60f92f3c0d422707b8b56473983ef0481df8d5236ed3ab8fdf24"
 dependencies = [
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
 ]
 
@@ -4783,7 +4797,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "schemafy_core",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_derive",
  "serde_json",
  "syn 1.0.109",
@@ -4802,15 +4816,15 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.7",
+ "ring 0.17.8",
  "untrusted 0.9.0",
 ]
 
 [[package]]
 name = "semver"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
@@ -4820,9 +4834,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -4846,29 +4860,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
 dependencies = [
  "ordered-float",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
@@ -4877,7 +4891,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
 dependencies = [
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
@@ -4887,7 +4901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
 dependencies = [
  "regex",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
@@ -4898,7 +4912,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4910,7 +4924,7 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
@@ -4921,7 +4935,7 @@ checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap 1.9.3",
  "ryu",
- "serde 1.0.196",
+ "serde 1.0.197",
  "yaml-rust",
 ]
 
@@ -4955,7 +4969,7 @@ dependencies = [
  "rust-embed",
  "rustls 0.20.9",
  "rustls-pemfile",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "simple-log",
@@ -4992,7 +5006,7 @@ dependencies = [
  "rsa",
  "schemafy",
  "schemafy_core",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "serde_yaml",
  "sha2",
@@ -5066,7 +5080,7 @@ dependencies = [
  "log",
  "log4rs",
  "once_cell",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
@@ -5135,12 +5149,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5248,7 +5262,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5270,9 +5284,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5333,9 +5347,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
@@ -5359,7 +5373,7 @@ dependencies = [
  "pest_derive",
  "rand",
  "regex",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "slug",
  "unic-segment",
@@ -5387,28 +5401,28 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5432,7 +5446,7 @@ dependencies = [
  "itoa",
  "num-conv",
  "powerfmt",
- "serde 1.0.196",
+ "serde 1.0.197",
  "time-core",
  "time-macros",
 ]
@@ -5491,7 +5505,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.5",
+ "socket2 0.5.6",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -5504,7 +5518,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5548,7 +5562,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
@@ -5563,7 +5577,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.5",
  "toml_datetime",
  "winnow",
 ]
@@ -5600,7 +5614,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5637,7 +5651,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.0.0",
+ "http 1.1.0",
  "httparse",
  "log",
  "rand",
@@ -5732,9 +5746,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
@@ -5759,19 +5773,20 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.9.1"
+version = "2.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
+checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
 dependencies = [
  "base64 0.21.7",
  "flate2",
  "log",
  "once_cell",
- "rustls 0.21.10",
- "rustls-webpki",
+ "rustls 0.22.2",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
  "socks",
  "url",
- "webpki-roots 0.25.4",
+ "webpki-roots 0.26.1",
 ]
 
 [[package]]
@@ -5820,7 +5835,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "env_logger 0.8.4",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "sha2",
  "thiserror",
@@ -5877,9 +5892,9 @@ checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -5902,9 +5917,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5912,24 +5927,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5939,9 +5954,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5949,28 +5964,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5982,7 +5997,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
- "ring 0.17.7",
+ "ring 0.17.8",
  "untrusted 0.9.0",
 ]
 
@@ -6000,6 +6015,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "which"
@@ -6057,7 +6081,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -6100,7 +6124,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -6120,17 +6144,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -6141,9 +6165,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6159,9 +6183,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6177,9 +6201,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6195,9 +6219,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6213,9 +6237,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6225,9 +6249,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6243,15 +6267,15 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
-version = "0.5.39"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
@@ -6353,7 +6377,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/server/cli/src/refresh_dates.rs
+++ b/server/cli/src/refresh_dates.rs
@@ -2,9 +2,8 @@ use chrono::Duration;
 use chrono::NaiveDate;
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
+use diesel::sql_query;
 use diesel::sql_types::*;
-use diesel::QueryDsl;
-use diesel::{sql_query, RunQueryDsl};
 use repository::DBType;
 use repository::RepositoryError;
 use repository::StorageConnection;
@@ -346,7 +345,6 @@ fn serialise_date(date: NaiveDate) -> String {
 
 #[cfg(test)]
 mod tests {
-    use chrono::NaiveDate;
     use repository::{
         mock::{
             mock_item_a, mock_item_link_from_item, mock_name_a, mock_store_a, MockData,

--- a/server/graphql/batch_mutations/src/batch_inbound_shipment.rs
+++ b/server/graphql/batch_mutations/src/batch_inbound_shipment.rs
@@ -6,7 +6,6 @@ use graphql_invoice_line::mutations::inbound_shipment_line;
 use service::auth::Resource;
 use service::auth::ResourceAccessRequest;
 use service::invoice::inbound_shipment::*;
-use service::invoice::inbound_shipment::{BatchInboundShipment, BatchInboundShipmentResult};
 
 use crate::to_standard_error;
 use crate::VecOrNone;

--- a/server/graphql/batch_mutations/src/batch_outbound_shipment.rs
+++ b/server/graphql/batch_mutations/src/batch_outbound_shipment.rs
@@ -1,3 +1,4 @@
+use crate::{to_standard_error, VecOrNone};
 use async_graphql::*;
 use graphql_core::standard_graphql_error::validate_auth;
 use graphql_core::ContextExt;
@@ -6,9 +7,6 @@ use graphql_invoice_line::mutations::outbound_shipment_line;
 use service::auth::Resource;
 use service::auth::ResourceAccessRequest;
 use service::invoice::outbound_shipment::*;
-use service::invoice::outbound_shipment::{BatchOutboundShipment, BatchOutboundShipmentResult};
-
-use crate::{to_standard_error, VecOrNone};
 
 #[derive(SimpleObject)]
 #[graphql(concrete(

--- a/server/graphql/batch_mutations/src/batch_prescription.rs
+++ b/server/graphql/batch_mutations/src/batch_prescription.rs
@@ -6,7 +6,6 @@ use graphql_invoice_line::mutations::prescription_line;
 use service::auth::Resource;
 use service::auth::ResourceAccessRequest;
 use service::invoice::prescription::*;
-use service::invoice::prescription::{BatchPrescription, BatchPrescriptionResult};
 
 use crate::{to_standard_error, VecOrNone};
 

--- a/server/graphql/core/src/loader/loader_registry.rs
+++ b/server/graphql/core/src/loader/loader_registry.rs
@@ -1,5 +1,4 @@
-use super::{json_schema::JsonSchemaLoader, *};
-use crate::loader::{ItemLoader, StoreByIdLoader, UserLoader};
+use crate::loader::*;
 use actix_web::web::Data;
 use anymap::{any::Any, Map};
 use async_graphql::dataloader::DataLoader;

--- a/server/graphql/general/src/queries/initialisation_status.rs
+++ b/server/graphql/general/src/queries/initialisation_status.rs
@@ -1,5 +1,5 @@
+use async_graphql::Enum;
 pub use async_graphql::*;
-use async_graphql::{Context, Enum};
 use graphql_core::ContextExt;
 use service::sync::sync_status::status::InitialisationStatus;
 

--- a/server/graphql/general/src/queries/log.rs
+++ b/server/graphql/general/src/queries/log.rs
@@ -1,4 +1,4 @@
-use async_graphql::{Context, *};
+use async_graphql::*;
 use graphql_core::{standard_graphql_error::validate_auth, ContextExt};
 use service::{
     auth::{Resource, ResourceAccessRequest},

--- a/server/graphql/stocktake/src/stocktake_queries.rs
+++ b/server/graphql/stocktake/src/stocktake_queries.rs
@@ -10,9 +10,8 @@ use graphql_core::simple_generic_errors::{
 use graphql_core::standard_graphql_error::{list_error_to_gql_err, validate_auth};
 use graphql_core::{map_filter, ContextExt};
 use graphql_types::types::{StocktakeNode, StocktakeNodeStatus};
-use repository::StocktakeFilter;
+use repository::StocktakeSortField;
 use repository::*;
-use repository::{StocktakeSort, StocktakeSortField};
 use service::auth::Resource;
 use service::auth::ResourceAccessRequest;
 

--- a/server/graphql/stocktake_line/src/lib.rs
+++ b/server/graphql/stocktake_line/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod mutations;
 pub mod stocktake_line_queries;
-use async_graphql::Context;
 use async_graphql::*;
 use graphql_core::{generic_inputs::PrintReportSortInput, pagination::PaginationInput};
 use mutations::{delete::*, insert::*, update::*};

--- a/server/graphql/stocktake_line/src/stocktake_line_queries.rs
+++ b/server/graphql/stocktake_line/src/stocktake_line_queries.rs
@@ -143,7 +143,6 @@ pub fn stocktake_lines(
 
 #[cfg(test)]
 mod test {
-    use async_graphql::EmptyMutation;
     use async_graphql::*;
     use chrono::NaiveDate;
     use graphql_core::assert_graphql_query;

--- a/server/graphql/types/src/types/barcode.rs
+++ b/server/graphql/types/src/types/barcode.rs
@@ -85,7 +85,7 @@ impl BarcodeConnector {
 
 #[cfg(test)]
 mod test {
-    use async_graphql::{EmptyMutation, Object};
+    use async_graphql::Object;
     use graphql_core::{assert_graphql_query, test_helpers::setup_graphl_test};
     use repository::mock::MockDataInserts;
     use serde_json::json;

--- a/server/graphql/types/src/types/item.rs
+++ b/server/graphql/types/src/types/item.rs
@@ -275,7 +275,7 @@ impl ItemConnector {
 
 #[cfg(test)]
 mod test {
-    use async_graphql::{EmptyMutation, Object};
+    use async_graphql::Object;
     use graphql_core::{assert_graphql_query, test_helpers::setup_graphl_test};
     use repository::mock::MockDataInserts;
     use serde_json::json;

--- a/server/graphql/types/src/types/item_chart.rs
+++ b/server/graphql/types/src/types/item_chart.rs
@@ -173,8 +173,7 @@ impl ItemChartNode {
 
 #[cfg(test)]
 mod test {
-    use async_graphql::{EmptyMutation, Object};
-    use chrono::NaiveDate;
+    use async_graphql::Object;
     use graphql_core::{assert_graphql_query, test_helpers::setup_graphl_test};
     use repository::mock::MockDataInserts;
     use serde_json::json;

--- a/server/graphql/types/src/types/location.rs
+++ b/server/graphql/types/src/types/location.rs
@@ -1,6 +1,6 @@
 use super::StockLineConnector;
+use async_graphql::dataloader::DataLoader;
 use async_graphql::*;
-use async_graphql::{dataloader::DataLoader, Context};
 use graphql_core::generic_filters::{EqualFilterStringInput, StringFilterInput};
 use graphql_core::simple_generic_errors::NodeError;
 use graphql_core::{loader::StockLineByLocationIdLoader, ContextExt};

--- a/server/graphql/types/src/types/name.rs
+++ b/server/graphql/types/src/types/name.rs
@@ -262,8 +262,7 @@ impl NameNode {
 
 #[cfg(test)]
 mod test {
-    use async_graphql::{EmptyMutation, Object};
-    use chrono::NaiveDate;
+    use async_graphql::Object;
     use graphql_core::{assert_graphql_query, test_helpers::setup_graphl_test};
     use repository::mock::MockDataInserts;
     use serde_json::json;

--- a/server/graphql/types/src/types/program/document.rs
+++ b/server/graphql/types/src/types/program/document.rs
@@ -1,5 +1,5 @@
+use async_graphql::dataloader::DataLoader;
 use async_graphql::*;
-use async_graphql::{dataloader::DataLoader, Context};
 use chrono::{DateTime, Utc};
 
 use graphql_core::loader::{

--- a/server/graphql/types/src/types/program/encounter.rs
+++ b/server/graphql/types/src/types/program/encounter.rs
@@ -247,7 +247,7 @@ pub struct SuggestedNextEncounterNode {
 #[Object]
 impl SuggestedNextEncounterNode {
     async fn start_datetime(&self) -> DateTime<Utc> {
-        DateTime::<Utc>::from_utc(self.suggested.start_datetime, Utc)
+        DateTime::<Utc>::from_naive_utc_and_offset(self.suggested.start_datetime, Utc)
     }
 
     async fn label(&self) -> &Option<String> {

--- a/server/graphql/types/src/types/stocktake.rs
+++ b/server/graphql/types/src/types/stocktake.rs
@@ -1,4 +1,4 @@
-use async_graphql::{self, dataloader::DataLoader, Context, Enum, ErrorExtensions, Object, Result};
+use async_graphql::{dataloader::DataLoader, Context, Enum, ErrorExtensions, Object, Result};
 use chrono::{DateTime, NaiveDate, Utc};
 use repository::{unknown_user, StocktakeRow, StocktakeStatus};
 use serde::Serialize;

--- a/server/report_builder/src/build.rs
+++ b/server/report_builder/src/build.rs
@@ -4,7 +4,6 @@ use service::report::definition::{
     ReportOutputType, TeraTemplate,
 };
 use std::{
-    self,
     collections::HashMap,
     fs,
     path::{Path, PathBuf},

--- a/server/repository/src/database_settings.rs
+++ b/server/repository/src/database_settings.rs
@@ -2,7 +2,6 @@ use crate::db_diesel::{DBBackendConnection, StorageConnectionManager};
 use diesel::connection::SimpleConnection;
 use diesel::r2d2::{ConnectionManager, Pool};
 use log::info;
-use serde;
 
 // Timeout for waiting for the SQLite lock (https://www.sqlite.org/c3ref/busy_timeout.html).
 // A locked DB results in the "SQLite database is locked" error.

--- a/server/repository/src/db_diesel/consumption.rs
+++ b/server/repository/src/db_diesel/consumption.rs
@@ -5,7 +5,6 @@ use crate::{
     DateFilter, EqualFilter, RepositoryError,
 };
 use diesel::prelude::*;
-use diesel::{QueryDsl, RunQueryDsl};
 
 table! {
     consumption (id) {

--- a/server/repository/src/db_diesel/stock_movement.rs
+++ b/server/repository/src/db_diesel/stock_movement.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
-use diesel::{QueryDsl, RunQueryDsl};
 use util::Defaults;
 
 table! {

--- a/server/repository/src/db_diesel/stock_on_hand.rs
+++ b/server/repository/src/db_diesel/stock_on_hand.rs
@@ -2,7 +2,6 @@ use super::{stock_on_hand::stock_on_hand::dsl as stock_on_hand_dsl, StorageConne
 
 use crate::{diesel_macros::apply_equal_filter, EqualFilter, RepositoryError};
 use diesel::prelude::*;
-use diesel::{QueryDsl, RunQueryDsl};
 
 table! {
     stock_on_hand (id) {

--- a/server/repository/src/db_diesel/temperature_chart/temperature_chart.rs
+++ b/server/repository/src/db_diesel/temperature_chart/temperature_chart.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use diesel::prelude::*;
 
-use super::temperature_chart_row::{Interval, *};
+use super::temperature_chart_row::*;
 
 pub struct TemperatureChartRepository<'a> {
     connection: &'a StorageConnection,
@@ -87,7 +87,7 @@ mod test {
         mock::{MockData, MockDataInserts},
         test_db::setup_all_with_data,
         EqualFilter, LocationRow, NameRow, SensorFilter, SensorRow, StoreRow, TemperatureBreachRow,
-        TemperatureChartRepository, TemperatureChartRow, TemperatureLogRow,
+        TemperatureLogRow,
     };
 
     use rand::{seq::SliceRandom, thread_rng};

--- a/server/repository/src/diesel_extensions.rs
+++ b/server/repository/src/diesel_extensions.rs
@@ -109,7 +109,7 @@ pub mod date_coalesce {
 #[cfg(test)]
 mod tests {
     use chrono::NaiveDate;
-    use diesel::{debug_query, prelude::*, sqlite::Sqlite, QueryDsl};
+    use diesel::{debug_query, prelude::*, sqlite::Sqlite};
 
     use crate::diesel_extensions::{date_coalesce, OrderByExtensions};
 

--- a/server/repository/src/migrations/templates/add_data_from_sync_buffer/mod.rs
+++ b/server/repository/src/migrations/templates/add_data_from_sync_buffer/mod.rs
@@ -1,4 +1,4 @@
-use crate::{migrations::*, StorageConnection};
+use crate::migrations::*;
 
 use anyhow::Context;
 use diesel::prelude::*;

--- a/server/repository/src/migrations/templates/adding_table/mod.rs
+++ b/server/repository/src/migrations/templates/adding_table/mod.rs
@@ -1,4 +1,4 @@
-use crate::{migrations::*, StorageConnection};
+use crate::migrations::*;
 pub(crate) struct V1_00_05;
 
 impl Migration for V1_00_05 {

--- a/server/repository/src/migrations/templates/data_and_schema/mod.rs
+++ b/server/repository/src/migrations/templates/data_and_schema/mod.rs
@@ -1,4 +1,4 @@
-use crate::{migrations::*, StorageConnection};
+use crate::migrations::*;
 
 use diesel::prelude::*;
 use diesel_derive_enum::DbEnum;

--- a/server/repository/src/migrations/templates/data_migration/mod.rs
+++ b/server/repository/src/migrations/templates/data_migration/mod.rs
@@ -1,4 +1,4 @@
-use crate::{migrations::*, StorageConnection};
+use crate::migrations::*;
 
 use chrono::{Duration, NaiveDateTime};
 use diesel::prelude::*;

--- a/server/repository/src/migrations/v1_03_00/user.rs
+++ b/server/repository/src/migrations/v1_03_00/user.rs
@@ -1,4 +1,4 @@
-use crate::{migrations::*, StorageConnection};
+use crate::migrations::*;
 
 pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
     sql!(

--- a/server/repository/src/migrations/v1_06_00/changelog_deduped.rs
+++ b/server/repository/src/migrations/v1_06_00/changelog_deduped.rs
@@ -1,4 +1,4 @@
-use crate::{migrations::*, StorageConnection};
+use crate::migrations::*;
 
 pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
     sql!(

--- a/server/repository/src/migrations/v1_06_00/plugin_data.rs
+++ b/server/repository/src/migrations/v1_06_00/plugin_data.rs
@@ -1,4 +1,4 @@
-use crate::{migrations::*, StorageConnection};
+use crate::migrations::*;
 
 pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
     #[cfg(not(feature = "postgres"))]

--- a/server/service/src/auth.rs
+++ b/server/service/src/auth.rs
@@ -1045,14 +1045,11 @@ mod permission_validation_test {
     use std::sync::{Arc, RwLock};
 
     use super::*;
-    use crate::{
-        auth_data::AuthData, service_provider::ServiceProvider, token_bucket::TokenBucket,
-    };
+    use crate::{service_provider::ServiceProvider, token_bucket::TokenBucket};
     use repository::{
         mock::{mock_user_account_a, MockData, MockDataInserts},
         test_db::{setup_all, setup_all_with_data},
-        NameRow, Permission, StoreRow, UserAccountRow, UserPermissionRow,
-        UserPermissionRowRepository,
+        NameRow, StoreRow, UserAccountRow, UserPermissionRowRepository,
     };
     use util::inline_init;
 

--- a/server/service/src/document/document_service.rs
+++ b/server/service/src/document/document_service.rs
@@ -241,7 +241,7 @@ mod document_service_test {
     };
     use serde_json::json;
 
-    use crate::{document::raw_document::RawDocument, service_provider::ServiceProvider};
+    use crate::service_provider::ServiceProvider;
 
     use super::*;
 

--- a/server/service/src/document/raw_document.rs
+++ b/server/service/src/document/raw_document.rs
@@ -63,7 +63,6 @@ impl RawDocument {
 #[cfg(test)]
 mod document_id_test {
     use chrono::TimeZone;
-    use repository::DocumentStatus;
     use serde_json::*;
 
     use super::*;

--- a/server/service/src/requisition_line/chart/mod.rs
+++ b/server/service/src/requisition_line/chart/mod.rs
@@ -171,14 +171,13 @@ mod test {
     use super::*;
     use crate::service_provider::ServiceProvider;
     use repository::{
-        db_diesel::requisition_row::RequisitionRowType,
         mock::{
             mock_item_a, mock_name_a, mock_new_response_requisition_for_update_test_line,
             mock_store_a, mock_store_b, MockData, MockDataInserts,
         },
         test_db::{setup_all, setup_all_with_data},
-        InvoiceLineRow, InvoiceLineRowType, InvoiceRow, InvoiceRowType, NameRow,
-        RequisitionLineRow, RequisitionRow, StockLineRow, StoreRow,
+        InvoiceLineRow, InvoiceLineRowType, InvoiceRow, InvoiceRowType, NameRow, RequisitionRow,
+        StockLineRow, StoreRow,
     };
     use util::{
         constants::NUMBER_OF_DAYS_IN_A_MONTH, date_now, inline_edit, inline_init, uuid::uuid,

--- a/server/service/src/stocktake/batch.rs
+++ b/server/service/src/stocktake/batch.rs
@@ -1,9 +1,6 @@
-use repository::{RepositoryError, Stocktake, StocktakeLine};
+use repository::StocktakeLine;
 
-use crate::{
-    service_provider::ServiceContext, stocktake_line::*, BatchMutationsProcessor, InputWithResult,
-    WithDBError,
-};
+use crate::{stocktake_line::*, BatchMutationsProcessor, InputWithResult, WithDBError};
 
 use super::*;
 

--- a/server/service/src/sync/translations/special/clinician_merge.rs
+++ b/server/service/src/sync/translations/special/clinician_merge.rs
@@ -71,8 +71,7 @@ mod tests {
 
     use super::*;
     use repository::{
-        mock::MockDataInserts, test_db::setup_all, ClinicianLinkRowRepository, SyncBufferAction,
-        SyncBufferRow, SyncBufferRowRepository,
+        mock::MockDataInserts, test_db::setup_all, SyncBufferAction, SyncBufferRowRepository,
     };
 
     #[actix_rt::test]

--- a/server/service/src/sync/translations/special/item_merge.rs
+++ b/server/service/src/sync/translations/special/item_merge.rs
@@ -69,8 +69,7 @@ mod tests {
 
     use super::*;
     use repository::{
-        mock::MockDataInserts, test_db::setup_all, ItemLinkRowRepository, SyncBufferAction,
-        SyncBufferRow, SyncBufferRowRepository,
+        mock::MockDataInserts, test_db::setup_all, SyncBufferAction, SyncBufferRowRepository,
     };
 
     #[actix_rt::test]

--- a/server/service/src/sync/translations/special/name_merge.rs
+++ b/server/service/src/sync/translations/special/name_merge.rs
@@ -68,8 +68,7 @@ mod tests {
 
     use super::*;
     use repository::{
-        mock::MockDataInserts, test_db::setup_all, NameLinkRowRepository, SyncBufferAction,
-        SyncBufferRow, SyncBufferRowRepository,
+        mock::MockDataInserts, test_db::setup_all, SyncBufferAction, SyncBufferRowRepository,
     };
 
     #[actix_rt::test]

--- a/server/service/src/token.rs
+++ b/server/service/src/token.rs
@@ -323,8 +323,6 @@ fn create_jwt_pair(
 mod user_account_test {
     use util::assert_matches;
 
-    use crate::token_bucket::TokenBucket;
-
     use super::*;
 
     #[actix_rt::test]

--- a/server/service/src/user_account.rs
+++ b/server/service/src/user_account.rs
@@ -202,8 +202,7 @@ mod user_account_test {
     use repository::{
         mock::{mock_user_account_a, mock_user_account_b, MockDataInserts},
         test_db::{self, setup_all},
-        EqualFilter, Permission, UserFilter, UserPermissionFilter, UserPermissionRepository,
-        UserRepository,
+        Permission,
     };
     use util::{assert_matches, inline_edit};
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3198 

# 👩🏻‍💻 What does this PR do? 
- Updates Cargo.lock using `cargo update`
- Fix resulting warnings

# 🧪 How has/should this change been tested? 
Compile/ run tests