### PR TITLE
'Code' column title is not visible under Replenishment -> Suppliers #3477

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
@@ -86,7 +86,7 @@ export function Autocomplete<T>({
         disableUnderline: false,
         ...props.InputProps,
       }}
-      sx={{ width }}
+      sx={{ minWidth: width }}
     />
   );
   const defaultGetOptionLabel = (option: T): string => {

--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
@@ -119,7 +119,7 @@ export const useStocktakeColumns = ({
       {
         key: 'locationCode',
         label: 'label.location',
-        width: 90,
+        width: 100,
         accessor: ({ rowData }) =>
           getColumnProperty(rowData, [
             { path: ['lines', 'location', 'code'] },

--- a/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
@@ -55,6 +55,7 @@ export const Toolbar: FC<{
             {otherParty && (
               <InputWithLabelRow
                 label={t('label.customer-name')}
+                sx={{ minWidth: 100 }}
                 Input={
                   <CustomerSearchInput
                     disabled={isDisabled || !!requisition}

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/columns.ts
@@ -37,7 +37,7 @@ export const usePrescriptionLineEditColumns = ({
         'location',
         {
           accessor: ({ rowData }) => rowData.location?.code,
-          width: 70,
+          width: 100,
           Cell: LocationCell,
         },
       ],
@@ -47,7 +47,7 @@ export const usePrescriptionLineEditColumns = ({
         Cell: CheckCell,
         accessor: ({ rowData }) => rowData.stockLine?.onHold,
         align: ColumnAlign.Center,
-        width: 80,
+        width: 70,
       },
       {
         Cell: NumberCell,

--- a/client/packages/system/src/InventoryAdjustmentReason/Components/InventoryAdjustmentReasonSearchInput.tsx
+++ b/client/packages/system/src/InventoryAdjustmentReason/Components/InventoryAdjustmentReasonSearchInput.tsx
@@ -72,7 +72,7 @@ export const InventoryAdjustmentReasonSearchInput: FC<
               style: props.disabled ? { paddingLeft: 0 } : {},
               ...props.InputProps,
             }}
-            sx={{ width }}
+            sx={{ minWidth: width }}
             error={isError}
             required={isRequired}
           />

--- a/client/packages/system/src/Name/Components/CustomerSearchInput/CustomerSearchInput.tsx
+++ b/client/packages/system/src/Name/Components/CustomerSearchInput/CustomerSearchInput.tsx
@@ -41,6 +41,7 @@ export const CustomerSearchInput: FC<NameSearchInputProps> = ({
       popperMinWidth={width}
       isOptionEqualToValue={(option, value) => option?.id === value?.id}
       getOptionDisabled={option => option.isOnHold}
+      sx={{ minWidth: width }}
     />
   );
 };

--- a/client/packages/system/src/Name/ListView/ListView.tsx
+++ b/client/packages/system/src/Name/ListView/ListView.tsx
@@ -35,7 +35,7 @@ const NameListComponent: FC<{ type: 'customer' | 'supplier' }> = ({ type }) => {
         Cell: ({ rowData }) => (
           <NameRenderer label={rowData.code} isStore={!!rowData.store} />
         ),
-        width: 60,
+        width: 100,
       },
       'name',
     ],


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3477

# 👩🏻‍💻 What does this PR do? 
Found these while doings docs and was fixing them along the way but though I'll just get this fix in since there's already an issue for it.

This PR fixes some columns/inputs that have changed. Probably a better way to fix this but was just doing this to make the docs screenshot look better >.>

# 🧪 How has/should this change been tested? 
- [ ] See that code is fully displayed wherever there is a code column
- [ ] Find an autocomplete component and make sure the input widths look ok
- [ ] Customer/Supplier field in invoices are same width as below component