### PR TITLE
3730 disable add batch button on inbound return reason step

### DIFF
--- a/client/packages/invoices/src/Returns/modals/InboundReturn/AddBatch.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/AddBatch.tsx
@@ -9,16 +9,18 @@ import { useReturns } from '../..';
 
 export const AddBatchButton = ({
   addDraftLine,
+  disabled,
 }: {
   addDraftLine: () => void;
+  disabled?: boolean;
 }) => {
   const t = useTranslation(['distribution']);
-  const isDisabled = useReturns.utils.inboundIsDisabled();
+  const returnIsDisabled = useReturns.utils.inboundIsDisabled();
 
   return (
     <Box flex={1} justifyContent="flex-end" display="flex">
       <ButtonWithIcon
-        disabled={isDisabled}
+        disabled={disabled ?? returnIsDisabled}
         color="primary"
         variant="outlined"
         onClick={addDraftLine}

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnSteps.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnSteps.tsx
@@ -68,7 +68,12 @@ export const ReturnSteps = ({
   return (
     <TabContext value={currentTab}>
       <WizardStepper activeStep={getActiveStep()} steps={returnsSteps} />
-      {addDraftLine && <AddBatchButton addDraftLine={addDraftLine} />}
+      {addDraftLine && (
+        <AddBatchButton
+          addDraftLine={addDraftLine}
+          disabled={currentTab !== Tabs.Quantity}
+        />
+      )}
       <TabPanel value={Tabs.Quantity}>
         {zeroQuantityAlert && (
           <Alert severity={zeroQuantityAlert}>{alertMessage}</Alert>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3730 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Disables the add batch button on the reason step for Inbound Returns:

![Screenshot 2024-05-06 at 12 40 47 PM](https://github.com/msupply-foundation/open-msupply/assets/55115239/0b805f96-d904-4374-882e-0fc66b457cb0)

You can't add new batches from the return step (batches with return quantity == 0 are filtered out, which any added batches would have!)

Users need to go back to the `Select quantity` step to add new batches.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a new manual inbound return
- [ ] Add an item
- [ ] Select item
- [ ] `Add batch` button is enabled
- [ ] Add at least one batch, and set a return quantity for it
- [ ] Click `Next step`
- [ ] `Add batch` button is disabled
- [ ] Click `Back`
- [ ] `Add batch` button is enabled

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Update screenshot for return reason step
