### PR TITLE
3800 sync assets fails with duplicate asset numbers

### DIFF
--- a/server/repository/src/migrations/v2_00_00/assets/asset.rs
+++ b/server/repository/src/migrations/v2_00_00/assets/asset.rs
@@ -20,11 +20,11 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
             replacement_date {DATE},
             deleted_datetime {DATETIME},
             created_datetime {DATETIME} NOT NULL,
-            modified_datetime {DATETIME} NOT NULL,
-            UNIQUE (asset_number) -- Asset numbers must be unique within a site
+            modified_datetime {DATETIME} NOT NULL
         );
         CREATE INDEX asset_catalogue_item_id ON asset (asset_catalogue_item_id);
         CREATE INDEX asset_serial_number ON asset (serial_number);
+        CREATE INDEX asset_asset_number ON asset (asset_number);
         CREATE INDEX asset_deleted_datetime ON asset (deleted_datetime);
         "#,
     )?;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3800

# 👩🏻‍💻 What does this PR do?

This removes the unique constraint on asset number
See issue description to explain why this is needed.

## 💌 Any notes for the reviewer?

In future, we should probably ensure we don't have unique constraints on non-id fields, as SQLite upsert logic is triggered on any unique constraint, no just on the id field. Especially with sync we need to be careful as duplicated records can come from different sites and might not go through service layer upsert logic.

# 🧪 Testing

To test this you'll need to either re-initialise OMS Central server as this is a database change...

- [ ] Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] Create assets on both sites with the same asset number
- [ ] Sync both sites
- [ ] Ensure both assets are available on central
- [ ] Try re-initialising the remote sites, make sure the asset records is downloaded sucessfully on initalisation.

# 📃 Documentation
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour

