### PR TITLE
advance v6 push cursor after initialisation

### DIFF
--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -119,6 +119,7 @@ impl RemoteDataSynchroniser {
         let cursor = ChangelogRepository::new(connection).latest_cursor()?;
 
         CursorController::new(KeyValueType::RemoteSyncPushCursor).update(connection, cursor + 1)?;
+        CursorController::new(KeyValueType::SyncPushCursorV6).update(connection, cursor + 1)?;
         Ok(())
     }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3692

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->



Advances the v6 push cursor after initialisation. Now # of records to push on first post-initialisation sync is same for v5 and v6:
![Screenshot 2024-04-30 at 5 27 08 PM](https://github.com/msupply-foundation/open-msupply/assets/55115239/4f28ede8-0f88-4df5-b9a0-e355c87f4c03)


<!-- why are the changes needed -->

After initialisation, we were advancing the remote (v5) push cursor, but not the v6 cursor, resulting in lots of records to push to v6 on first post-initialisation sync. 

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Reinitialise remote site
- [ ] Go to sync page and click sync
- [ ] Number of records should be same for `v6 push` and `Push` (i.e. not a big number for v6 push)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
