### PR TITLE
3189 add lines by item

### DIFF
--- a/client/packages/invoices/src/InboundShipment/api/hooks/utils/useSelectedStockLineIds.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/utils/useSelectedStockLineIds.ts
@@ -1,4 +1,4 @@
-import { useTableStore } from 'packages/common/src';
+import { useTableStore } from '@openmsupply-client/common';
 import { useInboundRows } from '../line/useInboundRows';
 import { isString } from 'lodash';
 

--- a/client/packages/invoices/src/Returns/InboundDetailView/DetailView.tsx
+++ b/client/packages/invoices/src/Returns/InboundDetailView/DetailView.tsx
@@ -17,7 +17,7 @@ import { AppBarButtons } from './AppBarButtons';
 import { InboundReturnLineFragment, useReturns } from '../api';
 import { AppRoute } from '@openmsupply-client/config';
 import { SidePanel } from './SidePanel/SidePanel';
-import { ActivityLogList } from 'packages/system/src';
+import { ActivityLogList } from '@openmsupply-client/system';
 import { Footer } from './Footer';
 import { InboundReturnItem } from '../../types';
 import { InboundReturnEditModal } from '../modals';

--- a/client/packages/invoices/src/Returns/InboundDetailView/DetailView.tsx
+++ b/client/packages/invoices/src/Returns/InboundDetailView/DetailView.tsx
@@ -9,6 +9,7 @@ import {
   useTranslation,
   createQueryParamsStore,
   DetailTabs,
+  useEditModal,
 } from '@openmsupply-client/common';
 import { ContentArea } from './ContentArea';
 import { Toolbar } from './Toolbar';
@@ -18,16 +19,27 @@ import { AppRoute } from '@openmsupply-client/config';
 import { SidePanel } from './SidePanel/SidePanel';
 import { ActivityLogList } from 'packages/system/src';
 import { Footer } from './Footer';
+import { InboundReturnItem } from '../../types';
+import { InboundReturnEditModal } from '../modals';
 
 export const InboundReturnDetailView: FC = () => {
   const { data, isLoading } = useReturns.document.inboundReturn();
   const t = useTranslation('distribution');
   const navigate = useNavigate();
 
-  // TODO: hook these up to modal
-  const onRowClick = () => {};
+  const {
+    onOpen,
+    onClose,
+    isOpen,
+    entity: itemId,
+    mode,
+  } = useEditModal<string>();
 
-  const onAddItem = () => {};
+  // TODO: hook these up to modal
+  const onRowClick = (row: InboundReturnLineFragment | InboundReturnItem) =>
+    onOpen(row.itemId);
+
+  const onAddItem = () => onOpen();
 
   if (isLoading) return <DetailViewSkeleton hasGroupBy={true} hasHold={true} />;
 
@@ -56,6 +68,17 @@ export const InboundReturnDetailView: FC = () => {
           })}
         >
           <AppBarButtons onAddItem={onAddItem} />
+          {isOpen && (
+            <InboundReturnEditModal
+              isOpen={isOpen}
+              onClose={onClose}
+              outboundShipmentLineIds={[]}
+              customerId={data.otherPartyId}
+              returnId={data.id}
+              // initialItemId={itemId}
+              modalMode={mode}
+            />
+          )}
 
           <Toolbar />
           <DetailTabs tabs={tabs} />

--- a/client/packages/invoices/src/Returns/InboundDetailView/DetailView.tsx
+++ b/client/packages/invoices/src/Returns/InboundDetailView/DetailView.tsx
@@ -38,13 +38,11 @@ export const InboundReturnDetailView: FC = () => {
   const onRowClick = (row: InboundReturnLineFragment | InboundReturnItem) =>
     onOpen(row.itemId);
 
-  const onAddItem = () => onOpen();
-
   if (isLoading) return <DetailViewSkeleton hasGroupBy={true} hasHold={true} />;
 
   const tabs = [
     {
-      Component: <ContentArea onRowClick={onRowClick} onAddItem={onAddItem} />,
+      Component: <ContentArea onRowClick={onRowClick} onAddItem={onOpen} />,
       value: t('label.details'),
     },
     {
@@ -66,7 +64,7 @@ export const InboundReturnDetailView: FC = () => {
             },
           })}
         >
-          <AppBarButtons onAddItem={onAddItem} />
+          <AppBarButtons onAddItem={onOpen} />
           {isOpen && (
             <InboundReturnEditModal
               isOpen={isOpen}

--- a/client/packages/invoices/src/Returns/InboundDetailView/DetailView.tsx
+++ b/client/packages/invoices/src/Returns/InboundDetailView/DetailView.tsx
@@ -35,7 +35,6 @@ export const InboundReturnDetailView: FC = () => {
     mode,
   } = useEditModal<string>();
 
-  // TODO: hook these up to modal
   const onRowClick = (row: InboundReturnLineFragment | InboundReturnItem) =>
     onOpen(row.itemId);
 
@@ -75,7 +74,7 @@ export const InboundReturnDetailView: FC = () => {
               outboundShipmentLineIds={[]}
               customerId={data.otherPartyId}
               returnId={data.id}
-              // initialItemId={itemId}
+              initialItemId={itemId}
               modalMode={mode}
             />
           )}

--- a/client/packages/invoices/src/Returns/api/api.ts
+++ b/client/packages/invoices/src/Returns/api/api.ts
@@ -1,4 +1,5 @@
 import {
+  GenerateInboundReturnLinesInput,
   InboundReturnInput,
   InvoiceNodeType,
   InvoiceSortFieldInput,
@@ -167,11 +168,11 @@ export const getReturnsQueries = (sdk: Sdk, storeId: string) => ({
 
       return result?.generateOutboundReturnLines;
     },
-    inboundReturnLines: async (outboundShipmentLineIds: string[]) => {
+    generateInboundReturnLines: async (
+      input: GenerateInboundReturnLinesInput
+    ) => {
       const result = await sdk.generateInboundReturnLines({
-        input: {
-          outboundShipmentLineIds,
-        },
+        input,
         storeId,
       });
 

--- a/client/packages/invoices/src/Returns/api/api.ts
+++ b/client/packages/invoices/src/Returns/api/api.ts
@@ -4,6 +4,7 @@ import {
   InvoiceNodeType,
   InvoiceSortFieldInput,
   OutboundReturnInput,
+  UpdateInboundReturnLinesInput,
   UpdateOutboundReturnInput,
   UpdateOutboundReturnLinesInput,
 } from '@common/types';
@@ -275,6 +276,20 @@ export const getReturnsQueries = (sdk: Sdk, storeId: string) => ({
 
     // TODO: handle error response...
     throw new Error('Could not delete outbound return');
+  },
+  updateInboundReturnLines: async (input: UpdateInboundReturnLinesInput) => {
+    const result = await sdk.updateInboundReturnLines({
+      input,
+      storeId,
+    });
+
+    const { updateInboundReturnLines } = result;
+
+    if (updateInboundReturnLines.__typename === 'InvoiceNode') {
+      return updateInboundReturnLines;
+    }
+
+    throw new Error('Could not update inbound return');
   },
   deleteInbound: async (
     returns: InboundReturnRowFragment[]

--- a/client/packages/invoices/src/Returns/api/hooks/document/useInboundReturn.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/document/useInboundReturn.ts
@@ -5,7 +5,7 @@ export const useInboundReturn = () => {
   const { invoiceNumber = '' } = useParams();
   const api = useReturnsApi();
 
-  return useQuery(api.keys.detail(invoiceNumber), () =>
+  return useQuery(api.keys.inboundDetail(invoiceNumber), () =>
     api.get.inboundReturnByNumber(Number(invoiceNumber))
   );
 };

--- a/client/packages/invoices/src/Returns/api/hooks/document/useInbounds.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/document/useInbounds.ts
@@ -1,4 +1,4 @@
-import { useQuery } from 'packages/common/src';
+import { useQuery } from '@openmsupply-client/common';
 import { InboundListParams } from '../../api';
 import { useReturnsApi } from '../utils/useReturnsApi';
 

--- a/client/packages/invoices/src/Returns/api/hooks/document/useInsertInboundReturn.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/document/useInsertInboundReturn.ts
@@ -5,7 +5,7 @@ import {
   RouteBuilder,
 } from '@openmsupply-client/common';
 import { useReturnsApi } from '../utils/useReturnsApi';
-import { AppRoute } from 'packages/config/src';
+import { AppRoute } from '@openmsupply-client/config';
 
 export const useInsertInboundReturn = () => {
   const queryClient = useQueryClient();

--- a/client/packages/invoices/src/Returns/api/hooks/document/useInsertOutboundReturn.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/document/useInsertOutboundReturn.ts
@@ -5,7 +5,7 @@ import {
   RouteBuilder,
 } from '@openmsupply-client/common';
 import { useReturnsApi } from '../utils/useReturnsApi';
-import { AppRoute } from 'packages/config/src';
+import { AppRoute } from '@openmsupply-client/config';
 
 export const useInsertOutboundReturn = () => {
   const queryClient = useQueryClient();

--- a/client/packages/invoices/src/Returns/api/hooks/document/useOutboundReturn.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/document/useOutboundReturn.ts
@@ -5,7 +5,7 @@ export const useOutboundReturn = () => {
   const { invoiceNumber } = useParams();
   const api = useReturnsApi();
 
-  return useQuery(api.keys.detail(invoiceNumber ?? ''), () =>
+  return useQuery(api.keys.outboundDetail(invoiceNumber ?? ''), () =>
     api.get.outboundReturnByNumber(Number(invoiceNumber))
   );
 };

--- a/client/packages/invoices/src/Returns/api/hooks/document/useOutbounds.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/document/useOutbounds.ts
@@ -1,4 +1,4 @@
-import { useQuery } from 'packages/common/src';
+import { useQuery } from '@openmsupply-client/common';
 import { OutboundListParams } from '../../api';
 import { useReturnsApi } from '../utils/useReturnsApi';
 

--- a/client/packages/invoices/src/Returns/api/hooks/index.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/index.ts
@@ -25,6 +25,7 @@ export const useReturns = {
 
     generateInboundReturnLines: Lines.useGenerateInboundReturnLines,
     inboundReturnRows: Lines.useInboundReturnRows,
+    updateInboundLines: Lines.useUpdateInboundReturnLines,
     deleteSelectedInboundLines: Lines.useDeleteSelectedInboundReturnLines,
   },
   utils: {

--- a/client/packages/invoices/src/Returns/api/hooks/line/index.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/line/index.ts
@@ -3,6 +3,7 @@ import { useDeleteSelectedInboundReturnLines } from './useDeleteSelectedInboundL
 import { useInboundReturnRows } from './useInboundReturnRows';
 import { useOutboundReturnLines } from './useOutboundReturnLines';
 import { useUpdateOutboundReturnLines } from './useUpdateOutboundReturnLines';
+import { useUpdateInboundReturnLines } from './useUpdateInboundReturnLines';
 
 export const Lines = {
   useOutboundReturnLines,
@@ -10,5 +11,6 @@ export const Lines = {
 
   useGenerateInboundReturnLines,
   useInboundReturnRows,
+  useUpdateInboundReturnLines,
   useDeleteSelectedInboundReturnLines,
 };

--- a/client/packages/invoices/src/Returns/api/hooks/line/useDeleteSelectedInboundLines.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/line/useDeleteSelectedInboundLines.ts
@@ -58,7 +58,7 @@ const useDeleteInboundLines = () => {
   const { invoiceNumber = '' } = useParams();
   const queryClient = useQueryClient();
   const api = useReturnsApi();
-  const queryKey = api.keys.detail(invoiceNumber);
+  const queryKey = api.keys.inboundDetail(invoiceNumber);
 
   // TODO: Replace with actual mutation
   // return useMutation(api.updateInboundReturnLines, {

--- a/client/packages/invoices/src/Returns/api/hooks/line/useGenerateInboundReturnLines.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/line/useGenerateInboundReturnLines.ts
@@ -2,13 +2,22 @@ import { useQuery } from '@openmsupply-client/common';
 import { useReturnsApi } from '../utils/useReturnsApi';
 
 export const useGenerateInboundReturnLines = (
-  outboundShipmentLineIds: string[]
+  outboundShipmentLineIds: string[],
+  returnId: string | undefined,
+  itemId: string | undefined
 ) => {
   const api = useReturnsApi();
 
+  const existingLinesInput =
+    returnId && itemId ? { returnId, itemId } : undefined;
+
   return useQuery(
     api.keys.generatedInboundLines(),
-    () => api.get.inboundReturnLines(outboundShipmentLineIds),
+    () =>
+      api.get.generateInboundReturnLines({
+        outboundShipmentLineIds,
+        existingLinesInput,
+      }),
     {
       enabled: false, // disables automatic fetching
     }

--- a/client/packages/invoices/src/Returns/api/hooks/line/useInboundReturnRows.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/line/useInboundReturnRows.ts
@@ -8,7 +8,7 @@ import {
 import { useInboundReturnColumns } from '../../../InboundDetailView/columns';
 import { useInboundReturn } from '../document/useInboundReturn';
 import { InboundReturnLineFragment } from '../../operations.generated';
-import { InboundReturnItem } from 'packages/invoices/src/types';
+import { InboundReturnItem } from '../../../../types';
 
 export const useInboundReturnRows = () => {
   const {

--- a/client/packages/invoices/src/Returns/api/hooks/line/useUpdateInboundReturnLines.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/line/useUpdateInboundReturnLines.ts
@@ -5,13 +5,13 @@ import {
 } from '@openmsupply-client/common';
 import { useReturnsApi } from '../utils/useReturnsApi';
 
-export const useUpdateOutboundReturnLines = () => {
+export const useUpdateInboundReturnLines = () => {
   const queryClient = useQueryClient();
   const api = useReturnsApi();
   const { invoiceNumber = '' } = useParams();
 
-  return useMutation(api.updateOutboundReturnLines, {
+  return useMutation(api.updateInboundReturnLines, {
     onSuccess: () =>
-      queryClient.invalidateQueries(api.keys.outboundDetail(invoiceNumber)),
+      queryClient.invalidateQueries(api.keys.inboundDetail(invoiceNumber)),
   });
 };

--- a/client/packages/invoices/src/Returns/api/hooks/utils/useReturnsApi.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/utils/useReturnsApi.ts
@@ -25,8 +25,10 @@ export const useReturnsApi = () => {
       [...keys.outboundList(), sortBy] as const,
     outboundParamList: (params: OutboundListParams) =>
       [...keys.outboundList(), params] as const,
-    detail: (invoiceNumber: string) =>
+    outboundDetail: (invoiceNumber: string) =>
       [...keys.base(), storeId, invoiceNumber] as const,
+    inboundDetail: (invoiceNumber: string) =>
+      [...keys.base(), storeId, 'inbound', invoiceNumber] as const,
     generatedOutboundLines: (itemId?: string) =>
       [...keys.base(), storeId, 'generatedOutboundLines', itemId] as const,
     generatedInboundLines: (itemId?: string) =>

--- a/client/packages/invoices/src/Returns/api/operations.generated.ts
+++ b/client/packages/invoices/src/Returns/api/operations.generated.ts
@@ -8,7 +8,7 @@ export type OutboundReturnRowFragment = { __typename: 'InvoiceNode', id: string,
 
 export type InboundReturnRowFragment = { __typename: 'InvoiceNode', id: string, otherPartyName: string, status: Types.InvoiceNodeStatus, invoiceNumber: number, colour?: string | null, createdDatetime: string, deliveredDatetime?: string | null };
 
-export type InboundReturnFragment = { __typename: 'InvoiceNode', id: string, status: Types.InvoiceNodeStatus, invoiceNumber: number, colour?: string | null, createdDatetime: string, pickedDatetime?: string | null, shippedDatetime?: string | null, deliveredDatetime?: string | null, verifiedDatetime?: string | null, otherPartyName: string, otherPartyStore?: { __typename: 'StoreNode', code: string } | null, user?: { __typename: 'UserNode', username: string, email?: string | null } | null };
+export type InboundReturnFragment = { __typename: 'InvoiceNode', id: string, status: Types.InvoiceNodeStatus, invoiceNumber: number, colour?: string | null, createdDatetime: string, pickedDatetime?: string | null, shippedDatetime?: string | null, deliveredDatetime?: string | null, verifiedDatetime?: string | null, otherPartyId: string, otherPartyName: string, otherPartyStore?: { __typename: 'StoreNode', code: string } | null, user?: { __typename: 'UserNode', username: string, email?: string | null } | null };
 
 export type OutboundReturnDetailRowFragment = { __typename: 'InvoiceLineNode', id: string, itemCode: string, itemName: string, itemId: string, batch?: string | null, expiryDate?: string | null, numberOfPacks: number, packSize: number, sellPricePerPack: number };
 
@@ -68,7 +68,7 @@ export type InboundReturnByNumberQueryVariables = Types.Exact<{
 }>;
 
 
-export type InboundReturnByNumberQuery = { __typename: 'Queries', invoiceByNumber: { __typename: 'InvoiceNode', id: string, status: Types.InvoiceNodeStatus, invoiceNumber: number, colour?: string | null, createdDatetime: string, pickedDatetime?: string | null, shippedDatetime?: string | null, deliveredDatetime?: string | null, verifiedDatetime?: string | null, otherPartyName: string, lines: { __typename: 'InvoiceLineConnector', nodes: Array<{ __typename: 'InvoiceLineNode', id: string, itemId: string, itemCode: string, itemName: string, batch?: string | null, expiryDate?: string | null, numberOfPacks: number, packSize: number }> }, otherPartyStore?: { __typename: 'StoreNode', code: string } | null, user?: { __typename: 'UserNode', username: string, email?: string | null } | null } | { __typename: 'NodeError' } };
+export type InboundReturnByNumberQuery = { __typename: 'Queries', invoiceByNumber: { __typename: 'InvoiceNode', id: string, status: Types.InvoiceNodeStatus, invoiceNumber: number, colour?: string | null, createdDatetime: string, pickedDatetime?: string | null, shippedDatetime?: string | null, deliveredDatetime?: string | null, verifiedDatetime?: string | null, otherPartyId: string, otherPartyName: string, lines: { __typename: 'InvoiceLineConnector', nodes: Array<{ __typename: 'InvoiceLineNode', id: string, itemId: string, itemCode: string, itemName: string, batch?: string | null, expiryDate?: string | null, numberOfPacks: number, packSize: number }> }, otherPartyStore?: { __typename: 'StoreNode', code: string } | null, user?: { __typename: 'UserNode', username: string, email?: string | null } | null } | { __typename: 'NodeError' } };
 
 export type InsertOutboundReturnMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -158,6 +158,7 @@ export const InboundReturnFragmentDoc = gql`
   shippedDatetime
   deliveredDatetime
   verifiedDatetime
+  otherPartyId
   otherPartyName
   otherPartyStore {
     code

--- a/client/packages/invoices/src/Returns/api/operations.generated.ts
+++ b/client/packages/invoices/src/Returns/api/operations.generated.ts
@@ -100,7 +100,7 @@ export type InsertInboundReturnMutationVariables = Types.Exact<{
 }>;
 
 
-export type InsertInboundReturnMutation = { __typename: 'Mutations', insertInboundReturn: { __typename: 'InsertInboundReturnError' } | { __typename: 'InvoiceNode', id: string, invoiceNumber: number } };
+export type InsertInboundReturnMutation = { __typename: 'Mutations', insertInboundReturn: { __typename: 'InsertInboundReturnError', error: { __typename: 'OtherPartyNotACustomer', description: string } | { __typename: 'OtherPartyNotVisible', description: string } } | { __typename: 'InvoiceNode', id: string, invoiceNumber: number } };
 
 export type DeleteOutboundReturnMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -371,6 +371,13 @@ export const InsertInboundReturnDocument = gql`
       __typename
       id
       invoiceNumber
+    }
+    ... on InsertInboundReturnError {
+      __typename
+      error {
+        __typename
+        description
+      }
     }
   }
 }

--- a/client/packages/invoices/src/Returns/api/operations.generated.ts
+++ b/client/packages/invoices/src/Returns/api/operations.generated.ts
@@ -110,6 +110,14 @@ export type DeleteOutboundReturnMutationVariables = Types.Exact<{
 
 export type DeleteOutboundReturnMutation = { __typename: 'Mutations', deleteOutboundReturn: { __typename: 'DeleteOutboundReturnError' } | { __typename: 'DeleteResponse', id: string } };
 
+export type UpdateInboundReturnLinesMutationVariables = Types.Exact<{
+  storeId: Types.Scalars['String']['input'];
+  input: Types.UpdateInboundReturnLinesInput;
+}>;
+
+
+export type UpdateInboundReturnLinesMutation = { __typename: 'Mutations', updateInboundReturnLines: { __typename: 'InvoiceNode', id: string } };
+
 export type DeleteInboundReturnsMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
   input: Array<Types.DeleteInboundReturnInput> | Types.DeleteInboundReturnInput;
@@ -392,6 +400,16 @@ export const DeleteOutboundReturnDocument = gql`
   }
 }
     `;
+export const UpdateInboundReturnLinesDocument = gql`
+    mutation updateInboundReturnLines($storeId: String!, $input: UpdateInboundReturnLinesInput!) {
+  updateInboundReturnLines(storeId: $storeId, input: $input) {
+    ... on InvoiceNode {
+      __typename
+      id
+    }
+  }
+}
+    `;
 export const DeleteInboundReturnsDocument = gql`
     mutation deleteInboundReturns($storeId: String!, $input: [DeleteInboundReturnInput!]!) {
   deleteInboundReturns(storeId: $storeId, input: $input) {
@@ -442,6 +460,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     deleteOutboundReturn(variables: DeleteOutboundReturnMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DeleteOutboundReturnMutation> {
       return withWrapper((wrappedRequestHeaders) => client.request<DeleteOutboundReturnMutation>(DeleteOutboundReturnDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'deleteOutboundReturn', 'mutation');
+    },
+    updateInboundReturnLines(variables: UpdateInboundReturnLinesMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<UpdateInboundReturnLinesMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<UpdateInboundReturnLinesMutation>(UpdateInboundReturnLinesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'updateInboundReturnLines', 'mutation');
     },
     deleteInboundReturns(variables: DeleteInboundReturnsMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DeleteInboundReturnsMutation> {
       return withWrapper((wrappedRequestHeaders) => client.request<DeleteInboundReturnsMutation>(DeleteInboundReturnsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'deleteInboundReturns', 'mutation');
@@ -634,6 +655,23 @@ export const mockInsertInboundReturnMutation = (resolver: ResponseResolver<Graph
 export const mockDeleteOutboundReturnMutation = (resolver: ResponseResolver<GraphQLRequest<DeleteOutboundReturnMutationVariables>, GraphQLContext<DeleteOutboundReturnMutation>, any>) =>
   graphql.mutation<DeleteOutboundReturnMutation, DeleteOutboundReturnMutationVariables>(
     'deleteOutboundReturn',
+    resolver
+  )
+
+/**
+ * @param resolver a function that accepts a captured request and may return a mocked response.
+ * @see https://mswjs.io/docs/basics/response-resolver
+ * @example
+ * mockUpdateInboundReturnLinesMutation((req, res, ctx) => {
+ *   const { storeId, input } = req.variables;
+ *   return res(
+ *     ctx.data({ updateInboundReturnLines })
+ *   )
+ * })
+ */
+export const mockUpdateInboundReturnLinesMutation = (resolver: ResponseResolver<GraphQLRequest<UpdateInboundReturnLinesMutationVariables>, GraphQLContext<UpdateInboundReturnLinesMutation>, any>) =>
+  graphql.mutation<UpdateInboundReturnLinesMutation, UpdateInboundReturnLinesMutationVariables>(
+    'updateInboundReturnLines',
     resolver
   )
 

--- a/client/packages/invoices/src/Returns/api/operations.graphql
+++ b/client/packages/invoices/src/Returns/api/operations.graphql
@@ -37,6 +37,7 @@ fragment InboundReturn on InvoiceNode {
   deliveredDatetime
   verifiedDatetime
 
+  otherPartyId
   otherPartyName
   otherPartyStore {
     code

--- a/client/packages/invoices/src/Returns/api/operations.graphql
+++ b/client/packages/invoices/src/Returns/api/operations.graphql
@@ -262,6 +262,14 @@ mutation insertInboundReturn($storeId: String!, $input: InboundReturnInput!) {
       id
       invoiceNumber
     }
+
+    ... on InsertInboundReturnError {
+      __typename
+      error {
+        __typename
+        description
+      }
+    }
   }
 }
 

--- a/client/packages/invoices/src/Returns/api/operations.graphql
+++ b/client/packages/invoices/src/Returns/api/operations.graphql
@@ -282,6 +282,18 @@ mutation deleteOutboundReturn($storeId: String!, $id: String!) {
   }
 }
 
+mutation updateInboundReturnLines(
+  $storeId: String!
+  $input: UpdateInboundReturnLinesInput!
+) {
+  updateInboundReturnLines(storeId: $storeId, input: $input) {
+    ... on InvoiceNode {
+      __typename
+      id
+    }
+  }
+}
+
 mutation deleteInboundReturns(
   $storeId: String!
   $input: [DeleteInboundReturnInput!]!

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/InboundReturn.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/InboundReturn.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import {
   useTranslation,
   useDialog,
@@ -57,19 +57,6 @@ export const InboundReturnEditModal = ({
       returnId,
       itemId,
     });
-
-  // TODO: own hook
-  useEffect(() => {
-    const keyBinding = (e: KeyboardEvent) => {
-      if (returnId && e.key === '+') {
-        e.preventDefault();
-        addDraftLine();
-      }
-    };
-
-    window.addEventListener('keydown', keyBinding);
-    return () => window.removeEventListener('keydown', keyBinding);
-  }, []);
 
   const onOk = async () => {
     try {
@@ -134,7 +121,7 @@ export const InboundReturnEditModal = ({
               update={update}
               zeroQuantityAlert={zeroQuantityAlert}
               setZeroQuantityAlert={setZeroQuantityAlert}
-              // We only want to allow adding draft lines when we are adding by item
+              // We only allow adding draft lines when we are adding by item
               addDraftLine={itemId ? addDraftLine : undefined}
             />
           )}

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/InboundReturn.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/InboundReturn.tsx
@@ -25,6 +25,7 @@ interface InboundReturnEditModalProps {
   customerId: string;
   onClose: () => void;
   modalMode: ModalMode | null;
+  returnId?: string;
 }
 
 enum Tabs {
@@ -38,6 +39,7 @@ export const InboundReturnEditModal = ({
   customerId,
   onClose,
   modalMode,
+  returnId,
 }: InboundReturnEditModalProps) => {
   const t = useTranslation(['distribution', 'replenishment']);
   const { currentTab, onChangeTab } = useTabs(Tabs.Quantity);
@@ -61,10 +63,11 @@ export const InboundReturnEditModal = ({
   const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
   const height = useKeyboardHeightAdjustment(600);
 
-  const { lines, update, saveInboundReturn } = useDraftInboundReturnLines(
+  const { lines, update, saveInboundReturn } = useDraftInboundReturnLines({
     outboundShipmentLineIds,
-    customerId
-  );
+    customerId,
+    returnId,
+  });
 
   const onOk = async () => {
     try {

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/InboundReturn.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/InboundReturn.tsx
@@ -6,19 +6,14 @@ import {
   TableProvider,
   createTableStore,
   useKeyboardHeightAdjustment,
-  WizardStepper,
   useTabs,
-  TabPanel,
-  TabContext,
   ModalMode,
   Box,
   AlertColor,
-  Alert,
 } from '@openmsupply-client/common';
-import { QuantityReturnedTable } from './ReturnQuantitiesTable';
 import { useDraftInboundReturnLines } from './useDraftInboundReturnLines';
-import { ReturnReasonsTable } from '../ReturnReasonsTable';
 import { ItemSelector } from './ItemSelector';
+import { ReturnSteps, Tabs } from './ReturnSteps';
 
 interface InboundReturnEditModalProps {
   isOpen: boolean;
@@ -28,11 +23,6 @@ interface InboundReturnEditModalProps {
   modalMode: ModalMode | null;
   returnId?: string;
   initialItemId?: string | null;
-}
-
-enum Tabs {
-  Quantity = 'Quantity',
-  Reason = 'Reason',
 }
 
 export const InboundReturnEditModal = ({
@@ -56,16 +46,6 @@ export const InboundReturnEditModal = ({
   const [zeroQuantityAlert, setZeroQuantityAlert] = useState<
     AlertColor | undefined
   >();
-
-  const returnsSteps = [
-    { tab: Tabs.Quantity, label: t('label.quantity'), description: '' },
-    { tab: Tabs.Reason, label: t('label.reason'), description: '' },
-  ];
-
-  const getActiveStep = () => {
-    const step = returnsSteps.findIndex(step => step.tab === currentTab);
-    return step === -1 ? 0 : step;
-  };
 
   const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
   const height = useKeyboardHeightAdjustment(600);
@@ -104,15 +84,6 @@ export const InboundReturnEditModal = ({
     alertRef?.current?.scrollIntoView({ behavior: 'smooth' });
   };
 
-  const alertMessage =
-    zeroQuantityAlert === 'warning'
-      ? t('messages.zero-return-quantity-will-delete-lines', {
-          ns: 'replenishment',
-        })
-      : t('messages.alert-zero-return-quantity', {
-          ns: 'replenishment',
-        });
-
   return (
     <TableProvider createStore={createTableStore}>
       <Modal
@@ -143,32 +114,13 @@ export const InboundReturnEditModal = ({
           )}
 
           {lines.length > 0 && (
-            <>
-              <WizardStepper
-                activeStep={getActiveStep()}
-                steps={returnsSteps}
-              />
-              <TabContext value={currentTab}>
-                <TabPanel value={Tabs.Quantity}>
-                  {zeroQuantityAlert && (
-                    <Alert severity={zeroQuantityAlert}>{alertMessage}</Alert>
-                  )}
-                  <QuantityReturnedTable
-                    lines={lines}
-                    updateLine={line => {
-                      if (zeroQuantityAlert) setZeroQuantityAlert(undefined);
-                      update(line);
-                    }}
-                  />
-                </TabPanel>
-                <TabPanel value={Tabs.Reason}>
-                  <ReturnReasonsTable
-                    lines={lines.filter(line => line.numberOfPacksReturned > 0)}
-                    updateLine={line => update(line)}
-                  />
-                </TabPanel>
-              </TabContext>
-            </>
+            <ReturnSteps
+              currentTab={currentTab}
+              lines={lines}
+              update={update}
+              zeroQuantityAlert={zeroQuantityAlert}
+              setZeroQuantityAlert={setZeroQuantityAlert}
+            />
           )}
         </Box>
       </Modal>

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/InboundReturn.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/InboundReturn.tsx
@@ -50,17 +50,16 @@ export const InboundReturnEditModal = ({
   const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
   const height = useKeyboardHeightAdjustment(700);
 
-  const { lines, update, saveInboundReturn, addDraftLine } =
-    useDraftInboundReturnLines({
-      outboundShipmentLineIds,
-      customerId,
-      returnId,
-      itemId,
-    });
+  const { lines, update, save, addDraftLine } = useDraftInboundReturnLines({
+    outboundShipmentLineIds,
+    customerId,
+    returnId,
+    itemId,
+  });
 
   const onOk = async () => {
     try {
-      await saveInboundReturn();
+      await save();
       onClose();
     } catch {
       // TODO: handle error display...

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/ItemSelector.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/ItemSelector.tsx
@@ -1,0 +1,52 @@
+import React, { FC } from 'react';
+import {
+  ModalRow,
+  ModalLabel,
+  Grid,
+  useTranslation,
+  Box,
+} from '@openmsupply-client/common';
+import { StockItemSearchInput } from '@openmsupply-client/system';
+import { useReturns } from '../../api';
+
+interface ItemSelectorProps {
+  itemId: string | undefined;
+  disabled: boolean;
+  onChangeItemId: (id: string) => void;
+}
+
+export const ItemSelector: FC<ItemSelectorProps> = ({
+  itemId,
+  disabled,
+  onChangeItemId,
+}) => {
+  const t = useTranslation();
+
+  const { items } = useReturns.lines.inboundReturnRows();
+
+  return (
+    <Box marginBottom="14px">
+      <ModalRow>
+        <ModalLabel
+          label={t('label.item', { count: 1 })}
+          justifyContent="flex-end"
+        />
+        <Grid item flex={1}>
+          <StockItemSearchInput
+            autoFocus={!itemId}
+            openOnFocus={!itemId}
+            disabled={disabled}
+            currentItemId={itemId}
+            onChange={newItem => newItem && onChangeItemId(newItem.id)}
+            extraFilter={
+              disabled
+                ? undefined
+                : item =>
+                    !items?.some(existingItem => existingItem.id === item.id)
+            }
+          />
+        </Grid>
+      </ModalRow>
+    </Box>
+  );
+};

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
@@ -3,7 +3,7 @@ import {
   GeneratedInboundReturnLineNode,
   NumberInputCell,
   useColumns,
-} from 'packages/common/src';
+} from '@openmsupply-client/common';
 import React from 'react';
 
 export const QuantityReturnedTableComponent = ({

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
@@ -7,9 +7,14 @@ import {
   GeneratedInboundReturnLineNode,
   NumberInputCell,
   TextInputCell,
+  getColumnLookupWithOverrides,
   getExpiryDateInputColumn,
   useColumns,
 } from '@openmsupply-client/common';
+import {
+  PACK_VARIANT_ENTRY_CELL_MIN_WIDTH,
+  PackVariantEntryCell,
+} from '@openmsupply-client/system';
 import React from 'react';
 
 export const QuantityReturnedTableComponent = ({
@@ -21,9 +26,6 @@ export const QuantityReturnedTableComponent = ({
     line: Partial<GeneratedInboundReturnLineNode> & { id: string }
   ) => void;
 }) => {
-  // what to do here if there are multiple items? Some might have PV and others not...
-  // const { packVariantExists } = usePackVariant(item?.id || '', null);
-
   const columns = useColumns<GeneratedInboundReturnLineNode>(
     [
       'itemCode',
@@ -52,25 +54,12 @@ export const QuantityReturnedTableComponent = ({
             }),
         },
       ],
-      [
-        'packSize',
-        {
-          width: 100,
-          setter: updateLine,
-          Cell: PackSizeInputCell,
-        },
-      ],
-      // TODO: implement pack variant
-      // getColumnLookupWithOverrides('packSize', {
-      //   Cell: PackUnitEntryCell,
-      //   setter: updateLine,
-      //   ...(packVariantExists
-      //     ? {
-      //         label: 'label.unit-variant-and-pack-size',
-      //         minWidth: PACK_VARIANT_ENTRY_CELL_MIN_WIDTH,
-      //       }
-      //     : { label: 'label.pack-size' }),
-      // }),
+      getColumnLookupWithOverrides('packSize', {
+        Cell: PackUnitEntryCell,
+        setter: updateLine,
+        label: 'label.unit-variant-and-pack-size',
+        minWidth: PACK_VARIANT_ENTRY_CELL_MIN_WIDTH,
+      }),
       ...(lines.some(l => l.numberOfPacksIssued !== null) // if any line has a value, show the column
         ? ([
             [
@@ -111,9 +100,12 @@ export const QuantityReturnedTableComponent = ({
 export const QuantityReturnedTable = React.memo(QuantityReturnedTableComponent);
 
 // Input cells can't be defined inline, otherwise they lose focus on re-render
-const PackSizeInputCell: React.FC<
-  CellProps<GeneratedInboundReturnLineNode>
-> = props => <NumberInputCell {...props} isRequired min={1} />;
+// eslint-disable-next-line new-cap
+const PackUnitEntryCell = PackVariantEntryCell<GeneratedInboundReturnLineNode>({
+  getItemId: r => r.itemId,
+  // getUnitName: r => r.item.unitName || null,
+  getUnitName: () => null,
+});
 
 const NumberOfPacksReturnedInputCell: React.FC<
   CellProps<GeneratedInboundReturnLineNode>

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
@@ -19,6 +19,9 @@ export const QuantityReturnedTableComponent = ({
     line: Partial<GeneratedInboundReturnLineNode> & { id: string }
   ) => void;
 }) => {
+  // what to do here if there are multiple items? Some might have PV and others not...
+  // const { packVariantExists } = usePackVariant(item?.id || '', null);
+
   const columns = useColumns<GeneratedInboundReturnLineNode>(
     [
       'itemCode',
@@ -47,7 +50,6 @@ export const QuantityReturnedTableComponent = ({
         },
       ],
       [
-        // TODO: PACK VARIANTS HERE
         'packSize',
         {
           width: 100,
@@ -55,6 +57,17 @@ export const QuantityReturnedTableComponent = ({
           Cell: props => <NumberInputCell {...props} isRequired min={1} />,
         },
       ],
+      // TODO: implement pack variant
+      // getColumnLookupWithOverrides('packSize', {
+      //   Cell: PackUnitEntryCell,
+      //   setter: updateLine,
+      //   ...(packVariantExists
+      //     ? {
+      //         label: 'label.unit-variant-and-pack-size',
+      //         minWidth: PACK_VARIANT_ENTRY_CELL_MIN_WIDTH,
+      //       }
+      //     : { label: 'label.pack-size' }),
+      // }),
       [
         'numberOfPacks',
         {

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
@@ -1,5 +1,6 @@
 import {
   BasicCell,
+  CellProps,
   DataTable,
   Formatter,
   GeneratedInboundReturnLineNode,
@@ -32,12 +33,13 @@ export const QuantityReturnedTableComponent = ({
         'batch',
         {
           width: 125,
+          accessor: ({ rowData }) => rowData.batch ?? '',
           setter: updateLine,
           Cell: TextInputCell,
         },
       ],
       [
-        getExpiryDateInputColumn<GeneratedInboundReturnLineNode>(),
+        expiryInputColumn,
         {
           width: 150,
           setter: l =>
@@ -54,7 +56,7 @@ export const QuantityReturnedTableComponent = ({
         {
           width: 100,
           setter: updateLine,
-          Cell: props => <NumberInputCell {...props} isRequired min={1} />,
+          Cell: PackSizeInputCell,
         },
       ],
       // TODO: implement pack variant
@@ -83,14 +85,7 @@ export const QuantityReturnedTableComponent = ({
           description: 'description.pack-quantity',
           width: 100,
           setter: updateLine,
-          Cell: props => (
-            <NumberInputCell
-              {...props}
-              isRequired
-              max={props.rowData.numberOfPacksIssued ?? undefined}
-              min={0}
-            />
-          ),
+          Cell: NumberOfPacksReturnedInputCell,
         },
       ],
     ],
@@ -109,3 +104,21 @@ export const QuantityReturnedTableComponent = ({
 };
 
 export const QuantityReturnedTable = React.memo(QuantityReturnedTableComponent);
+
+// Input cells can't be defined inline, otherwise they lose focus on re-render?
+const PackSizeInputCell: React.FC<
+  CellProps<GeneratedInboundReturnLineNode>
+> = props => <NumberInputCell {...props} isRequired min={1} />;
+
+const NumberOfPacksReturnedInputCell: React.FC<
+  CellProps<GeneratedInboundReturnLineNode>
+> = props => (
+  <NumberInputCell
+    {...props}
+    isRequired
+    max={props.rowData.numberOfPacksIssued ?? undefined}
+    min={0}
+  />
+);
+const expiryInputColumn =
+  getExpiryDateInputColumn<GeneratedInboundReturnLineNode>();

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
@@ -1,7 +1,11 @@
 import {
+  BasicCell,
   DataTable,
+  Formatter,
   GeneratedInboundReturnLineNode,
   NumberInputCell,
+  TextInputCell,
+  getExpiryDateInputColumn,
   useColumns,
 } from '@openmsupply-client/common';
 import React from 'react';
@@ -21,14 +25,43 @@ export const QuantityReturnedTableComponent = ({
       'itemName',
       // 'itemUnit', // not implemented for now
       // 'location',
-      'batch',
-      'expiryDate',
+      [
+        'batch',
+        {
+          width: 125,
+          setter: updateLine,
+          Cell: TextInputCell,
+        },
+      ],
+      [
+        getExpiryDateInputColumn<GeneratedInboundReturnLineNode>(),
+        {
+          width: 150,
+          setter: l =>
+            updateLine({
+              ...l,
+              expiryDate: l.expiryDate
+                ? Formatter.naiveDate(new Date(l.expiryDate))
+                : null,
+            }),
+        },
+      ],
+      [
+        // TODO: PACK VARIANTS HERE
+        'packSize',
+        {
+          width: 100,
+          setter: updateLine,
+          Cell: props => <NumberInputCell {...props} isRequired min={1} />,
+        },
+      ],
       [
         'numberOfPacks',
         {
           label: 'label.pack-quantity-issued',
-          width: 125,
-          accessor: ({ rowData }) => rowData.numberOfPacksIssued,
+          width: 110,
+          accessor: ({ rowData }) => rowData.numberOfPacksIssued ?? '--',
+          Cell: BasicCell,
         },
       ],
       [

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
@@ -105,7 +105,7 @@ export const QuantityReturnedTableComponent = ({
 
 export const QuantityReturnedTable = React.memo(QuantityReturnedTableComponent);
 
-// Input cells can't be defined inline, otherwise they lose focus on re-render?
+// Input cells can't be defined inline, otherwise they lose focus on re-render
 const PackSizeInputCell: React.FC<
   CellProps<GeneratedInboundReturnLineNode>
 > = props => <NumberInputCell {...props} isRequired min={1} />;

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
@@ -1,6 +1,7 @@
 import {
   BasicCell,
   CellProps,
+  ColumnDescription,
   DataTable,
   Formatter,
   GeneratedInboundReturnLineNode,
@@ -70,15 +71,19 @@ export const QuantityReturnedTableComponent = ({
       //       }
       //     : { label: 'label.pack-size' }),
       // }),
-      [
-        'numberOfPacks',
-        {
-          label: 'label.pack-quantity-issued',
-          width: 110,
-          accessor: ({ rowData }) => rowData.numberOfPacksIssued ?? '--',
-          Cell: BasicCell,
-        },
-      ],
+      ...(lines.some(l => l.numberOfPacksIssued !== null) // if any line has a value, show the column
+        ? ([
+            [
+              'numberOfPacks',
+              {
+                label: 'label.pack-quantity-issued',
+                width: 110,
+                accessor: ({ rowData }) => rowData.numberOfPacksIssued ?? '--',
+                Cell: BasicCell,
+              },
+            ],
+          ] as ColumnDescription<GeneratedInboundReturnLineNode>[])
+        : []),
       [
         'numberOfPacksReturned',
         {

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
@@ -67,6 +67,7 @@ export const QuantityReturnedTableComponent = ({
       [
         'numberOfPacksReturned',
         {
+          description: 'description.pack-quantity',
           width: 100,
           setter: updateLine,
           Cell: props => (

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnSteps.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnSteps.tsx
@@ -8,9 +8,13 @@ import {
   Alert,
   RecordPatch,
   GeneratedInboundReturnLineNode,
+  ButtonWithIcon,
+  PlusCircleIcon,
+  Box,
 } from '@openmsupply-client/common';
 import { QuantityReturnedTable } from './ReturnQuantitiesTable';
 import { ReturnReasonsTable } from '../ReturnReasonsTable';
+import { useReturns } from '../..';
 
 export enum Tabs {
   Quantity = 'Quantity',
@@ -21,6 +25,7 @@ interface ReturnStepsProps {
   currentTab: string;
   lines: GeneratedInboundReturnLineNode[];
   update: (patch: RecordPatch<GeneratedInboundReturnLineNode>) => void;
+  addDraftLine?: () => void;
   zeroQuantityAlert: AlertColor | undefined;
   setZeroQuantityAlert: React.Dispatch<
     React.SetStateAction<AlertColor | undefined>
@@ -31,10 +36,12 @@ export const ReturnSteps = ({
   currentTab,
   lines,
   update,
+  addDraftLine,
   zeroQuantityAlert,
   setZeroQuantityAlert,
 }: ReturnStepsProps) => {
   const t = useTranslation(['distribution', 'replenishment']);
+  const isDisabled = useReturns.utils.inboundIsDisabled();
 
   const returnsSteps = [
     { tab: Tabs.Quantity, label: t('label.quantity'), description: '' },
@@ -58,6 +65,18 @@ export const ReturnSteps = ({
   return (
     <TabContext value={currentTab}>
       <WizardStepper activeStep={getActiveStep()} steps={returnsSteps} />
+      {addDraftLine && (
+        <Box flex={1} justifyContent="flex-end" display="flex">
+          <ButtonWithIcon
+            disabled={isDisabled}
+            color="primary"
+            variant="outlined"
+            onClick={addDraftLine}
+            label={`${t('label.add-batch')} (+)`}
+            Icon={<PlusCircleIcon />}
+          />
+        </Box>
+      )}
       <TabPanel value={Tabs.Quantity}>
         {zeroQuantityAlert && (
           <Alert severity={zeroQuantityAlert}>{alertMessage}</Alert>

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnSteps.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnSteps.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import {
+  useTranslation,
+  WizardStepper,
+  TabPanel,
+  TabContext,
+  AlertColor,
+  Alert,
+  RecordPatch,
+  GeneratedInboundReturnLineNode,
+} from '@openmsupply-client/common';
+import { QuantityReturnedTable } from './ReturnQuantitiesTable';
+import { ReturnReasonsTable } from '../ReturnReasonsTable';
+
+export enum Tabs {
+  Quantity = 'Quantity',
+  Reason = 'Reason',
+}
+
+interface ReturnStepsProps {
+  currentTab: string;
+  lines: GeneratedInboundReturnLineNode[];
+  update: (patch: RecordPatch<GeneratedInboundReturnLineNode>) => void;
+  zeroQuantityAlert: AlertColor | undefined;
+  setZeroQuantityAlert: React.Dispatch<
+    React.SetStateAction<AlertColor | undefined>
+  >;
+}
+
+export const ReturnSteps = ({
+  currentTab,
+  lines,
+  update,
+  zeroQuantityAlert,
+  setZeroQuantityAlert,
+}: ReturnStepsProps) => {
+  const t = useTranslation(['distribution', 'replenishment']);
+
+  const returnsSteps = [
+    { tab: Tabs.Quantity, label: t('label.quantity'), description: '' },
+    { tab: Tabs.Reason, label: t('label.reason'), description: '' },
+  ];
+
+  const getActiveStep = () => {
+    const step = returnsSteps.findIndex(step => step.tab === currentTab);
+    return step === -1 ? 0 : step;
+  };
+
+  const alertMessage =
+    zeroQuantityAlert === 'warning'
+      ? t('messages.zero-return-quantity-will-delete-lines', {
+          ns: 'replenishment',
+        })
+      : t('messages.alert-zero-return-quantity', {
+          ns: 'replenishment',
+        });
+
+  return (
+    <TabContext value={currentTab}>
+      <WizardStepper activeStep={getActiveStep()} steps={returnsSteps} />
+      <TabPanel value={Tabs.Quantity}>
+        {zeroQuantityAlert && (
+          <Alert severity={zeroQuantityAlert}>{alertMessage}</Alert>
+        )}
+        <QuantityReturnedTable
+          lines={lines}
+          updateLine={line => {
+            if (zeroQuantityAlert) setZeroQuantityAlert(undefined);
+            update(line);
+          }}
+        />
+      </TabPanel>
+      <TabPanel value={Tabs.Reason}>
+        <ReturnReasonsTable
+          lines={lines.filter(line => line.numberOfPacksReturned > 0)}
+          updateLine={line => update(line)}
+        />
+      </TabPanel>
+    </TabContext>
+  );
+};

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnSteps.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnSteps.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   useTranslation,
   WizardStepper,
@@ -42,6 +42,8 @@ export const ReturnSteps = ({
 }: ReturnStepsProps) => {
   const t = useTranslation(['distribution', 'replenishment']);
   const isDisabled = useReturns.utils.inboundIsDisabled();
+
+  useAddDraftLineKeyBinding(addDraftLine);
 
   const returnsSteps = [
     { tab: Tabs.Quantity, label: t('label.quantity'), description: '' },
@@ -97,4 +99,18 @@ export const ReturnSteps = ({
       </TabPanel>
     </TabContext>
   );
+};
+
+const useAddDraftLineKeyBinding = (addDraftLine: (() => void) | undefined) => {
+  useEffect(() => {
+    const keyBinding = (e: KeyboardEvent) => {
+      if (addDraftLine && e.key === '+') {
+        e.preventDefault();
+        addDraftLine();
+      }
+    };
+
+    window.addEventListener('keydown', keyBinding);
+    return () => window.removeEventListener('keydown', keyBinding);
+  }, [addDraftLine]);
 };

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/useDraftInboundReturnLines.ts
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/useDraftInboundReturnLines.ts
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import {
   FnUtils,
-  InboundReturnInput,
   GeneratedInboundReturnLineNode,
   InboundReturnLineInput,
   RecordPatch,
@@ -33,7 +32,7 @@ export const useDraftInboundReturnLines = ({
   );
 
   const { mutateAsync: insert } = useReturns.document.insertInboundReturn();
-  // const { mutateAsync: updateLines } = useReturns.lines.updateInboundLines();
+  const { mutateAsync: updateLines } = useReturns.lines.updateInboundLines();
 
   useEffect(() => {
     if (!draftLines.length) getLines();
@@ -110,15 +109,20 @@ export const useDraftInboundReturnLines = ({
       }
     );
 
-    const input: InboundReturnInput = {
-      id: FnUtils.generateUUID(),
-      customerId,
-      inboundReturnLines,
-    };
-
     // TODO: error handling here
     // also need to consider what we do if the error was on the first page of the wizard
-    await insert(input);
+    if (!returnId) {
+      await insert({
+        id: FnUtils.generateUUID(),
+        customerId,
+        inboundReturnLines,
+      });
+    } else {
+      await updateLines({
+        inboundReturnId: returnId,
+        inboundReturnLines,
+      });
+    }
   };
 
   return { lines: draftLines, update, saveInboundReturn: save, addDraftLine };

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/useDraftInboundReturnLines.ts
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/useDraftInboundReturnLines.ts
@@ -44,13 +44,12 @@ export const useDraftInboundReturnLines = ({
       if (lines.length) {
         setDraftLines(lines);
       } else {
-        addPlaceholderLine();
+        addDraftLine();
       }
     }
   }, [item]);
 
-  // TODO: ew?
-  const addPlaceholderLine = () => {
+  const addDraftLine = () => {
     if (!item) return;
 
     setDraftLines(currLines => {
@@ -121,5 +120,5 @@ export const useDraftInboundReturnLines = ({
     await mutateAsync(input);
   };
 
-  return { lines: draftLines, update, saveInboundReturn };
+  return { lines: draftLines, update, saveInboundReturn, addDraftLine };
 };

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/useDraftInboundReturnLines.ts
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/useDraftInboundReturnLines.ts
@@ -32,7 +32,8 @@ export const useDraftInboundReturnLines = ({
     itemId
   );
 
-  const { mutateAsync } = useReturns.document.insertInboundReturn();
+  const { mutateAsync: insert } = useReturns.document.insertInboundReturn();
+  // const { mutateAsync: updateLines } = useReturns.lines.updateInboundLines();
 
   useEffect(() => {
     if (!draftLines.length) getLines();
@@ -84,7 +85,7 @@ export const useDraftInboundReturnLines = ({
     });
   };
 
-  const saveInboundReturn = async () => {
+  const save = async () => {
     const inboundReturnLines: InboundReturnLineInput[] = draftLines.map(
       ({
         id,
@@ -117,8 +118,8 @@ export const useDraftInboundReturnLines = ({
 
     // TODO: error handling here
     // also need to consider what we do if the error was on the first page of the wizard
-    await mutateAsync(input);
+    await insert(input);
   };
 
-  return { lines: draftLines, update, saveInboundReturn, addDraftLine };
+  return { lines: draftLines, update, saveInboundReturn: save, addDraftLine };
 };

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/useDraftInboundReturnLines.ts
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/useDraftInboundReturnLines.ts
@@ -8,16 +8,25 @@ import {
 } from '@openmsupply-client/common';
 import { useReturns } from '../../api';
 
-export const useDraftInboundReturnLines = (
-  outboundReturnLineIds: string[],
-  customerId: string
-) => {
+export const useDraftInboundReturnLines = ({
+  customerId,
+  outboundShipmentLineIds,
+  itemId,
+  returnId,
+}: {
+  outboundShipmentLineIds: string[];
+  customerId: string;
+  itemId?: string;
+  returnId?: string;
+}) => {
   const [draftLines, setDraftLines] = React.useState<
     GeneratedInboundReturnLineNode[]
   >([]);
 
   const { refetch } = useReturns.lines.generateInboundReturnLines(
-    outboundReturnLineIds
+    outboundShipmentLineIds,
+    returnId,
+    itemId
   );
 
   const { mutateAsync } = useReturns.document.insertInboundReturn();

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/useDraftInboundReturnLines.ts
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/useDraftInboundReturnLines.ts
@@ -125,5 +125,5 @@ export const useDraftInboundReturnLines = ({
     }
   };
 
-  return { lines: draftLines, update, saveInboundReturn: save, addDraftLine };
+  return { lines: draftLines, update, save, addDraftLine };
 };

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/useDraftInboundReturnLines.ts
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/useDraftInboundReturnLines.ts
@@ -63,10 +63,10 @@ export const useDraftInboundReturnLines = ({
           itemName: item.name,
           packSize: item.defaultPackSize,
           numberOfPacksReturned: 0,
-          reasonId: null,
           batch: null,
           expiryDate: null,
           note: null,
+          reasonId: null,
         },
       ];
     });

--- a/client/packages/invoices/src/Returns/modals/OutboundReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/OutboundReturn/ReturnQuantitiesTable.tsx
@@ -3,7 +3,7 @@ import {
   NumberInputCell,
   OutboundReturnLineNode,
   useColumns,
-} from 'packages/common/src';
+} from '@openmsupply-client/common';
 import React from 'react';
 
 export const QuantityToReturnTableComponent = ({

--- a/client/packages/invoices/src/Returns/modals/ReturnReasonsTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/ReturnReasonsTable.tsx
@@ -3,8 +3,8 @@ import {
   DataTable,
   TextInputCell,
   useColumns,
-} from 'packages/common/src';
-import { ReturnReasonSearchInput } from 'packages/system/src';
+} from '@openmsupply-client/common';
+import { ReturnReasonSearchInput } from '@openmsupply-client/system';
 import React from 'react';
 
 interface ReturnWithReason {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3189

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Implements the add by item/edit line version of the inbound return edit modal, and updates the table cells to be inputs:
![Screenshot 2024-03-15 at 2 36 23 PM](https://github.com/msupply-foundation/open-msupply/assets/55115239/7cbddafe-b74d-4f97-8eef-5fc5571b5818)


# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

- Add a new inbound return
- From the detail view, click Add Item
- Select an item
- [ ] A first draft line should appear
- [ ] Clicking `Add batch`, or using the `+` key, should add more lines
- [ ] You can input the line info
- Ok & Next, input reason/comment, OK
- [ ] The line is added to the return
- [ ] Clicking the line re-opens the modal
- [ ] You can update fields for that line
- [ ] Setting return quantity to 0 deletes the line

