### PR TITLE
#3536 Prescription input quantity fix

### DIFF
--- a/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.test.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.test.tsx
@@ -91,4 +91,48 @@ describe('Test NumericTextInput component', () => {
     fireEvent.blur(input);
     expect(input).toHaveValue('1.100');
   });
+
+  it('should handle negative number input', async () => {
+    const { getByRole } = render(<TestNumericTextInput allowNegative />);
+    const input = getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: '-' } });
+    expect(input).toHaveValue('-');
+    fireEvent.change(input, { target: { value: '-5' } });
+    expect(input).toHaveValue('-5');
+    fireEvent.blur(input);
+    expect(input).toHaveValue('-5');
+  });
+
+  it('should handle removing input', async () => {
+    const { getByRole } = render(<TestNumericTextInput />);
+    const input = getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: '500' } });
+    expect(input).toHaveValue('500');
+    fireEvent.change(input, { target: { value: '' } });
+    expect(input).toHaveValue('');
+    fireEvent.blur(input);
+    expect(input).toHaveValue('');
+  });
+
+  it('should format large numbers', async () => {
+    const { getByRole } = render(<TestNumericTextInput />);
+    const input = getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: '1000' } });
+    expect(input).toHaveValue('1,000');
+    fireEvent.blur(input);
+    expect(input).toHaveValue('1,000');
+  });
+
+  it('should not format large numbers when explicitly prevented', async () => {
+    const { getByRole } = render(<TestNumericTextInput noFormatting />);
+    const input = getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: '1000' } });
+    expect(input).toHaveValue('1000');
+    fireEvent.blur(input);
+    expect(input).toHaveValue('1000');
+  });
 });

--- a/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
@@ -55,7 +55,7 @@ export const NumericTextInput: FC<NumericTextInputProps> = React.forwardRef(
       (val: number | undefined) =>
         noFormatting
           ? val === undefined
-            ? undefined
+            ? ''
             : String(val)
           : format(val, { minimumFractionDigits: decimalMin }),
       [decimalMin, format, noFormatting]

--- a/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
@@ -67,14 +67,17 @@ export const NumericTextInput: FC<NumericTextInputProps> = React.forwardRef(
     const isFirstRender = useRef(true);
 
     const isInputIncomplete = useCallback(
-      (value: string) =>
-        new RegExp(
+      (value: string) => {
+        if (value === '-') return true;
+
+        return new RegExp(
           // Checks for a trailing `.` or a `0` (not necessarily immediately)
           // after a `.`
           `^\\d*${RegexUtils.escapeChars(
             decimal
           )}$|\\d*${RegexUtils.escapeChars(decimal)}\\d*0$`
-        ).test(value),
+        ).test(value);
+      },
       [decimal]
     );
 
@@ -164,7 +167,8 @@ export const NumericTextInput: FC<NumericTextInputProps> = React.forwardRef(
           onChange(newNum);
         }}
         onBlur={() => {
-          onChange(Number(parse(textValue ?? '')) || undefined);
+          const parsed = parse(textValue ?? '');
+          onChange(Number.isNaN(parsed) ? undefined : parsed);
           setTextValue(formatValue(value));
         }}
         onFocus={e => e.target.select()}

--- a/client/packages/host/src/Admin/LabelPrinterSettings.tsx
+++ b/client/packages/host/src/Admin/LabelPrinterSettings.tsx
@@ -106,9 +106,7 @@ export const LabelPrinterSettings = () => {
           <NumericTextInput
             value={draft.port}
             noFormatting
-            onChange={port => {
-              if (port !== undefined) onChange({ port });
-            }}
+            onChange={port => onChange({ port })}
           />
         }
         title={t('settings.printer-port')}

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
@@ -145,8 +145,8 @@ export const PrescriptionLineEditForm: React.FC<
     updateIssueQuantity(allocatedQuantity);
   };
 
-  const handleIssueQuantityChange = (quantity?: number) => {
-    if (quantity === undefined) return;
+  const handleIssueQuantityChange = (inputQuantity?: number) => {
+    const quantity = inputQuantity === undefined ? 0 : inputQuantity;
     setIssueQuantity(quantity);
     allocate(quantity, Number(packSizeController.selected?.value));
   };
@@ -240,7 +240,7 @@ export const PrescriptionLineEditForm: React.FC<
               autoFocus
               value={issueQuantity}
               onChange={handleIssueQuantityChange}
-              min={1}
+              min={0}
             />
 
             <Box marginLeft={1} />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3536

# 👩🏻‍💻 What does this PR do?

Fixed issue. Allowed quantity to be erased, but it still resets to `0` rather than empty, as it causes problems to pass `undefined` to the `allocate` method.

Also... found *another* regression with the numeric input component, which I've fixed. I've also added some more tests for this so we don't keep getting these regressions.

## 💌 Any notes for the reviewer?

See inline comments

# 🧪 Testing

## Prescription input
- [ ] Start a new prescription and add an item
- [ ] Enter a quantity
- [ ] Highlight and delete the quantity -- should revert to 0
- [ ] Try and click "OK" with 0 quantity entered -- should display warning

## Numeric input fixes
- Run `yarn test numeric` and confirm all tests pass
- If you feel like it, run `yarn storybook`, go to the Numeric inputs and check they still behave as expected

