### PR TITLE
3525 Outbound shipment status is automatically switching back to New in case of stock-transfer (to desktop-store)

### DIFF
--- a/server/service/src/processors/transfer/shipment/update_outbound_shipment_status.rs
+++ b/server/service/src/processors/transfer/shipment/update_outbound_shipment_status.rs
@@ -26,9 +26,11 @@ impl ShipmentTransferProcessor for UpdateOutboundShipmentStatusProcessor {
     /// 3. Linked shipment exists (the outbound shipment)
     /// 4. Linked outbound shipment status is not Verified (this is the last status possible)
     /// 5. Linked outbound shipment status is not source inbound shipment status
+    /// 6. Source shipment is from mSupply thus the status will be `New`. Shouldn't happen for OMS since
+    ///  OMS will follow OMS status sequence
     ///
     /// Can only run two times (one for Delivered and one for Verified status):
-    /// 6. Because linked outbound shipment status will be updated to source inbound shipment status and `5.` will never be true again
+    /// 7. Because linked outbound shipment status will be updated to source inbound shipment status and `5.` will never be true again
     ///    and business rules guarantee that Inbound shipment can only change status to Delivered and Verified
     ///    and status cannot be changed backwards
     fn try_process_record(
@@ -62,10 +64,14 @@ impl ShipmentTransferProcessor for UpdateOutboundShipmentStatusProcessor {
         if outbound_shipment.invoice_row.status == inbound_shipment.invoice_row.status {
             return Ok(None);
         }
+        // 6.
+        if inbound_shipment.invoice_row.status == InvoiceRowStatus::New {
+            return Ok(None);
+        }
 
         // Execute
         let updated_outbound_shipment = InvoiceRow {
-            // 6.
+            // 7.
             status: inbound_shipment.invoice_row.status.clone(),
             delivered_datetime: inbound_shipment.invoice_row.delivered_datetime.clone(),
             verified_datetime: inbound_shipment.invoice_row.verified_datetime.clone(),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3525 

# 👩🏻‍💻 What does this PR do? 
Stops the processor from updating status if source shipment is `New` as source shipment should only be `New` if it is being transferred from OG. OMS -> OMS transfers should follow the OMS status sequence.

# 🧪 How has/should this change been tested? 
- [ ] Have 2 sites: 1 OMS and 1 OG with stores on those sites.
- [ ] From OMS store: Create an `Outbound Shipment` to the OG store
- [ ] Add item and `Ship` OS
- [ ] Sync
- [ ] Status should still be `Shipped` for that OS 

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

or

- [ ] Functional change 1
- [ ] Functional change 2