### PR TITLE
Add store to equipment import

### DIFF
--- a/client/packages/coldchain/src/Equipment/ImportAsset/ImportReviewDataTable.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/ImportReviewDataTable.tsx
@@ -47,6 +47,7 @@ export const ImportReviewDataTable: FC<ImportReviewDataTableProps> = ({
       width: 50,
       sortable: false,
       label: 'label.store',
+      accessor: ({ rowData }) => rowData.store?.code,
     });
   }
 

--- a/client/packages/coldchain/src/Equipment/ImportAsset/ImportReviewDataTable.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/ImportReviewDataTable.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useState } from 'react';
 import {
+  ColumnDescription,
   DataTable,
   Grid,
   NothingHere,
@@ -7,6 +8,7 @@ import {
   SearchBar,
   TooltipTextCell,
   useColumns,
+  useIsCentralServerApi,
   useTranslation,
 } from '@openmsupply-client/common';
 import { ImportRow } from './EquipmentImportModal';
@@ -18,57 +20,65 @@ export const ImportReviewDataTable: FC<ImportReviewDataTableProps> = ({
   importRows,
 }) => {
   const t = useTranslation('coldchain');
+  const isCentralServer = useIsCentralServerApi();
   const [pagination, setPagination] = useState<Pagination>({
     page: 0,
     first: 20,
     offset: 0,
   });
   const [searchString, setSearchString] = useState<string>(() => '');
-  const columns = useColumns<ImportRow>(
-    [
-      {
-        key: 'assetNumber',
-        width: 70,
-        sortable: false,
-        label: 'label.asset-number',
-      },
-      {
-        key: 'catalogueItemCode',
-        width: 50,
-        sortable: false,
-        label: 'label.catalogue-item-code',
-      },
-      {
-        key: 'serialNumber',
-        width: 100,
-        sortable: false,
-        label: 'label.serial',
-        Cell: TooltipTextCell,
-      },
-      {
-        key: 'installationDate',
-        width: 100,
-        sortable: false,
-        label: 'label.installation-date',
-        Cell: TooltipTextCell,
-      },
-      {
-        key: 'notes',
-        width: 100,
-        sortable: false,
-        label: 'label.asset-notes',
-        Cell: TooltipTextCell,
-      },
-      {
-        key: 'errorMessage',
-        label: 'label.error-message',
-        width: 150,
-        Cell: TooltipTextCell,
-      },
-    ],
-    {},
-    []
-  );
+  const columnDescriptions: ColumnDescription<ImportRow>[] = [
+    {
+      key: 'assetNumber',
+      width: 70,
+      sortable: false,
+      label: 'label.asset-number',
+    },
+    {
+      key: 'catalogueItemCode',
+      width: 50,
+      sortable: false,
+      label: 'label.catalogue-item-code',
+    },
+  ];
+  if (isCentralServer) {
+    columnDescriptions.push({
+      key: 'store',
+      width: 50,
+      sortable: false,
+      label: 'label.store',
+    });
+  }
+
+  columnDescriptions.push({
+    key: 'serialNumber',
+    width: 100,
+    sortable: false,
+    label: 'label.serial',
+    Cell: TooltipTextCell,
+  });
+  columnDescriptions.push({
+    key: 'installationDate',
+    width: 100,
+    sortable: false,
+    label: 'label.installation-date',
+    Cell: TooltipTextCell,
+  });
+  columnDescriptions.push({
+    key: 'notes',
+    width: 100,
+    sortable: false,
+    label: 'label.asset-notes',
+    Cell: TooltipTextCell,
+  });
+  columnDescriptions.push({
+    key: 'errorMessage',
+    label: 'label.error-message',
+    width: 150,
+    Cell: TooltipTextCell,
+  });
+
+  const columns = useColumns<ImportRow>(columnDescriptions, {}, []);
 
   const filteredEquipment = importRows.filter(row => {
     if (!searchString) {

--- a/client/packages/coldchain/src/Equipment/utils.ts
+++ b/client/packages/coldchain/src/Equipment/utils.ts
@@ -137,50 +137,67 @@ export const translateReason = (
 
 export const importEquipmentToCsvWithErrors = (
   assets: Partial<ImportRow & LineNumber>[],
-  t: TypedTFunction<LocaleKey>
+  t: TypedTFunction<LocaleKey>,
+  isCentralServer: boolean
 ) => {
   const fields: string[] = [
     t('label.asset-number'),
     t('label.catalogue-item-code'),
-    t('label.asset-notes'),
-    t('label.serial'),
-    t('label.installation-date'),
-    t('label.line-number'),
-    t('label.error-message'),
   ];
 
-  const data = assets.map(node => [
-    node.assetNumber,
-    node.catalogueItemCode,
-    node.notes,
-    node.serialNumber,
-    node.installationDate,
-    node.lineNumber,
-    node.errorMessage,
-  ]);
+  if (isCentralServer) {
+    fields.push(t('label.store'));
+  }
 
+  fields.push(t('label.asset-notes'));
+  fields.push(t('label.serial'));
+  fields.push(t('label.installation-date'));
+  fields.push(t('label.line-number'));
+  fields.push(t('label.error-message'));
+
+  const data = assets.map(node => {
+    const mapped: (string | number | null | undefined)[] = [
+      node.assetNumber,
+      node.catalogueItemCode,
+    ];
+    if (isCentralServer) mapped.push(node.store?.code);
+    mapped.push(node.notes);
+    mapped.push(node.serialNumber);
+    mapped.push(node.installationDate);
+    mapped.push(node.lineNumber);
+    mapped.push(node.errorMessage);
+    return mapped;
+  });
   return Formatter.csv({ fields, data });
 };
 
 export const importEquipmentToCsv = (
   assets: Partial<ImportRow>[],
-  t: TypedTFunction<LocaleKey>
+  t: TypedTFunction<LocaleKey>,
+  isCentralServer: boolean = false
 ) => {
   const fields: string[] = [
     t('label.asset-number'),
     t('label.catalogue-item-code'),
-    t('label.asset-notes'),
-    t('label.serial'),
-    t('label.installation-date'),
   ];
+  if (isCentralServer) {
+    fields.push(t('label.store'));
+  }
+  fields.push(t('label.asset-notes'));
+  fields.push(t('label.serial'));
+  fields.push(t('label.installation-date'));
 
-  const data = assets.map(node => [
-    node.assetNumber,
-    node.catalogueItemCode,
-    node.notes,
-    node.serialNumber,
-    node.installationDate,
-  ]);
+  const data = assets.map(node => {
+    const row = [
+      node.assetNumber,
+      node.catalogueItemCode,
+      node.notes,
+      node.serialNumber,
+      node.installationDate,
+    ];
+    if (isCentralServer) row.push(node.store?.code);
+    return row;
+  });
 
   return Formatter.csv({ fields, data });
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3459 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
If running central server, the following happens:

* Sample template has a store column
* Store code is required
* Entering a store code will lookup against all stores
* the failed export shows the store code

![Screenshot 2024-04-12 at 12 33 38 PM](https://github.com/msupply-foundation/open-msupply/assets/9192912/734540a2-e03a-4038-a6ac-44096fc486ac)

Have refactored the import a little to make it simpler to add the new cell.
No change to functionality if running in Remote mode.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->
Start the central server using `IS_CENTRAL_SERVER=true  cargo run` to test the store upload.

## 📃 Documentation
<!-- 
  - Bullet points or screenshots of any functionality/UI changes which require documentation updates. 
  - Reminder: Label the PR with: docs: external or docs: internal 
  -->
_No user facing changes_

or

- [ ] Functional change 1
- [ ] Functional change 2