### PR TITLE
3563 Item id isn't being sent to query to display master lists in Item detail view

### DIFF
--- a/client/packages/system/src/Item/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Item/DetailView/DetailView.tsx
@@ -39,7 +39,7 @@ export const ItemDetailView: FC = () => {
       value: t('label.general'),
     },
     {
-      Component: <MasterListsTab />,
+      Component: <MasterListsTab itemId={data.id} />,
       value: t('label.master-lists'),
     },
     {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3563

# 👩🏻‍💻 What does this PR do?
Passes item id to the master list tab in the item page. Might have disappeared during a merge conflict? 

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to `items`
- [ ] Click on an item
- [ ] Go to the `Master List` tab
- [ ] The master list associated with the item should show up

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
