### PR TITLE
2229 move navigation out of delete hooks

### DIFF
--- a/client/packages/dashboard/src/widgets/DistributionWidget.tsx
+++ b/client/packages/dashboard/src/widgets/DistributionWidget.tsx
@@ -13,6 +13,7 @@ import {
   RouteBuilder,
   InvoiceNodeStatus,
   RequisitionNodeStatus,
+  useNavigate,
 } from '@openmsupply-client/common';
 import { useFormatNumber, useTranslation } from '@common/intl';
 import { useDashboard } from '../api';
@@ -20,9 +21,10 @@ import { useOutbound } from '@openmsupply-client/invoices';
 import { AppRoute } from '@openmsupply-client/config';
 
 export const DistributionWidget: React.FC = () => {
-  const modalControl = useToggle(false);
-  const { error: errorNotification } = useNotification();
   const t = useTranslation('dashboard');
+  const modalControl = useToggle(false);
+  const navigate = useNavigate();
+  const { error: errorNotification } = useNotification();
   const formatNumber = useFormatNumber();
   const {
     data: outboundCount,
@@ -60,7 +62,15 @@ export const DistributionWidget: React.FC = () => {
                 otherPartyId,
               },
               { onError }
-            );
+            ).then(invoiceNumber => {
+              navigate(
+                RouteBuilder.create(AppRoute.Distribution)
+                  .addPart(AppRoute.OutboundShipment)
+                  .addPart(String(invoiceNumber))
+                  .build(),
+                { replace: true }
+              );
+            });
           }}
         />
       ) : null}

--- a/client/packages/dashboard/src/widgets/ReplenishmentWidget.tsx
+++ b/client/packages/dashboard/src/widgets/ReplenishmentWidget.tsx
@@ -7,6 +7,7 @@ import {
   RANGE_SPLIT_CHAR,
   RouteBuilder,
   StatsPanel,
+  useNavigate,
   useNotification,
   useToggle,
   Widget,
@@ -29,10 +30,11 @@ import { InternalSupplierSearchModal } from '@openmsupply-client/system';
 import { AppRoute } from '@openmsupply-client/config';
 
 export const ReplenishmentWidget: React.FC<PropsWithChildrenOnly> = () => {
+  const t = useTranslation('dashboard');
   const modalControl = useToggle(false);
   const { error: errorNotification } = useNotification();
-  const t = useTranslation('dashboard');
   const formatNumber = useFormatNumber();
+  const navigate = useNavigate();
   const { data, isLoading, isError, error } = useDashboard.statistics.inbound();
   const {
     data: requisitionCount,
@@ -90,7 +92,15 @@ export const ReplenishmentWidget: React.FC<PropsWithChildrenOnly> = () => {
                 otherPartyId,
               },
               { onError }
-            );
+            ).then(invoiceNumber => {
+              navigate(
+                RouteBuilder.create(AppRoute.Replenishment)
+                  .addPart(AppRoute.InboundShipment)
+                  .addPart(String(invoiceNumber))
+                  .build(),
+                { replace: true }
+              );
+            });
           }}
         />
       ) : null}

--- a/client/packages/dashboard/src/widgets/StockWidget.tsx
+++ b/client/packages/dashboard/src/widgets/StockWidget.tsx
@@ -11,6 +11,7 @@ import {
   StatsPanel,
   useFormatDateTime,
   useFormatNumber,
+  useNavigate,
   useNotification,
   useToggle,
   useTranslation,
@@ -24,9 +25,10 @@ import { AppRoute } from '@openmsupply-client/config';
 const LOW_MOS_THRESHOLD = 3;
 
 export const StockWidget: React.FC = () => {
+  const t = useTranslation('dashboard');
+  const navigate = useNavigate();
   const modalControl = useToggle(false);
   const { error: errorNotification } = useNotification();
-  const t = useTranslation('dashboard');
   const formatNumber = useFormatNumber();
   const {
     data: expiryData,
@@ -77,7 +79,15 @@ export const StockWidget: React.FC = () => {
                 otherPartyId,
               },
               { onError }
-            );
+            ).then(requisitionNumber => {
+              navigate(
+                RouteBuilder.create(AppRoute.Replenishment)
+                  .addPart(AppRoute.InternalOrder)
+                  .addPart(String(requisitionNumber))
+                  .build(),
+                { replace: true }
+              );
+            });
           }}
         />
       ) : null}

--- a/client/packages/inventory/src/Stocktake/DetailView/SidePanel.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/SidePanel.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { AppRoute } from '@openmsupply-client/config';
 import {
   Grid,
   CopyIcon,
@@ -16,6 +17,8 @@ import {
   DeleteIcon,
   useDeleteConfirmation,
   useFormatDateTime,
+  useNavigate,
+  RouteBuilder,
 } from '@openmsupply-client/common';
 import { useStocktake } from '../api';
 import { canDeleteStocktake } from '../../utils';
@@ -57,8 +60,9 @@ const AdditionalInfoSection: FC = () => {
 };
 
 export const SidePanel = () => {
-  const { success } = useNotification();
   const t = useTranslation('inventory');
+  const { success } = useNotification();
+  const navigate = useNavigate();
   const { mutateAsync } = useStocktake.document.delete();
   const { data: stocktake } = useStocktake.document.get();
   const canDelete = stocktake ? canDeleteStocktake(stocktake) : false;
@@ -71,7 +75,13 @@ export const SidePanel = () => {
 
   const deleteAction = async () => {
     if (!stocktake) return;
-    await mutateAsync([stocktake]);
+    await mutateAsync([stocktake]).then(() => {
+      navigate(
+        RouteBuilder.create(AppRoute.Inventory)
+          .addPart(AppRoute.Stocktakes)
+          .build()
+      );
+    })
   };
 
   const onDelete = useDeleteConfirmation({

--- a/client/packages/inventory/src/Stocktake/DetailView/SidePanel.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/SidePanel.tsx
@@ -75,13 +75,12 @@ export const SidePanel = () => {
 
   const deleteAction = async () => {
     if (!stocktake) return;
-    await mutateAsync([stocktake]).then(() => {
-      navigate(
-        RouteBuilder.create(AppRoute.Inventory)
-          .addPart(AppRoute.Stocktakes)
-          .build()
-      );
-    })
+    await mutateAsync([stocktake]);
+    navigate(
+      RouteBuilder.create(AppRoute.Inventory)
+        .addPart(AppRoute.Stocktakes)
+        .build()
+    );
   };
 
   const onDelete = useDeleteConfirmation({

--- a/client/packages/inventory/src/Stocktake/api/hooks/document/useStocktakeDelete.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/document/useStocktakeDelete.ts
@@ -1,25 +1,16 @@
 import {
   useQueryClient,
   useMutation,
-  RouteBuilder,
-  useNavigate,
 } from '@openmsupply-client/common';
 import { useStocktakeApi } from '../utils/useStocktakeApi';
-import { AppRoute } from '@openmsupply-client/config';
 
 export const useStocktakeDelete = () => {
   const queryClient = useQueryClient();
   const api = useStocktakeApi();
-  const navigate = useNavigate();
 
   return useMutation(api.deleteStocktakes, {
     onSuccess: () => {
-      queryClient.invalidateQueries(api.keys.base()),
-        navigate(
-          RouteBuilder.create(AppRoute.Inventory)
-            .addPart(AppRoute.Stocktakes)
-            .build()
-        );
+      queryClient.invalidateQueries(api.keys.base())
     },
   });
 };

--- a/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/SidePanel.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/SidePanel.tsx
@@ -8,15 +8,19 @@ import {
   useNotification,
   useDeleteConfirmation,
   useTranslation,
+  RouteBuilder,
+  useNavigate,
 } from '@openmsupply-client/common';
 import { useInbound } from '../../api';
 import { AdditionalInfoSection } from './AdditionalInfoSection';
 import { PricingSection } from './PricingSection';
 import { RelatedDocumentsSection } from './RelatedDocumentsSection';
 import { TransportSection } from './TransportSection';
+import { AppRoute } from '@openmsupply-client/config';
 
 export const SidePanel: FC = () => {
   const t = useTranslation('replenishment');
+  const navigate = useNavigate();
   const { success } = useNotification();
   const { data } = useInbound.document.get();
   const { mutateAsync } = useInbound.document.delete();
@@ -31,7 +35,14 @@ export const SidePanel: FC = () => {
 
   const deleteAction = async () => {
     if (!data) return;
-    await mutateAsync([data]);
+    await mutateAsync([data]).then
+    (() => {
+      navigate(
+        RouteBuilder.create(AppRoute.Replenishment)
+          .addPart(AppRoute.InboundShipment)
+          .build()
+      );
+    });
   };
 
   const onDelete = useDeleteConfirmation({
@@ -72,3 +83,4 @@ export const SidePanel: FC = () => {
     </DetailPanelPortal>
   );
 };
+

--- a/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/SidePanel.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/SidePanel.tsx
@@ -35,14 +35,12 @@ export const SidePanel: FC = () => {
 
   const deleteAction = async () => {
     if (!data) return;
-    await mutateAsync([data]).then
-    (() => {
-      navigate(
-        RouteBuilder.create(AppRoute.Replenishment)
-          .addPart(AppRoute.InboundShipment)
-          .build()
-      );
-    });
+    await mutateAsync([data]);
+    navigate(
+      RouteBuilder.create(AppRoute.Replenishment)
+        .addPart(AppRoute.InboundShipment)
+        .build()
+    );
   };
 
   const onDelete = useDeleteConfirmation({
@@ -83,4 +81,3 @@ export const SidePanel: FC = () => {
     </DetailPanelPortal>
   );
 };
-

--- a/client/packages/invoices/src/InboundShipment/api/hooks/document/useInboundDelete.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/document/useInboundDelete.ts
@@ -1,8 +1,5 @@
-import { AppRoute } from '@openmsupply-client/config';
 import {
-  RouteBuilder,
   useMutation,
-  useNavigate,
   useQueryClient,
 } from '@openmsupply-client/common';
 import { useInboundApi } from '../utils/useInboundApi';
@@ -10,16 +7,10 @@ import { useInboundApi } from '../utils/useInboundApi';
 export const useInboundDelete = () => {
   const queryClient = useQueryClient();
   const api = useInboundApi();
-  const navigate = useNavigate();
 
   return useMutation(api.delete, {
     onSuccess: () => {
       queryClient.invalidateQueries(api.keys.base());
-      navigate(
-        RouteBuilder.create(AppRoute.Replenishment)
-          .addPart(AppRoute.InboundShipment)
-          .build()
-      );
     },
   });
 };

--- a/client/packages/invoices/src/InboundShipment/api/hooks/document/useInsertInbound.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/document/useInsertInbound.ts
@@ -1,23 +1,11 @@
-import {
-  useNavigate,
-  useQueryClient,
-  useMutation,
-  RouteBuilder,
-} from '@openmsupply-client/common';
-import { AppRoute } from '@openmsupply-client/config';
+import { useQueryClient, useMutation } from '@openmsupply-client/common';
 import { useInboundApi } from '../utils/useInboundApi';
 
 export const useInsertInbound = () => {
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
   const api = useInboundApi();
   return useMutation(api.insert, {
-    onSuccess: invoiceNumber => {
-      const route = RouteBuilder.create(AppRoute.Replenishment)
-        .addPart(AppRoute.InboundShipment)
-        .addPart(String(invoiceNumber))
-        .build();
-      navigate(route, { replace: true });
+    onSuccess: () => {
       return queryClient.invalidateQueries(api.keys.base());
     },
   });

--- a/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/SidePanel.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/SidePanel.tsx
@@ -1,4 +1,5 @@
 import React, { memo } from 'react';
+import { AppRoute } from '@openmsupply-client/config';
 import {
   CopyIcon,
   DeleteIcon,
@@ -7,6 +8,8 @@ import {
   useNotification,
   useDeleteConfirmation,
   useTranslation,
+  useNavigate,
+  RouteBuilder,
 } from '@openmsupply-client/common';
 import { useOutbound } from '../../api';
 import { AdditionalInfoSection } from './AdditionalInfoSection';
@@ -16,14 +19,22 @@ import { TransportSection } from './TransportSection';
 import { canDeleteInvoice } from '../../../utils';
 
 export const SidePanelComponent = () => {
-  const { success } = useNotification();
   const t = useTranslation('distribution');
+  const navigate = useNavigate();
+  const { success } = useNotification();
   const { data } = useOutbound.document.get();
   const { mutateAsync } = useOutbound.document.delete();
   const canDelete = data ? canDeleteInvoice(data) : false;
+
   const deleteAction = async () => {
     if (!data) return;
-    await mutateAsync([data]);
+    await mutateAsync([data]).then(()=> {
+      navigate(
+        RouteBuilder.create(AppRoute.Distribution)
+          .addPart(AppRoute.OutboundShipment)
+          .build()
+      );
+    })
   };
 
   const onDelete = useDeleteConfirmation({

--- a/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/SidePanel.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/SidePanel.tsx
@@ -28,13 +28,12 @@ export const SidePanelComponent = () => {
 
   const deleteAction = async () => {
     if (!data) return;
-    await mutateAsync([data]).then(()=> {
-      navigate(
-        RouteBuilder.create(AppRoute.Distribution)
-          .addPart(AppRoute.OutboundShipment)
-          .build()
-      );
-    })
+    await mutateAsync([data]);
+    navigate(
+      RouteBuilder.create(AppRoute.Distribution)
+        .addPart(AppRoute.OutboundShipment)
+        .build()
+    );
   };
 
   const onDelete = useDeleteConfirmation({

--- a/client/packages/invoices/src/OutboundShipment/ListView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/OutboundShipment/ListView/AppBarButtons.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { AppRoute } from '@openmsupply-client/config';
 import {
   DownloadIcon,
   PlusCircleIcon,
@@ -13,6 +14,8 @@ import {
   ToggleState,
   EnvUtils,
   Platform,
+  RouteBuilder,
+  useNavigate,
 } from '@openmsupply-client/common';
 import { CustomerSearchModal } from '@openmsupply-client/system';
 import { useOutbound } from '../api';
@@ -21,8 +24,9 @@ import { outboundsToCsv } from '../../utils';
 export const AppBarButtonsComponent: FC<{
   modalController: ToggleState;
 }> = ({ modalController }) => {
+  const navigate = useNavigate();
   const { success, error } = useNotification();
-  const { mutate: onCreate } = useOutbound.document.insert();
+  const { mutateAsync: onCreate } = useOutbound.document.insert();
   const t = useTranslation('distribution');
   const { fetchAsync, isLoading } = useOutbound.document.listAll({
     key: 'createdDateTime',
@@ -59,6 +63,14 @@ export const AppBarButtonsComponent: FC<{
               await onCreate({
                 id: FnUtils.generateUUID(),
                 otherPartyId: name?.id,
+              }).then(invoiceNumber => {
+                navigate(
+                  RouteBuilder.create(AppRoute.Distribution)
+                    .addPart(AppRoute.OutboundShipment)
+                    .addPart(String(invoiceNumber))
+                    .build(),
+                  { replace: true }
+                );
               });
             } catch (e) {
               const errorSnack = error(

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/document/useOutboundDelete.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/document/useOutboundDelete.ts
@@ -1,25 +1,16 @@
-import { AppRoute } from '@openmsupply-client/config';
 import { useOutboundApi } from './../utils/useOutboundApi';
 import {
-  RouteBuilder,
   useMutation,
-  useNavigate,
   useQueryClient,
 } from '@openmsupply-client/common';
 
 export const useOutboundDelete = () => {
   const queryClient = useQueryClient();
   const api = useOutboundApi();
-  const navigate = useNavigate();
 
   return useMutation(api.delete, {
     onSuccess: () => {
       queryClient.invalidateQueries(api.keys.base());
-      navigate(
-        RouteBuilder.create(AppRoute.Distribution)
-          .addPart(AppRoute.OutboundShipment)
-          .build()
-      );
     },
   });
 };

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/document/useOutboundInsert.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/document/useOutboundInsert.ts
@@ -1,23 +1,11 @@
-import {
-  RouteBuilder,
-  useNavigate,
-  useMutation,
-  useQueryClient,
-} from '@openmsupply-client/common';
-import { AppRoute } from '@openmsupply-client/config';
+import { useMutation, useQueryClient } from '@openmsupply-client/common';
 import { useOutboundApi } from './../utils/useOutboundApi';
 
 export const useOutboundInsert = () => {
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
   const api = useOutboundApi();
   return useMutation(api.insert.outbound, {
-    onSuccess: invoiceNumber => {
-      const route = RouteBuilder.create(AppRoute.Distribution)
-        .addPart(AppRoute.OutboundShipment)
-        .addPart(String(invoiceNumber))
-        .build();
-      navigate(route, { replace: true });
+    onSuccess: () => {
       queryClient.invalidateQueries(api.keys.base());
     },
   });

--- a/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/SidePanel.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/SidePanel.tsx
@@ -26,13 +26,12 @@ export const SidePanelComponent = () => {
 
   const deleteAction = async () => {
     if (!data) return;
-    await mutateAsync([data]).then(() => {
-      navigate(
-        RouteBuilder.create(AppRoute.Dispensary)
-          .addPart(AppRoute.Prescription)
-          .build()
-      );
-    })
+    await mutateAsync([data]);
+    navigate(
+      RouteBuilder.create(AppRoute.Dispensary)
+        .addPart(AppRoute.Prescription)
+        .build()
+    );
   };
 
   const copyToClipboard = () => {

--- a/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/SidePanel.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/SidePanel.tsx
@@ -1,4 +1,5 @@
 import React, { memo } from 'react';
+import { AppRoute } from '@openmsupply-client/config';
 import {
   CopyIcon,
   DeleteIcon,
@@ -7,6 +8,8 @@ import {
   useNotification,
   useDeleteConfirmation,
   useTranslation,
+  useNavigate,
+  RouteBuilder,
 } from '@openmsupply-client/common';
 import { usePrescription } from '../../api';
 import { AdditionalInfoSection } from './AdditionalInfoSection';
@@ -14,15 +17,22 @@ import { PricingSection } from './PricingSection';
 import { canDeleteInvoice } from '../../../utils';
 
 export const SidePanelComponent = () => {
-  const { success } = useNotification();
   const t = useTranslation('dispensary');
+  const navigate = useNavigate();
+  const { success } = useNotification();
   const { data } = usePrescription.document.get();
   const { mutateAsync } = usePrescription.document.delete();
   const canDelete = data ? canDeleteInvoice(data) : false;
 
   const deleteAction = async () => {
     if (!data) return;
-    await mutateAsync([data]);
+    await mutateAsync([data]).then(() => {
+      navigate(
+        RouteBuilder.create(AppRoute.Dispensary)
+          .addPart(AppRoute.Prescription)
+          .build()
+      );
+    })
   };
 
   const copyToClipboard = () => {

--- a/client/packages/invoices/src/Prescriptions/ListView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/Prescriptions/ListView/AppBarButtons.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { AppRoute } from '@openmsupply-client/config';
 import {
   DownloadIcon,
   PlusCircleIcon,
@@ -13,6 +14,8 @@ import {
   ToggleState,
   EnvUtils,
   Platform,
+  useNavigate,
+  RouteBuilder,
 } from '@openmsupply-client/common';
 import { PatientSearchModal } from '@openmsupply-client/system';
 import { usePrescription } from '../api';
@@ -21,9 +24,10 @@ import { prescriptionToCsv } from '../../utils';
 export const AppBarButtonsComponent: FC<{
   modalController: ToggleState;
 }> = ({ modalController }) => {
-  const { success, error } = useNotification();
-  const { mutate: onCreate } = usePrescription.document.insert();
   const t = useTranslation('dispensary');
+  const navigate = useNavigate();
+  const { success, error } = useNotification();
+  const { mutateAsync: onCreate } = usePrescription.document.insert();
   const { data, isLoading } = usePrescription.document.list();
 
   const csvExport = async () => {
@@ -54,6 +58,14 @@ export const AppBarButtonsComponent: FC<{
               onCreate({
                 id: FnUtils.generateUUID(),
                 patientId: name?.id,
+              }).then(invoiceNumber => {
+                navigate(
+                  RouteBuilder.create(AppRoute.Dispensary)
+                    .addPart(AppRoute.Prescription)
+                    .addPart(String(invoiceNumber))
+                    .build(),
+                  { replace: true }
+                );
               });
             } catch (e) {
               const errorSnack = error(

--- a/client/packages/invoices/src/Prescriptions/api/hooks/document/usePrescriptionDelete.ts
+++ b/client/packages/invoices/src/Prescriptions/api/hooks/document/usePrescriptionDelete.ts
@@ -1,25 +1,16 @@
 import {
-  RouteBuilder,
   useMutation,
-  useNavigate,
   useQueryClient,
 } from '@openmsupply-client/common';
 import { usePrescriptionApi } from '../utils/usePrescriptionApi';
-import { AppRoute } from '@openmsupply-client/config';
 
 export const usePrescriptionDelete = () => {
   const queryClient = useQueryClient();
   const api = usePrescriptionApi();
-  const navigate = useNavigate();
 
   return useMutation(api.delete, {
     onSuccess: () => {
       queryClient.invalidateQueries(api.keys.base());
-      navigate(
-        RouteBuilder.create(AppRoute.Dispensary)
-          .addPart(AppRoute.Prescription)
-          .build()
-      );
     },
   });
 };

--- a/client/packages/invoices/src/Prescriptions/api/hooks/document/usePrescriptionInsert.ts
+++ b/client/packages/invoices/src/Prescriptions/api/hooks/document/usePrescriptionInsert.ts
@@ -1,23 +1,11 @@
-import {
-  RouteBuilder,
-  useNavigate,
-  useMutation,
-  useQueryClient,
-} from '@openmsupply-client/common';
-import { AppRoute } from '@openmsupply-client/config';
+import { useMutation, useQueryClient } from '@openmsupply-client/common';
 import { usePrescriptionApi } from '../../utils/usePrescriptionApi';
 
 export const usePrescriptionInsert = () => {
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
   const api = usePrescriptionApi();
   return useMutation(api.insert, {
-    onSuccess: invoiceNumber => {
-      const route = RouteBuilder.create(AppRoute.Dispensary)
-        .addPart(AppRoute.Prescription)
-        .addPart(String(invoiceNumber))
-        .build();
-      navigate(route, { replace: true });
+    onSuccess: () => {
       queryClient.invalidateQueries(api.keys.base());
     },
   });

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/SidePanel.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/SidePanel.tsx
@@ -21,6 +21,7 @@ import {
   DeleteIcon,
   RequisitionNodeStatus,
   useDeleteConfirmation,
+  useNavigate,
 } from '@openmsupply-client/common';
 import { useRequest } from '../api';
 import { AppRoute } from '@openmsupply-client/config';
@@ -138,14 +139,21 @@ const RelatedDocumentsSection: FC = () => {
 
 export const SidePanel: FC = () => {
   const t = useTranslation('replenishment');
+  const navigate = useNavigate();
+  const { success } = useNotification();
   const { mutateAsync } = useRequest.document.delete();
   const { data } = useRequest.document.get();
-  const { success } = useNotification();
   const canDelete = data?.status === RequisitionNodeStatus.Draft;
 
   const deleteAction = async () => {
     if (!data) return;
-    await mutateAsync([data]);
+    await mutateAsync([data]).then(() => {
+      navigate(
+        RouteBuilder.create(AppRoute.Replenishment)
+          .addPart(AppRoute.InternalOrder)
+          .build()
+      );
+    })
   };
 
   const copyToClipboard = () => {

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/SidePanel.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/SidePanel.tsx
@@ -147,13 +147,12 @@ export const SidePanel: FC = () => {
 
   const deleteAction = async () => {
     if (!data) return;
-    await mutateAsync([data]).then(() => {
-      navigate(
-        RouteBuilder.create(AppRoute.Replenishment)
-          .addPart(AppRoute.InternalOrder)
-          .build()
-      );
-    })
+    await mutateAsync([data]);
+    navigate(
+      RouteBuilder.create(AppRoute.Replenishment)
+        .addPart(AppRoute.InternalOrder)
+        .build()
+    );
   };
 
   const copyToClipboard = () => {

--- a/client/packages/requisitions/src/RequestRequisition/ListView/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/ListView/AppBarButtons.tsx
@@ -1,5 +1,4 @@
 import React, { FC } from 'react';
-
 import {
   FnUtils,
   DownloadIcon,
@@ -14,19 +13,23 @@ import {
   ToggleState,
   Platform,
   EnvUtils,
+  useNavigate,
+  RouteBuilder,
 } from '@openmsupply-client/common';
 import { useRequest } from '../api';
 import { requestsToCsv } from '../../utils';
 import { CreateRequisitionModal } from './CreateRequisitionModal';
 import { NewRequisitionType } from './types';
+import { AppRoute } from '@openmsupply-client/config';
 
 export const AppBarButtons: FC<{
   modalController: ToggleState;
 }> = ({ modalController }) => {
-  const { mutate: onCreate } = useRequest.document.insert();
-  const { mutate: onProgramCreate } = useRequest.document.insertProgram();
-  const { success, error } = useNotification();
   const t = useTranslation();
+  const navigate = useNavigate();
+  const { mutateAsync: onCreate } = useRequest.document.insert();
+  const { mutateAsync: onProgramCreate } = useRequest.document.insertProgram();
+  const { success, error } = useNotification();
   const { isLoading, fetchAsync } = useRequest.document.listAll({
     key: 'createdDatetime',
     direction: 'desc',
@@ -73,6 +76,14 @@ export const AppBarButtons: FC<{
               return onCreate({
                 id: FnUtils.generateUUID(),
                 otherPartyId: newRequisition.name.id,
+              }).then(requisitionNumber => {
+                navigate(
+                  RouteBuilder.create(AppRoute.Replenishment)
+                    .addPart(AppRoute.InternalOrder)
+                    .addPart(String(requisitionNumber))
+                    .build(),
+                  { replace: true }
+                );
               });
             case NewRequisitionType.Program:
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -80,6 +91,14 @@ export const AppBarButtons: FC<{
               return onProgramCreate({
                 id: FnUtils.generateUUID(),
                 ...rest,
+              }).then(requisitionNumber => {
+                navigate(
+                  RouteBuilder.create(AppRoute.Replenishment)
+                    .addPart(AppRoute.InternalOrder)
+                    .addPart(String(requisitionNumber))
+                    .build(),
+                  { replace: true }
+                );
               });
           }
         }}

--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/document/useDeleteRequests.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/document/useDeleteRequests.ts
@@ -1,24 +1,15 @@
 import {
   useQueryClient,
   useMutation,
-  useNavigate,
-  RouteBuilder,
 } from '@openmsupply-client/common';
 import { useRequestApi } from '../utils/useRequestApi';
-import { AppRoute } from '@openmsupply-client/config';
 
 export const useDeleteRequests = () => {
   const queryClient = useQueryClient();
   const api = useRequestApi();
-  const navigate = useNavigate();
   return useMutation(api.deleteRequests, {
     onSuccess: () => {
-      queryClient.invalidateQueries(api.keys.base()),
-        navigate(
-          RouteBuilder.create(AppRoute.Replenishment)
-            .addPart(AppRoute.InternalOrder)
-            .build()
-        );
+      queryClient.invalidateQueries(api.keys.base())
     },
   });
 };

--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/document/useInsertProgramRequest.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/document/useInsertProgramRequest.ts
@@ -1,23 +1,11 @@
-import {
-  useQueryClient,
-  useNavigate,
-  useMutation,
-  RouteBuilder,
-} from '@openmsupply-client/common';
-import { AppRoute } from '@openmsupply-client/config';
+import { useQueryClient, useMutation } from '@openmsupply-client/common';
 import { useRequestApi } from '../utils/useRequestApi';
 
 export const useInsertProgramRequest = () => {
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
   const api = useRequestApi();
   return useMutation(api.insertProgram, {
-    onSuccess: ({ requisitionNumber }) => {
-      const route = RouteBuilder.create(AppRoute.Replenishment)
-        .addPart(AppRoute.InternalOrder)
-        .addPart(String(requisitionNumber))
-        .build();
-      navigate(route, { replace: true });
+    onSuccess: () => {
       queryClient.invalidateQueries(api.keys.base());
     },
   });

--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/document/useInsertRequest.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/document/useInsertRequest.ts
@@ -1,23 +1,11 @@
-import {
-  useQueryClient,
-  useNavigate,
-  useMutation,
-  RouteBuilder,
-} from '@openmsupply-client/common';
-import { AppRoute } from '@openmsupply-client/config';
+import { useQueryClient, useMutation } from '@openmsupply-client/common';
 import { useRequestApi } from '../utils/useRequestApi';
 
 export const useInsertRequest = () => {
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
   const api = useRequestApi();
   return useMutation(api.insert, {
-    onSuccess: ({ requisitionNumber }) => {
-      const route = RouteBuilder.create(AppRoute.Replenishment)
-        .addPart(AppRoute.InternalOrder)
-        .addPart(String(requisitionNumber))
-        .build();
-      navigate(route, { replace: true });
+    onSuccess: () => {
       queryClient.invalidateQueries(api.keys.base());
     },
   });

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/CreateShipmentButton.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/CreateShipmentButton.tsx
@@ -5,8 +5,11 @@ import {
   useTranslation,
   useConfirmationModal,
   useAlertModal,
+  RouteBuilder,
+  useNavigate,
 } from '@openmsupply-client/common';
 import { useResponse } from '../../api';
+import { AppRoute } from 'packages/config/src';
 
 export const CreateShipmentButtonComponent = () => {
   const { lines, linesRemainingToSupply } = useResponse.document.fields([
@@ -14,8 +17,19 @@ export const CreateShipmentButtonComponent = () => {
     'linesRemainingToSupply',
   ]);
   const t = useTranslation('distribution');
-  const { mutate: createOutbound } = useResponse.utils.createOutbound();
+  const { mutateAsync } = useResponse.utils.createOutbound();
   const isDisabled = useResponse.utils.isDisabled();
+  const navigate = useNavigate();
+  const createOutbound = () => {
+    mutateAsync().then(invoiceNumber => {
+      navigate(
+        RouteBuilder.create(AppRoute.Distribution)
+          .addPart(AppRoute.OutboundShipment)
+          .addPart(String(invoiceNumber))
+          .build()
+      );
+    });
+  };
 
   const getConfirmation = useConfirmationModal({
     iconType: 'info',
@@ -32,6 +46,7 @@ export const CreateShipmentButtonComponent = () => {
     ),
     onOk: () => {},
   });
+
   const onCreateShipment = () => {
     if (linesRemainingToSupply.totalCount > 0) {
       getConfirmation();

--- a/client/packages/requisitions/src/ResponseRequisition/api/hooks/utils/useCreateOutboundFromResponse.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/api/hooks/utils/useCreateOutboundFromResponse.ts
@@ -1,7 +1,4 @@
-import { AppRoute } from '@openmsupply-client/config';
 import {
-  RouteBuilder,
-  useOpenInNewTab,
   useQueryClient,
   useMutation,
   useNotification,
@@ -16,18 +13,9 @@ export const useCreateOutboundFromResponse = () => {
   const queryClient = useQueryClient();
   const { error, warning } = useNotification();
   const t = useTranslation('distribution');
-  const openInNewTab = useOpenInNewTab();
   const { id } = useResponseFields('id');
   const api = useResponseApi();
   return useMutation(() => api.createOutboundFromResponse(id), {
-    onSuccess: (invoiceNumber: number) => {
-      openInNewTab(
-        RouteBuilder.create(AppRoute.Distribution)
-          .addPart(AppRoute.OutboundShipment)
-          .addPart(String(invoiceNumber))
-          .build()
-      );
-    },
     onError: e => {
       const errorObj = e as Error;
       if (errorObj.message === 'NothingRemainingToSupply') {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2229

# 👩🏻‍💻 What does this PR do? 
Refactor to move all navigation out of hooks.

# 🧪 How has/should this change been tested? 
- [ ] Ensure that you still get navigated to new page when creating Inbound, Outbound, Stocktake, Requisition and Internal Orders