### PR TITLE
add installation date column

### DIFF
--- a/client/packages/coldchain/src/Equipment/ListView/ListView.tsx
+++ b/client/packages/coldchain/src/Equipment/ListView/ListView.tsx
@@ -106,6 +106,10 @@ const AssetListComponent: FC = () => {
       sortable: false,
     },
     {
+      key: 'installationDate',
+      label: 'label.installation-date',
+    },
+    {
       key: 'notes',
       label: 'label.notes',
       sortable: false,

--- a/client/packages/common/src/ui/components/inputs/DatePickers/DateTimePickerInput/DateTimePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/DateTimePickerInput/DateTimePickerInput.tsx
@@ -42,7 +42,8 @@ export const DateTimePickerInput: FC<
   const t = useTranslation();
   const { getLocale } = useIntlUtils();
   const dateParseOptions = { locale: getLocale() };
-  const format = props.format ?? showTime ? 'P p' : 'P';
+  const format =
+    props.format === undefined ? (showTime ? 'P p' : 'P') : props.format;
 
   // Max/Min should be restricted by the UI, but it's not restricting TIME input
   // (only Date component). So this function will enforce the max/min after


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3744

# 👩🏻‍💻 What does this PR do?
Add the installation date column. 
As a side bonus, fixes the `DateTimePickerInput` which was not allowing manual entry of date strings

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] View the equipment list view. check that the installation date shows
- [ ] and is sortable
- [ ] You can now manually enter a date and it will save correctly

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
