### PR TITLE
Hide the report printing frame to prevent it from being rendered

### DIFF
--- a/client/packages/system/src/Report/api/hooks/utils/usePrintReport.ts
+++ b/client/packages/system/src/Report/api/hooks/utils/usePrintReport.ts
@@ -40,7 +40,7 @@ const printPage = (url: string) => {
       Printer.print({ content: html });
     } else {
       const frame = document.createElement('iframe');
-
+      frame.hidden = true;
       frame.onload = () => {
         if (frame.contentDocument)
           frame.contentDocument.documentElement.innerHTML = html;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3328 

# 👩🏻‍💻 What does this PR do? 
The report iframe was suddenly displayed in the bottom left corner (firefox and chrome) even though I haven't seen this before.

Hiding the frame fixes the issue while still renders the report correctly.

# 🧪 How has/should this change been tested? 
Test if reports are still showing correctly.