### PR TITLE
Enable hold button for "Shipped" invoices

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/Footer/OnHoldButton.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Footer/OnHoldButton.tsx
@@ -9,7 +9,7 @@ import { useInbound } from '../../api';
 export const OnHoldButtonComponent = memo(() => {
   const t = useTranslation('replenishment');
   const { onHold, update } = useInbound.document.fields('onHold');
-  const isDisabled = useInbound.utils.isDisabled();
+  const isHoldable = useInbound.utils.isHoldable();
   const getConfirmation = useConfirmationModal({
     message: t(
       onHold
@@ -22,7 +22,7 @@ export const OnHoldButtonComponent = memo(() => {
 
   return (
     <ToggleButton
-      disabled={isDisabled}
+      disabled={!isHoldable}
       value={onHold}
       selected={onHold}
       onClick={() => getConfirmation()}

--- a/client/packages/invoices/src/InboundShipment/api/hooks/index.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/index.ts
@@ -33,6 +33,7 @@ export const useInbound = {
     addFromMasterList: Utils.useAddFromMasterList,
     api: Utils.useInboundApi,
     isDisabled: Utils.useIsInboundDisabled,
+    isHoldable: Utils.useIsInboundHoldable,
     isStatusChangeDisabled: Utils.useIsStatusChangeDisabled,
     selectedLines: Utils.useSelectedLines,
   },

--- a/client/packages/invoices/src/InboundShipment/api/hooks/utils/index.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/utils/index.ts
@@ -3,10 +3,12 @@ import { useIsInboundDisabled } from './useIsInboundDisabled';
 import { useIsStatusChangeDisabled } from './useIsStatusChangeDisabled';
 import { useAddFromMasterList } from './useAddFromMasterList';
 import { useSelectedLines } from './useSelectedLines';
+import { useIsInboundHoldable } from './useIsInboundHoldable';
 
 export const Utils = {
   useInboundApi,
   useIsInboundDisabled,
+  useIsInboundHoldable,
   useIsStatusChangeDisabled,
   useAddFromMasterList,
   useSelectedLines,

--- a/client/packages/invoices/src/InboundShipment/api/hooks/utils/useIsInboundHoldable.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/utils/useIsInboundHoldable.ts
@@ -1,0 +1,8 @@
+import { useInbound } from '../document/useInbound';
+import { isInboundHoldable } from './../../../../utils';
+
+export const useIsInboundHoldable = (): boolean => {
+  const { data } = useInbound();
+  if (!data) return true;
+  return isInboundHoldable(data);
+};

--- a/client/packages/invoices/src/utils.ts
+++ b/client/packages/invoices/src/utils.ts
@@ -177,6 +177,7 @@ export const isOutboundDisabled = (
   );
 };
 
+/** Returns true if the inbound shipment cannot be edited */
 export const isInboundDisabled = (inbound: InboundRowFragment): boolean => {
   const isManuallyCreated = !inbound.linkedShipment?.id;
   if (isManuallyCreated) {
@@ -185,12 +186,32 @@ export const isInboundDisabled = (inbound: InboundRowFragment): boolean => {
   switch (inbound.status) {
     case InvoiceNodeStatus.New:
     case InvoiceNodeStatus.Allocated:
+      return false;
     case InvoiceNodeStatus.Picked:
     case InvoiceNodeStatus.Shipped:
-      return false;
     case InvoiceNodeStatus.Delivered:
     case InvoiceNodeStatus.Verified:
       return true;
+    default:
+      return noOtherVariants(inbound.status);
+  }
+};
+
+/** Returns true if the inbound shipment ban be put on hold */
+export const isInboundHoldable = (inbound: InboundRowFragment): boolean => {
+  const isManuallyCreated = !inbound.linkedShipment?.id;
+  if (isManuallyCreated) {
+    return inbound.status !== InvoiceNodeStatus.Verified;
+  }
+  switch (inbound.status) {
+    case InvoiceNodeStatus.New:
+    case InvoiceNodeStatus.Allocated:
+    case InvoiceNodeStatus.Picked:
+    case InvoiceNodeStatus.Shipped:
+      return true;
+    case InvoiceNodeStatus.Delivered:
+    case InvoiceNodeStatus.Verified:
+      return false;
     default:
       return noOtherVariants(inbound.status);
   }

--- a/client/packages/invoices/src/utils.ts
+++ b/client/packages/invoices/src/utils.ts
@@ -10,6 +10,7 @@ import {
   ArrayUtils,
   Formatter,
   TypedTFunction,
+  noOtherVariants,
 } from '@openmsupply-client/common';
 import { OutboundFragment, OutboundRowFragment } from './OutboundShipment/api';
 import { InboundLineFragment } from './InboundShipment/api';
@@ -178,11 +179,21 @@ export const isOutboundDisabled = (
 
 export const isInboundDisabled = (inbound: InboundRowFragment): boolean => {
   const isManuallyCreated = !inbound.linkedShipment?.id;
-  return isManuallyCreated
-    ? inbound.status === InvoiceNodeStatus.Verified
-    : inbound.status === InvoiceNodeStatus.Picked ||
-        inbound.status === InvoiceNodeStatus.Shipped ||
-        inbound.status === InvoiceNodeStatus.Verified;
+  if (isManuallyCreated) {
+    return inbound.status === InvoiceNodeStatus.Verified;
+  }
+  switch (inbound.status) {
+    case InvoiceNodeStatus.New:
+    case InvoiceNodeStatus.Allocated:
+    case InvoiceNodeStatus.Picked:
+    case InvoiceNodeStatus.Shipped:
+      return false;
+    case InvoiceNodeStatus.Delivered:
+    case InvoiceNodeStatus.Verified:
+      return true;
+    default:
+      return noOtherVariants(inbound.status);
+  }
 };
 
 export const isInboundReturnDisabled = (

--- a/client/packages/invoices/src/utils.ts
+++ b/client/packages/invoices/src/utils.ts
@@ -197,25 +197,9 @@ export const isInboundDisabled = (inbound: InboundRowFragment): boolean => {
   }
 };
 
-/** Returns true if the inbound shipment ban be put on hold */
-export const isInboundHoldable = (inbound: InboundRowFragment): boolean => {
-  const isManuallyCreated = !inbound.linkedShipment?.id;
-  if (isManuallyCreated) {
-    return inbound.status !== InvoiceNodeStatus.Verified;
-  }
-  switch (inbound.status) {
-    case InvoiceNodeStatus.New:
-    case InvoiceNodeStatus.Allocated:
-    case InvoiceNodeStatus.Picked:
-    case InvoiceNodeStatus.Shipped:
-      return true;
-    case InvoiceNodeStatus.Delivered:
-    case InvoiceNodeStatus.Verified:
-      return false;
-    default:
-      return noOtherVariants(inbound.status);
-  }
-};
+/** Returns true if the inbound shipment can be put on hold */
+export const isInboundHoldable = (inbound: InboundRowFragment): boolean =>
+  inbound.status !== InvoiceNodeStatus.Verified;
 
 export const isInboundReturnDisabled = (
   inboundReturn: InboundReturnRowFragment


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3526 (at least partially, still not taken store pref into account, please see my question in the issue)

The incoming invoice with status Shipped can now be put on hold. However, @mark-prins should it always be possible to put it on hold if it is not Verified?


