### PR TITLE
Add sell price column to inbound shipment line pricing tab

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -213,6 +213,31 @@ export const PricingTableComponent: FC<
   }
 
   columnDefinitions.push([
+    'sellPricePerPack',
+    {
+      Cell: CurrencyInputCell,
+      width: 100,
+      setter: updateDraftLine,
+    },
+  ]);
+
+  if (isExternalSupplier && !!store?.preferences.issueInForeignCurrency) {
+    columnDefinitions.push({
+      key: 'foreignCurrencySellPricePerPack',
+      label: 'label.fc-sell-price',
+      description: 'description.fc-sell-price',
+      width: 100,
+      align: ColumnAlign.Right,
+      Cell: CurrencyCell,
+      accessor: ({ rowData }) => {
+        if (currency) {
+          return rowData.sellPricePerPack / currency.rate;
+        }
+      },
+    });
+  }
+
+  columnDefinitions.push([
     'lineTotal',
     {
       accessor: ({ rowData }) =>
@@ -220,7 +245,7 @@ export const PricingTableComponent: FC<
     },
   ]);
 
-  if (isExternalSupplier) {
+  if (isExternalSupplier && !!store?.preferences.issueInForeignCurrency) {
     columnDefinitions.push({
       key: 'foreignCurrencyLineTotal',
       label: 'label.fc-line-total',

--- a/client/packages/invoices/src/Returns/InboundDetailView/columns.ts
+++ b/client/packages/invoices/src/Returns/InboundDetailView/columns.ts
@@ -12,7 +12,7 @@ import {
 } from '@openmsupply-client/common';
 import { InboundReturnLineFragment } from '../api';
 import { InboundReturnItem } from '../../types';
-import { PackVariantCell } from 'packages/system';
+import { getPackVariantCell } from '@openmsupply-client/system';
 
 interface UseInboundReturnColumnOptions {
   sortBy: SortBy<InboundReturnLineFragment | InboundReturnItem>;
@@ -156,7 +156,7 @@ export const useInboundReturnColumns = ({
         key: 'packUnit',
         label: 'label.pack',
         sortable: false,
-        Cell: PackVariantCell({
+        Cell: getPackVariantCell({
           getItemId: row => {
             if ('lines' in row) return '';
             else return row?.item?.id;

--- a/client/packages/invoices/src/Returns/OutboundDetailView/columns.ts
+++ b/client/packages/invoices/src/Returns/OutboundDetailView/columns.ts
@@ -13,7 +13,7 @@ import {
 } from '@openmsupply-client/common';
 import { OutboundReturnLineFragment } from '../api';
 import { OutboundReturnItem } from '../../types';
-import { PackVariantCell } from 'packages/system';
+import { getPackVariantCell } from '@openmsupply-client/system';
 
 interface UseOutboundColumnOptions {
   sortBy: SortBy<OutboundReturnLineFragment | OutboundReturnItem>;
@@ -145,7 +145,7 @@ export const useOutboundReturnColumns = ({
         key: 'packUnit',
         label: 'label.pack',
         sortable: false,
-        Cell: PackVariantCell({
+        Cell: getPackVariantCell({
           getItemId: row => {
             if ('lines' in row) return '';
             else return row?.item?.id;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3559

# 👩🏻‍💻 What does this PR do? 
Adds back sell price to Inbound Shipment line edit modal in the pricing tab.

# 🧪 How has/should this change been tested? 
- [ ] Create Inbound Shipment
- [ ] Add item
- [ ] Go to pricing tab
- [ ] Should see sell price

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

or

- [ ] Functional change 1
- [ ] Functional change 2