### PR TITLE
#3308 Implement disabling of completed returns

### DIFF
--- a/client/packages/invoices/src/Returns/InboundListView/ListView.tsx
+++ b/client/packages/invoices/src/Returns/InboundListView/ListView.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import {
   useNavigate,
   DataTable,
@@ -12,8 +12,9 @@ import {
   useToggle,
   useUrlQueryParams,
   ColumnDataSetter,
+  useTableStore,
 } from '@openmsupply-client/common';
-import { getStatusTranslator } from '../../utils';
+import { getStatusTranslator, isInboundListItemDisabled } from '../../utils';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
 import { InboundReturnRowFragment, useReturns } from '../api';
@@ -32,6 +33,7 @@ const InboundReturnListViewComponent: FC = () => {
       { key: 'status', condition: 'equalTo' },
     ],
   });
+  const { setDisabledRows } = useTableStore();
   const navigate = useNavigate();
   const modalController = useToggle();
   const pagination = { page, first, offset };
@@ -48,7 +50,13 @@ const InboundReturnListViewComponent: FC = () => {
 
   const { data, isError, isLoading } =
     useReturns.document.listInbound(queryParams);
-  // useDisableInboundRows(data?.nodes); // see inbound shipment for implementation reference
+
+  useEffect(() => {
+    const disabledRows = data?.nodes
+      .filter(isInboundListItemDisabled)
+      .map(({ id }) => id);
+    if (disabledRows) setDisabledRows(disabledRows);
+  }, [data?.nodes, setDisabledRows]);
 
   const columns = useColumns<InboundReturnRowFragment>(
     [

--- a/client/packages/invoices/src/Returns/OutboundListView/ListView.tsx
+++ b/client/packages/invoices/src/Returns/OutboundListView/ListView.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import {
   useNavigate,
   DataTable,
@@ -12,19 +12,12 @@ import {
   useToggle,
   useUrlQueryParams,
   ColumnDataSetter,
+  useTableStore,
 } from '@openmsupply-client/common';
-import { getStatusTranslator } from '../../utils';
+import { getStatusTranslator, isOutboundDisabled } from '../../utils';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
 import { OutboundReturnRowFragment, useReturns } from '../api';
-
-// const useDisableOutboundRows = (rows?: OutboundReturnRowFragment[]) => {
-//   const { setDisabledRows } = useTableStore();
-//   useEffect(() => {
-//     const disabledRows = rows?.filter(isOutboundDisabled).map(({ id }) => id);
-//     if (disabledRows) setDisabledRows(disabledRows);
-//   }, [rows]);
-// };
 
 const OutboundReturnListViewComponent: FC = () => {
   const t = useTranslation('replenishment');
@@ -40,6 +33,7 @@ const OutboundReturnListViewComponent: FC = () => {
       { key: 'status', condition: 'equalTo' },
     ],
   });
+  const { setDisabledRows } = useTableStore();
   const navigate = useNavigate();
   const modalController = useToggle();
   const pagination = { page, first, offset };
@@ -47,7 +41,13 @@ const OutboundReturnListViewComponent: FC = () => {
 
   const { data, isError, isLoading } =
     useReturns.document.listOutbound(queryParams);
-  // useDisableOutboundRows(data?.nodes);
+
+  useEffect(() => {
+    const disabledRows = data?.nodes
+      .filter(isOutboundDisabled)
+      .map(({ id }) => id);
+    if (disabledRows) setDisabledRows(disabledRows);
+  }, [data?.nodes, setDisabledRows]);
 
   const { mutate } = useReturns.document.updateOutboundReturn();
 

--- a/client/packages/invoices/src/utils.ts
+++ b/client/packages/invoices/src/utils.ts
@@ -203,7 +203,7 @@ export const isPrescriptionDisabled = (
 };
 
 export const isInboundListItemDisabled = (
-  inbound: InboundRowFragment
+  inbound: InboundRowFragment | InboundReturnRowFragment
 ): boolean => {
   const isManuallyCreated = !inbound.linkedShipment?.id;
   return isManuallyCreated


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3308

~~Putting this as a "Draft" PR initially, as I'm thinking of consolidating a couple of the "isDisabled" methods in `utils.ts` -- just waiting for clarification~~ Left as is for now.

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Implements "disabled" rows in list view for completed returns. Have used the same criteria for disabled as the respective shipments use -- assume this is correct?

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Check returns lists -- any past "shipped" should be disabled (i.e greyed out, but still clickable)

## 💌 Any notes for the reviewer?

The Shipments List views made a separate for `useDisableOutboundRows` etc. I haven't done this, as all it is is a wrapper around `useEffect` -- so I've just used `useEffect` directly in the component. Seems more straightforward to me.