### PR TITLE
3538 number pad for number inputs

### DIFF
--- a/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
@@ -79,7 +79,9 @@ export const BasicTextInput: FC<BasicTextInputProps> = React.forwardRef(
             },
           }}
           inputProps={
-            props.disabled ? { style: { textOverflow: 'ellipsis' } } : {}
+            props.disabled
+              ? { style: { textOverflow: 'ellipsis' } }
+              : { inputMode: props.inputMode }
           }
           {...props}
         />

--- a/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
@@ -114,6 +114,7 @@ export const NumericTextInput: FC<NumericTextInputProps> = React.forwardRef(
           '& .MuiInput-input': { textAlign: 'right', width: `${width}px` },
           ...sx,
         }}
+        inputMode="numeric"
         InputProps={InputProps}
         onChange={e => {
           const input = e.target.value


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3538

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Sets the `inputmode` for the NumericTextInput the `numeric`, so the number pad opens on tablet, rather than alphanumeric keyboard:

![Screenshot 2024-05-06 at 11 44 16 AM](https://github.com/msupply-foundation/open-msupply/assets/55115239/5aef76ba-1eeb-4448-8c7d-4934036c01fc)


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

Should fix for all number inputs...

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] On tablet/android emulator:
- [ ] Create an inbound shipment
- [ ] Add item
- [ ] Select item
- [ ] Focus # Packs
- [ ] Number pad opens!

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
