### PR TITLE
Hide make/model for non-catalogue assets

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/Toolbar.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/Toolbar.tsx
@@ -16,30 +16,32 @@ export const Toolbar: FC = () => {
 
   return (
     <AppBarContentPortal sx={{ display: 'flex', flex: 1, marginBottom: 1 }}>
-      <Box paddingLeft={4} display="flex" flex={1} alignItems="flex-start">
-        <Box
-          flex={0}
-          display="flex"
-          alignItems="flex-start"
-          flexDirection="column"
-        >
-          <Box sx={{ fontWeight: 'bold' }} paddingRight={2}>
-            {t('label.manufacturer')}:
+      {!data.catalogueItem ? null : (
+        <Box paddingLeft={4} display="flex" flex={1} alignItems="flex-start">
+          <Box
+            flex={0}
+            display="flex"
+            alignItems="flex-start"
+            flexDirection="column"
+          >
+            <Box sx={{ fontWeight: 'bold' }} paddingRight={2}>
+              {t('label.manufacturer')}:
+            </Box>
+            <Box sx={{ fontWeight: 'bold' }} paddingRight={2}>
+              {t('label.model')}:
+            </Box>
           </Box>
-          <Box sx={{ fontWeight: 'bold' }} paddingRight={2}>
-            {t('label.model')}:
+          <Box
+            flex={1}
+            display="flex"
+            alignItems="flex-start"
+            flexDirection="column"
+          >
+            <Box flex={1}>{catalogueItem?.manufacturer}</Box>
+            <Box flex={1}>{catalogueItem?.model}</Box>
           </Box>
         </Box>
-        <Box
-          flex={1}
-          display="flex"
-          alignItems="flex-start"
-          flexDirection="column"
-        >
-          <Box flex={1}>{catalogueItem?.manufacturer}</Box>
-          <Box flex={1}>{catalogueItem?.model}</Box>
-        </Box>
-      </Box>
+      )}
     </AppBarContentPortal>
   );
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3460

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
What it says on the tin. Was thinking that when the sub-catalogue changes are merged we could add the catalogue to that toolbar area. For now though, this tidies up the issue.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Shouldn't show make/model for non-catalogue assets.
