### PR TITLE
Fix two warnings by renaming getPackVariantCell

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
@@ -16,7 +16,7 @@ import {
 } from '@openmsupply-client/common';
 import {
   InventoryAdjustmentReasonRowFragment,
-  PackVariantCell,
+  getPackVariantCell,
 } from '@openmsupply-client/system';
 import { StocktakeSummaryItem } from '../../../types';
 import { StocktakeLineFragment } from '../../api';
@@ -130,7 +130,7 @@ export const useStocktakeColumns = ({
         key: 'packUnit',
         label: 'label.pack',
         sortable: false,
-        Cell: PackVariantCell({
+        Cell: getPackVariantCell({
           getItemId: row => row?.item?.id ?? '',
           getPackSizes: row => {
             if ('lines' in row) return row.lines.map(l => l.packSize ?? 1);
@@ -254,7 +254,7 @@ export const useExpansionColumns = (): Column<StocktakeLineFragment>[] => {
       key: 'packUnit',
       label: 'label.pack',
       sortable: false,
-      Cell: PackVariantCell({
+      Cell: getPackVariantCell({
         getItemId: row => row?.itemId,
         getPackSizes: row => {
           return [row?.packSize ?? 1];

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -11,7 +11,7 @@ import {
   useColumnUtils,
   CurrencyCell,
 } from '@openmsupply-client/common';
-import { PackVariantCell } from '@openmsupply-client/system';
+import { getPackVariantCell } from '@openmsupply-client/system';
 import { InboundItem } from './../../../types';
 import { InboundLineFragment } from '../../api';
 import { isInboundPlaceholderRow } from '../../../utils';
@@ -126,7 +126,7 @@ export const useInboundShipmentColumns = () => {
         key: 'packUnit',
         label: 'label.pack',
         sortable: false,
-        Cell: PackVariantCell({
+        Cell: getPackVariantCell({
           getItemId: row => {
             if ('lines' in row) return '';
             else return row?.item?.id;
@@ -234,7 +234,7 @@ export const useExpansionColumns = (): Column<InboundLineFragment>[] =>
       key: 'packUnit',
       label: 'label.pack',
       sortable: false,
-      Cell: PackVariantCell({
+      Cell: getPackVariantCell({
         getItemId: row => row?.item?.id,
         getPackSizes: row => [row?.packSize ?? 1],
         getUnitName: row => row?.item?.unitName ?? null,

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
@@ -14,7 +14,7 @@ import {
 } from '@openmsupply-client/common';
 import { DraftStockOutLine } from '../../../types';
 import { PackQuantityCell, StockOutLineFragment } from '../../../StockOut';
-import { PackVariantCell } from '@openmsupply-client/system';
+import { getPackVariantCell } from '@openmsupply-client/system';
 import { CurrencyRowFragment } from '@openmsupply-client/system';
 
 export const useOutboundLineEditColumns = ({
@@ -86,7 +86,7 @@ export const useOutboundLineEditColumns = ({
       label: 'label.pack',
       sortable: false,
       width: 90,
-      Cell: PackVariantCell({
+      Cell: getPackVariantCell({
         getItemId: row => row?.item.id,
         getPackSizes: row => [row.packSize ?? 1],
         getUnitName: row => row?.item.unitName ?? null,
@@ -158,7 +158,7 @@ export const useExpansionColumns = (): Column<StockOutLineFragment>[] =>
       key: 'packUnit',
       label: 'label.pack',
       sortable: false,
-      Cell: PackVariantCell({
+      Cell: getPackVariantCell({
         getItemId: row => row?.item.id,
         getPackSizes: row => [row.packSize ?? 1],
         getUnitName: row => row?.item.unitName ?? null,

--- a/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -13,7 +13,7 @@ import {
   NumberCell,
   CurrencyCell,
 } from '@openmsupply-client/common';
-import { PackVariantCell } from '@openmsupply-client/system';
+import { getPackVariantCell } from '@openmsupply-client/system';
 import { StockOutLineFragment } from '../../StockOut';
 import { StockOutItem } from '../../types';
 
@@ -147,7 +147,7 @@ export const useOutboundColumns = ({
         key: 'packUnit',
         label: 'label.pack',
         sortable: false,
-        Cell: PackVariantCell({
+        Cell: getPackVariantCell({
           getItemId: row => {
             if ('lines' in row) return '';
             else return row?.item?.id;

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/columns.ts
@@ -9,7 +9,7 @@ import {
 } from '@openmsupply-client/common';
 import { DraftStockOutLine } from '../../../types';
 import { PackQuantityCell, StockOutLineFragment } from '../../../StockOut';
-import { PackVariantCell } from '@openmsupply-client/system';
+import { getPackVariantCell } from '@openmsupply-client/system';
 
 export const usePrescriptionLineEditColumns = ({
   onChange,
@@ -69,7 +69,7 @@ export const usePrescriptionLineEditColumns = ({
         key: 'packUnit',
         label: 'label.pack',
         sortable: false,
-        Cell: PackVariantCell({
+        Cell: getPackVariantCell({
           getItemId: row => row?.item?.id,
           getPackSizes: row => [row.packSize ?? 1],
           getUnitName: row => row?.item.unitName ?? null,

--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -12,7 +12,7 @@ import {
   NumberCell,
   CurrencyCell,
 } from '@openmsupply-client/common';
-import { PackVariantCell } from '@openmsupply-client/system';
+import { getPackVariantCell } from '@openmsupply-client/system';
 import { StockOutLineFragment } from '../../StockOut';
 import { StockOutItem } from '../../types';
 
@@ -161,7 +161,7 @@ export const usePrescriptionColumn = ({
         label: 'label.pack',
         sortable: false,
         // eslint-disable-next-line new-cap
-        Cell: PackVariantCell({
+        Cell: getPackVariantCell({
           getItemId: row => {
             if ('lines' in row) return '';
             else return row?.item?.id;

--- a/client/packages/invoices/src/Returns/modals/OutboundReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/OutboundReturn/ReturnQuantitiesTable.tsx
@@ -4,7 +4,7 @@ import {
   useColumns,
   CellProps,
 } from '@openmsupply-client/common';
-import { PackVariantCell } from '@openmsupply-client/system';
+import { getPackVariantCell } from '@openmsupply-client/system';
 import React from 'react';
 import { GenerateOutboundReturnLineFragment } from '../../api';
 
@@ -32,7 +32,7 @@ export const QuantityToReturnTableComponent = ({
         label: 'label.pack',
         sortable: false,
         // eslint-disable-next-line new-cap
-        Cell: PackVariantCell({
+        Cell: getPackVariantCell({
           getItemId: row => row.item.id,
           getPackSizes: row => [row.packSize],
           getUnitName: row => row.item.unitName || null,

--- a/client/packages/system/src/Item/Components/PackVariant/PackVariantCell.tsx
+++ b/client/packages/system/src/Item/Components/PackVariant/PackVariantCell.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 
 // Shows '[multiple]' if there is more then one pack size
 // otherwise shows pack size or unit variant short name
-export const PackVariantCell =
+export const getPackVariantCell =
   <T extends RecordWithId>({
     getItemId,
     getUnitName,

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -21,7 +21,7 @@ import {
 import { RepackModal, StockLineEditModal } from '../Components';
 import { StockLineRowFragment, useStock } from '../api';
 import { AppBarButtons } from './AppBarButtons';
-import { PackVariantCell } from '@openmsupply-client/system';
+import { getPackVariantCell } from '@openmsupply-client/system';
 import { Toolbar } from './Toolbar';
 
 const StockListComponent: FC = () => {
@@ -127,7 +127,7 @@ const StockListComponent: FC = () => {
       key: 'packUnit',
       label: 'label.pack',
       sortable: false,
-      Cell: PackVariantCell({
+      Cell: getPackVariantCell({
         getItemId: r => r.itemId,
         getPackSizes: r => [r.packSize],
         getUnitName: r => r.item.unitName || null,


### PR DESCRIPTION
Some warning I noticed while working on another issue. Fixes two warning by using the correct naming convention:

React Hook "usePackVariant" cannot be called inside a callback.

A function with a name starting with an uppercase letter should only be
used as a constructor.