### PR TITLE
Support multiple SQL report queries

### DIFF
--- a/server/report_builder/src/lib.rs
+++ b/server/report_builder/src/lib.rs
@@ -39,16 +39,16 @@ pub struct BuildArgs {
     #[clap(long)]
     pub query_default: Option<String>,
 
-    /// File name of the SQLite query.
-    /// If specified the query_postgres must be provided as well.
-    /// However, query_sqlite and query_postgres can point to the same file.
-    #[clap(long)]
-    pub query_sqlite: Option<String>,
-    /// File name of the Postgres query.
-    /// If specified the query_sqlite must be provided as well.
-    /// However, query_sqlite and query_postgres can point to the same file.
-    #[clap(long)]
-    pub query_postgres: Option<String>,
+    /// SQL query name.
+    /// This argument requires that there is either
+    /// - a single {query_sql}.sql file (for both Sqlite and Postgres)
+    /// - a {query_sql}.sqlite.sql file and a {query_sql}.postgres.sql file
+    ///
+    /// The query result is put in the data object under `data.{query_sql}`.
+    /// Thus, the user has to take care that the query name {query_sql} does not conflict with a
+    /// GraphQL query since otherwise data from the GraphQL query might get overwritten.
+    #[clap(long, value_parser, value_delimiter = ' ')]
+    pub query_sql: Option<Vec<String>>,
 }
 
 #[derive(clap::Args)]

--- a/server/repository/src/db_diesel/report_query.rs
+++ b/server/repository/src/db_diesel/report_query.rs
@@ -52,6 +52,7 @@ pub fn query_json(
     for (i, param) in used_params.iter().enumerate() {
         sql = sql.replace(&param.0, &format!("${}", i + 1));
     }
+
     // Create the string containing all the parameter values
     let param_values = used_params
         .iter()
@@ -125,7 +126,7 @@ pub fn query_json(
         let Some(param) = statement.parameter_name(p) else {
             continue;
         };
-        // remove trailing ":"
+        // remove trailing "$"
         let param_name = &param[1..];
         let Some(param) = parameters.get(param_name) else {
             return Err(RepositoryError::DBError {

--- a/server/service/src/report/definition.rs
+++ b/server/service/src/report/definition.rs
@@ -3,8 +3,11 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use super::string_or_vec::string_or_vec;
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct SQLQuery {
+    pub name: String,
     pub query_sqlite: String,
     pub query_postgres: String,
 }
@@ -73,7 +76,8 @@ pub struct ReportDefinitionIndex {
     pub template: Option<String>,
     pub header: Option<String>,
     pub footer: Option<String>,
-    pub query: Option<String>,
+    #[serde(deserialize_with = "string_or_vec")]
+    pub query: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -144,7 +148,7 @@ mod report_dsl_test {
                     template: Some("template.html".to_string()),
                     header: None,
                     footer: Some("local_footer.html".to_string()),
-                    query: Some("query".to_string()),
+                    query: vec!["query".to_string()],
                 },
                 entries: HashMap::from([
                     (

--- a/server/service/src/report/mod.rs
+++ b/server/service/src/report/mod.rs
@@ -2,3 +2,4 @@ pub mod default_queries;
 pub mod definition;
 mod html_printing;
 pub mod report_service;
+mod string_or_vec;

--- a/server/service/src/report/string_or_vec.rs
+++ b/server/service/src/report/string_or_vec.rs
@@ -1,0 +1,34 @@
+use std::fmt;
+
+use serde::de::{self, value, Deserialize, Deserializer, SeqAccess, Visitor};
+
+pub(crate) fn string_or_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct StringOrVec;
+
+    impl<'de> Visitor<'de> for StringOrVec {
+        type Value = Vec<String>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("string or list of strings")
+        }
+
+        fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(vec![s.to_owned()])
+        }
+
+        fn visit_seq<S>(self, seq: S) -> Result<Self::Value, S::Error>
+        where
+            S: SeqAccess<'de>,
+        {
+            Deserialize::deserialize(value::SeqAccessDeserializer::new(seq))
+        }
+    }
+
+    deserializer.deserialize_any(StringOrVec)
+}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3420 

# 👩🏻‍💻 What does this PR do? 
It's now possible to have 0 or 1 GraphGL queries + multiple sql queries. (See issue for the motivation)

# 🧪 How has/should this change been tested? 
Old reports should still work. I also updated the `examples/SQLReport` report in the `open-msupply-reports` repo to give a full example.
