### PR TITLE
2926 Datepicker moves if it is to close to the edge

### DIFF
--- a/client/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
@@ -91,6 +91,9 @@ export const BaseDatePickerInput: FC<
             '& .MuiPickersDay-root.Mui-selected': {
               backgroundColor: `${theme.palette.secondary.main}`,
             },
+            '& .MuiPickersPopper-paper': {
+              position: 'fixed',
+            },
           },
         },
         desktopPaper: {

--- a/client/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
@@ -91,6 +91,7 @@ export const BaseDatePickerInput: FC<
             '& .MuiPickersDay-root.Mui-selected': {
               backgroundColor: `${theme.palette.secondary.main}`,
             },
+            // Popper position needs to be fixed in place or it will disappear in some modals
             '& .MuiPickersPopper-paper': {
               position: 'fixed',
             },


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2926

# 👩🏻‍💻 What does this PR do? 
Fix position of the datetime popper, so that it doesn't move when selecting dates.

https://github.com/msupply-foundation/open-msupply/assets/61820074/1b781609-9e0e-4664-ab88-8e4fbecb7a9c

# 🧪 How has/should this change been tested? 
- [ ] Have an item with lots of lines for stocktake (8+)?
- [ ] Create a stocktake with that item
- [ ] Click on item to open the stocktake line edit modal
- [ ] Try change the date of the last line
- [ ] The date picker shouldn't move and you should be able to set an expiry date