### PR TITLE
Include all foreign key dependancies in Asset Catalogue Item Translation

### DIFF
--- a/server/service/src/sync/translations/asset_catalogue_item.rs
+++ b/server/service/src/sync/translations/asset_catalogue_item.rs
@@ -3,7 +3,10 @@ use repository::{
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
 };
 
-use crate::sync::translations::asset_category::AssetCategoryTranslation;
+use crate::sync::translations::{
+    asset_category::AssetCategoryTranslation, asset_class::AssetClassTranslation,
+    asset_type::AssetTypeTranslation,
+};
 
 use super::{
     PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
@@ -23,7 +26,11 @@ impl SyncTranslation for AssetCatalogueItemTranslation {
     }
 
     fn pull_dependencies(&self) -> Vec<&str> {
-        vec![AssetCategoryTranslation.table_name()]
+        vec![
+            AssetCategoryTranslation.table_name(),
+            AssetTypeTranslation.table_name(),
+            AssetClassTranslation.table_name(),
+        ]
     }
 
     fn try_translate_from_upsert_sync_record(


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes flaky test for `test_sync_pull_and_push` not all dependencies (AKA foreign keys) had been included in the Asset Catalogue Item Translations
 
## 💌 Any notes for the reviewer?

# 🧪 Testing
Run `cargo test` multiple times as this wasn't always failing depending on the order of operations in sync.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
