### PR TITLE
Soft delete currencies #3607

### DIFF
--- a/server/graphql/types/src/types/currency.rs
+++ b/server/graphql/types/src/types/currency.rs
@@ -28,6 +28,7 @@ pub struct CurrencySortInput {
 pub struct CurrencyFilterInput {
     pub id: Option<EqualFilterStringInput>,
     pub is_home_currency: Option<bool>,
+    pub is_active: Option<bool>,
 }
 
 impl CurrencyFilterInput {
@@ -35,11 +36,13 @@ impl CurrencyFilterInput {
         let CurrencyFilterInput {
             id,
             is_home_currency,
+            is_active,
         } = self;
 
         CurrencyFilter {
             id: id.map(EqualFilter::from),
             is_home_currency,
+            is_active,
         }
     }
 }

--- a/server/repository/src/db_diesel/currency.rs
+++ b/server/repository/src/db_diesel/currency.rs
@@ -20,6 +20,7 @@ pub struct Currency {
 pub struct CurrencyFilter {
     pub id: Option<EqualFilter<String>>,
     pub is_home_currency: Option<bool>,
+    pub is_active: Option<bool>,
 }
 
 pub enum CurrencySortField {
@@ -92,6 +93,12 @@ fn create_filtered_query(filter: Option<CurrencyFilter>) -> BoxedLogQuery {
             Some(false) => query.filter(currency_dsl::is_home_currency.eq(false)),
             None => query,
         };
+
+        query = match filter.is_active {
+            Some(true) => query.filter(currency_dsl::is_active.eq(true)),
+            Some(false) => query.filter(currency_dsl::is_active.eq(false)),
+            None => query,
+        };
     }
     query
 }
@@ -112,6 +119,11 @@ impl CurrencyFilter {
 
     pub fn is_home_currency(mut self, filter: bool) -> Self {
         self.is_home_currency = Some(filter);
+        self
+    }
+
+    pub fn is_active(mut self, filter: bool) -> Self {
+        self.is_active = Some(filter);
         self
     }
 }

--- a/server/repository/src/db_diesel/currency_row.rs
+++ b/server/repository/src/db_diesel/currency_row.rs
@@ -13,6 +13,7 @@ table! {
         code -> Text,
         is_home_currency -> Bool,
         date_updated -> Nullable<Date>,
+        is_active -> Bool,
     }
 }
 
@@ -25,6 +26,7 @@ pub struct CurrencyRow {
     pub code: String,
     pub is_home_currency: bool,
     pub date_updated: Option<NaiveDate>,
+    pub is_active: bool,
 }
 
 pub struct CurrencyRowRepository<'a> {
@@ -67,7 +69,8 @@ impl<'a> CurrencyRowRepository<'a> {
     }
 
     pub fn delete(&self, currency_id: &str) -> Result<(), RepositoryError> {
-        diesel::delete(currency_dsl::currency.filter(currency_dsl::id.eq(currency_id)))
+        diesel::update(currency_dsl::currency.filter(currency_dsl::id.eq(currency_id)))
+            .set(currency_dsl::is_active.eq(false))
             .execute(&self.connection.connection)?;
         Ok(())
     }

--- a/server/repository/src/db_diesel/currency_row.rs
+++ b/server/repository/src/db_diesel/currency_row.rs
@@ -1,5 +1,5 @@
 use super::{currency_row::currency::dsl as currency_dsl, StorageConnection};
-use crate::Upsert;
+use crate::{Delete, Upsert};
 
 use crate::repository_error::RepositoryError;
 
@@ -73,6 +73,24 @@ impl<'a> CurrencyRowRepository<'a> {
             .set(currency_dsl::is_active.eq(false))
             .execute(&self.connection.connection)?;
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CurrencyRowDelete(pub String);
+impl Delete for CurrencyRowDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<(), RepositoryError> {
+        CurrencyRowRepository::new(con).delete(&self.0)
+    }
+
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert!(matches!(
+            CurrencyRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(Some(CurrencyRow {
+                is_active: false,
+                ..
+            })) | Ok(None)
+        ));
     }
 }
 

--- a/server/repository/src/migrations/v2_00_00/currency_add_is_active.rs
+++ b/server/repository/src/migrations/v2_00_00/currency_add_is_active.rs
@@ -1,0 +1,12 @@
+use crate::{migrations::sql, StorageConnection};
+
+pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
+    sql!(
+        connection,
+        r#"
+        ALTER TABLE currency ADD COLUMN is_active BOOLEAN NOT NULL DEFAULT TRUE;
+        "#
+    )?;
+
+    Ok(())
+}

--- a/server/repository/src/migrations/v2_00_00/mod.rs
+++ b/server/repository/src/migrations/v2_00_00/mod.rs
@@ -6,6 +6,7 @@ mod activity_log_add_zero_line;
 mod add_source_site_id;
 mod assets;
 mod central_omsupply;
+mod currency_add_is_active;
 mod inventory_adjustment_logtype;
 mod inventory_adjustment_permissions;
 mod linked_shipment;
@@ -37,6 +38,7 @@ impl Migration for V2_00_00 {
         user_change_last_synced_to_optional::migrate(connection)?;
         inventory_adjustment_logtype::migrate(connection)?;
         report_views::migrate(connection)?;
+        currency_add_is_active::migrate(connection)?;
         Ok(())
     }
 }

--- a/server/repository/src/mock/currency.rs
+++ b/server/repository/src/mock/currency.rs
@@ -7,6 +7,7 @@ pub fn currency_a() -> CurrencyRow {
         rate: 1.0,
         is_home_currency: true,
         date_updated: None,
+        is_active: true,
     }
 }
 
@@ -17,6 +18,7 @@ pub fn currency_b() -> CurrencyRow {
         rate: 0.9,
         is_home_currency: false,
         date_updated: None,
+        is_active: true,
     }
 }
 
@@ -27,6 +29,7 @@ pub fn currency_c() -> CurrencyRow {
         rate: 1.6,
         is_home_currency: false,
         date_updated: None,
+        is_active: true,
     }
 }
 
@@ -37,6 +40,7 @@ pub fn currency_d() -> CurrencyRow {
         rate: 1.4,
         is_home_currency: false,
         date_updated: None,
+        is_active: true,
     }
 }
 

--- a/server/service/src/currency.rs
+++ b/server/service/src/currency.rs
@@ -25,8 +25,11 @@ pub trait CurrencyServiceTrait: Sync + Send {
     ) -> Result<ListResult<Currency>, ListError> {
         let repository = CurrencyRepository::new(&ctx.connection);
 
+        // Always filter by active currencies
+        let filter = filter.unwrap_or_default().is_active(true);
+
         Ok(ListResult {
-            rows: repository.query(filter.clone(), sort)?,
+            rows: repository.query(Some(filter.clone()), sort)?,
             count: i64_to_u32(repository.count(None)?),
         })
     }

--- a/server/service/src/sync/test/test_data/currency.rs
+++ b/server/service/src/sync/test/test_data/currency.rs
@@ -1,6 +1,6 @@
 use crate::sync::test::TestSyncIncomingRecord;
 use chrono::NaiveDate;
-use repository::CurrencyRow;
+use repository::{CurrencyRow, CurrencyRowDelete};
 
 const TABLE_NAME: &str = "currency";
 
@@ -39,6 +39,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
                 code: "NZD".to_string(),
                 is_home_currency: true,
                 date_updated: Some(NaiveDate::from_ymd_opt(2020, 1, 1).unwrap()),
+                is_active: true,
             },
         ),
         TestSyncIncomingRecord::new_pull_upsert(
@@ -50,7 +51,16 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
                 code: "AUD".to_string(),
                 is_home_currency: false,
                 date_updated: Some(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap()),
+                is_active: true,
             },
         ),
     ]
+}
+
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_delete(
+        TABLE_NAME,
+        CURRENCY_1.0,
+        CurrencyRowDelete(CURRENCY_1.0.to_string()),
+    )]
 }

--- a/server/service/src/sync/test/test_data/mod.rs
+++ b/server/service/src/sync/test/test_data/mod.rs
@@ -106,6 +106,7 @@ pub(crate) fn get_all_pull_delete_central_test_records() -> Vec<TestSyncIncoming
     test_records.append(&mut user_permission::test_pull_delete_records());
     test_records.append(&mut unit::test_pull_delete_records());
     test_records.append(&mut item::test_pull_delete_records());
+    test_records.append(&mut currency::test_pull_delete_records());
     test_records.append(&mut master_list_name_join::test_pull_delete_records());
     test_records.append(&mut report::test_pull_delete_records());
     test_records.append(&mut store::test_pull_delete_records());

--- a/server/service/src/sync/translations/currency.rs
+++ b/server/service/src/sync/translations/currency.rs
@@ -1,5 +1,7 @@
 use chrono::NaiveDate;
-use repository::{CurrencyRow, CurrencyRowRepository, StorageConnection, SyncBufferRow};
+use repository::{
+    CurrencyRow, CurrencyRowDelete, CurrencyRowRepository, StorageConnection, SyncBufferRow,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::sync::sync_serde::{date_option_to_isostring, zero_date_as_option};
@@ -62,6 +64,16 @@ impl SyncTranslation for CurrencyTranslation {
 
         Ok(PullTranslateResult::upsert(result))
     }
+
+    fn try_translate_from_delete_sync_record(
+        &self,
+        _: &StorageConnection,
+        sync_record: &SyncBufferRow,
+    ) -> Result<PullTranslateResult, anyhow::Error> {
+        Ok(PullTranslateResult::delete(CurrencyRowDelete(
+            sync_record.record_id.clone(),
+        )))
+    }
 }
 
 #[cfg(test)]
@@ -81,6 +93,15 @@ mod tests {
             assert!(translator.should_translate_from_sync_record(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_from_upsert_sync_record(&connection, &record.sync_buffer_row)
+                .unwrap();
+
+            assert_eq!(translation_result, record.translated_record);
+        }
+
+        for record in test_data::test_pull_delete_records() {
+            assert!(translator.should_translate_from_sync_record(&record.sync_buffer_row));
+            let translation_result = translator
+                .try_translate_from_delete_sync_record(&connection, &record.sync_buffer_row)
                 .unwrap();
 
             assert_eq!(translation_result, record.translated_record);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3607

# 👩🏻‍💻 What does this PR do? 
Adds an `is_active` field (not to be confused with OG's is_active field which isn't being used right now) to currency for soft deletion of currencies.

# 🧪 How has/should this change been tested? 
- [ ] Run tests
- [ ] Delete a currency from OG and check OMS DB to see bool value is false

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

or

- [ ] Functional change 1
- [ ] Functional change 2