### PR TITLE
Add rusttls to workspace features to fix graphql tests

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -4,7 +4,7 @@ strip = true
 [workspace.dependencies]
 # dependencies used in graphql crates:
 actix-web = { version = "4.0.1", default-features = false, features = [
-  "macros",
+  "macros","rustls"
 ] }
 anymap = "0.12"
 async-graphql = { version = "3.0.35", features = ["dataloader", "chrono"] }

--- a/server/cli/Cargo.toml
+++ b/server/cli/Cargo.toml
@@ -20,7 +20,7 @@ server = { path = "../server" }
 graphql = { path = "../graphql" }
 
 anyhow.workspace = true
-async-graphql = "3.0.35"
+async-graphql = { workspace = true }
 clap = { version = "3.1.8", features = ["derive"] }
 chrono = { version = "0.4.23" }
 diesel = { version = "1.4.7", default-features = false, features = ["chrono"] }

--- a/server/graphql/plugin/Cargo.toml
+++ b/server/graphql/plugin/Cargo.toml
@@ -14,13 +14,11 @@ graphql_core = { path = "../core" }
 graphql_general = { path = "../general" }
 graphql_types = { path = "../types" }
 
-actix-web = { version = "4.0.1", default-features = false, features = [
-    "macros",
-] }
+actix-web = { workspace = true }
 anymap = "0.12"
 async-std = "1.9.0"
 async-graphql = { version = "3.0.35", features = ["dataloader", "chrono"] }
-async-graphql-actix-web = "3.0.35"
+async-graphql-actix-web = { workspace = true }
 async-trait = "0.1.30"
 chrono = { version = "0.4", features = ["serde"] }
 reqwest = { workspace = true }

--- a/server/graphql/programs/Cargo.toml
+++ b/server/graphql/programs/Cargo.toml
@@ -16,11 +16,10 @@ graphql_general = { path = "../general" }
 graphql_types = { path = "../types" }
 
 async-std = { workspace = true }
-
-actix-web = { version = "4.0.1", default-features = false, features = ["macros"] }
+actix-web = { workspace = true }
 anymap = "0.12"
-async-graphql = { version = "3.0.35", features = ["dataloader", "chrono"] }
-async-graphql-actix-web = "3.0.35"
+async-graphql = { workspace = true }
+async-graphql-actix-web = { workspace = true }
 async-trait = "0.1.30"
 chrono = { version = "0.4", features = ["serde"] }
 reqwest = { workspace = true } 

--- a/server/graphql/sensor/Cargo.toml
+++ b/server/graphql/sensor/Cargo.toml
@@ -15,7 +15,7 @@ util = { path = "../../util" }
 graphql_core = { path = "../core" }
 graphql_types = { path = "../types" }
 
-actix-web = { workspace = true }
+actix-web = { version = "4.0.1", features = ["rustls"] }
 anymap= { workspace = true }
 async-graphql = { workspace = true }
 async-graphql-actix-web = { workspace = true }

--- a/server/graphql/sensor/Cargo.toml
+++ b/server/graphql/sensor/Cargo.toml
@@ -15,8 +15,8 @@ util = { path = "../../util" }
 graphql_core = { path = "../core" }
 graphql_types = { path = "../types" }
 
-actix-web = { version = "4.0.1", features = ["rustls"] }
-anymap= { workspace = true }
+actix-web = { workspace = true }
+anymap = { workspace = true }
 async-graphql = { workspace = true }
 async-graphql-actix-web = { workspace = true }
 async-trait = { workspace = true }

--- a/server/service/Cargo.toml
+++ b/server/service/Cargo.toml
@@ -49,7 +49,7 @@ x509-parser = { version = "0.15", features = ["verify"] }
 actix-rt = "2.6.0"
 assert-json-diff = "2.0.1"
 httpmock = "0.6.6"
-actix-web = { version = "4.0.1" }
+actix-web = { workspace = true }
 tokio = { version = "1.21.1", features = ["macros", "rt-multi-thread", "time"] }
 
 [features]


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3340 

# 👩🏻‍💻 What does this PR do? 
You can run graphql test!

# 🧪 How has/should this change been tested? 
Needs testing on Android in case something broke with the changes?

## 💌 Any notes for the reviewer?
Weirdly rust is building a newer version of `async-graphql-actix-web` than we specify in our workspace. 
Seems like this version only works if rusttls is included?

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_