### PR TITLE
Return empty string instead of "multiple" if there are no lines

### DIFF
--- a/client/packages/common/src/ui/layout/tables/utils/ColumnUtils.test.ts
+++ b/client/packages/common/src/ui/layout/tables/utils/ColumnUtils.test.ts
@@ -105,6 +105,24 @@ describe('getColumnProperty', () => {
 
     expect(value).toBe('[multiple]');
   });
+
+  it('returns "" when when there are no matching lines and no default', () => {
+    const result = renderHookWithProvider(useColumnUtils);
+    const { getColumnProperty } = result.result.current;
+    const row = {
+      id: '1',
+      itemId: '1',
+      lines: [],
+    } as StockOutItem | StockOutLineFragment;
+
+    const value = getColumnProperty(row, [
+      { path: ['lines', 'item', 'code'] },
+      { path: ['item', 'code'] },
+    ]);
+
+    expect(value).toBe('');
+  });
+
   it('uses supplied default for lines', () => {
     const result = renderHookWithProvider(useColumnUtils);
     const { getColumnProperty } = result.result.current;

--- a/client/packages/common/src/ui/layout/tables/utils/ColumnUtils.ts
+++ b/client/packages/common/src/ui/layout/tables/utils/ColumnUtils.ts
@@ -54,10 +54,10 @@ export const useColumnUtils = () => {
           return !!obj ? [obj] : [];
         });
         const isValid =
-          arr.length === 0 ||
-          arr[0] === undefined ||
-          typeof arr[0] !== 'object' ||
-          !(key in arr[0]);
+          arr.length > 0 &&
+          (arr[0] === undefined ||
+            typeof arr[0] !== 'object' ||
+            !(key in arr[0]));
 
         return isValid
           ? ArrayUtils.ifTheSameElseDefault(

--- a/client/packages/common/src/ui/layout/tables/utils/ColumnUtils.ts
+++ b/client/packages/common/src/ui/layout/tables/utils/ColumnUtils.ts
@@ -53,11 +53,16 @@ export const useColumnUtils = () => {
           const obj = line[key];
           return !!obj ? [obj] : [];
         });
+
+        // Extract a value from the array if:
+        // - Array is not empty
+        // - First array element has the required property:
         const isValid =
           arr.length > 0 &&
-          (arr[0] === undefined ||
-            typeof arr[0] !== 'object' ||
-            !(key in arr[0]));
+          !!propertyKey &&
+          arr[0] !== undefined &&
+          typeof arr[0] === 'object' &&
+          propertyKey in arr[0];
 
         return isValid
           ? ArrayUtils.ifTheSameElseDefault(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3029

# 👩🏻‍💻 What does this PR do? 
Handles the case if there are now lines, i.e. return "" instead of "multiple"

# 🧪 How has/should this change been tested? 
See issue description
