### PR TITLE
3246 Vertical scroll in modals breaks the rounded corners

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
@@ -88,7 +88,7 @@ export const OutboundLineEditTable: React.FC<OutboundLineEditTableProps> = ({
   allocatedQuantity,
   batch,
   currency,
-  isExternalSupplier
+  isExternalSupplier,
 }) => {
   const t = useTranslation('distribution');
   const { orderedRows, placeholderRow } = useOutboundLineEditRows(
@@ -113,7 +113,7 @@ export const OutboundLineEditTable: React.FC<OutboundLineEditTableProps> = ({
     onChange: onEditStockLine,
     unit,
     currency,
-    isExternalSupplier
+    isExternalSupplier,
   });
 
   const additionalRows = [
@@ -131,6 +131,7 @@ export const OutboundLineEditTable: React.FC<OutboundLineEditTableProps> = ({
       <Divider margin={10} />
       <Box
         style={{
+          maxHeight: 400,
           display: 'flex',
           flexDirection: 'column',
           overflowX: 'hidden',

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
@@ -131,7 +131,7 @@ export const OutboundLineEditTable: React.FC<OutboundLineEditTableProps> = ({
       <Divider margin={10} />
       <Box
         style={{
-          maxHeight: 400,
+          maxHeight: 325,
           display: 'flex',
           flexDirection: 'column',
           overflowX: 'hidden',

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditTable.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditTable.tsx
@@ -118,7 +118,7 @@ export const PrescriptionLineEditTable: React.FC<
       <Divider margin={10} />
       <Box
         style={{
-          maxHeight: 350,
+          maxHeight: 300,
           display: 'flex',
           flexDirection: 'column',
           overflowX: 'hidden',

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditTable.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditTable.tsx
@@ -118,6 +118,7 @@ export const PrescriptionLineEditTable: React.FC<
       <Divider margin={10} />
       <Box
         style={{
+          maxHeight: 350,
           display: 'flex',
           flexDirection: 'column',
           overflowX: 'hidden',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3246

# 👩🏻‍💻 What does this PR do? 
Have vertical scroll on table instead of in whole modal.

https://github.com/msupply-foundation/open-msupply/assets/61820074/46ed0b76-54fe-4d3b-9066-67d0be2e45fb

# 🧪 How has/should this change been tested? 
- [ ] Have lots of batches for a single item ( 9+ batches )
- [ ] Go to `Outbound Shipment`
- [ ] Add item to invoice
- [ ] See vertical scroll on table and edges still round for modal