### PR TITLE
3361 master list

### DIFF
--- a/client/packages/system/src/MasterList/api/api.ts
+++ b/client/packages/system/src/MasterList/api/api.ts
@@ -30,7 +30,7 @@ export const getMasterListQueries = (sdk: Sdk, storeId: string) => ({
         offset,
         key,
         desc,
-        filter: { ...filterBy, existsForStoreId: { equalTo: storeId } },
+        filter: filterBy,
         storeId,
       });
       return result?.masterLists;

--- a/server/graphql/general/src/queries/master_list.rs
+++ b/server/graphql/general/src/queries/master_list.rs
@@ -109,7 +109,7 @@ pub fn master_lists(
     )?;
 
     let service_provider = ctx.service_provider();
-    let service_context = service_provider.context(store_id, user.user_id)?;
+    let service_context = service_provider.context(store_id.clone(), user.user_id)?;
 
     let mut query_filter = MasterListFilter::new();
     if let Some(filter_input) = filter {
@@ -120,6 +120,7 @@ pub fn master_lists(
         .master_list_service
         .get_master_lists(
             &service_context,
+            &store_id,
             page.map(PaginationOption::from),
             Some(query_filter),
             // Currently only one sort option is supported, use the first from the list.

--- a/server/graphql/general/src/queries/tests/master_lists.rs
+++ b/server/graphql/general/src/queries/tests/master_lists.rs
@@ -31,6 +31,7 @@ mod graphql {
         fn get_master_lists(
             &self,
             _: &ServiceContext,
+            _: &str,
             pagination: Option<PaginationOption>,
             filter: Option<MasterListFilter>,
             sort: Option<MasterListSort>,

--- a/server/repository/src/db_diesel/master_list.rs
+++ b/server/repository/src/db_diesel/master_list.rs
@@ -25,7 +25,7 @@ pub struct MasterListRepository<'a> {
     connection: &'a StorageConnection,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct MasterListFilter {
     pub id: Option<EqualFilter<String>>,
     pub name: Option<StringFilter>,

--- a/server/repository/src/mock/full_master_list.rs
+++ b/server/repository/src/mock/full_master_list.rs
@@ -44,7 +44,7 @@ pub fn mock_master_list_master_list_filter_test() -> FullMockMasterList {
         joins: vec![MasterListNameJoinRow {
             id: "master_list_filter_test".to_owned(),
             master_list_id: "master_list_filter_test".to_owned(),
-            name_link_id: "id_master_list_filter_test".to_owned(),
+            name_link_id: "name_store_a".to_owned(),
         }],
         lines: Vec::new(),
     }

--- a/server/service/src/master_list/mod.rs
+++ b/server/service/src/master_list/mod.rs
@@ -11,11 +11,12 @@ pub trait MasterListServiceTrait: Sync + Send {
     fn get_master_lists(
         &self,
         ctx: &ServiceContext,
+        store_id: &str,
         pagination: Option<PaginationOption>,
         filter: Option<MasterListFilter>,
         sort: Option<MasterListSort>,
     ) -> Result<ListResult<MasterList>, ListError> {
-        get_master_lists(ctx, pagination, filter, sort)
+        get_master_lists(ctx, store_id, pagination, filter, sort)
     }
 }
 

--- a/server/service/src/master_list/query.rs
+++ b/server/service/src/master_list/query.rs
@@ -1,4 +1,4 @@
-use repository::PaginationOption;
+use repository::{EqualFilter, PaginationOption};
 use repository::{MasterList, MasterListFilter, MasterListRepository, MasterListSort};
 
 use crate::{
@@ -10,6 +10,7 @@ pub const MIN_LIMIT: u32 = 1;
 
 pub fn get_master_lists(
     ctx: &ServiceContext,
+    store_id: &str,
     pagination: Option<PaginationOption>,
     filter: Option<MasterListFilter>,
     sort: Option<MasterListSort>,
@@ -17,8 +18,12 @@ pub fn get_master_lists(
     let pagination = get_default_pagination(pagination, MAX_LIMIT, MIN_LIMIT)?;
     let repository = MasterListRepository::new(&ctx.connection);
 
+    let filter = filter
+        .unwrap_or_default()
+        .exists_for_store_id(EqualFilter::equal_to(store_id));
+
     Ok(ListResult {
-        rows: repository.query(pagination, filter.clone(), sort)?,
-        count: i64_to_u32(repository.count(filter)?),
+        rows: repository.query(pagination, Some(filter.clone()), sort)?,
+        count: i64_to_u32(repository.count(Some(filter))?),
     })
 }

--- a/server/service/src/master_list/tests/query.rs
+++ b/server/service/src/master_list/tests/query.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod query {
+    use repository::mock::mock_store_a;
     use repository::{mock::MockDataInserts, test_db::setup_all, MasterListFilter};
     use repository::{EqualFilter, StringFilter};
 
@@ -11,38 +12,39 @@ mod query {
             setup_all("test_master_list_filter", MockDataInserts::all()).await;
 
         let service_provider = ServiceProvider::new(connection_manager, "app_data");
-        let context = service_provider.basic_context().unwrap();
+        let context = service_provider
+            .context(mock_store_a().id, "".to_string())
+            .unwrap();
         let service = service_provider.master_list_service;
 
         let result = service
             .get_master_lists(
                 &context,
+                &context.store_id,
                 None,
                 Some(
                     MasterListFilter::new()
-                        .exists_for_name_id(EqualFilter::equal_to("id_master_list_filter_test")),
+                        .exists_for_name_id(EqualFilter::equal_to("name_store_a")),
                 ),
                 None,
             )
             .unwrap();
 
-        assert_eq!(result.count, 1);
-        assert_eq!(result.rows[0].id, "master_list_filter_test");
+        assert_eq!(result.count, 2);
+        assert_eq!(result.rows[0].id, "item_query_test1");
 
         let result = service
             .get_master_lists(
                 &context,
+                &context.store_id,
                 None,
-                Some(
-                    MasterListFilter::new()
-                        .exists_for_name(StringFilter::like("e_master_list_filter_te")),
-                ),
+                Some(MasterListFilter::new().exists_for_name(StringFilter::like("Store A"))),
                 None,
             )
             .unwrap();
 
-        let master_list_row = result.rows[0].clone();
-        assert_eq!(result.count, 1);
+        let master_list_row = result.rows[1].clone();
+        assert_eq!(result.count, 2);
         assert_eq!(master_list_row.id, "master_list_filter_test");
         assert_eq!(master_list_row.name, "name_master_list_filter_test");
 
@@ -50,25 +52,12 @@ mod query {
         let result = service
             .get_master_lists(
                 &context,
+                &context.store_id,
                 None,
                 Some(MasterListFilter::new().exists_for_store_id(EqualFilter::equal_to("store_a"))),
                 None,
             )
             .unwrap();
         assert!(result.count >= 1);
-
-        //Test filter for non existent store finds nothing
-        let result = service
-            .get_master_lists(
-                &context,
-                None,
-                Some(
-                    MasterListFilter::new()
-                        .exists_for_store_id(EqualFilter::equal_to("not_a_real_store")),
-                ),
-                None,
-            )
-            .unwrap();
-        assert_eq!(result.count, 0);
     }
 }

--- a/server/service/src/stocktake/insert.rs
+++ b/server/service/src/stocktake/insert.rs
@@ -517,7 +517,7 @@ mod test {
                 stocktake_date: Some(NaiveDate::from_ymd_opt(2020, 01, 02).unwrap()),
                 is_locked: Some(true),
                 location: None,
-                master_list_id: Some("master_list_filter_test".to_string()),
+                master_list_id: Some("invalid_master_list".to_string()),
                 items_have_stock: None,
             },
         );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3361

# 👩🏻‍💻 What does this PR do? 
Filters master lists by store in backend since this should only be limited to the current store.

# 🧪 How has/should this change been tested? 
- [ ] Have 2 stores with different master lists (Maybe best to have about 4 master lists and 2 on each store?)
- [ ] Look at the `Master List` on each store (Should only show the master lists that the store uses)
- [ ] Try exporting `Master List` information. (Should be same as above)