### PR TITLE
3428 remove breadcrums from supplier modal

### DIFF
--- a/client/packages/system/src/Name/DetailModal/DetailModal.tsx
+++ b/client/packages/system/src/Name/DetailModal/DetailModal.tsx
@@ -1,7 +1,6 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC } from 'react';
 import {
   useTranslation,
-  useBreadcrumbs,
   DetailContainer,
   DetailInputWithLabelRow,
   DetailSection,
@@ -22,13 +21,8 @@ interface DetailModalProps {
 export const DetailModal: FC<DetailModalProps> = ({ nameId }) => {
   const { data, isLoading } = useName.document.get(nameId);
   const t = useTranslation();
-  const { setSuffix } = useBreadcrumbs();
   const isDisabled = true;
   const { localisedDate } = useFormatDateTime();
-
-  useEffect(() => {
-    setSuffix(data?.name ?? '');
-  }, [data]);
 
   if (isLoading) return <BasicSpinner />;
 


### PR DESCRIPTION
Fixes #3428

# 👩🏻‍💻 What does this PR do?

Removes breadcrumbs from the detail modal so that suffix is not changed.

I like this more than setting the breadcrumbs in the background:

Current behaviour where breadcrumbs changes:

![Screenshot 2024-04-30 at 12 42 21](https://github.com/msupply-foundation/open-msupply/assets/90807420/a74f5987-ea64-43ad-a8db-1aa248138d72)

Proposed behaviour where breadcrumbs is static when opening modal:

![Screenshot 2024-04-30 at 12 42 03](https://github.com/msupply-foundation/open-msupply/assets/90807420/1c97bc7a-1c3b-4c80-8e94-05ff668d54e8)
