### PR TITLE
Fix central_server_only middleware wrap

### DIFF
--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -304,9 +304,8 @@ pub async fn start_server(
             .configure(config_cold_chain)
             .configure(config_upload_fridge_tag)
             .configure(config_sync_on_central)
-            // .wrap(central_server_only())
             .configure(config_support)
-            // Needs to be last to capture all unmatches routes
+            // Needs to be last to capture all unmatched routes
             .configure(config_serve_frontend)
     })
     .disable_signals();

--- a/server/server/src/sync_on_central/mod.rs
+++ b/server/server/src/sync_on_central/mod.rs
@@ -4,6 +4,7 @@ use actix_web::{
     Responder,
 };
 
+use crate::central_server_only;
 use service::{
     service_provider::ServiceProvider,
     sync::{
@@ -13,10 +14,14 @@ use service::{
 };
 
 pub fn config_sync_on_central(cfg: &mut web::ServiceConfig) {
-    cfg.service(pull);
+    cfg.service(
+        web::scope("central")
+            .wrap(central_server_only())
+            .service(pull),
+    );
 }
 
-#[post("central/sync/pull")]
+#[post("/sync/pull")]
 async fn pull(
     request: Json<SyncRequestV6>,
     service_provider: Data<ServiceProvider>,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->


# 👩🏻‍💻 What does this PR do? 
Moves the `central_server_only` middleware to be called inside a `Scope` otherwise it appears to apply more widely than I realised

# 🧪 How has/should this change been tested? 
See if you can login :)

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_