### PR TITLE
Implement master_list_line try_translate_pull_delete

### DIFF
--- a/server/service/src/sync/test/mod.rs
+++ b/server/service/src/sync/test/mod.rs
@@ -345,6 +345,9 @@ pub(crate) async fn check_records_against_database(
             ProgramRequisitionSettings => {
                 check_delete_record_by_id!(ProgramRequisitionSettingsRowRepository, con, id)
             }
+            MasterListLine => {
+                check_delete_record_by_id_option!(MasterListLineRowRepository, con, id)
+            }
             MasterListNameJoin => {
                 check_delete_record_by_id_option!(MasterListNameJoinRepository, con, id)
             }

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -275,6 +275,7 @@ impl PullDeleteRecord {
             ProgramRequisitionSettings => {
                 ProgramRequisitionSettingsRowRepository::new(con).delete(id)
             }
+            MasterListLine => MasterListLineRowRepository::new(con).delete(id),
             MasterListNameJoin => MasterListNameJoinRepository::new(con).delete(id),
             Report => ReportRowRepository::new(con).delete(id),
             NameStoreJoin => NameStoreJoinRepository::new(con).delete(id),

--- a/server/service/src/sync/translations/master_list_line.rs
+++ b/server/service/src/sync/translations/master_list_line.rs
@@ -3,7 +3,8 @@ use repository::{MasterListLineRow, StorageConnection, SyncBufferRow};
 use serde::Deserialize;
 
 use super::{
-    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
+    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullDependency, PullUpsertRecord,
+    SyncTranslation,
 };
 
 #[allow(non_snake_case)]
@@ -24,6 +25,21 @@ impl SyncTranslation for MasterListLineTranslation {
             table: LegacyTableName::LIST_MASTER_LINE,
             dependencies: vec![LegacyTableName::ITEM, LegacyTableName::LIST_MASTER],
         }
+    }
+
+    fn try_translate_pull_delete(
+        &self,
+        _: &StorageConnection,
+        sync_record: &SyncBufferRow,
+    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
+        let result = match_pull_table(sync_record).then(|| {
+            IntegrationRecords::from_delete(
+                &sync_record.record_id,
+                PullDeleteRecordTable::MasterListLine,
+            )
+        });
+
+        Ok(result)
     }
 
     fn try_translate_pull_upsert(

--- a/server/service/src/sync/translations/mod.rs
+++ b/server/service/src/sync/translations/mod.rs
@@ -231,6 +231,7 @@ pub(crate) enum PullDeleteRecordTable {
     Store,
     ProgramRequisitionSettings,
     ProgramRequisitionOrderType,
+    MasterListLine,
     MasterListNameJoin,
     Report,
     InventoryAdjustmentReason,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3306

# 👩🏻‍💻 What does this PR do? 
Adds support to delete master_list_lines. The delete request were coming from the central server but weren't handled by omSupply.

# 🧪 How has/should this change been tested? 
See issue on how to reproduce the bug