### PR TITLE
Improve/fix SnapshotCountCurrentCountMismatch error

### DIFF
--- a/client/packages/common/src/intl/locales/en/inventory.json
+++ b/client/packages/common/src/intl/locales/en/inventory.json
@@ -7,7 +7,7 @@
   "error.no-stocktake-items": "No items have been added to this stocktake.",
   "error.not-editable": "Stocktake is not editable.",
   "error.is-locked": "Stocktake is locked.",
-  "error.snapshot-total-mismatch": "Snapshot quantity does not match total quantity.",
+  "error.snapshot-total-mismatch": "One or more lines have a discrepancy between the current stock level and snapshot count.",
   "error.provide-reason": "A reason must be provided for any rows which have a difference in the counted number of packs.",
   "error.provide-valid-reason": "Adjustment reason does not match adjustment direction",
   "error.reduced-below-zero": "Stock line exist in new outbound shipments. The quantity cannot be reduced below zero.",

--- a/client/packages/common/src/intl/locales/en/inventory.json
+++ b/client/packages/common/src/intl/locales/en/inventory.json
@@ -7,7 +7,7 @@
   "error.no-stocktake-items": "No items have been added to this stocktake.",
   "error.not-editable": "Stocktake is not editable.",
   "error.is-locked": "Stocktake is locked.",
-  "error.snapshot-total-mismatch": "One or more lines have a discrepancy between the current stock level and snapshot count.",
+  "error.snapshot-total-mismatch": "Error: One or more lines have a discrepancy between the current stock level and snapshot count.",
   "error.provide-reason": "A reason must be provided for any rows which have a difference in the counted number of packs.",
   "error.provide-valid-reason": "Adjustment reason does not match adjustment direction",
   "error.reduced-below-zero": "Stock line exist in new outbound shipments. The quantity cannot be reduced below zero.",

--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
@@ -173,7 +173,7 @@ export const useStocktakeColumns = ({
         Cell: NumberCell,
         getIsError: row =>
           getLinesFromRow(row).some(
-            r => getError(r)?.__typename === 'SnapshotCountCurrentCountMismatch'
+            r => getError(r)?.__typename === 'StockLineReducedBelowZero'
           ),
         sortable: false,
         accessor: ({ rowData }) => {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Part of #3285

# 👩🏻‍💻 What does this PR do? 
Improves the error message and highlight the correct error columns, i.e. "Counted Pack" is not highlighted if there is a SnapshotCountCurrentCountMismatch error.

Please see issue for more details