### PR TITLE
use milliseconds for temp breach config millisecond filter 😅

### DIFF
--- a/server/service/src/sensor/berlinger.rs
+++ b/server/service/src/sensor/berlinger.rs
@@ -55,7 +55,7 @@ fn get_matching_sensor_breach_config(
     let filter = TemperatureBreachConfigFilter::new()
         .store_id(EqualFilter::equal_to(store_id))
         .duration_milliseconds(EqualFilter::equal_to_i32(
-            temperature_breach_config.duration.num_seconds() as i32,
+            temperature_breach_config.duration.num_milliseconds() as i32,
         ))
         .minimum_temperature(EqualFilter::equal_to_f64(
             temperature_breach_config.minimum_temperature,
@@ -151,7 +151,7 @@ fn sensor_add_breach_if_new(
                 threshold_duration_milliseconds: breach_config.duration.num_milliseconds() as i32,
                 threshold_minimum: breach_config.minimum_temperature,
                 threshold_maximum: breach_config.maximum_temperature,
-            comment: None,
+                comment: None,
             };
             log::info!("Added breach {:?} ", breach);
             breach


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->


# 👩🏻‍💻 What does this PR do?

Fixes fridge tag test... we were using seconds in a milliseconds filter 😁 


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Run berlinger tests with Postgres -> no error 🎉 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
