### PR TITLE
3276 delete duplicate name store joins on merge

### DIFF
--- a/server/graphql/general/src/queries/store.rs
+++ b/server/graphql/general/src/queries/store.rs
@@ -138,6 +138,7 @@ impl StoreFilterInput {
         StoreFilter {
             id: id.map(EqualFilter::from),
             code: code.map(StringFilter::from),
+            name_id: None,
             name: name.map(StringFilter::from),
             name_code: name_code.map(StringFilter::from),
             site_id: site_id.map(EqualFilter::from),

--- a/server/repository/src/db_diesel/store.rs
+++ b/server/repository/src/db_diesel/store.rs
@@ -22,6 +22,7 @@ pub struct Store {
 pub struct StoreFilter {
     pub id: Option<EqualFilter<String>>,
     pub code: Option<StringFilter>,
+    pub name_id: Option<EqualFilter<String>>,
     pub name: Option<StringFilter>,
     pub name_code: Option<StringFilter>,
     pub site_id: Option<EqualFilter<i32>>,
@@ -50,6 +51,11 @@ impl StoreFilter {
 
     pub fn code(mut self, filter: StringFilter) -> Self {
         self.code = Some(filter);
+        self
+    }
+
+    pub fn name_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.name_id = Some(filter);
         self
     }
 
@@ -132,6 +138,7 @@ fn create_filtered_query(filter: Option<StoreFilter>) -> BoxedStoreQuery {
         let StoreFilter {
             id,
             code,
+            name_id,
             name,
             name_code,
             site_id,
@@ -139,6 +146,7 @@ fn create_filtered_query(filter: Option<StoreFilter>) -> BoxedStoreQuery {
 
         apply_equal_filter!(query, id, store_dsl::id);
         apply_string_filter!(query, code, store_dsl::code);
+        apply_equal_filter!(query, name_id, store_dsl::name_id);
         apply_string_filter!(query, name, name_dsl::name_);
         apply_string_filter!(query, name_code, name_dsl::code);
         apply_equal_filter!(query, site_id, store_dsl::site_id);

--- a/server/repository/src/mock/name_store_join.rs
+++ b/server/repository/src/mock/name_store_join.rs
@@ -2,16 +2,6 @@ use crate::NameStoreJoinRow;
 
 use super::{mock_name_a, mock_name_store_a, mock_name_store_b, program_master_list_store};
 
-pub fn mock_name_store_join_a() -> NameStoreJoinRow {
-    NameStoreJoinRow {
-        id: String::from("name_store_join_a"),
-        name_link_id: String::from("name_store_a"),
-        store_id: String::from("store_a"),
-        name_is_customer: true,
-        name_is_supplier: false,
-    }
-}
-
 pub fn mock_name_store_join_b() -> NameStoreJoinRow {
     NameStoreJoinRow {
         id: String::from("name_store_join_b"),
@@ -104,7 +94,6 @@ pub fn name_store_join_program_a_name_a() -> NameStoreJoinRow {
 
 pub fn mock_name_store_joins() -> Vec<NameStoreJoinRow> {
     vec![
-        mock_name_store_join_a(),
         mock_name_store_join_b(),
         mock_name_store_join_c(),
         mock_name_store_join_d(),

--- a/server/repository/src/mock/name_store_join.rs
+++ b/server/repository/src/mock/name_store_join.rs
@@ -2,7 +2,7 @@ use crate::NameStoreJoinRow;
 
 use super::{mock_name_a, mock_name_store_a, mock_name_store_b, program_master_list_store};
 
-pub fn mock_name_store_join_b() -> NameStoreJoinRow {
+pub fn store_a_join_name_b() -> NameStoreJoinRow {
     NameStoreJoinRow {
         id: String::from("name_store_join_b"),
         name_link_id: String::from("name_store_b"),
@@ -12,7 +12,7 @@ pub fn mock_name_store_join_b() -> NameStoreJoinRow {
     }
 }
 
-pub fn mock_name_store_join_c() -> NameStoreJoinRow {
+pub fn store_a_join_name_c() -> NameStoreJoinRow {
     NameStoreJoinRow {
         id: String::from("name_store_join_c"),
         name_link_id: String::from("name_store_c"),
@@ -22,17 +22,17 @@ pub fn mock_name_store_join_c() -> NameStoreJoinRow {
     }
 }
 
-pub fn mock_name_store_join_d() -> NameStoreJoinRow {
+pub fn store_a_join_name_d() -> NameStoreJoinRow {
     NameStoreJoinRow {
         id: String::from("mock_name_store_join_d"),
-        name_link_id: String::from("name_a"),
+        name_link_id: String::from("name_a"), // Note store_a.name_ID == "name_store_a", so this isn't a self relation.
         store_id: String::from("store_a"),
         name_is_customer: false,
         name_is_supplier: true,
     }
 }
 
-pub fn mock_name_store_join_e() -> NameStoreJoinRow {
+pub fn store_a_join_name_e() -> NameStoreJoinRow {
     NameStoreJoinRow {
         id: String::from("mock_name_store_join_e"),
         name_link_id: String::from("name_a"),
@@ -42,7 +42,7 @@ pub fn mock_name_store_join_e() -> NameStoreJoinRow {
     }
 }
 
-pub fn mock_patient_store_join() -> NameStoreJoinRow {
+pub fn store_a_join_test_id() -> NameStoreJoinRow {
     NameStoreJoinRow {
         id: String::from("mock_patient_store_join"),
         name_link_id: String::from("testId"),
@@ -94,11 +94,11 @@ pub fn name_store_join_program_a_name_a() -> NameStoreJoinRow {
 
 pub fn mock_name_store_joins() -> Vec<NameStoreJoinRow> {
     vec![
-        mock_name_store_join_b(),
-        mock_name_store_join_c(),
-        mock_name_store_join_d(),
-        mock_name_store_join_e(),
-        mock_patient_store_join(),
+        store_a_join_name_b(),
+        store_a_join_name_c(),
+        store_a_join_name_d(),
+        store_a_join_name_e(),
+        store_a_join_test_id(),
         mock_patient_store_join_b(),
         name_store_join_program_a(),
         name_store_join_program_b(),

--- a/server/service/src/sync/translations/special/name_merge.rs
+++ b/server/service/src/sync/translations/special/name_merge.rs
@@ -61,12 +61,12 @@ impl SyncTranslation for NameMergeTranslation {
             .collect();
 
         let name_store_join_repo = NameStoreJoinRepository::new(connection);
-        let name_store_joins_for_delete = name_store_join_repo.query(Some(
+        let name_store_joins_for_delete = name_store_join_repo.query_by_filter(
             NameStoreJoinFilter::new().name_id(EqualFilter::equal_to(&data.merge_id_to_delete)),
-        ))?;
-        let name_store_joins_for_keep = name_store_join_repo.query(Some(
+        )?;
+        let name_store_joins_for_keep = name_store_join_repo.query_by_filter(
             NameStoreJoinFilter::new().name_id(EqualFilter::equal_to(&data.merge_id_to_keep)),
-        ))?;
+        )?;
         let mut deletes: Vec<PullDeleteRecord> = vec![];
 
         // We need to delete the name_store_joins that are no longer needed after the merge

--- a/server/service/src/sync/translations/special/name_merge.rs
+++ b/server/service/src/sync/translations/special/name_merge.rs
@@ -115,9 +115,8 @@ impl SyncTranslation for NameMergeTranslation {
         // nameD merged into nameK
         // storeK joined to nameK (delete the join before this happens, stores shouldn't be visible to themselves)
         let store_repo = StoreRepository::new(connection);
-        let store_filter =
-            StoreFilter::new().name_id(EqualFilter::equal_to(&data.merge_id_to_keep));
-        let store = store_repo.query_one(store_filter)?;
+        let store = store_repo
+            .query_one(StoreFilter::new().name_id(EqualFilter::equal_to(&data.merge_id_to_keep)))?;
 
         if let Some(store) = store {
             name_store_joins_for_delete.iter().for_each(|nsj_delete| {


### PR DESCRIPTION
Fixes #3276 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

When names are merged, this makes sure that name_store_joins that are effectively duplicates are deleted.

# 🧪 How has/should this change been tested? 

- [ ] mSupply central/primary server
- [ ] OMS remote with 2 stores which are not visible to each other
- [ ] Create 3 customers
- [ ] Make them all visible to store1 and only the 3rd visible to store2. Sync.
- [ ] Merge customers 3 and 2 and sync. customer 3 is no longer visible to both stores. customer 2 is now visible to store2.
- [ ] Merge customers 2 and 1 and sync. 2 is no longer visible. 1 is now visible to both stores.
- [ ] Merge the last remaining customer into a store active on the site and sync. When logged into that store, the store itself doesn't appear in the customer list. Store2 sees Store1 as a customer now.

## 💌 Any notes for the reviewer?

You must sync with each merge until [#3441](https://github.com/msupply-foundation/open-msupply/issues/3441) is done. Otherwise earlier merges will override later merges. e.g.

Create 3 customers, then merge 3->2->1 and THEN sync. The remote site will still have 3 visible, as the later merge overrode it in the buffer.
