### PR TITLE
2541 can't close a patient without first editing something

### DIFF
--- a/client/packages/system/src/Patient/PatientView/Footer.tsx
+++ b/client/packages/system/src/Patient/PatientView/Footer.tsx
@@ -23,6 +23,7 @@ interface FooterProps {
   validationError?: string | boolean;
   inputData?: FormInputData;
   showSaveConfirmation: () => void;
+  showCancelConfirmation: () => void;
 }
 
 export const Footer: FC<FooterProps> = ({
@@ -32,6 +33,7 @@ export const Footer: FC<FooterProps> = ({
   validationError,
   inputData,
   showSaveConfirmation,
+  showCancelConfirmation,
 }) => {
   const t = useTranslation();
   const { Modal, showDialog, hideDialog } = useDialog();
@@ -64,9 +66,13 @@ export const Footer: FC<FooterProps> = ({
           >
             <DialogButton
               variant="cancel"
-              disabled={!isDirty || isSaving}
+              disabled={isSaving}
               onClick={() => {
-                navigate(-1);
+                if (isDirty) {
+                  showCancelConfirmation();
+                } else {
+                  navigate(-1);
+                }
               }}
             />
             <LoadingButton

--- a/client/packages/system/src/Patient/PatientView/PatientView.tsx
+++ b/client/packages/system/src/Patient/PatientView/PatientView.tsx
@@ -13,6 +13,7 @@ import {
   UpdatePatientInput,
   BasicSpinner,
   DocumentRegistryCategoryNode,
+  useNavigate,
 } from '@openmsupply-client/common';
 import { usePatient } from '../api';
 import { AppBarButtons } from './AppBarButtons';
@@ -106,6 +107,7 @@ const PatientDetailView = ({
       },
     });
   const isLoading = isCurrentPatientLoading || isPatientRegistryLoading;
+  const navigate = useNavigate();
 
   const patientRegistry = patientRegistries?.nodes[0];
   const isCreatingPatient = !!createNewPatient;
@@ -228,6 +230,14 @@ const PatientDetailView = ({
     title: t('heading.are-you-sure'),
   });
 
+  const showCancelConfirmation = useConfirmationModal({
+    onConfirm: () => {
+      navigate(-1);
+    },
+    message: t('messages.confirm-cancel-generic'),
+    title: t('heading.are-you-sure'),
+  });
+
   if (isLoading) return <BasicSpinner />;
 
   return (
@@ -240,6 +250,7 @@ const PatientDetailView = ({
         validationError={validationError}
         inputData={inputData}
         showSaveConfirmation={showSaveConfirmation}
+        showCancelConfirmation={showCancelConfirmation}
       />
     </Box>
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2541

# 👩🏻‍💻 What does this PR do? 
Enables the cancel button on patient detail view and also show confirmation when user clicks on the cancel button if they have unsaved changes.

# 🧪 How has/should this change been tested? 
- [ ] Go into a patient and don't edit anything
- [ ] Click cancel button, should be redirected back
- [ ] Go into a patient and edit something
- [ ] Click cancel, see confirmation message