### PR TITLE
Put store at the top of asset creation on central server!

### DIFF
--- a/client/packages/coldchain/src/Equipment/ListView/CreateAssetModal.tsx
+++ b/client/packages/coldchain/src/Equipment/ListView/CreateAssetModal.tsx
@@ -163,6 +163,20 @@ export const CreateAssetModal = ({
               label={t('label.use-catalogue')}
             />
           </Box>
+          {isCentralServer && (
+            <InputRow
+              label={t('label.store')}
+              Input={
+                <StoreSearchInput
+                  clearable
+                  fullWidth
+                  value={draft.store ?? undefined}
+                  onChange={onStoreChange}
+                  onInputChange={onStoreInputChange}
+                />
+              }
+            />
+          )}
           <InputRow
             label={t('label.category')}
             Input={
@@ -233,20 +247,6 @@ export const CreateAssetModal = ({
               />
             }
           />
-          {isCentralServer && (
-            <InputRow
-              label={t('label.store')}
-              Input={
-                <StoreSearchInput
-                  clearable
-                  fullWidth
-                  value={draft.store ?? undefined}
-                  onChange={onStoreChange}
-                  onInputChange={onStoreInputChange}
-                />
-              }
-            />
-          )}
           <InputRow
             label={t('label.notes')}
             Input={


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3461

# 👩🏻‍💻 What does this PR do? 
![image](https://github.com/msupply-foundation/open-msupply/assets/8287373/503174b0-a22d-49f4-8ca4-d25c95983875)

# 🧪 How has/should this change been tested? 
Start open-mSupply in central server mode e.g. `IS_CENTRAL_SERVER=true cargo run`
Open Inventory-> Assets -> New Asset

Check store is at the opt

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_