### PR TITLE
3050 fix height input

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/Number.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Number.tsx
@@ -47,6 +47,7 @@ const UIComponent = (props: ControlProps) => {
       Input={
         <NumericTextInput
           {...inputProps}
+          decimalLimit={10}
           min={schema.minimum}
           max={schema.maximum}
         />

--- a/client/packages/programs/src/JsonForms/stripEmptyAdditions.test.ts
+++ b/client/packages/programs/src/JsonForms/stripEmptyAdditions.test.ts
@@ -1,3 +1,4 @@
+import { isEqual } from 'lodash';
 import {
   isEqualIgnoreUndefinedAndEmpty,
   stripEmptyAdditions,
@@ -86,5 +87,19 @@ describe('stripEmptyAdditions', () => {
     };
 
     expect(isEqualIgnoreUndefinedAndEmpty(old, add1)).toBeTruthy();
+  });
+
+  it('should allow removing item with simple types', () => {
+    const old = {
+      some: 2,
+      someMore: 'string',
+      array: [{ value: false }],
+    };
+    const add1 = {
+      array: [{ value: false, add1: undefined }],
+    };
+
+    const stripped = stripEmptyAdditions(old, add1);
+    expect(isEqual(add1, stripped)).toBeTruthy();
   });
 });

--- a/client/packages/programs/src/JsonForms/stripEmptyAdditions.test.ts
+++ b/client/packages/programs/src/JsonForms/stripEmptyAdditions.test.ts
@@ -1,4 +1,3 @@
-import { isEqual } from 'lodash';
 import {
   isEqualIgnoreUndefinedAndEmpty,
   stripEmptyAdditions,
@@ -94,12 +93,16 @@ describe('stripEmptyAdditions', () => {
       some: 2,
       someMore: 'string',
       array: [{ value: false }],
+      obj: { value: 1.7 },
     };
     const add1 = {
       array: [{ value: false, add1: undefined }],
+      obj: {},
     };
 
     const stripped = stripEmptyAdditions(old, add1);
-    expect(isEqual(add1, stripped)).toBeTruthy();
+    expect(stripped).toStrictEqual({
+      array: [{ value: false, add1: undefined }],
+    });
   });
 });

--- a/client/packages/programs/src/JsonForms/stripEmptyAdditions.ts
+++ b/client/packages/programs/src/JsonForms/stripEmptyAdditions.ts
@@ -58,7 +58,8 @@ export const stripEmptyAdditions = (
       const o = oldObj[key];
       let n = newData[key];
       if (n === undefined) {
-        if (o !== undefined) {
+        if (o !== undefined && objectOrArrayIsEmpty(o)) {
+          // keep existing empty object
           object[key] = o;
         }
         continue;

--- a/client/packages/programs/src/JsonForms/stripEmptyAdditions.ts
+++ b/client/packages/programs/src/JsonForms/stripEmptyAdditions.ts
@@ -80,7 +80,8 @@ export const stripEmptyAdditions = (
     if (Object.keys(object).length > 0) {
       return object;
     }
-    if (newData && old) return old;
+    // keep the empty object
+    if (newData && old) return {};
     return undefined;
   }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3050

# 👩🏻‍💻 What does this PR do? 
- Enables decimal values for the JSONFroms Number input. This was not part of the issue but it wasn't possible to enter the height in meter...
- Fix the underlying problem: stripEmptyAdditions re-added deleted primitive data fields

# 🧪 How has/should this change been tested? 
As described in the issue, save height reload and then delete the height. The save button should be enabled now.
