### PR TITLE
add useKeyboardHeightAdjustment to response line edit modal

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -5,6 +5,7 @@ import {
   BasicSpinner,
   useBufferState,
   ModalTabs,
+  useKeyboardHeightAdjustment,
 } from '@openmsupply-client/common';
 import { ResponseLineEditForm } from './ResponseLineEditForm';
 import { useResponse, ResponseLineFragment } from '../../api';
@@ -36,6 +37,8 @@ export const ResponseLineEdit = ({
     numberOfPacksFromQuantity,
     variantsControl,
   } = usePackVariant(draft.itemId, draft.item.unitName ?? null);
+
+  const height = useKeyboardHeightAdjustment(600);
 
   const tabs = [
     {
@@ -107,7 +110,7 @@ export const ResponseLineEdit = ({
           }}
         />
       }
-      height={600}
+      height={height}
       width={1024}
     >
       {!isLoading ? (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3540 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Adds the `useKeyboardHeightAdjustment` hook to Response Requisition modal, so the modal height adjusts when the keyboard opens:

![Screenshot 2024-05-07 at 11 23 38 AM](https://github.com/msupply-foundation/open-msupply/assets/55115239/ec0added-60cc-47bd-9346-f5e13d930ae8)


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Open edit modal for a line in a response requisition on Android
- [ ] Quantity to supply should autofocus, key pad appears
- [ ] Modal should adjust in size, so you can still see item name/code/requested quantity

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
