### PR TITLE
3254 User Login fails If sqlite database is locked for writing

### DIFF
--- a/client/packages/common/src/api/GqlContext.tsx
+++ b/client/packages/common/src/api/GqlContext.tsx
@@ -43,6 +43,14 @@ interface ResponseError {
   extensions?: { details?: string };
 }
 
+export class StdError extends Error {
+  public stdError?: string | undefined;
+  constructor(message: string, stdError: string | undefined) {
+    super(message);
+    this.stdError = stdError;
+  }
+}
+
 const hasError = (errors: ResponseError[], error: AuthError) =>
   errors.some(({ message }: { message?: string }) => message === error);
 
@@ -68,7 +76,10 @@ const handleResponseError = (errors: ResponseError[]) => {
   const error = errors[0];
   const { extensions } = error || {};
   const { details } = extensions || {};
-  throw new Error(details || error?.message || 'Unknown error');
+  throw new StdError(
+    details || error?.message || 'Unknown error',
+    error?.message
+  );
 };
 
 const shouldIgnoreQuery = (definitionNode: DefinitionNode) => {

--- a/client/packages/common/src/api/GqlContext.tsx
+++ b/client/packages/common/src/api/GqlContext.tsx
@@ -43,7 +43,7 @@ interface ResponseError {
   extensions?: { details?: string };
 }
 
-export class StdError extends Error {
+export class GraphqlStdError extends Error {
   public stdError?: string | undefined;
   constructor(message: string, stdError: string | undefined) {
     super(message);
@@ -76,7 +76,7 @@ const handleResponseError = (errors: ResponseError[]) => {
   const error = errors[0];
   const { extensions } = error || {};
   const { details } = extensions || {};
-  throw new StdError(
+  throw new GraphqlStdError(
     details || error?.message || 'Unknown error',
     error?.message
   );

--- a/client/packages/common/src/authentication/api/api.ts
+++ b/client/packages/common/src/authentication/api/api.ts
@@ -1,9 +1,16 @@
-import { AuthError, LocaleKey, LocalStorage, TypedTFunction } from '../..';
+import {
+  AuthError,
+  LocaleKey,
+  LocalStorage,
+  StdError,
+  TypedTFunction,
+} from '../..';
 import { Sdk, AuthTokenQuery, RefreshTokenQuery } from './operations.generated';
 
 export type AuthenticationError = {
   message: string;
   detail?: string;
+  stdError?: string | undefined;
   timeoutRemaining?: number;
 };
 
@@ -68,7 +75,7 @@ export const getAuthQueries = (sdk: Sdk, t: TypedTFunction<LocaleKey>) => ({
         });
         return authTokenGuard(result, t);
       } catch (e) {
-        const error = e as Error;
+        const error = e as StdError;
         if ('message' in error) {
           console.error(error.message);
         }
@@ -77,6 +84,7 @@ export const getAuthQueries = (sdk: Sdk, t: TypedTFunction<LocaleKey>) => ({
           error: {
             message: t('error.authentication-error'),
             detail: error.message,
+            stdError: error.stdError,
           },
         };
       }

--- a/client/packages/common/src/authentication/api/api.ts
+++ b/client/packages/common/src/authentication/api/api.ts
@@ -2,7 +2,7 @@ import {
   AuthError,
   LocaleKey,
   LocalStorage,
-  StdError,
+  GraphqlStdError,
   TypedTFunction,
 } from '../..';
 import { Sdk, AuthTokenQuery, RefreshTokenQuery } from './operations.generated';
@@ -75,7 +75,7 @@ export const getAuthQueries = (sdk: Sdk, t: TypedTFunction<LocaleKey>) => ({
         });
         return authTokenGuard(result, t);
       } catch (e) {
-        const error = e as StdError;
+        const error = e as GraphqlStdError;
         if ('message' in error) {
           console.error(error.message);
         }

--- a/client/packages/common/src/intl/locales/en/app.json
+++ b/client/packages/common/src/intl/locales/en/app.json
@@ -42,7 +42,7 @@
   "error.sync-api-incompatible": "Sync api version is not compatible",
   "error.authentication-error": "The server has returned an error",
   "error.connection-error": "Unable to connect to server",
-  "error.database-busy": "The server experienced a problem.",
+  "error.internal-error": "The server experienced a problem.",
   "error.integration-timeout-reached": "The central server took too long integrating pushed records. Please retry later.",
   "error.invalid-url": "Invalid url",
   "error.login": "Invalid username or password",

--- a/client/packages/common/src/intl/locales/en/app.json
+++ b/client/packages/common/src/intl/locales/en/app.json
@@ -42,7 +42,7 @@
   "error.sync-api-incompatible": "Sync api version is not compatible",
   "error.authentication-error": "The server has returned an error",
   "error.connection-error": "Unable to connect to server",
-  "error.database-busy": "Database is busy. Please try again later",
+  "error.database-busy": "The server experienced a problem. Please try again later",
   "error.integration-timeout-reached": "The central server took too long integrating pushed records. Please retry later.",
   "error.invalid-url": "Invalid url",
   "error.login": "Invalid username or password",

--- a/client/packages/common/src/intl/locales/en/app.json
+++ b/client/packages/common/src/intl/locales/en/app.json
@@ -42,7 +42,7 @@
   "error.sync-api-incompatible": "Sync api version is not compatible",
   "error.authentication-error": "The server has returned an error",
   "error.connection-error": "Unable to connect to server",
-  "error.database-busy": "The server experienced a problem. Please try again later",
+  "error.database-busy": "The server experienced a problem.",
   "error.integration-timeout-reached": "The central server took too long integrating pushed records. Please retry later.",
   "error.invalid-url": "Invalid url",
   "error.login": "Invalid username or password",

--- a/client/packages/common/src/intl/locales/en/app.json
+++ b/client/packages/common/src/intl/locales/en/app.json
@@ -42,6 +42,7 @@
   "error.sync-api-incompatible": "Sync api version is not compatible",
   "error.authentication-error": "The server has returned an error",
   "error.connection-error": "Unable to connect to server",
+  "error.database-busy": "Database is busy. Please try again later",
   "error.integration-timeout-reached": "The central server took too long integrating pushed records. Please retry later.",
   "error.invalid-url": "Invalid url",
   "error.login": "Invalid username or password",

--- a/client/packages/host/src/components/Login/Login.tsx
+++ b/client/packages/host/src/components/Login/Login.tsx
@@ -66,7 +66,7 @@ export const Login = () => {
       );
       return `${t('error.account-blocked')} ${formattedTime}`;
     }
-    if (error.detail?.includes('TransactionError')) {
+    if (error?.detail?.includes('UpdateUserError')) {
       return t('error.database-busy');
     }
 

--- a/client/packages/host/src/components/Login/Login.tsx
+++ b/client/packages/host/src/components/Login/Login.tsx
@@ -66,8 +66,8 @@ export const Login = () => {
       );
       return `${t('error.account-blocked')} ${formattedTime}`;
     }
-    if (error?.stdError?.includes('Internal error')) {
-      return t('error.database-busy');
+    if (error?.stdError === 'Internal error') {
+      return t('error.internal-error');
     }
 
     return t('error.login');

--- a/client/packages/host/src/components/Login/Login.tsx
+++ b/client/packages/host/src/components/Login/Login.tsx
@@ -66,6 +66,10 @@ export const Login = () => {
       );
       return `${t('error.account-blocked')} ${formattedTime}`;
     }
+    if (error.detail?.includes('TransactionError')) {
+      return t('error.database-busy');
+    }
+
     return t('error.login');
   }, [error, timeoutRemaining, customDate, t]);
 

--- a/client/packages/host/src/components/Login/Login.tsx
+++ b/client/packages/host/src/components/Login/Login.tsx
@@ -66,7 +66,7 @@ export const Login = () => {
       );
       return `${t('error.account-blocked')} ${formattedTime}`;
     }
-    if (error?.detail?.includes('UpdateUserError')) {
+    if (error?.stdError?.includes('Internal error')) {
       return t('error.database-busy');
     }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3254

# 👩🏻‍💻 What does this PR do? 
Improved message if db is locked on sign in... open for message suggestions
![Screenshot 2024-03-12 at 12 01 21](https://github.com/msupply-foundation/open-msupply/assets/61820074/9cf0a9cb-b7ed-4e72-860d-8818ee68bb2d)

# 🧪 How has/should this change been tested? 
- [ ] Have a store with a big data set
- [ ] On central -> Move that store to open mSupply site
- [ ] On open mSupply -> start sync
- [ ] Wait until integration step (4)
- [ ] Sign out
- [ ] Try sign in again
- [ ] See newly improved message