### PR TITLE
Add option to make text fields required in the UI schema

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/Text.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Text.tsx
@@ -17,7 +17,10 @@ const Options = z
      * Additional pattern to be matched that can be defined in ui schema
      */
     pattern: z.string().optional(),
-    /** Overwrite the schema definition, e.g. to make a non-required field required in the UI. */
+    /**
+     * Make the text value mandatory in the UI.
+     * For example, a field might be optional in the data schema but should be required in the UI.
+     */
     required: z.boolean().optional(),
     /**
      * Examples for the correct pattern

--- a/client/packages/system/src/Patient/DefaultPatientUISchema.json
+++ b/client/packages/system/src/Patient/DefaultPatientUISchema.json
@@ -37,12 +37,18 @@
         {
           "type": "Control",
           "scope": "#/properties/firstName",
-          "label": "First Name"
+          "label": "First Name",
+          "options": {
+            "required": true
+          }
         },
         {
           "type": "Control",
           "scope": "#/properties/lastName",
-          "label": "Last Name"
+          "label": "Last Name",
+          "options": {
+            "required": true
+          }
         },
         {
           "type": "Control",


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3126

# 👩🏻‍💻 What does this PR do? 
- Adds an option to make a text field required in the UI schema.
- Use this feature to make first and last name required (the base schema still has them as optional)

# 🧪 How has/should this change been tested? 
Create a new patient or move to an existing patient. Then delete first and/or last name. There should be an error.

## 💌 Any notes for the reviewer?
- Make both, first and last, required or just one of them?
