### PR TITLE
Don't allow clearing of languages

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Select/Select.tsx
+++ b/client/packages/common/src/ui/components/inputs/Select/Select.tsx
@@ -25,7 +25,7 @@ const defaultRenderOption = (option: Option) => (
 
 export const Select: FC<SelectProps> = React.forwardRef(
   (
-    { options, renderOption, sx, InputProps, clearable = true, ...props },
+    { options, renderOption, sx, InputProps, clearable = false, ...props },
     ref
   ) => {
     const t = useTranslation();

--- a/client/packages/host/src/components/LanguageMenu.tsx
+++ b/client/packages/host/src/components/LanguageMenu.tsx
@@ -35,7 +35,6 @@ export const LanguageMenu: React.FC = () => {
       options={languageOptions}
       value={currentLanguage}
       renderOption={renderOption}
-      clearable={false}
     />
   );
 };

--- a/client/packages/host/src/components/LanguageMenu.tsx
+++ b/client/packages/host/src/components/LanguageMenu.tsx
@@ -35,6 +35,7 @@ export const LanguageMenu: React.FC = () => {
       options={languageOptions}
       value={currentLanguage}
       renderOption={renderOption}
+      clearable={false}
     />
   );
 };

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -237,7 +237,6 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
                     sx={{ width: 110 }}
                     options={packSizeController.options}
                     value={packSizeController.selected?.value ?? ''}
-                    clearable={false}
                     onChange={e => {
                       const { value } = e.target;
                       onChangePackSize(Number(value));

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
@@ -255,7 +255,6 @@ export const PrescriptionLineEditForm: React.FC<
                     sx={{ width: 110 }}
                     options={packSizeController.options}
                     value={packSizeController.selected?.value ?? ''}
-                    clearable={false}
                     onChange={e => {
                       const { value } = e.target;
                       onChangePackSize(Number(value));


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3387

# 👩🏻‍💻 What does this PR do? 
Don't allow users to clear language 

# 🧪 How has/should this change been tested? 
- [ ] Login as admin
- [ ] Go to `Admin`
- [ ] Click on language selection
- [ ] Shouldn't see `Clear Selection`