### PR TITLE
Reduce bundle size

### DIFF
--- a/client/packages/coldchain/src/index.ts
+++ b/client/packages/coldchain/src/index.ts
@@ -1,3 +1,3 @@
 export { ColdchainService } from './ColdchainService';
 export { ColdchainNotification } from './ColdchainNotification';
-export * from './common';
+export { parseBreachType } from './common';

--- a/client/packages/common/src/intl/utils/IntlUtils.ts
+++ b/client/packages/common/src/intl/utils/IntlUtils.ts
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useCallback, useContext, useState } from 'react';
 import { EnvUtils } from '@common/utils';
 import { LanguageType } from '../../types/schema';
 import { LocalStorage } from '../../localStorage';
@@ -30,7 +30,7 @@ export const getLocale = (language: SupportedLocales) => {
   }
 };
 
-export const useIntl = () => React.useContext(IntlContext);
+export const useIntl = () => useContext(IntlContext);
 
 const languageOptions = [
   { label: 'عربي', value: 'ar' },
@@ -61,7 +61,7 @@ type StringOrEmpty = string | null | undefined;
 export const useIntlUtils = () => {
   const { i18n } = useIntl();
   const { language: i18nLanguage } = i18n;
-  const [language, setLanguage] = React.useState<string>(i18nLanguage);
+  const [language, setLanguage] = useState<string>(i18nLanguage);
 
   const changeLanguage = useCallback(
     (languageCode?: string) => {

--- a/client/packages/host/webpack.config.js
+++ b/client/packages/host/webpack.config.js
@@ -174,9 +174,6 @@ module.exports = env => {
         name: 'host',
         shared: [
           {
-            '@openmsupply-client/common': {
-              eager: true,
-            },
             react: {
               singleton: true,
               eager: true,
@@ -192,8 +189,8 @@ module.exports = env => {
         ],
       }),
       new EncodingPlugin({
-        encoding: 'UTF-16'
-    })
+        encoding: 'UTF-16',
+      }),
     ],
   };
 };

--- a/client/packages/programs/package.json
+++ b/client/packages/programs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@openmsupply-client/programs",
   "version": "0.0.0",
+  "sideEffects": false,
   "main": "./src/index.ts",
   "private": true,
   "scripts": {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2813 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The required change is to remove common package from the module federation shared bundles. The intention was that each package could use the federated version, the unintended consequence is that weback is unable to tree shake because it doesn't know what is required or not from that bundle. The entire common package was bundled up, all 8MB of it.

Tracked down to [this commit](https://github.com/msupply-foundation/open-msupply/pull/2568/commits/c52b31970bf730e0c9e5402e5759b6a9a21418b9#diff-b142eb1f4548423b3c912cf3b5570e8d2d5a823f5eb09da7607cfb845608e130)

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
The PR action should show if this works or not. Otherwise you could run the bundle analyzer plugin and see what size you get

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
