### PR TITLE
Soft Delete for Asset Catalogue Items

### DIFF
--- a/server/repository/src/db_diesel/assets/asset_catalogue_item.rs
+++ b/server/repository/src/db_diesel/assets/asset_catalogue_item.rs
@@ -92,6 +92,8 @@ impl<'a> AssetCatalogueItemRepository<'a> {
             query = query.order(asset_catalogue_item_dsl::id.asc())
         }
 
+        query = query.filter(asset_catalogue_item_dsl::deleted_datetime.is_null());
+
         // // Debug diesel query
         // println!("{}", diesel::debug_query::<DBType, _>(&query).to_string());
 

--- a/server/repository/src/db_diesel/assets/asset_catalogue_item_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_catalogue_item_row.rs
@@ -92,7 +92,7 @@ impl<'a> AssetCatalogueItemRowRepository<'a> {
         Ok(result)
     }
 
-    pub fn delete(&self, asset_catalogue_item_id: &str) -> Result<(), RepositoryError> {
+    pub fn mark_deleted(&self, asset_catalogue_item_id: &str) -> Result<(), RepositoryError> {
         diesel::update(asset_catalogue_item.filter(id.eq(asset_catalogue_item_id)))
             .set(deleted_datetime.eq(Some(chrono::Utc::now().naive_utc())))
             .execute(&self.connection.connection)?;

--- a/server/repository/src/migrations/v2_00_00/assets/asset_catalogue_item.rs
+++ b/server/repository/src/migrations/v2_00_00/assets/asset_catalogue_item.rs
@@ -1,3 +1,4 @@
+use crate::migrations::DATETIME;
 use crate::{migrations::sql, StorageConnection};
 
 pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
@@ -13,6 +14,7 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
             asset_catalogue_type_id TEXT NOT NULL REFERENCES asset_catalogue_type(id),
             manufacturer TEXT,
             model TEXT NOT NULL,
+            deleted_datetime {DATETIME},
             UNIQUE (code)
         );
         "#,

--- a/server/service/src/catalogue/delete.rs
+++ b/server/service/src/catalogue/delete.rs
@@ -36,7 +36,7 @@ pub fn delete_asset_catalogue_item(
                     Err(_) => (),
                 };
             });
-            match AssetCatalogueItemRowRepository::new(connection).delete(&id) {
+            match AssetCatalogueItemRowRepository::new(connection).mark_deleted(&id) {
                 Ok(_) => Ok(id),
                 Err(err) => Err(DeleteAssetCatalogueItemError::from(err)),
             }

--- a/server/service/src/catalogue/insert.rs
+++ b/server/service/src/catalogue/insert.rs
@@ -115,6 +115,7 @@ pub fn generate(
         manufacturer,
         model,
         type_id,
+        deleted_datetime: None,
     }
 }
 

--- a/server/service/src/sync/test/test_data/asset_catalogue_item.rs
+++ b/server/service/src/sync/test/test_data/asset_catalogue_item.rs
@@ -30,6 +30,7 @@ fn asset_catalogue_item1() -> AssetCatalogueItemRow {
         manufacturer: Some("Manufacturer 1".to_string()),
         model: "Model 1".to_string(),
         type_id: "a6625bba-052b-4cf8-9e0f-b96ebba0a31f".to_string(),
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3675 

# 👩🏻‍💻 What does this PR do?

Adds soft delete for asset catalogue items.
The prevents a bug with sync if the catalogue item is deleted centrally but used remotely.
See issue for reproduction steps.

## 💌 Any notes for the reviewer?

To add the new column to the database, you'll need to run this command...

`ALTER TABLE asset_catalogue_item add column  deleted_datetime TIMESTAMP;`

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

1. Import a new asset catalogue item (On central server)
2. Sync your remote site
4. Create an asset on the remote site using the new catalogue item
5. Before syncing to central, delete the catalogue item from central
6. Sync to central server
7.  Check that the asset show up in the central server

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->.
