### PR TITLE
#3288 Fix for 0 value in stocktake count

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -184,7 +184,7 @@ export const BatchTable: FC<StocktakeLineEditTableProps> = ({
       getIsError: rowData =>
         errorsContext.getError(rowData)?.__typename ===
         'StockLineReducedBelowZero',
-      Cell: props => <NumberInputCell {...props} decimalLimit={2} />,
+      Cell: props => <NumberInputCell {...props} decimalLimit={2} min={0} />,
       setter: patch => {
         // If counted number of packs was changed to result in no adjustment we
         // should remove inventoryAdjustmentReason, otherwise could have a

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -68,7 +68,6 @@ const NumberOfPacksCell: React.FC<CellProps<DraftInboundLine>> = ({
 }) => (
   <NumberInputCell
     {...props}
-    min={0}
     isRequired={rowData.numberOfPacks === 0}
     rowData={rowData}
   />

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -68,6 +68,7 @@ const NumberOfPacksCell: React.FC<CellProps<DraftInboundLine>> = ({
 }) => (
   <NumberInputCell
     {...props}
+    min={0}
     isRequired={rowData.numberOfPacks === 0}
     rowData={rowData}
   />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3288

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

When we refactored the NumberInputCell, we set the default `min` to `1` as that was the more common case in the implementations. However, this means we need to explicitly set `min=0` in the places that need it. 

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Working for stocktakes

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

@roxy-dao can you think of any other places this might be an issue? 