### PR TITLE
Handle app crash

### DIFF
--- a/client/packages/coldchain/src/Equipment/ListView/CreateAssetModal.tsx
+++ b/client/packages/coldchain/src/Equipment/ListView/CreateAssetModal.tsx
@@ -123,7 +123,7 @@ export const CreateAssetModal = ({
 
   const catalogueItems = ArrayUtils.flatMap(
     catalogueItemData?.pages,
-    page => page.nodes
+    page => page?.nodes ?? []
   );
 
   const selectedCatalogueItem = catalogueItems.find(

--- a/client/packages/dashboard/src/api/api.ts
+++ b/client/packages/dashboard/src/api/api.ts
@@ -13,8 +13,8 @@ export const getDashboardQueries = (
         daysTillExpired: 30,
       });
       return {
-        expired: result?.stockCounts.expired ?? 0,
-        expiringSoon: result?.stockCounts.expiringSoon ?? 0,
+        expired: result?.stockCounts?.expired ?? 0,
+        expiringSoon: result?.stockCounts?.expiringSoon ?? 0,
       };
     },
     itemCounts: async (lowStockThreshold: number) => {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3740 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
Handle two causes of a crash: 
* When using an infinite query, undefined is returned for one or more of the pages
* The `stockCounts` query returns null or undefined

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->
This is almost impossible to replicate - to cause the issue I've updated `useInfiniteAssets` in order to return an invalid result within the array:

```
  const result = useInfiniteQuery(api.keys.paramList(params), ({ pageParam }) =>
    api.get.list({ ...params, ...pagination, ...pageParam })
  );

  return { ...result, data: { ...result.data, pages: [undefined] } };

```

Simply deleting the auth cookie or invalidating the query in some way ( incorrect filter, for example ) is not enough! That will return null for the `data` prop and won't return invalid pages.


<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Check that the site behaves as normal 🤷 
- [ ] The only reliable test was to log into the demo server and leave that on the equipment list view until timed out. last time I tried this however, there was no error

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
