### PR TITLE
3736 bug: OS issue expired line value disappears on click

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -147,6 +147,10 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
   );
 
   const handleIssueQuantityChange = (quantity: number | undefined) => {
+    // this method is also called onBlur... check that there actually has been a change
+    // in quantity (to prevent triggering auto allocation if only focus has moved)
+    if (quantity === issueQuantity) return;
+
     setIssueQuantity(quantity ?? 0);
     setOkDisabled(true);
     debouncedAllocate(

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
@@ -146,6 +146,10 @@ export const PrescriptionLineEditForm: React.FC<
   };
 
   const handleIssueQuantityChange = (inputQuantity?: number) => {
+    // this method is also called onBlur... check that there actually has been a change
+    // in quantity (to prevent triggering auto allocation if only focus has moved)
+    if (inputQuantity === issueQuantity) return;
+
     const quantity = inputQuantity === undefined ? 0 : inputQuantity;
     setIssueQuantity(quantity);
     allocate(quantity, Number(packSizeController.selected?.value));

--- a/client/packages/invoices/src/StockOut/utils.tsx
+++ b/client/packages/invoices/src/StockOut/utils.tsx
@@ -344,7 +344,7 @@ export const PackQuantityCell = (props: CellProps<DraftStockOutLine>) => (
     {...props}
     max={props.rowData.stockLine?.availableNumberOfPacks}
     id={getPackQuantityCellId(props.rowData.stockLine?.batch)}
-    min={1}
+    min={0}
   />
 );
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3736

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Prevents the auto allocation from triggering when the `issue quantity` input field loses focus:

https://github.com/msupply-foundation/open-msupply/assets/55115239/a4bb2112-5171-4f66-949b-366bba05f5b4

NumericTextInput component calls the handleIssueQuantityChange on blur, which was triggering auto allocation even though we've not actually changed the value.

- Also fixes for prescriptions, as same bug was there




<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

Somewhat curious for thoughts on whether this could/should be the NumericTextInput's responsibility, to only call the onChange handler from `onBlur` if there actually is a change? 🤷‍♀️ If I were passing an onChange handler to a component, I wouldn't expect it to fire on blur in the first place, but if it does, I would expect it to be because the change in focus has updated the value in some way?

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Add a line to outbound shipment, issue stock from a line that the auto allocation wouldn't choose (e.g. expired)
- [ ] Click ok
- [ ] Reopen edit modal by clicking that line
- [ ] Click anywhere to shift focus away from the issue quantity input
- [ ] Your allocations don't change

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
