### PR TITLE
3601 authorisation required for sync file endpoints

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/Tabs/Documents.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/Tabs/Documents.tsx
@@ -56,6 +56,7 @@ export const Documents = ({ draft }: { draft: DraftAsset }) => {
   const deleteFile = (id: string) => {
     fetch(`${Environment.SYNC_FILES_URL}/asset/${draft.id}/${id}`, {
       method: 'DELETE',
+      credentials: 'include',
     })
       .then(response => {
         if (response.ok) {
@@ -84,6 +85,7 @@ export const Documents = ({ draft }: { draft: DraftAsset }) => {
         headers: {
           Accept: 'application/json',
         },
+        credentials: 'include',
         body: formData,
       });
       if (response.ok) {

--- a/client/packages/coldchain/src/Equipment/DetailView/UpdateStatusButton.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/UpdateStatusButton.tsx
@@ -69,6 +69,7 @@ export const UpdateStatusButtonComponent = ({
           headers: {
             Accept: 'application/json',
           },
+          credentials: 'include',
           body: formData,
         });
       })

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -5053,7 +5053,6 @@ dependencies = [
  "rust-embed",
  "rustls 0.20.9",
  "rustls-pemfile",
- "sanitize-filename",
  "serde 1.0.197",
  "serde_json",
  "service",
@@ -5068,6 +5067,7 @@ name = "service"
 version = "0.1.0"
 dependencies = [
  "actix-files",
+ "actix-multipart",
  "actix-rt",
  "actix-web",
  "anyhow",
@@ -5927,6 +5927,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "env_logger 0.8.4",
+ "sanitize-filename",
  "serde 1.0.197",
  "serde_json",
  "sha2",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -6,6 +6,7 @@ strip = true
 actix-web = { version = "4.0.1", default-features = false, features = [
   "macros","rustls"
 ] }
+actix-multipart = "0.6.1"
 anymap = "0.12"
 async-graphql = { version = "3.0.35", features = ["dataloader", "chrono"] }
 async-graphql-actix-web = "3.0.35"

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -42,9 +42,8 @@ futures = "0.3"
 simple-log = { version = "1.6" }
 rcgen = "0.9.2"
 regex = "1.5.5"
-actix-multipart = "0.6.1"
+actix-multipart = { workspace = true }
 futures-util = "0.3"
-sanitize-filename = "0.4"
 serde_json = "1.0.64"
 
 [dev-dependencies]

--- a/server/server/src/authentication.rs
+++ b/server/server/src/authentication.rs
@@ -1,0 +1,34 @@
+use actix_web::HttpRequest;
+use service::{
+    auth::{validate_auth, AuthDeniedKind, AuthError, ValidatedUserAuth},
+    auth_data::AuthData,
+};
+
+const COOKIE_NAME: &str = "auth";
+
+#[derive(serde::Deserialize)]
+struct AuthCookie {
+    token: String,
+}
+
+pub(crate) fn validate_cookie_auth(
+    request: HttpRequest,
+    auth_data: &AuthData,
+) -> Result<ValidatedUserAuth, AuthError> {
+    let token = match request.cookie(COOKIE_NAME) {
+        Some(cookie) => {
+            let auth_cookie: AuthCookie = match serde_json::from_str(cookie.value()) {
+                Ok(auth_cookie) => auth_cookie,
+                Err(err) => {
+                    return Err(AuthError::Denied(AuthDeniedKind::NotAuthenticated(
+                        err.to_string(),
+                    )))
+                }
+            };
+            Some(auth_cookie.token)
+        }
+        None => None,
+    };
+
+    validate_auth(auth_data, &token)
+}

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -37,6 +37,7 @@ use actix_web::{web::Data, App, HttpServer};
 use std::sync::{Arc, Mutex, RwLock};
 use util::is_central_server;
 
+mod authentication;
 pub mod certs;
 pub mod cold_chain;
 pub mod configuration;
@@ -49,6 +50,7 @@ pub mod static_files;
 pub mod support;
 mod upload_fridge_tag;
 pub use self::logging::*;
+
 pub mod print;
 mod sync_on_central;
 

--- a/server/server/src/print/label.rs
+++ b/server/server/src/print/label.rs
@@ -1,4 +1,3 @@
-use super::validate_request;
 use actix_web::{
     web::{self, Data},
     HttpRequest, HttpResponse,
@@ -10,6 +9,8 @@ use service::{
     service_provider::ServiceProvider,
     settings::LabelPrinterSettingNode,
 };
+
+use crate::authentication::validate_cookie_auth;
 
 #[derive(serde::Deserialize)]
 pub struct LabelData {
@@ -23,7 +24,7 @@ pub async fn print_label_qr(
     auth_data: Data<AuthData>,
     data: web::Json<LabelData>,
 ) -> HttpResponse {
-    let auth_result = validate_request(request.clone(), &auth_data);
+    let auth_result = validate_cookie_auth(request.clone(), &auth_data);
     match auth_result {
         Ok(_) => (),
         Err(error) => {

--- a/server/server/src/print/mod.rs
+++ b/server/server/src/print/mod.rs
@@ -1,16 +1,11 @@
-use actix_web::{web, HttpRequest};
+use actix_web::web;
 
 mod label;
 use label::print_label_qr;
-use service::{
-    auth::{validate_auth, AuthDeniedKind, AuthError, ValidatedUserAuth},
-    auth_data::AuthData,
-};
 
 use self::label::test_printer;
 
 const URL_PATH: &str = "/print";
-const COOKIE_NAME: &str = "auth";
 
 pub fn config_print(cfg: &mut web::ServiceConfig) {
     cfg.route(
@@ -21,31 +16,4 @@ pub fn config_print(cfg: &mut web::ServiceConfig) {
         &format!("{}/label-test", URL_PATH),
         web::post().to(test_printer),
     );
-}
-
-#[derive(serde::Deserialize)]
-struct AuthCookie {
-    token: String,
-}
-
-fn validate_request(
-    request: HttpRequest,
-    auth_data: &AuthData,
-) -> Result<ValidatedUserAuth, AuthError> {
-    let token = match request.cookie(COOKIE_NAME) {
-        Some(cookie) => {
-            let auth_cookie: AuthCookie = match serde_json::from_str(cookie.value()) {
-                Ok(auth_cookie) => auth_cookie,
-                Err(err) => {
-                    return Err(AuthError::Denied(AuthDeniedKind::NotAuthenticated(
-                        err.to_string(),
-                    )))
-                }
-            };
-            Some(auth_cookie.token)
-        }
-        None => None,
-    };
-
-    validate_auth(auth_data, &token)
 }

--- a/server/server/src/static_files.rs
+++ b/server/server/src/static_files.rs
@@ -335,6 +335,18 @@ async fn sync_files(
                 Arc::new(service),
             );
 
+            let file_synchroniser = match file_synchroniser {
+                Ok(file_synchroniser) => file_synchroniser,
+                Err(err) => {
+                    log::error!("Error creating file synchroniser: {}", err);
+                    return Err(InternalError::new(
+                        "Couldn't download this file from the central server.",
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                    )
+                    .into());
+                }
+            };
+
             file_synchroniser
                 .download_file_from_central(&file_id)
                 .await

--- a/server/server/src/static_files.rs
+++ b/server/server/src/static_files.rs
@@ -28,6 +28,7 @@ use service::static_files::{StaticFileCategory, StaticFileService};
 use service::sync::file_sync_driver::get_sync_settings;
 use service::sync::file_synchroniser::FileSynchroniser;
 use util::is_central_server;
+use util::sanitize_filename;
 
 use crate::authentication::validate_cookie_auth;
 use crate::middleware::limit_content_length;
@@ -127,8 +128,12 @@ pub(crate) async fn handle_file_upload(
         log::debug!("Content Disposition: {:?}", content_disposition);
         log::debug!("Content Type: {:?}", field.content_type());
 
-        let sanitized_filename =
-            sanitize_filename::sanitize(content_disposition.get_filename().unwrap_or_default());
+        let sanitized_filename = sanitize_filename(
+            content_disposition
+                .get_filename()
+                .unwrap_or_default()
+                .to_owned(),
+        );
         let static_file = service
             .reserve_file(&sanitized_filename, &file_category, file_id.clone())
             .map_err(|err| InternalError::new(err, StatusCode::INTERNAL_SERVER_ERROR))?;

--- a/server/server/src/support/mod.rs
+++ b/server/server/src/support/mod.rs
@@ -34,6 +34,8 @@ fn validate_request(
     service_provider: &ServiceProvider,
     auth_data: &AuthData,
 ) -> Result<ValidatedUser, AuthError> {
+    // TODO: Refactor to use authentication::validate_cookie_auth
+
     let service_context = service_provider
         .basic_context()
         .map_err(|err| AuthError::Denied(AuthDeniedKind::NotAuthenticated(err.to_string())))?;

--- a/server/server/src/sync_on_central/mod.rs
+++ b/server/server/src/sync_on_central/mod.rs
@@ -84,7 +84,7 @@ async fn download_file(
     request: Json<SyncDownloadFileRequestV6>,
     settings: Data<Settings>,
 ) -> actix_web::Result<impl Responder> {
-    println!("Download file requested");
+    log::info!("Sending a file via sync");
     let (file, file_description) = sync_on_central::download_file(&settings, request.into_inner())
         .await
         .map_err(ToResponseError)?;

--- a/server/server/src/sync_on_central/mod.rs
+++ b/server/server/src/sync_on_central/mod.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use actix_multipart::Multipart;
+use actix_multipart::form::MultipartForm;
 use actix_web::{
     error::InternalError,
     http::{
@@ -11,17 +11,15 @@ use actix_web::{
     web::{self, Data, Json},
     Error, HttpRequest, HttpResponse, Responder, ResponseError,
 };
-use repository::sync_file_reference_row::SyncFileReferenceRowRepository;
 
-use crate::{central_server_only, static_files::handle_file_upload};
+use crate::central_server_only;
 use service::{
     service_provider::ServiceProvider,
     settings::Settings,
-    static_files::StaticFileCategory,
     sync::{
         api_v6::{
             SyncDownloadFileRequestV6, SyncParsedErrorV6, SyncPullRequestV6, SyncPullResponseV6,
-            SyncPushRequestV6, SyncPushResponseV6,
+            SyncPushRequestV6, SyncPushResponseV6, SyncUploadFileRequestV6,
         },
         sync_on_central,
     },
@@ -103,68 +101,33 @@ async fn download_file(
 
 #[put("/sync/upload_file/{file_id}")]
 async fn upload_file(
-    payload: Multipart,
+    MultipartForm(form): MultipartForm<SyncUploadFileRequestV6>,
     settings: Data<Settings>,
     service_provider: Data<ServiceProvider>,
     path: web::Path<String>,
 ) -> Result<HttpResponse, Error> {
-    let db_connection = service_provider
-        .connection()
-        .map_err(|err| InternalError::new(err, StatusCode::INTERNAL_SERVER_ERROR))?;
-
     let file_id = path.into_inner();
-
-    let repo = SyncFileReferenceRowRepository::new(&db_connection);
     log::info!("Receiving a file via sync : {}", file_id);
-    let mut sync_file_reference = repo
-        .find_one_by_id(&file_id)
-        .map_err(|err| InternalError::new(err, StatusCode::INTERNAL_SERVER_ERROR))?
-        .ok_or({
-            log::error!(
-                "Sync File Reference not found, can't upload until this is synced: {}",
-                file_id
-            );
-            InternalError::new(
-                "Sync File Reference not found, can't upload until this is synced",
-                StatusCode::NOT_FOUND,
-            )
-        })?;
 
-    let files = handle_file_upload(
-        payload,
-        settings,
-        StaticFileCategory::SyncFile(
-            sync_file_reference.table_name.clone(),
-            sync_file_reference.record_id.clone(),
-        ),
-        Some(file_id),
-    )
-    .await?;
-
-    let repo = SyncFileReferenceRowRepository::new(&db_connection);
-    if files.len() != 1 {
-        log::error!(
-            "Incorrect sync file upload received: Expected to see 1 file uploaded, but got {}",
-            files.len()
-        );
-    }
-
-    for file in files.clone() {
-        sync_file_reference.uploaded_bytes += file.bytes;
-        let result = repo.upsert_one(&sync_file_reference);
-        match result {
-            Ok(_) => {}
-            Err(err) => {
-                log::error!(
-                    "Error saving sync file reference after sync upload: {}",
-                    err
-                );
-
-                return Err(InternalError::new(err, StatusCode::INTERNAL_SERVER_ERROR).into());
+    let result = sync_on_central::upload_file(&settings, &service_provider, file_id, form).await;
+    match result {
+        Ok(_) => {
+            log::info!("File uploaded successfully");
+            Ok(HttpResponse::Ok().finish())
+        }
+        Err(e) => {
+            log::error!("Error uploading file: {}", e);
+            match e {
+                SyncParsedErrorV6::NotACentralServer => {
+                    return Ok(HttpResponse::Forbidden().finish());
+                }
+                SyncParsedErrorV6::SyncFileNotFound => {
+                    return Ok(HttpResponse::NotFound().finish());
+                }
+                _ => {
+                    return Err(InternalError::new(e, StatusCode::INTERNAL_SERVER_ERROR).into());
+                }
             }
         }
-        break; // Only handle the first file
     }
-
-    Ok(HttpResponse::Ok().json(files))
 }

--- a/server/service/Cargo.toml
+++ b/server/service/Cargo.toml
@@ -18,7 +18,9 @@ topological-sort = "0.2.2"
 bcrypt = "0.12.0"
 chrono = { workspace = true }
 rand = { workspace = true }
+actix-web = { workspace = true }
 actix-files = { workspace = true }
+actix-multipart = { workspace = true }
 jsonschema = "0.16.0"
 jsonwebtoken = "8.0.1"
 log = "0.4.14"

--- a/server/service/src/sync/api_v6/mod.rs
+++ b/server/service/src/sync/api_v6/mod.rs
@@ -1,6 +1,6 @@
 mod core;
 pub mod download_file;
-// pub mod upload_file;
+pub mod upload_file;
 
 use actix_multipart::form::{json::Json, tempfile::TempFile, MultipartForm};
 use repository::RepositoryError;

--- a/server/service/src/sync/api_v6/mod.rs
+++ b/server/service/src/sync/api_v6/mod.rs
@@ -1,6 +1,8 @@
 mod core;
 pub mod download_file;
+// pub mod upload_file;
 
+use actix_multipart::form::{json::Json, tempfile::TempFile, MultipartForm};
 use repository::RepositoryError;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
@@ -35,6 +37,8 @@ pub enum SyncParsedErrorV6 {
     NotACentralServer,
     #[error("Could not parse record to sync buffer row: {0}")]
     ParsingSyncRecordError(String),
+    #[error("Sync File Not Found")]
+    SyncFileNotFound,
 }
 
 impl From<anyhow::Error> for SyncParsedErrorV6 {
@@ -161,4 +165,11 @@ pub struct SyncDownloadFileRequestV6 {
     pub(crate) record_id: String,
     pub(crate) id: String,
     pub(crate) sync_v5_settings: SyncApiSettings,
+}
+
+#[derive(MultipartForm)]
+pub struct SyncUploadFileRequestV6 {
+    pub sync_v5_settings: Json<SyncApiSettings>,
+    #[multipart(rename = "file")]
+    pub files: Vec<TempFile>,
 }

--- a/server/service/src/sync/api_v6/upload_file.rs
+++ b/server/service/src/sync/api_v6/upload_file.rs
@@ -91,7 +91,6 @@ impl SyncApiV6 {
         let client = Client::new();
 
         let request = client.put(url).multipart(form);
-        println!("request: {:#?}", request);
         let response = request.send().await;
         match response {
             Ok(response) => {

--- a/server/service/src/sync/api_v6/upload_file.rs
+++ b/server/service/src/sync/api_v6/upload_file.rs
@@ -1,0 +1,132 @@
+use super::*;
+use crate::{
+    static_files::{StaticFileCategory, StaticFileService},
+    sync::file_synchroniser::{FileSyncError, UploadError},
+};
+use repository::sync_file_reference_row::SyncFileReferenceRow;
+use reqwest::Client;
+use std::io::Read;
+
+impl SyncApiV6 {
+    pub async fn upload_file(
+        &self,
+        static_file_service: &StaticFileService,
+        sync_file_reference_row: &SyncFileReferenceRow,
+    ) -> Result<(), FileSyncError> {
+        let Self {
+            sync_v5_settings,
+            url,
+        } = self;
+
+        let route = "upload_file/";
+        let url = url
+            .join(route)
+            .unwrap()
+            .join(&sync_file_reference_row.id)
+            .unwrap(); // Unwrap should be safe here, because we know that sync_file.id is a UUID
+
+        // Get file path
+        let file = static_file_service
+            .find_file(
+                &sync_file_reference_row.id,
+                StaticFileCategory::SyncFile(
+                    sync_file_reference_row.table_name.to_owned(),
+                    sync_file_reference_row.record_id.to_owned(),
+                ),
+            )
+            .map_err(|err| {
+                log::error!("Error from static_file_service: {:#?}", err);
+                FileSyncError::CantFindFile("Error from static_file_service".to_string())
+            })?;
+        let file = match file {
+            Some(file) => file,
+            None => {
+                return Err(FileSyncError::CantFindFile(
+                    "File doesn't exist in static_file_service".to_string(),
+                ))
+            }
+        };
+
+        let mut file_handle = std::fs::File::open(file.path.clone()).map_err(|err| {
+            log::error!("Error opening file: {:#?}", err);
+            FileSyncError::StdIoError(err)
+        })?;
+
+        // Read the file into memory (ideally could be a stream or something, and upload the file in chunk so we can stop quickly when sync starts/stops/pauses)
+        let mut file_bytes = Vec::new();
+        file_handle.read_to_end(&mut file_bytes).map_err(|err| {
+            log::error!("Error reading file: {:#?}", err);
+            FileSyncError::StdIoError(err)
+        })?;
+
+        // This is an example request structure, it just exists to give a compiler warning if the structure changes
+        // You'll need to modify the actual request using the reqwest::multipart::Parts below if there's a change here...
+        let _canary_request = SyncUploadFileRequestV6 {
+            sync_v5_settings: actix_multipart::form::json::Json(sync_v5_settings.clone()),
+            files: vec![],
+        };
+        let file_upload_part = reqwest::multipart::Part::bytes(file_bytes)
+            .file_name(sync_file_reference_row.file_name.clone());
+
+        let sync_api_settings_json =
+            serde_json::to_string(&self.sync_v5_settings).map_err(|err| {
+                log::error!("Error serializing sync_api_settings: {:#?}", err);
+                FileSyncError::UploadError(UploadError::Other(
+                    "Error serializing sync_api_settings".to_string(),
+                ))
+            })?;
+        let sync_settings_part = reqwest::multipart::Part::text(sync_api_settings_json)
+            .mime_str("application/json")
+            .map_err(|err| {
+                log::error!("Error creating part for sync_api_settings: {:#?}", err);
+                FileSyncError::UploadError(UploadError::Other(
+                    "Error creating part for sync_api_settings".to_string(),
+                ))
+            })?;
+
+        let form = reqwest::multipart::Form::new()
+            .part("sync_v5_settings", sync_settings_part)
+            .part("file", file_upload_part);
+
+        let client = Client::new();
+
+        let request = client.put(url).multipart(form);
+        println!("request: {:#?}", request);
+        let response = request.send().await;
+        match response {
+            Ok(response) => {
+                if response.status().is_success() {
+                    log::info!("File {} uploaded successfully", sync_file_reference_row.id);
+                } else {
+                    let status = response.status();
+                    let text = response.text().await.unwrap_or_default();
+
+                    log::error!(
+                        "Error uploading file {} - {} : {:#?}",
+                        sync_file_reference_row.id,
+                        status,
+                        text
+                    );
+
+                    if status == reqwest::StatusCode::NOT_FOUND {
+                        return Err(FileSyncError::UploadError(UploadError::NotFound));
+                    }
+
+                    return Err(FileSyncError::UploadError(UploadError::Other(format!(
+                        "{}:{}",
+                        status, text
+                    ))));
+                }
+            }
+            Err(err) => {
+                log::error!("Error uploading file: {:#?}", err);
+                if err.is_connect() {
+                    return Err(FileSyncError::UploadError(UploadError::ConnectionError));
+                }
+                return Err(FileSyncError::ReqwestError(err));
+            }
+        };
+
+        Ok(())
+    }
+}

--- a/server/service/src/sync/sync_on_central/mod.rs
+++ b/server/service/src/sync/sync_on_central/mod.rs
@@ -242,7 +242,7 @@ pub async fn upload_file(
         let destination = Path::new(&static_file.path);
 
         // Copy the file from the temp location to the final location
-        // TODO: Ideally these fs operations should be done in a separate such as using web::block (see handle_upload in static_files.rs)
+        // TODO: Ideally these fs operations should be done in a separate thread e.g. using web::block (see handle_upload in static_files.rs)
         let result = move_file(file.file.path(), destination);
         match result {
             Ok(_) => {

--- a/server/service/src/sync/sync_on_central/mod.rs
+++ b/server/service/src/sync/sync_on_central/mod.rs
@@ -1,5 +1,7 @@
-use repository::{ChangelogRepository, SyncBufferRowRepository};
-use util::{format_error, is_central_server};
+use std::path::Path;
+
+use repository::{ChangelogRepository, SyncBufferRowRepository, SyncFileReferenceRowRepository};
+use util::{format_error, is_central_server, move_file, sanitize_filename};
 
 use crate::{
     service_provider::ServiceProvider,
@@ -11,7 +13,7 @@ use crate::{
 use super::{
     api_v6::{
         SyncBatchV6, SyncDownloadFileRequestV6, SyncParsedErrorV6, SyncPullRequestV6,
-        SyncPushRequestV6, SyncPushSuccessV6, SyncRecordV6,
+        SyncPushRequestV6, SyncPushSuccessV6, SyncRecordV6, SyncUploadFileRequestV6,
     },
     translations::translate_changelogs_to_sync_records,
 };
@@ -152,7 +154,7 @@ pub async fn download_file(
     use SyncParsedErrorV6 as Error;
 
     log::info!(
-        "Downloading file for table: {}, record: {}, file: {}",
+        "Downloading file to remote server for table: {}, record: {}, file: {}",
         table_name,
         record_id,
         id
@@ -179,4 +181,97 @@ pub async fn download_file(
     let named_file =
         actix_files::NamedFile::open(&file_description.path).map_err(|e| Error::from_error(&e))?;
     Ok((named_file, file_description))
+}
+
+/// Accept a file from a remote open-mSupply Server
+/// This is the endpoint that the remote server will call to upload a file
+pub async fn upload_file(
+    settings: &Settings,
+    service_provider: &ServiceProvider,
+    file_id: String,
+    SyncUploadFileRequestV6 {
+        files,
+        sync_v5_settings,
+    }: SyncUploadFileRequestV6,
+) -> Result<(), SyncParsedErrorV6> {
+    use SyncParsedErrorV6 as Error;
+
+    log::info!("Receiving a file via sync : {}", file_id);
+
+    if !is_central_server() {
+        return Err(Error::NotACentralServer);
+    }
+    // Check credentials again mSupply central server
+    let _ = SyncApiV5::new(sync_v5_settings.into_inner())
+        .map_err(|e| Error::OtherServerError(format_error(&e)))?
+        .get_site_info()
+        .await
+        .map_err(Error::from)?;
+
+    let file_service = StaticFileService::new(&settings.server.base_dir)?;
+    let db_connection = service_provider
+        .connection()
+        .map_err(|e| Error::OtherServerError(format_error(&e)))?;
+
+    let repo = SyncFileReferenceRowRepository::new(&db_connection);
+    let mut sync_file_reference = repo
+        .find_one_by_id(&file_id)
+        .map_err(|e| Error::OtherServerError(format_error(&e)))?
+        .ok_or({
+            log::error!(
+                "Sync File Reference not found, can't upload until this is synced: {}",
+                file_id
+            );
+            Error::SyncFileNotFound
+        })?;
+
+    // for each uploaded file reserve a file in the static files directory, then copy the file from the temp file location
+    // Should only be 1 file, but we will loop through them all just in case we need to do some clean up..
+    for file in files {
+        let static_file_category = StaticFileCategory::SyncFile(
+            sync_file_reference.table_name.clone(),
+            sync_file_reference.record_id.clone(),
+        );
+        let sanitized_filename = file.file_name.map(sanitize_filename).unwrap_or_default();
+
+        let static_file = file_service.reserve_file(
+            &sanitized_filename,
+            &static_file_category,
+            Some(file_id.clone()),
+        )?;
+        let destination = Path::new(&static_file.path);
+
+        // Copy the file from the temp location to the final location
+        // TODO: Ideally these fs operations should be done in a separate such as using web::block (see handle_upload in static_files.rs)
+        let result = move_file(file.file.path(), destination);
+        match result {
+            Ok(_) => {
+                sync_file_reference.uploaded_bytes = sync_file_reference.total_bytes;
+                let result = repo.upsert_one(&sync_file_reference);
+                match result {
+                    Ok(_) => {}
+                    Err(err) => {
+                        log::error!(
+                            "Error updating sync file reference: {} - DELETING UPLOADED FILE",
+                            err
+                        );
+                        // Delete uploaded file
+                        let _ = std::fs::remove_file(file.file.path());
+                    }
+                }
+            }
+            Err(err) => {
+                log::error!(
+                    "Error moving file {:?} to {:?} - {}",
+                    file.file.path(),
+                    destination,
+                    err
+                );
+                // Delete uploaded file
+                let _ = std::fs::remove_file(file.file.path());
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/server/util/Cargo.toml
+++ b/server/util/Cargo.toml
@@ -14,6 +14,7 @@ serde = "1.0.126"
 env_logger = "0.8.3"
 serde_json = "1.0.66"
 anyhow.workspace = true
+sanitize-filename = "0.4"
 
 [dev-dependencies]
 thiserror = {workspace = true}

--- a/server/util/src/file.rs
+++ b/server/util/src/file.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, str::FromStr};
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 pub fn prepare_file_dir(dir: &str, base_dir: &Option<String>) -> anyhow::Result<PathBuf> {
     let file_dir = match base_dir {
@@ -9,4 +12,27 @@ pub fn prepare_file_dir(dir: &str, base_dir: &Option<String>) -> anyhow::Result<
     std::fs::create_dir_all(&file_dir)?;
 
     Ok(file_dir)
+}
+
+pub fn move_file(from: &Path, to: &Path) -> std::io::Result<()> {
+    // First try to move file on same device. If this fails it might be because `from` and `to` are
+    // on different mount points. In this case the file needs to be copied and deleted manually.
+    let Err(_) = std::fs::rename(from, to) else {
+        return Ok(());
+    };
+
+    // The matching error kind is CrossesDevices but is currently unstable. In the future this
+    // should work:
+    //
+    // match err.kind() {
+    //     std::io::ErrorKind::CrossesDevices => {}
+    //     _ => return Err(err),
+    // };
+    std::fs::copy(from, to)?;
+    std::fs::remove_file(from)?;
+    Ok(())
+}
+
+pub fn sanitize_filename(filename: String) -> String {
+    sanitize_filename::sanitize(filename)
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3601

# 👩🏻‍💻 What does this PR do? 
Requests to upload, download files now have improved authentication

For remote_server the endpoints are just checking if the user is logged in or not.
For sync, we're using sync_v5 credentials similar to the other central sync requests.

# 🧪 How has/should this change been tested? 
Bit of local testing which seems ok...

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->
Could/should apply the Logged in Function logic to import fridge tag, and sqlite file downloads.
SQLite download need to retain the permissions check too.

## 📃 Documentation
_No user facing changes_
