### PR TITLE
only render quantity inputs after item is set

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
@@ -51,7 +51,7 @@ const InfoRow = ({ label, value }: { label: string; value: string }) => {
 
 interface RequestLineEditFormLayoutProps {
   Left: React.ReactElement;
-  Middle: React.ReactElement;
+  Middle: React.ReactElement | null;
   Right: React.ReactElement;
   Top: React.ReactElement;
 }
@@ -280,9 +280,7 @@ export const RequestLineEditForm = ({
               />
             )}
           </>
-        ) : (
-          <></>
-        )
+        ) : null
       }
       Right={
         <>

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
@@ -210,74 +210,79 @@ export const RequestLineEditForm = ({
         </>
       }
       Middle={
-        <>
-          {isPacksEnabled && (
-            <Box display="flex" justifyContent="flex-end" alignItems="center">
-              <Switch
-                label={t('label.units')}
-                checked={isPacks}
-                onChange={(_event, checked) => setIsPacks(checked)}
-                size="small"
-              />
-              <Box paddingLeft={2} paddingRight={2}>
-                {t('label.packs')}
+        currentItem ? (
+          <>
+            {isPacksEnabled && (
+              <Box display="flex" justifyContent="flex-end" alignItems="center">
+                <Switch
+                  label={t('label.units')}
+                  checked={isPacks}
+                  onChange={(_event, checked) => setIsPacks(checked)}
+                  size="small"
+                />
+                <Box paddingLeft={2} paddingRight={2}>
+                  {t('label.packs')}
+                </Box>
               </Box>
-            </Box>
-          )}
-          <InputWithLabelRow
-            Input={
-              <NumericTextInput
-                width={100}
-                value={numberOfPacksFromQuantity(
-                  draftLine?.suggestedQuantity ?? 0
-                )}
-                disabled
-              />
-            }
-            labelWidth="750px"
-            label={t('label.suggested-quantity')}
-          />
-          <InputWithLabelRow
-            Input={
-              <NumericTextInput
-                autoFocus
-                value={numberOfPacksFromQuantity(requestedQuantity)}
-                disabled={isPacks}
-                width={100}
-                onChange={q =>
-                  update({
-                    requestedQuantity: q && numberOfPacksToTotalQuantity(q),
-                  })
-                }
-              />
-            }
-            labelWidth="750px"
-            label={t('label.order-quantity')}
-          />
-          {isPacksEnabled && (
+            )}
+            <InputWithLabelRow
+              Input={
+                <NumericTextInput
+                  width={100}
+                  value={numberOfPacksFromQuantity(
+                    draftLine?.suggestedQuantity ?? 0
+                  )}
+                  disabled
+                />
+              }
+              labelWidth="750px"
+              label={t('label.suggested-quantity')}
+            />
             <InputWithLabelRow
               Input={
                 <NumericTextInput
                   autoFocus
-                  disabled={!isPacks}
-                  value={NumUtils.round(
-                    requestedQuantity / currentItem.defaultPackSize,
-                    2
-                  )}
+                  value={numberOfPacksFromQuantity(requestedQuantity)}
+                  disabled={isPacks}
                   width={100}
-                  onChange={quantity => {
-                    if (quantity === undefined) return;
+                  onChange={q =>
                     update({
-                      requestedQuantity: quantity * currentItem.defaultPackSize,
-                    });
-                  }}
+                      requestedQuantity: q && numberOfPacksToTotalQuantity(q),
+                    })
+                  }
                 />
               }
               labelWidth="750px"
-              label={t('label.requested-packs')}
+              label={t('label.order-quantity')}
             />
-          )}
-        </>
+            {isPacksEnabled && (
+              <InputWithLabelRow
+                Input={
+                  <NumericTextInput
+                    autoFocus
+                    disabled={!isPacks}
+                    value={NumUtils.round(
+                      requestedQuantity / currentItem.defaultPackSize,
+                      2
+                    )}
+                    width={100}
+                    onChange={quantity => {
+                      if (quantity === undefined) return;
+                      update({
+                        requestedQuantity:
+                          quantity * currentItem.defaultPackSize,
+                      });
+                    }}
+                  />
+                }
+                labelWidth="750px"
+                label={t('label.requested-packs')}
+              />
+            )}
+          </>
+        ) : (
+          <></>
+        )
       }
       Right={
         <>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3393

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Conditionally render requested quantity inputs on internal order, only once item has been set. Item picker now maintains focus, with correct keyboard:

![Screenshot 2024-05-06 at 12 09 07 PM](https://github.com/msupply-foundation/open-msupply/assets/55115239/6ffd2c3f-2e93-4ab3-be8c-e68c6fe10c73)



## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

Stacked on #3763 to make it slightly easier to validate (enables number pad for numeric quantity inputs)

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Use a Samsung tablet (or even an emulator)
- [ ] Create internal order
- [ ] Click Add Item
- [ ] Item picker is in focus (blue underline) and you have the alphanumeric keyboard
- [ ] If you click off the item picker (so it closes, without selecting an item) no quantity inputs are visible
- [ ] Select an item
- [ ] Quantity inputs now appear
- [ ] From Internal Order detail view, open the edit modal for an existing line
- [ ] Quantity inputs should be visible and should autofocus (with numeric keyboard)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
