### PR TITLE
Hide required asterisk when inv adj reason is disabled

### DIFF
--- a/client/packages/system/src/InventoryAdjustmentReason/Components/InventoryAdjustmentReasonSearchInput.tsx
+++ b/client/packages/system/src/InventoryAdjustmentReason/Components/InventoryAdjustmentReasonSearchInput.tsx
@@ -77,7 +77,7 @@ export const InventoryAdjustmentReasonSearchInput: FC<
             }}
             sx={{ minWidth: width }}
             error={isError}
-            required={isRequired}
+            required={isRequired && !isDisabled}
           />
         )}
         options={defaultOptionMapper(reasons, 'reason')}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3567

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Only show the `required` asterisk if the reason is actually required (because counted packs is different):

![Screenshot 2024-05-07 at 6 22 51 PM](https://github.com/msupply-foundation/open-msupply/assets/55115239/2efc5f2c-b27c-4c9a-9056-6f976e89cd10)


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have inventory adjustments reasons configured in central server
- [ ] Sync reasons to OMS
- [ ] Go to Stocktake
- [ ] Create a new Stocktake
- [ ] Click `Add item`
- [ ] Select an item
- [ ] See no reason inputs have asterisk
- [ ] Enter a different counted # packs
- [ ] Reason enables and asterisk appears

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
