### PR TITLE
Allow outbound shipments to be deleted until picked

### DIFF
--- a/client/packages/invoices/src/utils.ts
+++ b/client/packages/invoices/src/utils.ts
@@ -194,7 +194,8 @@ export const inboundLinesToSummaryItems = (
 };
 export const canDeleteInvoice = (invoice: OutboundRowFragment): boolean =>
   invoice.status === InvoiceNodeStatus.New ||
-  invoice.status === InvoiceNodeStatus.Allocated;
+  invoice.status === InvoiceNodeStatus.Allocated ||
+  invoice.status === InvoiceNodeStatus.Picked;
 
 export const canDeletePrescription = (
   invoice: PrescriptionRowFragment


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3363

# 👩🏻‍💻 What does this PR do? 
Consolidate frontend and backend logic for outbound shipment deletion. Have allowed deletion until status is `Picked` since stock does get added back on.

# 🧪 How has/should this change been tested? 
- [ ] Create an `Outbound Shipment`
- [ ] Set some lines
- [ ] Change to `Picked`
- [ ] Delete invoice
- [ ] Go to `Stock`
- [ ] See stock added back on

## 📃 Documentation
Have updated docs to match