### PR TITLE
Add asset number to equipment filter

### DIFF
--- a/client/packages/coldchain/src/Equipment/ListView/Toolbar.tsx
+++ b/client/packages/coldchain/src/Equipment/ListView/Toolbar.tsx
@@ -77,8 +77,8 @@ export const Toolbar = () => {
     },
     {
       type: 'text',
-      name: t('label.code'),
-      urlParameter: 'code',
+      name: t('label.asset-number'),
+      urlParameter: 'assetNumber',
       isDefault: true,
     },
     {

--- a/client/packages/coldchain/src/Equipment/api/hooks/document/useAssets.ts
+++ b/client/packages/coldchain/src/Equipment/api/hooks/document/useAssets.ts
@@ -6,7 +6,7 @@ export const useAssets = () => {
     filters: [
       { key: 'notes' },
       { key: 'model' },
-      { key: 'code' },
+      { key: 'assetNumber' },
       { key: 'installationDate', condition: 'equalTo' },
       { key: 'replacementDate', condition: 'equalTo' },
       { key: 'serialNumber' },

--- a/client/packages/common/src/intl/locales/en/coldchain.json
+++ b/client/packages/common/src/intl/locales/en/coldchain.json
@@ -50,7 +50,6 @@
   "heading.upload-cce-documents": "Upload CCE documents",
   "label.acknowledged": "Acknowledged",
   "label.asset-notes": "Notes",
-  "label.asset-number": "Asset Number",
   "label.breach-end": "Breach end",
   "label.breach-start": "Breach start",
   "label.breach-type": "Breach type",


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3743 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
The API filter has changed from `code` to `assetNumber`. This PR adjusts the front end.
Note, I wasn't able to repro the bug as raised.

<img width="907" alt="Screenshot 2024-05-06 at 11 46 51 AM" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/70197723-c687-43b0-ab2e-908027799e48">


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Open the cold chain equipment list and try to filter by asset number

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
