### PR TITLE
3126 mandatory patient fields 2

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/Text.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Text.tsx
@@ -81,7 +81,7 @@ const usePatternValidation = (
     } else {
       setCustomError(undefined);
     }
-  }, [pattern, value]);
+  }, [pattern, setCustomError, value]);
   return customError;
 };
 
@@ -98,7 +98,8 @@ const UIComponent = (props: ControlProps) => {
   const error = !!errors || !!zErrors || !!customErrors;
   const { text, onChange } = useDebouncedTextInput(
     data,
-    (value: string | undefined) => handleChange(path, value)
+    (value: string | undefined) =>
+      handleChange(path, !!value ? value : undefined)
   );
   const t = useTranslation();
 
@@ -129,7 +130,7 @@ const UIComponent = (props: ControlProps) => {
         value: text ?? '',
         sx: { width },
         style: { flexBasis: '100%' },
-        onChange: e => onChange(e.target.value || ''),
+        onChange: e => onChange(e.target.value ?? ''),
         disabled: !props.enabled,
         error,
         helperText,

--- a/client/packages/system/src/Patient/DefaultPatientSchema.json
+++ b/client/packages/system/src/Patient/DefaultPatientSchema.json
@@ -54,7 +54,7 @@
           "type": "string"
         }
       },
-      "required": ["id", "code"],
+      "required": ["id", "code", "firstName", "lastName"],
       "type": "object"
     }
   },


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3126

# 👩🏻‍💻 What does this PR do? 
Sets firstName and lastName to required for the default patient schema. This also required to unset empty text fields, e.g. when deleting all text from a text input the data field is set to undefined. This is needed because an empty string passes the required test.

I tested a bit and I think this should be fine...