### PR TITLE
Move requisition create shipment button

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
@@ -13,7 +13,6 @@ import {
   ReportSelector,
   useReport,
 } from '@openmsupply-client/system';
-import { CreateShipmentButton } from './CreateShipmentButton';
 import { SupplyRequestedQuantityButton } from './SupplyRequestedQuantityButton';
 import { useResponse } from '../../api';
 import { JsonData } from '@openmsupply-client/programs';
@@ -35,7 +34,6 @@ export const AppBarButtonsComponent = () => {
   return (
     <AppBarButtonsPortal>
       <Grid container gap={1}>
-        <CreateShipmentButton />
         <SupplyRequestedQuantityButton />
         <ReportSelector
           context={ReportContext.Requisition}

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/CreateShipmentButton.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/CreateShipmentButton.tsx
@@ -61,6 +61,7 @@ export const CreateShipmentButtonComponent = () => {
       label={t('button.create-shipment')}
       onClick={onCreateShipment}
       disabled={isDisabled}
+      color="secondary"
     />
   );
 };

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/Footer.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/Footer.tsx
@@ -9,6 +9,7 @@ import {
 import { responseStatuses, getRequisitionTranslator } from '../../../utils';
 import { ResponseFragment, useResponse } from '../../api';
 import { StatusChangeButton } from './StatusChangeButton';
+import { CreateShipmentButton } from './CreateShipmentButton';
 
 export const createStatusLog = (requisition: ResponseFragment) => {
   const statusLog: Record<RequisitionNodeStatus, null | undefined | string> = {
@@ -44,6 +45,7 @@ export const Footer: FC = () => {
             />
 
             <Box flex={1} display="flex" justifyContent="flex-end" gap={2}>
+              <CreateShipmentButton />
               <StatusChangeButton requisition={data} />
             </Box>
           </Box>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2787

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
Moved the button, and made it blue to be consistent with other footer buttons.

<!-- why are the changes needed -->
We had a discussion about this one, the resolution that I remember was that we'd move the button.

<!-- Add a screenshot if there are UI changes  -->
<img width="1538" alt="Screenshot 2024-04-24 at 5 19 11 PM" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/717a77ff-59d9-4bf8-afdc-1e40f1d46195">

## 💌 Any notes for the reviewer?


<!-- Do you have any specific questions for the reviewer? -->
An additional thought - what about asking the user if they'd like to finalise?

<img width="696" alt="Screenshot 2024-04-24 at 5 15 26 PM" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/899bc1de-2ea7-4897-8093-d2db367baaae">

If so, should we default the checkbox to unchecked? or checked?

Currently the behaviour is exactly as it was, with the button shifted.

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Open a response / customer / distribution Requisition
- [ ] try the button

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. The screenshots of this page need updating
  
