### PR TITLE
2109 Patient query fails for name_or_code AND identifier

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -3496,7 +3496,6 @@ export type PatientFilterInput = {
   identifier?: InputMaybe<StringFilterInput>;
   lastName?: InputMaybe<StringFilterInput>;
   name?: InputMaybe<StringFilterInput>;
-  nameOrCode?: InputMaybe<StringFilterInput>;
   phone?: InputMaybe<StringFilterInput>;
   programEnrolmentName?: InputMaybe<StringFilterInput>;
 };
@@ -3565,8 +3564,8 @@ export type PatientSearchInput = {
   dateOfBirth?: InputMaybe<Scalars['NaiveDate']['input']>;
   firstName?: InputMaybe<Scalars['String']['input']>;
   gender?: InputMaybe<GenderInput>;
+  identifier?: InputMaybe<Scalars['String']['input']>;
   lastName?: InputMaybe<Scalars['String']['input']>;
-  nameOrCode?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type PatientSearchNode = {
@@ -4597,6 +4596,7 @@ export type RequisitionLineConnector = {
 
 export type RequisitionLineNode = {
   __typename: 'RequisitionLineNode';
+  /** Quantity already issued in outbound shipments */
   alreadyIssued: Scalars['Float']['output'];
   approvalComment?: Maybe<Scalars['String']['output']>;
   approvedQuantity: Scalars['Int']['output'];

--- a/client/packages/programs/src/JsonForms/components/Search/SearchWithUserSource.tsx
+++ b/client/packages/programs/src/JsonForms/components/Search/SearchWithUserSource.tsx
@@ -171,8 +171,8 @@ const createSearchFilter = (
       ? (data['gender'] as GenderInput)
       : undefined,
     lastName: searchFields.includes('lastName') ? data['lastName'] : undefined,
-    nameOrCode: searchFields.includes('nameOrCode')
-      ? data['nameOrCode']
+    identifier: searchFields.includes('identifier')
+      ? data['identifier']
       : undefined,
   };
 

--- a/client/packages/system/src/Patient/Components/utils.ts
+++ b/client/packages/system/src/Patient/Components/utils.ts
@@ -14,7 +14,7 @@ export const useSearchPatient = () => {
   };
   useEffect(() => {
     if (shouldSearch(debouncedSearchText))
-      mutate({ nameOrCode: debouncedSearchText });
+      mutate({ identifier: debouncedSearchText });
   }, [debouncedSearchText, mutate]);
 
   let patients: ProgramPatientRowFragment[] = [];

--- a/server/graphql/programs/src/queries/patient_search.rs
+++ b/server/graphql/programs/src/queries/patient_search.rs
@@ -17,7 +17,7 @@ pub struct PatientSearchInput {
     last_name: Option<String>,
     date_of_birth: Option<NaiveDate>,
     gender: Option<GenderInput>,
-    name_or_code: Option<String>,
+    identifier: Option<String>,
 }
 
 pub struct PatientSearchNode {
@@ -99,7 +99,7 @@ impl PatientSearchInput {
             last_name: self.last_name,
             date_of_birth: self.date_of_birth,
             gender: self.gender.map(|g| g.to_domain()),
-            name_or_code: self.name_or_code,
+            identifier: self.identifier,
         }
     }
 }

--- a/server/graphql/programs/src/queries/patient_search_central.rs
+++ b/server/graphql/programs/src/queries/patient_search_central.rs
@@ -120,7 +120,7 @@ impl CentralPatientSearchInput {
             last_name: self.last_name,
             date_of_birth: self.date_of_birth,
             gender: None,
-            name_or_code: None,
+            identifier: None,
         }
     }
 }

--- a/server/graphql/types/src/types/program/patient.rs
+++ b/server/graphql/types/src/types/program/patient.rs
@@ -44,7 +44,6 @@ pub struct PatientFilterInput {
     pub country: Option<StringFilterInput>,
     pub email: Option<StringFilterInput>,
     pub identifier: Option<StringFilterInput>,
-    pub name_or_code: Option<StringFilterInput>,
     pub date_of_death: Option<DateFilterInput>,
     pub program_enrolment_name: Option<StringFilterInput>,
 }
@@ -66,7 +65,6 @@ impl From<PatientFilterInput> for PatientFilter {
             country: f.country.map(StringFilter::from),
             email: f.email.map(StringFilter::from),
             identifier: f.identifier.map(StringFilter::from),
-            name_or_code: f.name_or_code.map(StringFilter::from),
             date_of_death: f.date_of_death.map(DateFilter::from),
             program_enrolment_name: f.program_enrolment_name.map(StringFilter::from),
         }

--- a/server/repository/src/db_diesel/patient.rs
+++ b/server/repository/src/db_diesel/patient.rs
@@ -419,6 +419,34 @@ mod tests {
         });
         name_row_repo.upsert_one(&patient_row).unwrap();
 
+        // test identifier OR
+        let patient_row_a = inline_init(|row: &mut NameRow| {
+            row.id = "patient_a".to_string();
+            row.name = "patient_a_name".to_string();
+            row.r#type = NameType::Patient;
+            row.code = "example111".to_string();
+            row.national_health_number = Some("patient_a_nhn".to_string());
+        });
+
+        let patient_row_b = inline_init(|row: &mut NameRow| {
+            row.id = "patient_b".to_string();
+            row.name = "patient_b_name".to_string();
+            row.r#type = NameType::Patient;
+            row.code = "patient_b_code".to_string();
+            row.national_health_number = Some("example222".to_string());
+        });
+
+        let patient_row_c = inline_init(|row: &mut NameRow| {
+            row.id = "patient_c".to_string();
+            row.name = "example_name".to_string();
+            row.r#type = NameType::Patient;
+            row.code = "code333".to_string();
+            row.national_health_number = Some("patient_c_nhn".to_string());
+        });
+        name_row_repo.upsert_one(&patient_row_a).unwrap();
+        name_row_repo.upsert_one(&patient_row_b).unwrap();
+        name_row_repo.upsert_one(&patient_row_c).unwrap();
+
         // Test identifier search
         ProgramEnrolmentRowRepository::new(&connection)
             .upsert_one(&ProgramEnrolmentRow {
@@ -487,6 +515,15 @@ mod tests {
             )
             .unwrap();
         assert_eq!(result.get(0).unwrap().id, patient_row.id);
+
+        // Test identifier OR
+        let result = repo
+            .query_by_filter(
+                PatientFilter::new().identifier(StringFilter::like("example")),
+                None,
+            )
+            .unwrap();
+        assert_eq!(result.len(), 3);
     }
 
     #[actix_rt::test]

--- a/server/service/src/programs/patient/search.rs
+++ b/server/service/src/programs/patient/search.rs
@@ -20,7 +20,7 @@ pub struct PatientSearch {
     pub last_name: Option<String>,
     pub date_of_birth: Option<NaiveDate>,
     pub gender: Option<Gender>,
-    pub name_or_code: Option<String>,
+    pub identifier: Option<String>,
 }
 
 pub struct PatientSearchResult {
@@ -43,7 +43,7 @@ pub fn patient_search(
         last_name,
         date_of_birth,
         gender,
-        name_or_code,
+        identifier,
     } = input;
 
     if let Some(code) = code {
@@ -71,8 +71,8 @@ pub fn patient_search(
             is_null: None,
         });
     }
-    if let Some(name_or_code) = name_or_code {
-        filter = filter.name_or_code(StringFilter::like(&name_or_code));
+    if let Some(identifier) = identifier {
+        filter = filter.identifier(StringFilter::like(&identifier));
     }
     let results = service_provider.patient_service.get_patients(
         ctx,

--- a/server/service/src/programs/patient/search_central.rs
+++ b/server/service/src/programs/patient/search_central.rs
@@ -47,7 +47,7 @@ pub async fn patient_search_central(
         last_name,
         date_of_birth,
         gender: _,
-        name_or_code: _,
+        identifier: _,
     } = params;
     let patients = api
         .patient(PatientParamsV4 {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2109

# 👩🏻‍💻 What does this PR do? 
Unify name_or_code and identifier filter for patient (i.e. add `OR` name filtering to identifier and remove name_or_code)

# 🧪 How has/should this change been tested? 
- [ ] Test patient search in `New Patient` still works