### PR TITLE
3757 Open mSupply hangs when you order form Dashboard

### DIFF
--- a/client/packages/dashboard/src/widgets/StockWidget.tsx
+++ b/client/packages/dashboard/src/widgets/StockWidget.tsx
@@ -79,7 +79,7 @@ export const StockWidget: React.FC = () => {
                 otherPartyId,
               },
               { onError }
-            ).then(requisitionNumber => {
+            ).then(({ requisitionNumber }) => {
               navigate(
                 RouteBuilder.create(AppRoute.Replenishment)
                   .addPart(AppRoute.InternalOrder)


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3757

# 👩🏻‍💻 What does this PR do?
Pass correct requisition number when creating IO from dashboard
<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to `Dashboard`
- [ ] Click `Order more`
- [ ] Be redirected to new `Internal Order`

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
