### PR TITLE
3408 Repacks: 'Number of packs to repack' field is not required

### DIFF
--- a/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
+++ b/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
@@ -137,12 +137,7 @@ export const RepackModal: FC<RepackModalControlProps> = ({
       okButton={
         <DialogButton
           variant="save"
-          disabled={
-            draft?.newPackSize === 0 ||
-            draft?.numberOfPacks === 0 ||
-            !draft.newPackSize ||
-            !draft.numberOfPacks
-          }
+          disabled={!draft?.newPackSize || !draft?.numberOfPacks}
           onClick={async () => {
             try {
               const result = await onInsert();

--- a/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
+++ b/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
@@ -137,7 +137,12 @@ export const RepackModal: FC<RepackModalControlProps> = ({
       okButton={
         <DialogButton
           variant="save"
-          disabled={draft?.newPackSize === 0 || draft?.numberOfPacks === 0}
+          disabled={
+            draft?.newPackSize === 0 ||
+            draft?.numberOfPacks === 0 ||
+            !draft.newPackSize ||
+            !draft.numberOfPacks
+          }
           onClick={async () => {
             try {
               const result = await onInsert();


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3408

# 👩🏻‍💻 What does this PR do? 
Disable save button if input has been cleared

# 🧪 How has/should this change been tested? 
- [ ] Go to `Stock`
- [ ] Click on `Repack` box
- [ ] Create `New` repack
- [ ] Enter numbers into both `Number of packs to repack` and `New pack size`
- [ ] Clear one of the numbers
- [ ] Save button should be disabled