### PR TITLE
3704-Fix-fully-issued-lines-dissapearing-in-outbound-shipment

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
@@ -33,31 +33,33 @@ export const useDraftOutboundLines = (
   const [draftStockOutLines, setDraftStockOutLines] = useState<
     DraftStockOutLine[]
   >([]);
-  const noStockLines = !data?.nodes.length;
 
   useConfirmOnLeaving(isDirty);
 
   useEffect(() => {
     // Check placed in since last else in the map is needed to show placeholder row,
     // but also causes a placeholder row to be created when there is no stock lines.
-    if (!item || noStockLines) {
+    if (!item) {
       return setDraftStockOutLines([]);
     }
 
     if (!data) return;
 
-    setDraftStockOutLines(() => {
-      // Stocklines (date.nodes) are coming from availableStockLines from itemNode
-      // these are filtered by totalNumberOfPacks > 0 but it's possible to issue all of the packs
-      // from the batch in picked status, need to make sure these are not hidden
-      const invoiceLineStockLines = (lines ?? []).flatMap(l =>
-        l.stockLine ? [l.stockLine] : []
-      );
-      const stockLines = uniqBy(
-        [...data.nodes, ...invoiceLineStockLines],
-        'id'
-      );
+    // Stocklines (date.nodes) are coming from availableStockLines from itemNode
+    // these are filtered by totalNumberOfPacks > 0 but it's possible to issue all of the packs
+    // from the batch in picked status, need to make sure these are not hidden
+    const invoiceLineStockLines = (lines ?? []).flatMap(l =>
+      l.stockLine ? [l.stockLine] : []
+    );
+    const stockLines = uniqBy([...data.nodes, ...invoiceLineStockLines], 'id');
 
+    const noStockLines = stockLines.length == 0;
+
+    if (noStockLines) {
+      return setDraftStockOutLines([]);
+    }
+
+    setDraftStockOutLines(() => {
       const rows = stockLines
         .map(batch => {
           const invoiceLine = lines?.find(

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
@@ -45,7 +45,7 @@ export const useDraftOutboundLines = (
 
     if (!data) return;
 
-    // Stocklines (data.nodes) are coming from availableStockLines from itemNode
+    // Stock lines (data.nodes) are coming from availableStockLines from itemNode
     // these are filtered by totalNumberOfPacks > 0 but it's possible to issue all of the packs
     // from the batch in picked status, need to make sure these are not hidden
     const invoiceLineStockLines = (lines ?? []).flatMap(l =>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3704

# 👩🏻‍💻 What does this PR do? 

Combined stock lines frmo invoice lines with stock lines from item availableStockLines (which filters out totalNumberOfPack == 0) when creating draftLines in OS line edit

# 🧪 How has/should this change been tested? 

1. Create an `Outbound Shipment` 
2. Add invoice line
3. Issue all stock from stock line
4. Change status to `Picked`
5. Go back to invoice line
6. See that stock line has disappeared

Also it's good to check that no duplicate lines appear in OS line edit. Issue some stock in new status and refresh page