### PR TITLE
Add inventory adjustments feature flag for v2.0.0

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -24,7 +24,11 @@ To see it in action, check out the [demo server](https://demo-open.msupply.org/)
 
 `yarn start-local` (using localhost:8000 as API - ensure you have already gone through the `server` setup instructions)
 
-`cd packages/host && yarn start -- --env API_HOST='http://localhost:8001'` (using custom API url, see [config.ts for more info](./packages/config/src/config.ts))
+`yarn start -- -- --env API_HOST='http://localhost:8001'` (using custom API url, see [config.ts for more info](./packages/config/src/config.ts))
+
+- If there are feature flags in use, they are set as environment variables. For example:
+
+`yarn start-local-features FEATURE_INVENTORY_ADJUSTMENTS=true`
 
 - Bundle for production:
 

--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "sideEffects": false,
   "private": true,
   "scripts": {
+    "start-local-features": "yarn start-local -- -- --env $1",
     "start-local": "lerna run --scope @openmsupply-client/* --parallel start-local",
     "start-remote": "lerna run --scope @openmsupply-client/* --parallel start-remote",
     "start": "yarn start-remote",

--- a/client/packages/config/src/config.ts
+++ b/client/packages/config/src/config.ts
@@ -1,4 +1,5 @@
 declare const API_HOST: string;
+declare const FEATURE_INVENTORY_ADJUSTMENTS: boolean;
 
 // For production, API is on the same domain/ip and port as web app, available through sub-route
 // i.e. web app is on https://my.openmsupply.com/, then graphql will be available https://my.openmsupply.com/graphql
@@ -32,6 +33,9 @@ export const Environment = {
   UPLOAD_FRIDGE_TAG: `${apiHost}/fridge-tag`,
   PRINT_LABEL_QR: `${apiHost}/print/label-qr`,
   PRINT_LABEL_TEST: `${apiHost}/print/label-test`,
+
+  // Feature flags
+  FEATURE_INVENTORY_ADJUSTMENTS,
 };
 
 export default Environment;

--- a/client/packages/host/webpack.config.js
+++ b/client/packages/host/webpack.config.js
@@ -144,6 +144,9 @@ module.exports = env => {
     plugins: [
       new ReactRefreshWebpackPlugin(),
       new webpack.DefinePlugin({
+        FEATURE_INVENTORY_ADJUSTMENTS: JSON.stringify(
+          env.FEATURE_INVENTORY_ADJUSTMENTS
+        ),
         API_HOST: JSON.stringify(env.API_HOST),
         LOCAL_PLUGINS: JSON.stringify(localPlugins()),
       }),

--- a/client/packages/host/webpack.config.js
+++ b/client/packages/host/webpack.config.js
@@ -144,9 +144,7 @@ module.exports = env => {
     plugins: [
       new ReactRefreshWebpackPlugin(),
       new webpack.DefinePlugin({
-        FEATURE_INVENTORY_ADJUSTMENTS: JSON.stringify(
-          env.FEATURE_INVENTORY_ADJUSTMENTS
-        ),
+        FEATURE_INVENTORY_ADJUSTMENTS: env.FEATURE_INVENTORY_ADJUSTMENTS,
         API_HOST: JSON.stringify(env.API_HOST),
         LOCAL_PLUGINS: JSON.stringify(localPlugins()),
       }),

--- a/client/packages/inventory/src/Stocktake/DetailView/Toolbar.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/Toolbar.tsx
@@ -23,6 +23,7 @@ import {
   useNotification,
   ArrowRightIcon,
 } from '@openmsupply-client/common';
+import { Environment } from '@openmsupply-client/config';
 import { useStocktake } from '../api';
 import { ReduceLinesToZeroConfirmationModal } from './ReduceLinesToZeroModal';
 import { ChangeLocationConfirmationModal } from './ChangeLocationModal';
@@ -158,18 +159,22 @@ export const Toolbar = () => {
             />
           </Box>
           <DropdownMenu disabled={isDisabled} label={t('label.actions')}>
-            <DropdownMenuItem
-              IconComponent={ArrowRightIcon}
-              onClick={openChangeLocationModal}
-            >
-              {t('button.change-location')}
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              IconComponent={RewindIcon}
-              onClick={openReduceToZeroModal}
-            >
-              {t('button.reduce-lines-to-zero')}
-            </DropdownMenuItem>
+            {Environment.FEATURE_INVENTORY_ADJUSTMENTS && (
+              <>
+                <DropdownMenuItem
+                  IconComponent={ArrowRightIcon}
+                  onClick={openChangeLocationModal}
+                >
+                  {t('button.change-location')}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  IconComponent={RewindIcon}
+                  onClick={openReduceToZeroModal}
+                >
+                  {t('button.reduce-lines-to-zero')}
+                </DropdownMenuItem>
+              </>
+            )}
             <DropdownMenuItem IconComponent={DeleteIcon} onClick={onDelete}>
               {t('button.delete-lines')}
             </DropdownMenuItem>

--- a/client/packages/system/src/Stock/Components/StockLineEditModal.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineEditModal.tsx
@@ -12,6 +12,7 @@ import {
   usePluginElements,
   PluginEventListener,
 } from '@openmsupply-client/common';
+import { Environment } from '@openmsupply-client/config';
 import { StockLineRowFragment, useStock } from '../api';
 import { ActivityLogList } from '../../ActivityLog';
 import { StockLineForm } from './StockLineForm';
@@ -81,12 +82,16 @@ export const StockLineEditModal: FC<StockLineEditModalProps> = ({
       ),
       value: 'label.details',
     },
-    {
-      Component: (
-        <InventoryAdjustmentForm stockLine={draft} onUpdate={onUpdate} />
-      ),
-      value: 'label.adjust',
-    },
+    ...(Environment.FEATURE_INVENTORY_ADJUSTMENTS
+      ? [
+          {
+            Component: (
+              <InventoryAdjustmentForm stockLine={draft} onUpdate={onUpdate} />
+            ),
+            value: 'label.adjust',
+          },
+        ]
+      : []),
     {
       Component: <ActivityLogList recordId={draft?.id ?? ''} />,
       value: 'label.log',

--- a/client/packages/system/src/Stock/ListView/AppBarButtons.tsx
+++ b/client/packages/system/src/Stock/ListView/AppBarButtons.tsx
@@ -13,6 +13,7 @@ import {
   ButtonWithIcon,
   useEditModal,
 } from '@openmsupply-client/common';
+import { Environment } from '@openmsupply-client/config';
 import { useStock } from '../api';
 import { stockLinesToCsv } from '../../utils';
 import { NewStockLineModal } from '../Components/NewStockLineModal';
@@ -44,11 +45,13 @@ export const AppBarButtonsComponent = () => {
       {isOpen && <NewStockLineModal isOpen={isOpen} onClose={onClose} />}
 
       <Grid container gap={1}>
-        <ButtonWithIcon
-          Icon={<PlusCircleIcon />}
-          label={t('button.new-stock')}
-          onClick={onOpen}
-        />
+        {Environment.FEATURE_INVENTORY_ADJUSTMENTS && (
+          <ButtonWithIcon
+            Icon={<PlusCircleIcon />}
+            label={t('button.new-stock')}
+            onClick={onOpen}
+          />
+        )}
         <LoadingButton
           startIcon={<DownloadIcon />}
           isLoading={isLoading}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3604

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Adds a feature flag to hide inventory adjustments features for v2.0.0.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

- Start with usual `yarn start-local` 
  - [ ] no inventory adjustments features
- Start with the below script:
```sh
# yep, that many -- to pass through lerna scripts 😅
yarn start-local -- -- --env FEATURE_INVENTORY_ADJUSTMENTS=true
```
- You should now see:
  - [ ] `New stock` button at the top of the stock view
  - [ ] `Adjust` tab in the stock detail/edit modal
  - [ ] `Change location` and `Reduce lines to 0` actions in the stocktake details action dropdown


## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

This still feels like the fastest way to a feature flag for now, but if it's something we're going to use more of, the `-- -- --env` feels super clunky. Maybe should set up .env file? Is that worth doing now?

## 📃 Documentation
<!-- 
  - Bullet points or screenshots of any functionality/UI changes which require documentation updates. 
  - Reminder: Label the PR with: docs: external or docs: internal 
  -->
_No user facing changes_
