### PR TITLE
Add home button to error boundary

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -138,6 +138,30 @@ Standard semver rules apply:
 2. MINOR version when you add functionality in a backwards compatible manner
 3. PATCH version when you make backwards compatible bug fixes
 
+### Error handling
+
+When running the website in development mode (e.g. `yarn start`) you will see errors are displayed, not by the error boundary, but by another screen which shows additional detail.
+If you want to see the error boundary instead (for example, when testing the boundary!) you will need to disable the dev overlay:
+
+In `/packages/host/webpack.config.js`:
+
+```
+  // update the devServer entry, to add the overlay: false
+  devServer: {
+    ...
+    client: {
+      overlay: false,
+    },
+  }
+
+  // and update the ReactRefresh plugin also:
+
+  new ReactRefreshWebpackPlugin({ overlay: false }),
+
+```
+
+There is typically no need though, as you can press escape to close the overlay and see the error boundary in action.
+
 ## Queries
 
 We're using [React Query](https://react-query.tanstack.com/overview) to query the server and manage a local cache of queries.

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -42,6 +42,7 @@
   "button.sync-now": "Sync now!",
   "button.test": "Test",
   "button.try-again": "Try again",
+  "button.home": "Home",
   "button.view": "View",
   "button.zero-line-quantity": "Set quantities to 0",
   "description.already-issued": "Quantity already issued in shipments.",

--- a/client/packages/common/src/ui/components/errors/GenericErrorFallback.tsx
+++ b/client/packages/common/src/ui/components/errors/GenericErrorFallback.tsx
@@ -1,4 +1,4 @@
-import { Box, Grid, Typography } from '@mui/material';
+import { Box, Grid, Tooltip, Typography } from '@mui/material';
 import React, { FC } from 'react';
 import { ErrorBoundaryFallbackProps } from './types';
 import { UnhappyMan } from '@common/icons';
@@ -24,14 +24,16 @@ export const GenericErrorFallback: FC<ErrorBoundaryFallbackProps> = ({
       </Typography>
       <Grid container gap={1} justifyContent="center">
         <BaseButton onClick={onClearError}>{t('button.try-again')}</BaseButton>
-        <BaseButton
-          onClick={() => {
-            onClearError;
-            window.location.href = window.location.origin;
-          }}
-        >
-          {t('button.home')}
-        </BaseButton>
+        <Tooltip title={window.location.origin}>
+          <BaseButton
+            onClick={() => {
+              onClearError;
+              window.location.href = window.location.origin;
+            }}
+          >
+            {t('button.home')}
+          </BaseButton>
+        </Tooltip>
       </Grid>
     </Box>
   );

--- a/client/packages/common/src/ui/components/errors/GenericErrorFallback.tsx
+++ b/client/packages/common/src/ui/components/errors/GenericErrorFallback.tsx
@@ -1,15 +1,14 @@
-import { Box, Typography } from '@mui/material';
+import { Box, Grid, Typography } from '@mui/material';
 import React, { FC } from 'react';
 import { ErrorBoundaryFallbackProps } from './types';
 import { UnhappyMan } from '@common/icons';
-import { useTranslation } from '@common/intl';
 import { BaseButton } from '../buttons';
+import { useTranslation } from '@openmsupply-client/common';
 
 export const GenericErrorFallback: FC<ErrorBoundaryFallbackProps> = ({
   onClearError,
 }) => {
   const t = useTranslation();
-
   return (
     <Box
       display="flex"
@@ -23,7 +22,17 @@ export const GenericErrorFallback: FC<ErrorBoundaryFallbackProps> = ({
       <Typography style={{ padding: 20 }} variant="h3">
         {t('error.something-wrong')}
       </Typography>
-      <BaseButton onClick={onClearError}>{t('button.try-again')}</BaseButton>
+      <Grid container gap={1} justifyContent="center">
+        <BaseButton onClick={onClearError}>{t('button.try-again')}</BaseButton>
+        <BaseButton
+          onClick={() => {
+            onClearError;
+            window.location.href = window.location.origin;
+          }}
+        >
+          {t('button.home')}
+        </BaseButton>
+      </Grid>
     </Box>
   );
 };


### PR DESCRIPTION
Fixes #3515 

# 👩🏻‍💻 What does this PR do?
Adds link to navigate back to home from error

## 💌 Any notes for the reviewer?

# 🧪 Testing

I was a bit dissatisfied with working through how to test this because a lot of errors thrown will not be caught by our error handler. 

A future issue could be more comprehensive error catching with this provider.

@Roxy I wonder how you were able to trigger the error in this way? 

Regardless this will allow users to navigate back to home where their current url triggers the error for whatever reason.