### PR TITLE
3112 fix sort direction

### DIFF
--- a/client/packages/common/src/hooks/useQueryParams/types.ts
+++ b/client/packages/common/src/hooks/useQueryParams/types.ts
@@ -54,5 +54,6 @@ export interface SortBy<T> extends SortRule<T> {
 }
 export interface SortController<T extends RecordWithId> {
   sortBy: SortBy<T>;
+  /** Changes the sort options as specified */
   onChangeSortBy: (sort: string, dir: 'desc' | 'asc') => void;
 }

--- a/client/packages/common/src/hooks/useQueryParams/types.ts
+++ b/client/packages/common/src/hooks/useQueryParams/types.ts
@@ -1,5 +1,4 @@
 import { RecordWithId } from '@common/types';
-import { Column } from '../../ui/layout/tables';
 
 export interface FilterByConditionByType {
   string: 'equalTo' | 'like' | 'notEqualTo';
@@ -55,5 +54,5 @@ export interface SortBy<T> extends SortRule<T> {
 }
 export interface SortController<T extends RecordWithId> {
   sortBy: SortBy<T>;
-  onChangeSortBy: (newSortRule: Column<T>) => SortBy<T>;
+  onChangeSortBy: (sort: string, dir: 'desc' | 'asc') => void;
 }

--- a/client/packages/common/src/hooks/useQueryParams/useQueryParams.test.tsx
+++ b/client/packages/common/src/hooks/useQueryParams/useQueryParams.test.tsx
@@ -191,7 +191,7 @@ describe('sort', () => {
       wrapper: getWrapper(),
     });
     act(() => {
-      result.current.sort.onChangeSortBy(quantityColumn);
+      result.current.sort.onChangeSortBy(quantityColumn.key, 'asc');
     });
     expect(result.current.sort.sortBy).toEqual({
       key: 'quantity',
@@ -206,7 +206,7 @@ describe('sort', () => {
       wrapper: getWrapper(),
     });
     act(() => {
-      result.current.sort.onChangeSortBy(idColumn);
+      result.current.sort.onChangeSortBy(idColumn.key, 'desc');
     });
     expect(result.current.sort.sortBy).toEqual({
       key: 'id',
@@ -215,7 +215,7 @@ describe('sort', () => {
     });
   });
 
-  it('has the correct values after triggering a few sort bys in sequence', () => {
+  it('has the correct values after sorts', () => {
     const idColumn = createColumnWithDefaults<TestSortBy>({ key: 'id' });
     const quantityColumn = createColumnWithDefaults<TestSortBy>({
       key: 'quantity',
@@ -225,17 +225,27 @@ describe('sort', () => {
     });
     act(() => {
       // initially: id/asc
-      result.current.sort.onChangeSortBy(idColumn);
+      result.current.sort.onChangeSortBy(idColumn.key, 'asc');
+    });
+    expect(result.current.sort.sortBy).toEqual({
+      key: 'id',
+      isDesc: false,
+      direction: 'asc',
+    });
+
+    act(() => {
       // should be: id/desc
-      result.current.sort.onChangeSortBy(idColumn);
-      // should be: quantity/asc
-      result.current.sort.onChangeSortBy(quantityColumn);
-      // should be: id/asc
-      result.current.sort.onChangeSortBy(idColumn);
-      // should be: quantity/asc
-      result.current.sort.onChangeSortBy(quantityColumn);
+      result.current.sort.onChangeSortBy(idColumn.key, 'desc');
+    });
+    expect(result.current.sort.sortBy).toEqual({
+      key: 'id',
+      isDesc: true,
+      direction: 'desc',
+    });
+
+    act(() => {
       // should be: quantity/desc
-      result.current.sort.onChangeSortBy(quantityColumn);
+      result.current.sort.onChangeSortBy(quantityColumn.key, 'desc');
     });
     expect(result.current.sort.sortBy).toEqual({
       key: 'quantity',

--- a/client/packages/common/src/hooks/useQueryParams/useQueryParamsStore.tsx
+++ b/client/packages/common/src/hooks/useQueryParams/useQueryParamsStore.tsx
@@ -10,7 +10,6 @@ import {
   SortController,
   SortBy,
 } from './types';
-import { Column } from '../../ui';
 
 export interface QueryParamsState<T extends RecordWithId> {
   pagination: PaginationController;
@@ -84,19 +83,14 @@ export const createQueryParamsStore = <T extends RecordWithId>({
         isDesc: initialSortBy.isDesc ?? false,
         direction: getDirection(initialSortBy.isDesc ?? false),
       },
-      onChangeSortBy: (column: Column<T>) => {
+      onChangeSortBy: (sortKey: string, sortDir: 'desc' | 'asc') => {
         let sortBy = { key: '', direction: 'asc' } as SortBy<T>;
         set(state => {
-          const { key, sortBy: { isDesc: maybeNewIsDesc } = {} } = column;
           const { sort } = state;
-          const isDesc =
-            sort.sortBy.key === key
-              ? !sort.sortBy.isDesc
-              : !!maybeNewIsDesc ?? false;
-
+          const isDesc = sortDir === 'desc';
           sortBy = {
             ...sort.sortBy,
-            key,
+            key: sortKey,
             isDesc,
             direction: getDirection(isDesc),
           };

--- a/client/packages/common/src/hooks/useUrlQuery/useUrlQuery.ts
+++ b/client/packages/common/src/hooks/useUrlQuery/useUrlQuery.ts
@@ -54,45 +54,43 @@ interface useUrlQueryProps {
 
 export const useUrlQuery = ({ skipParse }: useUrlQueryProps = {}) => {
   const [searchParams, setSearchParams] = useSearchParams();
+  return useMemo(() => {
+    const updateQuery = (values: UrlQueryObject, overwrite = false) => {
+      // We use this rather than searchParams as this function uses a stale
+      // version of searchParams (closure from when the hook was first called)
+      const urlSearchParams = new URLSearchParams(window.location.search);
 
-  const updateQuery = (values: UrlQueryObject, overwrite = false) => {
-    // We use this rather than searchParams as this function uses a stale
-    // version of searchParams (closure from when the hook was first called)
-    const urlSearchParams = new URLSearchParams(window.location.search);
+      const newQueryObject = overwrite
+        ? {}
+        : Object.fromEntries(urlSearchParams.entries());
 
-    const newQueryObject = overwrite
-      ? {}
-      : Object.fromEntries(urlSearchParams.entries());
+      Object.entries(values).forEach(([key, value]) => {
+        if (!value) delete newQueryObject[key];
+        else {
+          if (typeof value === 'object' && ('from' in value || 'to' in value)) {
+            const range = parseRangeString(newQueryObject[key]) as RangeObject<
+              string | number
+            >;
+            const { from, to } = value;
+            if (from !== undefined) range.from = from;
+            if (to !== undefined) range.to = to;
 
-    Object.entries(values).forEach(([key, value]) => {
-      if (!value) delete newQueryObject[key];
-      else {
-        if (typeof value === 'object' && ('from' in value || 'to' in value)) {
-          const range = parseRangeString(newQueryObject[key]) as RangeObject<
-            string | number
-          >;
-          const { from, to } = value;
-          if (from !== undefined) range.from = from;
-          if (to !== undefined) range.to = to;
+            const rangeString = stringifyRange(range);
+            if (rangeString === '') delete newQueryObject[key];
+            else newQueryObject[key] = rangeString;
+          } else newQueryObject[key] = String(value);
+        }
+      });
 
-          const rangeString = stringifyRange(range);
-          if (rangeString === '') delete newQueryObject[key];
-          else newQueryObject[key] = rangeString;
-        } else newQueryObject[key] = String(value);
-      }
-    });
+      setSearchParams(newQueryObject, { replace: true });
+    };
 
-    setSearchParams(newQueryObject, { replace: true });
-  };
-
-  return useMemo(
-    () => ({
+    return {
       urlQuery: parseSearchParams(searchParams, skipParse ?? []),
       updateQuery,
       parseRangeString,
-    }),
-    [searchParams, skipParse]
-  );
+    };
+  }, [searchParams, skipParse, setSearchParams]);
 };
 
 // Coerces url params to appropriate type

--- a/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
+++ b/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
@@ -5,12 +5,7 @@ import {
   UrlQueryValue,
   useUrlQuery,
 } from './useUrlQuery';
-import {
-  Column,
-  Formatter,
-  RecordWithId,
-  useLocalStorage,
-} from '@openmsupply-client/common';
+import { Formatter, useLocalStorage } from '@openmsupply-client/common';
 import {
   FilterBy,
   FilterByWithBoolean,
@@ -72,21 +67,11 @@ export const useUrlQueryParams = ({
     updateQuery({ sort, dir: dir === 'desc' ? 'desc' : '' });
   }, [initialSort, updateQuery, urlQuery]);
 
-  // Changes sort key or, if the sort key is already selected, toggles the sort direction.
   const updateSortQuery = useCallback(
-    <T extends RecordWithId>(column: Column<T>) => {
-      const currentSort = urlQuery['sort'];
-      const sort = column.key as string;
-      if (sort !== currentSort) {
-        // change sort key
-        updateQuery({ sort, dir: '', page: '' });
-      } else {
-        // toggle sort direction
-        const dir = column.sortBy?.direction === 'desc' ? '' : 'desc';
-        updateQuery({ dir });
-      }
+    (sort: string, dir: 'desc' | 'asc') => {
+      updateQuery({ sort, dir: dir === 'asc' ? '' : 'desc' });
     },
-    [updateQuery, urlQuery]
+    [updateQuery]
   );
 
   const updatePaginationQuery = (page: number) => {

--- a/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
+++ b/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
@@ -150,8 +150,8 @@ export const useUrlQueryParams = ({
     first: rowsPerPage,
     sortBy: {
       key: urlQuery['sort'] ?? initialSort?.key ?? '',
-      direction: urlQuery['dir'] ?? initialSort?.dir ?? 'asc',
-      isDesc: (urlQuery['dir'] ?? initialSort?.dir) === 'desc',
+      direction: urlQuery['dir'] ?? 'asc',
+      isDesc: urlQuery['dir'] === 'desc',
     } as SortBy<unknown>,
     filterBy: filter.filterBy,
   };

--- a/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
+++ b/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import {
   NESTED_SPLIT_CHAR,
   RANGE_SPLIT_CHAR,
@@ -70,18 +70,24 @@ export const useUrlQueryParams = ({
 
     const { key: sort, dir } = initialSort;
     updateQuery({ sort, dir: dir === 'desc' ? 'desc' : '' });
-  }, [initialSort]);
+  }, [initialSort, updateQuery, urlQuery]);
 
-  const updateSortQuery = <T extends RecordWithId>(column: Column<T>) => {
-    const currentSort = urlQuery['sort'];
-    const sort = column.key as string;
-    if (sort !== currentSort) {
-      updateQuery({ sort, dir: '', page: '' });
-    } else {
-      const dir = column.sortBy?.direction === 'desc' ? '' : 'desc';
-      updateQuery({ dir });
-    }
-  };
+  // Changes sort key or, if the sort key is already selected, toggles the sort direction.
+  const updateSortQuery = useCallback(
+    <T extends RecordWithId>(column: Column<T>) => {
+      const currentSort = urlQuery['sort'];
+      const sort = column.key as string;
+      if (sort !== currentSort) {
+        // change sort key
+        updateQuery({ sort, dir: '', page: '' });
+      } else {
+        // toggle sort direction
+        const dir = column.sortBy?.direction === 'desc' ? '' : 'desc';
+        updateQuery({ dir });
+      }
+    },
+    [updateQuery, urlQuery]
+  );
 
   const updatePaginationQuery = (page: number) => {
     // Page is zero-indexed in useQueryParams store, so increase it by one

--- a/client/packages/common/src/ui/layout/tables/columns/types.ts
+++ b/client/packages/common/src/ui/layout/tables/columns/types.ts
@@ -80,7 +80,7 @@ export interface Column<T extends RecordWithId> {
   getIsError?: (row: T) => boolean;
   getIsDisabled?: (row: T) => boolean;
 
-  onChangeSortBy?: (column: Column<T>) => void;
+  onChangeSortBy?: (sort: string, dir: 'desc' | 'asc') => void;
   sortBy?: SortBy<T>;
 
   width?: number | string;

--- a/client/packages/common/src/ui/layout/tables/components/Header/Header.stories.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Header/Header.stories.tsx
@@ -4,7 +4,6 @@ import { Table, TableHead } from '@mui/material';
 import { HeaderCell, HeaderRow } from './Header';
 import { useColumns } from '../../hooks';
 import { SortBy } from '@common/hooks';
-import { Column } from '../../columns';
 
 export default {
   title: 'Table/HeaderRow',
@@ -27,13 +26,10 @@ const Template: Story = () => {
   const getDirection = (isDesc: boolean): 'asc' | 'desc' =>
     isDesc ? 'desc' : 'asc';
 
-  const onChangeSortBy = (column: Column<Test>) => {
+  const onChangeSortBy = (newSortKey: string, dir: 'desc' | 'asc') => {
     let newSortBy = sortBy;
-    setSortBy(({ key: prevSortKey, isDesc: prevIsDesc = false }) => {
-      const { key: newSortKey, sortBy: { isDesc: maybeNewIsDesc } = {} } =
-        column;
-      const newIsDesc =
-        prevSortKey === newSortKey ? !prevIsDesc : !!maybeNewIsDesc ?? false;
+    setSortBy(() => {
+      const newIsDesc = dir === 'desc';
       newSortBy = {
         key: newSortKey,
         isDesc: newIsDesc,

--- a/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -44,9 +44,21 @@ export const HeaderCell = <T extends RecordWithId>({
   const t = useTranslation();
   const isSorted = key === currentSortKey;
 
+  // Changes sort key or, if the sort key is already selected, toggles the sort direction.
   const onSort = useDebounceCallback(
-    () => onChangeSortBy && sortable && onChangeSortBy(column),
-    [column],
+    () => {
+      if (!onChangeSortBy || !sortable) return;
+
+      if (key !== currentSortKey) {
+        // change sort key
+        onChangeSortBy(key as string, 'asc');
+      } else {
+        // toggle sort direction
+        const dir = direction === 'desc' ? 'asc' : 'desc';
+        onChangeSortBy(key as string, dir);
+      }
+    },
+    [sortable, key, currentSortKey, direction, onChangeSortBy],
     150
   );
 

--- a/client/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
+++ b/client/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
@@ -110,6 +110,7 @@ const getDefaultColumnAlign = <T extends RecordWithId>(
 };
 
 interface ColumnOptions<T extends RecordWithId> {
+  /** Changes the sort options as specified */
   onChangeSortBy?: (sort: string, dir: 'desc' | 'asc') => void;
   sortBy?: SortBy<T>;
 }

--- a/client/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
+++ b/client/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
@@ -110,7 +110,7 @@ const getDefaultColumnAlign = <T extends RecordWithId>(
 };
 
 interface ColumnOptions<T extends RecordWithId> {
-  onChangeSortBy?: (column: Column<T>) => void;
+  onChangeSortBy?: (sort: string, dir: 'desc' | 'asc') => void;
   sortBy?: SortBy<T>;
 }
 

--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
@@ -21,9 +21,7 @@ import { useStocktakeLineErrorContext } from '../../context';
 
 interface UseStocktakeColumnOptions {
   sortBy: SortBy<StocktakeLineFragment | StocktakeSummaryItem>;
-  onChangeSortBy: (
-    column: Column<StocktakeLineFragment | StocktakeSummaryItem>
-  ) => void;
+  onChangeSortBy: (sort: string, dir: 'desc' | 'asc') => void;
 }
 
 const expandColumn = getRowExpandColumn<

--- a/client/packages/invoices/src/InboundShipment/api/hooks/line/useInboundItems.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/line/useInboundItems.ts
@@ -10,7 +10,7 @@ import { useInboundSelector } from './useInboundLines';
 
 export const useInboundItems = () => {
   const { sort } = useQueryParamsStore();
-  const { sortBy, onChangeSortBy } = sort;
+  const { sortBy } = sort;
   const selectItems = (invoice: InboundFragment) =>
     inboundLinesToSummaryItems(
       invoice.lines.nodes.filter(line => isA.stockInLine(line))
@@ -28,5 +28,5 @@ export const useInboundItems = () => {
       );
   const { data } = useInboundSelector(selectItems);
 
-  return { data, sortBy, onSort: onChangeSortBy };
+  return { data, sortBy };
 };

--- a/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -18,7 +18,7 @@ import { StockOutItem } from '../../types';
 
 interface UseOutboundColumnOptions {
   sortBy: SortBy<StockOutLineFragment | StockOutItem>;
-  onChangeSortBy: (column: Column<StockOutLineFragment | StockOutItem>) => void;
+  onChangeSortBy: (sort: string, dir: 'desc' | 'asc') => void;
 }
 
 const expansionColumn = getRowExpandColumn<

--- a/client/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/client/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -25,7 +25,7 @@ const useDisableOutboundRows = (rows?: OutboundRowFragment[]) => {
   useEffect(() => {
     const disabledRows = rows?.filter(isOutboundDisabled).map(({ id }) => id);
     if (disabledRows) setDisabledRows(disabledRows);
-  }, [rows]);
+  }, [rows, setDisabledRows]);
 };
 
 const OutboundShipmentListViewComponent: FC = () => {

--- a/client/packages/invoices/src/OutboundShipment/api/api.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/api.ts
@@ -48,6 +48,9 @@ const outboundParsers = {
       case 'invoiceNumber': {
         return InvoiceSortFieldInput.InvoiceNumber;
       }
+      case 'theirReference': {
+        return InvoiceSortFieldInput.TheirReference;
+      }
       case 'status':
       default: {
         return InvoiceSortFieldInput.Status;

--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -17,7 +17,7 @@ import { StockOutItem } from '../../types';
 
 interface UsePrescriptionColumnOptions {
   sortBy: SortBy<StockOutLineFragment | StockOutItem>;
-  onChangeSortBy: (column: Column<StockOutLineFragment | StockOutItem>) => void;
+  onChangeSortBy: (sort: string, dir: 'desc' | 'asc') => void;
 }
 
 const expansionColumn = getRowExpandColumn<

--- a/client/packages/system/src/Encounter/ListView/columns.ts
+++ b/client/packages/system/src/Encounter/ListView/columns.ts
@@ -1,7 +1,6 @@
 import {
   useColumns,
   ColumnAlign,
-  Column,
   ColumnDescription,
   SortBy,
   ColumnDataAccessor,
@@ -18,7 +17,7 @@ import { getLogicalStatus } from '../utils';
 import { ChipTableCell } from '../../Patient';
 
 interface useEncounterListColumnsProps {
-  onChangeSortBy: (column: Column<EncounterRowFragment>) => void;
+  onChangeSortBy: (sort: string, dir: 'desc' | 'asc') => void;
   sortBy: SortBy<EncounterRowFragment>;
   includePatient?: boolean;
 }

--- a/client/packages/system/src/Patient/ContactTrace/Components/ListView.tsx
+++ b/client/packages/system/src/Patient/ContactTrace/Components/ListView.tsx
@@ -10,7 +10,6 @@ import {
   RouteBuilder,
   useColumns,
   ColumnAlign,
-  Column,
   SortBy,
   ColumnDescription,
 } from '@openmsupply-client/common';
@@ -22,7 +21,7 @@ import { useFormatDateTime } from '@common/intl';
 import { AppRoute } from '@openmsupply-client/config';
 
 interface ContactTraceListColumnsProps {
-  onChangeSortBy: (column: Column<ContactTraceRowFragment>) => void;
+  onChangeSortBy: (sort: string, dir: 'desc' | 'asc') => void;
   sortBy: SortBy<ContactTraceRowFragment>;
 }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3112 

The bug has been introduced here:
https://github.com/msupply-foundation/open-msupply/pull/2638/files#r1426169816

The problem was that `asc` is mapped to an empty query string. This means when there was no sort direction because of that, the initial direction was always used.

# 👩🏻‍💻 What does this PR do? 
- Fixes some lint warnings (first commit)
- Fixes the sort problem

Note: the initial sort direction is not used now...