### PR TITLE
Add login to graphql playground

### DIFF
--- a/server/graphql/lib.rs
+++ b/server/graphql/lib.rs
@@ -7,7 +7,6 @@ use actix_web::web::{self, Data};
 use actix_web::HttpResponse;
 use actix_web::{guard, HttpRequest};
 
-use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
 use async_graphql::{EmptyMutation, EmptySubscription, Object, Schema};
 use async_graphql::{MergedObject, Response};
 use async_graphql_actix_web::{GraphQLRequest, GraphQLResponse};
@@ -288,7 +287,7 @@ async fn graphql_index(
 async fn graphql_playground() -> HttpResponse {
     HttpResponse::Ok()
         .content_type("text/html; charset=utf-8")
-        .body(playground_source(GraphQLPlaygroundConfig::new("/graphql")))
+        .body(include_str!("playground.html"))
 }
 
 // TODO remove this and just do reqwest query to self

--- a/server/graphql/playground.html
+++ b/server/graphql/playground.html
@@ -28,15 +28,8 @@
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
 
-    <script
-      src="https://unpkg.com/graphiql@3.0.6/graphiql.min.js"
-      integrity="sha384-Sntd+AoO/Fp2wXBOr+uLca2KhF+tmz4821GENMGBejijmj12LZ8YQ01Lr7lNQC5z"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js"
-      crossorigin="anonymous"
-    ></script>
+    <script src="https://unpkg.com/graphiql/graphiql.min.js"></script>
+    <script src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js"></script>
 
     <script>
       // Login plugin for GraphiQL

--- a/server/graphql/playground.html
+++ b/server/graphql/playground.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>GraphiQL Playground</title>
+    <style>
+      body {
+        height: 100%;
+        margin: 0;
+        width: 100%;
+        overflow: hidden;
+      }
+
+      #graphiql {
+        height: 100vh;
+      }
+      input {
+        margin-bottom: 10px;
+      }
+    </style>
+
+    <link rel="stylesheet" href="https://unpkg.com/graphiql@3.0.6/graphiql.min.css" />
+    <link rel="stylesheet" href="https://unpkg.com/@graphiql/plugin-explorer/dist/style.css" />
+  </head>
+
+  <body>
+    <div id="graphiql">Loading...</div>
+
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+
+    <script
+      src="https://unpkg.com/graphiql@3.0.6/graphiql.min.js"
+      integrity="sha384-Sntd+AoO/Fp2wXBOr+uLca2KhF+tmz4821GENMGBejijmj12LZ8YQ01Lr7lNQC5z"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js"
+      crossorigin="anonymous"
+    ></script>
+
+    <script>
+      // Login plugin for GraphiQL
+      function LoginContent() {
+        return React.createElement(
+          'div',
+          {
+            style: {
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              height: '100%',
+            },
+          },
+          React.createElement('h1', null, 'Login'),
+          React.createElement('input', {
+            type: 'text',
+            id: 'username',
+            placeholder: 'Username',
+          }),
+          React.createElement('input', {
+            type: 'password',
+            id: 'password',
+            placeholder: 'Password',
+          }),
+          React.createElement(
+            'button',
+            {
+              onClick: () => {
+                const username = document.getElementById('username').value;
+                const password = document.getElementById('password').value;
+                fetch('/graphql', {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                  },
+                  body: JSON.stringify({
+                    query: `query Login {
+    authToken(password: "${password}", username: "${username}") {
+        ... on AuthToken {
+            __typename
+            token
+        }
+    }
+}`,
+                  }),
+                })
+                  .then((res) => res.json())
+                  .then((res) => {
+                    const token = res.data.authToken.token;
+                    localStorage.setItem('token', token);
+                    window.location.reload();
+                  });
+              },
+            },
+            'Login'
+          )
+        );
+      }
+
+      function LoginImage() {
+        // FeatherIcons login icon
+        return React.createElement(
+          'svg',
+          {
+            width: 24,
+            height: 24,
+            viewBox: '0 0 24 24',
+            fill: 'none',
+            xmlns: 'http://www.w3.org/2000/svg',
+          },
+          React.createElement('path', {
+            d: 'M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4',
+            stroke: 'currentColor',
+            strokeWidth: '2',
+            strokeLinecap: 'round',
+            strokeLinejoin: 'round',
+          }),
+          React.createElement('polyline', {
+            points: '10 17 15 12 10 7',
+            stroke: 'currentColor',
+            strokeWidth: '2',
+            strokeLinecap: 'round',
+            strokeLinejoin: 'round',
+          }),
+          React.createElement('line', {
+            x1: '15',
+            y1: '12',
+            x2: '3',
+            y2: '12',
+            stroke: 'currentColor',
+            strokeWidth: '2',
+            strokeLinecap: 'round',
+            strokeLinejoin: 'round',
+          })
+        );
+      }
+    </script>
+
+    <script>
+      // Always connect to the current app's local graphql endpoint
+      // Pass the token from local storage as the Authorization header if it exists
+      const authHeader = 'Bearer ' + localStorage.getItem('token');
+      var fetcher = GraphiQL.createFetcher({
+        url: '/graphql',
+        headers: { Authorization: authHeader },
+      });
+
+      var defaultQuery = `
+query MyQuery {
+  me {
+    ... on UserAccountNode {
+      username
+    }
+  }
+}
+`;
+      var explorerPlugin = GraphiQLPluginExplorer.explorerPlugin();
+      const loginPlugin = {
+        title: 'Login',
+        icon: LoginImage,
+        content: LoginContent,
+      };
+
+      function GraphiQLWithPlugins() {
+        return React.createElement(GraphiQL, {
+          fetcher: fetcher,
+          defaultEditorToolsVisibility: true,
+          plugins: [explorerPlugin, loginPlugin],
+          defaultQuery: defaultQuery,
+        });
+      }
+
+      const root = ReactDOM.createRoot(document.getElementById('graphiql'));
+      root.render(React.createElement(GraphiQLWithPlugins));
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3378

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Simply brings the changes through from the original PR.
You can now login if you use the /graphql endpoint. Doesn't help me with [graphiql](https://cloud.hasura.io/public/graphiql] which is what I normally use.. might be time to switch over though. the login is super useful.

https://github.com/msupply-foundation/open-msupply/assets/9192912/60820c3a-6785-4db2-962c-592c8c303084


# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

or

- [ ] Functional change 1
- [ ] Functional change 2