### PR TITLE
Rename TestSync Types to better reflect how they're used

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2498,7 +2498,7 @@ dependencies = [
  "graphql_types",
  "repository",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "service",
  "thiserror",

--- a/server/service/src/sync/test/mod.rs
+++ b/server/service/src/sync/test/mod.rs
@@ -8,7 +8,7 @@ use super::translations::{IntegrationOperation, PullTranslateResult};
 use repository::{mock::MockData, *};
 use util::inline_init;
 
-pub(crate) struct TestSyncPullRecord {
+pub(crate) struct TestFromSyncRecord {
     /// Expected result for the imported data
     pub(crate) translated_record: PullTranslateResult,
     /// Row as stored in the remote sync buffer
@@ -17,17 +17,17 @@ pub(crate) struct TestSyncPullRecord {
     pub(crate) extra_data: Option<MockData>,
 }
 
-impl TestSyncPullRecord {
+impl TestFromSyncRecord {
     fn new_pull_upsert<U>(
         table_name: &str,
         // .0 = id .1 = data
         id_and_data: (&str, &str),
         upsert: U,
-    ) -> TestSyncPullRecord
+    ) -> TestFromSyncRecord
     where
         U: Upsert + 'static,
     {
-        TestSyncPullRecord {
+        TestFromSyncRecord {
             translated_record: PullTranslateResult::upsert(upsert),
             sync_buffer_row: inline_init(|r: &mut SyncBufferRow| {
                 r.table_name = table_name.to_owned();
@@ -39,17 +39,17 @@ impl TestSyncPullRecord {
         }
     }
 
-    fn new_pull_delete<U>(table_name: &str, id: &str, result: U) -> TestSyncPullRecord
+    fn new_pull_delete<U>(table_name: &str, id: &str, result: U) -> TestFromSyncRecord
     where
         U: Delete + 'static,
     {
         Self::new_pull_deletes(table_name, id, vec![result])
     }
-    fn new_pull_deletes<U>(table_name: &str, id: &str, deletes: Vec<U>) -> TestSyncPullRecord
+    fn new_pull_deletes<U>(table_name: &str, id: &str, deletes: Vec<U>) -> TestFromSyncRecord
     where
         U: Delete + 'static,
     {
-        TestSyncPullRecord {
+        TestFromSyncRecord {
             translated_record: PullTranslateResult::deletes(deletes),
             sync_buffer_row: inline_init(|r: &mut SyncBufferRow| {
                 r.table_name = table_name.to_owned();
@@ -68,20 +68,20 @@ impl TestSyncPullRecord {
     }
 }
 
-/// To be used in combination with TestSyncPullRecord.
-/// I.e. first run and integrate a row from TestSyncPullRecord and then try to push this record out
+/// To be used in combination with TestFromSyncRecord.
+/// I.e. first run and integrate a row from TestFromSyncRecord and then try to push this record out
 #[derive(Debug)]
-pub struct TestSyncPushRecord {
+pub struct TestToSyncRecord {
     /// Record id for the row to be pushed.
     /// Its assumed the row exists, e.g. because it has been integrated before through a
-    /// TestSyncPullRecord
+    /// TestFromSyncRecord
     pub record_id: String,
     pub table_name: String,
     /// Expected record as pushed out to the server
     pub push_data: serde_json::Value,
 }
 
-pub(crate) fn extract_sync_buffer_rows(records: &Vec<TestSyncPullRecord>) -> Vec<SyncBufferRow> {
+pub(crate) fn extract_sync_buffer_rows(records: &Vec<TestFromSyncRecord>) -> Vec<SyncBufferRow> {
     records
         .into_iter()
         .map(|test_record| test_record.sync_buffer_row.clone())
@@ -89,7 +89,7 @@ pub(crate) fn extract_sync_buffer_rows(records: &Vec<TestSyncPullRecord>) -> Vec
 }
 
 pub(crate) async fn insert_all_extra_data(
-    records: &Vec<TestSyncPullRecord>,
+    records: &Vec<TestFromSyncRecord>,
     connection: &StorageConnection,
 ) {
     for record in records {
@@ -99,7 +99,7 @@ pub(crate) async fn insert_all_extra_data(
 
 pub(crate) async fn check_test_records_against_database(
     con: &StorageConnection,
-    test_records: Vec<TestSyncPullRecord>,
+    test_records: Vec<TestFromSyncRecord>,
 ) {
     for test_record in test_records {
         let translated_records = match test_record.translated_record {

--- a/server/service/src/sync/test/pull_and_push.rs
+++ b/server/service/src/sync/test/pull_and_push.rs
@@ -5,7 +5,7 @@ use crate::sync::{
     test::{
         check_test_records_against_database, extract_sync_buffer_rows,
         test_data::{get_all_omsupply_central_push_records, get_all_push_test_records},
-        TestSyncPushRecord,
+        TestToSyncRecord,
     },
     translations::{
         translate_changelogs_to_sync_records, PushSyncRecord, ToSyncRecordTranslationType,
@@ -81,7 +81,7 @@ async fn test_sync_pull_and_push() {
     ]
     .into_iter()
     .flatten()
-    .collect::<Vec<TestSyncPushRecord>>();
+    .collect::<Vec<TestToSyncRecord>>();
 
     // Not using get_sync_push_changelogs_filter, since this test uses record integrated via sync as push records
     // which are usually filtered out via is_sync_updated flag

--- a/server/service/src/sync/test/pull_and_push.rs
+++ b/server/service/src/sync/test/pull_and_push.rs
@@ -5,7 +5,7 @@ use crate::sync::{
     test::{
         check_test_records_against_database, extract_sync_buffer_rows,
         test_data::{get_all_omsupply_central_push_records, get_all_push_test_records},
-        TestToSyncRecord,
+        TestSyncOutgoingRecord,
     },
     translations::{
         translate_changelogs_to_sync_records, PushSyncRecord, ToSyncRecordTranslationType,
@@ -81,7 +81,7 @@ async fn test_sync_pull_and_push() {
     ]
     .into_iter()
     .flatten()
-    .collect::<Vec<TestToSyncRecord>>();
+    .collect::<Vec<TestSyncOutgoingRecord>>();
 
     // Not using get_sync_push_changelogs_filter, since this test uses record integrated via sync as push records
     // which are usually filtered out via is_sync_updated flag

--- a/server/service/src/sync/test/test_data/activity_log.rs
+++ b/server/service/src/sync/test/test_data/activity_log.rs
@@ -1,5 +1,5 @@
 use crate::sync::{
-    test::{TestSyncPullRecord, TestSyncPushRecord},
+    test::{TestFromSyncRecord, TestToSyncRecord},
     translations::activity_log::LegacyActivityLogRow,
 };
 use chrono::NaiveDate;
@@ -36,9 +36,9 @@ const ACTIVITY_LOG_2: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             ACTIVITY_LOG_1,
             ActivityLogRow {
@@ -55,7 +55,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 changed_from: None,
             },
         ),
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             ACTIVITY_LOG_2,
             ActivityLogRow {
@@ -75,9 +75,9 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     ]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
+pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
     vec![
-        TestSyncPushRecord {
+        TestToSyncRecord {
             record_id: ACTIVITY_LOG_1.0.to_string(),
             table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyActivityLogRow {
@@ -94,7 +94,7 @@ pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
                 changed_from: None,
             }),
         },
-        TestSyncPushRecord {
+        TestToSyncRecord {
             record_id: ACTIVITY_LOG_2.0.to_string(),
             table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyActivityLogRow {

--- a/server/service/src/sync/test/test_data/activity_log.rs
+++ b/server/service/src/sync/test/test_data/activity_log.rs
@@ -1,5 +1,5 @@
 use crate::sync::{
-    test::{TestFromSyncRecord, TestToSyncRecord},
+    test::{TestSyncIncomingRecord, TestSyncOutgoingRecord},
     translations::activity_log::LegacyActivityLogRow,
 };
 use chrono::NaiveDate;
@@ -36,9 +36,9 @@ const ACTIVITY_LOG_2: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             ACTIVITY_LOG_1,
             ActivityLogRow {
@@ -55,7 +55,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
                 changed_from: None,
             },
         ),
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             ACTIVITY_LOG_2,
             ActivityLogRow {
@@ -75,9 +75,9 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     ]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
+pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
     vec![
-        TestToSyncRecord {
+        TestSyncOutgoingRecord {
             record_id: ACTIVITY_LOG_1.0.to_string(),
             table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyActivityLogRow {
@@ -94,7 +94,7 @@ pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
                 changed_from: None,
             }),
         },
-        TestToSyncRecord {
+        TestSyncOutgoingRecord {
             record_id: ACTIVITY_LOG_2.0.to_string(),
             table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyActivityLogRow {

--- a/server/service/src/sync/test/test_data/barcode.rs
+++ b/server/service/src/sync/test/test_data/barcode.rs
@@ -1,5 +1,5 @@
 use crate::sync::{
-    test::{TestSyncPullRecord, TestSyncPushRecord},
+    test::{TestFromSyncRecord, TestToSyncRecord},
     translations::barcode::LegacyBarcodeRow,
 };
 
@@ -32,9 +32,9 @@ const BARCODE_2: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             BARCODE_1,
             BarcodeRow {
@@ -46,7 +46,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 parent_id: None,
             },
         ),
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             BARCODE_2,
             BarcodeRow {
@@ -61,9 +61,9 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     ]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
+pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
     vec![
-        TestSyncPushRecord {
+        TestToSyncRecord {
             record_id: BARCODE_1.0.to_string(),
             table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyBarcodeRow {
@@ -75,7 +75,7 @@ pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
                 parent_id: None,
             }),
         },
-        TestSyncPushRecord {
+        TestToSyncRecord {
             record_id: BARCODE_2.0.to_string(),
             table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyBarcodeRow {

--- a/server/service/src/sync/test/test_data/barcode.rs
+++ b/server/service/src/sync/test/test_data/barcode.rs
@@ -1,5 +1,5 @@
 use crate::sync::{
-    test::{TestFromSyncRecord, TestToSyncRecord},
+    test::{TestSyncIncomingRecord, TestSyncOutgoingRecord},
     translations::barcode::LegacyBarcodeRow,
 };
 
@@ -32,9 +32,9 @@ const BARCODE_2: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             BARCODE_1,
             BarcodeRow {
@@ -46,7 +46,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
                 parent_id: None,
             },
         ),
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             BARCODE_2,
             BarcodeRow {
@@ -61,9 +61,9 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     ]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
+pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
     vec![
-        TestToSyncRecord {
+        TestSyncOutgoingRecord {
             record_id: BARCODE_1.0.to_string(),
             table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyBarcodeRow {
@@ -75,7 +75,7 @@ pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
                 parent_id: None,
             }),
         },
-        TestToSyncRecord {
+        TestSyncOutgoingRecord {
             record_id: BARCODE_2.0.to_string(),
             table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyBarcodeRow {

--- a/server/service/src/sync/test/test_data/currency.rs
+++ b/server/service/src/sync/test/test_data/currency.rs
@@ -1,4 +1,4 @@
-use crate::sync::test::TestFromSyncRecord;
+use crate::sync::test::TestSyncIncomingRecord;
 use chrono::NaiveDate;
 use repository::CurrencyRow;
 
@@ -28,9 +28,9 @@ const CURRENCY_2: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             CURRENCY_1,
             CurrencyRow {
@@ -41,7 +41,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
                 date_updated: Some(NaiveDate::from_ymd_opt(2020, 1, 1).unwrap()),
             },
         ),
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             CURRENCY_2,
             CurrencyRow {

--- a/server/service/src/sync/test/test_data/currency.rs
+++ b/server/service/src/sync/test/test_data/currency.rs
@@ -1,4 +1,4 @@
-use crate::sync::test::TestSyncPullRecord;
+use crate::sync::test::TestFromSyncRecord;
 use chrono::NaiveDate;
 use repository::CurrencyRow;
 
@@ -28,9 +28,9 @@ const CURRENCY_2: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             CURRENCY_1,
             CurrencyRow {
@@ -41,7 +41,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 date_updated: Some(NaiveDate::from_ymd_opt(2020, 1, 1).unwrap()),
             },
         ),
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             CURRENCY_2,
             CurrencyRow {

--- a/server/service/src/sync/test/test_data/inventory_adjustment_reason.rs
+++ b/server/service/src/sync/test/test_data/inventory_adjustment_reason.rs
@@ -1,4 +1,4 @@
-use crate::sync::test::TestSyncPullRecord;
+use crate::sync::test::TestFromSyncRecord;
 use repository::{InventoryAdjustmentReasonRow, InventoryAdjustmentReasonType};
 
 const INVENTORY_ADJUSTMENT_REASON_1: (&'static str, &'static str) = (
@@ -11,8 +11,8 @@ const INVENTORY_ADJUSTMENT_REASON_1: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_upsert(
         "options",
         INVENTORY_ADJUSTMENT_REASON_1,
         InventoryAdjustmentReasonRow {

--- a/server/service/src/sync/test/test_data/inventory_adjustment_reason.rs
+++ b/server/service/src/sync/test/test_data/inventory_adjustment_reason.rs
@@ -1,4 +1,4 @@
-use crate::sync::test::TestFromSyncRecord;
+use crate::sync::test::TestSyncIncomingRecord;
 use repository::{InventoryAdjustmentReasonRow, InventoryAdjustmentReasonType};
 
 const INVENTORY_ADJUSTMENT_REASON_1: (&'static str, &'static str) = (
@@ -11,8 +11,8 @@ const INVENTORY_ADJUSTMENT_REASON_1: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_upsert(
         "options",
         INVENTORY_ADJUSTMENT_REASON_1,
         InventoryAdjustmentReasonRow {

--- a/server/service/src/sync/test/test_data/invoice.rs
+++ b/server/service/src/sync/test/test_data/invoice.rs
@@ -1,5 +1,5 @@
 use crate::sync::{
-    test::TestFromSyncRecord,
+    test::TestSyncIncomingRecord,
     translations::invoice::{
         LegacyTransactRow, LegacyTransactStatus, LegacyTransactType, TransactMode,
     },
@@ -9,7 +9,7 @@ use repository::{InvoiceRow, InvoiceRowDelete, InvoiceRowStatus, InvoiceRowType}
 use serde_json::json;
 use util::constants::INVENTORY_ADJUSTMENT_NAME_CODE;
 
-use super::TestToSyncRecord;
+use super::TestSyncOutgoingRecord;
 
 const TABLE_NAME: &'static str = "transact";
 
@@ -96,8 +96,8 @@ const TRANSACT_1: (&'static str, &'static str) = (
       "om_transport_reference": ""
   }"#,
 );
-fn transact_1_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn transact_1_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         TRANSACT_1,
         InvoiceRow {
@@ -139,8 +139,8 @@ fn transact_1_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn transact_1_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn transact_1_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: TRANSACT_1.0.to_string(),
         push_data: json!(LegacyTransactRow {
@@ -269,8 +269,8 @@ const TRANSACT_2: (&str, &str) = (
         "om_transport_reference": "transport reference"
     }"#,
 );
-fn transact_2_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn transact_2_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         TRANSACT_2,
         InvoiceRow {
@@ -306,8 +306,8 @@ fn transact_2_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn transact_2_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn transact_2_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: TRANSACT_2.0.to_string(),
         push_data: json!(LegacyTransactRow {
@@ -441,8 +441,8 @@ const TRANSACT_OM_FIELDS: (&str, &str) = (
     }"#,
 );
 
-fn transact_om_fields_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn transact_om_fields_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         TRANSACT_OM_FIELDS,
         InvoiceRow {
@@ -502,8 +502,8 @@ fn transact_om_fields_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn transact_om_fields_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn transact_om_fields_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: TRANSACT_OM_FIELDS.0.to_string(),
         push_data: json!(LegacyTransactRow {
@@ -663,8 +663,8 @@ const INVENTORY_ADDITION: (&str, &str) = (
     }"#,
 );
 
-fn inventory_addition_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn inventory_addition_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         INVENTORY_ADDITION,
         InvoiceRow {
@@ -706,8 +706,8 @@ fn inventory_addition_pull_record() -> TestFromSyncRecord {
     )
 }
 
-fn inventory_addition_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn inventory_addition_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: INVENTORY_ADDITION.0.to_string(),
         push_data: json!(LegacyTransactRow {
@@ -847,8 +847,8 @@ const INVENTORY_REDUCTION: (&str, &str) = (
     }"#,
 );
 
-fn inventory_reduction_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn inventory_reduction_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         INVENTORY_REDUCTION,
         InvoiceRow {
@@ -890,8 +890,8 @@ fn inventory_reduction_pull_record() -> TestFromSyncRecord {
     )
 }
 
-fn inventory_reduction_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn inventory_reduction_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: INVENTORY_REDUCTION.0.to_string(),
         push_data: json!(LegacyTransactRow {
@@ -1026,8 +1026,8 @@ const PRESCRIPTION_1: (&str, &str) = (
       "om_transport_reference": ""
   }"#,
 );
-fn prescription_1_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn prescription_1_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         PRESCRIPTION_1,
         InvoiceRow {
@@ -1069,8 +1069,8 @@ fn prescription_1_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn prescription_1_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn prescription_1_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: PRESCRIPTION_1.0.to_string(),
         push_data: json!(LegacyTransactRow {
@@ -1122,7 +1122,7 @@ fn prescription_1_push_record() -> TestToSyncRecord {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
         transact_1_pull_record(),
         transact_2_pull_record(),
@@ -1133,15 +1133,15 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     ]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_delete(
         TABLE_NAME,
         TRANSACT_OM_FIELDS.0,
         InvoiceRowDelete(TRANSACT_OM_FIELDS.0.to_string()),
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
+pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
     vec![
         transact_1_push_record(),
         transact_2_push_record(),

--- a/server/service/src/sync/test/test_data/invoice.rs
+++ b/server/service/src/sync/test/test_data/invoice.rs
@@ -1,5 +1,5 @@
 use crate::sync::{
-    test::TestSyncPullRecord,
+    test::TestFromSyncRecord,
     translations::invoice::{
         LegacyTransactRow, LegacyTransactStatus, LegacyTransactType, TransactMode,
     },
@@ -9,7 +9,7 @@ use repository::{InvoiceRow, InvoiceRowDelete, InvoiceRowStatus, InvoiceRowType}
 use serde_json::json;
 use util::constants::INVENTORY_ADJUSTMENT_NAME_CODE;
 
-use super::TestSyncPushRecord;
+use super::TestToSyncRecord;
 
 const TABLE_NAME: &'static str = "transact";
 
@@ -96,8 +96,8 @@ const TRANSACT_1: (&'static str, &'static str) = (
       "om_transport_reference": ""
   }"#,
 );
-fn transact_1_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn transact_1_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         TRANSACT_1,
         InvoiceRow {
@@ -139,8 +139,8 @@ fn transact_1_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn transact_1_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn transact_1_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: TRANSACT_1.0.to_string(),
         push_data: json!(LegacyTransactRow {
@@ -269,8 +269,8 @@ const TRANSACT_2: (&str, &str) = (
         "om_transport_reference": "transport reference"
     }"#,
 );
-fn transact_2_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn transact_2_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         TRANSACT_2,
         InvoiceRow {
@@ -306,8 +306,8 @@ fn transact_2_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn transact_2_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn transact_2_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: TRANSACT_2.0.to_string(),
         push_data: json!(LegacyTransactRow {
@@ -441,8 +441,8 @@ const TRANSACT_OM_FIELDS: (&str, &str) = (
     }"#,
 );
 
-fn transact_om_fields_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn transact_om_fields_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         TRANSACT_OM_FIELDS,
         InvoiceRow {
@@ -502,8 +502,8 @@ fn transact_om_fields_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn transact_om_fields_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn transact_om_fields_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: TRANSACT_OM_FIELDS.0.to_string(),
         push_data: json!(LegacyTransactRow {
@@ -663,8 +663,8 @@ const INVENTORY_ADDITION: (&str, &str) = (
     }"#,
 );
 
-fn inventory_addition_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn inventory_addition_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         INVENTORY_ADDITION,
         InvoiceRow {
@@ -706,8 +706,8 @@ fn inventory_addition_pull_record() -> TestSyncPullRecord {
     )
 }
 
-fn inventory_addition_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn inventory_addition_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: INVENTORY_ADDITION.0.to_string(),
         push_data: json!(LegacyTransactRow {
@@ -847,8 +847,8 @@ const INVENTORY_REDUCTION: (&str, &str) = (
     }"#,
 );
 
-fn inventory_reduction_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn inventory_reduction_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         INVENTORY_REDUCTION,
         InvoiceRow {
@@ -890,8 +890,8 @@ fn inventory_reduction_pull_record() -> TestSyncPullRecord {
     )
 }
 
-fn inventory_reduction_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn inventory_reduction_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: INVENTORY_REDUCTION.0.to_string(),
         push_data: json!(LegacyTransactRow {
@@ -1026,8 +1026,8 @@ const PRESCRIPTION_1: (&str, &str) = (
       "om_transport_reference": ""
   }"#,
 );
-fn prescription_1_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn prescription_1_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         PRESCRIPTION_1,
         InvoiceRow {
@@ -1069,8 +1069,8 @@ fn prescription_1_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn prescription_1_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn prescription_1_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: PRESCRIPTION_1.0.to_string(),
         push_data: json!(LegacyTransactRow {
@@ -1122,7 +1122,7 @@ fn prescription_1_push_record() -> TestSyncPushRecord {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![
         transact_1_pull_record(),
         transact_2_pull_record(),
@@ -1133,15 +1133,15 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     ]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_delete(
         TABLE_NAME,
         TRANSACT_OM_FIELDS.0,
         InvoiceRowDelete(TRANSACT_OM_FIELDS.0.to_string()),
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
+pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
     vec![
         transact_1_push_record(),
         transact_2_push_record(),

--- a/server/service/src/sync/test/test_data/invoice_line.rs
+++ b/server/service/src/sync/test/test_data/invoice_line.rs
@@ -1,6 +1,6 @@
-use super::TestToSyncRecord;
+use super::TestSyncOutgoingRecord;
 use crate::sync::{
-    test::TestFromSyncRecord,
+    test::TestSyncIncomingRecord,
     translations::invoice_line::{LegacyTransLineRow, LegacyTransLineType},
 };
 use chrono::NaiveDate;
@@ -68,8 +68,8 @@ const TRANS_LINE_1: (&'static str, &'static str) = (
         }
     "#,
 );
-fn trans_line_1_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn trans_line_1_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         TRANS_LINE_1,
         InvoiceLineRow {
@@ -96,8 +96,8 @@ fn trans_line_1_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn trans_line_1_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn trans_line_1_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         record_id: TRANS_LINE_1.0.to_string(),
         table_name: TABLE_NAME.to_string(),
         push_data: json!(LegacyTransLineRow {
@@ -182,8 +182,8 @@ const TRANS_LINE_2: (&'static str, &'static str) = (
         "volume_per_pack": 0
     }"#,
 );
-fn trans_line_2_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn trans_line_2_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         TRANS_LINE_2,
         InvoiceLineRow {
@@ -210,8 +210,8 @@ fn trans_line_2_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn trans_line_2_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn trans_line_2_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: TRANS_LINE_2.0.to_string(),
         push_data: json!(LegacyTransLineRow {
@@ -299,8 +299,8 @@ const TRANS_LINE_OM_FIELDS: (&'static str, &'static str) = (
         "om_total_after_tax": 130.5
     }"#,
 );
-fn trans_line_om_fields_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn trans_line_om_fields_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         TRANS_LINE_OM_FIELDS,
         InvoiceLineRow {
@@ -327,8 +327,8 @@ fn trans_line_om_fields_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn trans_line_om_fields_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn trans_line_om_fields_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: TRANS_LINE_OM_FIELDS.0.to_string(),
         push_data: json!(LegacyTransLineRow {
@@ -416,8 +416,8 @@ const TRANS_LINE_OM_UNSET_TAX_FIELDS: (&'static str, &'static str) = (
         "om_total_after_tax": 130.5
     }"#,
 );
-fn trans_line_om_fields_unset_tax_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn trans_line_om_fields_unset_tax_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         TRANS_LINE_OM_UNSET_TAX_FIELDS,
         InvoiceLineRow {
@@ -444,8 +444,8 @@ fn trans_line_om_fields_unset_tax_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn trans_line_om_fields_unset_tax_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn trans_line_om_fields_unset_tax_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: TRANS_LINE_OM_UNSET_TAX_FIELDS.0.to_string(),
         push_data: json!(LegacyTransLineRow {
@@ -473,7 +473,7 @@ fn trans_line_om_fields_unset_tax_push_record() -> TestToSyncRecord {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
         trans_line_1_pull_record(),
         trans_line_2_pull_record(),
@@ -482,15 +482,15 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     ]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_delete(
         TABLE_NAME,
         TRANS_LINE_OM_UNSET_TAX_FIELDS.0,
         InvoiceLineRowDelete(TRANS_LINE_OM_UNSET_TAX_FIELDS.0.to_string()),
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
+pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
     vec![
         trans_line_1_push_record(),
         trans_line_2_push_record(),

--- a/server/service/src/sync/test/test_data/invoice_line.rs
+++ b/server/service/src/sync/test/test_data/invoice_line.rs
@@ -1,6 +1,6 @@
-use super::TestSyncPushRecord;
+use super::TestToSyncRecord;
 use crate::sync::{
-    test::TestSyncPullRecord,
+    test::TestFromSyncRecord,
     translations::invoice_line::{LegacyTransLineRow, LegacyTransLineType},
 };
 use chrono::NaiveDate;
@@ -68,8 +68,8 @@ const TRANS_LINE_1: (&'static str, &'static str) = (
         }
     "#,
 );
-fn trans_line_1_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn trans_line_1_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         TRANS_LINE_1,
         InvoiceLineRow {
@@ -96,8 +96,8 @@ fn trans_line_1_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn trans_line_1_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn trans_line_1_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         record_id: TRANS_LINE_1.0.to_string(),
         table_name: TABLE_NAME.to_string(),
         push_data: json!(LegacyTransLineRow {
@@ -182,8 +182,8 @@ const TRANS_LINE_2: (&'static str, &'static str) = (
         "volume_per_pack": 0
     }"#,
 );
-fn trans_line_2_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn trans_line_2_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         TRANS_LINE_2,
         InvoiceLineRow {
@@ -210,8 +210,8 @@ fn trans_line_2_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn trans_line_2_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn trans_line_2_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: TRANS_LINE_2.0.to_string(),
         push_data: json!(LegacyTransLineRow {
@@ -299,8 +299,8 @@ const TRANS_LINE_OM_FIELDS: (&'static str, &'static str) = (
         "om_total_after_tax": 130.5
     }"#,
 );
-fn trans_line_om_fields_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn trans_line_om_fields_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         TRANS_LINE_OM_FIELDS,
         InvoiceLineRow {
@@ -327,8 +327,8 @@ fn trans_line_om_fields_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn trans_line_om_fields_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn trans_line_om_fields_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: TRANS_LINE_OM_FIELDS.0.to_string(),
         push_data: json!(LegacyTransLineRow {
@@ -416,8 +416,8 @@ const TRANS_LINE_OM_UNSET_TAX_FIELDS: (&'static str, &'static str) = (
         "om_total_after_tax": 130.5
     }"#,
 );
-fn trans_line_om_fields_unset_tax_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn trans_line_om_fields_unset_tax_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         TRANS_LINE_OM_UNSET_TAX_FIELDS,
         InvoiceLineRow {
@@ -444,8 +444,8 @@ fn trans_line_om_fields_unset_tax_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn trans_line_om_fields_unset_tax_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn trans_line_om_fields_unset_tax_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: TRANS_LINE_OM_UNSET_TAX_FIELDS.0.to_string(),
         push_data: json!(LegacyTransLineRow {
@@ -473,7 +473,7 @@ fn trans_line_om_fields_unset_tax_push_record() -> TestSyncPushRecord {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![
         trans_line_1_pull_record(),
         trans_line_2_pull_record(),
@@ -482,15 +482,15 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     ]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_delete(
         TABLE_NAME,
         TRANS_LINE_OM_UNSET_TAX_FIELDS.0,
         InvoiceLineRowDelete(TRANS_LINE_OM_UNSET_TAX_FIELDS.0.to_string()),
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
+pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
     vec![
         trans_line_1_push_record(),
         trans_line_2_push_record(),

--- a/server/service/src/sync/test/test_data/item.rs
+++ b/server/service/src/sync/test/test_data/item.rs
@@ -1,4 +1,4 @@
-use crate::sync::{test::TestFromSyncRecord, translations::item::ordered_simple_json};
+use crate::sync::{test::TestSyncIncomingRecord, translations::item::ordered_simple_json};
 use repository::{ItemRow, ItemRowDelete, ItemRowType};
 
 const TABLE_NAME: &'static str = "item";
@@ -163,9 +163,9 @@ const ITEM_2: (&'static str, &'static str) = (
 }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             (ITEM_1.0, &ordered_simple_json(ITEM_1.1).unwrap()),
             ItemRow {
@@ -179,7 +179,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
                 is_active: true,
             },
         ),
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             (ITEM_2.0, &ordered_simple_json(ITEM_2.1).unwrap()),
             ItemRow {
@@ -196,8 +196,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     ]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_delete(
         TABLE_NAME,
         ITEM_1.0,
         ItemRowDelete(ITEM_1.0.to_string()),

--- a/server/service/src/sync/test/test_data/item.rs
+++ b/server/service/src/sync/test/test_data/item.rs
@@ -1,4 +1,4 @@
-use crate::sync::{test::TestSyncPullRecord, translations::item::ordered_simple_json};
+use crate::sync::{test::TestFromSyncRecord, translations::item::ordered_simple_json};
 use repository::{ItemRow, ItemRowDelete, ItemRowType};
 
 const TABLE_NAME: &'static str = "item";
@@ -163,9 +163,9 @@ const ITEM_2: (&'static str, &'static str) = (
 }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             (ITEM_1.0, &ordered_simple_json(ITEM_1.1).unwrap()),
             ItemRow {
@@ -179,7 +179,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 is_active: true,
             },
         ),
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             (ITEM_2.0, &ordered_simple_json(ITEM_2.1).unwrap()),
             ItemRow {
@@ -196,8 +196,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     ]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_delete(
         TABLE_NAME,
         ITEM_1.0,
         ItemRowDelete(ITEM_1.0.to_string()),

--- a/server/service/src/sync/test/test_data/location.rs
+++ b/server/service/src/sync/test/test_data/location.rs
@@ -3,7 +3,7 @@ use crate::sync::translations::location::LegacyLocationRow;
 use repository::LocationRow;
 use serde_json::json;
 
-use super::{TestSyncPullRecord, TestSyncPushRecord};
+use super::{TestFromSyncRecord, TestToSyncRecord};
 
 const TABLE_NAME: &'static str = "Location";
 
@@ -29,8 +29,8 @@ const LOCATION_1: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         LOCATION_1,
         LocationRow {
@@ -43,8 +43,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
-    vec![TestSyncPushRecord {
+pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
+    vec![TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: LOCATION_1.0.to_string(),
         push_data: json!(LegacyLocationRow {

--- a/server/service/src/sync/test/test_data/location.rs
+++ b/server/service/src/sync/test/test_data/location.rs
@@ -3,7 +3,7 @@ use crate::sync::translations::location::LegacyLocationRow;
 use repository::LocationRow;
 use serde_json::json;
 
-use super::{TestFromSyncRecord, TestToSyncRecord};
+use super::{TestSyncIncomingRecord, TestSyncOutgoingRecord};
 
 const TABLE_NAME: &'static str = "Location";
 
@@ -29,8 +29,8 @@ const LOCATION_1: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         LOCATION_1,
         LocationRow {
@@ -43,8 +43,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
-    vec![TestToSyncRecord {
+pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
+    vec![TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: LOCATION_1.0.to_string(),
         push_data: json!(LegacyLocationRow {

--- a/server/service/src/sync/test/test_data/location_movement.rs
+++ b/server/service/src/sync/test/test_data/location_movement.rs
@@ -4,7 +4,7 @@ use chrono::{NaiveDate, NaiveTime};
 use repository::LocationMovementRow;
 use serde_json::json;
 
-use super::{TestSyncPullRecord, TestSyncPushRecord};
+use super::{TestFromSyncRecord, TestToSyncRecord};
 
 const TABLE_NAME: &'static str = "location_movement";
 
@@ -22,8 +22,8 @@ const LOCATION_MOVEMENT_1: (&'static str, &'static str) = (
   }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         LOCATION_MOVEMENT_1,
         LocationMovementRow {
@@ -41,8 +41,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
-    vec![TestSyncPushRecord {
+pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
+    vec![TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: LOCATION_MOVEMENT_1.0.to_string(),
         push_data: json!(LegacyLocationMovementRow {

--- a/server/service/src/sync/test/test_data/location_movement.rs
+++ b/server/service/src/sync/test/test_data/location_movement.rs
@@ -4,7 +4,7 @@ use chrono::{NaiveDate, NaiveTime};
 use repository::LocationMovementRow;
 use serde_json::json;
 
-use super::{TestFromSyncRecord, TestToSyncRecord};
+use super::{TestSyncIncomingRecord, TestSyncOutgoingRecord};
 
 const TABLE_NAME: &'static str = "location_movement";
 
@@ -22,8 +22,8 @@ const LOCATION_MOVEMENT_1: (&'static str, &'static str) = (
   }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         LOCATION_MOVEMENT_1,
         LocationMovementRow {
@@ -41,8 +41,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
-    vec![TestToSyncRecord {
+pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
+    vec![TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: LOCATION_MOVEMENT_1.0.to_string(),
         push_data: json!(LegacyLocationMovementRow {

--- a/server/service/src/sync/test/test_data/master_list.rs
+++ b/server/service/src/sync/test/test_data/master_list.rs
@@ -1,6 +1,6 @@
 use repository::MasterListRow;
 
-use crate::sync::test::TestFromSyncRecord;
+use crate::sync::test::TestSyncIncomingRecord;
 
 const TABLE_NAME: &'static str = "list_master";
 
@@ -44,9 +44,9 @@ const MASTER_LIST_2: (&'static str, &'static str) = (
 }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             MASTER_LIST_1,
             MasterListRow {
@@ -57,7 +57,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
                 is_active: false,
             },
         ),
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             MASTER_LIST_2,
             MasterListRow {

--- a/server/service/src/sync/test/test_data/master_list.rs
+++ b/server/service/src/sync/test/test_data/master_list.rs
@@ -1,6 +1,6 @@
 use repository::MasterListRow;
 
-use crate::sync::test::TestSyncPullRecord;
+use crate::sync::test::TestFromSyncRecord;
 
 const TABLE_NAME: &'static str = "list_master";
 
@@ -44,9 +44,9 @@ const MASTER_LIST_2: (&'static str, &'static str) = (
 }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             MASTER_LIST_1,
             MasterListRow {
@@ -57,7 +57,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 is_active: false,
             },
         ),
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             MASTER_LIST_2,
             MasterListRow {

--- a/server/service/src/sync/test/test_data/master_list_line.rs
+++ b/server/service/src/sync/test/test_data/master_list_line.rs
@@ -1,6 +1,6 @@
 use repository::MasterListLineRow;
 
-use crate::sync::test::TestFromSyncRecord;
+use crate::sync::test::TestSyncIncomingRecord;
 
 const MASTER_LIST_LINE_1: (&'static str, &'static str) = (
     "9B02D0770B544BD1AC7DB99BB85FCDD5",
@@ -14,8 +14,8 @@ const MASTER_LIST_LINE_1: (&'static str, &'static str) = (
   }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_upsert(
         "list_master_line",
         MASTER_LIST_LINE_1,
         MasterListLineRow {

--- a/server/service/src/sync/test/test_data/master_list_line.rs
+++ b/server/service/src/sync/test/test_data/master_list_line.rs
@@ -1,6 +1,6 @@
 use repository::MasterListLineRow;
 
-use crate::sync::test::TestSyncPullRecord;
+use crate::sync::test::TestFromSyncRecord;
 
 const MASTER_LIST_LINE_1: (&'static str, &'static str) = (
     "9B02D0770B544BD1AC7DB99BB85FCDD5",
@@ -14,8 +14,8 @@ const MASTER_LIST_LINE_1: (&'static str, &'static str) = (
   }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_upsert(
         "list_master_line",
         MASTER_LIST_LINE_1,
         MasterListLineRow {

--- a/server/service/src/sync/test/test_data/master_list_name_join.rs
+++ b/server/service/src/sync/test/test_data/master_list_name_join.rs
@@ -1,4 +1,4 @@
-use crate::sync::test::TestSyncPullRecord;
+use crate::sync::test::TestFromSyncRecord;
 use repository::{MasterListNameJoinRow, MasterListNameJoinRowDelete};
 
 const TABLE_NAME: &'static str = "list_master_name_join";
@@ -17,8 +17,8 @@ const LIST_MASTER_NAME_JOIN_1: (&'static str, &'static str) = (
   }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         LIST_MASTER_NAME_JOIN_1,
         MasterListNameJoinRow {
@@ -29,8 +29,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     )]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_delete(
         TABLE_NAME,
         LIST_MASTER_NAME_JOIN_1.0,
         MasterListNameJoinRowDelete(LIST_MASTER_NAME_JOIN_1.0.to_string()),

--- a/server/service/src/sync/test/test_data/master_list_name_join.rs
+++ b/server/service/src/sync/test/test_data/master_list_name_join.rs
@@ -1,4 +1,4 @@
-use crate::sync::test::TestFromSyncRecord;
+use crate::sync::test::TestSyncIncomingRecord;
 use repository::{MasterListNameJoinRow, MasterListNameJoinRowDelete};
 
 const TABLE_NAME: &'static str = "list_master_name_join";
@@ -17,8 +17,8 @@ const LIST_MASTER_NAME_JOIN_1: (&'static str, &'static str) = (
   }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         LIST_MASTER_NAME_JOIN_1,
         MasterListNameJoinRow {
@@ -29,8 +29,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     )]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_delete(
         TABLE_NAME,
         LIST_MASTER_NAME_JOIN_1.0,
         MasterListNameJoinRowDelete(LIST_MASTER_NAME_JOIN_1.0.to_string()),

--- a/server/service/src/sync/test/test_data/mod.rs
+++ b/server/service/src/sync/test/test_data/mod.rs
@@ -1,6 +1,6 @@
 use self::special::name_to_name_store_join;
 
-use super::{TestFromSyncRecord, TestToSyncRecord};
+use super::{TestSyncIncomingRecord, TestSyncOutgoingRecord};
 
 pub(crate) mod activity_log;
 pub(crate) mod barcode;
@@ -37,7 +37,7 @@ pub(crate) mod temperature_log;
 pub(crate) mod unit;
 pub(crate) mod user_permission;
 
-pub(crate) fn get_all_pull_upsert_central_test_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn get_all_pull_upsert_central_test_records() -> Vec<TestSyncIncomingRecord> {
     let mut test_records = Vec::new();
     test_records.append(&mut user_permission::test_pull_upsert_records());
     test_records.append(&mut item::test_pull_upsert_records());
@@ -61,7 +61,7 @@ pub(crate) fn get_all_pull_upsert_central_test_records() -> Vec<TestFromSyncReco
     test_records
 }
 
-pub(crate) fn get_all_pull_upsert_remote_test_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn get_all_pull_upsert_remote_test_records() -> Vec<TestSyncIncomingRecord> {
     let mut test_records = Vec::new();
     test_records.append(&mut location::test_pull_upsert_records());
     test_records.append(&mut sensor::test_pull_upsert_records());
@@ -84,7 +84,7 @@ pub(crate) fn get_all_pull_upsert_remote_test_records() -> Vec<TestFromSyncRecor
     test_records
 }
 
-pub(crate) fn get_all_pull_delete_central_test_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn get_all_pull_delete_central_test_records() -> Vec<TestSyncIncomingRecord> {
     let mut test_records = Vec::new();
     test_records.append(&mut user_permission::test_pull_delete_records());
     test_records.append(&mut unit::test_pull_delete_records());
@@ -98,7 +98,7 @@ pub(crate) fn get_all_pull_delete_central_test_records() -> Vec<TestFromSyncReco
     test_records
 }
 
-pub(crate) fn get_all_pull_delete_remote_test_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn get_all_pull_delete_remote_test_records() -> Vec<TestSyncIncomingRecord> {
     let mut test_records = Vec::new();
     test_records.append(&mut requisition::test_pull_delete_records());
     test_records.append(&mut requisition_line::test_pull_delete_records());
@@ -109,7 +109,7 @@ pub(crate) fn get_all_pull_delete_remote_test_records() -> Vec<TestFromSyncRecor
     test_records
 }
 
-pub(crate) fn get_all_push_test_records() -> Vec<TestToSyncRecord> {
+pub(crate) fn get_all_push_test_records() -> Vec<TestSyncOutgoingRecord> {
     let mut test_records = Vec::new();
     test_records.append(&mut name::test_push_records());
     test_records.append(&mut location::test_push_records());
@@ -132,7 +132,7 @@ pub(crate) fn get_all_push_test_records() -> Vec<TestToSyncRecord> {
     test_records
 }
 
-pub(crate) fn get_all_omsupply_central_push_records() -> Vec<TestToSyncRecord> {
+pub(crate) fn get_all_omsupply_central_push_records() -> Vec<TestSyncOutgoingRecord> {
     let mut test_records = Vec::new();
     test_records.append(&mut pack_variant::test_omsupply_central_push_records());
 

--- a/server/service/src/sync/test/test_data/mod.rs
+++ b/server/service/src/sync/test/test_data/mod.rs
@@ -1,6 +1,6 @@
 use self::special::name_to_name_store_join;
 
-use super::{TestSyncPullRecord, TestSyncPushRecord};
+use super::{TestFromSyncRecord, TestToSyncRecord};
 
 pub(crate) mod activity_log;
 pub(crate) mod barcode;
@@ -37,7 +37,7 @@ pub(crate) mod temperature_log;
 pub(crate) mod unit;
 pub(crate) mod user_permission;
 
-pub(crate) fn get_all_pull_upsert_central_test_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn get_all_pull_upsert_central_test_records() -> Vec<TestFromSyncRecord> {
     let mut test_records = Vec::new();
     test_records.append(&mut user_permission::test_pull_upsert_records());
     test_records.append(&mut item::test_pull_upsert_records());
@@ -61,7 +61,7 @@ pub(crate) fn get_all_pull_upsert_central_test_records() -> Vec<TestSyncPullReco
     test_records
 }
 
-pub(crate) fn get_all_pull_upsert_remote_test_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn get_all_pull_upsert_remote_test_records() -> Vec<TestFromSyncRecord> {
     let mut test_records = Vec::new();
     test_records.append(&mut location::test_pull_upsert_records());
     test_records.append(&mut sensor::test_pull_upsert_records());
@@ -84,7 +84,7 @@ pub(crate) fn get_all_pull_upsert_remote_test_records() -> Vec<TestSyncPullRecor
     test_records
 }
 
-pub(crate) fn get_all_pull_delete_central_test_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn get_all_pull_delete_central_test_records() -> Vec<TestFromSyncRecord> {
     let mut test_records = Vec::new();
     test_records.append(&mut user_permission::test_pull_delete_records());
     test_records.append(&mut unit::test_pull_delete_records());
@@ -98,7 +98,7 @@ pub(crate) fn get_all_pull_delete_central_test_records() -> Vec<TestSyncPullReco
     test_records
 }
 
-pub(crate) fn get_all_pull_delete_remote_test_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn get_all_pull_delete_remote_test_records() -> Vec<TestFromSyncRecord> {
     let mut test_records = Vec::new();
     test_records.append(&mut requisition::test_pull_delete_records());
     test_records.append(&mut requisition_line::test_pull_delete_records());
@@ -109,7 +109,7 @@ pub(crate) fn get_all_pull_delete_remote_test_records() -> Vec<TestSyncPullRecor
     test_records
 }
 
-pub(crate) fn get_all_push_test_records() -> Vec<TestSyncPushRecord> {
+pub(crate) fn get_all_push_test_records() -> Vec<TestToSyncRecord> {
     let mut test_records = Vec::new();
     test_records.append(&mut name::test_push_records());
     test_records.append(&mut location::test_push_records());
@@ -132,7 +132,7 @@ pub(crate) fn get_all_push_test_records() -> Vec<TestSyncPushRecord> {
     test_records
 }
 
-pub(crate) fn get_all_omsupply_central_push_records() -> Vec<TestSyncPushRecord> {
+pub(crate) fn get_all_omsupply_central_push_records() -> Vec<TestToSyncRecord> {
     let mut test_records = Vec::new();
     test_records.append(&mut pack_variant::test_omsupply_central_push_records());
 

--- a/server/service/src/sync/test/test_data/name.rs
+++ b/server/service/src/sync/test/test_data/name.rs
@@ -1,5 +1,5 @@
 use crate::sync::{
-    test::{TestSyncPullRecord, TestSyncPushRecord},
+    test::{TestFromSyncRecord, TestToSyncRecord},
     translations::name::{LegacyNameRow, LegacyNameType},
 };
 use chrono::NaiveDate;
@@ -106,8 +106,8 @@ const NAME_1: (&'static str, &'static str) = (
 }"#,
 );
 
-fn name_1() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn name_1() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_1,
         NameRow {
@@ -246,8 +246,8 @@ const NAME_2: (&'static str, &'static str) = (
 }"#,
 );
 
-fn name_2() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn name_2() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_2,
         NameRow {
@@ -380,8 +380,8 @@ const NAME_3: (&'static str, &'static str) = (
 }"#,
 );
 
-fn name_3() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn name_3() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_3,
         NameRow {
@@ -515,8 +515,8 @@ const NAME_4: (&'static str, &'static str) = (
   }"#,
 );
 
-fn name_4() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn name_4() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_4,
         NameRow {
@@ -556,8 +556,8 @@ fn name_4() -> TestSyncPullRecord {
     )
 }
 
-fn name_push_record_1() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn name_push_record_1() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: NAME_1.0.to_string(),
         push_data: json!(LegacyNameRow {
@@ -599,8 +599,8 @@ fn name_push_record_1() -> TestSyncPushRecord {
     }
 }
 
-fn name_push_record_2() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn name_push_record_2() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: NAME_4.0.to_string(),
         push_data: json!(LegacyNameRow {
@@ -642,18 +642,18 @@ fn name_push_record_2() -> TestSyncPushRecord {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![name_1(), name_2(), name_3(), name_4()]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_delete(
         TABLE_NAME,
         NAME_4.0,
         NameRowDelete(NAME_4.0.to_string()),
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
+pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
     vec![name_push_record_1(), name_push_record_2()]
 }

--- a/server/service/src/sync/test/test_data/name.rs
+++ b/server/service/src/sync/test/test_data/name.rs
@@ -1,5 +1,5 @@
 use crate::sync::{
-    test::{TestFromSyncRecord, TestToSyncRecord},
+    test::{TestSyncIncomingRecord, TestSyncOutgoingRecord},
     translations::name::{LegacyNameRow, LegacyNameType},
 };
 use chrono::NaiveDate;
@@ -106,8 +106,8 @@ const NAME_1: (&'static str, &'static str) = (
 }"#,
 );
 
-fn name_1() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn name_1() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_1,
         NameRow {
@@ -246,8 +246,8 @@ const NAME_2: (&'static str, &'static str) = (
 }"#,
 );
 
-fn name_2() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn name_2() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_2,
         NameRow {
@@ -380,8 +380,8 @@ const NAME_3: (&'static str, &'static str) = (
 }"#,
 );
 
-fn name_3() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn name_3() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_3,
         NameRow {
@@ -515,8 +515,8 @@ const NAME_4: (&'static str, &'static str) = (
   }"#,
 );
 
-fn name_4() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn name_4() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_4,
         NameRow {
@@ -556,8 +556,8 @@ fn name_4() -> TestFromSyncRecord {
     )
 }
 
-fn name_push_record_1() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn name_push_record_1() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: NAME_1.0.to_string(),
         push_data: json!(LegacyNameRow {
@@ -599,8 +599,8 @@ fn name_push_record_1() -> TestToSyncRecord {
     }
 }
 
-fn name_push_record_2() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn name_push_record_2() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: NAME_4.0.to_string(),
         push_data: json!(LegacyNameRow {
@@ -642,18 +642,18 @@ fn name_push_record_2() -> TestToSyncRecord {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![name_1(), name_2(), name_3(), name_4()]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_delete(
         TABLE_NAME,
         NAME_4.0,
         NameRowDelete(NAME_4.0.to_string()),
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
+pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
     vec![name_push_record_1(), name_push_record_2()]
 }

--- a/server/service/src/sync/test/test_data/name_store_join.rs
+++ b/server/service/src/sync/test/test_data/name_store_join.rs
@@ -1,5 +1,5 @@
 use crate::sync::{
-    test::{TestSyncPullRecord, TestSyncPushRecord},
+    test::{TestFromSyncRecord, TestToSyncRecord},
     translations::name_store_join::LegacyNameStoreJoinRow,
 };
 use repository::{NameStoreJoinRow, NameStoreJoinRowDelete};
@@ -20,8 +20,8 @@ const NAME_STORE_JOIN_1: (&'static str, &'static str) = (
   }"#,
 );
 
-fn name_store_join_1_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn name_store_join_1_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_STORE_JOIN_1,
         NameStoreJoinRow {
@@ -58,8 +58,8 @@ const NAME_STORE_JOIN_INACTIVE_2: (&'static str, &'static str) = (
       "store_ID": "store_b"
   }"#,
 );
-fn name_store_join_2_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn name_store_join_2_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_STORE_JOIN_2,
         NameStoreJoinRow {
@@ -71,15 +71,15 @@ fn name_store_join_2_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn name_store_join_2_delete_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_delete(
+fn name_store_join_2_delete_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_delete(
         TABLE_NAME,
         NAME_STORE_JOIN_2.0,
         NameStoreJoinRowDelete(NAME_STORE_JOIN_2.0.to_string()),
     )
 }
 
-fn name_store_join_2_inactive_pull_record() -> TestSyncPullRecord {
+fn name_store_join_2_inactive_pull_record() -> TestFromSyncRecord {
     let mut record = name_store_join_2_delete_record();
     record.sync_buffer_row.data = NAME_STORE_JOIN_INACTIVE_2.1.to_string();
     record
@@ -101,8 +101,8 @@ fn name_store_join_2_inactive_pull_record() -> TestSyncPullRecord {
 //       "om_name_is_supplier": true
 //   }"#,
 // );
-// fn name_store_join_3_pull_record() -> TestSyncPullRecord {
-//     TestSyncPullRecord::new_pull_upsert(
+// fn name_store_join_3_pull_record() -> TestFromSyncRecord {
+//     TestFromSyncRecord::new_pull_upsert(
 //         TABLE_NAME,
 //         NAME_STORE_JOIN_3,
 //         NameStoreJoinRow {
@@ -115,7 +115,7 @@ fn name_store_join_2_inactive_pull_record() -> TestSyncPullRecord {
 //     )
 // }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![
         name_store_join_1_pull_record(),
         name_store_join_2_pull_record(),
@@ -123,17 +123,17 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     ]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
     vec![name_store_join_2_delete_record()]
 }
 
-pub(crate) fn test_pull_upsert_inactive_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_inactive_records() -> Vec<TestFromSyncRecord> {
     vec![name_store_join_2_inactive_pull_record()]
 }
 
-pub(crate) fn test_push_upsert() -> Vec<TestSyncPushRecord> {
+pub(crate) fn test_push_upsert() -> Vec<TestToSyncRecord> {
     vec![
-        TestSyncPushRecord {
+        TestToSyncRecord {
             record_id: NAME_STORE_JOIN_1.0.to_string(),
             table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyNameStoreJoinRow {
@@ -145,7 +145,7 @@ pub(crate) fn test_push_upsert() -> Vec<TestSyncPushRecord> {
                 name_is_supplier: Some(true),
             }),
         },
-        TestSyncPushRecord {
+        TestToSyncRecord {
             record_id: NAME_STORE_JOIN_2.0.to_string(),
             table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyNameStoreJoinRow {

--- a/server/service/src/sync/test/test_data/name_store_join.rs
+++ b/server/service/src/sync/test/test_data/name_store_join.rs
@@ -1,5 +1,5 @@
 use crate::sync::{
-    test::{TestFromSyncRecord, TestToSyncRecord},
+    test::{TestSyncIncomingRecord, TestSyncOutgoingRecord},
     translations::name_store_join::LegacyNameStoreJoinRow,
 };
 use repository::{NameStoreJoinRow, NameStoreJoinRowDelete};
@@ -20,8 +20,8 @@ const NAME_STORE_JOIN_1: (&'static str, &'static str) = (
   }"#,
 );
 
-fn name_store_join_1_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn name_store_join_1_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_STORE_JOIN_1,
         NameStoreJoinRow {
@@ -58,8 +58,8 @@ const NAME_STORE_JOIN_INACTIVE_2: (&'static str, &'static str) = (
       "store_ID": "store_b"
   }"#,
 );
-fn name_store_join_2_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn name_store_join_2_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_STORE_JOIN_2,
         NameStoreJoinRow {
@@ -71,15 +71,15 @@ fn name_store_join_2_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn name_store_join_2_delete_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_delete(
+fn name_store_join_2_delete_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_delete(
         TABLE_NAME,
         NAME_STORE_JOIN_2.0,
         NameStoreJoinRowDelete(NAME_STORE_JOIN_2.0.to_string()),
     )
 }
 
-fn name_store_join_2_inactive_pull_record() -> TestFromSyncRecord {
+fn name_store_join_2_inactive_pull_record() -> TestSyncIncomingRecord {
     let mut record = name_store_join_2_delete_record();
     record.sync_buffer_row.data = NAME_STORE_JOIN_INACTIVE_2.1.to_string();
     record
@@ -101,8 +101,8 @@ fn name_store_join_2_inactive_pull_record() -> TestFromSyncRecord {
 //       "om_name_is_supplier": true
 //   }"#,
 // );
-// fn name_store_join_3_pull_record() -> TestFromSyncRecord {
-//     TestFromSyncRecord::new_pull_upsert(
+// fn name_store_join_3_pull_record() -> TestSyncIncomingRecord {
+//     TestSyncIncomingRecord::new_pull_upsert(
 //         TABLE_NAME,
 //         NAME_STORE_JOIN_3,
 //         NameStoreJoinRow {
@@ -115,7 +115,7 @@ fn name_store_join_2_inactive_pull_record() -> TestFromSyncRecord {
 //     )
 // }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
         name_store_join_1_pull_record(),
         name_store_join_2_pull_record(),
@@ -123,17 +123,17 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     ]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
     vec![name_store_join_2_delete_record()]
 }
 
-pub(crate) fn test_pull_upsert_inactive_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_inactive_records() -> Vec<TestSyncIncomingRecord> {
     vec![name_store_join_2_inactive_pull_record()]
 }
 
-pub(crate) fn test_push_upsert() -> Vec<TestToSyncRecord> {
+pub(crate) fn test_push_upsert() -> Vec<TestSyncOutgoingRecord> {
     vec![
-        TestToSyncRecord {
+        TestSyncOutgoingRecord {
             record_id: NAME_STORE_JOIN_1.0.to_string(),
             table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyNameStoreJoinRow {
@@ -145,7 +145,7 @@ pub(crate) fn test_push_upsert() -> Vec<TestToSyncRecord> {
                 name_is_supplier: Some(true),
             }),
         },
-        TestToSyncRecord {
+        TestSyncOutgoingRecord {
             record_id: NAME_STORE_JOIN_2.0.to_string(),
             table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyNameStoreJoinRow {

--- a/server/service/src/sync/test/test_data/name_tag.rs
+++ b/server/service/src/sync/test/test_data/name_tag.rs
@@ -1,4 +1,4 @@
-use crate::sync::test::TestSyncPullRecord;
+use crate::sync::test::TestFromSyncRecord;
 
 use repository::NameTagRow;
 
@@ -12,8 +12,8 @@ const NAME_TAG_1: (&'static str, &'static str) = (
     }"#,
 );
 
-fn name_tag_1() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn name_tag_1() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_TAG_1,
         NameTagRow {
@@ -31,8 +31,8 @@ const NAME_TAG_2: (&'static str, &'static str) = (
 }"#,
 );
 
-fn name_tag_2() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn name_tag_2() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_TAG_2,
         NameTagRow {
@@ -42,6 +42,6 @@ fn name_tag_2() -> TestSyncPullRecord {
     )
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![name_tag_1(), name_tag_2()]
 }

--- a/server/service/src/sync/test/test_data/name_tag.rs
+++ b/server/service/src/sync/test/test_data/name_tag.rs
@@ -1,4 +1,4 @@
-use crate::sync::test::TestFromSyncRecord;
+use crate::sync::test::TestSyncIncomingRecord;
 
 use repository::NameTagRow;
 
@@ -12,8 +12,8 @@ const NAME_TAG_1: (&'static str, &'static str) = (
     }"#,
 );
 
-fn name_tag_1() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn name_tag_1() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_TAG_1,
         NameTagRow {
@@ -31,8 +31,8 @@ const NAME_TAG_2: (&'static str, &'static str) = (
 }"#,
 );
 
-fn name_tag_2() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn name_tag_2() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_TAG_2,
         NameTagRow {
@@ -42,6 +42,6 @@ fn name_tag_2() -> TestFromSyncRecord {
     )
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![name_tag_1(), name_tag_2()]
 }

--- a/server/service/src/sync/test/test_data/name_tag_join.rs
+++ b/server/service/src/sync/test/test_data/name_tag_join.rs
@@ -1,4 +1,4 @@
-use crate::sync::test::TestSyncPullRecord;
+use crate::sync::test::TestFromSyncRecord;
 
 use repository::{NameTagJoinRow, NameTagJoinRowDelete};
 
@@ -13,8 +13,8 @@ const NAME_TAG_JOIN_1: (&'static str, &'static str) = (
     }"#,
 );
 
-fn name_tag_join_1() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn name_tag_join_1() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_TAG_JOIN_1,
         NameTagJoinRow {
@@ -34,8 +34,8 @@ const NAME_TAG_JOIN_2: (&'static str, &'static str) = (
 }"#,
 );
 
-fn name_tag_join_2() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn name_tag_join_2() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_TAG_JOIN_2,
         NameTagJoinRow {
@@ -46,12 +46,12 @@ fn name_tag_join_2() -> TestSyncPullRecord {
     )
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![name_tag_join_1(), name_tag_join_2()]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_delete(
         TABLE_NAME,
         NAME_TAG_JOIN_2.0,
         NameTagJoinRowDelete(NAME_TAG_JOIN_2.0.to_string()),

--- a/server/service/src/sync/test/test_data/name_tag_join.rs
+++ b/server/service/src/sync/test/test_data/name_tag_join.rs
@@ -1,4 +1,4 @@
-use crate::sync::test::TestFromSyncRecord;
+use crate::sync::test::TestSyncIncomingRecord;
 
 use repository::{NameTagJoinRow, NameTagJoinRowDelete};
 
@@ -13,8 +13,8 @@ const NAME_TAG_JOIN_1: (&'static str, &'static str) = (
     }"#,
 );
 
-fn name_tag_join_1() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn name_tag_join_1() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_TAG_JOIN_1,
         NameTagJoinRow {
@@ -34,8 +34,8 @@ const NAME_TAG_JOIN_2: (&'static str, &'static str) = (
 }"#,
 );
 
-fn name_tag_join_2() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn name_tag_join_2() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         NAME_TAG_JOIN_2,
         NameTagJoinRow {
@@ -46,12 +46,12 @@ fn name_tag_join_2() -> TestFromSyncRecord {
     )
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![name_tag_join_1(), name_tag_join_2()]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_delete(
         TABLE_NAME,
         NAME_TAG_JOIN_2.0,
         NameTagJoinRowDelete(NAME_TAG_JOIN_2.0.to_string()),

--- a/server/service/src/sync/test/test_data/pack_variant.rs
+++ b/server/service/src/sync/test/test_data/pack_variant.rs
@@ -1,7 +1,7 @@
 use repository::PackVariantRow;
 use serde_json::json;
 
-use super::{TestFromSyncRecord, TestToSyncRecord};
+use super::{TestSyncIncomingRecord, TestSyncOutgoingRecord};
 
 const TABLE_NAME: &'static str = "pack_variant";
 
@@ -28,16 +28,16 @@ fn pack_variant1() -> PackVariantRow {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         PACK_VARIANT1,
         pack_variant1(),
     )]
 }
 
-pub(crate) fn test_omsupply_central_push_records() -> Vec<TestToSyncRecord> {
-    vec![TestToSyncRecord {
+pub(crate) fn test_omsupply_central_push_records() -> Vec<TestSyncOutgoingRecord> {
+    vec![TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: PACK_VARIANT1.0.to_string(),
         push_data: json!(pack_variant1()),

--- a/server/service/src/sync/test/test_data/pack_variant.rs
+++ b/server/service/src/sync/test/test_data/pack_variant.rs
@@ -1,7 +1,7 @@
 use repository::PackVariantRow;
 use serde_json::json;
 
-use super::{TestSyncPullRecord, TestSyncPushRecord};
+use super::{TestFromSyncRecord, TestToSyncRecord};
 
 const TABLE_NAME: &'static str = "pack_variant";
 
@@ -28,16 +28,16 @@ fn pack_variant1() -> PackVariantRow {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         PACK_VARIANT1,
         pack_variant1(),
     )]
 }
 
-pub(crate) fn test_omsupply_central_push_records() -> Vec<TestSyncPushRecord> {
-    vec![TestSyncPushRecord {
+pub(crate) fn test_omsupply_central_push_records() -> Vec<TestToSyncRecord> {
+    vec![TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: PACK_VARIANT1.0.to_string(),
         push_data: json!(pack_variant1()),

--- a/server/service/src/sync/test/test_data/period.rs
+++ b/server/service/src/sync/test/test_data/period.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDate;
 use repository::PeriodRow;
 
-use crate::sync::test::TestFromSyncRecord;
+use crate::sync::test::TestSyncIncomingRecord;
 
 const TABLE_NAME: &'static str = "period";
 
@@ -51,9 +51,9 @@ const PERIOD_4: (&'static str, &'static str) = (
 "#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             PERIOD_1,
             PeriodRow {
@@ -64,7 +64,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
                 end_date: NaiveDate::from_ymd_opt(2023, 01, 07).unwrap(),
             },
         ),
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             PERIOD_2,
             PeriodRow {
@@ -75,7 +75,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
                 end_date: NaiveDate::from_ymd_opt(2023, 12, 31).unwrap(),
             },
         ),
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             PERIOD_3,
             PeriodRow {
@@ -86,7 +86,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
                 end_date: NaiveDate::from_ymd_opt(2020, 06, 30).unwrap(),
             },
         ),
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             PERIOD_4,
             PeriodRow {

--- a/server/service/src/sync/test/test_data/period.rs
+++ b/server/service/src/sync/test/test_data/period.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDate;
 use repository::PeriodRow;
 
-use crate::sync::test::TestSyncPullRecord;
+use crate::sync::test::TestFromSyncRecord;
 
 const TABLE_NAME: &'static str = "period";
 
@@ -51,9 +51,9 @@ const PERIOD_4: (&'static str, &'static str) = (
 "#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             PERIOD_1,
             PeriodRow {
@@ -64,7 +64,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 end_date: NaiveDate::from_ymd_opt(2023, 01, 07).unwrap(),
             },
         ),
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             PERIOD_2,
             PeriodRow {
@@ -75,7 +75,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 end_date: NaiveDate::from_ymd_opt(2023, 12, 31).unwrap(),
             },
         ),
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             PERIOD_3,
             PeriodRow {
@@ -86,7 +86,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 end_date: NaiveDate::from_ymd_opt(2020, 06, 30).unwrap(),
             },
         ),
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             PERIOD_4,
             PeriodRow {

--- a/server/service/src/sync/test/test_data/period_schedule.rs
+++ b/server/service/src/sync/test/test_data/period_schedule.rs
@@ -1,6 +1,6 @@
 use repository::PeriodScheduleRow;
 
-use crate::sync::test::TestFromSyncRecord;
+use crate::sync::test::TestSyncIncomingRecord;
 
 const TABLE_NAME: &'static str = "periodSchedule";
 
@@ -28,9 +28,9 @@ const PERIOD_SCHEDULE_3: (&'static str, &'static str) = (
 }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             PERIOD_SCHEDULE_1,
             PeriodScheduleRow {
@@ -38,7 +38,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
                 name: "Weekly1".to_string(),
             },
         ),
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             PERIOD_SCHEDULE_2,
             PeriodScheduleRow {
@@ -46,7 +46,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
                 name: "Yearly2".to_string(),
             },
         ),
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             PERIOD_SCHEDULE_3,
             PeriodScheduleRow {

--- a/server/service/src/sync/test/test_data/period_schedule.rs
+++ b/server/service/src/sync/test/test_data/period_schedule.rs
@@ -1,6 +1,6 @@
 use repository::PeriodScheduleRow;
 
-use crate::sync::test::TestSyncPullRecord;
+use crate::sync::test::TestFromSyncRecord;
 
 const TABLE_NAME: &'static str = "periodSchedule";
 
@@ -28,9 +28,9 @@ const PERIOD_SCHEDULE_3: (&'static str, &'static str) = (
 }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             PERIOD_SCHEDULE_1,
             PeriodScheduleRow {
@@ -38,7 +38,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 name: "Weekly1".to_string(),
             },
         ),
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             PERIOD_SCHEDULE_2,
             PeriodScheduleRow {
@@ -46,7 +46,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 name: "Yearly2".to_string(),
             },
         ),
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             PERIOD_SCHEDULE_3,
             PeriodScheduleRow {

--- a/server/service/src/sync/test/test_data/program_requisition_settings.rs
+++ b/server/service/src/sync/test/test_data/program_requisition_settings.rs
@@ -8,7 +8,7 @@ use repository::{
 };
 
 use crate::sync::{
-    test::TestSyncPullRecord,
+    test::TestFromSyncRecord,
     translations::{IntegrationOperation, PullTranslateResult},
 };
 
@@ -117,9 +117,9 @@ const MASTER_LIST_WITH_PROGRAM_2: (&'static str, &'static str) = (
 }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![
-        TestSyncPullRecord {
+        TestFromSyncRecord {
             translated_record: PullTranslateResult::IntegrationOperations(vec![
                 IntegrationOperation::upsert(ContextRow {
                     id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
@@ -203,7 +203,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
             },
             extra_data: None,
         },
-        TestSyncPullRecord {
+        TestFromSyncRecord {
             translated_record: PullTranslateResult::IntegrationOperations(vec![
                 IntegrationOperation::upsert(ContextRow {
                     id: MASTER_LIST_WITH_PROGRAM_2.0.to_owned(),

--- a/server/service/src/sync/test/test_data/program_requisition_settings.rs
+++ b/server/service/src/sync/test/test_data/program_requisition_settings.rs
@@ -8,7 +8,7 @@ use repository::{
 };
 
 use crate::sync::{
-    test::TestFromSyncRecord,
+    test::TestSyncIncomingRecord,
     translations::{IntegrationOperation, PullTranslateResult},
 };
 
@@ -117,9 +117,9 @@ const MASTER_LIST_WITH_PROGRAM_2: (&'static str, &'static str) = (
 }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
-        TestFromSyncRecord {
+        TestSyncIncomingRecord {
             translated_record: PullTranslateResult::IntegrationOperations(vec![
                 IntegrationOperation::upsert(ContextRow {
                     id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
@@ -203,7 +203,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
             },
             extra_data: None,
         },
-        TestFromSyncRecord {
+        TestSyncIncomingRecord {
             translated_record: PullTranslateResult::IntegrationOperations(vec![
                 IntegrationOperation::upsert(ContextRow {
                     id: MASTER_LIST_WITH_PROGRAM_2.0.to_owned(),

--- a/server/service/src/sync/test/test_data/report.rs
+++ b/server/service/src/sync/test/test_data/report.rs
@@ -1,4 +1,4 @@
-use crate::sync::test::TestFromSyncRecord;
+use crate::sync::test::TestSyncIncomingRecord;
 use repository::{ReportContext, ReportRow, ReportRowDelete, ReportType};
 
 const TABLE_NAME: &'static str = "report";
@@ -26,8 +26,8 @@ const REPORT_1: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         REPORT_1,
         ReportRow {
@@ -43,8 +43,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     )]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_delete(
         TABLE_NAME,
         REPORT_1.0,
         ReportRowDelete(REPORT_1.0.to_string()),

--- a/server/service/src/sync/test/test_data/report.rs
+++ b/server/service/src/sync/test/test_data/report.rs
@@ -1,4 +1,4 @@
-use crate::sync::test::TestSyncPullRecord;
+use crate::sync::test::TestFromSyncRecord;
 use repository::{ReportContext, ReportRow, ReportRowDelete, ReportType};
 
 const TABLE_NAME: &'static str = "report";
@@ -26,8 +26,8 @@ const REPORT_1: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         REPORT_1,
         ReportRow {
@@ -43,8 +43,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     )]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_delete(
         TABLE_NAME,
         REPORT_1.0,
         ReportRowDelete(REPORT_1.0.to_string()),

--- a/server/service/src/sync/test/test_data/requisition.rs
+++ b/server/service/src/sync/test/test_data/requisition.rs
@@ -1,4 +1,4 @@
-use super::{TestSyncPullRecord, TestSyncPushRecord};
+use super::{TestFromSyncRecord, TestToSyncRecord};
 use crate::sync::translations::requisition::{
     LegacyAuthorisationStatus, LegacyRequisitionRow, LegacyRequisitionStatus, LegacyRequisitionType,
 };
@@ -50,8 +50,8 @@ const REQUISITION_REQUEST: (&'static str, &'static str) = (
       "om_colour": "" 
     }"#,
 );
-fn requisition_request_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn requisition_request_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         REQUISITION_REQUEST,
         RequisitionRow {
@@ -87,8 +87,8 @@ fn requisition_request_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn requisition_request_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn requisition_request_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: REQUISITION_REQUEST.0.to_string(),
         push_data: json!(LegacyRequisitionRow {
@@ -163,8 +163,8 @@ const REQUISITION_RESPONSE: (&'static str, &'static str) = (
       "isRemoteOrder": false
     }"#,
 );
-fn requisition_response_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn requisition_response_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         REQUISITION_RESPONSE,
         RequisitionRow {
@@ -200,8 +200,8 @@ fn requisition_response_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn requisition_response_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn requisition_response_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: REQUISITION_RESPONSE.0.to_string(),
         push_data: json!(LegacyRequisitionRow {
@@ -283,8 +283,8 @@ const REQUISITION_OM_FIELDS: (&'static str, &'static str) = (
       "om_colour": "Colour" 
     }"#,
 );
-fn requisition_om_fields_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn requisition_om_fields_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         REQUISITION_OM_FIELDS,
         RequisitionRow {
@@ -325,8 +325,8 @@ fn requisition_om_fields_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn requisition_om_fields_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn requisition_om_fields_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: REQUISITION_OM_FIELDS.0.to_string(),
         push_data: json!(LegacyRequisitionRow {
@@ -413,8 +413,8 @@ const PROGRAM_REQUISITION_REQUEST: (&'static str, &'static str) = (
       "om_colour": "" 
     }"#,
 );
-fn program_requisition_request_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn program_requisition_request_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         PROGRAM_REQUISITION_REQUEST,
         RequisitionRow {
@@ -450,8 +450,8 @@ fn program_requisition_request_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn program_requisition_request_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn program_requisition_request_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: PROGRAM_REQUISITION_REQUEST.0.to_string(),
         push_data: json!(LegacyRequisitionRow {
@@ -494,7 +494,7 @@ fn program_requisition_request_push_record() -> TestSyncPushRecord {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![
         requisition_request_pull_record(),
         program_requisition_request_pull_record(),
@@ -503,15 +503,15 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     ]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_delete(
         TABLE_NAME,
         REQUISITION_OM_FIELDS.0,
         RequisitionRowDelete(REQUISITION_OM_FIELDS.0.to_string()),
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
+pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
     vec![
         requisition_request_push_record(),
         program_requisition_request_push_record(),

--- a/server/service/src/sync/test/test_data/requisition.rs
+++ b/server/service/src/sync/test/test_data/requisition.rs
@@ -1,4 +1,4 @@
-use super::{TestFromSyncRecord, TestToSyncRecord};
+use super::{TestSyncIncomingRecord, TestSyncOutgoingRecord};
 use crate::sync::translations::requisition::{
     LegacyAuthorisationStatus, LegacyRequisitionRow, LegacyRequisitionStatus, LegacyRequisitionType,
 };
@@ -50,8 +50,8 @@ const REQUISITION_REQUEST: (&'static str, &'static str) = (
       "om_colour": "" 
     }"#,
 );
-fn requisition_request_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn requisition_request_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         REQUISITION_REQUEST,
         RequisitionRow {
@@ -87,8 +87,8 @@ fn requisition_request_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn requisition_request_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn requisition_request_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: REQUISITION_REQUEST.0.to_string(),
         push_data: json!(LegacyRequisitionRow {
@@ -163,8 +163,8 @@ const REQUISITION_RESPONSE: (&'static str, &'static str) = (
       "isRemoteOrder": false
     }"#,
 );
-fn requisition_response_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn requisition_response_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         REQUISITION_RESPONSE,
         RequisitionRow {
@@ -200,8 +200,8 @@ fn requisition_response_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn requisition_response_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn requisition_response_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: REQUISITION_RESPONSE.0.to_string(),
         push_data: json!(LegacyRequisitionRow {
@@ -283,8 +283,8 @@ const REQUISITION_OM_FIELDS: (&'static str, &'static str) = (
       "om_colour": "Colour" 
     }"#,
 );
-fn requisition_om_fields_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn requisition_om_fields_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         REQUISITION_OM_FIELDS,
         RequisitionRow {
@@ -325,8 +325,8 @@ fn requisition_om_fields_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn requisition_om_fields_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn requisition_om_fields_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: REQUISITION_OM_FIELDS.0.to_string(),
         push_data: json!(LegacyRequisitionRow {
@@ -413,8 +413,8 @@ const PROGRAM_REQUISITION_REQUEST: (&'static str, &'static str) = (
       "om_colour": "" 
     }"#,
 );
-fn program_requisition_request_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn program_requisition_request_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         PROGRAM_REQUISITION_REQUEST,
         RequisitionRow {
@@ -450,8 +450,8 @@ fn program_requisition_request_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn program_requisition_request_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn program_requisition_request_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: PROGRAM_REQUISITION_REQUEST.0.to_string(),
         push_data: json!(LegacyRequisitionRow {
@@ -494,7 +494,7 @@ fn program_requisition_request_push_record() -> TestToSyncRecord {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
         requisition_request_pull_record(),
         program_requisition_request_pull_record(),
@@ -503,15 +503,15 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     ]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_delete(
         TABLE_NAME,
         REQUISITION_OM_FIELDS.0,
         RequisitionRowDelete(REQUISITION_OM_FIELDS.0.to_string()),
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
+pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
     vec![
         requisition_request_push_record(),
         program_requisition_request_push_record(),

--- a/server/service/src/sync/test/test_data/requisition_line.rs
+++ b/server/service/src/sync/test/test_data/requisition_line.rs
@@ -1,6 +1,6 @@
 use crate::sync::translations::requisition_line::LegacyRequisitionLineRow;
 
-use super::{TestSyncPullRecord, TestSyncPushRecord};
+use super::{TestFromSyncRecord, TestToSyncRecord};
 use chrono::NaiveDate;
 use repository::{RequisitionLineRow, RequisitionLineRowDelete};
 use serde_json::json;
@@ -44,8 +44,8 @@ const REQUISITION_LINE_1: (&'static str, &'static str) = (
         "om_snapshot_datetime": ""
     }"#,
 );
-fn requisition_line_request_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn requisition_line_request_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         REQUISITION_LINE_1,
         RequisitionLineRow {
@@ -64,8 +64,8 @@ fn requisition_line_request_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn requisition_line_request_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn requisition_line_request_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: REQUISITION_LINE_1.0.to_string(),
         push_data: json!(LegacyRequisitionLineRow {
@@ -122,8 +122,8 @@ const REQUISITION_LINE_OM_FIELD: (&'static str, &'static str) = (
         "om_snapshot_datetime": "2022-04-04T14:48:11"
     }"#,
 );
-fn requisition_line_om_fields_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn requisition_line_om_fields_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         REQUISITION_LINE_OM_FIELD,
         RequisitionLineRow {
@@ -147,8 +147,8 @@ fn requisition_line_om_fields_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn requisition_line_om_fields_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn requisition_line_om_fields_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: REQUISITION_LINE_OM_FIELD.0.to_string(),
         push_data: json!(LegacyRequisitionLineRow {
@@ -174,22 +174,22 @@ fn requisition_line_om_fields_push_record() -> TestSyncPushRecord {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![
         requisition_line_request_pull_record(),
         requisition_line_om_fields_pull_record(),
     ]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_delete(
         TABLE_NAME,
         REQUISITION_LINE_OM_FIELD.0,
         RequisitionLineRowDelete(REQUISITION_LINE_OM_FIELD.0.to_string()),
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
+pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
     vec![
         requisition_line_request_push_record(),
         requisition_line_om_fields_push_record(),

--- a/server/service/src/sync/test/test_data/requisition_line.rs
+++ b/server/service/src/sync/test/test_data/requisition_line.rs
@@ -1,6 +1,6 @@
 use crate::sync::translations::requisition_line::LegacyRequisitionLineRow;
 
-use super::{TestFromSyncRecord, TestToSyncRecord};
+use super::{TestSyncIncomingRecord, TestSyncOutgoingRecord};
 use chrono::NaiveDate;
 use repository::{RequisitionLineRow, RequisitionLineRowDelete};
 use serde_json::json;
@@ -44,8 +44,8 @@ const REQUISITION_LINE_1: (&'static str, &'static str) = (
         "om_snapshot_datetime": ""
     }"#,
 );
-fn requisition_line_request_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn requisition_line_request_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         REQUISITION_LINE_1,
         RequisitionLineRow {
@@ -64,8 +64,8 @@ fn requisition_line_request_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn requisition_line_request_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn requisition_line_request_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: REQUISITION_LINE_1.0.to_string(),
         push_data: json!(LegacyRequisitionLineRow {
@@ -122,8 +122,8 @@ const REQUISITION_LINE_OM_FIELD: (&'static str, &'static str) = (
         "om_snapshot_datetime": "2022-04-04T14:48:11"
     }"#,
 );
-fn requisition_line_om_fields_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn requisition_line_om_fields_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         REQUISITION_LINE_OM_FIELD,
         RequisitionLineRow {
@@ -147,8 +147,8 @@ fn requisition_line_om_fields_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn requisition_line_om_fields_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn requisition_line_om_fields_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: REQUISITION_LINE_OM_FIELD.0.to_string(),
         push_data: json!(LegacyRequisitionLineRow {
@@ -174,22 +174,22 @@ fn requisition_line_om_fields_push_record() -> TestToSyncRecord {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
         requisition_line_request_pull_record(),
         requisition_line_om_fields_pull_record(),
     ]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_delete(
         TABLE_NAME,
         REQUISITION_LINE_OM_FIELD.0,
         RequisitionLineRowDelete(REQUISITION_LINE_OM_FIELD.0.to_string()),
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
+pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
     vec![
         requisition_line_request_push_record(),
         requisition_line_om_fields_push_record(),

--- a/server/service/src/sync/test/test_data/sensor.rs
+++ b/server/service/src/sync/test/test_data/sensor.rs
@@ -4,7 +4,7 @@ use chrono::{Duration, NaiveDate, NaiveTime};
 use repository::{SensorRow, SensorType};
 use serde_json::json;
 
-use super::{TestFromSyncRecord, TestToSyncRecord};
+use super::{TestSyncIncomingRecord, TestSyncOutgoingRecord};
 
 const TABLE_NAME: &'static str = "sensor";
 
@@ -25,8 +25,8 @@ const SENSOR_1: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         SENSOR_1,
         SensorRow {
@@ -50,8 +50,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
-    vec![TestToSyncRecord {
+pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
+    vec![TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: SENSOR_1.0.to_string(),
         push_data: json!(LegacySensorRow {

--- a/server/service/src/sync/test/test_data/sensor.rs
+++ b/server/service/src/sync/test/test_data/sensor.rs
@@ -4,7 +4,7 @@ use chrono::{Duration, NaiveDate, NaiveTime};
 use repository::{SensorRow, SensorType};
 use serde_json::json;
 
-use super::{TestSyncPullRecord, TestSyncPushRecord};
+use super::{TestFromSyncRecord, TestToSyncRecord};
 
 const TABLE_NAME: &'static str = "sensor";
 
@@ -25,8 +25,8 @@ const SENSOR_1: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         SENSOR_1,
         SensorRow {
@@ -50,8 +50,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
-    vec![TestSyncPushRecord {
+pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
+    vec![TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: SENSOR_1.0.to_string(),
         push_data: json!(LegacySensorRow {

--- a/server/service/src/sync/test/test_data/special/name_to_name_store_join.rs
+++ b/server/service/src/sync/test/test_data/special/name_to_name_store_join.rs
@@ -3,7 +3,7 @@ use serde_json::json;
 use util::{inline_edit, inline_init};
 
 use crate::sync::{
-    test::{TestFromSyncRecord, TestToSyncRecord},
+    test::{TestSyncIncomingRecord, TestSyncOutgoingRecord},
     translations::{name_store_join::LegacyNameStoreJoinRow, PullTranslateResult},
 };
 
@@ -158,8 +158,8 @@ pub fn name_store_join3() -> NameStoreJoinRow {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord {
         translated_record: PullTranslateResult::upserts(vec![
             inline_edit(&name_store_join1(), |mut r| {
                 r.name_is_customer = true;
@@ -185,9 +185,9 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     }]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
+pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
     vec![
-        TestToSyncRecord {
+        TestSyncOutgoingRecord {
             record_id: name_store_join1().id,
             table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyNameStoreJoinRow {
@@ -200,7 +200,7 @@ pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
                 name_is_supplier: Some(false),
             }),
         },
-        TestToSyncRecord {
+        TestSyncOutgoingRecord {
             record_id: name_store_join2().id,
             table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyNameStoreJoinRow {
@@ -212,7 +212,7 @@ pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
                 name_is_supplier: Some(false),
             }),
         },
-        TestToSyncRecord {
+        TestSyncOutgoingRecord {
             record_id: name_store_join3().id,
             table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyNameStoreJoinRow {

--- a/server/service/src/sync/test/test_data/special/name_to_name_store_join.rs
+++ b/server/service/src/sync/test/test_data/special/name_to_name_store_join.rs
@@ -3,7 +3,7 @@ use serde_json::json;
 use util::{inline_edit, inline_init};
 
 use crate::sync::{
-    test::{TestSyncPullRecord, TestSyncPushRecord},
+    test::{TestFromSyncRecord, TestToSyncRecord},
     translations::{name_store_join::LegacyNameStoreJoinRow, PullTranslateResult},
 };
 
@@ -158,8 +158,8 @@ pub fn name_store_join3() -> NameStoreJoinRow {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord {
         translated_record: PullTranslateResult::upserts(vec![
             inline_edit(&name_store_join1(), |mut r| {
                 r.name_is_customer = true;
@@ -185,9 +185,9 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     }]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
+pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
     vec![
-        TestSyncPushRecord {
+        TestToSyncRecord {
             record_id: name_store_join1().id,
             table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyNameStoreJoinRow {
@@ -200,7 +200,7 @@ pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
                 name_is_supplier: Some(false),
             }),
         },
-        TestSyncPushRecord {
+        TestToSyncRecord {
             record_id: name_store_join2().id,
             table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyNameStoreJoinRow {
@@ -212,7 +212,7 @@ pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
                 name_is_supplier: Some(false),
             }),
         },
-        TestSyncPushRecord {
+        TestToSyncRecord {
             record_id: name_store_join3().id,
             table_name: TABLE_NAME.to_string(),
             push_data: json!(LegacyNameStoreJoinRow {

--- a/server/service/src/sync/test/test_data/stock_line.rs
+++ b/server/service/src/sync/test/test_data/stock_line.rs
@@ -2,9 +2,9 @@ use chrono::NaiveDate;
 use repository::StockLineRow;
 use serde_json::json;
 
-use crate::sync::{test::TestFromSyncRecord, translations::stock_line::LegacyStockLineRow};
+use crate::sync::{test::TestSyncIncomingRecord, translations::stock_line::LegacyStockLineRow};
 
-use super::TestToSyncRecord;
+use super::TestSyncOutgoingRecord;
 
 const TABLE_NAME: &'static str = "item_line";
 
@@ -51,8 +51,8 @@ const ITEM_LINE_1: (&'static str, &'static str) = (
       "weight_per_pack": 0
     }"#,
 );
-fn item_line_1_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn item_line_1_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         ITEM_LINE_1,
         StockLineRow {
@@ -74,8 +74,8 @@ fn item_line_1_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn item_line_1_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn item_line_1_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: ITEM_LINE_1.0.to_string(),
         push_data: json!(LegacyStockLineRow {
@@ -141,8 +141,8 @@ const ITEM_LINE_2: (&'static str, &'static str) = (
       "weight_per_pack": 0
   }"#,
 );
-fn item_line_2_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn item_line_2_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         ITEM_LINE_2,
         StockLineRow {
@@ -164,8 +164,8 @@ fn item_line_2_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn item_line_2_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn item_line_2_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: ITEM_LINE_2.0.to_string(),
         push_data: json!(LegacyStockLineRow {
@@ -188,10 +188,10 @@ fn item_line_2_push_record() -> TestToSyncRecord {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![item_line_1_pull_record(), item_line_2_pull_record()]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
+pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
     vec![item_line_1_push_record(), item_line_2_push_record()]
 }

--- a/server/service/src/sync/test/test_data/stock_line.rs
+++ b/server/service/src/sync/test/test_data/stock_line.rs
@@ -2,9 +2,9 @@ use chrono::NaiveDate;
 use repository::StockLineRow;
 use serde_json::json;
 
-use crate::sync::{test::TestSyncPullRecord, translations::stock_line::LegacyStockLineRow};
+use crate::sync::{test::TestFromSyncRecord, translations::stock_line::LegacyStockLineRow};
 
-use super::TestSyncPushRecord;
+use super::TestToSyncRecord;
 
 const TABLE_NAME: &'static str = "item_line";
 
@@ -51,8 +51,8 @@ const ITEM_LINE_1: (&'static str, &'static str) = (
       "weight_per_pack": 0
     }"#,
 );
-fn item_line_1_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn item_line_1_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         ITEM_LINE_1,
         StockLineRow {
@@ -74,8 +74,8 @@ fn item_line_1_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn item_line_1_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn item_line_1_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: ITEM_LINE_1.0.to_string(),
         push_data: json!(LegacyStockLineRow {
@@ -141,8 +141,8 @@ const ITEM_LINE_2: (&'static str, &'static str) = (
       "weight_per_pack": 0
   }"#,
 );
-fn item_line_2_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn item_line_2_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         ITEM_LINE_2,
         StockLineRow {
@@ -164,8 +164,8 @@ fn item_line_2_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn item_line_2_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn item_line_2_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: ITEM_LINE_2.0.to_string(),
         push_data: json!(LegacyStockLineRow {
@@ -188,10 +188,10 @@ fn item_line_2_push_record() -> TestSyncPushRecord {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![item_line_1_pull_record(), item_line_2_pull_record()]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
+pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
     vec![item_line_1_push_record(), item_line_2_push_record()]
 }

--- a/server/service/src/sync/test/test_data/stocktake.rs
+++ b/server/service/src/sync/test/test_data/stocktake.rs
@@ -1,12 +1,12 @@
 use crate::sync::{
-    test::TestSyncPullRecord,
+    test::TestFromSyncRecord,
     translations::stocktake::{LegacyStocktakeRow, LegacyStocktakeStatus},
 };
 use chrono::{NaiveDate, NaiveTime};
 use repository::{StocktakeRow, StocktakeStatus};
 use serde_json::json;
 
-use super::TestSyncPushRecord;
+use super::TestToSyncRecord;
 
 const TABLE_NAME: &'static str = "Stock_take";
 
@@ -32,8 +32,8 @@ const STOCKTAKE_1: (&'static str, &'static str) = (
       "om_created_datetime": ""
     }"#,
 );
-fn stocktake_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn stocktake_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         STOCKTAKE_1,
         StocktakeRow {
@@ -55,8 +55,8 @@ fn stocktake_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn stocktake_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn stocktake_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: STOCKTAKE_1.0.to_string(),
         push_data: json!(LegacyStocktakeRow {
@@ -106,8 +106,8 @@ const STOCKTAKE_OM_FIELD: (&'static str, &'static str) = (
       "om_finalised_datetime": "2021-07-31T15:15:15"
     }"#,
 );
-fn stocktake_om_field_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn stocktake_om_field_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         STOCKTAKE_OM_FIELD,
         StocktakeRow {
@@ -135,8 +135,8 @@ fn stocktake_om_field_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn stocktake_om_field_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn stocktake_om_field_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: STOCKTAKE_OM_FIELD.0.to_string(),
         push_data: json!(LegacyStocktakeRow {
@@ -169,10 +169,10 @@ fn stocktake_om_field_push_record() -> TestSyncPushRecord {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![stocktake_pull_record(), stocktake_om_field_pull_record()]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
+pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
     vec![stocktake_push_record(), stocktake_om_field_push_record()]
 }

--- a/server/service/src/sync/test/test_data/stocktake.rs
+++ b/server/service/src/sync/test/test_data/stocktake.rs
@@ -1,12 +1,12 @@
 use crate::sync::{
-    test::TestFromSyncRecord,
+    test::TestSyncIncomingRecord,
     translations::stocktake::{LegacyStocktakeRow, LegacyStocktakeStatus},
 };
 use chrono::{NaiveDate, NaiveTime};
 use repository::{StocktakeRow, StocktakeStatus};
 use serde_json::json;
 
-use super::TestToSyncRecord;
+use super::TestSyncOutgoingRecord;
 
 const TABLE_NAME: &'static str = "Stock_take";
 
@@ -32,8 +32,8 @@ const STOCKTAKE_1: (&'static str, &'static str) = (
       "om_created_datetime": ""
     }"#,
 );
-fn stocktake_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn stocktake_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         STOCKTAKE_1,
         StocktakeRow {
@@ -55,8 +55,8 @@ fn stocktake_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn stocktake_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn stocktake_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: STOCKTAKE_1.0.to_string(),
         push_data: json!(LegacyStocktakeRow {
@@ -106,8 +106,8 @@ const STOCKTAKE_OM_FIELD: (&'static str, &'static str) = (
       "om_finalised_datetime": "2021-07-31T15:15:15"
     }"#,
 );
-fn stocktake_om_field_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn stocktake_om_field_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         STOCKTAKE_OM_FIELD,
         StocktakeRow {
@@ -135,8 +135,8 @@ fn stocktake_om_field_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn stocktake_om_field_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn stocktake_om_field_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: STOCKTAKE_OM_FIELD.0.to_string(),
         push_data: json!(LegacyStocktakeRow {
@@ -169,10 +169,10 @@ fn stocktake_om_field_push_record() -> TestToSyncRecord {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![stocktake_pull_record(), stocktake_om_field_pull_record()]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
+pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
     vec![stocktake_push_record(), stocktake_om_field_push_record()]
 }

--- a/server/service/src/sync/test/test_data/stocktake_line.rs
+++ b/server/service/src/sync/test/test_data/stocktake_line.rs
@@ -1,5 +1,5 @@
-use super::TestSyncPushRecord;
-use crate::sync::{test::TestSyncPullRecord, translations::stocktake_line::LegacyStocktakeLineRow};
+use super::TestToSyncRecord;
+use crate::sync::{test::TestFromSyncRecord, translations::stocktake_line::LegacyStocktakeLineRow};
 use repository::StocktakeLineRow;
 use serde_json::json;
 
@@ -30,8 +30,8 @@ const STOCKTAKE_LINE_1: (&'static str, &'static str) = (
       "vaccine_vial_monitor_status_ID": ""
     }"#,
 );
-fn stocktake_line_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn stocktake_line_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         STOCKTAKE_LINE_1,
         StocktakeLineRow {
@@ -53,8 +53,8 @@ fn stocktake_line_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn stocktake_line_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn stocktake_line_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: STOCKTAKE_LINE_1.0.to_string(),
         push_data: json!(LegacyStocktakeLineRow {
@@ -104,8 +104,8 @@ const STOCKTAKE_LINE_OM_FIELDS: (&'static str, &'static str) = (
       "om_note": "om note"
     }"#,
 );
-fn stocktake_line_om_field_pull_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn stocktake_line_om_field_pull_record() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         STOCKTAKE_LINE_OM_FIELDS,
         StocktakeLineRow {
@@ -127,8 +127,8 @@ fn stocktake_line_om_field_pull_record() -> TestSyncPullRecord {
         },
     )
 }
-fn stocktake_line_om_field_push_record() -> TestSyncPushRecord {
-    TestSyncPushRecord {
+fn stocktake_line_om_field_push_record() -> TestToSyncRecord {
+    TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: STOCKTAKE_LINE_OM_FIELDS.0.to_string(),
         push_data: json!(LegacyStocktakeLineRow {
@@ -152,14 +152,14 @@ fn stocktake_line_om_field_push_record() -> TestSyncPushRecord {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![
         stocktake_line_pull_record(),
         stocktake_line_om_field_pull_record(),
     ]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
+pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
     vec![
         stocktake_line_push_record(),
         stocktake_line_om_field_push_record(),

--- a/server/service/src/sync/test/test_data/stocktake_line.rs
+++ b/server/service/src/sync/test/test_data/stocktake_line.rs
@@ -1,5 +1,7 @@
-use super::TestToSyncRecord;
-use crate::sync::{test::TestFromSyncRecord, translations::stocktake_line::LegacyStocktakeLineRow};
+use super::TestSyncOutgoingRecord;
+use crate::sync::{
+    test::TestSyncIncomingRecord, translations::stocktake_line::LegacyStocktakeLineRow,
+};
 use repository::StocktakeLineRow;
 use serde_json::json;
 
@@ -30,8 +32,8 @@ const STOCKTAKE_LINE_1: (&'static str, &'static str) = (
       "vaccine_vial_monitor_status_ID": ""
     }"#,
 );
-fn stocktake_line_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn stocktake_line_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         STOCKTAKE_LINE_1,
         StocktakeLineRow {
@@ -53,8 +55,8 @@ fn stocktake_line_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn stocktake_line_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn stocktake_line_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: STOCKTAKE_LINE_1.0.to_string(),
         push_data: json!(LegacyStocktakeLineRow {
@@ -104,8 +106,8 @@ const STOCKTAKE_LINE_OM_FIELDS: (&'static str, &'static str) = (
       "om_note": "om note"
     }"#,
 );
-fn stocktake_line_om_field_pull_record() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn stocktake_line_om_field_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         STOCKTAKE_LINE_OM_FIELDS,
         StocktakeLineRow {
@@ -127,8 +129,8 @@ fn stocktake_line_om_field_pull_record() -> TestFromSyncRecord {
         },
     )
 }
-fn stocktake_line_om_field_push_record() -> TestToSyncRecord {
-    TestToSyncRecord {
+fn stocktake_line_om_field_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: STOCKTAKE_LINE_OM_FIELDS.0.to_string(),
         push_data: json!(LegacyStocktakeLineRow {
@@ -152,14 +154,14 @@ fn stocktake_line_om_field_push_record() -> TestToSyncRecord {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
         stocktake_line_pull_record(),
         stocktake_line_om_field_pull_record(),
     ]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
+pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
     vec![
         stocktake_line_push_record(),
         stocktake_line_om_field_push_record(),

--- a/server/service/src/sync/test/test_data/store.rs
+++ b/server/service/src/sync/test/test_data/store.rs
@@ -1,4 +1,4 @@
-use crate::sync::{test::TestSyncPullRecord, translations::PullTranslateResult};
+use crate::sync::{test::TestFromSyncRecord, translations::PullTranslateResult};
 use repository::{StoreRow, StoreRowDelete, SyncBufferRow};
 use util::inline_init;
 
@@ -49,8 +49,8 @@ const STORE_1: (&'static str, &'static str) = (
 }"#,
 );
 
-fn store_1() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_upsert(
+fn store_1() -> TestFromSyncRecord {
+    TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         STORE_1,
         inline_init(|s: &mut StoreRow| {
@@ -109,8 +109,8 @@ const STORE_2: (&'static str, &'static str) = (
 }"#,
 );
 
-fn store_2() -> TestSyncPullRecord {
-    TestSyncPullRecord {
+fn store_2() -> TestFromSyncRecord {
+    TestFromSyncRecord {
         translated_record: PullTranslateResult::Ignored(
             "Ignoring not implemented system names".to_string(),
         ),
@@ -169,8 +169,8 @@ const STORE_3: (&'static str, &'static str) = (
 }"#,
 );
 
-fn store_3() -> TestSyncPullRecord {
-    TestSyncPullRecord {
+fn store_3() -> TestFromSyncRecord {
+    TestFromSyncRecord {
         translated_record: PullTranslateResult::Ignored(
             "Ignoring not implemented system names".to_string(),
         ),
@@ -229,8 +229,8 @@ const STORE_4: (&'static str, &'static str) = (
 }"#,
 );
 
-fn store_4() -> TestSyncPullRecord {
-    TestSyncPullRecord {
+fn store_4() -> TestFromSyncRecord {
+    TestFromSyncRecord {
         translated_record: PullTranslateResult::Ignored(
             "Ignoring not implemented system names".to_string(),
         ),
@@ -243,12 +243,12 @@ fn store_4() -> TestSyncPullRecord {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![store_1(), store_2(), store_3(), store_4()]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_delete(
         TABLE_NAME,
         STORE_4.0,
         StoreRowDelete(STORE_4.0.to_string()),

--- a/server/service/src/sync/test/test_data/store.rs
+++ b/server/service/src/sync/test/test_data/store.rs
@@ -1,4 +1,4 @@
-use crate::sync::{test::TestFromSyncRecord, translations::PullTranslateResult};
+use crate::sync::{test::TestSyncIncomingRecord, translations::PullTranslateResult};
 use repository::{StoreRow, StoreRowDelete, SyncBufferRow};
 use util::inline_init;
 
@@ -49,8 +49,8 @@ const STORE_1: (&'static str, &'static str) = (
 }"#,
 );
 
-fn store_1() -> TestFromSyncRecord {
-    TestFromSyncRecord::new_pull_upsert(
+fn store_1() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         STORE_1,
         inline_init(|s: &mut StoreRow| {
@@ -109,8 +109,8 @@ const STORE_2: (&'static str, &'static str) = (
 }"#,
 );
 
-fn store_2() -> TestFromSyncRecord {
-    TestFromSyncRecord {
+fn store_2() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord {
         translated_record: PullTranslateResult::Ignored(
             "Ignoring not implemented system names".to_string(),
         ),
@@ -169,8 +169,8 @@ const STORE_3: (&'static str, &'static str) = (
 }"#,
 );
 
-fn store_3() -> TestFromSyncRecord {
-    TestFromSyncRecord {
+fn store_3() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord {
         translated_record: PullTranslateResult::Ignored(
             "Ignoring not implemented system names".to_string(),
         ),
@@ -229,8 +229,8 @@ const STORE_4: (&'static str, &'static str) = (
 }"#,
 );
 
-fn store_4() -> TestFromSyncRecord {
-    TestFromSyncRecord {
+fn store_4() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord {
         translated_record: PullTranslateResult::Ignored(
             "Ignoring not implemented system names".to_string(),
         ),
@@ -243,12 +243,12 @@ fn store_4() -> TestFromSyncRecord {
     }
 }
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![store_1(), store_2(), store_3(), store_4()]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_delete(
         TABLE_NAME,
         STORE_4.0,
         StoreRowDelete(STORE_4.0.to_string()),

--- a/server/service/src/sync/test/test_data/store_preference.rs
+++ b/server/service/src/sync/test/test_data/store_preference.rs
@@ -1,4 +1,4 @@
-use crate::sync::test::TestSyncPullRecord;
+use crate::sync::test::TestFromSyncRecord;
 use repository::{StorePreferenceRow, StorePreferenceType};
 
 const TABLE_NAME: &'static str = "pref";
@@ -134,9 +134,9 @@ const STORE_PREFERENCE_2: (&'static str, &'static str) = (
 }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             STORE_PREFERENCE_1,
             StorePreferenceRow {
@@ -150,7 +150,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 issue_in_foreign_currency: true,
             },
         ),
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             STORE_PREFERENCE_2,
             StorePreferenceRow {

--- a/server/service/src/sync/test/test_data/store_preference.rs
+++ b/server/service/src/sync/test/test_data/store_preference.rs
@@ -1,4 +1,4 @@
-use crate::sync::test::TestFromSyncRecord;
+use crate::sync::test::TestSyncIncomingRecord;
 use repository::{StorePreferenceRow, StorePreferenceType};
 
 const TABLE_NAME: &'static str = "pref";
@@ -134,9 +134,9 @@ const STORE_PREFERENCE_2: (&'static str, &'static str) = (
 }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             STORE_PREFERENCE_1,
             StorePreferenceRow {
@@ -150,7 +150,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
                 issue_in_foreign_currency: true,
             },
         ),
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             STORE_PREFERENCE_2,
             StorePreferenceRow {

--- a/server/service/src/sync/test/test_data/temperature_breach.rs
+++ b/server/service/src/sync/test/test_data/temperature_breach.rs
@@ -6,7 +6,7 @@ use chrono::{Duration, NaiveDate, NaiveTime};
 use repository::{TemperatureBreachRow, TemperatureBreachRowType};
 use serde_json::json;
 
-use super::{TestSyncPullRecord, TestSyncPushRecord};
+use super::{TestFromSyncRecord, TestToSyncRecord};
 
 const TABLE_NAME: &'static str = "temperature_breach";
 
@@ -33,8 +33,8 @@ const TEMPERATURE_BREACH_1: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         TEMPERATURE_BREACH_1,
         TemperatureBreachRow {
@@ -65,8 +65,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
-    vec![TestSyncPushRecord {
+pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
+    vec![TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: TEMPERATURE_BREACH_1.0.to_string(),
         push_data: json!(LegacyTemperatureBreachRow {

--- a/server/service/src/sync/test/test_data/temperature_breach.rs
+++ b/server/service/src/sync/test/test_data/temperature_breach.rs
@@ -6,7 +6,7 @@ use chrono::{Duration, NaiveDate, NaiveTime};
 use repository::{TemperatureBreachRow, TemperatureBreachRowType};
 use serde_json::json;
 
-use super::{TestFromSyncRecord, TestToSyncRecord};
+use super::{TestSyncIncomingRecord, TestSyncOutgoingRecord};
 
 const TABLE_NAME: &'static str = "temperature_breach";
 
@@ -33,8 +33,8 @@ const TEMPERATURE_BREACH_1: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         TEMPERATURE_BREACH_1,
         TemperatureBreachRow {
@@ -65,8 +65,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
-    vec![TestToSyncRecord {
+pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
+    vec![TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: TEMPERATURE_BREACH_1.0.to_string(),
         push_data: json!(LegacyTemperatureBreachRow {

--- a/server/service/src/sync/test/test_data/temperature_log.rs
+++ b/server/service/src/sync/test/test_data/temperature_log.rs
@@ -4,7 +4,7 @@ use chrono::{Duration, NaiveDate, NaiveTime};
 use repository::TemperatureLogRow;
 use serde_json::json;
 
-use super::{TestSyncPullRecord, TestSyncPushRecord};
+use super::{TestFromSyncRecord, TestToSyncRecord};
 
 const TABLE_NAME: &'static str = "temperature_log";
 
@@ -23,8 +23,8 @@ const TEMPERATURE_LOG_1: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_upsert(
         TABLE_NAME,
         TEMPERATURE_LOG_1,
         TemperatureLogRow {
@@ -43,8 +43,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
-    vec![TestSyncPushRecord {
+pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
+    vec![TestToSyncRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: TEMPERATURE_LOG_1.0.to_string(),
         push_data: json!(LegacyTemperatureLogRow {

--- a/server/service/src/sync/test/test_data/temperature_log.rs
+++ b/server/service/src/sync/test/test_data/temperature_log.rs
@@ -4,7 +4,7 @@ use chrono::{Duration, NaiveDate, NaiveTime};
 use repository::TemperatureLogRow;
 use serde_json::json;
 
-use super::{TestFromSyncRecord, TestToSyncRecord};
+use super::{TestSyncIncomingRecord, TestSyncOutgoingRecord};
 
 const TABLE_NAME: &'static str = "temperature_log";
 
@@ -23,8 +23,8 @@ const TEMPERATURE_LOG_1: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_upsert(
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         TEMPERATURE_LOG_1,
         TemperatureLogRow {
@@ -43,8 +43,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     )]
 }
 
-pub(crate) fn test_push_records() -> Vec<TestToSyncRecord> {
-    vec![TestToSyncRecord {
+pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
+    vec![TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
         record_id: TEMPERATURE_LOG_1.0.to_string(),
         push_data: json!(LegacyTemperatureLogRow {

--- a/server/service/src/sync/test/test_data/unit.rs
+++ b/server/service/src/sync/test/test_data/unit.rs
@@ -1,6 +1,6 @@
 use repository::{UnitRow, UnitRowDelete};
 
-use crate::sync::test::TestFromSyncRecord;
+use crate::sync::test::TestSyncIncomingRecord;
 
 const TABLE_NAME: &'static str = "unit";
 
@@ -34,9 +34,9 @@ const UNIT_3: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             UNIT_1,
             UnitRow {
@@ -47,7 +47,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
                 is_active: true,
             },
         ),
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             UNIT_2,
             UnitRow {
@@ -58,7 +58,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
                 is_active: true,
             },
         ),
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             UNIT_3,
             UnitRow {
@@ -72,8 +72,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     ]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_delete(
         TABLE_NAME,
         UNIT_1.0,
         UnitRowDelete(UNIT_1.0.to_string()),

--- a/server/service/src/sync/test/test_data/unit.rs
+++ b/server/service/src/sync/test/test_data/unit.rs
@@ -1,6 +1,6 @@
 use repository::{UnitRow, UnitRowDelete};
 
-use crate::sync::test::TestSyncPullRecord;
+use crate::sync::test::TestFromSyncRecord;
 
 const TABLE_NAME: &'static str = "unit";
 
@@ -34,9 +34,9 @@ const UNIT_3: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             UNIT_1,
             UnitRow {
@@ -47,7 +47,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 is_active: true,
             },
         ),
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             UNIT_2,
             UnitRow {
@@ -58,7 +58,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 is_active: true,
             },
         ),
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             UNIT_3,
             UnitRow {
@@ -72,8 +72,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     ]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_delete(
         TABLE_NAME,
         UNIT_1.0,
         UnitRowDelete(UNIT_1.0.to_string()),

--- a/server/service/src/sync/test/test_data/user_permission.rs
+++ b/server/service/src/sync/test/test_data/user_permission.rs
@@ -1,6 +1,6 @@
 use repository::{mock::context_program_a, Permission, UserPermissionRow, UserPermissionRowDelete};
 
-use crate::sync::test::TestSyncPullRecord;
+use crate::sync::test::TestFromSyncRecord;
 
 const TABLE_NAME: &'static str = "om_user_permission";
 
@@ -26,9 +26,9 @@ const USER_PERMISSION_2: (&'static str, &'static str) = (
 }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     vec![
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             USER_PERMISSION_1,
             UserPermissionRow {
@@ -39,7 +39,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 context_id: Some(context_program_a().id.to_string()),
             },
         ),
-        TestSyncPullRecord::new_pull_upsert(
+        TestFromSyncRecord::new_pull_upsert(
             TABLE_NAME,
             USER_PERMISSION_2,
             UserPermissionRow {
@@ -53,8 +53,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     ]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
+    vec![TestFromSyncRecord::new_pull_delete(
         TABLE_NAME,
         USER_PERMISSION_2.0,
         UserPermissionRowDelete(USER_PERMISSION_2.0.to_string()),

--- a/server/service/src/sync/test/test_data/user_permission.rs
+++ b/server/service/src/sync/test/test_data/user_permission.rs
@@ -1,6 +1,6 @@
 use repository::{mock::context_program_a, Permission, UserPermissionRow, UserPermissionRowDelete};
 
-use crate::sync::test::TestFromSyncRecord;
+use crate::sync::test::TestSyncIncomingRecord;
 
 const TABLE_NAME: &'static str = "om_user_permission";
 
@@ -26,9 +26,9 @@ const USER_PERMISSION_2: (&'static str, &'static str) = (
 }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             USER_PERMISSION_1,
             UserPermissionRow {
@@ -39,7 +39,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
                 context_id: Some(context_program_a().id.to_string()),
             },
         ),
-        TestFromSyncRecord::new_pull_upsert(
+        TestSyncIncomingRecord::new_pull_upsert(
             TABLE_NAME,
             USER_PERMISSION_2,
             UserPermissionRow {
@@ -53,8 +53,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestFromSyncRecord> {
     ]
 }
 
-pub(crate) fn test_pull_delete_records() -> Vec<TestFromSyncRecord> {
-    vec![TestFromSyncRecord::new_pull_delete(
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_delete(
         TABLE_NAME,
         USER_PERMISSION_2.0,
         UserPermissionRowDelete(USER_PERMISSION_2.0.to_string()),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #....

# 👩🏻‍💻 What does this PR do? 

There are/were two types used in sync testing.
`TestSyncPullRecord` and  `TestSyncPushRecord`
However with the recent changes to central open-mSupply server these names are a bit confusing and possibly miss leading?

`TestSyncPullRecord` has been renamed to `TestIncomingSyncRecord`
`TestSyncPushRecord` has been renamed to `TestOutgoingSyncRecord`

`TestIncomingSyncRecord` represents a record that's come in via a sync process (pull or push)
`TestOutgoingSyncRecord` represents a record that will be sent via sync

# 🧪 How has/should this change been tested? 
Tests pass

## 💌 Any notes for the reviewer?
Rename suggested by @andreievg maybe there's a better naming, or more changes that should be included with this?

> Doing this as a separate PR to avoid a huge PR with logic and renaming changes.

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_