### PR TITLE
3458 Fix receiving stock more than once in the stock transfer

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
@@ -49,8 +49,8 @@ const getStatusOptions = (
     },
   ];
 
-  if (currentStatus === InvoiceNodeStatus.New) {
-    // When the status is new, delivered and verified are available to
+  if (currentStatus === InvoiceNodeStatus.Shipped) {
+    // When the status is shipped, delivered and verified are available to
     // select.
     options[3].isDisabled = false;
     options[4].isDisabled = false;
@@ -94,6 +94,7 @@ const getManualStatusOptions = (
     // When the status is new, delivered and verified are available to
     // select.
     options[1].isDisabled = false;
+    options[2].isDisabled = false;
   }
 
   // When the status is delivered, only verified is available to select.
@@ -135,7 +136,7 @@ const useStatusChangeButton = () => {
       isManuallyCreated
         ? getManualStatusOptions(status, getButtonLabel(t))
         : getStatusOptions(status, getButtonLabel(t)),
-    [status, getButtonLabel]
+    [isManuallyCreated, status, t]
   );
 
   const [selectedOption, setSelectedOption] =

--- a/server/repository/src/db_diesel/invoice_line_row.rs
+++ b/server/repository/src/db_diesel/invoice_line_row.rs
@@ -117,6 +117,36 @@ impl<'a> InvoiceLineRowRepository<'a> {
         Ok(())
     }
 
+    pub fn update_tax(
+        &self,
+        record_id: &str,
+        tax_input: Option<f64>,
+        total_after_tax_calculation: f64,
+    ) -> Result<(), RepositoryError> {
+        diesel::update(invoice_line)
+            .filter(id.eq(record_id))
+            .set((
+                tax.eq(tax_input),
+                total_after_tax.eq(total_after_tax_calculation),
+            ))
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
+
+    pub fn update_currency(
+        &self,
+        record_id: &str,
+        foreign_currency_price_before_tax_calculation: Option<f64>,
+    ) -> Result<(), RepositoryError> {
+        diesel::update(invoice_line)
+            .filter(id.eq(record_id))
+            .set(
+                foreign_currency_price_before_tax.eq(foreign_currency_price_before_tax_calculation),
+            )
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
+
     pub fn delete(&self, invoice_line_id: &str) -> Result<(), RepositoryError> {
         diesel::delete(invoice_line.filter(id.eq(invoice_line_id)))
             .execute(&self.connection.connection)?;

--- a/server/service/src/invoice/inbound_shipment/update/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/update/generate.rs
@@ -116,7 +116,7 @@ pub fn should_create_batches(invoice: &InvoiceRow, patch: &UpdateInboundShipment
         let invoice_status_index = invoice.status.index();
         let new_invoice_status_index = new_invoice_status.index();
 
-        new_invoice_status_index >= InvoiceRowStatus::Delivered.index()
+        new_invoice_status_index == InvoiceRowStatus::Delivered.index()
             && invoice_status_index < new_invoice_status_index
     } else {
         false

--- a/server/service/src/invoice/inbound_shipment/update/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/update/generate.rs
@@ -24,7 +24,8 @@ pub(crate) struct GenerateResult {
     pub(crate) update_invoice: InvoiceRow,
     pub(crate) empty_lines_to_trim: Option<Vec<InvoiceLineRow>>,
     pub(crate) location_movements: Option<Vec<LocationMovementRow>>,
-    pub(crate) update_lines: Option<Vec<InvoiceLineRow>>,
+    pub(crate) update_tax_for_lines: Option<Vec<InvoiceLineRow>>,
+    pub(crate) update_currency_for_lines: Option<Vec<InvoiceLineRow>>,
 }
 
 pub(crate) fn generate(
@@ -90,11 +91,20 @@ pub(crate) fn generate(
         None
     };
 
-    let update_lines = if update_invoice.tax.is_some() || patch.currency_rate.is_some() {
-        Some(generate_update_for_lines(
+    let update_tax_for_lines = if update_invoice.tax.is_some() {
+        Some(generate_tax_update_for_lines(
             connection,
             &update_invoice.id,
             update_invoice.tax,
+        )?)
+    } else {
+        None
+    };
+
+    let update_currency_for_lines = if patch.currency_rate.is_some() {
+        Some(generate_currency_update_for_lines(
+            connection,
+            &update_invoice.id,
             update_invoice.currency_id.clone(),
             &update_invoice.currency_rate,
         )?)
@@ -107,7 +117,8 @@ pub(crate) fn generate(
         empty_lines_to_trim: empty_lines_to_trim(connection, &existing_invoice, &patch.status)?,
         update_invoice,
         location_movements,
-        update_lines,
+        update_tax_for_lines,
+        update_currency_for_lines,
     })
 }
 
@@ -116,19 +127,17 @@ pub fn should_create_batches(invoice: &InvoiceRow, patch: &UpdateInboundShipment
         let invoice_status_index = invoice.status.index();
         let new_invoice_status_index = new_invoice_status.index();
 
-        new_invoice_status_index == InvoiceRowStatus::Delivered.index()
+        new_invoice_status_index >= InvoiceRowStatus::Delivered.index()
             && invoice_status_index < new_invoice_status_index
     } else {
         false
     }
 }
 
-fn generate_update_for_lines(
+fn generate_tax_update_for_lines(
     connection: &StorageConnection,
     invoice_id: &str,
     tax: Option<f64>,
-    currency_id: Option<String>,
-    currency_rate: &f64,
 ) -> Result<Vec<InvoiceLineRow>, UpdateInboundShipmentError> {
     let invoice_lines = InvoiceLineRepository::new(connection).query_by_filter(
         InvoiceLineFilter::new()
@@ -142,6 +151,27 @@ fn generate_update_for_lines(
         invoice_line_row.tax = tax;
         invoice_line_row.total_after_tax =
             calculate_total_after_tax(invoice_line_row.total_before_tax, tax);
+        result.push(invoice_line_row);
+    }
+
+    Ok(result)
+}
+
+fn generate_currency_update_for_lines(
+    connection: &StorageConnection,
+    invoice_id: &str,
+    currency_id: Option<String>,
+    currency_rate: &f64,
+) -> Result<Vec<InvoiceLineRow>, UpdateInboundShipmentError> {
+    let invoice_lines = InvoiceLineRepository::new(connection).query_by_filter(
+        InvoiceLineFilter::new()
+            .invoice_id(EqualFilter::equal_to(invoice_id))
+            .r#type(InvoiceLineRowType::StockIn.equal_to()),
+    )?;
+
+    let mut result = Vec::new();
+    for invoice_line in invoice_lines {
+        let mut invoice_line_row = invoice_line.invoice_line_row;
         invoice_line_row.foreign_currency_price_before_tax = calculate_foreign_currency_total(
             connection,
             invoice_line_row.total_before_tax,

--- a/server/service/src/invoice/inbound_shipment/update/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/update/generate.rs
@@ -128,7 +128,7 @@ pub fn should_create_batches(invoice: &InvoiceRow, patch: &UpdateInboundShipment
         let new_invoice_status_index = new_invoice_status.index();
 
         new_invoice_status_index >= InvoiceRowStatus::Delivered.index()
-            && invoice_status_index < new_invoice_status_index
+            && invoice_status_index < InvoiceRowStatus::Delivered.index()
     } else {
         false
     }

--- a/server/service/src/invoice/inbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/update/mod.rs
@@ -52,7 +52,8 @@ pub fn update_inbound_shipment(
                 update_invoice,
                 empty_lines_to_trim,
                 location_movements,
-                update_lines,
+                update_tax_for_lines,
+                update_currency_for_lines,
             } = generate(
                 connection,
                 &ctx.store_id,
@@ -89,9 +90,16 @@ pub fn update_inbound_shipment(
                 }
             }
 
-            if let Some(update_lines) = update_lines {
-                for line in update_lines {
-                    invoice_line_repository.upsert_one(&line)?;
+            if let Some(update_tax) = update_tax_for_lines {
+                for line in update_tax {
+                    invoice_line_repository.update_tax(&line.id, line.tax, line.total_after_tax)?;
+                }
+            }
+
+            if let Some(update_currency) = update_currency_for_lines {
+                for line in update_currency {
+                    invoice_line_repository
+                        .update_currency(&line.id, line.foreign_currency_price_before_tax)?;
                 }
             }
 

--- a/server/service/src/invoice/inbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/update/mod.rs
@@ -354,10 +354,10 @@ mod test {
             })
         }
 
-        fn invoice_tax_test() -> InvoiceRow {
+        fn invoice_test() -> InvoiceRow {
             inline_init(|r: &mut InvoiceRow| {
-                r.id = "invoice_tax_test".to_string();
-                r.name_link_id = "name_store_b".to_string();
+                r.id = "invoice_test".to_string();
+                r.name_link_id = "supplier".to_string();
                 r.store_id = "store_a".to_string();
                 r.invoice_number = 123;
                 r.r#type = InvoiceRowType::InboundShipment;
@@ -369,10 +369,10 @@ mod test {
             })
         }
 
-        fn invoice_line_for_tax_test() -> InvoiceLineRow {
+        fn invoice_line_for_test() -> InvoiceLineRow {
             inline_init(|r: &mut InvoiceLineRow| {
-                r.id = "invoice_line_for_tax_test".to_string();
-                r.invoice_id = "invoice_tax_test".to_string();
+                r.id = "invoice_line_for_test".to_string();
+                r.invoice_id = "invoice_test".to_string();
                 r.item_link_id = "item_a".to_string();
                 r.pack_size = 1;
                 r.number_of_packs = 1.0;
@@ -386,8 +386,8 @@ mod test {
             inline_init(|r: &mut MockData| {
                 r.names = vec![supplier()];
                 r.name_store_joins = vec![supplier_join()];
-                r.invoices = vec![invoice_tax_test()];
-                r.invoice_lines = vec![invoice_line_for_tax_test()];
+                r.invoices = vec![invoice_test()];
+                r.invoice_lines = vec![invoice_line_for_test()];
             }),
         )
         .await;
@@ -429,7 +429,7 @@ mod test {
             .update_inbound_shipment(
                 &context,
                 inline_init(|r: &mut UpdateInboundShipment| {
-                    r.id = invoice_tax_test().id;
+                    r.id = invoice_test().id;
                     r.tax = Some(ShipmentTaxUpdate {
                         percentage: Some(0.0),
                     });
@@ -438,7 +438,7 @@ mod test {
             .unwrap();
 
         let invoice = InvoiceRowRepository::new(&connection)
-            .find_one_by_id(&invoice_tax_test().id)
+            .find_one_by_id(&invoice_test().id)
             .unwrap();
 
         assert_eq!(
@@ -469,7 +469,7 @@ mod test {
         // Test delivered status change with tax
         let updated_line = InvoiceLineRow {
             stock_line_id: Some(mock_stock_line_a().id),
-            ..invoice_line_for_tax_test()
+            ..invoice_line_for_test()
         };
 
         InvoiceLineRowRepository::new(&connection)
@@ -480,7 +480,7 @@ mod test {
             .update_inbound_shipment(
                 &context,
                 inline_init(|r: &mut UpdateInboundShipment| {
-                    r.id = invoice_tax_test().id;
+                    r.id = invoice_test().id;
                     r.status = Some(UpdateInboundShipmentStatus::Delivered);
                     r.tax = Some(ShipmentTaxUpdate {
                         percentage: Some(10.0),
@@ -490,7 +490,7 @@ mod test {
             .unwrap();
 
         let invoice = InvoiceRowRepository::new(&connection)
-            .find_one_by_id(&invoice_tax_test().id)
+            .find_one_by_id(&invoice_test().id)
             .unwrap();
 
         assert_eq!(
@@ -530,7 +530,7 @@ mod test {
             .update_inbound_shipment(
                 &context,
                 inline_init(|r: &mut UpdateInboundShipment| {
-                    r.id = invoice_tax_test().id;
+                    r.id = invoice_test().id;
                     r.status = Some(UpdateInboundShipmentStatus::Verified);
                     r.tax = Some(ShipmentTaxUpdate {
                         percentage: Some(10.0),
@@ -540,7 +540,7 @@ mod test {
             .unwrap();
 
         let invoice = InvoiceRowRepository::new(&connection)
-            .find_one_by_id(&invoice_tax_test().id)
+            .find_one_by_id(&invoice_test().id)
             .unwrap();
         let filter =
             InvoiceLineFilter::new().invoice_id(EqualFilter::equal_any(vec![invoice.clone().id]));
@@ -553,6 +553,168 @@ mod test {
             None,
         )
         .unwrap();
+        let mut stock_lines_verified = Vec::new();
+
+        for lines in invoice_lines.rows {
+            let stock_line_id = lines.invoice_line_row.stock_line_id.clone().unwrap();
+            let stock_line = StockLineRowRepository::new(&connection)
+                .find_one_by_id(&stock_line_id)
+                .unwrap();
+            stock_lines_verified.push(stock_line.clone());
+        }
+
+        assert_eq!(stock_lines_delivered, stock_lines_verified);
+
+        let (_, connection, connection_manager, _) = setup_all_with_data(
+            "update_inbound_shipment_success_currency",
+            MockDataInserts::all(),
+            inline_init(|r: &mut MockData| {
+                r.names = vec![supplier()];
+                r.name_store_joins = vec![supplier_join()];
+                r.invoices = vec![invoice_test()];
+                r.invoice_lines = vec![invoice_line_for_test()];
+            }),
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let context = service_provider
+            .context(mock_store_a().id, mock_user_account_a().id)
+            .unwrap();
+        let service = service_provider.invoice_service;
+
+        // Success with currency change (no stock lines saved)
+        service
+            .update_inbound_shipment(
+                &context,
+                inline_init(|r: &mut UpdateInboundShipment| {
+                    r.id = invoice_test().id;
+                    r.currency_id = Some("currency_a".to_string());
+                    r.currency_rate = Some(1.0);
+                }),
+            )
+            .unwrap();
+
+        let invoice = InvoiceRowRepository::new(&connection)
+            .find_one_by_id(&invoice_test().id)
+            .unwrap();
+
+        assert_eq!(
+            invoice,
+            inline_edit(&invoice, |mut u| {
+                u.currency_id = Some("currency_a".to_string());
+                u.currency_rate = 1.0;
+                u.user_id = Some(mock_user_account_a().id);
+                u
+            })
+        );
+
+        let filter =
+            InvoiceLineFilter::new().invoice_id(EqualFilter::equal_any(vec![invoice.clone().id]));
+        let invoice_lines = get_invoice_lines(
+            &context,
+            &invoice.clone().store_id,
+            &invoice.clone().id,
+            None,
+            Some(filter),
+            None,
+        )
+        .unwrap();
+
+        for line in invoice_lines.rows {
+            assert_eq!(
+                line.invoice_line_row.foreign_currency_price_before_tax,
+                None
+            )
+        }
+
+        // Test delivered status change with currency
+        let updated_line = InvoiceLineRow {
+            stock_line_id: Some(mock_stock_line_a().id),
+            ..invoice_line_for_test()
+        };
+
+        InvoiceLineRowRepository::new(&connection)
+            .upsert_one(&updated_line)
+            .unwrap();
+
+        service
+            .update_inbound_shipment(
+                &context,
+                inline_init(|r: &mut UpdateInboundShipment| {
+                    r.id = invoice_test().id;
+                    r.status = Some(UpdateInboundShipmentStatus::Delivered);
+                    r.currency_id = Some("currency_a".to_string());
+                    r.currency_rate = Some(1.0);
+                }),
+            )
+            .unwrap();
+
+        let invoice = InvoiceRowRepository::new(&connection)
+            .find_one_by_id(&invoice_test().id)
+            .unwrap();
+
+        assert_eq!(
+            invoice,
+            inline_edit(&invoice, |mut u| {
+                u.currency_id = Some("currency_a".to_string());
+                u.currency_rate = 1.0;
+                u.user_id = Some(mock_user_account_a().id);
+                u.status = InvoiceRowStatus::Delivered;
+                u
+            })
+        );
+
+        let filter =
+            InvoiceLineFilter::new().invoice_id(EqualFilter::equal_any(vec![invoice.clone().id]));
+        let invoice_lines = get_invoice_lines(
+            &context,
+            &invoice.clone().store_id,
+            &invoice.clone().id,
+            None,
+            Some(filter),
+            None,
+        )
+        .unwrap();
+        let mut stock_lines_delivered = Vec::new();
+
+        for lines in invoice_lines.rows {
+            let stock_line_id = lines.invoice_line_row.stock_line_id.clone().unwrap();
+            let stock_line = StockLineRowRepository::new(&connection)
+                .find_one_by_id(&stock_line_id)
+                .unwrap();
+            stock_lines_delivered.push(stock_line.clone());
+            assert_eq!(lines.invoice_line_row.stock_line_id, Some(stock_line.id));
+        }
+
+        // Test verified status change with currency
+        service
+            .update_inbound_shipment(
+                &context,
+                inline_init(|r: &mut UpdateInboundShipment| {
+                    r.id = invoice_test().id;
+                    r.status = Some(UpdateInboundShipmentStatus::Verified);
+                    r.currency_id = Some("currency_a".to_string());
+                    r.currency_rate = Some(1.0);
+                }),
+            )
+            .unwrap();
+
+        let invoice = InvoiceRowRepository::new(&connection)
+            .find_one_by_id(&invoice_test().id)
+            .unwrap();
+        let filter =
+            InvoiceLineFilter::new().invoice_id(EqualFilter::equal_any(vec![invoice.clone().id]));
+        let invoice_lines = get_invoice_lines(
+            &context,
+            &invoice.clone().store_id,
+            &invoice.clone().id,
+            None,
+            Some(filter),
+            None,
+        )
+        .unwrap();
+
         let mut stock_lines_verified = Vec::new();
 
         for lines in invoice_lines.rows {

--- a/server/service/src/processors/transfer/shipment/create_inbound_shipment.rs
+++ b/server/service/src/processors/transfer/shipment/create_inbound_shipment.rs
@@ -152,6 +152,13 @@ fn generate_inbound_shipment(
         None => format!("Stock transfer"),
     };
 
+    // If outbound shipment has tax, then we will also have tax in inbound shipment
+    // but greater than 0.0
+    let tax = match outbound_shipment_row.tax {
+        Some(tax) if tax > 0.0 => Some(tax),
+        _ => None,
+    };
+
     let result = InvoiceRow {
         id: uuid(),
         invoice_number: next_number(connection, &NumberRowType::InboundShipment, &store_id)?,
@@ -169,7 +176,7 @@ fn generate_inbound_shipment(
         shipped_datetime: outbound_shipment_row.shipped_datetime,
         transport_reference: outbound_shipment_row.transport_reference.clone(),
         comment: Some(formatted_comment),
-        tax: outbound_shipment_row.tax,
+        tax,
         currency_id: outbound_shipment_row.currency_id.clone(),
         currency_rate: outbound_shipment_row.currency_rate,
         // Default

--- a/server/service/src/processors/transfer/shipment/create_inbound_shipment.rs
+++ b/server/service/src/processors/transfer/shipment/create_inbound_shipment.rs
@@ -152,13 +152,6 @@ fn generate_inbound_shipment(
         None => format!("Stock transfer"),
     };
 
-    // If outbound shipment has tax, then we will also have tax in inbound shipment
-    // but greater than 0.0
-    let tax = match outbound_shipment_row.tax {
-        Some(tax) if tax > 0.0 => Some(tax),
-        _ => None,
-    };
-
     let result = InvoiceRow {
         id: uuid(),
         invoice_number: next_number(connection, &NumberRowType::InboundShipment, &store_id)?,
@@ -176,7 +169,7 @@ fn generate_inbound_shipment(
         shipped_datetime: outbound_shipment_row.shipped_datetime,
         transport_reference: outbound_shipment_row.transport_reference.clone(),
         comment: Some(formatted_comment),
-        tax,
+        tax: outbound_shipment_row.tax,
         currency_id: outbound_shipment_row.currency_id.clone(),
         currency_rate: outbound_shipment_row.currency_rate,
         // Default


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3458

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Fixes receiving stock not more than once during stock transfer.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
- Setup multiple oms sites along with msupply desktop sites and the central sync server.
- Make visible of those sites' active stores among each other from the central sync server.
- Create an outbound shipment against one of those remote site from an another remote site and sync.
- Sync from another site and in the inbound shipment list you'll see a new inbound shipment from your supplying store.
- Now process that shipment and confirm it.
- Check item's stock, note it down.
- Again to goto the same inbound shipment and click confirm verified and again check the stock of that item.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

or

- [ ] Functional change 1
- [ ] Functional change 2