### PR TITLE
Handle long column labels in table headers

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -150,7 +150,7 @@
   "label.chargeCode": "Charge Code",
   "label.clear-filter": "Clear filter",
   "label.clear-selection": "Clear selection",
-  "label.click-to-sort": "Click to sort by this column",
+  "label.click-to-sort": "Click to sort by ",
   "label.client": "Client",
   "label.code": "Code",
   "label.collapse": "Collapse",

--- a/client/packages/common/src/intl/locales/en/inventory.json
+++ b/client/packages/common/src/intl/locales/en/inventory.json
@@ -37,7 +37,6 @@
   "label.pricing": "Pricing",
   "label.supplier": "Supplier",
   "label.to-expiry": "To expiry",
-  "label.location": "Location",
   "label.master-list": "Master List",
   "label.items-with-stock": "Items with Stock",
   "label.new": "New",

--- a/client/packages/common/src/intl/locales/en/replenishment.json
+++ b/client/packages/common/src/intl/locales/en/replenishment.json
@@ -33,7 +33,6 @@
   "label.draft": "Draft",
   "label.finalised": "Finalised",
   "label.hide-stock-over-minimum": "Hide stock over minimum",
-  "label.location": "Location",
   "label.max": "Max",
   "label.max-months-of-stock": "Target MOS",
   "label.min": "Min",

--- a/client/packages/common/src/intl/locales/es/inventory.json
+++ b/client/packages/common/src/intl/locales/es/inventory.json
@@ -2,7 +2,6 @@
   "label.finalised": "Finalizado",
   "heading.description": "Descripción",
   "label.batch": "Lote",
-  "label.location": "Ubicación",
   "label.suggested": "Sugerido",
   "label.supplier": "Proveedor",
   "placeholder.enter-an-item-code-or-name": "Ingrese el código o el nombre del artículo",

--- a/client/packages/common/src/intl/locales/es/replenishment.json
+++ b/client/packages/common/src/intl/locales/es/replenishment.json
@@ -1,6 +1,5 @@
 {
   "label.finalised": "Finalizado",
-  "label.location": "Ubicación",
   "label.new": "Nuevo",
   "messages.confirm-status-as": "¿Confirmar estado como $t({{status}})?",
   "messages.saved": "Guardado",

--- a/client/packages/common/src/intl/locales/fr/inventory.json
+++ b/client/packages/common/src/intl/locales/fr/inventory.json
@@ -52,7 +52,6 @@
   "error.provide-valid-reason": "La raison de l'ajustement de stock ne correspond pas à la direction de l'ajustement (positif ou négatif)",
   "error.reduced-below-zero": "Une ligne de stock existe dans une nouvelle livraison sortante. La quantité ne peut pas être en dessous de zéro.",
   "label.supplier": "Fournisseur",
-  "label.location": "Emplacement",
   "error.stocktake-has-stock-reduced-below-zero": "L'inventaire ne peut pas être finalisé car une partie du stock est utilisé dans une nouvelle livraison sortante.",
   "label.master-list": "Liste Maîtresse",
   "message.no-supplier": "Ajustement de stock",

--- a/client/packages/common/src/intl/locales/fr/replenishment.json
+++ b/client/packages/common/src/intl/locales/fr/replenishment.json
@@ -36,7 +36,6 @@
   "label.finalised": "Finalisé(e)",
   "label.group-by-item": "Grouper par article",
   "label.hide-stock-over-minimum": "Masquer articles supérieurs au minimum",
-  "label.location": "Emplacement",
   "label.max": "Max",
   "label.min": "Min",
   "label.moving-average": "Moy. Mob. (3mois)",

--- a/client/packages/common/src/intl/locales/pt/inventory.json
+++ b/client/packages/common/src/intl/locales/pt/inventory.json
@@ -28,7 +28,6 @@
   "label.cant-delete-disabled": "Só é possível excluir linhas se o status é Novo",
   "label.pricing": "Preços",
   "label.supplier": "Fornecedor",
-  "label.location": "Local",
   "label.master-list": "Lista Mestra",
   "label.items-with-stock": "Itens em Estoque",
   "message.no-supplier": "Ajuste de Inventário",

--- a/client/packages/common/src/intl/locales/pt/replenishment.json
+++ b/client/packages/common/src/intl/locales/pt/replenishment.json
@@ -27,7 +27,6 @@
   "info.manual-shipment": "Este envio foi criado manualmente. O status the entrega será automaticamente atualizado.",
   "label.consumption": "Consumo",
   "label.draft": "Rascunho",
-  "label.location": "Local",
   "label.hide-stock-over-minimum": "Ocultar estoque acima do mínimo",
   "label.max": "Máximo",
   "label.min": "Mínimo",

--- a/client/packages/common/src/intl/locales/ru/inventory.json
+++ b/client/packages/common/src/intl/locales/ru/inventory.json
@@ -5,7 +5,6 @@
   "error.stocktake-not-found": "Учёт не найден",
   "heading.description": "Описание",
   "label.add-new-line": "Добавить новую строку",
-  "label.location": "Локация",
   "label.new": "Новый",
   "error.no-stocktakes": "Нет Учётов для отображения.",
   "error.no-stocktake-items": "К этой инвентаризации не добавлено ни одного товара.",

--- a/client/packages/common/src/intl/locales/ru/replenishment.json
+++ b/client/packages/common/src/intl/locales/ru/replenishment.json
@@ -1,5 +1,4 @@
 {
-  "label.location": "Локация",
   "heading.tax": "Налог",
   "label.draft": "Черновик",
   "heading.are-you-sure": "Вы уверены?",

--- a/client/packages/common/src/intl/locales/tet/inventory.json
+++ b/client/packages/common/src/intl/locales/tet/inventory.json
@@ -53,7 +53,6 @@
   "messages.on-hold-stock-take": "Stocktake ida ne'e iha Hold hela no labele atu hadia",
   "stocktake.description-template": "Kria husi {{username}} iha {{date}}",
   "error.stocktake-has-stock-reduced-below-zero": "Stock take labele atu finaliza tamba stock sira ne'e balun utiliza ona iha remessas sasan sai nian.",
-  "label.location": "Lokalizasaun",
   "label.cant-delete-disabled": "Bele deit hamos linas wainhira nia estatus foun",
   "error.not-editable": "Stocktake labele atu hadia.",
   "error.is-locked": "Stocktake xave metin.",

--- a/client/packages/common/src/intl/locales/tet/replenishment.json
+++ b/client/packages/common/src/intl/locales/tet/replenishment.json
@@ -30,7 +30,6 @@
   "heading.total": "Total",
   "info.automatic-shipment": "Remessa ne'e kria Automatiku, tanba iha remessa Sasan Sai iha Store seluk. Ita labele hadia detaliu sira ne'e, antes estatus konfirmadu hanesan entrega tiha ona.",
   "label.add-batch": "Aumenta Lote",
-  "label.location": "Lokalizasaun",
   "info.manual-shipment": "Remessa ne'e kria ho manual. Status 'entrega tiha ona' sei la atualiza automatiku.",
   "label.consumption": "Konsumu",
   "label.draft": "Draf",

--- a/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -63,14 +63,23 @@ export const HeaderCell = <T extends RecordWithId>({
   );
 
   const showTooltip = !!description || sortable;
+  const columnLabel = column.label === '' ? '' : t(column.label);
   const tooltip = showTooltip ? (
     <>
       {!!description && <div>{t(description)}</div>}
-      {sortable && <div>{t('label.click-to-sort')}</div>}
+      {sortable ? (
+        <div>
+          {t('label.click-to-sort')}
+          {` ${columnLabel}`}
+        </div>
+      ) : (
+        columnLabel
+      )}
     </>
   ) : (
     ''
   );
+
   const infoIcon = !!description ? (
     <InfoOutlineIcon
       sx={{
@@ -84,9 +93,10 @@ export const HeaderCell = <T extends RecordWithId>({
   const child = (
     <div
       style={{
-        display: 'inline-flex',
         flexWrap: 'nowrap',
         alignItems: 'center',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
       }}
     >
       <Header column={column} />
@@ -100,6 +110,7 @@ export const HeaderCell = <T extends RecordWithId>({
       active={isSorted}
       direction={direction}
       IconComponent={SortDescIcon}
+      sx={{ maxWidth: maxWidth }}
     >
       {child}
     </TableSortLabel>

--- a/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -62,9 +62,8 @@ export const HeaderCell = <T extends RecordWithId>({
     150
   );
 
-  const showTooltip = !!description || sortable;
   const columnLabel = column.label === '' ? '' : t(column.label);
-  const tooltip = showTooltip ? (
+  const tooltip = (
     <>
       {!!description && <div>{t(description)}</div>}
       {sortable ? (
@@ -76,8 +75,6 @@ export const HeaderCell = <T extends RecordWithId>({
         columnLabel
       )}
     </>
-  ) : (
-    ''
   );
 
   const infoIcon = !!description ? (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3173 

# 👩🏻‍💻 What does this PR do? 
- Add an ellipsis to prevent label overflow
- Put the description in the header tooltip (to show the full label if the label is too long

![image](https://github.com/msupply-foundation/open-msupply/assets/88299195/2ed588fb-4102-4967-8780-e4e4fd8192e5)

# 🧪 How has/should this change been tested? 
Test as described in issue or set "label.location" to a long label