### PR TITLE
3386  Show all suppliers when creating inbound shipment from dashboard

### DIFF
--- a/client/packages/dashboard/src/widgets/ReplenishmentWidget.tsx
+++ b/client/packages/dashboard/src/widgets/ReplenishmentWidget.tsx
@@ -25,7 +25,7 @@ import {
 } from '@common/types';
 import { useDashboard } from '../api';
 import { useInbound } from '@openmsupply-client/invoices';
-import { InternalSupplierSearchModal } from '@openmsupply-client/system';
+import { SupplierSearchModal } from '@openmsupply-client/system';
 import { AppRoute } from '@openmsupply-client/config';
 
 export const ReplenishmentWidget: React.FC<PropsWithChildrenOnly> = () => {
@@ -79,7 +79,7 @@ export const ReplenishmentWidget: React.FC<PropsWithChildrenOnly> = () => {
   return (
     <>
       {modalControl.isOn ? (
-        <InternalSupplierSearchModal
+        <SupplierSearchModal
           open={true}
           onClose={modalControl.toggleOff}
           onChange={async ({ id: otherPartyId }) => {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3386

# 👩🏻‍💻 What does this PR do? 
Show all suppliers regardless of external or internal when creating an inbound shipment from dashboard.

# 🧪 How has/should this change been tested? 
- [ ] Have external and internal suppliers for a store
- [ ] Click `New inbound shipment` button on the dashboard
- [ ] Should see all suppliers