### PR TITLE
911 show created date in the detail panel for invoice, requisition, stocktake windows

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/SidePanel.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/SidePanel.tsx
@@ -15,6 +15,7 @@ import {
   InfoTooltipIcon,
   DeleteIcon,
   useDeleteConfirmation,
+  useFormatDateTime,
 } from '@openmsupply-client/common';
 import { useStocktake } from '../api';
 import { canDeleteStocktake } from '../../utils';
@@ -22,12 +23,11 @@ import { canDeleteStocktake } from '../../utils';
 const AdditionalInfoSection: FC = () => {
   const t = useTranslation();
 
-  const { comment, user, update } = useStocktake.document.fields([
-    'comment',
-    'user',
-  ]);
+  const { comment, user, createdDatetime, update } =
+    useStocktake.document.fields(['comment', 'user', 'createdDatetime']);
   const [bufferedComment, setBufferedComment] = useBufferState(comment ?? '');
   const isDisabled = useStocktake.utils.isDisabled();
+  const { localisedDate } = useFormatDateTime();
 
   return (
     <DetailPanelSection title={t('heading.additional-info')}>
@@ -36,6 +36,10 @@ const AdditionalInfoSection: FC = () => {
           <PanelLabel>{t('label.entered-by')}</PanelLabel>
           <PanelField>{user?.username}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user.email} /> : null}
+        </PanelRow>
+        <PanelRow>
+          <PanelLabel>{t('label.entered')}</PanelLabel>
+          <PanelField>{localisedDate(createdDatetime)}</PanelField>
         </PanelRow>
 
         <PanelLabel>{t('heading.comment')}</PanelLabel>

--- a/client/packages/inventory/src/Stocktake/ListView/ListView.tsx
+++ b/client/packages/inventory/src/Stocktake/ListView/ListView.tsx
@@ -11,6 +11,7 @@ import {
   useToggle,
   NothingHere,
   useUrlQueryParams,
+  ColumnFormat,
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
@@ -53,7 +54,7 @@ export const StocktakeListView: FC = () => {
         },
       ],
       ['description', { sortable: false }],
-      'createdDatetime',
+      ['createdDatetime', { format: ColumnFormat.Date }],
       ['stocktakeDate', { sortable: false }],
       ['comment', { sortable: false }],
       'selection',

--- a/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/AdditionalInfoSection.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/AdditionalInfoSection.tsx
@@ -10,18 +10,22 @@ import {
   ColorSelectButton,
   useBufferState,
   InfoTooltipIcon,
+  useFormatDateTime,
 } from '@openmsupply-client/common';
 import { useInbound } from '../../api';
 
 export const AdditionalInfoSectionComponent = () => {
-  const { user, comment, colour, update } = useInbound.document.fields([
-    'comment',
-    'colour',
-    'user',
-  ]);
+  const { user, comment, colour, createdDatetime, update } =
+    useInbound.document.fields([
+      'comment',
+      'colour',
+      'user',
+      'createdDatetime',
+    ]);
   const isDisabled = useInbound.utils.isDisabled();
   const t = useTranslation(['common', 'replenishment']);
   const [bufferedColor, setBufferedColor] = useBufferState(colour);
+  const { localisedDate } = useFormatDateTime();
 
   return (
     <DetailPanelSection title={t('heading.additional-info')}>
@@ -31,7 +35,10 @@ export const AdditionalInfoSectionComponent = () => {
           <PanelField>{user?.username}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user?.email} /> : null}
         </PanelRow>
-
+        <PanelRow>
+          <PanelLabel>{t('label.entered')}</PanelLabel>
+          <PanelField>{localisedDate(createdDatetime)}</PanelField>
+        </PanelRow>
         <PanelRow>
           <PanelLabel>{t('label.color')}</PanelLabel>
           <PanelField>

--- a/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/AdditionalInfoSection.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/AdditionalInfoSection.tsx
@@ -10,19 +10,23 @@ import {
   ColorSelectButton,
   useBufferState,
   InfoTooltipIcon,
+  useFormatDateTime,
 } from '@openmsupply-client/common';
 import { useOutbound } from '../../api';
 
 export const AdditionalInfoSectionComponent: FC = () => {
   const t = useTranslation('distribution');
   const isDisabled = useOutbound.utils.isDisabled();
-  const { colour, comment, user, update } = useOutbound.document.fields([
-    'colour',
-    'comment',
-    'user',
-  ]);
+  const { colour, comment, user, createdDatetime, update } =
+    useOutbound.document.fields([
+      'colour',
+      'comment',
+      'user',
+      'createdDatetime',
+    ]);
   const [colorBuffer, setColorBuffer] = useBufferState(colour);
   const [commentBuffer, setCommentBuffer] = useBufferState(comment ?? '');
+  const { localisedDate } = useFormatDateTime();
 
   return (
     <DetailPanelSection title={t('heading.additional-info')}>
@@ -32,7 +36,10 @@ export const AdditionalInfoSectionComponent: FC = () => {
           <PanelField>{user?.username}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user?.email} /> : null}
         </PanelRow>
-
+        <PanelRow>
+          <PanelLabel>{t('label.entered')}</PanelLabel>
+          <PanelField>{localisedDate(createdDatetime)}</PanelField>
+        </PanelRow>
         <PanelRow>
           <PanelLabel>{t('label.color')}</PanelLabel>
           <PanelField>

--- a/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/AdditionalInfoSection.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/AdditionalInfoSection.tsx
@@ -10,19 +10,23 @@ import {
   ColorSelectButton,
   useBufferState,
   InfoTooltipIcon,
+  useFormatDateTime,
 } from '@openmsupply-client/common';
 import { usePrescription } from '../../api';
 
 export const AdditionalInfoSectionComponent: FC = () => {
   const t = useTranslation('dispensary');
   const isDisabled = usePrescription.utils.isDisabled();
-  const { colour, comment, user, update } = usePrescription.document.fields([
-    'colour',
-    'comment',
-    'user',
-  ]);
+  const { colour, comment, user, createdDatetime, update } =
+    usePrescription.document.fields([
+      'colour',
+      'comment',
+      'user',
+      'createdDatetime',
+    ]);
   const [colorBuffer, setColorBuffer] = useBufferState(colour);
   const [commentBuffer, setCommentBuffer] = useBufferState(comment ?? '');
+  const { localisedDate } = useFormatDateTime();
 
   return (
     <DetailPanelSection title={t('heading.additional-info')}>
@@ -32,7 +36,10 @@ export const AdditionalInfoSectionComponent: FC = () => {
           <PanelField>{user?.username}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user?.email} /> : null}
         </PanelRow>
-
+        <PanelRow>
+          <PanelLabel>{t('label.entered')}</PanelLabel>
+          <PanelField>{localisedDate(createdDatetime)}</PanelField>
+        </PanelRow>
         <PanelRow>
           <PanelLabel>{t('label.color')}</PanelLabel>
           <PanelField>

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/AdditionalInfoSection.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/AdditionalInfoSection.tsx
@@ -10,17 +10,21 @@ import {
   useBufferState,
   BufferedTextArea,
   InfoTooltipIcon,
+  useFormatDateTime,
 } from '@openmsupply-client/common';
 import { useResponse } from '../api';
 
 export const AdditionalInfoSection: FC = () => {
   const isDisabled = useResponse.utils.isDisabled();
-  const { user, colour, comment, update } = useResponse.document.fields([
-    'colour',
-    'comment',
-    'user',
-  ]);
+  const { user, colour, comment, createdDatetime, update } =
+    useResponse.document.fields([
+      'colour',
+      'comment',
+      'user',
+      'createdDatetime',
+    ]);
   const [bufferedColor, setBufferedColor] = useBufferState(colour);
+  const { localisedDate } = useFormatDateTime();
   const t = useTranslation('distribution');
 
   return (
@@ -30,6 +34,10 @@ export const AdditionalInfoSection: FC = () => {
           <PanelLabel>{t('label.edited-by')}</PanelLabel>
           <PanelField>{user?.username}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user?.email} /> : null}
+        </PanelRow>
+        <PanelRow>
+          <PanelLabel>{t('label.entered')}</PanelLabel>
+          <PanelField>{localisedDate(createdDatetime)}</PanelField>
         </PanelRow>
         <PanelRow>
           <PanelLabel>{t('label.color')}</PanelLabel>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #911

# 👩🏻‍💻 What does this PR do? 
Add created datetime to the side panel and also localise the stocktake list view created datetime for consistency.

# 🧪 How has/should this change been tested? 
- [ ] Go to these views: Outbound Shipment, Inbound Shipment, Requisition, Stocktake, Prescription
- [ ] Go to side panel
- [ ] See created datetime

## 💌 Any notes for the reviewer?
I've noticed that some datetimes throughout the app might not be localised and have created an issue here to fix it... #3357. Currently the tooltip stocktake date is different from the created datetime since its not localised... probably also want to discuss if we want this enabled some time since stocktake date can differ from created datetime