### PR TITLE
Update stock line on scan

### DIFF
--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -5,7 +5,6 @@ import {
   DateUtils,
   Formatter,
   TextWithLabelRow,
-  BasicTextInput,
   CurrencyInput,
   ExpiryDateInput,
   useTranslation,
@@ -18,6 +17,7 @@ import {
   Tooltip,
   useDebounceCallback,
   NumericTextInput,
+  BufferedTextInput,
 } from '@openmsupply-client/common';
 import { StockLineRowFragment } from '../api';
 import { LocationSearchInput } from '../../Location/Components/LocationSearchInput';
@@ -55,7 +55,6 @@ export const StockLineForm: FC<StockLineFormProps> = ({
     draft.item.unitName ?? null
   );
   const packUnit = asPackVariant(draft.packSize);
-
   const scanBarcode = async () => {
     try {
       const result = await startScan();
@@ -158,9 +157,9 @@ export const StockLineForm: FC<StockLineFormProps> = ({
         <StyledInputRow
           label={t('label.batch')}
           Input={
-            <BasicTextInput
-              defaultValue={draft.batch ?? ''}
-              onChange={e => debouncedUpdate({ batch: e.target.value })}
+            <BufferedTextInput
+              value={draft.batch ?? ''}
+              onChange={e => onUpdate({ batch: e.target.value })}
             />
           }
         />
@@ -225,9 +224,9 @@ export const StockLineForm: FC<StockLineFormProps> = ({
           label={t('label.barcode')}
           Input={
             <Box display="flex" style={{ width: 162 }}>
-              <BasicTextInput
-                defaultValue={draft.barcode ?? ''}
-                onChange={e => debouncedUpdate({ barcode: e.target.value })}
+              <BufferedTextInput
+                value={draft.barcode ?? ''}
+                onChange={e => onUpdate({ barcode: e.target.value })}
               />
               {isEnabled && (
                 <Tooltip


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2931

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
Change the expiry and barcode inputs to use a buffered input, and assign the value from the draft directly.

This version has come from @roxy-dao's [comment](https://github.com/msupply-foundation/open-msupply/pull/3756#issuecomment-2097151642) - I rebased and that didn't go well, so have had to create a new branch and cherry pick instead.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Open a stock line, scan a GTIN barcode
# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
