### PR TITLE
Show error but don't block sync if OMS Central is not available

### DIFF
--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -174,10 +174,17 @@ impl Synchroniser {
         // PUSH V6
         logger.start_step(SyncStep::PushCentralV6)?;
         if is_initialised && !is_central_server() {
-            self.central_v6
+            let result = self
+                .central_v6
                 .push(&ctx.connection, batch_size.remote_push, logger)
-                .await?;
-            // TODO: Wait for OMS Central integration?
+                .await;
+
+            if let Err(error) = result {
+                // Log but ignore error for now, to allow omSupply to run without omSupply server
+                // TODO : Fix at some point!
+                log::info!("{}", format_error(&error));
+                let _ = logger.error(&error.into());
+            };
         }
         logger.done_step(SyncStep::PushCentralV6)?;
 
@@ -222,8 +229,8 @@ impl Synchroniser {
             {
                 // Log but ignore error for now, to allow omSupply to run without omSupply server
                 // TODO : Fix at some point!
-                // let _ = logger.error(&error.into());
                 log::info!("{}", format_error(&error));
+                let _ = logger.error(&error.into());
             }
             logger.done_step(SyncStep::PullCentralV6)?;
         }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3495

# 👩🏻‍💻 What does this PR do? 
Logs an error but doesn't stop sync if there's an error uploading to open-mSupply Central

# 🧪 How has/should this change been tested? 
Works for me :)

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_