### PR TITLE
Add missing postgres enums

### DIFF
--- a/server/repository/src/migrations/v2_00_00/assets/asset_log.rs
+++ b/server/repository/src/migrations/v2_00_00/assets/asset_log.rs
@@ -2,6 +2,26 @@ use crate::migrations::DATETIME;
 use crate::{migrations::sql, StorageConnection};
 
 pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
+    #[cfg(feature = "postgres")]
+    sql!(
+        connection,
+        r#"
+          CREATE TYPE asset_log_status AS ENUM (
+            'NOT_IN_USE',
+            'FUNCTIONING',
+            'FUNCTIONING_BUT_NEEDS_ATTENTION',
+            'NOT_FUNCTIONING',
+            'DECOMMISSIONED'
+          );
+        "#
+    )?;
+
+    const ASSET_LOG_STATUS_ENUM_TYPE: &str = if cfg!(feature = "postgres") {
+        "asset_log_status"
+    } else {
+        "TEXT"
+    };
+
     sql!(
         connection,
         r#"
@@ -9,7 +29,7 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
             id TEXT NOT NULL PRIMARY KEY,
             asset_id TEXT NOT NULL REFERENCES asset(id),
             user_id TEXT NOT NULL REFERENCES user_account(id),
-            status TEXT,
+            status {ASSET_LOG_STATUS_ENUM_TYPE},
             reason_id TEXT REFERENCES asset_log_reason(id),
             comment TEXT,
             type TEXT,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Part of #3654

# 👩🏻‍💻 What does this PR do?

Adds missing pg enums for assets and file sync. This is much easier to add now than to ALTER the table in 2.1.0

## Testing

Please check enums match the Rust types, i.e. the variants and the Rust type should match the PG type for the Diesel 2.0 update.