### PR TITLE
#2918 Currency input fix

### DIFF
--- a/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -64,7 +64,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
       groupSeparator={options.separator}
       decimalsLimit={options.precision}
       allowDecimals={allowDecimals}
-      fixedDecimalLength={allowDecimals ? options.precision : undefined}
+      decimalScale={allowDecimals ? options.precision : undefined}
       {...restOfProps}
     />
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2918

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Turned out to be a very small thing, though I'm surprised it's gone unnoticed this long:) 

Anyway, looks like a slight misunderstanding of what the different props for `react-currency-input-field` do, although understandable given the way they're named. But what we want is actually `decimalScale`, not `fixedDecimalLength`

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Input currency values should be formatted correctly after losing focus for any input, regardless of whether decimals were included or not.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

I would like to do a more substantial refactor of the CurrencyInput at some stage and not have to use `react-currency-input-field` at all, but that's a bit more work. This PR fixes the immediate bug only.