### PR TITLE
Catalogue   master lists   export exports all master lists, not just the ones the store has visibility to #3361

### DIFF
--- a/client/packages/system/src/MasterList/ListView/AppBarButtons.tsx
+++ b/client/packages/system/src/MasterList/ListView/AppBarButtons.tsx
@@ -9,6 +9,7 @@ import {
   LoadingButton,
   EnvUtils,
   Platform,
+  useAuthContext,
 } from '@openmsupply-client/common';
 import { useMasterList } from '../api/hooks';
 import { masterListsToCsv } from '../../utils';
@@ -16,10 +17,14 @@ import { masterListsToCsv } from '../../utils';
 export const AppBarButtons = () => {
   const { success, error } = useNotification();
   const t = useTranslation('inventory');
-  const { isLoading, fetchAsync } = useMasterList.document.listAll({
-    key: 'name',
-    direction: 'asc',
-  });
+  const { storeId } = useAuthContext();
+  const { isLoading, fetchAsync } = useMasterList.document.listAll(
+    {
+      key: 'name',
+      direction: 'asc',
+    },
+    { existsForStoreId: { equalTo: storeId } }
+  );
 
   const csvExport = async () => {
     const data = await fetchAsync();

--- a/server/repository/src/mock/full_master_list.rs
+++ b/server/repository/src/mock/full_master_list.rs
@@ -22,7 +22,7 @@ pub fn mock_master_list_item_query_test1() -> FullMockMasterList {
         joins: vec![MasterListNameJoinRow {
             id: "item_query_test1".to_owned(),
             master_list_id: "item_query_test1".to_owned(),
-            name_link_id: "id_master_list_filter_test".to_owned(),
+            name_link_id: "name_store_a".to_owned(),
         }],
         lines: vec![MasterListLineRow {
             id: "item_query_test1".to_owned(),
@@ -44,7 +44,7 @@ pub fn mock_master_list_master_list_filter_test() -> FullMockMasterList {
         joins: vec![MasterListNameJoinRow {
             id: "master_list_filter_test".to_owned(),
             master_list_id: "master_list_filter_test".to_owned(),
-            name_link_id: "name_store_a".to_owned(),
+            name_link_id: "id_master_list_filter_test".to_owned(),
         }],
         lines: Vec::new(),
     }

--- a/server/service/src/master_list/tests/query.rs
+++ b/server/service/src/master_list/tests/query.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod query {
-    use repository::mock::mock_store_a;
     use repository::{mock::MockDataInserts, test_db::setup_all, MasterListFilter};
     use repository::{EqualFilter, StringFilter};
 
@@ -21,7 +20,7 @@ mod query {
                 None,
                 Some(
                     MasterListFilter::new()
-                        .exists_for_name_id(EqualFilter::equal_to("id_master_list_filter_test")),
+                        .exists_for_name_id(EqualFilter::equal_to("name_store_a")),
                 ),
                 None,
             )
@@ -36,13 +35,12 @@ mod query {
                 None,
                 Some(
                     MasterListFilter::new()
-                        .exists_for_name(StringFilter::like("e_master_list_filter_te")),
+                        .exists_for_name(StringFilter::like("name_master_list_filter_test")),
                 ),
                 None,
             )
             .unwrap();
 
-        let master_list_row = result.rows[0].clone();
         assert_eq!(result.count, 1);
         assert_eq!(result.rows[0].id, "master_list_filter_test");
 

--- a/server/service/src/stocktake/insert.rs
+++ b/server/service/src/stocktake/insert.rs
@@ -501,7 +501,7 @@ mod test {
             setup_all("insert_stocktake_with_master_list", MockDataInserts::all()).await;
 
         let service_provider = ServiceProvider::new(connection_manager, "app_data");
-        let mut context = service_provider
+        let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();
         let service = service_provider.stocktake_service;
@@ -517,7 +517,7 @@ mod test {
                 stocktake_date: Some(NaiveDate::from_ymd_opt(2020, 01, 02).unwrap()),
                 is_locked: Some(true),
                 location: None,
-                master_list_id: Some("item_query_test1".to_string()),
+                master_list_id: Some("invalid".to_string()),
                 items_have_stock: None,
             },
         );
@@ -532,7 +532,6 @@ mod test {
             })
         });
 
-        context.store_id = mock_store_a().id;
         service
             .insert_stocktake(
                 &context,
@@ -564,17 +563,16 @@ mod test {
         let stock_line_row = stocktake_rows
             .iter()
             .find(|r| r.line.stock_line_id == Some("item_query_test1".to_string()));
-        assert_eq!(stock_line_row.is_some(), true);
+        assert!(stock_line_row.is_some());
         assert_eq!(
             stock_line_row.unwrap().line.stock_line_id,
             Some("item_query_test1".to_string())
         );
 
-        // and the stock line for store_b?
         let stock_line_row = stocktake_rows
             .iter()
             .find(|r| r.line.stock_line_id == Some("stock_line_row_1".to_string()));
-        assert_eq!(stock_line_row.is_some(), false);
+        assert!(stock_line_row.is_none());
 
         // add another item to the master list and check that it is added to the stocktake
         let _ = MasterListLineRowRepository::new(&connection).upsert_one(&MasterListLineRow {
@@ -625,13 +623,12 @@ mod test {
             setup_all("insert_stocktake_with_location", MockDataInserts::all()).await;
 
         let service_provider = ServiceProvider::new(connection_manager, "app_data");
-        let mut context = service_provider
+        let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();
         let service = service_provider.stocktake_service;
         let location_id = mock_location_1().id;
 
-        context.store_id = mock_store_a().id;
         service
             .insert_stocktake(
                 &context,
@@ -702,7 +699,7 @@ mod test {
         let stock_line_row = stocktake_rows
             .iter()
             .find(|r| r.line.stock_line_id == Some("stock_line_row_1".to_string()));
-        assert_eq!(stock_line_row.is_some(), true);
+        assert!(stock_line_row.is_some());
         assert_eq!(
             stock_line_row.unwrap().line.stock_line_id,
             Some("stock_line_row_1".to_string())


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3361

# 👩🏻‍💻 What does this PR do? 
To fix revert. Export button for master list should only show master lists for store

# 🧪 How has/should this change been tested? 
- [ ] Export Master Lists