### PR TITLE
3543 Fix outbound shipment not including service charge in total

### DIFF
--- a/server/service/src/invoice/outbound_shipment/update/generate.rs
+++ b/server/service/src/invoice/outbound_shipment/update/generate.rs
@@ -146,7 +146,7 @@ fn lines_to_trim(
     }
 
     // If new invoice status is not new and previous invoice status is new
-    // add all unallocated lines to be deleted
+    // add all unallocated lines or empty lines to be deleted
 
     let mut lines = InvoiceLineRepository::new(connection).query_by_filter(
         InvoiceLineFilter::new()
@@ -157,7 +157,8 @@ fn lines_to_trim(
     let mut empty_lines = InvoiceLineRepository::new(connection).query_by_filter(
         InvoiceLineFilter::new()
             .invoice_id(EqualFilter::equal_to(&invoice.id))
-            .number_of_packs(EqualFilter::equal_to_f64(0.0)),
+            .number_of_packs(EqualFilter::equal_to_f64(0.0))
+            .r#type(InvoiceLineRowType::StockOut.equal_to()),
     )?;
 
     if lines.is_empty() && empty_lines.is_empty() {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3543

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Include service charge amount in the grand total calculation for the outbound shipment.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
1. Create a outbound with some line. Better to have line totals
2. More> Add service charges - some values so that `Grand total`>`Line total`
3. Confirm the shipment to Shipped status
4. The grand-total is adjusted to line-total

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

or

- [ ] Functional change 1
- [ ] Functional change 2