### PR TITLE
2853 sql reports

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1977,6 +1977,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2754,6 +2766,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -2766,6 +2787,15 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "hashlink"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+dependencies = [
+ "hashbrown 0.11.2",
+]
 
 [[package]]
 name = "headless_chrome"
@@ -4365,6 +4395,8 @@ dependencies = [
  "log",
  "pretty_assertions",
  "rand",
+ "regex",
+ "rusqlite",
  "rust-embed",
  "serde 1.0.197",
  "serde_json",
@@ -4478,6 +4510,21 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4b1eaf239b47034fb450ee9cdedd7d0226571689d8823030c4b6c2cb407152"
+dependencies = [
+ "bitflags 1.3.2",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "memchr",
+ "smallvec",
 ]
 
 [[package]]

--- a/server/graphql/asset_catalogue/src/lib.rs
+++ b/server/graphql/asset_catalogue/src/lib.rs
@@ -1,4 +1,3 @@
-use asset_catalogue_item_queries::{AssetCatalogueItemFilterInput, AssetCatalogueItemSortInput};
 use async_graphql::*;
 use graphql_core::pagination::PaginationInput;
 use types::{

--- a/server/graphql/reports/src/lib.rs
+++ b/server/graphql/reports/src/lib.rs
@@ -66,6 +66,8 @@ impl ReportQueries {
         .await
     }
 
+    /// Can be used when developing reports, e.g. to print a report that is not already in the
+    /// system.
     pub async fn print_report_definition(
         &self,
         ctx: &Context<'_>,

--- a/server/graphql/reports/src/printing.rs
+++ b/server/graphql/reports/src/printing.rs
@@ -1,10 +1,12 @@
 use async_graphql::*;
+use chrono::Utc;
 use graphql_core::generic_inputs::PrintReportSortInput;
 use graphql_core::standard_graphql_error::{validate_auth, StandardGraphqlError};
 use graphql_core::{ContextExt, RequestUserData};
+use repository::query_json;
 use service::auth::{Resource, ResourceAccessRequest};
-use service::report::definition::{GraphQlQuery, PrintReportSort, ReportDefinition};
-use service::report::report_service::{PrintFormat, ReportError};
+use service::report::definition::{GraphQlQuery, PrintReportSort, ReportDefinition, SQLQuery};
+use service::report::report_service::{PrintFormat, ReportError, ResolvedReportQuery};
 
 pub struct FailedToFetchReportData {
     errors: serde_json::Value,
@@ -83,11 +85,10 @@ pub async fn print_report(
         }
     };
     let query = resolved_report.query.clone();
-
     // fetch data required for the report
     let result = fetch_data(ctx, query, &store_id, data_id, arguments.clone(), sort)
         .await
-        .map_err(|err| StandardGraphqlError::InternalError(format!("{:#?}", err)))?;
+        .map_err(|err| StandardGraphqlError::InternalError(format!("{:#?}", err)).extend())?;
     let report_data = match result {
         FetchResult::Data(data) => data,
         FetchResult::Error(errors) => {
@@ -158,7 +159,7 @@ pub async fn print_report_definition(
     // fetch data required for the report
     let result = fetch_data(ctx, query, &store_id, data_id, arguments.clone(), None)
         .await
-        .map_err(|err| StandardGraphqlError::InternalError(format!("{:#?}", err)))?;
+        .map_err(|err| StandardGraphqlError::InternalError(format!("{:#?}", err)).extend())?;
     let report_data = match result {
         FetchResult::Data(data) => data,
         FetchResult::Error(errors) => {
@@ -194,18 +195,113 @@ enum FetchResult {
     Error(serde_json::Value),
 }
 
+/// Create query variables for the query
+/// * `query_variables` Some variables that came with the query
+fn query_variables(
+    store_id: &str,
+    data_id: Option<String>,
+    arguments: Option<serde_json::Value>,
+    sort: Option<PrintReportSort>,
+    query_variables: &Option<serde_json::Value>,
+) -> serde_json::Map<String, serde_json::Value> {
+    let mut variables = match query_variables {
+        Some(variables) => {
+            if let serde_json::Value::Object(variables) = variables {
+                variables.clone()
+            } else {
+                // ensure variables are an object
+                serde_json::Map::new()
+            }
+        }
+        None => serde_json::Map::new(),
+    };
+
+    if let Some(data_id) = data_id {
+        variables.insert("dataId".to_string(), serde_json::Value::String(data_id));
+    }
+    // allow the arguments to overwrite the dataId but not the storeId (to reduce the attack
+    // vector)
+    if let Some(serde_json::Value::Object(arguments)) = arguments {
+        for (key, value) in arguments {
+            variables[&key] = value;
+        }
+    };
+
+    if let Some(sort) = sort {
+        variables.insert(
+            "sort".to_string(),
+            serde_json::json!({
+                "key": sort.key,
+                "desc": sort.desc
+            }),
+        );
+    }
+
+    variables.insert(
+        "storeId".to_string(),
+        serde_json::Value::String(store_id.to_string()),
+    );
+    variables.insert(
+        "now".to_string(),
+        serde_json::Value::String(Utc::now().to_rfc3339()),
+    );
+
+    variables
+}
+
 async fn fetch_data(
     ctx: &Context<'_>,
-    query: GraphQlQuery,
+    query: ResolvedReportQuery,
     store_id: &str,
     data_id: Option<String>,
     arguments: Option<serde_json::Value>,
     sort: Option<PrintReportSort>,
 ) -> anyhow::Result<FetchResult> {
+    match query {
+        ResolvedReportQuery::SQLQuery(sql) => {
+            let variables = query_variables(store_id, data_id, arguments, sort, &None);
+            fetch_sql_data(ctx, sql, variables)
+        }
+        ResolvedReportQuery::GraphQlQuery(gql) => {
+            let variables = query_variables(store_id, data_id, arguments, sort, &gql.variables);
+            fetch_graphq_data(ctx, gql, variables).await
+        }
+    }
+}
+
+#[cfg(not(feature = "postgres"))]
+fn fetch_sql_data(
+    ctx: &Context<'_>,
+    query: SQLQuery,
+    variables: serde_json::Map<String, serde_json::Value>,
+) -> anyhow::Result<FetchResult> {
+    let data = query_json(
+        &ctx.get_settings().database,
+        &query.query_sqlite,
+        &variables,
+    )?;
+    Ok(FetchResult::Data(serde_json::Value::Array(data)))
+}
+
+#[cfg(feature = "postgres")]
+fn fetch_sql_data(
+    ctx: &Context<'_>,
+    query: SQLQuery,
+    variables: serde_json::Map<String, serde_json::Value>,
+) -> anyhow::Result<FetchResult> {
+    let connection = ctx.get_connection_manager().connection()?;
+    let data = query_json(&connection, &query.query_postgres, &variables)?;
+    Ok(FetchResult::Data(serde_json::Value::Array(data)))
+}
+
+async fn fetch_graphq_data(
+    ctx: &Context<'_>,
+    query: GraphQlQuery,
+    variables: serde_json::Map<String, serde_json::Value>,
+) -> anyhow::Result<FetchResult> {
+    let variables = serde_json::from_value(serde_json::Value::Object(variables))?;
     let user_data = ctx.data_unchecked::<RequestUserData>().clone();
     let self_requester = ctx.self_request().unwrap();
-    let variables =
-        serde_json::from_value(query.query_variables(store_id, data_id, arguments, sort))?;
     let request = Request::new(query.query).variables(variables);
     let response = self_requester.call(request, user_data).await;
     if !response.errors.is_empty() {

--- a/server/graphql/reports/src/printing.rs
+++ b/server/graphql/reports/src/printing.rs
@@ -130,7 +130,7 @@ pub async fn print_report_definition(
     let user = validate_auth(
         ctx,
         &ResourceAccessRequest {
-            resource: Resource::Report,
+            resource: Resource::ReportDev,
             store_id: Some(store_id.to_string()),
         },
     )?;

--- a/server/report_builder/src/build.rs
+++ b/server/report_builder/src/build.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use service::report::definition::{
     DefaultQuery, GraphQlQuery, ReportDefinition, ReportDefinitionEntry, ReportDefinitionIndex,
-    ReportOutputType, TeraTemplate,
+    ReportOutputType, SQLQuery, TeraTemplate,
 };
 use std::{
     collections::HashMap,
@@ -41,6 +41,46 @@ fn parse_default_query(input: &str) -> anyhow::Result<DefaultQuery> {
         }
     };
     Ok(query)
+}
+
+/// Returns query name and SQLQuery
+fn extract_sql_entry(
+    args: &BuildArgs,
+    files: &mut HashMap<String, PathBuf>,
+) -> Result<Option<(String, SQLQuery)>> {
+    match (&args.query_sqlite, &args.query_postgres) {
+        (None, None) => Ok(None),
+        (Some(query_sqlite), Some(query_postgres)) => {
+            let file_path = files
+                .remove(query_sqlite)
+                .ok_or(anyhow::Error::msg("Sqlite query file does not exist"))?;
+            let query_sqlite_sql = fs::read_to_string(file_path).map_err(|err| {
+                anyhow::Error::msg(format!("Failed to load Sqlite query file: {}", err))
+            })?;
+            let file_path = files
+                .remove(query_postgres)
+                .ok_or(anyhow::Error::msg("Postgres query file does not exist"))?;
+            let query_postgres_sql = fs::read_to_string(file_path).map_err(|err| {
+                anyhow::Error::msg(format!("Failed to load Postgres query file: {}", err))
+            })?;
+            Ok(Some((
+                // Use the Sqlite file name for reference...
+                query_sqlite.clone(),
+                SQLQuery {
+                    query_sqlite: query_sqlite_sql,
+                    query_postgres: query_postgres_sql,
+                },
+            )))
+        }
+        (None, Some(_)) => {
+            return Err(anyhow::Error::msg("Sqlite query must be specified as well"))
+        }
+        (Some(_), None) => {
+            return Err(anyhow::Error::msg(
+                "Postgres query must be specified as well",
+            ))
+        }
+    }
 }
 
 fn make_report(args: &BuildArgs, mut files: HashMap<String, PathBuf>) -> Result<ReportDefinition> {
@@ -115,6 +155,9 @@ fn make_report(args: &BuildArgs, mut files: HashMap<String, PathBuf>) -> Result<
                 variables: None,
             }),
         );
+    } else if let Some((query, sql_query)) = extract_sql_entry(&args, &mut files)? {
+        index.query = Some(query.clone());
+        entries.insert(query, ReportDefinitionEntry::SQLQuery(sql_query));
     } else if let Some(query_default) = &args.query_default {
         index.query = Some("query_default".to_string());
         entries.insert(

--- a/server/report_builder/src/build.rs
+++ b/server/report_builder/src/build.rs
@@ -57,12 +57,16 @@ fn extract_sql_entry(
             let query_sqlite_sql = fs::read_to_string(file_path).map_err(|err| {
                 anyhow::Error::msg(format!("Failed to load Sqlite query file: {}", err))
             })?;
-            let file_path = files
-                .remove(query_postgres)
-                .ok_or(anyhow::Error::msg("Postgres query file does not exist"))?;
-            let query_postgres_sql = fs::read_to_string(file_path).map_err(|err| {
-                anyhow::Error::msg(format!("Failed to load Postgres query file: {}", err))
-            })?;
+            let query_postgres_sql = if query_postgres == query_sqlite {
+                query_sqlite_sql.clone()
+            } else {
+                let file_path = files
+                    .remove(query_postgres)
+                    .ok_or(anyhow::Error::msg("Postgres query file does not exist"))?;
+                fs::read_to_string(file_path).map_err(|err| {
+                    anyhow::Error::msg(format!("Failed to load Postgres query file: {}", err))
+                })?
+            };
             Ok(Some((
                 // Use the Sqlite file name for reference...
                 query_sqlite.clone(),

--- a/server/report_builder/src/lib.rs
+++ b/server/report_builder/src/lib.rs
@@ -38,6 +38,11 @@ pub struct BuildArgs {
     /// Default query type, one of: "invoice" | "stocktake" | "requisition",
     #[clap(long)]
     pub query_default: Option<String>,
+
+    #[clap(long)]
+    pub query_sqlite: Option<String>,
+    #[clap(long)]
+    pub query_postgres: Option<String>,
 }
 
 #[derive(clap::Args)]

--- a/server/report_builder/src/lib.rs
+++ b/server/report_builder/src/lib.rs
@@ -39,8 +39,14 @@ pub struct BuildArgs {
     #[clap(long)]
     pub query_default: Option<String>,
 
+    /// File name of the SQLite query.
+    /// If specified the query_postgres must be provided as well.
+    /// However, query_sqlite and query_postgres can point to the same file.
     #[clap(long)]
     pub query_sqlite: Option<String>,
+    /// File name of the Postgres query.
+    /// If specified the query_sqlite must be provided as well.
+    /// However, query_sqlite and query_postgres can point to the same file.
     #[clap(long)]
     pub query_postgres: Option<String>,
 }

--- a/server/repository/Cargo.toml
+++ b/server/repository/Cargo.toml
@@ -23,7 +23,10 @@ diesel-derive-enum = { version = "1.1.1", default-features = false }
 diesel_migrations = "1.4.0"
 futures-util = "0.3.15"
 libsqlite3-sys = { version = "0.22.2", features = ["bundled"], optional = true }
+# 0.25.4 depends on libsqlite3-sys 0.22.2
+rusqlite = "0.25.4"
 uuid = { version = "0.8", features = ["v4"] }
+regex = "1.10.3"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.66"
 thiserror = {workspace = true}

--- a/server/repository/src/db_diesel/mod.rs
+++ b/server/repository/src/db_diesel/mod.rs
@@ -23,6 +23,7 @@ mod document_registry_row;
 pub mod encounter;
 mod name_link_row;
 pub mod sync_file_reference_row;
+mod report_query;
 
 mod clinician_link_row;
 pub mod encounter_row;
@@ -160,6 +161,7 @@ pub use program_event::*;
 pub use program_event_row::*;
 pub use program_requisition::*;
 pub use report::*;
+pub use report_query::*;
 pub use report_row::*;
 pub use requisition::*;
 pub use requisition_line::*;

--- a/server/repository/src/db_diesel/report_query.rs
+++ b/server/repository/src/db_diesel/report_query.rs
@@ -1,4 +1,6 @@
-use crate::{RepositoryError, StorageConnection};
+use crate::RepositoryError;
+#[cfg(feature = "postgres")]
+use crate::StorageConnection;
 #[cfg(feature = "postgres")]
 use diesel::sql_types::*;
 

--- a/server/repository/src/db_diesel/report_query.rs
+++ b/server/repository/src/db_diesel/report_query.rs
@@ -1,0 +1,276 @@
+use crate::{RepositoryError, StorageConnection};
+#[cfg(feature = "postgres")]
+use diesel::sql_types::*;
+
+#[cfg(feature = "postgres")]
+#[derive(QueryableByName, Debug, PartialEq)]
+pub struct JsonDataRow {
+    #[sql_type = "Text"]
+    data: String,
+}
+
+#[cfg(feature = "postgres")]
+pub fn query_json(
+    connection: &StorageConnection,
+    sql: &str,
+    parameters: &serde_json::Map<String, serde_json::Value>,
+) -> Result<Vec<serde_json::Value>, RepositoryError> {
+    use diesel::connection::SimpleConnection;
+    use diesel::{sql_query, RunQueryDsl};
+    use regex::Regex;
+    use util::uuid::small_uuid;
+
+    // extract all used params from the sql query string, e.g. $myVariable
+    let re = Regex::new(r"(\$[a-zA-Z0-9]+)").unwrap();
+    // stores the variable name and the found parameter value, e.g. ($myVariable, "Hello")
+    let mut used_params = Vec::<(String, serde_json::Value)>::new();
+    for param in re.captures_iter(sql) {
+        let param: &str = &param[0];
+        if used_params.iter().any(|it| &it.0 == param) {
+            continue;
+        }
+        let param_name = &param[1..];
+        let Some(param_value) = parameters.get(param_name) else {
+            return Err(RepositoryError::DBError {
+                msg: format!("Invalid parameter: {param_name}"),
+                extra: "".to_string(),
+            });
+        };
+        used_params.push((param.to_string(), param_value.clone()))
+    }
+
+    // remove trailing ";" if there is any
+    let mut sql = if sql.chars().last() == Some(';') {
+        sql[..sql.len() - 1].to_string()
+    } else {
+        sql.to_string()
+    };
+    // Replace named variable like $myVariable with the numbered parameters like $1. Using the order
+    // in which variables where first used.
+    for (i, param) in used_params.iter().enumerate() {
+        sql = sql.replace(&param.0, &format!("${}", i + 1));
+    }
+    // Create the string containing all the parameter values
+    let param_values = used_params
+        .iter()
+        .map(|it| match &it.1 {
+            serde_json::Value::Null => "NULL".to_string(),
+            serde_json::Value::Bool(b) => format!("{b}"),
+            serde_json::Value::Number(n) => format!("{n}"),
+            serde_json::Value::String(s) => format!("'{}'", s),
+            // not supported but just add them...
+            serde_json::Value::Array(_) => format!("{}", it.1.to_string()),
+            serde_json::Value::Object(_) => format!("{}", it.1.to_string()),
+        })
+        .collect::<Vec<String>>()
+        .join(", ");
+    let param_values = if param_values.is_empty() {
+        "".to_string()
+    } else {
+        format!("({})", param_values)
+    };
+
+    // do the query
+    let pg_connection = &connection.connection;
+    let statement_name = format!("statement_{}", small_uuid());
+    let json_row_sql_query = format!(
+        "PREPARE {} AS
+            WITH provided_query AS(
+                {}
+                ) SELECT row_to_json(provided_query) as data FROM provided_query;
+        ",
+        statement_name, sql
+    );
+    pg_connection.batch_execute(&json_row_sql_query)?;
+    let json_results = sql_query(&format!("EXECUTE {}{};", statement_name, param_values))
+        .load::<JsonDataRow>(pg_connection)?;
+    pg_connection.batch_execute(&format!("DEALLOCATE PREPARE {};", statement_name))?;
+
+    let rows: Vec<serde_json::Value> = json_results
+        .into_iter()
+        .map(|r| serde_json::from_str(&r.data).unwrap())
+        .collect();
+
+    Ok(rows)
+}
+
+#[cfg(not(feature = "postgres"))]
+use crate::database_settings::DatabaseSettings;
+#[cfg(not(feature = "postgres"))]
+impl From<rusqlite::Error> for RepositoryError {
+    fn from(value: rusqlite::Error) -> Self {
+        RepositoryError::DBError {
+            msg: format!("{}", value),
+            extra: "".to_string(),
+        }
+    }
+}
+
+#[cfg(not(feature = "postgres"))]
+pub fn query_json(
+    settings: &DatabaseSettings,
+    sql: &str,
+    parameters: &serde_json::Map<String, serde_json::Value>,
+) -> Result<Vec<serde_json::Value>, RepositoryError> {
+    use rusqlite::{types::Null, Connection as RusqliteConnection};
+    use serde_json::Number;
+
+    let conn = RusqliteConnection::open(settings.connection_string())?;
+
+    let mut statement = conn.prepare(sql)?;
+
+    for p in 1..=statement.parameter_count() {
+        let Some(param) = statement.parameter_name(p) else {
+            continue;
+        };
+        // remove trailing ":"
+        let param_name = &param[1..];
+        let Some(param) = parameters.get(param_name) else {
+            return Err(RepositoryError::DBError {
+                msg: format!("Invalid parameter: {param_name}"),
+                extra: "".to_string(),
+            });
+        };
+        match param {
+            serde_json::Value::Null => statement.raw_bind_parameter(p, Null)?,
+            serde_json::Value::Bool(b) => statement.raw_bind_parameter(p, b)?,
+            serde_json::Value::Number(number) => {
+                if let Some(number) = number.as_f64() {
+                    statement.raw_bind_parameter(p, number)?;
+                } else if let Some(number) = number.as_u64() {
+                    statement.raw_bind_parameter(p, number)?;
+                } else if let Some(number) = number.as_i64() {
+                    statement.raw_bind_parameter(p, number)?;
+                }
+            }
+            serde_json::Value::String(s) => statement.raw_bind_parameter(p, s)?,
+            serde_json::Value::Array(_) => statement.raw_bind_parameter(p, Null)?,
+            serde_json::Value::Object(_) => statement.raw_bind_parameter(p, Null)?,
+        };
+    }
+    let rows = statement.raw_query();
+    let rows = rows.mapped(|row| {
+        let mut object = serde_json::Map::<String, serde_json::Value>::new();
+        for c in 0..row.column_count() {
+            let value = row.get_ref(c)?;
+            let name = row.column_name(c)?.to_string();
+            match value.data_type() {
+                rusqlite::types::Type::Null => {
+                    object.insert(name, serde_json::Value::Null);
+                }
+                rusqlite::types::Type::Integer => {
+                    let int: i64 = row.get(c)?;
+                    object.insert(name, serde_json::Value::Number(Number::from(int)));
+                }
+                rusqlite::types::Type::Real => {
+                    let f: f64 = row.get(c)?;
+                    if let Some(number) = Number::from_f64(f) {
+                        object.insert(name, serde_json::Value::Number(number));
+                    }
+                }
+                rusqlite::types::Type::Text => {
+                    object.insert(name, serde_json::Value::String(row.get(c)?));
+                }
+                rusqlite::types::Type::Blob => {
+                    // do nothing?
+                }
+            };
+        }
+        Ok(serde_json::Value::Object(object))
+    });
+    let mut result = Vec::new();
+    for row in rows.into_iter() {
+        result.push(row?);
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::{mock::MockDataInserts, query_json, test_db};
+
+    use crate::{database_settings::DatabaseSettings, RepositoryError, StorageConnection};
+
+    #[cfg(feature = "postgres")]
+    pub fn query(
+        connection: &StorageConnection,
+        _settings: &DatabaseSettings,
+        sql: &str,
+        parameters: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<Vec<serde_json::Value>, RepositoryError> {
+        query_json(connection, sql, parameters)
+    }
+
+    #[cfg(not(feature = "postgres"))]
+    pub fn query(
+        _connection: &StorageConnection,
+        settings: &DatabaseSettings,
+        sql: &str,
+        parameters: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<Vec<serde_json::Value>, RepositoryError> {
+        query_json(settings, sql, parameters)
+    }
+
+    #[actix_rt::test]
+    async fn test_report_query() {
+        let (_, connection, _, settings) = test_db::setup_all(
+            "test_report_query",
+            MockDataInserts::none().names().stores(),
+        )
+        .await;
+
+        // query with no params
+        let result = query(
+            &connection,
+            &settings,
+            "SELECT id, code, logo FROM store LIMIT 1;", // test with trailing ";"
+            &serde_json::Map::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            &format!("{}", serde_json::to_string(&result).unwrap()),
+            "[{\"code\":\"code\",\"id\":\"store_a\",\"logo\":null}]"
+        );
+
+        // simple params
+        let result = query(
+            &connection,
+            &settings,
+            "SELECT id, code FROM store WHERE code=$code LIMIT $limit", // test without trailing ";"
+            &json!({
+                "code": "code",
+                "limit": 2,
+            })
+            .as_object()
+            .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            &format!("{}", serde_json::to_string(&result).unwrap()),
+            "[{\"code\":\"code\",\"id\":\"store_a\"},{\"code\":\"code\",\"id\":\"store_b\"}]"
+        );
+
+        // multiple used params
+        let result = query(
+            &connection,
+            &settings,
+            "SELECT id, code FROM store WHERE id LIKE $b || '%' AND code LIKE $b || '%' LIMIT $a",
+            &json!({
+                "a": 5,
+                "b": "name",
+            })
+            .as_object()
+            .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            &format!("{}", serde_json::to_string(&result).unwrap()),
+            "[{\"code\":\"name_store_code\",\"id\":\"name_store_id\"},{\"code\":\"name_store_code_a\",\"id\":\"name_store_a_id\"}]"
+        );
+    }
+}

--- a/server/repository/src/db_diesel/report_query.rs
+++ b/server/repository/src/db_diesel/report_query.rs
@@ -241,9 +241,9 @@ mod tests {
         let result = query(
             &connection,
             &settings,
-            "SELECT id, code FROM store WHERE code=$code LIMIT $limit", // test without trailing ";"
+            "SELECT id, code FROM store WHERE id=$store LIMIT $limit", // test without trailing ";"
             &json!({
-                "code": "code",
+                "store": "store_a",
                 "limit": 2,
             })
             .as_object()
@@ -253,7 +253,7 @@ mod tests {
 
         assert_eq!(
             &format!("{}", serde_json::to_string(&result).unwrap()),
-            "[{\"code\":\"code\",\"id\":\"store_a\"},{\"code\":\"code\",\"id\":\"store_b\"}]"
+            "[{\"code\":\"code\",\"id\":\"store_a\"}]"
         );
 
         // multiple used params

--- a/server/repository/src/migrations/v1_08_00/central_omsupply.rs
+++ b/server/repository/src/migrations/v1_08_00/central_omsupply.rs
@@ -1,4 +1,4 @@
-use crate::{migrations::*, StorageConnection};
+use crate::migrations::*;
 
 pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
     sql!(

--- a/server/repository/src/migrations/v1_08_00/pack_variant.rs
+++ b/server/repository/src/migrations/v1_08_00/pack_variant.rs
@@ -1,4 +1,4 @@
-use crate::{migrations::*, StorageConnection};
+use crate::migrations::*;
 
 pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
     sql!(

--- a/server/repository/src/migrations/v1_08_00/sync_file_reference.rs
+++ b/server/repository/src/migrations/v1_08_00/sync_file_reference.rs
@@ -1,4 +1,4 @@
-use crate::{migrations::*, StorageConnection};
+use crate::migrations::*;
 
 pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
     sql!(

--- a/server/service/src/asset/update.rs
+++ b/server/service/src/asset/update.rs
@@ -11,7 +11,6 @@ use repository::{
     },
     ActivityLogType, EqualFilter, RepositoryError, StorageConnection, StringFilter,
 };
-use serde_json;
 
 #[derive(PartialEq, Debug)]
 pub enum UpdateAssetError {

--- a/server/service/src/auth.rs
+++ b/server/service/src/auth.rs
@@ -78,6 +78,7 @@ pub enum Resource {
     MutatePrescription,
     // reporting
     Report,
+    ReportDev,
     QueryLog,
     // view/edit server setting
     ServerAdmin,
@@ -350,6 +351,15 @@ fn all_permissions() -> HashMap<Resource, PermissionDSL> {
         PermissionDSL::And(vec![
             PermissionDSL::HasStoreAccess,
             PermissionDSL::HasPermission(Permission::Report),
+        ]),
+    );
+    // report development
+    map.insert(
+        Resource::ReportDev,
+        PermissionDSL::And(vec![
+            PermissionDSL::HasStoreAccess,
+            // SQL reports can do raw queries, i.e. you need to be server admin
+            PermissionDSL::HasPermission(Permission::ServerAdmin),
         ]),
     );
 

--- a/server/service/src/report/definition.rs
+++ b/server/service/src/report/definition.rs
@@ -5,6 +5,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct SQLQuery {
+    pub query_sqlite: String,
+    pub query_postgres: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct GraphQlQuery {
     pub query: String,
     /// Must be an Object. If `dataId` is set it will be overwritten.
@@ -18,52 +24,6 @@ pub struct PrintReportSort {
     pub key: String,
     /// Whether to sort in descending order
     pub desc: Option<bool>,
-}
-
-impl GraphQlQuery {
-    /// Create query variables for the query
-    pub fn query_variables(
-        &self,
-        store_id: &str,
-        data_id: Option<String>,
-        arguments: Option<Value>,
-        sort: Option<PrintReportSort>,
-    ) -> Value {
-        let mut variables = match &self.variables {
-            Some(variables) => {
-                if matches!(variables, Value::Object(_)) {
-                    variables.clone()
-                } else {
-                    // ensure variables are an object
-                    serde_json::json!({})
-                }
-            }
-            None => serde_json::json!({}),
-        };
-
-        if let Some(data_id) = data_id {
-            variables["dataId"] = Value::String(data_id);
-        }
-        // allow the arguments to overwrite the dataId but not the storeId (to reduce the attack
-        // vector)
-        if let Some(Value::Object(arguments)) = arguments {
-            for (key, value) in arguments {
-                variables[key] = value;
-            }
-        };
-
-        if let Some(sort) = sort {
-            variables["sort"] = serde_json::json!({
-                "key": sort.key,
-                "desc": sort.desc
-            });
-        }
-
-        variables["storeId"] = Value::String(store_id.to_string());
-        variables["now"] = Value::String(Utc::now().to_rfc3339());
-
-        variables
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -102,6 +62,7 @@ pub enum ReportDefinitionEntry {
     GraphGLQuery(GraphQlQuery),
     /// Use default predefined query
     DefaultQuery(DefaultQuery),
+    SQLQuery(SQLQuery),
     Resource(serde_json::Value),
     /// Entry reference to another report definition
     Ref(ReportRef),

--- a/server/service/src/report/definition.rs
+++ b/server/service/src/report/definition.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 

--- a/server/service/src/report/report_service.rs
+++ b/server/service/src/report/report_service.rs
@@ -16,8 +16,7 @@ use crate::{
 use super::{
     default_queries::get_default_gql_query,
     definition::{
-        DefaultQuery, GraphQlQuery, ReportDefinition, ReportDefinitionEntry, ReportRef,
-        TeraTemplate,
+        GraphQlQuery, ReportDefinition, ReportDefinitionEntry, ReportRef, SQLQuery, TeraTemplate,
     },
     html_printing::html_to_pdf,
 };
@@ -39,11 +38,11 @@ pub enum ReportError {
     HTMLToPDFError(String),
 }
 
+#[derive(Debug, Clone)]
 pub enum ResolvedReportQuery {
+    SQLQuery(SQLQuery),
     /// Custom http query
     GraphQlQuery(GraphQlQuery),
-    // Use default predefined query
-    Default(DefaultQuery),
 }
 
 /// Resolved and validated report definition, i.e. its guaranteed that there is a main template and
@@ -58,7 +57,7 @@ pub struct ResolvedReportDefinition {
     pub footer: Option<String>,
     /// Map of all found Tera templates in the report definition
     pub templates: HashMap<String, TeraTemplate>,
-    pub query: GraphQlQuery,
+    pub query: ResolvedReportQuery,
     pub resources: HashMap<String, serde_json::Value>,
 }
 
@@ -288,10 +287,6 @@ fn resolve_report_definition(
 
     // resolve the query entry
     let query = query_from_resolved_template(query_entry).ok_or(ReportError::QueryNotSpecified)?;
-    let query = match query {
-        ResolvedReportQuery::GraphQlQuery(query) => query,
-        ResolvedReportQuery::Default(query) => get_default_gql_query(query),
-    };
 
     let resources = resources_from_resolved_template(&fully_loaded_report);
 
@@ -392,7 +387,10 @@ fn query_from_resolved_template(
         ReportDefinitionEntry::GraphGLQuery(query) => {
             ResolvedReportQuery::GraphQlQuery(query.clone())
         }
-        ReportDefinitionEntry::DefaultQuery(query) => ResolvedReportQuery::Default(query.clone()),
+        ReportDefinitionEntry::SQLQuery(query) => ResolvedReportQuery::SQLQuery(query.clone()),
+        ReportDefinitionEntry::DefaultQuery(query) => {
+            ResolvedReportQuery::GraphQlQuery(get_default_gql_query(query.clone()))
+        }
         _ => return None,
     };
     Some(query)

--- a/server/service/src/sync/api_v6/core.rs
+++ b/server/service/src/sync/api_v6/core.rs
@@ -1,7 +1,6 @@
-use crate::sync::api::{ParsingResponseError, SyncApiSettings};
 use reqwest::{Client, Response};
 use thiserror::Error;
-use url::{ParseError, Url};
+use url::ParseError;
 
 use super::*;
 

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -221,12 +221,8 @@ impl TranslationAndIntegrationResults {
 #[cfg(test)]
 mod test {
     use super::*;
-    use repository::{
-        mock::MockDataInserts, test_db, ItemRow, ItemRowRepository, UnitRow, UnitRowRepository,
-    };
+    use repository::mock::MockDataInserts;
     use util::{assert_matches, inline_init};
-
-    use crate::sync::translations::IntegrationOperation;
 
     #[actix_rt::test]
     async fn test_fall_through_inner_transaction() {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes most of #2853 

# 👩🏻‍💻 What does this PR do? 
- Add support to the report builder cli to specify SQL queries (sqlite and postgres) (see doc comment on new params)
- `query_json` helper method for SQLite and Postgres to do raw queries returning the result as a JSON object.
-  The print_report_definition endpoint requires ServerAdmin permissions now since it effectively allows the caller to execute arbitrary queries now(!)

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
There is a new test for the query_json method. Test with SQLite and Postgres.

Furthermore, there is this branch in the report repo:
https://github.com/msupply-foundation/open-msupply-reports/tree/2853-sql-reports
There is a report under `examples/SQLReport`

To run it create a `config.yaml` in the root directory of the repo like:
```yaml
url: "http://localhost:8000"
username: "..."
password: "..."
# Huff:
store_id: "34660F1A61E249DF9777FCC6588FE98C"
```
and run `./print.sh` in the `examples/SQLReport` directory

![image](https://github.com/msupply-foundation/open-msupply/assets/88299195/e231b6fc-1429-4cca-941a-7c403a7e356e)

## 💌 Any notes for the reviewer?
Missing:
- Report permissions, e.g. use sub_context to check if a user can print a report?
- Report table views? For example, in the example report the report contains name_link_id (see above) which are internal details and shouldn't leak out. We might want to define some stable report views and by convention reports are only allowed to use these report views.
