### PR TITLE
3242 Outbound shipment line edit modal truncating important column values, over crowded with horizontal scroll

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
@@ -21,7 +21,7 @@ export const useOutboundLineEditColumns = ({
   onChange,
   unit,
   currency,
-  isExternalSupplier
+  isExternalSupplier,
 }: {
   onChange: (key: string, value: number, packSize: number) => void;
   unit: string;
@@ -51,7 +51,7 @@ export const useOutboundLineEditColumns = ({
       'location',
       {
         accessor: ({ rowData }) => rowData.location?.code,
-        width: 70,
+        width: 85,
         Cell: LocationCell,
       },
     ],
@@ -59,17 +59,17 @@ export const useOutboundLineEditColumns = ({
       'sellPricePerPack',
       {
         Cell: CurrencyCell,
-        width: 120,
+        width: 85,
       },
     ],
-  ]
-  
+  ];
+
   if (isExternalSupplier && !!store?.preferences.issueInForeignCurrency) {
     columnDefinitions.push({
       key: 'foreignCurrencySellPricePerPack',
       label: 'label.fc-sell-price',
       description: 'description.fc-sell-price',
-      width: 100,
+      width: 85,
       align: ColumnAlign.Right,
       Cell: ForeignCurrencyCell,
       accessor: ({ rowData }) => {
@@ -85,6 +85,7 @@ export const useOutboundLineEditColumns = ({
       key: 'packUnit',
       label: 'label.pack',
       sortable: false,
+      width: 90,
       Cell: PackVariantCell({
         getItemId: row => row?.item.id,
         getPackSizes: row => [row.packSize ?? 1],
@@ -104,14 +105,14 @@ export const useOutboundLineEditColumns = ({
       label: 'label.available-packs',
       key: 'availableNumberOfPacks',
       align: ColumnAlign.Right,
-      width: 85,
+      width: 90,
       accessor: ({ rowData }) => rowData.stockLine?.availableNumberOfPacks,
     },
     [
       'numberOfPacks',
       {
         Cell: PackQuantityCell,
-        width: 120,
+        width: 100,
         label: 'label.pack-quantity-issued',
         setter: ({ packSize, id, numberOfPacks }) =>
           onChange(id, numberOfPacks ?? 0, packSize ?? 1),
@@ -123,7 +124,7 @@ export const useOutboundLineEditColumns = ({
         label: 'label.unit-quantity-issued',
         labelProps: { unit },
         accessor: ({ rowData }) => rowData.numberOfPacks * rowData.packSize,
-        width: 120,
+        width: 90,
       },
     ],
     {
@@ -132,43 +133,8 @@ export const useOutboundLineEditColumns = ({
       Cell: CheckCell,
       accessor: ({ rowData }) => rowData.stockLine?.onHold,
       align: ColumnAlign.Center,
-      width: 80,
-    },
-    {
-      Cell: NumberCell,
-      label: 'label.in-store',
-      key: 'totalNumberOfPacks',
-      align: ColumnAlign.Right,
-      width: 80,
-      accessor: ({ rowData }) => rowData.stockLine?.totalNumberOfPacks,
-    },
-    {
-      Cell: NumberCell,
-      label: 'label.available-packs',
-      key: 'availableNumberOfPacks',
-      align: ColumnAlign.Right,
-      width: 85,
-      accessor: ({ rowData }) => rowData.stockLine?.availableNumberOfPacks,
-    },
-    [
-      'unitQuantity',
-      {
-        label: 'label.unit-quantity-issued',
-        labelProps: { unit },
-        accessor: ({ rowData }) => rowData.numberOfPacks * rowData.packSize,
-        width: 120,
-      },
-    ],
-    [
-      'numberOfPacks',
-      {
-        Cell: PackQuantityCell,
-        width: 120,
-        label: 'label.pack-quantity-issued',
-        setter: ({ packSize, id, numberOfPacks }) =>
-          onChange(id, numberOfPacks ?? 0, packSize ?? 1),
-      },
-    ]
+      width: 70,
+    }
   );
 
   const columns = useColumns<DraftStockOutLine>(columnDefinitions, {}, [


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3242

# 👩🏻‍💻 What does this PR do? 
Removes dup columns that got put in during conflict and resize some columns to be smaller... with FC the scroll bar still shows up... but everything fits? 😭 

![Screenshot 2024-04-02 at 16 24 44](https://github.com/msupply-foundation/open-msupply/assets/61820074/bf088fdb-87e5-46e2-885a-716adf61a18b)
![Screenshot 2024-04-02 at 16 25 36](https://github.com/msupply-foundation/open-msupply/assets/61820074/648520a6-8fc3-4275-b06c-69616ac60cc7)


# 🧪 How has/should this change been tested? 
- [ ] Go to Outbound Shipment line
- [ ] See changes

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
- [ ] Docs updated.