### PR TITLE
prevent duplicates

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
@@ -8,6 +8,7 @@ import {
 } from '@common/components';
 import { DateUtils, useFormatDateTime, useTranslation } from '@common/intl';
 import {
+  ArrayUtils,
   Box,
   Formatter,
   useIsCentralServerApi,
@@ -176,6 +177,9 @@ export const Summary = ({ draft, onChange, locations }: SummaryProps) => {
           <Row label={t('label.cold-storage-location')}>
             {locations ? (
               <AutocompleteMulti
+                isOptionEqualToValue={(option, value) =>
+                  option.value === value.value
+                }
                 defaultValue={defaultLocations}
                 filterSelectedOptions
                 getOptionLabel={option => option.label}
@@ -188,8 +192,8 @@ export const Summary = ({ draft, onChange, locations }: SummaryProps) => {
                   }[]
                 ) => {
                   onChange({
-                    locationIds: newSelectedLocations.map(
-                      location => location.value
+                    locationIds: ArrayUtils.dedupe(
+                      newSelectedLocations.map(location => location.value)
                     ),
                   });
                 }}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3758

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
Two fixes in here:

* Filter out duplicates of the location ids before saving the draft
* Removed duplicates from the available options

<img width="628" alt="Screenshot 2024-05-06 at 2 52 44 PM" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/457353a8-c555-4c28-9b09-60d2285054ce">



<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

One outstanding issue, which I won't fix here.
If you assign a location, save the asset; then remove the location and save; the location is no longer available to be selected from the list. Refreshing the page will repopulate the list and allow the location to be added again.

The issue here is that the Autocomplete component is managing its value internally and not updating as expected when removing. 
<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] as per the issue; try to add a location multiple times.

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
