### PR TITLE
Use a TooltipTextCell to display batch columns

### DIFF
--- a/client/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
+++ b/client/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
@@ -3,7 +3,7 @@ import { ColumnAlign, ColumnFormat } from '../columns/types';
 import { Formatter } from '@common/utils';
 import { RecordWithId } from '@common/types';
 import { ColumnDefinition } from '../columns/types';
-import { CurrencyCell, NumberCell } from '../components';
+import { CurrencyCell, NumberCell, TooltipTextCell } from '../components';
 
 const createColumn = <T extends RecordWithId>(
   column: ColumnDefinition<T>
@@ -191,6 +191,7 @@ const getColumnLookup = <T extends RecordWithId>(): Record<
     label: 'label.batch',
     key: 'batch',
     width: 100,
+    Cell: TooltipTextCell,
   },
   costPricePerPack: {
     label: 'label.cost',


### PR DESCRIPTION
Fixes #3174 

Without increasing the column width `TooltipTextCell` can display up to 8 char. Plus there is a tooltip now:

![image](https://github.com/msupply-foundation/open-msupply/assets/88299195/a8d92708-6e05-4dc2-8874-da2f7f5f9540)

Note, I made a comment regarding padding:
https://github.com/msupply-foundation/open-msupply/issues/3174#issuecomment-2002643639
TooltipTextCell doesn't have this padding for which reason I kept the column width.

Also should we use TooltipTextCell as a default? Probably other columns suffer the same problem?
