### PR TITLE
3269 remove service charge when adding from master list

### DIFF
--- a/server/repository/src/db_diesel/item.rs
+++ b/server/repository/src/db_diesel/item.rs
@@ -13,6 +13,7 @@ use diesel::{
     dsl::{IntoBoxed, LeftJoin},
     prelude::*,
 };
+use util::inline_init;
 
 use crate::{
     diesel_macros::{
@@ -247,6 +248,16 @@ impl Item {
         self.unit_row
             .as_ref()
             .map(|unit_row| unit_row.name.as_str())
+    }
+}
+
+impl ItemRowType {
+    pub fn equal_to(&self) -> EqualFilter<Self> {
+        inline_init(|r: &mut EqualFilter<Self>| r.equal_to = Some(self.clone()))
+    }
+
+    pub fn not_equal_to(&self) -> EqualFilter<Self> {
+        inline_init(|r: &mut EqualFilter<Self>| r.not_equal_to = Some(self.clone()))
     }
 }
 

--- a/server/repository/src/db_diesel/master_list_line.rs
+++ b/server/repository/src/db_diesel/master_list_line.rs
@@ -1,6 +1,6 @@
 use crate::{
     diesel_macros::apply_equal_filter, repository_error::RepositoryError, EqualFilter, ItemLinkRow,
-    ItemRow, Pagination,
+    ItemRow, ItemRowType, Pagination,
 };
 
 use super::{
@@ -29,6 +29,7 @@ pub struct MasterListLineFilter {
     pub id: Option<EqualFilter<String>>,
     pub item_id: Option<EqualFilter<String>>,
     pub master_list_id: Option<EqualFilter<String>>,
+    pub item_type: Option<EqualFilter<ItemRowType>>,
 }
 
 pub struct MasterListLineRepository<'a> {
@@ -101,6 +102,7 @@ fn create_filtered_query(
             f.master_list_id,
             master_list_line_dsl::master_list_id
         );
+        apply_equal_filter!(query, f.item_type, item_dsl::type_)
     }
 
     Ok(query)
@@ -120,6 +122,7 @@ impl MasterListLineFilter {
             id: None,
             item_id: None,
             master_list_id: None,
+            item_type: None,
         }
     }
 
@@ -135,6 +138,11 @@ impl MasterListLineFilter {
 
     pub fn master_list_id(mut self, filter: EqualFilter<String>) -> Self {
         self.master_list_id = Some(filter);
+        self
+    }
+
+    pub fn item_type(mut self, filter: EqualFilter<ItemRowType>) -> Self {
+        self.item_type = Some(filter);
         self
     }
 }

--- a/server/service/src/invoice/inbound_shipment/add_from_master_list.rs
+++ b/server/service/src/invoice/inbound_shipment/add_from_master_list.rs
@@ -3,7 +3,7 @@ use crate::invoice::common::{
 };
 use crate::invoice::{check_invoice_exists, common::check_master_list_for_store};
 use crate::service_provider::ServiceContext;
-use repository::EqualFilter;
+use repository::{EqualFilter, ItemRowType};
 use repository::{
     InvoiceLine, InvoiceLineFilter, InvoiceLineRepository, InvoiceLineRow,
     InvoiceLineRowRepository, InvoiceRow, InvoiceRowStatus, InvoiceRowType, MasterListLineFilter,
@@ -98,7 +98,8 @@ fn generate(
         .query_by_filter(
             MasterListLineFilter::new()
                 .master_list_id(EqualFilter::equal_to(&input.master_list_id))
-                .item_id(EqualFilter::not_equal_all(item_ids_in_invoice)),
+                .item_id(EqualFilter::not_equal_all(item_ids_in_invoice))
+                .item_type(ItemRowType::Stock.equal_to()),
         )?;
 
     let items_ids_not_in_invoice: Vec<String> = master_list_lines_not_in_invoice

--- a/server/service/src/invoice/outbound_shipment/add_from_master_list.rs
+++ b/server/service/src/invoice/outbound_shipment/add_from_master_list.rs
@@ -3,6 +3,7 @@ use crate::invoice::common::get_lines_for_invoice;
 use crate::invoice::common::AddToShipmentFromMasterListInput as ServiceInput;
 use crate::{invoice::check_invoice_exists, service_provider::ServiceContext};
 use repository::EqualFilter;
+use repository::ItemRowType;
 use repository::{
     InvoiceLine, InvoiceLineFilter, InvoiceLineRepository, InvoiceLineRow,
     InvoiceLineRowRepository, InvoiceRow, InvoiceRowStatus, InvoiceRowType, MasterListLineFilter,
@@ -104,7 +105,8 @@ fn generate(
         .query_by_filter(
             MasterListLineFilter::new()
                 .master_list_id(EqualFilter::equal_to(&input.master_list_id))
-                .item_id(EqualFilter::not_equal_all(item_ids_in_invoice)),
+                .item_id(EqualFilter::not_equal_all(item_ids_in_invoice))
+                .item_type(ItemRowType::Stock.equal_to()),
         )?;
 
     let items_ids_not_in_invoice: Vec<String> = master_list_lines_not_in_invoice

--- a/server/service/src/requisition/request_requisition/add_from_master_list.rs
+++ b/server/service/src/requisition/request_requisition/add_from_master_list.rs
@@ -2,13 +2,13 @@ use crate::{
     requisition::common::{check_requisition_row_exists, get_lines_for_requisition},
     service_provider::ServiceContext,
 };
-use repository::EqualFilter;
 use repository::{
     requisition_row::{RequisitionRow, RequisitionRowStatus, RequisitionRowType},
     MasterList, MasterListFilter, MasterListLineFilter, MasterListLineRepository,
     MasterListRepository, RepositoryError, RequisitionLine, RequisitionLineFilter,
     RequisitionLineRepository, RequisitionLineRow, RequisitionLineRowRepository, StorageConnection,
 };
+use repository::{EqualFilter, ItemRowType};
 
 use super::generate_requisition_lines;
 
@@ -102,7 +102,8 @@ fn generate(
         .query_by_filter(
             MasterListLineFilter::new()
                 .master_list_id(EqualFilter::equal_to(&input.master_list_id))
-                .item_id(EqualFilter::not_equal_all(item_ids_in_requisition)),
+                .item_id(EqualFilter::not_equal_all(item_ids_in_requisition))
+                .item_type(ItemRowType::Stock.equal_to()),
         )?;
 
     let items_ids_not_in_requisition: Vec<String> = master_list_lines_not_in_requisition

--- a/server/service/src/stocktake/insert.rs
+++ b/server/service/src/stocktake/insert.rs
@@ -1,9 +1,10 @@
 use chrono::{NaiveDate, Utc};
 use repository::{
-    ActivityLogType, EqualFilter, MasterListFilter, MasterListLineFilter, MasterListLineRepository,
-    MasterListRepository, NumberRowType, RepositoryError, StockLineFilter, StockLineRepository,
-    StockLineRow, Stocktake, StocktakeFilter, StocktakeLineRow, StocktakeLineRowRepository,
-    StocktakeRepository, StocktakeRow, StocktakeRowRepository, StocktakeStatus, StorageConnection,
+    ActivityLogType, EqualFilter, ItemRowType, MasterListFilter, MasterListLineFilter,
+    MasterListLineRepository, MasterListRepository, NumberRowType, RepositoryError,
+    StockLineFilter, StockLineRepository, StockLineRow, Stocktake, StocktakeFilter,
+    StocktakeLineRow, StocktakeLineRowRepository, StocktakeRepository, StocktakeRow,
+    StocktakeRowRepository, StocktakeStatus, StorageConnection,
 };
 use util::uuid::uuid;
 
@@ -157,7 +158,9 @@ fn generate_lines_from_master_list(
 ) -> Result<Vec<StocktakeLineRow>, RepositoryError> {
     let item_ids: Vec<String> = MasterListLineRepository::new(&connection)
         .query_by_filter(
-            MasterListLineFilter::new().master_list_id(EqualFilter::equal_to(&master_list_id)),
+            MasterListLineFilter::new()
+                .master_list_id(EqualFilter::equal_to(&master_list_id))
+                .item_type(ItemRowType::Stock.equal_to()),
         )?
         .into_iter()
         .map(|r| r.item_id)


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3269

# 👩🏻‍💻 What does this PR do? 
Removes service items when adding from Master List.

# 🧪 How has/should this change been tested? 
- [ ] Have some service charges in `Master List`
- [ ] Go to anywhere that has an `Add from Master List button` (Inbound, Outbound, Internal Order or Master List
- [ ] Add from `Master List` 
- [ ] Shouldn't see any service items

## 💌 Any notes for the reviewer?
Quick fix until Service Charge KDD done and we decide what to do with service charges.