### PR TITLE
3213 Selected tab underline doesn't move correctly with SidePanel open/close

### DIFF
--- a/client/packages/common/src/ui/components/navigation/Tabs/DetailTabs.tsx
+++ b/client/packages/common/src/ui/components/navigation/Tabs/DetailTabs.tsx
@@ -9,7 +9,6 @@ import {
   useDrawer,
 } from '@common/hooks';
 import { LocaleKey, useTranslation } from '@common/intl';
-import { debounce } from '@common/utils';
 import { AppBarTabsPortal } from '../../portals';
 import { DetailTab } from './DetailTab';
 import { ShortTabList, Tab } from './Tabs';
@@ -42,17 +41,19 @@ export const DetailTabs: FC<DetailTabsProps> = ({
   const currentTab = isValidTab(currentUrlTab)
     ? currentUrlTab
     : tabs[0]?.value ?? '';
+  const { showConfirmation } = useConfirmOnLeaving(false);
 
   // Inelegant hack to force the "Underline" indicator for the currently active
   // tab to re-render in the correct position when one of the side "drawers" is
   // expanded. See issue #777 for more detail.
   const { isOpen: detailPanelOpen } = useDetailPanelStore();
   const { isOpen: drawerOpen } = useDrawer();
-  const { showConfirmation } = useConfirmOnLeaving(false);
-  const handleResize = useCallback(
-    () => debounce(() => window.dispatchEvent(new Event('resize')), 100),
-    []
-  );
+  const handleResize = useCallback(() => {
+    window.dispatchEvent(new Event('resize'));
+  }, []);
+  useEffect(() => {
+    handleResize();
+  }, [detailPanelOpen, drawerOpen, handleResize]);
 
   const [tabQueryParams, setTabQueryParams] = useState<
     Record<string, UrlQueryObject>
@@ -79,10 +80,6 @@ export const DetailTabs: FC<DetailTabsProps> = ({
       updateQuery(query, true);
     }
   };
-
-  useEffect(() => {
-    handleResize();
-  }, [detailPanelOpen, drawerOpen, handleResize]);
 
   useEffect(() => {
     const tab = urlQuery['tab'] as string | undefined;

--- a/client/packages/common/src/ui/components/navigation/Tabs/DetailTabs.tsx
+++ b/client/packages/common/src/ui/components/navigation/Tabs/DetailTabs.tsx
@@ -48,9 +48,6 @@ export const DetailTabs: FC<DetailTabsProps> = ({
   // expanded. See issue #777 for more detail.
   const { isOpen: detailPanelOpen } = useDetailPanelStore();
   const { isOpen: drawerOpen } = useDrawer();
-  // const handleResize = useCallback(() => {
-  //   window.dispatchEvent(new Event('resize'));
-  // }, []);
   useEffect(() => {
     setTimeout(() => {
       window.dispatchEvent(new Event('resize'));

--- a/client/packages/common/src/ui/components/navigation/Tabs/DetailTabs.tsx
+++ b/client/packages/common/src/ui/components/navigation/Tabs/DetailTabs.tsx
@@ -48,12 +48,14 @@ export const DetailTabs: FC<DetailTabsProps> = ({
   // expanded. See issue #777 for more detail.
   const { isOpen: detailPanelOpen } = useDetailPanelStore();
   const { isOpen: drawerOpen } = useDrawer();
-  const handleResize = useCallback(() => {
-    window.dispatchEvent(new Event('resize'));
-  }, []);
+  // const handleResize = useCallback(() => {
+  //   window.dispatchEvent(new Event('resize'));
+  // }, []);
   useEffect(() => {
-    handleResize();
-  }, [detailPanelOpen, drawerOpen, handleResize]);
+    setTimeout(() => {
+      window.dispatchEvent(new Event('resize'));
+    }, 100);
+  }, [detailPanelOpen, drawerOpen]);
 
   const [tabQueryParams, setTabQueryParams] = useState<
     Record<string, UrlQueryObject>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3213

# 👩🏻‍💻 What does this PR do? 
Fixes underline being in funky places

# 🧪 How has/should this change been tested? 
- [ ] Go to invoice
- [ ] Open side panel by clicking more
- [ ] Check that the underline is still in the correct place 
- [ ] Can even move tabs