### PR TITLE
Fix onClick callback handling

### DIFF
--- a/client/packages/system/src/ContactTrace/DetailView/Footer.tsx
+++ b/client/packages/system/src/ContactTrace/DetailView/Footer.tsx
@@ -78,7 +78,7 @@ export const Footer: FC<FooterProps> = ({
               variant="outlined"
               disabled={isDisabled || isSaving}
               isLoading={isSaving}
-              onClick={onSave}
+              onClick={() => onSave()}
               startIcon={<CheckIcon />}
             >
               {t('button.save')}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3584 

# 👩🏻‍💻 What does this PR do?

Use onClick callback correctly. Bit tricky one because this is not obvious.

From commit message:
```
onClick has an event parameter, this parameter got silently passed
forward to the onSave method which interpreted it as a boolean.
```

Maybe a good practice it s to not pass "function pointers" around but always create a new arrow method and call the target manually? @mark-prins 