### PR TITLE
3684 pack variant feature flag

### DIFF
--- a/client/packages/config/src/config.ts
+++ b/client/packages/config/src/config.ts
@@ -1,5 +1,6 @@
 declare const API_HOST: string;
 declare const FEATURE_INVENTORY_ADJUSTMENTS: boolean;
+declare const FEATURE_PACK_VARIANTS: boolean;
 
 // For production, API is on the same domain/ip and port as web app, available through sub-route
 // i.e. web app is on https://my.openmsupply.com/, then graphql will be available https://my.openmsupply.com/graphql
@@ -39,6 +40,11 @@ export const Environment = {
     typeof FEATURE_INVENTORY_ADJUSTMENTS === 'undefined'
       ? false
       : FEATURE_INVENTORY_ADJUSTMENTS,
+
+  FEATURE_PACK_VARIANTS:
+    typeof FEATURE_PACK_VARIANTS === 'undefined'
+      ? false
+      : FEATURE_PACK_VARIANTS,
 };
 
 export default Environment;

--- a/client/packages/host/webpack.config.js
+++ b/client/packages/host/webpack.config.js
@@ -145,6 +145,7 @@ module.exports = env => {
       new ReactRefreshWebpackPlugin(),
       new webpack.DefinePlugin({
         FEATURE_INVENTORY_ADJUSTMENTS: env.FEATURE_INVENTORY_ADJUSTMENTS,
+        FEATURE_PACK_VARIANTS: env.FEATURE_PACK_VARIANTS,
         API_HOST: JSON.stringify(env.API_HOST),
         LOCAL_PLUGINS: JSON.stringify(localPlugins()),
       }),

--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
@@ -13,10 +13,12 @@ import {
   LocaleKey,
   useColumnUtils,
   NumberCell,
+  ColumnDescription,
 } from '@openmsupply-client/common';
 import {
   InventoryAdjustmentReasonRowFragment,
   getPackVariantCell,
+  usePackVariantsEnabled,
 } from '@openmsupply-client/system';
 import { StocktakeSummaryItem } from '../../../types';
 import { StocktakeLineFragment } from '../../api';
@@ -66,185 +68,223 @@ export const useStocktakeColumns = ({
   const t = useTranslation();
   const { getColumnPropertyAsString, getColumnProperty } = useColumnUtils();
 
-  return useColumns<StocktakeLineFragment | StocktakeSummaryItem>(
+  const packVariantsEnabled = usePackVariantsEnabled();
+
+  const columns: ColumnDescription<
+    StocktakeLineFragment | StocktakeSummaryItem
+  >[] = [
     [
+      'itemCode',
+      {
+        getSortValue: row => {
+          return row.item?.code ?? '';
+        },
+        accessor: ({ rowData }) => {
+          return rowData.item?.code ?? '';
+        },
+      },
+    ],
+    [
+      'itemName',
+      {
+        Cell: TooltipTextCell,
+        getSortValue: row =>
+          getColumnPropertyAsString(row, [
+            { path: ['lines', 'itemName'] },
+            { path: ['itemName'], default: '' },
+          ]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [
+            { path: ['lines', 'itemName'] },
+            { path: ['itemName'], default: '' },
+          ]),
+      },
+    ],
+    [
+      'batch',
+      {
+        getSortValue: row =>
+          getColumnPropertyAsString(row, [
+            { path: ['lines', 'batch'] },
+            { path: ['batch'], default: '' },
+          ]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [
+            { path: ['lines', 'batch'] },
+            { path: ['batch'] },
+          ]),
+      },
+    ],
+    [
+      'expiryDate',
+      {
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [
+            { path: ['lines', 'expiryDate'] },
+            { path: ['expiryDate'] },
+          ]),
+      },
+    ],
+    {
+      key: 'locationCode',
+      label: 'label.location',
+      width: 100,
+      accessor: ({ rowData }) =>
+        getColumnProperty(rowData, [
+          { path: ['lines', 'location', 'code'] },
+          { path: ['location', 'code'] },
+        ]),
+    },
+  ];
+
+  if (packVariantsEnabled) {
+    columns.push({
+      key: 'packUnit',
+      label: 'label.pack',
+      sortable: false,
+      Cell: getPackVariantCell({
+        getItemId: row => row?.item?.id ?? '',
+        getPackSizes: row => {
+          if ('lines' in row) return row.lines.map(l => l.packSize ?? 1);
+          else return [row.packSize ?? 1];
+        },
+        getUnitName: row => row?.item?.unitName ?? null,
+      }),
+      width: 130,
+    });
+  } else {
+    columns.push(
       [
-        'itemCode',
+        'itemUnit',
         {
           getSortValue: row => {
-            return row.item?.code ?? '';
+            return row.item?.unitName ?? '';
           },
           accessor: ({ rowData }) => {
-            return rowData.item?.code ?? '';
+            return rowData.item?.unitName ?? '';
           },
+          sortable: false,
         },
       ],
       [
-        'itemName',
-        {
-          Cell: TooltipTextCell,
-          getSortValue: row =>
-            getColumnPropertyAsString(row, [
-              { path: ['lines', 'itemName'] },
-              { path: ['itemName'], default: '' },
-            ]),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [
-              { path: ['lines', 'itemName'] },
-              { path: ['itemName'], default: '' },
-            ]),
-        },
-      ],
-      [
-        'batch',
-        {
-          getSortValue: row =>
-            getColumnPropertyAsString(row, [
-              { path: ['lines', 'batch'] },
-              { path: ['batch'], default: '' },
-            ]),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [
-              { path: ['lines', 'batch'] },
-              { path: ['batch'] },
-            ]),
-        },
-      ],
-      [
-        'expiryDate',
+        'packSize',
         {
           accessor: ({ rowData }) =>
             getColumnProperty(rowData, [
-              { path: ['lines', 'expiryDate'] },
-              { path: ['expiryDate'] },
+              { path: ['lines', 'packSize'] },
+              { path: ['packSize'] },
             ]),
         },
-      ],
-      {
-        key: 'locationCode',
-        label: 'label.location',
-        width: 100,
-        accessor: ({ rowData }) =>
-          getColumnProperty(rowData, [
-            { path: ['lines', 'location', 'code'] },
-            { path: ['location', 'code'] },
-          ]),
+      ]
+    );
+  }
+
+  columns.push(
+    {
+      key: 'snapshotNumPacks',
+      label: 'label.snapshot-num-of-packs',
+      description: 'description.snapshot-num-of-packs',
+      align: ColumnAlign.Right,
+      Cell: NumberCell,
+      getIsError: row =>
+        getLinesFromRow(row).some(
+          r => getError(r)?.__typename === 'SnapshotCountCurrentCountMismatch'
+        ),
+      sortable: false,
+      accessor: ({ rowData }) => {
+        if ('lines' in rowData) {
+          const { lines } = rowData;
+          return (
+            lines.reduce(
+              (total, line) => total + line.snapshotNumberOfPacks,
+              0
+            ) ?? 0
+          ).toString();
+        } else {
+          return rowData.snapshotNumberOfPacks;
+        }
       },
-      {
-        key: 'packUnit',
-        label: 'label.pack',
-        sortable: false,
-        Cell: getPackVariantCell({
-          getItemId: row => row?.item?.id ?? '',
-          getPackSizes: row => {
-            if ('lines' in row) return row.lines.map(l => l.packSize ?? 1);
-            else return [row.packSize ?? 1];
-          },
-          getUnitName: row => row?.item?.unitName ?? null,
-        }),
-        width: 130,
+    },
+    {
+      key: 'countedNumPacks',
+      label: 'label.counted-num-of-packs',
+      description: 'description.counted-num-of-packs',
+      align: ColumnAlign.Right,
+      Cell: NumberCell,
+      getIsError: row =>
+        getLinesFromRow(row).some(
+          r => getError(r)?.__typename === 'StockLineReducedBelowZero'
+        ),
+      sortable: false,
+      accessor: ({ rowData }) => {
+        if ('lines' in rowData) {
+          const { lines } = rowData;
+          return (
+            lines.reduce(
+              (total, line) => total + (line.countedNumberOfPacks ?? 0),
+              0
+            ) ?? 0
+          ).toString();
+        } else {
+          return rowData.countedNumberOfPacks;
+        }
       },
-      {
-        key: 'snapshotNumPacks',
-        label: 'label.snapshot-num-of-packs',
-        description: 'description.snapshot-num-of-packs',
-        align: ColumnAlign.Right,
-        Cell: NumberCell,
-        getIsError: row =>
-          getLinesFromRow(row).some(
-            r => getError(r)?.__typename === 'SnapshotCountCurrentCountMismatch'
-          ),
-        sortable: false,
-        accessor: ({ rowData }) => {
-          if ('lines' in rowData) {
-            const { lines } = rowData;
-            return (
-              lines.reduce(
-                (total, line) => total + line.snapshotNumberOfPacks,
-                0
-              ) ?? 0
-            ).toString();
-          } else {
-            return rowData.snapshotNumberOfPacks;
-          }
-        },
+    },
+    {
+      key: 'difference',
+      label: 'label.difference',
+      align: ColumnAlign.Right,
+      sortable: false,
+      accessor: ({ rowData }) => {
+        if ('lines' in rowData) {
+          const { lines } = rowData;
+          const total =
+            lines.reduce(
+              (total, line) =>
+                total +
+                (line.snapshotNumberOfPacks -
+                  (line.countedNumberOfPacks ?? line.snapshotNumberOfPacks)),
+              0
+            ) ?? 0;
+          return (total < 0 ? Math.abs(total) : -total).toString();
+        } else {
+          return (
+            (rowData.countedNumberOfPacks ?? rowData.snapshotNumberOfPacks) -
+            rowData.snapshotNumberOfPacks
+          );
+        }
       },
-      {
-        key: 'countedNumPacks',
-        label: 'label.counted-num-of-packs',
-        description: 'description.counted-num-of-packs',
-        align: ColumnAlign.Right,
-        Cell: NumberCell,
-        getIsError: row =>
-          getLinesFromRow(row).some(
-            r => getError(r)?.__typename === 'StockLineReducedBelowZero'
-          ),
-        sortable: false,
-        accessor: ({ rowData }) => {
-          if ('lines' in rowData) {
-            const { lines } = rowData;
-            return (
-              lines.reduce(
-                (total, line) => total + (line.countedNumberOfPacks ?? 0),
-                0
-              ) ?? 0
-            ).toString();
-          } else {
-            return rowData.countedNumberOfPacks;
-          }
-        },
-      },
-      {
-        key: 'difference',
-        label: 'label.difference',
-        align: ColumnAlign.Right,
-        sortable: false,
-        accessor: ({ rowData }) => {
-          if ('lines' in rowData) {
-            const { lines } = rowData;
-            const total =
-              lines.reduce(
-                (total, line) =>
-                  total +
-                  (line.snapshotNumberOfPacks -
-                    (line.countedNumberOfPacks ?? line.snapshotNumberOfPacks)),
-                0
-              ) ?? 0;
-            return (total < 0 ? Math.abs(total) : -total).toString();
-          } else {
-            return (
-              (rowData.countedNumberOfPacks ?? rowData.snapshotNumberOfPacks) -
-              rowData.snapshotNumberOfPacks
-            );
-          }
-        },
-      },
-      {
-        key: 'inventoryAdjustmentReason',
-        label: 'label.reason',
-        accessor: ({ rowData }) => getStocktakeReasons(rowData, t),
-        sortable: false,
-      },
-      {
-        key: 'comment',
-        label: 'label.stocktake-comment',
-        sortable: false,
-        accessor: ({ rowData }) =>
-          getColumnProperty(rowData, [
-            { path: ['lines', 'comment'] },
-            { path: ['comment'] },
-          ]),
-      },
-      expandColumn,
-      GenericColumnKey.Selection,
-    ],
-    { sortBy, onChangeSortBy },
-    [sortBy, onChangeSortBy]
+    },
+    {
+      key: 'inventoryAdjustmentReason',
+      label: 'label.reason',
+      accessor: ({ rowData }) => getStocktakeReasons(rowData, t),
+      sortable: false,
+    },
+    {
+      key: 'comment',
+      label: 'label.stocktake-comment',
+      sortable: false,
+      accessor: ({ rowData }) =>
+        getColumnProperty(rowData, [
+          { path: ['lines', 'comment'] },
+          { path: ['comment'] },
+        ]),
+    },
+    expandColumn,
+    GenericColumnKey.Selection
   );
+
+  return useColumns(columns, { sortBy, onChangeSortBy }, [
+    sortBy,
+    onChangeSortBy,
+  ]);
 };
 
 export const useExpansionColumns = (): Column<StocktakeLineFragment>[] => {
   const { getError } = useStocktakeLineErrorContext();
+  const packVariantsEnabled = usePackVariantsEnabled();
+
   return useColumns([
     'batch',
     'expiryDate',
@@ -254,19 +294,23 @@ export const useExpansionColumns = (): Column<StocktakeLineFragment>[] => {
         accessor: ({ rowData }) => rowData.location?.code,
       },
     ],
-    {
-      key: 'packUnit',
-      label: 'label.pack',
-      sortable: false,
-      Cell: getPackVariantCell({
-        getItemId: row => row?.itemId,
-        getPackSizes: row => {
-          return [row?.packSize ?? 1];
-        },
-        getUnitName: row => row?.item.unitName ?? null,
-      }),
-      width: 130,
-    },
+    ...(packVariantsEnabled
+      ? [
+          {
+            key: 'packUnit',
+            label: 'label.pack',
+            sortable: false,
+            Cell: getPackVariantCell({
+              getItemId: row => row?.itemId,
+              getPackSizes: row => {
+                return [row?.packSize ?? 1];
+              },
+              getUnitName: row => row?.item.unitName ?? null,
+            }),
+            width: 130,
+          } as ColumnDescription<StocktakeLineFragment>,
+        ]
+      : ['packSize' as ColumnDescription<StocktakeLineFragment>]),
     {
       key: 'snapshotNumPacks',
       width: 150,

--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
@@ -18,7 +18,7 @@ import {
 import {
   InventoryAdjustmentReasonRowFragment,
   getPackVariantCell,
-  usePackVariantsEnabled,
+  useIsPackVariantsEnabled,
 } from '@openmsupply-client/system';
 import { StocktakeSummaryItem } from '../../../types';
 import { StocktakeLineFragment } from '../../api';
@@ -68,7 +68,7 @@ export const useStocktakeColumns = ({
   const t = useTranslation();
   const { getColumnPropertyAsString, getColumnProperty } = useColumnUtils();
 
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
 
   const columns: ColumnDescription<
     StocktakeLineFragment | StocktakeSummaryItem
@@ -137,7 +137,7 @@ export const useStocktakeColumns = ({
     },
   ];
 
-  if (packVariantsEnabled) {
+  if (isPackVariantsEnabled) {
     columns.push({
       key: 'packUnit',
       label: 'label.pack',
@@ -283,7 +283,7 @@ export const useStocktakeColumns = ({
 
 export const useExpansionColumns = (): Column<StocktakeLineFragment>[] => {
   const { getError } = useStocktakeLineErrorContext();
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
 
   return useColumns([
     'batch',
@@ -294,7 +294,7 @@ export const useExpansionColumns = (): Column<StocktakeLineFragment>[] => {
         accessor: ({ rowData }) => rowData.location?.code,
       },
     ],
-    ...(packVariantsEnabled
+    ...(isPackVariantsEnabled
       ? [
           {
             key: 'packUnit',

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -14,7 +14,7 @@ import {
 } from '@openmsupply-client/common';
 import {
   getPackVariantCell,
-  usePackVariantsEnabled,
+  useIsPackVariantsEnabled,
 } from '@openmsupply-client/system';
 import { InboundItem } from './../../../types';
 import { InboundLineFragment } from '../../api';
@@ -36,7 +36,7 @@ export const useInboundShipmentColumns = () => {
     isInboundPlaceholderRow(row) ? 0 : row.sellPricePerPack;
   const { getColumnPropertyAsString, getColumnProperty } = useColumnUtils();
 
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
 
   const columns = useColumns<InboundLineFragment | InboundItem>(
     [
@@ -132,7 +132,7 @@ export const useInboundShipmentColumns = () => {
         },
       ],
 
-      ...((packVariantsEnabled
+      ...((isPackVariantsEnabled
         ? [
             {
               key: 'packUnit',
@@ -273,13 +273,13 @@ export const useInboundShipmentColumns = () => {
 };
 
 export const useExpansionColumns = (): Column<InboundLineFragment>[] => {
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
 
   return useColumns<InboundLineFragment>([
     'batch',
     'expiryDate',
     'location',
-    ...(packVariantsEnabled
+    ...(isPackVariantsEnabled
       ? [
           {
             key: 'packUnit',

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -10,11 +10,19 @@ import {
   TooltipTextCell,
   useColumnUtils,
   CurrencyCell,
+  ColumnDescription,
 } from '@openmsupply-client/common';
-import { getPackVariantCell } from '@openmsupply-client/system';
+import {
+  getPackVariantCell,
+  usePackVariantsEnabled,
+} from '@openmsupply-client/system';
 import { InboundItem } from './../../../types';
 import { InboundLineFragment } from '../../api';
 import { isInboundPlaceholderRow } from '../../../utils';
+
+type InboundShipmentColumnDescription = ColumnDescription<
+  InboundLineFragment | InboundItem
+>;
 
 const getUnitQuantity = (row: InboundLineFragment) =>
   row.packSize * row.numberOfPacks;
@@ -27,6 +35,8 @@ export const useInboundShipmentColumns = () => {
   const getSellPrice = (row: InboundLineFragment) =>
     isInboundPlaceholderRow(row) ? 0 : row.sellPricePerPack;
   const { getColumnPropertyAsString, getColumnProperty } = useColumnUtils();
+
+  const packVariantsEnabled = usePackVariantsEnabled();
 
   const columns = useColumns<InboundLineFragment | InboundItem>(
     [
@@ -122,26 +132,63 @@ export const useInboundShipmentColumns = () => {
         },
       ],
 
-      {
-        key: 'packUnit',
-        label: 'label.pack',
-        sortable: false,
-        Cell: getPackVariantCell({
-          getItemId: row => {
-            if ('lines' in row) return '';
-            else return row?.item?.id;
-          },
-          getPackSizes: row => {
-            if ('lines' in row) return row.lines.map(l => l.packSize ?? 1);
-            else return [row?.packSize ?? 1];
-          },
-          getUnitName: row => {
-            if ('lines' in row) return row.lines[0]?.item?.unitName ?? null;
-            else return row?.item?.unitName ?? null;
-          },
-        }),
-        width: 130,
-      },
+      ...((packVariantsEnabled
+        ? [
+            {
+              key: 'packUnit',
+              label: 'label.pack',
+              sortable: false,
+              Cell: getPackVariantCell({
+                getItemId: row => {
+                  if ('lines' in row) return '';
+                  else return row?.item?.id;
+                },
+                getPackSizes: row => {
+                  if ('lines' in row)
+                    return row.lines.map(l => l.packSize ?? 1);
+                  else return [row?.packSize ?? 1];
+                },
+                getUnitName: row => {
+                  if ('lines' in row)
+                    return row.lines[0]?.item?.unitName ?? null;
+                  else return row?.item?.unitName ?? null;
+                },
+              }),
+              width: 130,
+            },
+          ]
+        : [
+            [
+              'itemUnit',
+              {
+                getSortValue: row =>
+                  getColumnPropertyAsString(row, [
+                    { path: ['lines', 'item', 'unitName'] },
+                    { path: ['item', 'unitName'], default: '' },
+                  ]),
+                accessor: ({ rowData }) =>
+                  getColumnProperty(rowData, [
+                    { path: ['lines', 'item', 'unitName'] },
+                    { path: ['item', 'unitName'], default: '' },
+                  ]),
+              },
+            ],
+            [
+              'packSize',
+              {
+                accessor: ({ rowData }) =>
+                  getColumnProperty(rowData, [
+                    { path: ['lines', 'packSize'], default: '' },
+                    { path: ['packSize'], default: '' },
+                  ]),
+                getSortValue: row =>
+                  getColumnPropertyAsString(row, [
+                    { path: ['lines', 'packSize'], default: '' },
+                    { path: ['packSize'], default: '' },
+                  ]),
+              },
+            ],
+          ]) as InboundShipmentColumnDescription[]),
       [
         'numberOfPacks',
         {
@@ -225,22 +272,29 @@ export const useInboundShipmentColumns = () => {
   return { columns, sortBy };
 };
 
-export const useExpansionColumns = (): Column<InboundLineFragment>[] =>
-  useColumns<InboundLineFragment>([
+export const useExpansionColumns = (): Column<InboundLineFragment>[] => {
+  const packVariantsEnabled = usePackVariantsEnabled();
+
+  return useColumns<InboundLineFragment>([
     'batch',
     'expiryDate',
     'location',
-    {
-      key: 'packUnit',
-      label: 'label.pack',
-      sortable: false,
-      Cell: getPackVariantCell({
-        getItemId: row => row?.item?.id,
-        getPackSizes: row => [row?.packSize ?? 1],
-        getUnitName: row => row?.item?.unitName ?? null,
-      }),
-      width: 130,
-    },
+    ...(packVariantsEnabled
+      ? [
+          {
+            key: 'packUnit',
+            label: 'label.pack',
+            sortable: false,
+            Cell: getPackVariantCell({
+              getItemId: row => row?.item?.id,
+              getPackSizes: row => [row?.packSize ?? 1],
+              getUnitName: row => row?.item?.unitName ?? null,
+            }),
+            width: 130,
+          } as ColumnDescription<InboundLineFragment>,
+        ]
+      : ['packSize' as ColumnDescription<InboundLineFragment>]),
     'numberOfPacks',
     'costPricePerPack',
   ]);
+};

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -19,7 +19,7 @@ import {
   ItemStockOnHandFragment,
   StockItemSearchInput,
   usePackVariant,
-  usePackVariantsEnabled,
+  useIsPackVariantsEnabled,
 } from '@openmsupply-client/system';
 import { useOutbound } from '../../api';
 import { DraftItem } from '../../..';
@@ -79,7 +79,7 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
     item?.id ?? '',
     item?.unitName ?? null
   );
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
 
   const onChangePackSize = (newPackSize: number) => {
     const packSize = newPackSize === -1 ? 1 : newPackSize;
@@ -229,7 +229,7 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
 
             {packSizeController.options.length ? (
               <>
-                {!packVariantsEnabled && (
+                {!isPackVariantsEnabled && (
                   <Grid
                     item
                     alignItems="center"
@@ -258,7 +258,7 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
                     onChangePackSize(Number(value));
                   }}
                 />
-                {!packVariantsEnabled &&
+                {!isPackVariantsEnabled &&
                   packSizeController.selected?.value !== -1 && (
                     <Grid
                       item

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -13,11 +13,13 @@ import {
   useDebounceCallback,
   NumericTextInput,
   useDebouncedValueCallback,
+  InputLabel,
 } from '@openmsupply-client/common';
 import {
   ItemStockOnHandFragment,
   StockItemSearchInput,
   usePackVariant,
+  usePackVariantsEnabled,
 } from '@openmsupply-client/system';
 import { useOutbound } from '../../api';
 import { DraftItem } from '../../..';
@@ -77,6 +79,7 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
     item?.id ?? '',
     item?.unitName ?? null
   );
+  const packVariantsEnabled = usePackVariantsEnabled();
 
   const onChangePackSize = (newPackSize: number) => {
     const packSize = newPackSize === -1 ? 1 : newPackSize;
@@ -226,23 +229,51 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
 
             {packSizeController.options.length ? (
               <>
-                <Grid
-                  item
-                  alignItems="center"
-                  display="flex"
-                  justifyContent="flex-start"
-                  style={{ minWidth: 125 }}
-                >
-                  <Select
-                    sx={{ width: 110 }}
-                    options={packSizeController.options}
-                    value={packSizeController.selected?.value ?? ''}
-                    onChange={e => {
-                      const { value } = e.target;
-                      onChangePackSize(Number(value));
-                    }}
-                  />
-                </Grid>
+                {!packVariantsEnabled && (
+                  <Grid
+                    item
+                    alignItems="center"
+                    display="flex"
+                    justifyContent="flex-start"
+                    style={{ minWidth: 125 }}
+                  >
+                    <InputLabel sx={{ fontSize: '12px' }}>
+                      {packSizeController.selected?.value === -1
+                        ? `${t('label.unit-plural', {
+                            unit: activePackVariant,
+                            count: issueQuantity,
+                          })} ${t('label.in-packs-of')}`
+                        : t('label.in-packs-of')}
+                    </InputLabel>
+                  </Grid>
+                )}
+                <Box marginLeft={1} />
+
+                <Select
+                  sx={{ width: 110 }}
+                  options={packSizeController.options}
+                  value={packSizeController.selected?.value ?? ''}
+                  onChange={e => {
+                    const { value } = e.target;
+                    onChangePackSize(Number(value));
+                  }}
+                />
+                {!packVariantsEnabled &&
+                  packSizeController.selected?.value !== -1 && (
+                    <Grid
+                      item
+                      alignItems="center"
+                      display="flex"
+                      justifyContent="flex-start"
+                    >
+                      <InputLabel style={{ fontSize: 12, marginLeft: 8 }}>
+                        {t('label.unit-plural', {
+                          count: packSizeController.selected?.value,
+                          unit: activePackVariant,
+                        })}
+                      </InputLabel>
+                    </Grid>
+                  )}
                 <Box marginLeft="auto" />
               </>
             ) : null}

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
@@ -108,6 +108,7 @@ export const OutboundLineEditTable: React.FC<OutboundLineEditTableProps> = ({
     }
   };
   const unit = item?.unitName ?? t('label.unit');
+  console.log(unit);
 
   const columns = useOutboundLineEditColumns({
     onChange: onEditStockLine,

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
@@ -108,7 +108,6 @@ export const OutboundLineEditTable: React.FC<OutboundLineEditTableProps> = ({
     }
   };
   const unit = item?.unitName ?? t('label.unit');
-  console.log(unit);
 
   const columns = useOutboundLineEditColumns({
     onChange: onEditStockLine,

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
@@ -16,7 +16,7 @@ import { DraftStockOutLine } from '../../../types';
 import { PackQuantityCell, StockOutLineFragment } from '../../../StockOut';
 import {
   getPackVariantCell,
-  usePackVariantsEnabled,
+  useIsPackVariantsEnabled,
 } from '@openmsupply-client/system';
 import { CurrencyRowFragment } from '@openmsupply-client/system';
 
@@ -32,7 +32,7 @@ export const useOutboundLineEditColumns = ({
   isExternalSupplier: boolean;
 }) => {
   const { store } = useAuthContext();
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
 
   const ForeignCurrencyCell = useCurrencyCell<DraftStockOutLine>(
     currency?.code as Currencies
@@ -84,7 +84,7 @@ export const useOutboundLineEditColumns = ({
     });
   }
 
-  if (packVariantsEnabled) {
+  if (isPackVariantsEnabled) {
     columnDefinitions.push({
       key: 'packUnit',
       label: 'label.pack',
@@ -154,7 +154,7 @@ export const useOutboundLineEditColumns = ({
 };
 
 export const useExpansionColumns = (): Column<StockOutLineFragment>[] => {
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
 
   const columns: ColumnDescription<StockOutLineFragment>[] = [
     'batch',
@@ -167,7 +167,7 @@ export const useExpansionColumns = (): Column<StockOutLineFragment>[] => {
     ],
   ];
 
-  if (packVariantsEnabled) {
+  if (isPackVariantsEnabled) {
     columns.push({
       key: 'packUnit',
       label: 'label.pack',

--- a/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -12,8 +12,12 @@ import {
   useColumnUtils,
   NumberCell,
   CurrencyCell,
+  ColumnDescription,
 } from '@openmsupply-client/common';
-import { getPackVariantCell } from '@openmsupply-client/system';
+import {
+  getPackVariantCell,
+  usePackVariantsEnabled,
+} from '@openmsupply-client/system';
 import { StockOutLineFragment } from '../../StockOut';
 import { StockOutItem } from '../../types';
 
@@ -32,6 +36,9 @@ const notePopoverColumn = getNotePopoverColumn<
 const isDefaultPlaceholderRow = (row: StockOutLineFragment) =>
   row.type === InvoiceLineNodeType.UnallocatedStock && !row.numberOfPacks;
 
+const getPackSize = (row: StockOutLineFragment) =>
+  isDefaultPlaceholderRow(row) ? '' : row.packSize;
+
 const getNumberOfPacks = (row: StockOutLineFragment) =>
   isDefaultPlaceholderRow(row) ? '' : row.numberOfPacks;
 
@@ -44,257 +51,295 @@ export const useOutboundColumns = ({
 }: UseOutboundColumnOptions): Column<StockOutLineFragment | StockOutItem>[] => {
   const { getColumnProperty, getColumnPropertyAsString } = useColumnUtils();
 
-  return useColumns(
+  const packVariantsEnabled = usePackVariantsEnabled();
+
+  const columns: ColumnDescription<StockOutLineFragment | StockOutItem>[] = [
     [
-      [
-        notePopoverColumn,
-        {
-          accessor: ({ rowData }) => {
-            if ('lines' in rowData) {
-              const { lines } = rowData;
-              const noteSections = lines
-                .map(({ batch, note }) => ({
-                  header: batch ?? '',
-                  body: note ?? '',
-                }))
-                .filter(({ body }) => !!body);
-              return noteSections.length ? noteSections : null;
-            } else {
-              return rowData.batch && rowData.note
-                ? { header: rowData.batch, body: rowData.note }
-                : null;
-            }
-          },
-        },
-      ],
-      [
-        'itemCode',
-        {
-          getSortValue: row =>
-            getColumnPropertyAsString(row, [
-              { path: ['lines', 'item', 'code'], default: '' },
-              { path: ['item', 'code'], default: '' },
-            ]),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [
-              { path: ['lines', 'item', 'code'], default: '' },
-              { path: ['item', 'code'], default: '' },
-            ]),
-        },
-      ],
-      [
-        'itemName',
-        {
-          Cell: TooltipTextCell,
-          getSortValue: row =>
-            getColumnPropertyAsString(row, [
-              { path: ['lines', 'itemName'] },
-              { path: ['itemName'], default: '' },
-            ]),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [
-              { path: ['lines', 'itemName'] },
-              { path: ['itemName'], default: '' },
-            ]),
-        },
-      ],
-      [
-        'batch',
-        {
-          getSortValue: row =>
-            getColumnPropertyAsString(row, [
-              { path: ['lines', 'batch'] },
-              { path: ['batch'], default: '' },
-            ]),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [
-              { path: ['lines', 'batch'] },
-              { path: ['batch'] },
-            ]),
-        },
-      ],
-      [
-        'expiryDate',
-        {
-          getSortValue: row =>
-            getColumnPropertyAsString(row, [
-              { path: ['lines', 'expiryDate'] },
-              { path: ['expiryDate'], default: '' },
-            ]),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [
-              { path: ['lines', 'expiryDate'] },
-              { path: ['expiryDate'] },
-            ]),
-        },
-      ],
-      [
-        'location',
-        {
-          getSortValue: row =>
-            getColumnPropertyAsString(row, [
-              { path: ['lines', 'location', 'code'] },
-              { path: ['location', 'code'], default: '' },
-            ]),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [
-              { path: ['lines', 'location', 'code'] },
-              { path: ['location', 'code'], default: '' },
-            ]),
-        },
-      ],
+      notePopoverColumn,
       {
-        key: 'packUnit',
-        label: 'label.pack',
-        sortable: false,
-        Cell: getPackVariantCell({
-          getItemId: row => {
-            if ('lines' in row) return '';
-            else return row?.item?.id;
-          },
-          getPackSizes: row => {
-            if ('lines' in row) return row.lines.map(l => l.packSize ?? 1);
-            else return [row.packSize ?? 1];
-          },
-          getUnitName: row => {
-            if ('lines' in row) return row.lines[0]?.item?.unitName ?? null;
-            else return row?.item?.unitName ?? null;
-          },
-        }),
-        width: 130,
+        accessor: ({ rowData }) => {
+          if ('lines' in rowData) {
+            const { lines } = rowData;
+            const noteSections = lines
+              .map(({ batch, note }) => ({
+                header: batch ?? '',
+                body: note ?? '',
+              }))
+              .filter(({ body }) => !!body);
+            return noteSections.length ? noteSections : null;
+          } else {
+            return rowData.batch && rowData.note
+              ? { header: rowData.batch, body: rowData.note }
+              : null;
+          }
+        },
       },
+    ],
+    [
+      'itemCode',
+      {
+        getSortValue: row =>
+          getColumnPropertyAsString(row, [
+            { path: ['lines', 'item', 'code'], default: '' },
+            { path: ['item', 'code'], default: '' },
+          ]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [
+            { path: ['lines', 'item', 'code'], default: '' },
+            { path: ['item', 'code'], default: '' },
+          ]),
+      },
+    ],
+    [
+      'itemName',
+      {
+        Cell: TooltipTextCell,
+        getSortValue: row =>
+          getColumnPropertyAsString(row, [
+            { path: ['lines', 'itemName'] },
+            { path: ['itemName'], default: '' },
+          ]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [
+            { path: ['lines', 'itemName'] },
+            { path: ['itemName'], default: '' },
+          ]),
+      },
+    ],
+    [
+      'batch',
+      {
+        getSortValue: row =>
+          getColumnPropertyAsString(row, [
+            { path: ['lines', 'batch'] },
+            { path: ['batch'], default: '' },
+          ]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [
+            { path: ['lines', 'batch'] },
+            { path: ['batch'] },
+          ]),
+      },
+    ],
+    [
+      'expiryDate',
+      {
+        getSortValue: row =>
+          getColumnPropertyAsString(row, [
+            { path: ['lines', 'expiryDate'] },
+            { path: ['expiryDate'], default: '' },
+          ]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [
+            { path: ['lines', 'expiryDate'] },
+            { path: ['expiryDate'] },
+          ]),
+      },
+    ],
+    [
+      'location',
+      {
+        getSortValue: row =>
+          getColumnPropertyAsString(row, [
+            { path: ['lines', 'location', 'code'] },
+            { path: ['location', 'code'], default: '' },
+          ]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [
+            { path: ['lines', 'location', 'code'] },
+            { path: ['location', 'code'], default: '' },
+          ]),
+      },
+    ],
+  ];
+
+  if (packVariantsEnabled) {
+    columns.push({
+      key: 'packUnit',
+      label: 'label.pack',
+      sortable: false,
+      Cell: getPackVariantCell({
+        getItemId: row => {
+          if ('lines' in row) return '';
+          else return row?.item?.id;
+        },
+        getPackSizes: row => {
+          if ('lines' in row) return row.lines.map(l => l.packSize ?? 1);
+          else return [row.packSize ?? 1];
+        },
+        getUnitName: row => {
+          if ('lines' in row) return row.lines[0]?.item?.unitName ?? null;
+          else return row?.item?.unitName ?? null;
+        },
+      }),
+      width: 130,
+    });
+  } else {
+    columns.push(
       [
-        'numberOfPacks',
+        'itemUnit',
         {
-          Cell: NumberCell,
+          getSortValue: row =>
+            getColumnPropertyAsString(row, [
+              { path: ['lines', 'item', 'unitName'] },
+              { path: ['item', 'unitName'], default: '' },
+            ]),
+          accessor: ({ rowData }) =>
+            getColumnProperty(rowData, [
+              { path: ['lines', 'item', 'unitName'] },
+              { path: ['item', 'unitName'], default: '' },
+            ]),
+        },
+      ],
+      [
+        'packSize',
+        {
           getSortValue: row => {
             if ('lines' in row) {
               const { lines } = row;
-              const packSize = ArrayUtils.ifTheSameElseDefault(
-                lines,
-                'packSize',
-                ''
+              return (
+                ArrayUtils.ifTheSameElseDefault(lines, 'packSize', '') ?? ''
               );
-              if (packSize) {
-                return lines.reduce(
-                  (acc, value) => acc + value.numberOfPacks,
-                  0
-                );
-              } else {
-                return '';
-              }
             } else {
-              return getNumberOfPacks(row);
+              return getPackSize(row) ?? '';
             }
           },
           accessor: ({ rowData }) => {
             if ('lines' in rowData) {
               const { lines } = rowData;
-              const packSize = ArrayUtils.ifTheSameElseDefault(
-                lines,
-                'packSize',
-                ''
-              );
-              if (packSize) {
-                return lines.reduce(
-                  (acc, value) => acc + value.numberOfPacks,
-                  0
-                );
-              } else {
-                return '';
-              }
+              return ArrayUtils.ifTheSameElseDefault(lines, 'packSize', '');
             } else {
-              return getNumberOfPacks(rowData);
+              return getPackSize(rowData);
             }
           },
         },
-      ],
-      [
-        'unitQuantity',
-        {
-          accessor: ({ rowData }) => {
-            if ('lines' in rowData) {
-              const { lines } = rowData;
-              return ArrayUtils.getUnitQuantity(lines);
-            } else {
-              return getUnitQuantity(rowData);
-            }
-          },
-          getSortValue: rowData => {
-            if ('lines' in rowData) {
-              const { lines } = rowData;
-              return ArrayUtils.getUnitQuantity(lines);
-            } else {
-              return getUnitQuantity(rowData);
-            }
-          },
-        },
-      ],
+      ]
+    );
+  }
+  columns.push(
+    [
+      'numberOfPacks',
       {
-        label: 'label.unit-price',
-        key: 'sellPricePerUnit',
-        align: ColumnAlign.Right,
-        Cell: CurrencyCell,
+        Cell: NumberCell,
+        getSortValue: row => {
+          if ('lines' in row) {
+            const { lines } = row;
+            const packSize = ArrayUtils.ifTheSameElseDefault(
+              lines,
+              'packSize',
+              ''
+            );
+            if (packSize) {
+              return lines.reduce((acc, value) => acc + value.numberOfPacks, 0);
+            } else {
+              return '';
+            }
+          } else {
+            return getNumberOfPacks(row);
+          }
+        },
         accessor: ({ rowData }) => {
           if ('lines' in rowData) {
-            return Object.values(rowData.lines).reduce(
-              (sum, batch) =>
-                sum + (batch.sellPricePerPack ?? 0) / batch.packSize,
-              0
+            const { lines } = rowData;
+            const packSize = ArrayUtils.ifTheSameElseDefault(
+              lines,
+              'packSize',
+              ''
             );
+            if (packSize) {
+              return lines.reduce((acc, value) => acc + value.numberOfPacks, 0);
+            } else {
+              return '';
+            }
           } else {
-            if (isDefaultPlaceholderRow(rowData)) return undefined;
-            return (rowData.sellPricePerPack ?? 0) / rowData.packSize;
+            return getNumberOfPacks(rowData);
+          }
+        },
+      },
+    ],
+    [
+      'unitQuantity',
+      {
+        accessor: ({ rowData }) => {
+          if ('lines' in rowData) {
+            const { lines } = rowData;
+            return ArrayUtils.getUnitQuantity(lines);
+          } else {
+            return getUnitQuantity(rowData);
           }
         },
         getSortValue: rowData => {
           if ('lines' in rowData) {
-            return Object.values(rowData.lines).reduce(
-              (sum, batch) =>
-                sum + (batch.sellPricePerPack ?? 0) / batch.packSize,
-              0
-            );
+            const { lines } = rowData;
+            return ArrayUtils.getUnitQuantity(lines);
           } else {
-            return (rowData.sellPricePerPack ?? 0) / rowData.packSize;
+            return getUnitQuantity(rowData);
           }
         },
       },
-      {
-        label: 'label.line-total',
-        key: 'lineTotal',
-        align: ColumnAlign.Right,
-        Cell: CurrencyCell,
-        accessor: ({ rowData }) => {
-          if ('lines' in rowData) {
-            return Object.values(rowData.lines).reduce(
-              (sum, batch) =>
-                sum + batch.sellPricePerPack * batch.numberOfPacks,
-              0
-            );
-          } else {
-            if (isDefaultPlaceholderRow(rowData)) return '';
-
-            const x = rowData.sellPricePerPack * rowData.numberOfPacks;
-            return x;
-          }
-        },
-        getSortValue: row => {
-          if ('lines' in row) {
-            return Object.values(row.lines).reduce(
-              (sum, batch) =>
-                sum + batch.sellPricePerPack * batch.numberOfPacks,
-              0
-            );
-          } else {
-            const x = row.sellPricePerPack * row.numberOfPacks;
-            return x;
-          }
-        },
-      },
-      expansionColumn,
-      GenericColumnKey.Selection,
     ],
-    { onChangeSortBy, sortBy },
-    [sortBy]
+    {
+      label: 'label.unit-price',
+      key: 'sellPricePerUnit',
+      align: ColumnAlign.Right,
+      Cell: CurrencyCell,
+      accessor: ({ rowData }) => {
+        if ('lines' in rowData) {
+          return Object.values(rowData.lines).reduce(
+            (sum, batch) =>
+              sum + (batch.sellPricePerPack ?? 0) / batch.packSize,
+            0
+          );
+        } else {
+          if (isDefaultPlaceholderRow(rowData)) return undefined;
+          return (rowData.sellPricePerPack ?? 0) / rowData.packSize;
+        }
+      },
+      getSortValue: rowData => {
+        if ('lines' in rowData) {
+          return Object.values(rowData.lines).reduce(
+            (sum, batch) =>
+              sum + (batch.sellPricePerPack ?? 0) / batch.packSize,
+            0
+          );
+        } else {
+          return (rowData.sellPricePerPack ?? 0) / rowData.packSize;
+        }
+      },
+    },
+    {
+      label: 'label.line-total',
+      key: 'lineTotal',
+      align: ColumnAlign.Right,
+      Cell: CurrencyCell,
+      accessor: ({ rowData }) => {
+        if ('lines' in rowData) {
+          return Object.values(rowData.lines).reduce(
+            (sum, batch) => sum + batch.sellPricePerPack * batch.numberOfPacks,
+            0
+          );
+        } else {
+          if (isDefaultPlaceholderRow(rowData)) return '';
+
+          const x = rowData.sellPricePerPack * rowData.numberOfPacks;
+          return x;
+        }
+      },
+      getSortValue: row => {
+        if ('lines' in row) {
+          return Object.values(row.lines).reduce(
+            (sum, batch) => sum + batch.sellPricePerPack * batch.numberOfPacks,
+            0
+          );
+        } else {
+          const x = row.sellPricePerPack * row.numberOfPacks;
+          return x;
+        }
+      },
+    },
+    expansionColumn,
+    GenericColumnKey.Selection
   );
+
+  return useColumns(columns, { onChangeSortBy, sortBy }, [sortBy]);
 };

--- a/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -16,7 +16,7 @@ import {
 } from '@openmsupply-client/common';
 import {
   getPackVariantCell,
-  usePackVariantsEnabled,
+  useIsPackVariantsEnabled,
 } from '@openmsupply-client/system';
 import { StockOutLineFragment } from '../../StockOut';
 import { StockOutItem } from '../../types';
@@ -51,7 +51,7 @@ export const useOutboundColumns = ({
 }: UseOutboundColumnOptions): Column<StockOutLineFragment | StockOutItem>[] => {
   const { getColumnProperty, getColumnPropertyAsString } = useColumnUtils();
 
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
 
   const columns: ColumnDescription<StockOutLineFragment | StockOutItem>[] = [
     [
@@ -153,7 +153,7 @@ export const useOutboundColumns = ({
     ],
   ];
 
-  if (packVariantsEnabled) {
+  if (isPackVariantsEnabled) {
     columns.push({
       key: 'packUnit',
       label: 'label.pack',

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
@@ -18,7 +18,7 @@ import {
   StockItemSearchInput,
   ItemRowFragment,
   usePackVariant,
-  usePackVariantsEnabled,
+  useIsPackVariantsEnabled,
 } from '@openmsupply-client/system';
 import { usePrescription } from '../../api';
 import { DraftItem } from '../../..';
@@ -76,7 +76,7 @@ export const PrescriptionLineEditForm: React.FC<
   const { format } = useFormatNumber();
   const { items } = usePrescription.line.rows();
 
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
   const { activePackVariant } = usePackVariant(
     item?.id ?? '',
     item?.unitName ?? null
@@ -247,7 +247,7 @@ export const PrescriptionLineEditForm: React.FC<
 
             {packSizeController.options.length ? (
               <>
-                {!packVariantsEnabled && (
+                {!isPackVariantsEnabled && (
                   <Grid
                     item
                     alignItems="center"
@@ -275,7 +275,7 @@ export const PrescriptionLineEditForm: React.FC<
                     onChangePackSize(Number(value));
                   }}
                 />
-                {!packVariantsEnabled &&
+                {!isPackVariantsEnabled &&
                   packSizeController.selected?.value !== -1 && (
                     <Grid
                       item

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
@@ -12,11 +12,13 @@ import {
   Typography,
   useFormatNumber,
   useDebounceCallback,
+  InputLabel,
 } from '@openmsupply-client/common';
 import {
   StockItemSearchInput,
   ItemRowFragment,
   usePackVariant,
+  usePackVariantsEnabled,
 } from '@openmsupply-client/system';
 import { usePrescription } from '../../api';
 import { DraftItem } from '../../..';
@@ -74,6 +76,7 @@ export const PrescriptionLineEditForm: React.FC<
   const { format } = useFormatNumber();
   const { items } = usePrescription.line.rows();
 
+  const packVariantsEnabled = usePackVariantsEnabled();
   const { activePackVariant } = usePackVariant(
     item?.id ?? '',
     item?.unitName ?? null
@@ -244,23 +247,50 @@ export const PrescriptionLineEditForm: React.FC<
 
             {packSizeController.options.length ? (
               <>
-                <Grid
-                  item
-                  alignItems="center"
-                  display="flex"
-                  justifyContent="flex-start"
-                  style={{ minWidth: 125 }}
-                >
-                  <Select
-                    sx={{ width: 110 }}
-                    options={packSizeController.options}
-                    value={packSizeController.selected?.value ?? ''}
-                    onChange={e => {
-                      const { value } = e.target;
-                      onChangePackSize(Number(value));
-                    }}
-                  />
-                </Grid>
+                {!packVariantsEnabled && (
+                  <Grid
+                    item
+                    alignItems="center"
+                    display="flex"
+                    justifyContent="flex-start"
+                    style={{ minWidth: 125 }}
+                  >
+                    <InputLabel sx={{ fontSize: '12px' }}>
+                      {packSizeController.selected?.value === -1
+                        ? `${t('label.unit-plural', {
+                            unit: activePackVariant,
+                            count: issueQuantity,
+                          })} ${t('label.in-packs-of')}`
+                        : t('label.in-packs-of')}
+                    </InputLabel>
+                  </Grid>
+                )}
+                <Box marginLeft={1} />
+                <Select
+                  sx={{ width: 110 }}
+                  options={packSizeController.options}
+                  value={packSizeController.selected?.value ?? ''}
+                  onChange={e => {
+                    const { value } = e.target;
+                    onChangePackSize(Number(value));
+                  }}
+                />
+                {!packVariantsEnabled &&
+                  packSizeController.selected?.value !== -1 && (
+                    <Grid
+                      item
+                      alignItems="center"
+                      display="flex"
+                      justifyContent="flex-start"
+                    >
+                      <InputLabel style={{ fontSize: 12, marginLeft: 8 }}>
+                        {t('label.unit-plural', {
+                          count: packSizeController.selected?.value,
+                          unit: activePackVariant,
+                        })}
+                      </InputLabel>
+                    </Grid>
+                  )}
                 <Box marginLeft="auto" />
               </>
             ) : null}

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/columns.ts
@@ -2,6 +2,7 @@ import {
   CheckCell,
   Column,
   ColumnAlign,
+  ColumnDescription,
   ExpiryDateCell,
   LocationCell,
   NumberCell,
@@ -9,7 +10,10 @@ import {
 } from '@openmsupply-client/common';
 import { DraftStockOutLine } from '../../../types';
 import { PackQuantityCell, StockOutLineFragment } from '../../../StockOut';
-import { getPackVariantCell } from '@openmsupply-client/system';
+import {
+  getPackVariantCell,
+  usePackVariantsEnabled,
+} from '@openmsupply-client/system';
 
 export const usePrescriptionLineEditColumns = ({
   onChange,
@@ -18,89 +22,95 @@ export const usePrescriptionLineEditColumns = ({
   onChange: (key: string, value: number, packSize: number) => void;
   unit: string;
 }) => {
-  const columns = useColumns<DraftStockOutLine>(
+  const packVariantsEnabled = usePackVariantsEnabled();
+
+  const columns: ColumnDescription<DraftStockOutLine>[] = [
     [
-      [
-        'batch',
-        {
-          accessor: ({ rowData }) => rowData.stockLine?.batch,
-        },
-      ],
-      [
-        'expiryDate',
-        {
-          Cell: ExpiryDateCell,
-          width: 80,
-        },
-      ],
-      [
-        'location',
-        {
-          accessor: ({ rowData }) => rowData.location?.code,
-          width: 100,
-          Cell: LocationCell,
-        },
-      ],
+      'batch',
       {
-        label: 'label.on-hold',
-        key: 'onHold',
-        Cell: CheckCell,
-        accessor: ({ rowData }) => rowData.stockLine?.onHold,
-        align: ColumnAlign.Center,
-        width: 70,
+        accessor: ({ rowData }) => rowData.stockLine?.batch,
       },
-      {
-        Cell: NumberCell,
-        label: 'label.in-store',
-        key: 'totalNumberOfPacks',
-        align: ColumnAlign.Right,
-        width: 80,
-        accessor: ({ rowData }) => rowData.stockLine?.totalNumberOfPacks,
-      },
-      {
-        Cell: NumberCell,
-        label: 'label.available-packs',
-        key: 'availableNumberOfPacks',
-        align: ColumnAlign.Right,
-        width: 85,
-        accessor: ({ rowData }) => rowData.stockLine?.availableNumberOfPacks,
-      },
-      {
-        key: 'packUnit',
-        label: 'label.pack',
-        sortable: false,
-        Cell: getPackVariantCell({
-          getItemId: row => row?.item?.id,
-          getPackSizes: row => [row.packSize ?? 1],
-          getUnitName: row => row?.item.unitName ?? null,
-        }),
-        width: 130,
-      },
-      [
-        'unitQuantity',
-        {
-          label: 'label.unit-quantity-issued',
-          labelProps: { unit },
-          accessor: ({ rowData }) => rowData.numberOfPacks * rowData.packSize,
-          width: 120,
-        },
-      ],
-      [
-        'numberOfPacks',
-        {
-          Cell: PackQuantityCell,
-          width: 120,
-          label: 'label.pack-quantity-issued',
-          setter: ({ packSize, id, numberOfPacks }) =>
-            onChange(id, numberOfPacks ?? 0, packSize ?? 1),
-        },
-      ],
     ],
-    {},
-    [onChange]
+    [
+      'expiryDate',
+      {
+        Cell: ExpiryDateCell,
+        width: 80,
+      },
+    ],
+    [
+      'location',
+      {
+        accessor: ({ rowData }) => rowData.location?.code,
+        width: 100,
+        Cell: LocationCell,
+      },
+    ],
+    {
+      label: 'label.on-hold',
+      key: 'onHold',
+      Cell: CheckCell,
+      accessor: ({ rowData }) => rowData.stockLine?.onHold,
+      align: ColumnAlign.Center,
+      width: 70,
+    },
+    {
+      Cell: NumberCell,
+      label: 'label.in-store',
+      key: 'totalNumberOfPacks',
+      align: ColumnAlign.Right,
+      width: 80,
+      accessor: ({ rowData }) => rowData.stockLine?.totalNumberOfPacks,
+    },
+    {
+      Cell: NumberCell,
+      label: 'label.available-packs',
+      key: 'availableNumberOfPacks',
+      align: ColumnAlign.Right,
+      width: 85,
+      accessor: ({ rowData }) => rowData.stockLine?.availableNumberOfPacks,
+    },
+  ];
+
+  columns.push(
+    packVariantsEnabled
+      ? {
+          key: 'packUnit',
+          label: 'label.pack',
+          sortable: false,
+          Cell: getPackVariantCell({
+            getItemId: row => row?.item?.id,
+            getPackSizes: row => [row.packSize ?? 1],
+            getUnitName: row => row?.item.unitName ?? null,
+          }),
+          width: 130,
+        }
+      : ['packSize', { width: 90 }]
   );
 
-  return columns;
+  columns.push(
+    [
+      'unitQuantity',
+      {
+        label: 'label.unit-quantity-issued',
+        labelProps: { unit },
+        accessor: ({ rowData }) => rowData.numberOfPacks * rowData.packSize,
+        width: 120,
+      },
+    ],
+    [
+      'numberOfPacks',
+      {
+        Cell: PackQuantityCell,
+        width: 120,
+        label: 'label.pack-quantity-issued',
+        setter: ({ packSize, id, numberOfPacks }) =>
+          onChange(id, numberOfPacks ?? 0, packSize ?? 1),
+      },
+    ]
+  );
+
+  return useColumns(columns, {}, [onChange]);
 };
 
 export const useExpansionColumns = (): Column<StockOutLineFragment>[] =>

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/columns.ts
@@ -12,7 +12,7 @@ import { DraftStockOutLine } from '../../../types';
 import { PackQuantityCell, StockOutLineFragment } from '../../../StockOut';
 import {
   getPackVariantCell,
-  usePackVariantsEnabled,
+  useIsPackVariantsEnabled,
 } from '@openmsupply-client/system';
 
 export const usePrescriptionLineEditColumns = ({
@@ -22,7 +22,7 @@ export const usePrescriptionLineEditColumns = ({
   onChange: (key: string, value: number, packSize: number) => void;
   unit: string;
 }) => {
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
 
   const columns: ColumnDescription<DraftStockOutLine>[] = [
     [
@@ -73,7 +73,7 @@ export const usePrescriptionLineEditColumns = ({
   ];
 
   columns.push(
-    packVariantsEnabled
+    isPackVariantsEnabled
       ? {
           key: 'packUnit',
           label: 'label.pack',

--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -15,7 +15,7 @@ import {
 } from '@openmsupply-client/common';
 import {
   getPackVariantCell,
-  usePackVariantsEnabled,
+  useIsPackVariantsEnabled,
 } from '@openmsupply-client/system';
 import { StockOutLineFragment } from '../../StockOut';
 import { StockOutItem } from '../../types';
@@ -38,7 +38,7 @@ export const usePrescriptionColumn = ({
   const t = useTranslation('dispensary');
   const { getColumnPropertyAsString, getColumnProperty } = useColumnUtils();
 
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
 
   const columns: ColumnDescription<StockOutLineFragment | StockOutItem>[] = [
     [
@@ -139,7 +139,7 @@ export const usePrescriptionColumn = ({
     ],
   ];
 
-  if (packVariantsEnabled) {
+  if (isPackVariantsEnabled) {
     columns.push({
       key: 'packUnit',
       label: 'label.pack',

--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -11,8 +11,12 @@ import {
   useColumnUtils,
   NumberCell,
   CurrencyCell,
+  ColumnDescription,
 } from '@openmsupply-client/common';
-import { getPackVariantCell } from '@openmsupply-client/system';
+import {
+  getPackVariantCell,
+  usePackVariantsEnabled,
+} from '@openmsupply-client/system';
 import { StockOutLineFragment } from '../../StockOut';
 import { StockOutItem } from '../../types';
 
@@ -34,258 +38,287 @@ export const usePrescriptionColumn = ({
   const t = useTranslation('dispensary');
   const { getColumnPropertyAsString, getColumnProperty } = useColumnUtils();
 
-  return useColumns(
-    [
-      [
-        getNotePopoverColumn(t('label.directions')),
-        {
-          accessor: ({ rowData }) => {
-            if ('lines' in rowData) {
-              const { lines } = rowData;
-              const noteSections = lines
-                .map(({ batch, note }) => ({
-                  header: batch ?? '',
-                  body: note ?? '',
-                }))
-                .filter(({ body }) => !!body);
-              return noteSections.length ? noteSections : null;
-            } else {
-              return rowData.batch && rowData.note
-                ? { header: rowData.batch, body: rowData.note }
-                : null;
-            }
-          },
-        },
-      ],
-      [
-        'itemCode',
-        {
-          getSortValue: row =>
-            getColumnPropertyAsString<StockOutLineFragment | StockOutItem>(
-              row,
-              [
-                { path: ['lines', 'item', 'code'] },
-                { path: ['item', 'code'], default: '' },
-              ]
-            ),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [
-              { path: ['lines', 'item', 'code'] },
-              { path: ['item', 'code'], default: '' },
-            ]),
-        },
-      ],
-      [
-        'itemName',
-        {
-          getSortValue: row =>
-            getColumnPropertyAsString(row, [
-              { path: ['lines', 'itemName'] },
-              { path: ['itemName'], default: '' },
-            ]),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [
-              { path: ['lines', 'itemName'] },
-              { path: ['itemName'], default: '' },
-            ]),
-        },
-      ],
-      [
-        'batch',
-        {
-          getSortValue: row =>
-            getColumnPropertyAsString(row, [
-              { path: ['lines', 'batch'] },
-              { path: ['batch'], default: '' },
-            ]),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [
-              { path: ['lines', 'batch'] },
-              { path: ['batch'] },
-            ]),
-        },
-      ],
-      [
-        'expiryDate',
-        {
-          getSortValue: row =>
-            getColumnPropertyAsString(row, [
-              { path: ['lines', 'expiryDate'] },
-              { path: ['expiryDate'], default: '' },
-            ]),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [
-              { path: ['lines', 'expiryDate'] },
-              { path: ['expiryDate'] },
-            ]),
-        },
-      ],
-      [
-        'location',
-        {
-          getSortValue: row =>
-            getColumnPropertyAsString(row, [
-              { path: ['lines', 'location', 'code'] },
-              { path: ['location', 'code'], default: '' },
-            ]),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [
-              { path: ['lines', 'location', 'code'] },
-              { path: ['location', 'code'] },
-            ]),
-        },
-      ],
-      [
-        'unitQuantity',
-        {
-          accessor: ({ rowData }) => {
-            if ('lines' in rowData) {
-              const { lines } = rowData;
-              return ArrayUtils.getUnitQuantity(lines);
-            } else {
-              return rowData.packSize * rowData.numberOfPacks;
-            }
-          },
-          getSortValue: rowData => {
-            if ('lines' in rowData) {
-              const { lines } = rowData;
-              return ArrayUtils.getUnitQuantity(lines);
-            } else {
-              return rowData.packSize * rowData.numberOfPacks;
-            }
-          },
-        },
-      ],
-      {
-        key: 'packUnit',
-        label: 'label.pack',
-        sortable: false,
-        // eslint-disable-next-line new-cap
-        Cell: getPackVariantCell({
-          getItemId: row => {
-            if ('lines' in row) return '';
-            else return row?.item?.id;
-          },
-          getPackSizes: row => {
-            if ('lines' in row) return row.lines.map(l => l.packSize ?? 1);
-            else return [row.packSize ?? 1];
-          },
-          getUnitName: row => {
-            if ('lines' in row) return row.lines[0]?.item?.unitName ?? null;
-            else return row?.item?.unitName ?? null;
-          },
-        }),
-        width: 130,
-      },
-      [
-        'numberOfPacks',
-        {
-          Cell: NumberCell,
-          getSortValue: row => {
-            if ('lines' in row) {
-              const { lines } = row;
-              const packSize = ArrayUtils.ifTheSameElseDefault(
-                lines,
-                'packSize',
-                ''
-              );
-              if (packSize) {
-                return lines.reduce(
-                  (acc, value) => acc + value.numberOfPacks,
-                  0
-                );
-              } else {
-                return '';
-              }
-            } else {
-              return row.numberOfPacks;
-            }
-          },
-          accessor: ({ rowData }) => {
-            if ('lines' in rowData) {
-              const { lines } = rowData;
-              const packSize = ArrayUtils.ifTheSameElseDefault(
-                lines,
-                'packSize',
-                ''
-              );
-              if (packSize) {
-                return lines.reduce(
-                  (acc, value) => acc + value.numberOfPacks,
-                  0
-                );
-              } else {
-                return '';
-              }
-            } else {
-              return rowData.numberOfPacks;
-            }
-          },
-        },
-      ],
+  const packVariantsEnabled = usePackVariantsEnabled();
 
+  const columns: ColumnDescription<StockOutLineFragment | StockOutItem>[] = [
+    [
+      getNotePopoverColumn(t('label.directions')),
       {
-        label: 'label.unit-price',
-        key: 'sellPricePerUnit',
-        align: ColumnAlign.Right,
-        Cell: CurrencyCell,
         accessor: ({ rowData }) => {
           if ('lines' in rowData) {
-            return Object.values(rowData.lines).reduce(
-              (sum, batch) =>
-                sum + (batch.sellPricePerPack ?? 0) / batch.packSize,
-              0
-            );
+            const { lines } = rowData;
+            const noteSections = lines
+              .map(({ batch, note }) => ({
+                header: batch ?? '',
+                body: note ?? '',
+              }))
+              .filter(({ body }) => !!body);
+            return noteSections.length ? noteSections : null;
           } else {
-            return (rowData.sellPricePerPack ?? 0) / rowData.packSize;
+            return rowData.batch && rowData.note
+              ? { header: rowData.batch, body: rowData.note }
+              : null;
+          }
+        },
+      },
+    ],
+    [
+      'itemCode',
+      {
+        getSortValue: row =>
+          getColumnPropertyAsString<StockOutLineFragment | StockOutItem>(row, [
+            { path: ['lines', 'item', 'code'] },
+            { path: ['item', 'code'], default: '' },
+          ]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [
+            { path: ['lines', 'item', 'code'] },
+            { path: ['item', 'code'], default: '' },
+          ]),
+      },
+    ],
+    [
+      'itemName',
+      {
+        getSortValue: row =>
+          getColumnPropertyAsString(row, [
+            { path: ['lines', 'itemName'] },
+            { path: ['itemName'], default: '' },
+          ]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [
+            { path: ['lines', 'itemName'] },
+            { path: ['itemName'], default: '' },
+          ]),
+      },
+    ],
+    [
+      'batch',
+      {
+        getSortValue: row =>
+          getColumnPropertyAsString(row, [
+            { path: ['lines', 'batch'] },
+            { path: ['batch'], default: '' },
+          ]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [
+            { path: ['lines', 'batch'] },
+            { path: ['batch'] },
+          ]),
+      },
+    ],
+    [
+      'expiryDate',
+      {
+        getSortValue: row =>
+          getColumnPropertyAsString(row, [
+            { path: ['lines', 'expiryDate'] },
+            { path: ['expiryDate'], default: '' },
+          ]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [
+            { path: ['lines', 'expiryDate'] },
+            { path: ['expiryDate'] },
+          ]),
+      },
+    ],
+    [
+      'location',
+      {
+        getSortValue: row =>
+          getColumnPropertyAsString(row, [
+            { path: ['lines', 'location', 'code'] },
+            { path: ['location', 'code'], default: '' },
+          ]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [
+            { path: ['lines', 'location', 'code'] },
+            { path: ['location', 'code'] },
+          ]),
+      },
+    ],
+  ];
+
+  if (packVariantsEnabled) {
+    columns.push({
+      key: 'packUnit',
+      label: 'label.pack',
+      sortable: false,
+      // eslint-disable-next-line new-cap
+      Cell: getPackVariantCell({
+        getItemId: row => {
+          if ('lines' in row) return '';
+          else return row?.item?.id;
+        },
+        getPackSizes: row => {
+          if ('lines' in row) return row.lines.map(l => l.packSize ?? 1);
+          else return [row.packSize ?? 1];
+        },
+        getUnitName: row => {
+          if ('lines' in row) return row.lines[0]?.item?.unitName ?? null;
+          else return row?.item?.unitName ?? null;
+        },
+      }),
+      width: 130,
+    });
+  } else {
+    columns.push(
+      [
+        'itemUnit',
+        {
+          getSortValue: row =>
+            getColumnPropertyAsString(row, [
+              { path: ['lines', 'item', 'unitName'] },
+              { path: ['item', 'unitName'], default: '' },
+            ]),
+          accessor: ({ rowData }) =>
+            getColumnProperty(rowData, [
+              { path: ['lines', 'item', 'unitName'] },
+              { path: ['item', 'unitName'], default: '' },
+            ]),
+        },
+      ],
+      [
+        'packSize',
+        {
+          getSortValue: row =>
+            getColumnPropertyAsString(row, [
+              { path: ['lines', 'packSize'] },
+              { path: ['packSize'], default: '' },
+            ]),
+          accessor: ({ rowData }) =>
+            getColumnProperty(rowData, [
+              { path: ['lines', 'packSize'] },
+              { path: ['packSize'] },
+            ]),
+        },
+      ]
+    );
+  }
+
+  columns.push(
+    [
+      'unitQuantity',
+      {
+        accessor: ({ rowData }) => {
+          if ('lines' in rowData) {
+            const { lines } = rowData;
+            return ArrayUtils.getUnitQuantity(lines);
+          } else {
+            return rowData.packSize * rowData.numberOfPacks;
           }
         },
         getSortValue: rowData => {
           if ('lines' in rowData) {
-            return Object.values(rowData.lines).reduce(
-              (sum, batch) =>
-                sum + (batch.sellPricePerPack ?? 0) / batch.packSize,
-              0
-            );
+            const { lines } = rowData;
+            return ArrayUtils.getUnitQuantity(lines);
           } else {
-            return (rowData.sellPricePerPack ?? 0) / rowData.packSize;
+            return rowData.packSize * rowData.numberOfPacks;
           }
         },
       },
+    ],
+
+    [
+      'numberOfPacks',
       {
-        label: 'label.line-total',
-        key: 'lineTotal',
-        align: ColumnAlign.Right,
-        Cell: CurrencyCell,
-        accessor: ({ rowData }) => {
-          if ('lines' in rowData) {
-            return Object.values(rowData.lines).reduce(
-              (sum, batch) =>
-                sum + batch.sellPricePerPack * batch.numberOfPacks,
-              0
-            );
-          } else {
-            const x = rowData.sellPricePerPack * rowData.numberOfPacks;
-            return x;
-          }
-        },
+        Cell: NumberCell,
         getSortValue: row => {
           if ('lines' in row) {
-            return Object.values(row.lines).reduce(
-              (sum, batch) =>
-                sum + batch.sellPricePerPack * batch.numberOfPacks,
-              0
+            const { lines } = row;
+            const packSize = ArrayUtils.ifTheSameElseDefault(
+              lines,
+              'packSize',
+              ''
             );
+            if (packSize) {
+              return lines.reduce((acc, value) => acc + value.numberOfPacks, 0);
+            } else {
+              return '';
+            }
           } else {
-            const x = row.sellPricePerPack * row.numberOfPacks;
-            return x;
+            return row.numberOfPacks;
+          }
+        },
+        accessor: ({ rowData }) => {
+          if ('lines' in rowData) {
+            const { lines } = rowData;
+            const packSize = ArrayUtils.ifTheSameElseDefault(
+              lines,
+              'packSize',
+              ''
+            );
+            if (packSize) {
+              return lines.reduce((acc, value) => acc + value.numberOfPacks, 0);
+            } else {
+              return '';
+            }
+          } else {
+            return rowData.numberOfPacks;
           }
         },
       },
-      expansionColumn,
-      GenericColumnKey.Selection,
     ],
-    { onChangeSortBy, sortBy },
-    [sortBy]
+
+    {
+      label: 'label.unit-price',
+      key: 'sellPricePerUnit',
+      align: ColumnAlign.Right,
+      Cell: CurrencyCell,
+      accessor: ({ rowData }) => {
+        if ('lines' in rowData) {
+          return Object.values(rowData.lines).reduce(
+            (sum, batch) =>
+              sum + (batch.sellPricePerPack ?? 0) / batch.packSize,
+            0
+          );
+        } else {
+          return (rowData.sellPricePerPack ?? 0) / rowData.packSize;
+        }
+      },
+      getSortValue: rowData => {
+        if ('lines' in rowData) {
+          return Object.values(rowData.lines).reduce(
+            (sum, batch) =>
+              sum + (batch.sellPricePerPack ?? 0) / batch.packSize,
+            0
+          );
+        } else {
+          return (rowData.sellPricePerPack ?? 0) / rowData.packSize;
+        }
+      },
+    },
+    {
+      label: 'label.line-total',
+      key: 'lineTotal',
+      align: ColumnAlign.Right,
+      Cell: CurrencyCell,
+      accessor: ({ rowData }) => {
+        if ('lines' in rowData) {
+          return Object.values(rowData.lines).reduce(
+            (sum, batch) => sum + batch.sellPricePerPack * batch.numberOfPacks,
+            0
+          );
+        } else {
+          const x = rowData.sellPricePerPack * rowData.numberOfPacks;
+          return x;
+        }
+      },
+      getSortValue: row => {
+        if ('lines' in row) {
+          return Object.values(row.lines).reduce(
+            (sum, batch) => sum + batch.sellPricePerPack * batch.numberOfPacks,
+            0
+          );
+        } else {
+          const x = row.sellPricePerPack * row.numberOfPacks;
+          return x;
+        }
+      },
+    },
+    expansionColumn,
+    GenericColumnKey.Selection
   );
+
+  return useColumns(columns, { onChangeSortBy, sortBy }, [sortBy]);
 };

--- a/client/packages/invoices/src/Returns/InboundDetailView/columns.ts
+++ b/client/packages/invoices/src/Returns/InboundDetailView/columns.ts
@@ -15,7 +15,7 @@ import { InboundReturnLineFragment } from '../api';
 import { InboundReturnItem } from '../../types';
 import {
   getPackVariantCell,
-  usePackVariantsEnabled,
+  useIsPackVariantsEnabled,
 } from '@openmsupply-client/system';
 
 interface UseInboundReturnColumnOptions {
@@ -42,7 +42,7 @@ export const useInboundReturnColumns = ({
 >[] => {
   const { getColumnProperty, getColumnPropertyAsString } = useColumnUtils();
 
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
   const columns: ColumnDescription<
     InboundReturnLineFragment | InboundReturnItem
   >[] = [
@@ -145,7 +145,7 @@ export const useInboundReturnColumns = ({
     ],
   ];
 
-  if (packVariantsEnabled) {
+  if (isPackVariantsEnabled) {
     columns.push({
       key: 'packUnit',
       label: 'label.pack',

--- a/client/packages/invoices/src/Returns/InboundDetailView/columns.ts
+++ b/client/packages/invoices/src/Returns/InboundDetailView/columns.ts
@@ -9,10 +9,14 @@ import {
   NumberCell,
   getRowExpandColumn,
   ArrayUtils,
+  ColumnDescription,
 } from '@openmsupply-client/common';
 import { InboundReturnLineFragment } from '../api';
 import { InboundReturnItem } from '../../types';
-import { getPackVariantCell } from '@openmsupply-client/system';
+import {
+  getPackVariantCell,
+  usePackVariantsEnabled,
+} from '@openmsupply-client/system';
 
 interface UseInboundReturnColumnOptions {
   sortBy: SortBy<InboundReturnLineFragment | InboundReturnItem>;
@@ -38,189 +42,221 @@ export const useInboundReturnColumns = ({
 >[] => {
   const { getColumnProperty, getColumnPropertyAsString } = useColumnUtils();
 
-  return useColumns(
+  const packVariantsEnabled = usePackVariantsEnabled();
+  const columns: ColumnDescription<
+    InboundReturnLineFragment | InboundReturnItem
+  >[] = [
+    //   [
+    //     notePopoverColumn,
+    //     {
+    //       accessor: ({ rowData }) => {
+    //         if ('lines' in rowData) {
+    //           const { lines } = rowData;
+    //           const noteSections = lines
+    //             .map(({ batch, note }) => ({
+    //               header: batch ?? '',
+    //               body: note ?? '',
+    //             }))
+    //             .filter(({ body }) => !!body);
+    //           return noteSections.length ? noteSections : null;
+    //         } else {
+    //           return rowData.batch && rowData.note
+    //             ? { header: rowData.batch, body: rowData.note }
+    //             : null;
+    //         }
+    //       },
+    //     },
+    //   ],
     [
-      //   [
-      //     notePopoverColumn,
-      //     {
-      //       accessor: ({ rowData }) => {
-      //         if ('lines' in rowData) {
-      //           const { lines } = rowData;
-      //           const noteSections = lines
-      //             .map(({ batch, note }) => ({
-      //               header: batch ?? '',
-      //               body: note ?? '',
-      //             }))
-      //             .filter(({ body }) => !!body);
-      //           return noteSections.length ? noteSections : null;
-      //         } else {
-      //           return rowData.batch && rowData.note
-      //             ? { header: rowData.batch, body: rowData.note }
-      //             : null;
-      //         }
-      //       },
-      //     },
-      //   ],
-      [
-        'itemCode',
-        {
-          getSortValue: row =>
-            getColumnPropertyAsString(row, [
-              { path: ['lines', 'itemCode'] },
-              { path: ['itemCode'], default: '' },
-            ]),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [
-              { path: ['lines', 'itemCode'] },
-              { path: ['itemCode'], default: '' },
-            ]),
-        },
-      ],
-      [
-        'itemName',
-        {
-          Cell: TooltipTextCell,
-          getSortValue: row =>
-            getColumnPropertyAsString(row, [
-              { path: ['lines', 'itemName'] },
-              { path: ['itemName'], default: '' },
-            ]),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [
-              { path: ['lines', 'itemName'] },
-              { path: ['itemName'], default: '' },
-            ]),
-        },
-      ],
-      //   [
-      //     'itemUnit',
-      //     {
-      //       getSortValue: row =>
-      //         getColumnPropertyAsString(row, [
-      //           { path: ['lines', 'item', 'unitName'] },
-      //           { path: ['item', 'unitName'], default: '' },
-      //         ]),
-      //       accessor: ({ rowData }) =>
-      //         getColumnProperty(rowData, [
-      //           { path: ['lines', 'item', 'unitName'] },
-      //           { path: ['item', 'unitName'], default: '' },
-      //         ]),
-      //     },
-      //   ],
-      [
-        'batch',
-        {
-          getSortValue: row =>
-            getColumnPropertyAsString(row, [
-              { path: ['lines', 'batch'] },
-              { path: ['batch'] },
-            ]),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [
-              { path: ['lines', 'batch'] },
-              { path: ['batch'] },
-            ]),
-        },
-      ],
-      [
-        'expiryDate',
-        {
-          getSortValue: row =>
-            getColumnPropertyAsString(row, [
-              { path: ['lines', 'expiryDate'] },
-              { path: ['expiryDate'] },
-            ]),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [
-              { path: ['lines', 'expiryDate'] },
-              { path: ['expiryDate'] },
-            ]),
-        },
-      ],
-      //   [
-      //     'location',
-      //     {
-      //       getSortValue: row =>
-      //         getColumnPropertyAsString(row, [
-      //           { path: ['lines', 'location', 'code'] },
-      //           { path: ['location', 'code'], default: '' },
-      //         ]),
-      //       accessor: ({ rowData }) =>
-      //         getColumnProperty(rowData, [
-      //           { path: ['lines', 'location', 'code'] },
-      //           { path: ['location', 'code'], default: '' },
-      //         ]),
-      //     },
-      //   ],
+      'itemCode',
       {
-        key: 'packUnit',
-        label: 'label.pack',
-        sortable: false,
-        Cell: getPackVariantCell({
-          getItemId: row => {
-            if ('lines' in row) return '';
-            else return row?.item?.id;
-          },
-          getPackSizes: row => {
-            if ('lines' in row) return row.lines.map(l => l.packSize ?? 1);
-            else return [row?.packSize ?? 1];
-          },
-          getUnitName: row => {
-            if ('lines' in row) return row.lines[0]?.item?.unitName ?? null;
-            else return row?.item?.unitName ?? null;
-          },
-        }),
-        width: 130,
+        getSortValue: row =>
+          getColumnPropertyAsString(row, [
+            { path: ['lines', 'itemCode'] },
+            { path: ['itemCode'], default: '' },
+          ]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [
+            { path: ['lines', 'itemCode'] },
+            { path: ['itemCode'], default: '' },
+          ]),
       },
-      [
-        'numberOfPacks',
-        {
-          Cell: NumberCell,
-          accessor: ({ rowData }) => {
-            if ('lines' in rowData) {
-              const { lines } = rowData;
-              return ArrayUtils.getSum(lines, 'numberOfPacks');
-            } else {
-              return rowData.numberOfPacks;
-            }
-          },
-          getSortValue: rowData => {
-            if ('lines' in rowData) {
-              const { lines } = rowData;
-              return ArrayUtils.getSum(lines, 'numberOfPacks');
-            } else {
-              return rowData.numberOfPacks;
-            }
-          },
-        },
-      ],
-      [
-        'unitQuantity',
-        {
-          accessor: ({ rowData }) => {
-            if ('lines' in rowData) {
-              const { lines } = rowData;
-              return ArrayUtils.getUnitQuantity(lines);
-            } else {
-              return getUnitQuantity(rowData);
-            }
-          },
-          getSortValue: rowData => {
-            if ('lines' in rowData) {
-              const { lines } = rowData;
-              return ArrayUtils.getUnitQuantity(lines);
-            } else {
-              return getUnitQuantity(rowData);
-            }
-          },
-        },
-      ],
-      expansionColumn,
-      GenericColumnKey.Selection,
     ],
-    { onChangeSortBy, sortBy },
-    [sortBy]
+    [
+      'itemName',
+      {
+        Cell: TooltipTextCell,
+        getSortValue: row =>
+          getColumnPropertyAsString(row, [
+            { path: ['lines', 'itemName'] },
+            { path: ['itemName'], default: '' },
+          ]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [
+            { path: ['lines', 'itemName'] },
+            { path: ['itemName'], default: '' },
+          ]),
+      },
+    ],
+    //   [
+    //     'itemUnit',
+    //     {
+    //       getSortValue: row =>
+    //         getColumnPropertyAsString(row, [
+    //           { path: ['lines', 'item', 'unitName'] },
+    //           { path: ['item', 'unitName'], default: '' },
+    //         ]),
+    //       accessor: ({ rowData }) =>
+    //         getColumnProperty(rowData, [
+    //           { path: ['lines', 'item', 'unitName'] },
+    //           { path: ['item', 'unitName'], default: '' },
+    //         ]),
+    //     },
+    //   ],
+    [
+      'batch',
+      {
+        getSortValue: row =>
+          getColumnPropertyAsString(row, [
+            { path: ['lines', 'batch'] },
+            { path: ['batch'] },
+          ]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [
+            { path: ['lines', 'batch'] },
+            { path: ['batch'] },
+          ]),
+      },
+    ],
+    [
+      'expiryDate',
+      {
+        getSortValue: row =>
+          getColumnPropertyAsString(row, [
+            { path: ['lines', 'expiryDate'] },
+            { path: ['expiryDate'] },
+          ]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [
+            { path: ['lines', 'expiryDate'] },
+            { path: ['expiryDate'] },
+          ]),
+      },
+    ],
+  ];
+
+  if (packVariantsEnabled) {
+    columns.push({
+      key: 'packUnit',
+      label: 'label.pack',
+      sortable: false,
+      Cell: getPackVariantCell({
+        getItemId: row => {
+          if ('lines' in row) return '';
+          else return row?.item?.id;
+        },
+        getPackSizes: row => {
+          if ('lines' in row) return row.lines.map(l => l.packSize ?? 1);
+          else return [row?.packSize ?? 1];
+        },
+        getUnitName: row => {
+          if ('lines' in row) return row.lines[0]?.item?.unitName ?? null;
+          else return row?.item?.unitName ?? null;
+        },
+      }),
+      width: 130,
+    });
+  } else {
+    columns.push(
+      [
+        'itemUnit',
+        {
+          getSortValue: row =>
+            getColumnPropertyAsString(row, [
+              { path: ['lines', 'item', 'unitName'] },
+              { path: ['item', 'unitName'], default: '' },
+            ]),
+          accessor: ({ rowData }) =>
+            getColumnProperty(rowData, [
+              { path: ['lines', 'item', 'unitName'] },
+              { path: ['item', 'unitName'], default: '' },
+            ]),
+        },
+      ],
+      [
+        'packSize',
+        {
+          getSortValue: row => {
+            if ('lines' in row) {
+              const { lines } = row;
+              return (
+                ArrayUtils.ifTheSameElseDefault(lines, 'packSize', '') ?? ''
+              );
+            } else {
+              return row.packSize ?? '';
+            }
+          },
+          accessor: ({ rowData }) => {
+            if ('lines' in rowData) {
+              const { lines } = rowData;
+              return ArrayUtils.ifTheSameElseDefault(lines, 'packSize', '');
+            } else {
+              return rowData.packSize;
+            }
+          },
+        },
+      ]
+    );
+  }
+  columns.push(
+    [
+      'numberOfPacks',
+      {
+        Cell: NumberCell,
+        accessor: ({ rowData }) => {
+          if ('lines' in rowData) {
+            const { lines } = rowData;
+            return ArrayUtils.getSum(lines, 'numberOfPacks');
+          } else {
+            return rowData.numberOfPacks;
+          }
+        },
+        getSortValue: rowData => {
+          if ('lines' in rowData) {
+            const { lines } = rowData;
+            return ArrayUtils.getSum(lines, 'numberOfPacks');
+          } else {
+            return rowData.numberOfPacks;
+          }
+        },
+      },
+    ],
+    [
+      'unitQuantity',
+      {
+        accessor: ({ rowData }) => {
+          if ('lines' in rowData) {
+            const { lines } = rowData;
+            return ArrayUtils.getUnitQuantity(lines);
+          } else {
+            return getUnitQuantity(rowData);
+          }
+        },
+        getSortValue: rowData => {
+          if ('lines' in rowData) {
+            const { lines } = rowData;
+            return ArrayUtils.getUnitQuantity(lines);
+          } else {
+            return getUnitQuantity(rowData);
+          }
+        },
+      },
+    ],
+    expansionColumn,
+    GenericColumnKey.Selection
   );
+
+  return useColumns(columns, { onChangeSortBy, sortBy }, [sortBy]);
 };
 
 export const useExpansionColumns = (): Column<InboundReturnLineFragment>[] =>

--- a/client/packages/invoices/src/Returns/OutboundDetailView/columns.ts
+++ b/client/packages/invoices/src/Returns/OutboundDetailView/columns.ts
@@ -10,10 +10,14 @@ import {
   getRowExpandColumn,
   ArrayUtils,
   ColumnAlign,
+  ColumnDescription,
 } from '@openmsupply-client/common';
 import { OutboundReturnLineFragment } from '../api';
 import { OutboundReturnItem } from '../../types';
-import { getPackVariantCell } from '@openmsupply-client/system';
+import {
+  getPackVariantCell,
+  usePackVariantsEnabled,
+} from '@openmsupply-client/system';
 
 interface UseOutboundColumnOptions {
   sortBy: SortBy<OutboundReturnLineFragment | OutboundReturnItem>;
@@ -39,247 +43,292 @@ export const useOutboundReturnColumns = ({
   const { c } = useCurrency();
   const { getColumnProperty, getColumnPropertyAsString } = useColumnUtils();
 
-  return useColumns(
+  const packVariantsEnabled = usePackVariantsEnabled();
+
+  const columns: ColumnDescription<
+    OutboundReturnLineFragment | OutboundReturnItem
+  >[] = [
+    //   [
+    //     notePopoverColumn,
+    //     {
+    //       accessor: ({ rowData }) => {
+    //         if ('lines' in rowData) {
+    //           const { lines } = rowData;
+    //           const noteSections = lines
+    //             .map(({ batch, note }) => ({
+    //               header: batch ?? '',
+    //               body: note ?? '',
+    //             }))
+    //             .filter(({ body }) => !!body);
+    //           return noteSections.length ? noteSections : null;
+    //         } else {
+    //           return rowData.batch && rowData.note
+    //             ? { header: rowData.batch, body: rowData.note }
+    //             : null;
+    //         }
+    //       },
+    //     },
+    //   ],
     [
-      //   [
-      //     notePopoverColumn,
-      //     {
-      //       accessor: ({ rowData }) => {
-      //         if ('lines' in rowData) {
-      //           const { lines } = rowData;
-      //           const noteSections = lines
-      //             .map(({ batch, note }) => ({
-      //               header: batch ?? '',
-      //               body: note ?? '',
-      //             }))
-      //             .filter(({ body }) => !!body);
-      //           return noteSections.length ? noteSections : null;
-      //         } else {
-      //           return rowData.batch && rowData.note
-      //             ? { header: rowData.batch, body: rowData.note }
-      //             : null;
-      //         }
-      //       },
-      //     },
-      //   ],
-      [
-        'itemCode',
-        {
-          getSortValue: row =>
-            getColumnPropertyAsString(row, [
-              { path: ['lines', 'itemCode'] },
-              { path: ['itemCode'], default: '' },
-            ]),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [
-              { path: ['lines', 'itemCode'] },
-              { path: ['itemCode'], default: '' },
-            ]),
-        },
-      ],
-      [
-        'itemName',
-        {
-          Cell: TooltipTextCell,
-          getSortValue: row =>
-            getColumnPropertyAsString(row, [
-              { path: ['lines', 'itemName'] },
-              { path: ['itemName'], default: '' },
-            ]),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [
-              { path: ['lines', 'itemName'] },
-              { path: ['itemName'], default: '' },
-            ]),
-        },
-      ],
-      //   [
-      //     'itemUnit',
-      //     {
-      //       getSortValue: row =>
-      //         getColumnPropertyAsString(row, [
-      //           { path: ['lines', 'item', 'unitName'] },
-      //           { path: ['item', 'unitName'], default: '' },
-      //         ]),
-      //       accessor: ({ rowData }) =>
-      //         getColumnProperty(rowData, [
-      //           { path: ['lines', 'item', 'unitName'] },
-      //           { path: ['item', 'unitName'], default: '' },
-      //         ]),
-      //     },
-      //   ],
-      [
-        'batch',
-        {
-          getSortValue: row =>
-            getColumnPropertyAsString(row, [{ path: ['batch'] }]),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [{ path: ['batch'] }]),
-        },
-      ],
-      [
-        'expiryDate',
-        {
-          getSortValue: row =>
-            getColumnPropertyAsString(row, [{ path: ['expiryDate'] }]),
-          accessor: ({ rowData }) =>
-            getColumnProperty(rowData, [{ path: ['expiryDate'] }]),
-        },
-      ],
-      //   [
-      //     'location',
-      //     {
-      //       getSortValue: row =>
-      //         getColumnPropertyAsString(row, [
-      //           { path: ['lines', 'location', 'code'] },
-      //           { path: ['location', 'code'], default: '' },
-      //         ]),
-      //       accessor: ({ rowData }) =>
-      //         getColumnProperty(rowData, [
-      //           { path: ['lines', 'location', 'code'] },
-      //           { path: ['location', 'code'], default: '' },
-      //         ]),
-      //     },
-      //   ],
+      'itemCode',
       {
-        key: 'packUnit',
-        label: 'label.pack',
-        sortable: false,
-        Cell: getPackVariantCell({
-          getItemId: row => {
-            if ('lines' in row) return '';
-            else return row?.item?.id;
-          },
-          getPackSizes: row => {
-            if ('lines' in row) return row.lines.map(l => l.packSize ?? 1);
-            else return [row.packSize ?? 1];
-          },
-          getUnitName: row => {
-            if ('lines' in row) return row.lines[0]?.item?.unitName ?? null;
-            else return row?.item?.unitName ?? null;
-          },
-        }),
-        width: 130,
+        getSortValue: row =>
+          getColumnPropertyAsString(row, [
+            { path: ['lines', 'itemCode'] },
+            { path: ['itemCode'], default: '' },
+          ]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [
+            { path: ['lines', 'itemCode'] },
+            { path: ['itemCode'], default: '' },
+          ]),
       },
-      [
-        'numberOfPacks',
-        {
-          Cell: NumberCell,
-          accessor: ({ rowData }) => {
-            if ('lines' in rowData) {
-              const { lines } = rowData;
-              return ArrayUtils.getSum(lines, 'numberOfPacks');
-            } else {
-              return rowData.numberOfPacks;
-            }
-          },
-          getSortValue: rowData => {
-            if ('lines' in rowData) {
-              const { lines } = rowData;
-              return ArrayUtils.getSum(lines, 'numberOfPacks');
-            } else {
-              return rowData.numberOfPacks;
-            }
-          },
-        },
-      ],
-      [
-        'unitQuantity',
-        {
-          accessor: ({ rowData }) => {
-            if ('lines' in rowData) {
-              const { lines } = rowData;
-              return ArrayUtils.getUnitQuantity(lines);
-            } else {
-              return getUnitQuantity(rowData);
-            }
-          },
-          getSortValue: rowData => {
-            if ('lines' in rowData) {
-              const { lines } = rowData;
-              return ArrayUtils.getUnitQuantity(lines);
-            } else {
-              return getUnitQuantity(rowData);
-            }
-          },
-        },
-      ],
+    ],
+    [
+      'itemName',
       {
-        label: 'label.unit-price',
-        key: 'sellPricePerUnit',
-        align: ColumnAlign.Right,
+        Cell: TooltipTextCell,
+        getSortValue: row =>
+          getColumnPropertyAsString(row, [
+            { path: ['lines', 'itemName'] },
+            { path: ['itemName'], default: '' },
+          ]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [
+            { path: ['lines', 'itemName'] },
+            { path: ['itemName'], default: '' },
+          ]),
+      },
+    ],
+    //   [
+    //     'itemUnit',
+    //     {
+    //       getSortValue: row =>
+    //         getColumnPropertyAsString(row, [
+    //           { path: ['lines', 'item', 'unitName'] },
+    //           { path: ['item', 'unitName'], default: '' },
+    //         ]),
+    //       accessor: ({ rowData }) =>
+    //         getColumnProperty(rowData, [
+    //           { path: ['lines', 'item', 'unitName'] },
+    //           { path: ['item', 'unitName'], default: '' },
+    //         ]),
+    //     },
+    //   ],
+    [
+      'batch',
+      {
+        getSortValue: row =>
+          getColumnPropertyAsString(row, [{ path: ['batch'] }]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [{ path: ['batch'] }]),
+      },
+    ],
+    [
+      'expiryDate',
+      {
+        getSortValue: row =>
+          getColumnPropertyAsString(row, [{ path: ['expiryDate'] }]),
+        accessor: ({ rowData }) =>
+          getColumnProperty(rowData, [{ path: ['expiryDate'] }]),
+      },
+    ],
+    //   [
+    //     'location',
+    //     {
+    //       getSortValue: row =>
+    //         getColumnPropertyAsString(row, [
+    //           { path: ['lines', 'location', 'code'] },
+    //           { path: ['location', 'code'], default: '' },
+    //         ]),
+    //       accessor: ({ rowData }) =>
+    //         getColumnProperty(rowData, [
+    //           { path: ['lines', 'location', 'code'] },
+    //           { path: ['location', 'code'], default: '' },
+    //         ]),
+    //     },
+    //   ],
+  ];
+
+  if (packVariantsEnabled) {
+    columns.push({
+      key: 'packUnit',
+      label: 'label.pack',
+      sortable: false,
+      Cell: getPackVariantCell({
+        getItemId: row => {
+          if ('lines' in row) return '';
+          else return row?.item?.id;
+        },
+        getPackSizes: row => {
+          if ('lines' in row) return row.lines.map(l => l.packSize ?? 1);
+          else return [row.packSize ?? 1];
+        },
+        getUnitName: row => {
+          if ('lines' in row) return row.lines[0]?.item?.unitName ?? null;
+          else return row?.item?.unitName ?? null;
+        },
+      }),
+      width: 130,
+    });
+  } else {
+    columns.push(
+      [
+        'itemUnit',
+        {
+          getSortValue: row =>
+            getColumnPropertyAsString(row, [
+              { path: ['lines', 'item', 'unitName'] },
+              { path: ['item', 'unitName'], default: '' },
+            ]),
+          accessor: ({ rowData }) =>
+            getColumnProperty(rowData, [
+              { path: ['lines', 'item', 'unitName'] },
+              { path: ['item', 'unitName'], default: '' },
+            ]),
+        },
+      ],
+      [
+        'packSize',
+        {
+          getSortValue: row => {
+            if ('lines' in row) {
+              const { lines } = row;
+              return (
+                ArrayUtils.ifTheSameElseDefault(lines, 'packSize', '') ?? ''
+              );
+            } else {
+              return row.packSize ?? '';
+            }
+          },
+          accessor: ({ rowData }) => {
+            if ('lines' in rowData) {
+              const { lines } = rowData;
+              return ArrayUtils.ifTheSameElseDefault(lines, 'packSize', '');
+            } else {
+              return rowData.packSize;
+            }
+          },
+        },
+      ]
+    );
+  }
+
+  columns.push(
+    [
+      'numberOfPacks',
+      {
+        Cell: NumberCell,
         accessor: ({ rowData }) => {
           if ('lines' in rowData) {
-            return c(
-              Object.values(rowData.lines).reduce(
-                (sum, batch) =>
-                  sum + (batch.sellPricePerPack ?? 0) / batch.packSize,
-                0
-              )
-            ).format();
+            const { lines } = rowData;
+            return ArrayUtils.getSum(lines, 'numberOfPacks');
           } else {
-            return c(
-              (rowData.sellPricePerPack ?? 0) / rowData.packSize
-            ).format();
+            return rowData.numberOfPacks;
           }
         },
         getSortValue: rowData => {
           if ('lines' in rowData) {
-            return c(
-              Object.values(rowData.lines).reduce(
-                (sum, batch) =>
-                  sum + (batch.sellPricePerPack ?? 0) / batch.packSize,
-                0
-              )
-            ).format();
+            const { lines } = rowData;
+            return ArrayUtils.getSum(lines, 'numberOfPacks');
           } else {
-            return c(
-              (rowData.sellPricePerPack ?? 0) / rowData.packSize
-            ).format();
+            return rowData.numberOfPacks;
           }
         },
       },
+    ],
+    [
+      'unitQuantity',
       {
-        label: 'label.line-total',
-        key: 'lineTotal',
-        align: ColumnAlign.Right,
         accessor: ({ rowData }) => {
           if ('lines' in rowData) {
-            return c(
-              Object.values(rowData.lines).reduce(
-                (sum, batch) =>
-                  sum + batch.sellPricePerPack * batch.numberOfPacks,
-                0
-              )
-            ).format();
+            const { lines } = rowData;
+            return ArrayUtils.getUnitQuantity(lines);
           } else {
-            const x = c(
-              rowData.sellPricePerPack * rowData.numberOfPacks
-            ).format();
-            return x;
+            return getUnitQuantity(rowData);
           }
         },
-        getSortValue: row => {
-          if ('lines' in row) {
-            return c(
-              Object.values(row.lines).reduce(
-                (sum, batch) =>
-                  sum + batch.sellPricePerPack * batch.numberOfPacks,
-                0
-              )
-            ).format();
+        getSortValue: rowData => {
+          if ('lines' in rowData) {
+            const { lines } = rowData;
+            return ArrayUtils.getUnitQuantity(lines);
           } else {
-            const x = c(row.sellPricePerPack * row.numberOfPacks).format();
-            return x;
+            return getUnitQuantity(rowData);
           }
         },
       },
-      expansionColumn,
-      GenericColumnKey.Selection,
     ],
-    { onChangeSortBy, sortBy },
-    [sortBy]
+    {
+      label: 'label.unit-price',
+      key: 'sellPricePerUnit',
+      align: ColumnAlign.Right,
+      accessor: ({ rowData }) => {
+        if ('lines' in rowData) {
+          return c(
+            Object.values(rowData.lines).reduce(
+              (sum, batch) =>
+                sum + (batch.sellPricePerPack ?? 0) / batch.packSize,
+              0
+            )
+          ).format();
+        } else {
+          return c((rowData.sellPricePerPack ?? 0) / rowData.packSize).format();
+        }
+      },
+      getSortValue: rowData => {
+        if ('lines' in rowData) {
+          return c(
+            Object.values(rowData.lines).reduce(
+              (sum, batch) =>
+                sum + (batch.sellPricePerPack ?? 0) / batch.packSize,
+              0
+            )
+          ).format();
+        } else {
+          return c((rowData.sellPricePerPack ?? 0) / rowData.packSize).format();
+        }
+      },
+    },
+    {
+      label: 'label.line-total',
+      key: 'lineTotal',
+      align: ColumnAlign.Right,
+      accessor: ({ rowData }) => {
+        if ('lines' in rowData) {
+          return c(
+            Object.values(rowData.lines).reduce(
+              (sum, batch) =>
+                sum + batch.sellPricePerPack * batch.numberOfPacks,
+              0
+            )
+          ).format();
+        } else {
+          const x = c(
+            rowData.sellPricePerPack * rowData.numberOfPacks
+          ).format();
+          return x;
+        }
+      },
+      getSortValue: row => {
+        if ('lines' in row) {
+          return c(
+            Object.values(row.lines).reduce(
+              (sum, batch) =>
+                sum + batch.sellPricePerPack * batch.numberOfPacks,
+              0
+            )
+          ).format();
+        } else {
+          const x = c(row.sellPricePerPack * row.numberOfPacks).format();
+          return x;
+        }
+      },
+    },
+    expansionColumn,
+    GenericColumnKey.Selection
   );
+
+  return useColumns(columns, { onChangeSortBy, sortBy }, [sortBy]);
 };
 
 export const useExpansionColumns = (): Column<OutboundReturnLineFragment>[] =>

--- a/client/packages/invoices/src/Returns/OutboundDetailView/columns.ts
+++ b/client/packages/invoices/src/Returns/OutboundDetailView/columns.ts
@@ -16,7 +16,7 @@ import { OutboundReturnLineFragment } from '../api';
 import { OutboundReturnItem } from '../../types';
 import {
   getPackVariantCell,
-  usePackVariantsEnabled,
+  useIsPackVariantsEnabled,
 } from '@openmsupply-client/system';
 
 interface UseOutboundColumnOptions {
@@ -43,7 +43,7 @@ export const useOutboundReturnColumns = ({
   const { c } = useCurrency();
   const { getColumnProperty, getColumnPropertyAsString } = useColumnUtils();
 
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
 
   const columns: ColumnDescription<
     OutboundReturnLineFragment | OutboundReturnItem
@@ -150,7 +150,7 @@ export const useOutboundReturnColumns = ({
     //   ],
   ];
 
-  if (packVariantsEnabled) {
+  if (isPackVariantsEnabled) {
     columns.push({
       key: 'packUnit',
       label: 'label.pack',

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
@@ -13,7 +13,7 @@ import {
 import {
   PACK_VARIANT_ENTRY_CELL_MIN_WIDTH,
   PackVariantEntryCell,
-  usePackVariantsEnabled,
+  useIsPackVariantsEnabled,
 } from '@openmsupply-client/system';
 import React from 'react';
 import { GenerateInboundReturnLineFragment } from '../../api';
@@ -29,7 +29,7 @@ export const QuantityReturnedTableComponent = ({
   ) => void;
   isDisabled: boolean;
 }) => {
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
   const columns = useColumns<GenerateInboundReturnLineFragment>(
     [
       'itemCode',
@@ -64,7 +64,7 @@ export const QuantityReturnedTableComponent = ({
         Cell: PackUnitEntryCell,
         setter: updateLine,
         getIsDisabled: () => isDisabled,
-        ...(packVariantsEnabled
+        ...(isPackVariantsEnabled
           ? {
               label: 'label.unit-variant-and-pack-size',
               minWidth: PACK_VARIANT_ENTRY_CELL_MIN_WIDTH,

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
@@ -13,6 +13,7 @@ import {
 import {
   PACK_VARIANT_ENTRY_CELL_MIN_WIDTH,
   PackVariantEntryCell,
+  usePackVariantsEnabled,
 } from '@openmsupply-client/system';
 import React from 'react';
 import { GenerateInboundReturnLineFragment } from '../../api';
@@ -28,6 +29,7 @@ export const QuantityReturnedTableComponent = ({
   ) => void;
   isDisabled: boolean;
 }) => {
+  const packVariantsEnabled = usePackVariantsEnabled();
   const columns = useColumns<GenerateInboundReturnLineFragment>(
     [
       'itemCode',
@@ -62,8 +64,12 @@ export const QuantityReturnedTableComponent = ({
         Cell: PackUnitEntryCell,
         setter: updateLine,
         getIsDisabled: () => isDisabled,
-        label: 'label.unit-variant-and-pack-size',
-        minWidth: PACK_VARIANT_ENTRY_CELL_MIN_WIDTH,
+        ...(packVariantsEnabled
+          ? {
+              label: 'label.unit-variant-and-pack-size',
+              minWidth: PACK_VARIANT_ENTRY_CELL_MIN_WIDTH,
+            }
+          : { label: 'label.pack-size' }),
       }),
       ...(lines.some(l => l.numberOfPacksIssued !== null) // if any line has a value, show the column
         ? ([
@@ -107,8 +113,8 @@ export const QuantityReturnedTableComponent = ({
 export const QuantityReturnedTable = React.memo(QuantityReturnedTableComponent);
 
 // Input cells can't be defined inline, otherwise they lose focus on re-render
-// eslint-disable-next-line new-cap
 const PackUnitEntryCell =
+  // eslint-disable-next-line new-cap
   PackVariantEntryCell<GenerateInboundReturnLineFragment>({
     getItemId: r => r.item.id,
     getUnitName: r => r.item.unitName || null,

--- a/client/packages/invoices/src/Returns/modals/OutboundReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/OutboundReturn/ReturnQuantitiesTable.tsx
@@ -7,7 +7,7 @@ import {
 } from '@openmsupply-client/common';
 import {
   getPackVariantCell,
-  usePackVariantsEnabled,
+  useIsPackVariantsEnabled,
 } from '@openmsupply-client/system';
 import React from 'react';
 import { GenerateOutboundReturnLineFragment } from '../../api';
@@ -23,7 +23,7 @@ export const QuantityToReturnTableComponent = ({
   ) => void;
   isDisabled: boolean;
 }) => {
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
 
   const columnDescriptions: ColumnDescription<GenerateOutboundReturnLineFragment>[] =
     [
@@ -34,7 +34,7 @@ export const QuantityToReturnTableComponent = ({
       'expiryDate',
     ];
 
-  if (packVariantsEnabled) {
+  if (isPackVariantsEnabled) {
     columnDescriptions.push({
       key: 'packUnit',
       label: 'label.pack',

--- a/client/packages/invoices/src/Returns/modals/OutboundReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/OutboundReturn/ReturnQuantitiesTable.tsx
@@ -3,8 +3,12 @@ import {
   NumberInputCell,
   useColumns,
   CellProps,
+  ColumnDescription,
 } from '@openmsupply-client/common';
-import { getPackVariantCell } from '@openmsupply-client/system';
+import {
+  getPackVariantCell,
+  usePackVariantsEnabled,
+} from '@openmsupply-client/system';
 import React from 'react';
 import { GenerateOutboundReturnLineFragment } from '../../api';
 
@@ -19,42 +23,62 @@ export const QuantityToReturnTableComponent = ({
   ) => void;
   isDisabled: boolean;
 }) => {
-  const columns = useColumns<GenerateOutboundReturnLineFragment>(
+  const packVariantsEnabled = usePackVariantsEnabled();
+
+  const columnDescriptions: ColumnDescription<GenerateOutboundReturnLineFragment>[] =
     [
       'itemCode',
       'itemName',
-      // 'itemUnit', // not implemented for now
       // 'location',
       'batch',
       'expiryDate',
+    ];
+
+  if (packVariantsEnabled) {
+    columnDescriptions.push({
+      key: 'packUnit',
+      label: 'label.pack',
+      sortable: false,
+      // eslint-disable-next-line new-cap
+      Cell: getPackVariantCell({
+        getItemId: row => row.item.id,
+        getPackSizes: row => [row.packSize],
+        getUnitName: row => row.item.unitName || null,
+      }),
+    });
+  } else {
+    columnDescriptions.push(
+      [
+        'itemUnit',
+        {
+          accessor: ({ rowData }) => rowData.item.unitName ?? '',
+        },
+      ],
+      'packSize'
+    );
+  }
+
+  columnDescriptions.push(
+    [
+      'availableNumberOfPacks',
       {
-        key: 'packUnit',
-        label: 'label.pack',
-        sortable: false,
-        // eslint-disable-next-line new-cap
-        Cell: getPackVariantCell({
-          getItemId: row => row.item.id,
-          getPackSizes: row => [row.packSize],
-          getUnitName: row => row.item.unitName || null,
-        }),
+        description: 'description.pack-quantity',
       },
-      [
-        'availableNumberOfPacks',
-        {
-          description: 'description.pack-quantity',
-        },
-      ],
-      [
-        'numberOfPacksToReturn',
-        {
-          description: 'description.pack-quantity',
-          width: 100,
-          setter: updateLine,
-          getIsDisabled: () => isDisabled,
-          Cell: NumberOfPacksToReturnReturnInputCell,
-        },
-      ],
     ],
+    [
+      'numberOfPacksToReturn',
+      {
+        description: 'description.pack-quantity',
+        width: 100,
+        setter: updateLine,
+        getIsDisabled: () => isDisabled,
+        Cell: NumberOfPacksToReturnReturnInputCell,
+      },
+    ]
+  );
+
+  const columns = useColumns<GenerateOutboundReturnLineFragment>(
+    columnDescriptions,
     {},
     [updateLine, lines]
   );

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
@@ -16,7 +16,7 @@ import {
   ItemRowWithStatsFragment,
   VariantControl,
   PackVariantSelect,
-  usePackVariantsEnabled,
+  useIsPackVariantsEnabled,
 } from '@openmsupply-client/system';
 import { useRequest } from '../../api';
 import { DraftRequestLine } from './hooks';
@@ -123,9 +123,10 @@ export const RequestLineEditForm = ({
     ({ item }) => item.id === currentItem?.id
   )?.itemName;
 
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
 
-  const isPacksEnabled = !packVariantsEnabled && !!currentItem?.defaultPackSize;
+  const isPacksEnabled =
+    !isPackVariantsEnabled && !!currentItem?.defaultPackSize;
   const [isPacks, setIsPacks] = useState(isPacksEnabled);
 
   return (

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEditForm.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEditForm.tsx
@@ -106,6 +106,8 @@ export const ResponseLineEditForm = ({
               label={t('label.pack')}
               value={variantsControl.activeVariant.longName}
             />
+          ) : item.unitName ? (
+            <InfoRow label={t('label.unit')} value={item.unitName} />
           ) : null}
         </>
       }

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
@@ -13,7 +13,7 @@ import { ResponseLineFragment, useResponse } from './../api';
 import {
   PackVariantQuantityCell,
   usePackVariant,
-  usePackVariantsEnabled,
+  useIsPackVariantsEnabled,
 } from '@openmsupply-client/system';
 
 export const useResponseColumns = () => {
@@ -22,7 +22,7 @@ export const useResponseColumns = () => {
     queryParams: { sortBy },
   } = useUrlQueryParams({ initialSort: { key: 'itemName', dir: 'asc' } });
   const { isRemoteAuthorisation } = useResponse.utils.isRemoteAuthorisation();
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
 
   const columnDefinitions: ColumnDescription<ResponseLineFragment>[] = [
     getCommentPopoverColumn(),
@@ -44,7 +44,7 @@ export const useResponseColumns = () => {
     ],
     {
       key: 'packUnit',
-      label: packVariantsEnabled ? 'label.pack' : 'label.unit',
+      label: isPackVariantsEnabled ? 'label.pack' : 'label.unit',
       sortable: false,
       accessor: ({ rowData }) => {
         // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
@@ -13,6 +13,7 @@ import { ResponseLineFragment, useResponse } from './../api';
 import {
   PackVariantQuantityCell,
   usePackVariant,
+  usePackVariantsEnabled,
 } from '@openmsupply-client/system';
 
 export const useResponseColumns = () => {
@@ -21,6 +22,8 @@ export const useResponseColumns = () => {
     queryParams: { sortBy },
   } = useUrlQueryParams({ initialSort: { key: 'itemName', dir: 'asc' } });
   const { isRemoteAuthorisation } = useResponse.utils.isRemoteAuthorisation();
+  const packVariantsEnabled = usePackVariantsEnabled();
+
   const columnDefinitions: ColumnDescription<ResponseLineFragment>[] = [
     getCommentPopoverColumn(),
     [
@@ -41,7 +44,7 @@ export const useResponseColumns = () => {
     ],
     {
       key: 'packUnit',
-      label: 'label.pack',
+      label: packVariantsEnabled ? 'label.pack' : 'label.unit',
       sortable: false,
       accessor: ({ rowData }) => {
         // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/client/packages/system/src/Item/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Item/DetailView/DetailView.tsx
@@ -13,7 +13,7 @@ import { useItem } from '../api';
 import { Toolbar } from './Toolbar';
 import { GeneralTab } from './Tabs/General';
 import { MasterListsTab } from './Tabs/MasterLists';
-import { AppRoute } from '@openmsupply-client/config';
+import { AppRoute, Environment } from '@openmsupply-client/config';
 import { usePackVariant } from '../context';
 import { PackVariantsTab } from './Tabs/PackVariants';
 
@@ -42,11 +42,13 @@ export const ItemDetailView: FC = () => {
       Component: <MasterListsTab />,
       value: t('label.master-lists'),
     },
-    {
+  ];
+
+  Environment.FEATURE_PACK_VARIANTS &&
+    tabs.push({
       Component: <PackVariantsTab itemId={data.id} />,
       value: t('label.pack-variants'),
-    },
-  ];
+    });
 
   return !!data ? (
     <Box style={{ width: '100%' }}>

--- a/client/packages/system/src/Item/context/usePackVariant.ts
+++ b/client/packages/system/src/Item/context/usePackVariant.ts
@@ -69,6 +69,13 @@ export const useRefreshPackVariant = () => {
   }, [data, setItems]);
 };
 
+export const usePackVariantsEnabled = () => {
+  // return Environment.FEATURE_PACK_VARIANTS;
+  const { items } = usePackVariantStore();
+  // If any pack variants are defined, then pack variants feature is enabled
+  return Object.keys(items).length > 0;
+};
+
 export const usePackVariant = (
   itemId: string,
   variantName: string | null
@@ -92,7 +99,9 @@ export const usePackVariant = (
   const UserSelectedPackVariantId = UserSelectedPackVariant?.[itemId];
   const item = usePackVariantStore(state => state.items[itemId], isEqual);
 
-  if (!item || item.packVariants.length == 0) {
+  const packVariantsEnabled = usePackVariantsEnabled();
+
+  if (!packVariantsEnabled || !item || item.packVariants.length == 0) {
     return {
       asPackVariant: (packSize, defaultPackVariant) =>
         commonAsPackVariant({ packSize, variantName, t, defaultPackVariant }),

--- a/client/packages/system/src/Item/context/usePackVariant.ts
+++ b/client/packages/system/src/Item/context/usePackVariant.ts
@@ -4,6 +4,7 @@ import { PackVariantFragment, VariantFragment, usePackVariants } from '../api';
 import { ArrayUtils, NumUtils, isEqual } from '@common/utils';
 import { LocaleKey, TypedTFunction, useTranslation } from '@common/intl';
 import { useAuthContext, useLocalStorage } from '@openmsupply-client/common';
+import { Environment } from '@openmsupply-client/config';
 
 interface PackVariantState {
   // From back end
@@ -70,9 +71,12 @@ export const useRefreshPackVariant = () => {
 };
 
 export const usePackVariantsEnabled = () => {
-  const { items } = usePackVariantStore();
-  // If any pack variants are defined, then pack variants feature is enabled
-  return Object.keys(items).length > 0;
+  // For now, we are using a feature flag to enable pack variants
+  return Environment.FEATURE_PACK_VARIANTS;
+
+  // const { items } = usePackVariantStore();
+  // // If any pack variants are defined, then pack variants feature is enabled
+  // return Object.keys(items).length > 0;
 };
 
 export const usePackVariant = (

--- a/client/packages/system/src/Item/context/usePackVariant.ts
+++ b/client/packages/system/src/Item/context/usePackVariant.ts
@@ -70,7 +70,7 @@ export const useRefreshPackVariant = () => {
   }, [data, setItems]);
 };
 
-export const usePackVariantsEnabled = () => {
+export const useIsPackVariantsEnabled = () => {
   // For now, we are using a feature flag to enable pack variants
   return Environment.FEATURE_PACK_VARIANTS;
 
@@ -102,9 +102,9 @@ export const usePackVariant = (
   const UserSelectedPackVariantId = UserSelectedPackVariant?.[itemId];
   const item = usePackVariantStore(state => state.items[itemId], isEqual);
 
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
 
-  if (!packVariantsEnabled || !item || item.packVariants.length == 0) {
+  if (!isPackVariantsEnabled || !item || item.packVariants.length == 0) {
     return {
       asPackVariant: (packSize, defaultPackVariant) =>
         commonAsPackVariant({ packSize, variantName, t, defaultPackVariant }),

--- a/client/packages/system/src/Item/context/usePackVariant.ts
+++ b/client/packages/system/src/Item/context/usePackVariant.ts
@@ -70,7 +70,6 @@ export const useRefreshPackVariant = () => {
 };
 
 export const usePackVariantsEnabled = () => {
-  // return Environment.FEATURE_PACK_VARIANTS;
   const { items } = usePackVariantStore();
   // If any pack variants are defined, then pack variants feature is enabled
   return Object.keys(items).length > 0;

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -21,7 +21,11 @@ import {
 } from '@openmsupply-client/common';
 import { StockLineRowFragment } from '../api';
 import { LocationSearchInput } from '../../Location/Components/LocationSearchInput';
-import { PackVariantInput, usePackVariant } from '../..';
+import {
+  PackVariantInput,
+  usePackVariant,
+  usePackVariantsEnabled,
+} from '../..';
 import { StyledInputRow } from './StyledInputRow';
 
 interface StockLineFormProps {
@@ -45,6 +49,7 @@ export const StockLineForm: FC<StockLineFormProps> = ({
     : t('message.no-supplier');
   const location = draft?.location ?? null;
 
+  const packVariantsEnabled = usePackVariantsEnabled();
   const { asPackVariant } = usePackVariant(
     draft.itemId,
     draft.item.unitName ?? null
@@ -171,7 +176,7 @@ export const StockLineForm: FC<StockLineFormProps> = ({
       >
         {packEditable ? (
           <StyledInputRow
-            label={t('label.pack')}
+            label={packVariantsEnabled ? t('label.pack') : t('label.pack-size')}
             Input={
               <PackVariantInput
                 isDisabled={!packEditable}
@@ -184,8 +189,8 @@ export const StockLineForm: FC<StockLineFormProps> = ({
           />
         ) : (
           <TextWithLabelRow
-            label={t('label.pack')}
-            text={String(packUnit)}
+            label={packVariantsEnabled ? t('label.pack') : t('label.pack-size')}
+            text={String(packVariantsEnabled ? packUnit : draft.packSize)}
             textProps={{ textAlign: 'end' }}
           />
         )}

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -24,7 +24,7 @@ import { LocationSearchInput } from '../../Location/Components/LocationSearchInp
 import {
   PackVariantInput,
   usePackVariant,
-  usePackVariantsEnabled,
+  useIsPackVariantsEnabled,
 } from '../..';
 import { StyledInputRow } from './StyledInputRow';
 
@@ -49,7 +49,7 @@ export const StockLineForm: FC<StockLineFormProps> = ({
     : t('message.no-supplier');
   const location = draft?.location ?? null;
 
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
   const { asPackVariant } = usePackVariant(
     draft.itemId,
     draft.item.unitName ?? null
@@ -176,7 +176,9 @@ export const StockLineForm: FC<StockLineFormProps> = ({
       >
         {packEditable ? (
           <StyledInputRow
-            label={packVariantsEnabled ? t('label.pack') : t('label.pack-size')}
+            label={
+              isPackVariantsEnabled ? t('label.pack') : t('label.pack-size')
+            }
             Input={
               <PackVariantInput
                 isDisabled={!packEditable}
@@ -189,8 +191,10 @@ export const StockLineForm: FC<StockLineFormProps> = ({
           />
         ) : (
           <TextWithLabelRow
-            label={packVariantsEnabled ? t('label.pack') : t('label.pack-size')}
-            text={String(packVariantsEnabled ? packUnit : draft.packSize)}
+            label={
+              isPackVariantsEnabled ? t('label.pack') : t('label.pack-size')
+            }
+            text={String(isPackVariantsEnabled ? packUnit : draft.packSize)}
             textProps={{ textAlign: 'end' }}
           />
         )}

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -23,7 +23,7 @@ import { StockLineRowFragment, useStock } from '../api';
 import { AppBarButtons } from './AppBarButtons';
 import {
   getPackVariantCell,
-  usePackVariantsEnabled,
+  useIsPackVariantsEnabled,
 } from '@openmsupply-client/system';
 import { Toolbar } from './Toolbar';
 
@@ -53,7 +53,7 @@ const StockListComponent: FC = () => {
     first,
   };
 
-  const packVariantsEnabled = usePackVariantsEnabled();
+  const isPackVariantsEnabled = useIsPackVariantsEnabled();
   const pagination = { page, first, offset };
   const t = useTranslation('inventory');
   const { data, isLoading, isError } = useStock.line.list(queryParams);
@@ -87,7 +87,7 @@ const StockListComponent: FC = () => {
   );
 
   const packSizeAndUnitColumns: ColumnDescription<StockLineRowFragment>[] =
-    packVariantsEnabled
+    isPackVariantsEnabled
       ? [
           {
             key: 'packUnit',

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -21,7 +21,10 @@ import {
 import { RepackModal, StockLineEditModal } from '../Components';
 import { StockLineRowFragment, useStock } from '../api';
 import { AppBarButtons } from './AppBarButtons';
-import { getPackVariantCell } from '@openmsupply-client/system';
+import {
+  getPackVariantCell,
+  usePackVariantsEnabled,
+} from '@openmsupply-client/system';
 import { Toolbar } from './Toolbar';
 
 const StockListComponent: FC = () => {
@@ -50,6 +53,7 @@ const StockListComponent: FC = () => {
     first,
   };
 
+  const packVariantsEnabled = usePackVariantsEnabled();
   const pagination = { page, first, offset };
   const t = useTranslation('inventory');
   const { data, isLoading, isError } = useStock.line.list(queryParams);
@@ -81,6 +85,34 @@ const StockListComponent: FC = () => {
       }}
     />
   );
+
+  const packSizeAndUnitColumns: ColumnDescription<StockLineRowFragment>[] =
+    packVariantsEnabled
+      ? [
+          {
+            key: 'packUnit',
+            label: 'label.pack',
+            sortable: false,
+            Cell: getPackVariantCell({
+              getItemId: r => r.itemId,
+              getPackSizes: r => [r.packSize],
+              getUnitName: r => r.item.unitName || null,
+            }),
+            width: 130,
+          },
+        ]
+      : [
+          [
+            'itemUnit',
+            {
+              accessor: ({ rowData }) => rowData.item.unitName,
+              sortable: false,
+              Cell: TooltipTextCell,
+              width: 75,
+            },
+          ],
+          ['packSize', { Cell: TooltipTextCell, width: 125 }],
+        ];
 
   const columnDefinitions: ColumnDescription<StockLineRowFragment>[] = [
     {
@@ -123,17 +155,7 @@ const StockListComponent: FC = () => {
         accessor: ({ rowData }) => rowData.location?.code,
       },
     ],
-    {
-      key: 'packUnit',
-      label: 'label.pack',
-      sortable: false,
-      Cell: getPackVariantCell({
-        getItemId: r => r.itemId,
-        getPackSizes: r => [r.packSize],
-        getUnitName: r => r.item.unitName || null,
-      }),
-      width: 130,
-    },
+    ...packSizeAndUnitColumns,
     [
       'numberOfPacks',
       {

--- a/server/service/src/pack_variant/query.rs
+++ b/server/service/src/pack_variant/query.rs
@@ -1,13 +1,15 @@
 use std::collections::HashMap;
 
-use repository::{
-    EqualFilter, PackVariantFilter, PackVariantRepository, PackVariantRow, RepositoryError,
-    StockLineFilter, StockLineRepository, StockOnHandFilter, StockOnHandRepository,
-};
+use repository::{PackVariantFilter, PackVariantRepository, PackVariantRow, RepositoryError};
 
 use crate::service_provider::ServiceContext;
 
 use super::ItemPackVariant;
+
+// [29-04-24] - Pack Variant feature is currently behind a feature flag in the UI.
+// Unsure if the `most used variant` logic has performance issues, so commenting it out for now.
+// To be revisited when the feature is enabled.
+// See this issue for more details: https://github.com/msupply-foundation/open-msupply/issues/3684#issuecomment-2081831450
 
 // TODO should only search for items with active variants
 // TODO should use SQL aggregate functions
@@ -16,42 +18,43 @@ use super::ItemPackVariant;
 /// used pack unit for each item (see ItemPackVariant return type).
 pub fn get_pack_variants(ctx: &ServiceContext) -> Result<Vec<ItemPackVariant>, RepositoryError> {
     let connection = &ctx.connection;
-    let store_id = &ctx.store_id;
+    // let store_id = &ctx.store_id;
 
-    let stock_lines = StockLineRepository::new(connection).query_by_filter(
-        StockLineFilter::new().store_id(EqualFilter::equal_to(store_id)),
-        None,
-    )?;
-    let stock_on_hand = StockOnHandRepository::new(connection).query(Some(
-        StockOnHandFilter::new().store_id(EqualFilter::equal_to(store_id)),
-    ))?;
+    // let stock_lines = StockLineRepository::new(connection).query_by_filter(
+    //     StockLineFilter::new().store_id(EqualFilter::equal_to(store_id)),
+    //     None,
+    // )?;
+    // let stock_on_hand = StockOnHandRepository::new(connection).query(Some(
+    //     StockOnHandFilter::new().store_id(EqualFilter::equal_to(store_id)),
+    // ))?;
     let pack_variants = PackVariantRepository::new(connection)
         .query_by_filter(PackVariantFilter::new().is_active(true))?;
 
     // Calculate the most used variant for each item and pack size by total number of packs
     // if item has stock on hand else by empty line count. HashMap keys are (item_id, pack_size)
     // for easier management.
-    let mut total_number_of_packs: HashMap<(String, i32), f64> = HashMap::new();
-    let mut total_number_of_lines: HashMap<(String, i32), f64> = HashMap::new();
-    for stock_line in stock_lines {
-        let item_id = stock_line.item_row.id.clone();
-        let pack_size = stock_line.stock_line_row.pack_size;
 
-        if stock_on_hand
-            .iter()
-            .any(|s| s.item_id == item_id && s.available_stock_on_hand != 0)
-        {
-            total_number_of_packs
-                .entry((item_id, pack_size))
-                .and_modify(|e| *e += stock_line.stock_line_row.total_number_of_packs)
-                .or_insert(0.0);
-        } else {
-            total_number_of_lines
-                .entry((item_id, pack_size))
-                .and_modify(|e| *e += 1.0)
-                .or_insert(0.0);
-        }
-    }
+    // let mut total_number_of_packs: HashMap<(String, i32), f64> = HashMap::new();
+    // let mut total_number_of_lines: HashMap<(String, i32), f64> = HashMap::new();
+    // for stock_line in stock_lines {
+    //     let item_id = stock_line.item_row.id.clone();
+    //     let pack_size = stock_line.stock_line_row.pack_size;
+
+    //     if stock_on_hand
+    //         .iter()
+    //         .any(|s| s.item_id == item_id && s.available_stock_on_hand != 0)
+    //     {
+    //         total_number_of_packs
+    //             .entry((item_id, pack_size))
+    //             .and_modify(|e| *e += stock_line.stock_line_row.total_number_of_packs)
+    //             .or_insert(0.0);
+    //     } else {
+    //         total_number_of_lines
+    //             .entry((item_id, pack_size))
+    //             .and_modify(|e| *e += 1.0)
+    //             .or_insert(0.0);
+    //     }
+    // }
 
     // Find the most used variant id for each item based on total number of packs (if SOH) or total number of lines,
     // and group all the pack variants with their item
@@ -59,39 +62,41 @@ pub fn get_pack_variants(ctx: &ServiceContext) -> Result<Vec<ItemPackVariant>, R
     for pack_variant in pack_variants.clone() {
         let item_id = pack_variant.item_id.clone();
 
-        let most_used_pack_variant_id = pack_variants
-            .iter()
-            .filter(|p| p.item_id == item_id)
-            .max_by(|a, b| {
-                let ordering_by_packs = total_number_of_packs
-                    .get(&(a.item_id.clone(), a.pack_size))
-                    .unwrap_or(&0.0)
-                    .partial_cmp(
-                        total_number_of_packs
-                            .get(&(b.item_id.clone(), b.pack_size))
-                            .unwrap_or(&0.0),
-                    )
-                    .unwrap();
+        // let most_used_pack_variant_id = pack_variants
+        //     .iter()
+        //     .filter(|p| p.item_id == item_id)
+        //     .max_by(|a, b| {
+        //         let ordering_by_packs = total_number_of_packs
+        //             .get(&(a.item_id.clone(), a.pack_size))
+        //             .unwrap_or(&0.0)
+        //             .partial_cmp(
+        //                 total_number_of_packs
+        //                     .get(&(b.item_id.clone(), b.pack_size))
+        //                     .unwrap_or(&0.0),
+        //             )
+        //             .unwrap();
 
-                let ordering_by_lines = total_number_of_lines
-                    .get(&(a.item_id.clone(), a.pack_size))
-                    .unwrap_or(&0.0)
-                    .partial_cmp(
-                        total_number_of_lines
-                            .get(&(b.item_id.clone(), b.pack_size))
-                            .unwrap_or(&0.0),
-                    )
-                    .unwrap();
+        //         let ordering_by_lines = total_number_of_lines
+        //             .get(&(a.item_id.clone(), a.pack_size))
+        //             .unwrap_or(&0.0)
+        //             .partial_cmp(
+        //                 total_number_of_lines
+        //                     .get(&(b.item_id.clone(), b.pack_size))
+        //                     .unwrap_or(&0.0),
+        //             )
+        //             .unwrap();
 
-                ordering_by_packs.then(ordering_by_lines)
-            })
-            .map(|p| p.id.clone())
-            .unwrap_or("".to_string());
+        //         ordering_by_packs.then(ordering_by_lines)
+        //     })
+        //     .map(|p| p.id.clone())
+        //     .unwrap_or("".to_string());
 
         pack_variants_grouped
             .entry(item_id)
             .and_modify(|e| e.1.push(pack_variant.clone()))
-            .or_insert((most_used_pack_variant_id, vec![pack_variant]));
+            // TODO: should use most_used_pack_variant_id, just using the id of the first found pack variant for now
+            .or_insert((pack_variant.id.clone(), vec![pack_variant]));
+        // .or_insert((most_used_pack_variant_id, vec![pack_variant]));
     }
 
     Ok(pack_variants_grouped


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3684

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Adds feature flagging of pack variant features.

<!-- why are the changes needed -->

As per issue... Pack Variant UI was rushed in the end, we need more time to consider if this is what we want. This PR adds a toggle for pack variant column/UI changes.

<!-- Add a screenshot if there are UI changes  -->

Pack variants enabled: 
![Screenshot 2024-04-30 at 12 59 20 PM](https://github.com/msupply-foundation/open-msupply/assets/55115239/66cada1b-0928-4508-aac7-0b0202d819f4)

Disabled:
![Screenshot 2024-04-30 at 2 20 26 PM](https://github.com/msupply-foundation/open-msupply/assets/55115239/a933aae3-ce42-4f81-93cc-424b7ac6239c)

Also when disabled, brings back the "in packs of" labels in prescription/outbound shipment edit line modal:
![Screenshot 2024-04-30 at 3 18 20 PM](https://github.com/msupply-foundation/open-msupply/assets/55115239/a2d6c366-b945-4494-bff4-51c6d60b137d)

And the packs/units toggle in Internal Order modal:
![Screenshot 2024-04-30 at 3 19 35 PM](https://github.com/msupply-foundation/open-msupply/assets/55115239/d8da7d59-220f-46a1-b65a-70212f3479a0)



Also comments out the `mostUsePackVariant` logic in the backend, as this was raised as a maybe performance issue (especially as it was running against all items even when no variants were defined..) - seeing as the UI will be hidden for now, have commented out so we don't need to investigate performance at this stage. 

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

Have added a feature flag, but this only hides the `Pack Variants` tab in the Item detail view, where a user could configure pack variants.

For the most part, I'm using a hook `usePackVariantsEnabled`, which is checking if there are any pack variants defined for any items. This should be safe in that no sites will have pack variants defined yet, so it's the same as hiding behind a feature flag. The thinking in Ruru team was that if pack variants aren't being used, the UI shouldn't change (regardless of whether pack variants is enabled as a feature). This was largely the intention of pack variant work anyways, except for the merging of the two columns. 

If that doesn't sit right, could always change the `usePackVariantsEnabled` hook to return the feature flag boolean instead 🤷‍♀️ 

Main thing I'm hoping is that this is enough to hide pack variants for this release, but it's not a complete toggle to "reverse" the changes. Am still using the pack variant default logic in most places, which looks the same as the old pack size/unit stuff. I guess just wanting to flag that if we end up deciding to abandon/back out pack variants, that's more work than just removing what's behind this flag.

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Start frontend without feature flag (ensure you have no existing pack variants configured)
- [ ] Hoon through them pages - should be just like old times, no mention of pack variants
- [ ] Should be `Pack Size` and `Unit` columns everywhere instead of `Pack`
- [ ] Outbound Shipment/Prescription/Internal order modals look as above
- [ ] Restart frontend with feature flag: `yarn start-local-features FEATURE_PACK_VARIANTS=true`
- [ ] Before configuring any pack variants, should still be separate columns
- [ ] (Running as central server) configure some pack variants for items
- [ ] Now you see one column `Pack`, it's a changeable dropdown in places like Item, `Unit Variant / Pack Size` input displays for that item in places like Inbound Shipment

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [X] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  - [ ] I know returns screenshots/column descriptions were based on pack variants enabled
  - [ ] Probably other screenshots too?? Might need a sweep of anywhere that's seen updates recently 👀 
