### PR TITLE
3532 issue stock not clearing values

### DIFF
--- a/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
@@ -47,6 +47,7 @@ export const NumberInputCell = <T extends RecordWithId>({
       }}
       onChange={num => {
         const newValue = num === undefined ? min : num;
+        if (buffer === newValue) return;
         setBuffer(newValue);
         updater({ ...rowData, [column.key]: Number(newValue) });
       }}

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
@@ -244,6 +244,7 @@ export const OutboundLineEdit: React.FC<ItemDetailsModalProps> = ({
           packSizeController={packSizeController}
           onChangeItem={(item: ItemRowFragment | null) => {
             if (status === InvoiceNodeStatus.New) setIsDirty(true);
+            setIsAutoAllocated(false);
             setCurrentItem(item);
           }}
           item={currentItem}

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
@@ -81,14 +81,10 @@ export const useDraftOutboundLines = (
         .sort(SortUtils.byExpiryAsc);
 
       if (status === InvoiceNodeStatus.New) {
-        let placeholder = lines?.find(
+        const placeholder = lines?.find(
           ({ type }) => type === InvoiceLineNodeType.UnallocatedStock
         );
-        if (!placeholder) {
-          placeholder = draftStockOutLines.find(
-            ({ type }) => type === InvoiceLineNodeType.UnallocatedStock
-          );
-        }
+
         if (placeholder) {
           const placeHolderItem = lines?.find(l => l.item.id === item.id)?.item;
           if (!!placeHolderItem) placeholder.item = placeHolderItem;

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
@@ -215,6 +215,7 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
           packSizeController={packSizeController}
           onChangeItem={(item: ItemRowFragment | null) => {
             if (status === InvoiceNodeStatus.New) setIsDirty(true);
+            setIsAutoAllocated(false);
             setCurrentItem(item);
           }}
           item={currentItem}

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
@@ -13,6 +13,7 @@ import {
   useFormatNumber,
   useDebounceCallback,
   InputLabel,
+  useDebouncedValueCallback,
 } from '@openmsupply-client/common';
 import {
   StockItemSearchInput,
@@ -145,6 +146,21 @@ export const PrescriptionLineEditForm: React.FC<
     updateIssueQuantity(allocatedQuantity);
   };
 
+  // using a debounced value for the allocation. In the scenario where
+  // you have only pack sizes > 1 available, and try to type a quantity which starts with 1
+  // e.g. 10, 12, 100.. then the allocation rounds the 1 up immediately to the available
+  // pack size which stops you entering the required quantity.
+  // See https://github.com/msupply-foundation/open-msupply/issues/2727
+  // and https://github.com/msupply-foundation/open-msupply/issues/3532
+  const debouncedAllocate = useDebouncedValueCallback(
+    (quantity, packSize) => {
+      allocate(quantity, packSize);
+    },
+    [],
+    500,
+    [draftPrescriptionLines] // this is needed to prevent a captured enclosure of onChangeQuantity
+  );
+
   const handleIssueQuantityChange = (inputQuantity?: number) => {
     // this method is also called onBlur... check that there actually has been a change
     // in quantity (to prevent triggering auto allocation if only focus has moved)
@@ -152,7 +168,7 @@ export const PrescriptionLineEditForm: React.FC<
 
     const quantity = inputQuantity === undefined ? 0 : inputQuantity;
     setIssueQuantity(quantity);
-    allocate(quantity, Number(packSizeController.selected?.value));
+    debouncedAllocate(quantity, Number(packSizeController.selected?.value));
   };
 
   const prescriptionLineWithNote = draftPrescriptionLines.find(l => !!l.note);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3532

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

- Resets issue quantity to 0 if you change items for Prescription/OS (and clears any warnings)
- Prevents allocation warnings from clearing until you make a change to an issue packs quantity
- Adds debouncing to prescription issue quantity input (immediate auto allocation prevented being able to clear it!)

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

Stacked on #3814, because #3736 reallocation issue was also mentioned in this issue. But now have realised that maybe I should rebase off develop, seeing this issue was actually slated for 2.1.0... thoughts?

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

Resets issue quantity to 0 if you change items for Prescription/OS (and clears any warnings)

- [ ] Go to outbound shipment
- [ ] Click add item
- [ ] Select an item
- [ ] Enter a value in `Issue [quantity]`
- [ ] Change the item
- [ ] TEST: Issue quantity should be reset to 0
- [ ] TEST: same for prescription

Prevents allocation warnings from clearing until you make a change to an issue packs quantity

- [ ] In OS, enter a quantity to issue that results in a warning (e.g. if only pack size 10 available, and you say to issue 8)
- [ ] Click on the pack quantity input of one of the rows
- [ ] Click off that input (defocus)
- [ ] TEST: warnings still visible
- [ ] Change the value of the pack quantity input of one of the rows
- [ ] TEST: warnings now disappear
- [ ] TEST: same for prescription

Adds debouncing to prescription issue quantity input (immediate auto allocation prevented being able to clear it!)

- [ ] In prescription edit modal, enter a value in `Issue [quantity]`
- [ ] TEST: You should be able to backspace to clear the value
- [ ] In prescription, issue stock for an item where pack sizes > 1 available
- [ ] TEST: you can type a quantity which starts with 1 e.g. 10, 12, 100.. 


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
