### PR TITLE
Alert user if permission denied

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/AppBarButtons.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/AppBarButtons.tsx
@@ -5,8 +5,8 @@ import {
   useTranslation,
   PrinterIcon,
   useNotification,
-  useDisabledNotification,
   LoadingButton,
+  useDisabledNotificationPopover,
 } from '@openmsupply-client/common';
 
 import { useAssets } from '../api';
@@ -19,7 +19,7 @@ export const AppBarButtonsComponent = () => {
   const { error, success } = useNotification();
   const { data: settings } = useAssets.utils.labelPrinterSettings();
   const [isPrinting, setIsPrinting] = React.useState(false);
-  const { show, DisabledNotification } = useDisabledNotification({
+  const { show, DisabledNotification } = useDisabledNotificationPopover({
     title: t('heading.unable-to-print'),
     message: t('error.label-printer-not-configured'),
   });

--- a/client/packages/coldchain/src/Equipment/ListView/AddFromScannerButton.tsx
+++ b/client/packages/coldchain/src/Equipment/ListView/AddFromScannerButton.tsx
@@ -10,7 +10,7 @@ import {
   useRegisterActions,
   Box,
   useNavigate,
-  useDisabledNotification,
+  useDisabledNotificationPopover,
   RouteBuilder,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
@@ -23,7 +23,7 @@ export const AddFromScannerButtonComponent = () => {
   const { error } = useNotification();
   const buttonRef = useRef<HTMLButtonElement>(null);
   const navigate = useNavigate();
-  const { DisabledNotification, show } = useDisabledNotification({
+  const { DisabledNotification, show } = useDisabledNotificationPopover({
     title: t('error.unable-to-scan'),
     message: t('error.scanner-not-connected'),
   });

--- a/client/packages/coldchain/src/Equipment/ListView/AppBarButtons.tsx
+++ b/client/packages/coldchain/src/Equipment/ListView/AppBarButtons.tsx
@@ -13,7 +13,7 @@ import {
   PlusCircleIcon,
   ToggleState,
   UploadIcon,
-  useDisabledNotification,
+  useDisabledNotificationToast,
   useAuthContext,
   UserPermission,
 } from '@openmsupply-client/common';
@@ -32,15 +32,14 @@ export const AppBarButtonsComponent = ({
   const t = useTranslation('coldchain');
   const { fetchAsync, isLoading } = useAssets.document.listAll();
   const { userHasPermission } = useAuthContext();
-  const { show, DisabledNotification } = useDisabledNotification({
-    title: t('auth.permission-denied'),
-    message: t('error.no-asset-create-permission'),
-  });
+  const showDisabledNotification = useDisabledNotificationToast(
+    t('error.no-asset-create-permission')
+  );
 
-  const onAdd = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const onAdd = () => {
     if (userHasPermission(UserPermission.AssetMutate))
       modalController.toggleOn();
-    else show(e);
+    else showDisabledNotification();
   };
   const csvExport = async () => {
     const data = await fetchAsync();
@@ -78,7 +77,6 @@ export const AppBarButtonsComponent = ({
           {t('button.export')}
         </LoadingButton>
       </Grid>
-      <DisabledNotification />
     </AppBarButtonsPortal>
   );
 };

--- a/client/packages/common/src/ui/components/popover/DisabledNotification/DisabledNotification.stories.tsx
+++ b/client/packages/common/src/ui/components/popover/DisabledNotification/DisabledNotification.stories.tsx
@@ -3,7 +3,8 @@ import { StoryFn } from '@storybook/react';
 import Box from '@mui/material/Box';
 import { BasePopover } from '../BasePopover';
 import { BaseButton } from '../../buttons';
-import { useDisabledNotification } from './useDisabledNotification';
+import { useDisabledNotificationPopover } from './useDisabledNotificationPopover';
+import { useDisabledNotificationToast } from './useDisabledNotificationToast';
 
 export default {
   title: 'Popover/DisabledNotification',
@@ -11,16 +12,26 @@ export default {
 };
 
 const Example: StoryFn = () => {
-  const { show, DisabledNotification } = useDisabledNotification({
+  const { show, DisabledNotification } = useDisabledNotificationPopover({
     title: 'Permission denied',
     message: 'You do not have permission to perform this action.',
   });
+
+  const showToast = useDisabledNotificationToast(
+    'You do not have permission to perform this action.'
+  );
+
   return (
     <>
       <DisabledNotification />
       <Box>
         <BaseButton onClick={show}>Click this button.. if you dare!</BaseButton>
         <div>You can click the message to close it.</div>
+      </Box>
+      <Box>
+        <BaseButton onClick={showToast}>
+          For a toast version, click this one
+        </BaseButton>
       </Box>
     </>
   );

--- a/client/packages/common/src/ui/components/popover/DisabledNotification/index.ts
+++ b/client/packages/common/src/ui/components/popover/DisabledNotification/index.ts
@@ -1,1 +1,2 @@
-export * from './useDisabledNotification';
+export * from './useDisabledNotificationPopover';
+export * from './useDisabledNotificationToast';

--- a/client/packages/common/src/ui/components/popover/DisabledNotification/useDisabledNotificationPopover.tsx
+++ b/client/packages/common/src/ui/components/popover/DisabledNotification/useDisabledNotificationPopover.tsx
@@ -3,7 +3,7 @@ import { PaperPopoverSection, usePaperClickPopover } from '../PaperPopover';
 import { AlertIcon } from '../../../icons/Alert';
 import { Typography } from '@mui/material';
 
-export const useDisabledNotification = ({
+export const useDisabledNotificationPopover = ({
   title,
   message,
 }: {
@@ -12,6 +12,13 @@ export const useDisabledNotification = ({
 }) => {
   const { hide, PaperClickPopover, show } = usePaperClickPopover();
 
+  /**
+   * Display a notification that the user is not allowed to perform an action
+   * Uses a PaperClickPopover to display the notification, which allows for more
+   * information than the useDisabledNotificationToast
+   * @param title
+   * @returns
+   */
   const DisabledNotification = ({
     placement = 'bottom',
   }: {

--- a/client/packages/common/src/ui/components/popover/DisabledNotification/useDisabledNotificationToast.tsx
+++ b/client/packages/common/src/ui/components/popover/DisabledNotification/useDisabledNotificationToast.tsx
@@ -1,0 +1,15 @@
+import { useNotification } from '@common/hooks';
+import { useTranslation } from '@common/intl';
+
+/**
+ * Display a notification that the user is not allowed to perform an action
+ * Uses a toast to display the notification; for longer messages use the useDisabledNotificationPopover
+ * @param message string: message to display; defaults to 'Permission denied'
+ * @returns function to show a toast
+ */
+export const useDisabledNotificationToast = (message?: string) => {
+  const { info } = useNotification();
+  const t = useTranslation();
+
+  return info(message ?? t('auth.permission-denied'));
+};

--- a/client/packages/invoices/src/Returns/InboundListView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/Returns/InboundListView/AppBarButtons.tsx
@@ -15,6 +15,7 @@ import {
   FnUtils,
   useAuthContext,
   UserPermission,
+  useDisabledNotificationToast,
 } from '@openmsupply-client/common';
 import { CustomerSearchModal } from '@openmsupply-client/system';
 import { useReturns } from '../api';
@@ -26,6 +27,7 @@ export const AppBarButtonsComponent: FC<{
   const t = useTranslation('distribution');
   const { success, error } = useNotification();
   const { userHasPermission } = useAuthContext();
+  const showPermissionDenied = useDisabledNotificationToast();
 
   const { mutateAsync: onCreate } = useReturns.document.insertInboundReturn();
   const { fetchAsync, isLoading } = useReturns.document.listAllInbound({
@@ -47,8 +49,7 @@ export const AppBarButtonsComponent: FC<{
 
   const openModal = () => {
     if (!userHasPermission(UserPermission.InboundReturnMutate)) {
-      const errorSnack = error(t('auth.permission-denied', { ns: 'app' }));
-      errorSnack();
+      showPermissionDenied();
       return;
     }
     modalController.toggleOn();

--- a/client/packages/invoices/src/Returns/OutboundListView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/Returns/OutboundListView/AppBarButtons.tsx
@@ -15,6 +15,7 @@ import {
   FnUtils,
   UserPermission,
   useAuthContext,
+  useDisabledNotificationToast,
 } from '@openmsupply-client/common';
 import { SupplierSearchModal } from '@openmsupply-client/system';
 import { useReturns } from '../api';
@@ -26,6 +27,7 @@ export const AppBarButtonsComponent: FC<{
   const t = useTranslation('replenishment');
   const { success, error } = useNotification();
   const { userHasPermission } = useAuthContext();
+  const showPermissionDenied = useDisabledNotificationToast();
 
   const { mutateAsync: onCreate } = useReturns.document.insertOutboundReturn();
   const { fetchAsync, isLoading } = useReturns.document.listAllOutbound({
@@ -47,8 +49,7 @@ export const AppBarButtonsComponent: FC<{
 
   const openModal = () => {
     if (!userHasPermission(UserPermission.OutboundReturnMutate)) {
-      const errorSnack = error(t('auth.permission-denied', { ns: 'app' }));
-      errorSnack();
+      showPermissionDenied();
       return;
     }
     modalController.toggleOn();

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
@@ -9,8 +9,8 @@ import {
   ButtonWithIcon,
   useAuthContext,
   UserPermission,
-  Tooltip,
   useIntlUtils,
+  useDisabledNotificationToast,
 } from '@openmsupply-client/common';
 import { getNextRequestStatus, getStatusTranslation } from '../../../utils';
 import { useRequest } from '../../api';
@@ -80,7 +80,7 @@ const useStatusChangeButton = () => {
 
   const options = useMemo(
     () => getStatusOptions(status, getButtonLabel(t)),
-    [status, getButtonLabel]
+    [status, t]
   );
 
   const [selectedOption, setSelectedOption] =
@@ -144,6 +144,11 @@ export const StatusChangeButton = () => {
   const t = useTranslation('app');
   const noLines = lines?.totalCount === 0;
 
+  const showPermissionDenied = useDisabledNotificationToast(
+    t('auth.permission-denied')
+  );
+  const showNoLines = useDisabledNotificationToast(t('messages.no-lines'));
+
   if (!selectedOption) return null;
   if (isDisabled) return null;
 
@@ -151,23 +156,23 @@ export const StatusChangeButton = () => {
     selectedOption.value === RequisitionNodeStatus.Sent
       ? userHasPermission(UserPermission.RequisitionSend)
       : true;
-  const permissionDenied = hasPermission ? '' : t('auth.permission-denied');
-  const disabledNoLines = noLines ? t('messages.no-lines') : '';
+
+  const onClick = () => {
+    if (!hasPermission) return showPermissionDenied();
+    if (noLines) return showNoLines();
+
+    getConfirmation();
+  };
 
   return (
-    <>
-      <Tooltip title={permissionDenied || disabledNoLines}>
-        <div>
-          <ButtonWithIcon
-            color="secondary"
-            variant="contained"
-            disabled={!hasPermission || noLines}
-            label={selectedOption.label}
-            Icon={<ArrowRightIcon />}
-            onClick={() => getConfirmation()}
-          />
-        </div>
-      </Tooltip>
-    </>
+    <div>
+      <ButtonWithIcon
+        color="secondary"
+        variant="contained"
+        label={selectedOption.label}
+        Icon={<ArrowRightIcon />}
+        onClick={onClick}
+      />
+    </div>
   );
 };

--- a/client/packages/system/src/Item/DetailView/Tabs/PackVariants.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/PackVariants.tsx
@@ -13,12 +13,12 @@ import {
   Grid,
   useEditModal,
   useAuthContext,
-  useNotification,
   UserPermission,
   DropdownMenu,
   DropdownMenuItem,
   DeleteIcon,
   useCentralServerCallback,
+  useDisabledNotificationToast,
 } from '@openmsupply-client/common';
 import { usePackVariant } from '../../context';
 import { PackVariantEditModal } from '../../Components/PackVariantEditModal';
@@ -29,9 +29,8 @@ const PackVariantTable: FC<{ itemId: string }> = ({ itemId }) => {
   const { variantsControl } = usePackVariant(itemId, null);
   const { isOpen, entity, mode, onClose, onOpen } =
     useEditModal<VariantFragment>();
-  const { warning } = useNotification();
   const { userHasPermission } = useAuthContext();
-  const warningSnack = warning(t('auth.permission-denied'));
+  const warningSnack = useDisabledNotificationToast();
   const hasPermission = userHasPermission(
     UserPermission.ItemNamesCodesAndUnitsMutate
   );

--- a/client/packages/system/src/Patient/ListView/AppBarButtons.tsx
+++ b/client/packages/system/src/Patient/ListView/AppBarButtons.tsx
@@ -12,6 +12,7 @@ import {
   SortBy,
   useAuthContext,
   UserPermission,
+  useDisabledNotificationToast,
 } from '@openmsupply-client/common';
 import { PatientRowFragment, usePatient } from '../api';
 import { patientsToCsv } from '../utils';
@@ -25,6 +26,7 @@ export const AppBarButtons: FC<{ sortBy: SortBy<PatientRowFragment> }> = ({
   const { isLoading, mutateAsync } = usePatient.document.listAll(sortBy);
   const { userHasPermission } = useAuthContext();
   const [createModalOpen, setCreateModalOpen] = useState(false);
+  const showPermissionDenied = useDisabledNotificationToast();
 
   const csvExport = async () => {
     const data = await mutateAsync();
@@ -38,14 +40,21 @@ export const AppBarButtons: FC<{ sortBy: SortBy<PatientRowFragment> }> = ({
     success(t('success'))();
   };
 
+  const onCreatePatient = () => {
+    if (!userHasPermission(UserPermission.PatientMutate)) {
+      showPermissionDenied();
+      return;
+    }
+    setCreateModalOpen(true);
+  };
+
   return (
     <AppBarButtonsPortal>
       <Grid container gap={1}>
         <ButtonWithIcon
           Icon={<PlusCircleIcon />}
           label={t('button.new-patient')}
-          disabled={!userHasPermission(UserPermission.PatientMutate)}
-          onClick={() => setCreateModalOpen(true)}
+          onClick={onCreatePatient}
         />
         <LoadingButton
           startIcon={<DownloadIcon />}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1912

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
Updates the newly implemented `useDisabledNotification` hook to make the popover more explicit. Have updated usages, including changing the popover call to be a toast where it makes sense.

The following areas have been updated:

* Cold chain equipment > Create asset button
* Cold chain equipment > Add from scanner button
*  Cold chain equipment > Print QR code
* Inbound returns list view > New return
* Outbound returns list view > New return
* Pack variants > Create or Delete
* Patient list view > Create patient

<!-- why are the changes needed -->
This provides an example for permission denied notification, with two different UI approaches.

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->
I've used an info toast, as I think this isn't an alert or an error - just a little bit of info. Feel free to argue your case if you disagree.

Shouldn't affect anything else, the change is pretty targeted.
<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->
You may need to turn off permissions and then login again in order to properly test. I tweaked the code bc I'm lazy.
- [ ] Cold chain equipment > Create asset button
- [ ] Cold chain equipment > Add from scanner button
- [ ] Cold chain equipment > Print QR code
- [ ] Inbound returns list view > New return
- [ ] Outbound returns list view > New return
- [ ] Pack variants > Create or Delete
- [ ] Patient list view > Create patient

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. I don't see the need for separate docs / updates on this one
