### PR TITLE
3143 fetching patient from central

### DIFF
--- a/client/packages/system/src/Patient/CreatePatientModal/PatientResultsTab.tsx
+++ b/client/packages/system/src/Patient/CreatePatientModal/PatientResultsTab.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   BasicSpinner,
   Box,
@@ -181,6 +181,12 @@ export const PatientResultsTab: FC<PatientPanel & { active: boolean }> = ({
     setData(patients);
   }, [localSearchData, centralSearchData]);
 
+  const onClose = useCallback(() => {
+    // refresh local list so that patient shows up to be in the current store
+    search(searchParams);
+    setFetchingPatient(undefined);
+  }, [search, searchParams]);
+
   if (!active) {
     return null;
   }
@@ -192,14 +198,7 @@ export const PatientResultsTab: FC<PatientPanel & { active: boolean }> = ({
   return (
     <PatientPanel value={value} patient={patient}>
       {fetchingPatient ? (
-        <FetchPatientModal
-          patient={fetchingPatient}
-          onClose={() => {
-            // refresh local list so that patient shows up to be in the current store
-            search(searchParams);
-            setFetchingPatient(undefined);
-          }}
-        />
+        <FetchPatientModal patient={fetchingPatient} onClose={onClose} />
       ) : null}
       <>
         <Box

--- a/client/packages/system/src/Patient/CreatePatientModal/useFetchPatient.ts
+++ b/client/packages/system/src/Patient/CreatePatientModal/useFetchPatient.ts
@@ -1,0 +1,75 @@
+import {
+  noOtherVariants,
+  useMutation,
+  useQueryClient,
+  useTranslation,
+} from '@openmsupply-client/common';
+import { mapSyncError, useSync } from '../../Sync';
+import { useCallback, useEffect, useState } from 'react';
+import { usePatientApi } from '../api/hooks/utils/usePatientApi';
+
+export type Step = 'Start' | 'Linking' | 'Syncing' | 'Synced';
+const STATUS_POLLING_INTERVAL = 500;
+
+/**
+ * Links the patient to the current store and sync the patient over.
+ */
+export const useFetchPatient = () => {
+  const api = usePatientApi();
+  const queryClient = useQueryClient();
+
+  const [step, setStep] = useState<Step>('Start');
+  const t = useTranslation('dispensary');
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  const { mutateAsync: linkPatientToStore } = useMutation((nameId: string) =>
+    api.linkPatientToStore(nameId)
+  );
+  const { mutateAsync: manualSync, data: manualSyncResult } =
+    useSync.sync.manualSync();
+  const { data: syncStatus } = useSync.utils.syncStatus(
+    STATUS_POLLING_INTERVAL,
+    !!manualSyncResult && step !== 'Synced'
+  );
+
+  const mutateAsync = useCallback(
+    async (patientId: string) => {
+      setStep('Linking');
+      const patientStoreLink = await linkPatientToStore(patientId);
+      if (patientStoreLink.__typename === 'LinkPatientPatientToStoreError') {
+        switch (patientStoreLink.error.__typename) {
+          case 'ConnectionError': {
+            setError(t('messages.failed-to-reach-central'));
+            break;
+          }
+          default:
+            noOtherVariants(patientStoreLink.error.__typename);
+        }
+        return;
+      }
+
+      setStep('Syncing');
+      await manualSync();
+    },
+    [linkPatientToStore, manualSync, t]
+  );
+
+  useEffect(() => {
+    if (step !== 'Syncing' || !syncStatus) return;
+    if (syncStatus.error) {
+      const error = mapSyncError(
+        t,
+        syncStatus.error,
+        'error.unknown-sync-error'
+      );
+      setError(error.error);
+    } else if (!syncStatus.isSyncing) {
+      // invalidate all patient queries
+      queryClient.invalidateQueries(api.keys.list()).then(() => {
+        setStep('Synced');
+      });
+    }
+  }, [api.keys, queryClient, step, syncStatus, t]);
+
+  return { mutateAsync, error, step };
+};

--- a/client/packages/system/src/Patient/ListView/AppBarButtons.tsx
+++ b/client/packages/system/src/Patient/ListView/AppBarButtons.tsx
@@ -24,7 +24,7 @@ export const AppBarButtons: FC<{ sortBy: SortBy<PatientRowFragment> }> = ({
   const t = useTranslation('dispensary');
   const { isLoading, mutateAsync } = usePatient.document.listAll(sortBy);
   const { userHasPermission } = useAuthContext();
-  const [open, setOpen] = useState(false);
+  const [createModalOpen, setCreateModalOpen] = useState(false);
 
   const csvExport = async () => {
     const data = await mutateAsync();
@@ -45,7 +45,7 @@ export const AppBarButtons: FC<{ sortBy: SortBy<PatientRowFragment> }> = ({
           Icon={<PlusCircleIcon />}
           label={t('button.new-patient')}
           disabled={!userHasPermission(UserPermission.PatientMutate)}
-          onClick={() => setOpen(true)}
+          onClick={() => setCreateModalOpen(true)}
         />
         <LoadingButton
           startIcon={<DownloadIcon />}
@@ -57,7 +57,9 @@ export const AppBarButtons: FC<{ sortBy: SortBy<PatientRowFragment> }> = ({
         </LoadingButton>
       </Grid>
 
-      {open ? <CreatePatientModal onClose={() => setOpen(false)} /> : null}
+      {createModalOpen ? (
+        <CreatePatientModal onClose={() => setCreateModalOpen(false)} />
+      ) : null}
     </AppBarButtonsPortal>
   );
 };

--- a/client/packages/system/src/Patient/api/hooks/utils/usePatientApi.ts
+++ b/client/packages/system/src/Patient/api/hooks/utils/usePatientApi.ts
@@ -21,7 +21,7 @@ export const usePatientApi = () => {
     search: (params: PatientSearchInput) =>
       [...keys.list(), 'search', params] as const,
     centralSearch: (params: CentralPatientSearchInput) =>
-      [...keys.list(), 'centralSearch', params] as const,
+      [...keys.base(), 'centralSearch', params] as const,
     latestPatientEncounter: (
       patientId: string,
       encounterType: string | undefined

--- a/client/packages/system/src/Sync/api/hooks/index.ts
+++ b/client/packages/system/src/Sync/api/hooks/index.ts
@@ -14,6 +14,7 @@ export const useSync = {
   },
   utils: {
     syncStatus: Utils.useSyncStatus,
+    mutateSyncStatus: Utils.useMutateSyncStatus,
     syncInfo: Utils.useSyncInfo,
     lastSuccessfulUserSync: Utils.useLastSuccessfulUserSync,
   },

--- a/client/packages/system/src/Sync/api/hooks/utils/index.ts
+++ b/client/packages/system/src/Sync/api/hooks/utils/index.ts
@@ -1,5 +1,5 @@
 import { useSyncApi } from './useSyncApi';
-import { useSyncStatus } from './useSyncStatus';
+import { useSyncStatus, useMutateSyncStatus } from './useSyncStatus';
 import { useSyncInfo } from './useSyncInfo';
 import { useLastSuccessfulUserSync } from './useLastSuccessfulUserSync';
 
@@ -7,5 +7,6 @@ export const Utils = {
   useSyncApi,
   useSyncStatus,
   useSyncInfo,
+  useMutateSyncStatus,
   useLastSuccessfulUserSync,
 };

--- a/client/packages/system/src/Sync/api/hooks/utils/useSyncStatus.ts
+++ b/client/packages/system/src/Sync/api/hooks/utils/useSyncStatus.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@openmsupply-client/common';
+import { useMutation, useQuery } from '@openmsupply-client/common';
 import { useSyncApi } from './useSyncApi';
 
 export const useSyncStatus = (
@@ -12,4 +12,9 @@ export const useSyncStatus = (
     refetchInterval,
     enabled,
   });
+};
+
+export const useMutateSyncStatus = () => {
+  const api = useSyncApi();
+  return useMutation(api.get.syncStatus);
 };

--- a/server/service/src/programs/patient/search_central.rs
+++ b/server/service/src/programs/patient/search_central.rs
@@ -53,8 +53,8 @@ pub async fn patient_search_central(
         .patient(PatientParamsV4 {
             limit: None,
             offset: None,
-            first_name,
-            last_name,
+            first_name: first_name.map(|it| format!("@{it}@")),
+            last_name: last_name.map(|it| format!("@{it}@")),
             dob: date_of_birth,
             policy_number: None,
             barcode: None,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Part of #3143 

# 👩🏻‍💻 What does this PR do? 

- Refactor/create a hook to fetch a patient. I found the previous implementation a bit messy and hope this makes it clearer.
- Enable LIKE patient search for central server patients

There are still some issues I like to look at, at a later stage because I can't figure them out right now:
- After moving the patient over to the local site. The search endpoint fails to return it even though it is in the database and a full page reload fixes it!
- I can't get tanquery to refetch the main patient list automatically even though I invalidated the query key...
