### PR TITLE
Fix asset_log test

### DIFF
--- a/server/service/src/asset/tests/insert_log.rs
+++ b/server/service/src/asset/tests/insert_log.rs
@@ -1,5 +1,4 @@
 #[cfg(test)]
-
 mod query {
     use crate::{
         asset::insert_log::{InsertAssetLog, InsertAssetLogError},
@@ -7,7 +6,7 @@ mod query {
     };
     use repository::{
         asset_log_row::{AssetLogReason, AssetLogStatus},
-        mock::{mock_asset_a, mock_user_account_a, MockDataInserts},
+        mock::{mock_asset_a, mock_store_a, mock_user_account_a, MockDataInserts},
         test_db::setup_all,
     };
 
@@ -22,7 +21,7 @@ mod query {
 
         let service_provider = ServiceProvider::new(connection_manager, "app_data");
         let ctx = service_provider
-            .context(mock_asset_a().id, mock_user_account_a().id)
+            .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();
         let service = service_provider.asset_service;
 


### PR DESCRIPTION
Context was incorrectly created causing a `FOREIGN KEY constraint failed` error on store_id.
Turns out `asset_id` was used instead of `store_id`