### PR TITLE
Change Outbound Shipment list default sort from "Created" to "Number"? #3092

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/client/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -37,7 +37,7 @@ const OutboundShipmentListViewComponent: FC = () => {
     filter,
     queryParams: { sortBy, page, first, offset },
   } = useUrlQueryParams({
-    initialSort: { key: 'createdDatetime', dir: 'desc' },
+    initialSort: { key: 'invoiceNumber', dir: 'desc' },
     filters: [
       { key: 'otherPartyName' },
       { key: 'status', condition: 'equalTo' },


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3092

# 👩🏻‍💻 What does this PR do?
Sort outbound shipments by number instead of created date
<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?
Do we want this for inbound/prescriptions as well?
<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to outbound shipments
- [ ] Should be sorted by number by default

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
