### PR TITLE
3568 Current patient selection modal makes it seem like the store has 0 patients

### DIFF
--- a/client/packages/system/src/Patient/Components/PatientSearchModal/PatientSearchModal.tsx
+++ b/client/packages/system/src/Patient/Components/PatientSearchModal/PatientSearchModal.tsx
@@ -42,7 +42,7 @@ const PatientSearchComponent: FC<PatientSearchModalProps> = ({
       <Box padding={2}>
         <Box>
           <Typography variant="body1">
-            {isSuccess
+            {isSuccess && patients.length > 0
               ? t('messages.results-found', { totalCount })
               : t('placeholder.search-by-name-or-code')}
           </Typography>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3568

# 👩🏻‍💻 What does this PR do?
Shows search message for patient search modal if search result is 0.
<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to `Prescriptions`
- [ ] Enter some text to search for patient
- [ ] Delete text
- [ ] Should see search message again

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
