### PR TITLE
3326 qty available for return should include amount already in return

### DIFF
--- a/server/graphql/types/src/types/outbound_return_line.rs
+++ b/server/graphql/types/src/types/outbound_return_line.rs
@@ -83,9 +83,7 @@ impl OutboundReturnLineNode {
     }
 
     pub async fn available_number_of_packs(&self) -> f64 {
-        // Quantity available for return should include the number of packs already in the return
-        // (Available stock is reduced as soon as it is added to a return)
-        self.stock_line_row().available_number_of_packs + self.return_line.number_of_packs
+        self.return_line.available_number_of_packs
     }
 
     pub async fn pack_size(&self) -> &i32 {

--- a/server/graphql/types/src/types/outbound_return_line.rs
+++ b/server/graphql/types/src/types/outbound_return_line.rs
@@ -82,8 +82,10 @@ impl OutboundReturnLineNode {
         &self.stock_line_row().expiry_date
     }
 
-    pub async fn available_number_of_packs(&self) -> &f64 {
-        &self.stock_line_row().available_number_of_packs
+    pub async fn available_number_of_packs(&self) -> f64 {
+        // Quantity available for return should include the number of packs already in the return
+        // (Available stock is reduced as soon as it is added to a return)
+        self.stock_line_row().available_number_of_packs + self.return_line.number_of_packs
     }
 
     pub async fn pack_size(&self) -> &i32 {

--- a/server/service/src/invoice/outbound_return/generate_outbound_return_lines.rs
+++ b/server/service/src/invoice/outbound_return/generate_outbound_return_lines.rs
@@ -11,6 +11,7 @@ pub struct OutboundReturnLine {
     pub reason_id: Option<String>,
     pub note: Option<String>,
     pub number_of_packs: f64,
+    pub available_number_of_packs: f64,
     pub stock_line: StockLine,
 }
 
@@ -169,6 +170,7 @@ fn outbound_line_from_stock_line_and_invoice_line(
             reason_id: None,
             note: None,
             number_of_packs: 0.0,
+            available_number_of_packs: stock_line.stock_line_row.available_number_of_packs,
             stock_line,
         };
     };
@@ -181,11 +183,17 @@ fn outbound_line_from_stock_line_and_invoice_line(
         ..
     } = invoice_line.invoice_line_row;
 
+    // Quantity available for return should include the number of packs already in the return
+    // (Available stock is reduced as soon as it is added to a return)
+    let number_of_packs_available_to_return =
+        stock_line.stock_line_row.available_number_of_packs + number_of_packs;
+
     return OutboundReturnLine {
         id,
         note,
         number_of_packs,
         reason_id: return_reason_id,
+        available_number_of_packs: number_of_packs_available_to_return,
         stock_line,
     };
 }

--- a/server/service/src/invoice/outbound_return/generate_outbound_return_lines.rs
+++ b/server/service/src/invoice/outbound_return/generate_outbound_return_lines.rs
@@ -354,6 +354,16 @@ mod test {
             .unwrap();
 
         assert_eq!(result.count, 2);
+
+        let return_line_for_stock_line_a = result
+            .rows
+            .iter()
+            .find(|line| line.stock_line.stock_line_row.id == mock_stock_line_a().id)
+            .unwrap();
+
+        assert_eq!(return_line_for_stock_line_a.number_of_packs, 0.0);
+        assert_eq!(return_line_for_stock_line_a.available_number_of_packs, 30.0);
+        // available on stock_line_a
     }
 
     #[actix_rt::test]
@@ -541,14 +551,13 @@ mod test {
             existing_line.stock_line.stock_line_row.id,
             unavailable_stock_line().id
         );
-        assert_eq!(existing_line.number_of_packs, 1.0);
         assert_eq!(existing_line.note, item_a_return_line().note);
+        assert_eq!(existing_line.number_of_packs, 1.0);
+        assert_eq!(existing_line.available_number_of_packs, 1.0); // num of packs in stock line (0.0) + num of packs in return (1.0)
 
         assert!(result.rows.iter().all(|line| {
-            // except for the line that is already in the return
-            line.stock_line.stock_line_row.id == unavailable_stock_line().id
-                // all lines have available packs
-                || line.stock_line.stock_line_row.available_number_of_packs > 0.0
+            // all lines have available packs (even if no further available stock, packs already included in the return are counted as available here)
+            line.available_number_of_packs > 0.0
         }));
     }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3326 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Includes the quantity already in the return in the available qty for return.

Adding new item:
![Screenshot 2024-03-20 at 3 21 43 PM](https://github.com/msupply-foundation/open-msupply/assets/55115239/daf852e9-7e34-48b4-8dea-98c91f4d24d5)

Set value to 5:
![Screenshot 2024-03-20 at 3 21 50 PM](https://github.com/msupply-foundation/open-msupply/assets/55115239/88ff5bde-4858-428e-9136-53d2386e65ab)

Save. Click row to re-open modal, available to return is still 10:
![Screenshot 2024-03-20 at 3 21 50 PM](https://github.com/msupply-foundation/open-msupply/assets/55115239/88ff5bde-4858-428e-9136-53d2386e65ab)


