### PR TITLE
2594 link temperature logs to breaches suggestion

### DIFF
--- a/server/graphql/types/src/types/temperature_log.rs
+++ b/server/graphql/types/src/types/temperature_log.rs
@@ -54,6 +54,8 @@ impl From<TemperatureLogFilterInput> for TemperatureLogFilter {
             sensor: f.sensor.map(SensorFilterInput::into),
             location: f.location.map(LocationFilterInput::into),
             temperature_breach: f.temperature_breach.map(TemperatureBreachFilterInput::into),
+            temperature: None,
+            temperature_breach_id: None,
         }
     }
 }

--- a/server/repository/src/db_diesel/filter_sort_pagination.rs
+++ b/server/repository/src/db_diesel/filter_sort_pagination.rs
@@ -1,3 +1,5 @@
+use std::ops::Range;
+
 use chrono::{NaiveDate, NaiveDateTime};
 use util::inline_init;
 
@@ -178,6 +180,20 @@ impl EqualFilter<String> {
 
     pub fn is_null(value: bool) -> Self {
         inline_init(|r: &mut Self| r.is_null = Some(value))
+    }
+}
+
+#[derive(Clone, PartialEq, Debug, Default)]
+pub struct NumberFilter<T> {
+    /// ( {field} < range.start or range.end < {field} )
+    pub not_in_range: Option<Range<T>>,
+}
+
+impl<T> NumberFilter<T> {
+    pub fn not_in_range(value: Range<T>) -> Self {
+        Self {
+            not_in_range: Some(value),
+        }
     }
 }
 

--- a/server/repository/src/db_diesel/temperature_breach.rs
+++ b/server/repository/src/db_diesel/temperature_breach.rs
@@ -7,7 +7,6 @@ use super::{
     DBType, StorageConnection, TemperatureBreachRow, TemperatureBreachRowType,
 };
 use diesel::prelude::*;
-use util::inline_init;
 
 use crate::{
     diesel_macros::{apply_date_time_filter, apply_equal_filter, apply_sort, apply_sort_no_case},
@@ -33,12 +32,6 @@ pub struct TemperatureBreachFilter {
     pub unacknowledged: Option<bool>,
     pub sensor: Option<SensorFilter>,
     pub location: Option<LocationFilter>,
-}
-
-impl EqualFilter<TemperatureBreachRowType> {
-    pub fn equal_to_breach_type(value: &TemperatureBreachRowType) -> Self {
-        inline_init(|r: &mut Self| r.equal_to = Some(value.to_owned()))
-    }
 }
 
 #[derive(PartialEq, Debug)]
@@ -152,20 +145,6 @@ impl<'a> TemperatureBreachRepository<'a> {
 
 type BoxedTemperatureBreachQuery = temperature_breach::BoxedQuery<'static, DBType>;
 
-impl TemperatureBreachRowType {
-    pub fn equal_to(&self) -> EqualFilter<Self> {
-        inline_init(|r: &mut EqualFilter<Self>| r.equal_to = Some(self.clone()))
-    }
-
-    pub fn not_equal_to(&self) -> EqualFilter<Self> {
-        inline_init(|r: &mut EqualFilter<Self>| r.not_equal_to = Some(self.clone()))
-    }
-
-    pub fn equal_any(value: Vec<Self>) -> EqualFilter<Self> {
-        inline_init(|r: &mut EqualFilter<Self>| r.equal_any = Some(value))
-    }
-}
-
 pub fn to_domain(temperature_breach_row: TemperatureBreachRow) -> TemperatureBreach {
     TemperatureBreach {
         temperature_breach_row,
@@ -224,5 +203,14 @@ impl TemperatureBreachFilter {
     pub fn location(mut self, filter: LocationFilter) -> Self {
         self.location = Some(filter);
         self
+    }
+}
+
+impl TemperatureBreachRowType {
+    pub fn equal_to(&self) -> EqualFilter<Self> {
+        EqualFilter {
+            equal_to: Some(self.clone()),
+            ..Default::default()
+        }
     }
 }

--- a/server/repository/src/db_diesel/temperature_breach_config.rs
+++ b/server/repository/src/db_diesel/temperature_breach_config.rs
@@ -18,12 +18,15 @@ pub struct TemperatureBreachConfig {
     pub temperature_breach_config_row: TemperatureBreachConfigRow,
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, Default)]
 pub struct TemperatureBreachConfigFilter {
     pub id: Option<EqualFilter<String>>,
     pub r#type: Option<EqualFilter<TemperatureBreachRowType>>,
     pub is_active: Option<bool>,
     pub store_id: Option<EqualFilter<String>>,
+    pub duration_milliseconds: Option<EqualFilter<i32>>,
+    pub minimum_temperature: Option<EqualFilter<f64>>,
+    pub maximum_temperature: Option<EqualFilter<f64>>,
     pub description: Option<EqualFilter<String>>,
 }
 
@@ -97,24 +100,45 @@ type BoxedLogQuery = temperature_breach_config::BoxedQuery<'static, DBType>;
 fn create_filtered_query(filter: Option<TemperatureBreachConfigFilter>) -> BoxedLogQuery {
     let mut query = temperature_breach_config::table.into_boxed();
 
-    if let Some(filter) = filter {
-        apply_equal_filter!(query, filter.id, temperature_breach_config_dsl::id);
-        apply_equal_filter!(query, filter.r#type, temperature_breach_config_dsl::type_);
+    if let Some(TemperatureBreachConfigFilter {
+        id,
+        r#type,
+        is_active,
+        store_id,
+        duration_milliseconds,
+        minimum_temperature,
+        maximum_temperature,
+        description,
+    }) = filter
+    {
+        apply_equal_filter!(query, id, temperature_breach_config_dsl::id);
+        apply_equal_filter!(query, r#type, temperature_breach_config_dsl::type_);
         apply_equal_filter!(
             query,
-            filter.description,
+            duration_milliseconds,
+            temperature_breach_config_dsl::duration_milliseconds
+        );
+        apply_equal_filter!(
+            query,
+            minimum_temperature,
+            temperature_breach_config_dsl::minimum_temperature
+        );
+        apply_equal_filter!(
+            query,
+            maximum_temperature,
+            temperature_breach_config_dsl::maximum_temperature
+        );
+        apply_equal_filter!(
+            query,
+            description,
             temperature_breach_config_dsl::description
         );
 
-        if let Some(value) = filter.is_active {
+        if let Some(value) = is_active {
             query = query.filter(temperature_breach_config_dsl::is_active.eq(value));
         }
 
-        apply_equal_filter!(
-            query,
-            filter.store_id,
-            temperature_breach_config_dsl::store_id
-        );
+        apply_equal_filter!(query, store_id, temperature_breach_config_dsl::store_id);
     }
 
     query
@@ -130,13 +154,7 @@ pub fn to_domain(
 
 impl TemperatureBreachConfigFilter {
     pub fn new() -> TemperatureBreachConfigFilter {
-        TemperatureBreachConfigFilter {
-            id: None,
-            is_active: None,
-            r#type: None,
-            store_id: None,
-            description: None,
-        }
+        Default::default()
     }
 
     pub fn id(mut self, filter: EqualFilter<String>) -> Self {
@@ -161,6 +179,21 @@ impl TemperatureBreachConfigFilter {
 
     pub fn description(mut self, filter: EqualFilter<String>) -> Self {
         self.description = Some(filter);
+        self
+    }
+
+    pub fn duration_milliseconds(mut self, filter: EqualFilter<i32>) -> Self {
+        self.duration_milliseconds = Some(filter);
+        self
+    }
+
+    pub fn minimum_temperature(mut self, filter: EqualFilter<f64>) -> Self {
+        self.minimum_temperature = Some(filter);
+        self
+    }
+
+    pub fn maximum_temperature(mut self, filter: EqualFilter<f64>) -> Self {
+        self.maximum_temperature = Some(filter);
         self
     }
 }

--- a/server/repository/src/db_diesel/temperature_log_row.rs
+++ b/server/repository/src/db_diesel/temperature_log_row.rs
@@ -79,6 +79,18 @@ impl<'a> TemperatureLogRowRepository<'a> {
         Ok(())
     }
 
+    pub fn update_breach_id(
+        &self,
+        breach_id: &str,
+        temperature_log_ids: &Vec<String>,
+    ) -> Result<(), RepositoryError> {
+        diesel::update(temperature_log_dsl::temperature_log)
+            .filter(temperature_log_dsl::id.eq_any(temperature_log_ids))
+            .set(temperature_log_dsl::temperature_breach_id.eq(breach_id))
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
+
     pub fn find_one_by_id(&self, id: &str) -> Result<Option<TemperatureLogRow>, RepositoryError> {
         let result = temperature_log_dsl::temperature_log
             .filter(temperature_log_dsl::id.eq(id))

--- a/server/repository/src/diesel_macros.rs
+++ b/server/repository/src/diesel_macros.rs
@@ -247,6 +247,16 @@ macro_rules! apply_date_time_filter {
     }};
 }
 
+macro_rules! apply_number_filter {
+    ($query:ident, $filter_field:expr, $dsl_field:expr ) => {{
+        if let Some(number_filter) = $filter_field {
+            if let Some(range) = number_filter.not_in_range {
+                $query = $query.filter($dsl_field.lt(range.start).or($dsl_field.gt(range.end)));
+            }
+        }
+    }};
+}
+
 macro_rules! apply_date_filter {
     ($query:ident, $filter_field:expr, $dsl_field:expr ) => {{
         if let Some(date_filter) = $filter_field {
@@ -363,6 +373,7 @@ macro_rules! apply_sort_asc_nulls_first {
 pub(crate) use apply_date_filter;
 pub(crate) use apply_date_time_filter;
 pub(crate) use apply_equal_filter;
+pub(crate) use apply_number_filter;
 pub(crate) use apply_sort;
 pub(crate) use apply_sort_asc_nulls_first;
 pub(crate) use apply_sort_asc_nulls_last;

--- a/server/service/src/sensor/berlinger.rs
+++ b/server/service/src/sensor/berlinger.rs
@@ -17,7 +17,7 @@ use util::uuid::uuid;
 
 use temperature_sensor::*;
 
-pub fn get_breach_row_type(breach_type: &BreachType) -> TemperatureBreachRowType {
+fn get_breach_row_type(breach_type: &BreachType) -> TemperatureBreachRowType {
     match breach_type {
         BreachType::ColdConsecutive => TemperatureBreachRowType::ColdConsecutive,
         BreachType::ColdCumulative => TemperatureBreachRowType::ColdCumulative,
@@ -26,7 +26,7 @@ pub fn get_breach_row_type(breach_type: &BreachType) -> TemperatureBreachRowType
     }
 }
 
-pub fn get_matching_sensor_serial(
+fn get_matching_sensor_serial(
     connection: &StorageConnection,
     serial: &str,
 ) -> Result<Vec<Sensor>, RepositoryError> {
@@ -34,7 +34,7 @@ pub fn get_matching_sensor_serial(
         .query_by_filter(SensorFilter::new().serial(EqualFilter::equal_to(&serial)))
 }
 
-pub fn get_matching_sensor_log(
+fn get_matching_sensor_log(
     connection: &StorageConnection,
     sensor_id: &str,
     datetime: NaiveDateTime,
@@ -46,71 +46,42 @@ pub fn get_matching_sensor_log(
     TemperatureLogRepository::new(connection).query_by_filter(filter)
 }
 
-pub fn get_matching_sensor_breach_config(
+fn get_matching_sensor_breach_config(
     connection: &StorageConnection,
-    description: &str,
+    store_id: &str,
+    temperature_breach_config: &temperature_sensor::TemperatureBreachConfig,
     breach_type: &TemperatureBreachRowType,
 ) -> Result<Vec<TemperatureBreachConfig>, RepositoryError> {
     let filter = TemperatureBreachConfigFilter::new()
-        .description(EqualFilter::equal_to(description))
-        .r#type(EqualFilter::equal_to_breach_type(&breach_type));
+        .store_id(EqualFilter::equal_to(store_id))
+        .duration_milliseconds(EqualFilter::equal_to_i32(
+            temperature_breach_config.duration.num_seconds() as i32,
+        ))
+        .minimum_temperature(EqualFilter::equal_to_f64(
+            temperature_breach_config.minimum_temperature,
+        ))
+        .maximum_temperature(EqualFilter::equal_to_f64(
+            temperature_breach_config.maximum_temperature,
+        ))
+        .r#type(breach_type.equal_to());
 
     TemperatureBreachConfigRepository::new(connection).query_by_filter(filter)
 }
 
-pub fn get_matching_sensor_breach(
+fn get_matching_sensor_breach(
     connection: &StorageConnection,
     sensor_id: &str,
     start_datetime: NaiveDateTime,
-    _end_datetime: NaiveDateTime, // don't match on the end time, just the breach type and start time
     breach_type: &TemperatureBreachRowType,
-) -> Result<Vec<TemperatureBreach>, RepositoryError> {
-    let mut filter = TemperatureBreachFilter::new()
+) -> Result<Option<TemperatureBreach>, RepositoryError> {
+    let filter = TemperatureBreachFilter::new()
         .sensor(SensorFilter::new().id(EqualFilter::equal_to(sensor_id)))
-        .r#type(EqualFilter::equal_to_breach_type(&breach_type));
+        .r#type(breach_type.equal_to())
+        .start_datetime(DatetimeFilter::equal_to(start_datetime));
 
-    match breach_type {
-        TemperatureBreachRowType::ColdCumulative | TemperatureBreachRowType::HotCumulative => {
-            // Cumulative breach can start any time on the same day (can only be at most one hot/cold per day)
-            let start_breach = start_datetime.date().and_hms_opt(0, 0, 0).unwrap();
-            let end_breach = start_datetime.date().and_hms_opt(23, 59, 59).unwrap();
-            filter = filter.start_datetime(DatetimeFilter::date_range(start_breach, end_breach));
-        }
-        TemperatureBreachRowType::ColdConsecutive | TemperatureBreachRowType::HotConsecutive => {
-            filter = filter.start_datetime(DatetimeFilter::equal_to(start_datetime));
-        }
-    }
-
-    TemperatureBreachRepository::new(connection).query_by_filter(filter)
-}
-
-pub fn get_logs_for_sensor(
-    connection: &StorageConnection,
-    sensor_id: &str,
-) -> Result<Vec<TemperatureLog>, RepositoryError> {
-    TemperatureLogRepository::new(connection).query_by_filter(
-        TemperatureLogFilter::new()
-            .sensor(SensorFilter::new().id(EqualFilter::equal_to(sensor_id))),
-    )
-}
-
-pub fn get_breaches_for_sensor(
-    connection: &StorageConnection,
-    sensor_id: &str,
-) -> Result<Vec<TemperatureBreach>, RepositoryError> {
-    TemperatureBreachRepository::new(connection).query_by_filter(
-        TemperatureBreachFilter::new()
-            .sensor(SensorFilter::new().id(EqualFilter::equal_to(sensor_id)))
-            .unacknowledged(true),
-    )
-}
-
-pub fn get_breach_configs_for_sensor(
-    connection: &StorageConnection,
-    _sensor_id: &str,
-) -> Result<Vec<TemperatureBreachConfig>, RepositoryError> {
-    TemperatureBreachConfigRepository::new(connection)
-        .query_by_filter(TemperatureBreachConfigFilter::new().is_active(true))
+    Ok(TemperatureBreachRepository::new(connection)
+        .query_by_filter(filter)?
+        .pop())
 }
 
 fn sensor_add_log_if_new(
@@ -143,45 +114,52 @@ fn sensor_add_breach_if_new(
     sensor_row: &SensorRow,
     temperature_breach: &temperature_sensor::TemperatureBreach,
     breach_config: &temperature_sensor::TemperatureBreachConfig,
-) -> Result<(), RepositoryError> {
+) -> Result<Option<TemperatureBreachRow>, RepositoryError> {
     let breach_row_type = get_breach_row_type(&temperature_breach.breach_type);
-    let result = get_matching_sensor_breach(
+    let temperature_breach_option = get_matching_sensor_breach(
         connection,
         &sensor_row.id,
         temperature_breach.start_timestamp,
-        temperature_breach.end_timestamp,
         &breach_row_type,
     )?;
 
-    if let Some(mut record) = result.clone().pop() {
-        if record.temperature_breach_row.end_datetime != Some(temperature_breach.end_timestamp) {
-            // Update breach end time if it has changed
-            record.temperature_breach_row.end_datetime = Some(temperature_breach.end_timestamp);
-            TemperatureBreachRowRepository::new(connection)
-                .upsert_one(&record.temperature_breach_row)?;
-            update_sensor_logs_for_breach(connection, &record.temperature_breach_row.id)?;
+    let temperature_breach_upsert = match temperature_breach_option {
+        Some(existing_breach) => {
+            let existing_breach_row = existing_breach.temperature_breach_row;
+            if existing_breach_row.end_datetime == Some(temperature_breach.end_timestamp) {
+                return Ok(None);
+            }
+            let breach = TemperatureBreachRow {
+                end_datetime: Some(temperature_breach.end_timestamp),
+                duration_milliseconds: temperature_breach.duration.num_milliseconds() as i32,
+                ..existing_breach_row
+            };
+            log::info!("Updating breach {:?} ", breach);
+            breach
         }
-        Ok(())
-    } else {
-        let new_temperature_breach = TemperatureBreachRow {
-            id: uuid(),
-            store_id: sensor_row.store_id.clone(),
-            sensor_id: sensor_row.id.clone(),
-            location_id: sensor_row.location_id.clone(),
-            start_datetime: temperature_breach.start_timestamp,
-            end_datetime: Some(temperature_breach.end_timestamp),
-            unacknowledged: true,
-            duration_milliseconds: temperature_breach.duration.num_seconds() as i32,
-            r#type: breach_row_type,
-            threshold_duration_milliseconds: breach_config.duration.num_seconds() as i32,
-            threshold_minimum: breach_config.minimum_temperature,
-            threshold_maximum: breach_config.maximum_temperature,
-        };
-        TemperatureBreachRowRepository::new(connection).upsert_one(&new_temperature_breach)?;
-        update_sensor_logs_for_breach(connection, &new_temperature_breach.id)?;
-        log::info!("Added sensor breach {:?} ", new_temperature_breach);
-        Ok(())
-    }
+        None => {
+            let breach = TemperatureBreachRow {
+                id: uuid(),
+                store_id: sensor_row.store_id.clone(),
+                sensor_id: sensor_row.id.clone(),
+                location_id: sensor_row.location_id.clone(),
+                start_datetime: temperature_breach.start_timestamp,
+                end_datetime: Some(temperature_breach.end_timestamp),
+                unacknowledged: true,
+                duration_milliseconds: temperature_breach.duration.num_milliseconds() as i32,
+                r#type: breach_row_type,
+                threshold_duration_milliseconds: breach_config.duration.num_milliseconds() as i32,
+                threshold_minimum: breach_config.minimum_temperature,
+                threshold_maximum: breach_config.maximum_temperature,
+            };
+            log::info!("Added breach {:?} ", breach);
+            breach
+        }
+    };
+
+    TemperatureBreachRowRepository::new(connection).upsert_one(&temperature_breach_upsert)?;
+
+    Ok(Some(temperature_breach_upsert))
 }
 
 fn sensor_add_breach_config_if_new(
@@ -189,41 +167,45 @@ fn sensor_add_breach_config_if_new(
     sensor_row: &SensorRow,
     temperature_breach_config: &temperature_sensor::TemperatureBreachConfig,
 ) -> Result<(), RepositoryError> {
-    let mut config_description = format!(
+    let config_description = format!(
         "for {} minutes",
         temperature_breach_config.duration.num_minutes()
     );
     let breach_row_type = get_breach_row_type(&temperature_breach_config.breach_type);
 
-    match temperature_breach_config.breach_type {
+    let config_description = match temperature_breach_config.breach_type {
         BreachType::ColdConsecutive => {
-            config_description = format!(
-                "Consecutive {} colder than {}",
-                config_description, temperature_breach_config.minimum_temperature
+            format!(
+                "Consecutive {config_description} colder than {}",
+                temperature_breach_config.minimum_temperature
             )
         }
         BreachType::ColdCumulative => {
-            config_description = format!(
-                "Cumulative {} colder than {}",
-                config_description, temperature_breach_config.minimum_temperature
+            format!(
+                "Cumulative {config_description} colder than {}",
+                temperature_breach_config.minimum_temperature
             )
         }
         BreachType::HotConsecutive => {
-            config_description = format!(
-                "Consecutive {} hotter than {}",
-                config_description, temperature_breach_config.maximum_temperature
+            format!(
+                "Consecutive {config_description} hotter than {}",
+                temperature_breach_config.maximum_temperature
             )
         }
         BreachType::HotCumulative => {
-            config_description = format!(
-                "Cumulative {} hotter than {}",
-                config_description, temperature_breach_config.maximum_temperature
+            format!(
+                "Cumulative {config_description} hotter than {}",
+                temperature_breach_config.maximum_temperature
             )
         }
-    }
+    };
 
-    let result =
-        get_matching_sensor_breach_config(connection, &config_description, &breach_row_type)?;
+    let result = get_matching_sensor_breach_config(
+        connection,
+        &sensor_row.store_id,
+        &temperature_breach_config,
+        &breach_row_type,
+    )?;
 
     if !result.is_empty() {
         return Ok(());
@@ -234,11 +216,12 @@ fn sensor_add_breach_config_if_new(
         store_id: sensor_row.store_id.clone(),
         is_active: true,
         description: config_description.clone(),
-        duration_milliseconds: temperature_breach_config.duration.num_seconds() as i32,
+        duration_milliseconds: temperature_breach_config.duration.num_milliseconds() as i32,
         r#type: breach_row_type,
         minimum_temperature: temperature_breach_config.minimum_temperature,
         maximum_temperature: temperature_breach_config.maximum_temperature,
     };
+
     TemperatureBreachConfigRowRepository::new(connection)
         .upsert_one(&new_temperature_breach_config)?;
     log::info!(
@@ -304,30 +287,39 @@ pub fn read_sensor(
 ) -> anyhow::Result<ReadSensor, ReadSensorError> {
     let filename = fridgetag_file.to_string_lossy();
 
-    let mut temperature_sensor =
+    let temperature_sensor =
         temperature_sensor::read_sensor_file(&filename).map_err(ReadSensorError::StringError)?;
 
+    Ok(integrate_sensor_data(
+        connection,
+        store_id,
+        temperature_sensor,
+    )?)
+}
+
+fn integrate_sensor_data(
+    connection: &StorageConnection,
+    store_id: &str,
+    temperature_sensor: temperature_sensor::Sensor,
+) -> anyhow::Result<ReadSensor, ReadSensorError> {
     sensor_add_if_new(connection, &store_id, &temperature_sensor)?;
 
     let result = get_matching_sensor_serial(connection, &temperature_sensor.serial)?;
 
-    let record = result
+    let sensor_row = result
         .clone()
         .pop()
-        .context("Sensor could not be inserted or found in database")?;
+        .context("Sensor could not be inserted or found in database")?
+        .sensor_row;
 
     // Filter sensor data by previous last connected time
-    let last_connected = record.sensor_row.last_connection_datetime;
-    temperature_sensor =
+    let last_connected = sensor_row.last_connection_datetime;
+    let temperature_sensor =
         temperature_sensor::filter_sensor(temperature_sensor, last_connected, None);
 
     let temperature_sensor_configs = temperature_sensor.configs.unwrap_or_default();
     for temperature_sensor_config in temperature_sensor_configs.iter() {
-        sensor_add_breach_config_if_new(
-            connection,
-            &record.sensor_row,
-            &temperature_sensor_config,
-        )?;
+        sensor_add_breach_config_if_new(connection, &sensor_row, &temperature_sensor_config)?;
     }
 
     let temperature_sensor_breaches = temperature_sensor.breaches.unwrap_or_default();
@@ -339,33 +331,440 @@ pub fn read_sensor(
     };
 
     for temperature_sensor_log in temperature_sensor_logs {
-        sensor_add_log_if_new(connection, &record.sensor_row, &temperature_sensor_log)?;
+        sensor_add_log_if_new(connection, &sensor_row, &temperature_sensor_log)?;
     }
 
-    for temperature_sensor_breach in temperature_sensor_breaches {
+    // Add consequitive then cumulative breaches, order is important because breach and log association
+    // is priorities for consequitive breach i.e. if log is in both cumulative and consequitive breach
+    // the breach id would be from consequitive
+    for temperature_sensor_breach in sort_breaches_by_type(temperature_sensor_breaches) {
         // Look up matching config from the USB data and snapshot it as part of the breach
         if let Some(temperature_sensor_config) = temperature_sensor_configs
             .iter()
             .find(|&t| t.breach_type == temperature_sensor_breach.breach_type)
         {
-            sensor_add_breach_if_new(
+            let upserted_breach = sensor_add_breach_if_new(
                 connection,
-                &record.sensor_row,
+                &sensor_row,
                 &temperature_sensor_breach,
                 &temperature_sensor_config,
             )?;
+
+            if let Some(upserted_breach) = upserted_breach {
+                update_sensor_logs_for_breach(connection, &upserted_breach)?;
+            }
         }
     }
 
     // Finally, update sensor's last connected time if it has changed
-    if record.sensor_row.last_connection_datetime != temperature_sensor.last_connected_timestamp {
+    if sensor_row.last_connection_datetime != temperature_sensor.last_connected_timestamp {
         SensorRowRepository::new(connection).upsert_one(&SensorRow {
             last_connection_datetime: temperature_sensor.last_connected_timestamp,
-            ..record.sensor_row
+            ..sensor_row
         })?;
     }
 
     Ok(result)
 }
 
-// TODO tests
+// First of all consequitive and then cumulative
+fn breach_sort_weight(breach: &TemperatureBreachRowType) -> u8 {
+    use TemperatureBreachRowType::*;
+    match breach {
+        ColdConsecutive => 1,
+        HotConsecutive => 2,
+        ColdCumulative => 3,
+        HotCumulative => 4,
+    }
+}
+
+fn sort_breaches_by_type(
+    mut breaches: Vec<temperature_sensor::TemperatureBreach>,
+) -> Vec<temperature_sensor::TemperatureBreach> {
+    breaches.sort_by(|a, b| {
+        breach_sort_weight(&get_breach_row_type(&a.breach_type))
+            .cmp(&breach_sort_weight(&get_breach_row_type(&b.breach_type)))
+    });
+
+    breaches
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::integrate_sensor_data;
+    use crate::{
+        sensor::berlinger::breach_sort_weight,
+        test_helpers::{setup_all_and_service_provider, ServiceTestContext},
+    };
+    use chrono::{Duration, NaiveDate, NaiveDateTime};
+    use repository::{
+        mock::{mock_store_a, MockDataInserts},
+        Pagination, Sort, TemperatureBreachFilter, TemperatureBreachRepository,
+        TemperatureBreachRow, TemperatureBreachRowType, TemperatureLogRepository,
+        TemperatureLogSortField,
+    };
+    use temperature_sensor as ts;
+
+    #[actix_rt::test]
+    async fn data_from_fridge_tag() {
+        // util::init_logger(util::LogLevel::Warn);
+
+        let ServiceTestContext { connection, .. } = setup_all_and_service_provider(
+            "data_from_fridge_tag",
+            MockDataInserts::none().names().stores(),
+        )
+        .await;
+
+        let base_date = NaiveDate::from_ymd_opt(2024, 01, 01).unwrap();
+        // This data is mapped to temperature log row insert and then to expected results
+        // of temperature logs with associated breaches
+
+        // MOCK DATA
+        let log_data = vec![
+            ((09, 01, 01), 3.0, "normal"),
+            ((09, 15, 01), 9.0, "not captured by breach"),
+            ((09, 30, 01), 3.0, "normal"),
+            ((09, 45, 01), 3.0, "normal"),
+            ((10, 01, 01), 3.0, "normal"),
+            ((10, 15, 01), 10.0, "hotcumulative"),
+            ((10, 30, 01), 8.1, "hotcumulative"),
+            ((10, 45, 01), 3.0, "normal"),
+            ((11, 01, 02), 8.5, "hotconsequitive"),
+            ((11, 15, 01), 8.6, "hotconsequitive"),
+            ((11, 30, 01), 8.2, "hotconsequitive"),
+            ((11, 45, 01), 8.9, "hotconsequitive"),
+            ((12, 01, 01), 8.1, "hotconsequitive"),
+            ((12, 15, 01), 8.9, "hotconsequitive"),
+            ((12, 30, 01), 10.0, "hotcumulative"),
+            ((12, 45, 01), 11.0, "hotcumulative"),
+            ((13, 01, 01), 9.0, "hotcumulative"),
+            ((13, 15, 01), 8.6, "hotcumulative"),
+            // s2 = step two
+            ((13, 30, 01), 10.1, "s2-hotcumulative"),
+            ((13, 45, 01), -1.0, "s2-coldcumulative"),
+            ((14, 01, 01), 9.0, "s2-hotcumulative"),
+        ];
+
+        let s2_log_data = vec![
+            ((14, 15, 01), 7.0, "normal"),
+            ((14, 30, 01), 9.0, "s2-hotcumulative"),
+            ((14, 45, 01), 1.5, "s2-coldcumulative"),
+            ((15, 01, 01), 1.1, "s2-coldconsequitive"),
+            ((15, 15, 01), 0.5, "s2-coldconsequitive"),
+            ((15, 30, 01), -3.0, "s2-coldconsequitive"),
+            ((15, 45, 01), 0.0, "s2-coldcumulative"),
+            ((16, 01, 01), -2.5, "s2-coldcumulative"),
+            ((16, 15, 01), 3.0, "normal"),
+        ];
+
+        let breach_data = vec![
+            (
+                ts::BreachType::HotCumulative,
+                base_date.and_hms_opt(10, 01, 01).unwrap(), // Start
+                base_date.and_hms_opt(13, 20, 01).unwrap(), // Finish
+            ),
+            (
+                ts::BreachType::HotConsecutive,
+                base_date.and_hms_opt(11, 01, 01).unwrap(), // Start
+                base_date.and_hms_opt(12, 20, 01).unwrap(), // Finish
+            ),
+        ];
+
+        let s2_breach_data = vec![
+            (
+                ts::BreachType::HotCumulative,
+                base_date.and_hms_opt(10, 01, 01).unwrap(), // Start
+                base_date.and_hms_opt(14, 30, 01).unwrap(), // Finish - Updated
+            ),
+            // Added
+            (
+                ts::BreachType::ColdConsecutive,
+                base_date.and_hms_opt(15, 01, 01).unwrap(), // Start
+                base_date.and_hms_opt(15, 30, 01).unwrap(), // Finish
+            ),
+            (
+                ts::BreachType::ColdCumulative,
+                base_date.and_hms_opt(13, 45, 01).unwrap(), // Start
+                base_date.and_hms_opt(16, 01, 01).unwrap(), // Finish
+            ),
+            // Previous
+            (
+                ts::BreachType::HotConsecutive,
+                base_date.and_hms_opt(11, 01, 01).unwrap(), // Start
+                base_date.and_hms_opt(12, 20, 01).unwrap(), // Finish
+            ),
+        ];
+
+        let configs = Some(vec![
+            ts::TemperatureBreachConfig {
+                breach_type: ts::BreachType::HotCumulative,
+                maximum_temperature: 8.0,
+                minimum_temperature: -273.0,
+                duration: Duration::minutes(60),
+            },
+            ts::TemperatureBreachConfig {
+                breach_type: ts::BreachType::HotConsecutive,
+                maximum_temperature: 8.0,
+                minimum_temperature: -273.0,
+                duration: Duration::minutes(5),
+            },
+            ts::TemperatureBreachConfig {
+                breach_type: ts::BreachType::ColdConsecutive,
+                maximum_temperature: 100.0,
+                minimum_temperature: 2.0,
+                duration: Duration::minutes(5),
+            },
+            ts::TemperatureBreachConfig {
+                breach_type: ts::BreachType::ColdCumulative,
+                maximum_temperature: 100.0,
+                minimum_temperature: 2.0,
+                duration: Duration::minutes(60),
+            },
+        ]);
+
+        // STEP 1
+        let data = ts::Sensor {
+            sensor_type: ts::SensorType::Berlinger,
+            breaches: Some(
+                breach_data
+                    .into_iter()
+                    .map(
+                        |(breach_type, start_timestamp, end_timestamp)| ts::TemperatureBreach {
+                            duration: end_timestamp - start_timestamp,
+                            breach_type,
+                            start_timestamp,
+                            end_timestamp,
+                            acknowledged: true,
+                        },
+                    )
+                    .collect(),
+            ),
+            configs,
+            logs: Some(
+                log_data
+                    .iter()
+                    .map(|((h, mi, s), t, _)| ts::TemperatureLog {
+                        temperature: *t,
+                        timestamp: base_date.and_hms_opt(*h, *mi, *s).unwrap(),
+                    })
+                    .collect(),
+            ),
+            // Required, but not used fields
+            serial: "sensor1_serial".to_string(),
+            name: "sensor1_name".to_string(),
+            last_connected_timestamp: None,
+            log_interval: None,
+        };
+
+        // INTERGRATE MOCK DATA
+        integrate_sensor_data(&connection, &mock_store_a().id, data.clone()).unwrap();
+
+        // CHECK BREACHES
+        let mut breaches = TemperatureBreachRepository::new(&connection)
+            .query_by_filter(TemperatureBreachFilter::new())
+            .unwrap();
+
+        // Sort them
+        breaches.sort_by(|a, b| {
+            breach_sort_weight(&a.temperature_breach_row.r#type)
+                .cmp(&breach_sort_weight(&b.temperature_breach_row.r#type))
+        });
+
+        assert_eq!(breaches.len(), 2);
+        let s1_breaches = breaches
+            .into_iter()
+            .map(|b| b.temperature_breach_row)
+            .collect::<Vec<TemperatureBreachRow>>();
+
+        assert_eq!(
+            s1_breaches,
+            vec![
+                TemperatureBreachRow {
+                    duration_milliseconds: ((1 * 60) + 19) * 60 * 1000,
+                    r#type: TemperatureBreachRowType::HotConsecutive,
+                    threshold_minimum: -273.0,
+                    threshold_maximum: 8.0,
+                    threshold_duration_milliseconds: 5 * 60 * 1000,
+                    start_datetime: base_date.and_hms_opt(11, 01, 01).unwrap(),
+                    end_datetime: base_date.and_hms_opt(12, 20, 01),
+                    ..s1_breaches[0].clone()
+                },
+                TemperatureBreachRow {
+                    duration_milliseconds: ((3 * 60) + 19) * 60 * 1000,
+                    r#type: TemperatureBreachRowType::HotCumulative,
+                    threshold_minimum: -273.0,
+                    threshold_maximum: 8.0,
+                    threshold_duration_milliseconds: 60 * 60 * 1000,
+                    start_datetime: base_date.and_hms_opt(10, 01, 01).unwrap(),
+                    end_datetime: base_date.and_hms_opt(13, 20, 01),
+                    ..s1_breaches[1].clone()
+                }
+            ]
+        );
+
+        // CHECK LOGS
+        type VecShape = Vec<(Option<NaiveDateTime>, f64, Option<String>)>;
+        let logs = TemperatureLogRepository::new(&connection)
+            .query(
+                Pagination::all(),
+                None,
+                Some(Sort {
+                    key: TemperatureLogSortField::Datetime,
+                    desc: Some(false),
+                }),
+            )
+            .unwrap()
+            .into_iter()
+            .map(|l| {
+                // Map to (datetime, temperature, breach_id)
+                (
+                    Some(l.temperature_log_row.datetime),
+                    l.temperature_log_row.temperature,
+                    l.temperature_log_row.temperature_breach_id,
+                )
+            })
+            .collect::<VecShape>();
+
+        assert_eq!(
+            logs,
+            // Map to (datetime, temperature, breach_id)
+            log_data
+                .iter()
+                .map(|((h, mi, s), t, desc)| (
+                    base_date.and_hms_opt(*h, *mi, *s),
+                    *t,
+                    match *desc {
+                        "hotconsequitive" => Some(s1_breaches[0].id.clone()),
+                        "hotcumulative" => Some(s1_breaches[1].id.clone()),
+                        _ => None,
+                    }
+                ))
+                .collect::<VecShape>(),
+        );
+
+        // STEP 2
+        // Use s2 data and add cold configs
+        let s2_data = temperature_sensor::Sensor {
+            breaches: Some(
+                s2_breach_data
+                    .into_iter()
+                    .map(
+                        |(breach_type, start_timestamp, end_timestamp)| ts::TemperatureBreach {
+                            duration: end_timestamp - start_timestamp,
+                            breach_type,
+                            start_timestamp,
+                            end_timestamp,
+                            acknowledged: true,
+                        },
+                    )
+                    .collect(),
+            ),
+            logs: Some(
+                s2_log_data
+                    .iter()
+                    .map(|((h, mi, s), t, _)| ts::TemperatureLog {
+                        temperature: *t,
+                        timestamp: base_date.and_hms_opt(*h, *mi, *s).unwrap(),
+                    })
+                    .collect(),
+            ),
+            ..data.clone()
+        };
+
+        // INTERGRATE MOCK DATA
+        integrate_sensor_data(&connection, &mock_store_a().id, s2_data).unwrap();
+
+        // CHECK BREACHES
+        let mut breaches = TemperatureBreachRepository::new(&connection)
+            .query_by_filter(TemperatureBreachFilter::new())
+            .unwrap();
+
+        // Sort them
+        breaches.sort_by(|a, b| {
+            breach_sort_weight(&a.temperature_breach_row.r#type)
+                .cmp(&breach_sort_weight(&b.temperature_breach_row.r#type))
+        });
+
+        assert_eq!(breaches.len(), 4); // Now 4
+        let s2_breaches = breaches
+            .into_iter()
+            .map(|b| b.temperature_breach_row)
+            .collect::<Vec<TemperatureBreachRow>>();
+
+        assert_eq!(
+            s2_breaches,
+            vec![
+                TemperatureBreachRow {
+                    duration_milliseconds: (29) * 60 * 1000,
+                    r#type: TemperatureBreachRowType::ColdConsecutive,
+                    threshold_minimum: 2.0,
+                    threshold_maximum: 100.0,
+                    threshold_duration_milliseconds: 5 * 60 * 1000,
+                    start_datetime: base_date.and_hms_opt(15, 01, 01).unwrap(),
+                    end_datetime: base_date.and_hms_opt(15, 30, 01),
+                    ..s2_breaches[0].clone()
+                },
+                s1_breaches[0].clone(), // Hot consequitive didn't change
+                TemperatureBreachRow {
+                    duration_milliseconds: ((2 * 60) + 15 + 1) * 60 * 1000,
+                    r#type: TemperatureBreachRowType::ColdCumulative,
+                    threshold_minimum: 2.0,
+                    threshold_maximum: 100.0,
+                    threshold_duration_milliseconds: 60 * 60 * 1000,
+                    start_datetime: base_date.and_hms_opt(13, 45, 01).unwrap(),
+                    end_datetime: base_date.and_hms_opt(16, 01, 01),
+                    ..s2_breaches[2].clone()
+                },
+                TemperatureBreachRow {
+                    // Only duration and end_datetime changed for Hot cumulative
+                    duration_milliseconds: ((4 * 60) + 29) * 60 * 1000,
+                    end_datetime: base_date.and_hms_opt(14, 30, 01),
+                    ..s1_breaches[1].clone()
+                }
+            ]
+        );
+
+        // CHECK LOGS
+        let logs = TemperatureLogRepository::new(&connection)
+            .query(
+                Pagination::all(),
+                None,
+                Some(Sort {
+                    key: TemperatureLogSortField::Datetime,
+                    desc: Some(false),
+                }),
+            )
+            .unwrap()
+            .into_iter()
+            .map(|l| {
+                // Map to (datetime, temperature, breach_id)
+                (
+                    Some(l.temperature_log_row.datetime),
+                    l.temperature_log_row.temperature,
+                    l.temperature_log_row.temperature_breach_id,
+                )
+            })
+            .collect::<VecShape>();
+
+        pretty_assertions::assert_eq!(
+            logs,
+            // Map to (datetime, temperature, breach_id)
+            log_data
+                .iter()
+                .chain(s2_log_data.iter())
+                .map(|((h, mi, s), t, desc)| (
+                    base_date.and_hms_opt(*h, *mi, *s),
+                    *t,
+                    match *desc {
+                        "hotconsequitive" => Some(s2_breaches[1].id.clone()),
+                        "hotcumulative" | "s2-hotcumulative" => Some(s2_breaches[3].id.clone()),
+                        "s2-coldconsequitive" => Some(s2_breaches[0].id.clone()),
+                        "s2-coldcumulative" => Some(s2_breaches[2].id.clone()),
+                        _ => None,
+                    }
+                ))
+                .collect::<VecShape>(),
+        );
+    }
+}

--- a/server/service/src/sensor/berlinger.rs
+++ b/server/service/src/sensor/berlinger.rs
@@ -747,7 +747,7 @@ mod test {
             })
             .collect::<VecShape>();
 
-        pretty_assertions::assert_eq!(
+        assert_eq!(
             logs,
             // Map to (datetime, temperature, breach_id)
             log_data

--- a/server/service/src/sensor/query.rs
+++ b/server/service/src/sensor/query.rs
@@ -1,10 +1,8 @@
-use chrono::{Duration, NaiveDateTime, NaiveTime};
+use std::ops::Range;
 
 use repository::{
-    DatetimeFilter, EqualFilter, Pagination, PaginationOption, RepositoryError, Sensor,
-    SensorFilter, SensorRepository, SensorSort, Sort, StorageConnection,
-    TemperatureBreachRowRepository, TemperatureBreachRowType, TemperatureLog, TemperatureLogFilter,
-    TemperatureLogRepository, TemperatureLogSortField,
+    DatetimeFilter, EqualFilter, NumberFilter, PaginationOption, Sensor, SensorFilter,
+    SensorRepository, SensorSort, TemperatureBreachRow, TemperatureLogFilter,
 };
 
 use crate::{
@@ -43,80 +41,26 @@ pub fn get_sensor(ctx: &ServiceContext, id: String) -> Result<Sensor, SingleReco
     }
 }
 
-pub fn get_sensor_logs_for_breach(
-    connection: &StorageConnection,
-    breach_id: &String,
-) -> Result<Vec<TemperatureLog>, RepositoryError> {
-    let mut temperature_logs: Vec<TemperatureLog> = Vec::new();
+pub fn get_sensor_logs_filter_for_breach(
+    breach: &TemperatureBreachRow,
+) -> Option<TemperatureLogFilter> {
+    let Some(end_datetime) = breach.end_datetime else {
+        log::info!("Breach {:?} has no end time", breach);
+        return None;
+    };
+    // Add datetime range
+    let datetime_filter = DatetimeFilter::date_range(breach.start_datetime, end_datetime);
 
-    let breach_result =
-        TemperatureBreachRowRepository::new(connection).find_one_by_id(breach_id)?;
+    // Add temperature threashold filter
+    let temperature_filter = NumberFilter::not_in_range(Range {
+        start: breach.threshold_minimum,
+        end: breach.threshold_maximum,
+    });
 
-    if let Some(breach_record) = breach_result {
-        if let Some(end_datetime) = breach_record.end_datetime {
-            // Find all temperature logs in the breach time range, sorted by date/time
+    let filter = TemperatureLogFilter::new()
+        .sensor(SensorFilter::new().id(EqualFilter::equal_to(&breach.sensor_id)))
+        .datetime(datetime_filter)
+        .temperature(temperature_filter);
 
-            let mut filter = TemperatureLogFilter::new()
-                .sensor(SensorFilter::new().id(EqualFilter::equal_to(&breach_record.sensor_id)));
-            let sort = Sort {
-                key: TemperatureLogSortField::Datetime,
-                desc: None,
-            };
-
-            match breach_record.r#type {
-                TemperatureBreachRowType::ColdCumulative
-                | TemperatureBreachRowType::HotCumulative => {
-                    // Cumulative breach can include any time on the same day (can only be at most one of hot/cold starting per day)
-                    let start_breach = breach_record.start_datetime.date().and_hms_opt(0,0,0).unwrap(); // set to start of day
-                    let mut end_breach = end_datetime;
-                    if end_datetime.date() == start_breach.date() { 
-                        // If ending on the same day, then extend to midnight
-                        end_breach = start_breach + Duration::days(1);
-                    }
-                    filter = filter.datetime(DatetimeFilter::date_range(start_breach, end_breach));
-                }
-                TemperatureBreachRowType::ColdConsecutive
-                | TemperatureBreachRowType::HotConsecutive => {
-                    filter = filter.datetime(DatetimeFilter::date_range(
-                        breach_record.start_datetime,
-                        end_datetime,
-                    ));
-                }
-            }
-
-            let log_result = TemperatureLogRepository::new(connection).query(
-                Pagination::all(),
-                Some(filter),
-                Some(sort),
-            )?;
-
-            for temperature_log in log_result {
-                // Add log to breach if temperature is outside breach parameters
-                match breach_record.r#type {
-                    TemperatureBreachRowType::ColdCumulative
-                    | TemperatureBreachRowType::ColdConsecutive => {
-                        if temperature_log.temperature_log_row.temperature
-                            < breach_record.threshold_minimum
-                        {
-                            temperature_logs.push(temperature_log.clone());
-                        }
-                    }
-                    TemperatureBreachRowType::HotCumulative
-                    | TemperatureBreachRowType::HotConsecutive => {
-                        if temperature_log.temperature_log_row.temperature
-                            > breach_record.threshold_maximum
-                        {
-                            temperature_logs.push(temperature_log.clone());
-                        }
-                    }
-                }
-            }
-        } else {
-            log::info!("Breach {:?} has no end time", breach_record);
-        }
-
-        Ok(temperature_logs)
-    } else {
-        Err(RepositoryError::NotFound)
-    }
+    Some(filter)
 }

--- a/server/service/src/sensor/update.rs
+++ b/server/service/src/sensor/update.rs
@@ -1,16 +1,15 @@
 use super::{
-    query::{get_sensor, get_sensor_logs_for_breach},
+    query::{get_sensor, get_sensor_logs_filter_for_breach},
     validate::check_sensor_exists,
 };
 use crate::{
     activity_log::activity_log_entry, service_provider::ServiceContext, NullableUpdate,
     SingleRecordError,
 };
-use chrono::{Duration, NaiveDateTime, NaiveTime};
+
 use repository::{
-    ActivityLogType, RepositoryError, Sensor, SensorRow, SensorRowRepository, StorageConnection,
-    TemperatureBreachRowRepository, TemperatureBreachRowType, TemperatureLog,
-    TemperatureLogRowRepository,
+    ActivityLogType, EqualFilter, RepositoryError, Sensor, SensorRow, SensorRowRepository,
+    StorageConnection, TemperatureBreachRow, TemperatureLogRepository, TemperatureLogRowRepository,
 };
 
 #[derive(PartialEq, Debug)]
@@ -60,98 +59,6 @@ pub fn update_sensor(
     Ok(sensor)
 }
 
-pub fn update_sensor_logs_for_breach(
-    connection: &StorageConnection,
-    breach_id: &String,
-) -> Result<Vec<TemperatureLog>, RepositoryError> {
-    let mut temperature_logs: Vec<TemperatureLog> = Vec::new();
-
-    let breach_result =
-        TemperatureBreachRowRepository::new(connection).find_one_by_id(breach_id)?;
-
-    if let Some(mut breach_record) = breach_result {
-        let is_cumulative_breach = (breach_record.r#type
-            == TemperatureBreachRowType::ColdCumulative)
-            | (breach_record.r#type == TemperatureBreachRowType::HotCumulative);
-        let logs = get_sensor_logs_for_breach(connection, breach_id)?; //sorted by date/time
-        let mut log_interval = 0;
-        let zero_time = NaiveTime::parse_from_str("00:00", "%H:%M").unwrap(); // hard-coded -> should always work!
-
-        if let Some(sensor) = SensorRowRepository::new(connection).find_one_by_id(&breach_record.sensor_id)? {
-            if let Some(interval) = sensor.log_interval {
-                log_interval = interval;
-            }
-        }
-        
-        if is_cumulative_breach {
-            // Update breach start/end from first/last logs if it has changed
-            if let Some(first_log) = logs.first() {
-                // If within log_interval seconds of the start of the day,
-                // use the start of the day as first log time
-                let mut first_breach_datetime = NaiveDateTime::new(first_log.temperature_log_row.datetime.date(), zero_time);
-                let first_log_datetime = first_breach_datetime + Duration::seconds(log_interval.into());
-
-                if first_log_datetime < first_log.temperature_log_row.datetime {
-                    first_breach_datetime = first_log.temperature_log_row.datetime;
-                }
-
-                // Use the first log time if it's either earlier than the calculated breach end
-                // or if the calculated breach start is less than the sensor log interval before the first log time
-                if (breach_record.start_datetime > first_breach_datetime) | (log_interval > 0) & (breach_record.start_datetime < first_breach_datetime - Duration::seconds(log_interval.into())) {
-                    log::info!(
-                        "Updating cumulative breach start for {:?} to {:?}",
-                        breach_record,
-                        first_breach_datetime
-                    );
-                    breach_record.start_datetime = first_breach_datetime;
-                    TemperatureBreachRowRepository::new(connection).upsert_one(&breach_record)?;
-                }
-            }
-            if let Some(last_log) = logs.last() {
-                // If within log_interval seconds of the end of the day,
-                // use the end of the day as last log time
-                let mut last_breach_datetime = NaiveDateTime::new(last_log.temperature_log_row.datetime.date(), zero_time) + Duration::days(1);
-                let last_log_datetime = last_breach_datetime - Duration::seconds(log_interval.into());
-
-                if last_log_datetime > last_log.temperature_log_row.datetime {
-                    last_breach_datetime = last_log.temperature_log_row.datetime;
-                }
-                
-                // Use the last log time if it's either later than the calculated breach end
-                // or if the calculated breach end is more than the sensor log interval after the last log time
-                if (breach_record.end_datetime < Some(last_breach_datetime)) | (log_interval > 0) & (breach_record.end_datetime > Some(last_breach_datetime + Duration::seconds(log_interval.into()))) {
-                    log::info!(
-                        "Updating cumulative breach end for {:?} to {:?}",
-                        breach_record,
-                        last_breach_datetime
-                    );
-                    breach_record.end_datetime = Some(last_breach_datetime);
-                    TemperatureBreachRowRepository::new(connection).upsert_one(&breach_record)?;
-                }
-            }
-        }
-
-        for mut temperature_log in logs {
-            if let Some(_breach_id) = &temperature_log.temperature_log_row.temperature_breach_id {
-                if is_cumulative_breach {
-                    // Skip as cumulative breach can only update unassigned temperature logs
-                    continue;
-                }
-            };
-
-            temperature_log.temperature_log_row.temperature_breach_id = Some(breach_id.to_string());
-            TemperatureLogRowRepository::new(connection)
-                .upsert_one(&temperature_log.temperature_log_row)?;
-            temperature_logs.push(temperature_log.clone());
-        }
-        log::info!("Temperature logs assigned for breach {:?}", breach_record);
-
-        Ok(temperature_logs)
-    } else {
-        Err(RepositoryError::NotFound)
-    }
-}
-
 pub fn validate(
     connection: &StorageConnection,
     store_id: &str,
@@ -190,6 +97,27 @@ pub fn generate(
     sensor_row.log_interval = log_interval.or(sensor_row.log_interval);
     sensor_row.battery_level = battery_level.or(sensor_row.battery_level);
     sensor_row
+}
+
+pub fn update_sensor_logs_for_breach(
+    connection: &StorageConnection,
+    breach: &TemperatureBreachRow,
+) -> Result<(), RepositoryError> {
+    let Some(temperature_log_filter) = get_sensor_logs_filter_for_breach(&breach) else {
+        // End time is not set on breach
+        return Ok(());
+    };
+
+    // And temperature log is not associated with any breaches
+    let temperature_log_filter =
+        temperature_log_filter.temperature_breach_id(EqualFilter::is_null(true));
+
+    let logs =
+        TemperatureLogRepository::new(&connection).query_by_filter(temperature_log_filter)?;
+
+    let log_ids = logs.into_iter().map(|l| l.temperature_log_row.id).collect();
+
+    TemperatureLogRowRepository::new(&connection).update_breach_id(&breach.id, &log_ids)
 }
 
 impl From<RepositoryError> for UpdateSensorError {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2594

# 👩🏻‍💻 What does this PR do? 

Simplifies https://github.com/msupply-foundation/open-msupply/pull/2629 by:

* Reducing the logic in associating temperature breaches to just check by start and end date time on breach
* Adds test for validating this logic
* Adds filters to help with this task

# 🧪 How has/should this change been tested? 

* Run the tests in repo.
* Try to import: https://github.com/msupply-foundation/temperature-sensor/blob/main/data/FridgeTag%202L/130500109088_202206081014.txt via cold chain/sensor UI. Then you should see that temperature logs are linked to breaches (by temperature and start/end end time of the breach)

cold-chain/monitoring?tab=Breaches&sort=startDatetime&dir=desc&startDatetime=2022-06-04+00%3A59_2022-06-04+23%3A59

cold-chain/monitoring?tab=Log&sort=datetime&dir=desc&datetime=2022-06-04+00%3A01_2022-06-04+23%3A59


## 💌 Any notes for the reviewer?

Please see comments in PR description and for more context please see https://github.com/msupply-foundation/open-msupply/pull/2629.

There are still a couple of carry overs:

* Internal documentation about the logic of temperature logs with breaches
* Update from develop and making sure that datetimes are adjusted based on local time offset

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

or

- [ ] Functional change 1
- [ ] Functional change 2