### PR TITLE
Make the supplier name website look like another, disabled text input

### DIFF
--- a/client/packages/common/src/ui/forms/Detail/InputWithLabelRow.tsx
+++ b/client/packages/common/src/ui/forms/Detail/InputWithLabelRow.tsx
@@ -27,8 +27,8 @@ export const DetailInputWithLabelRow: FC<InputWithLabelRowProps> = ({
   labelWidthPercentage = 40,
   inputAlignment = 'end',
   inputProps,
-  Input = <BasicTextInput {...inputProps} />,
-  DisabledInput = <BasicTextInput {...inputProps} />,
+  Input = <BasicTextInput fullWidth {...inputProps} />,
+  DisabledInput = <BasicTextInput fullWidth {...inputProps} />,
   labelProps,
 }) => {
   const { sx: labelSx, ...labelPropsRest } = labelProps || {};

--- a/client/packages/system/src/Name/DetailModal/DetailModal.tsx
+++ b/client/packages/system/src/Name/DetailModal/DetailModal.tsx
@@ -75,14 +75,10 @@ export const DetailModal: FC<DetailModalProps> = ({ nameId }) => {
                   target="_blank"
                   rel="noopener"
                   sx={{
-                    // truncate long links
-                    overflow: 'hidden',
-                    textWrap: 'nowrap',
-                    textOverflow: 'ellipsis',
                     // Make it look like another disabled text input consistence with other text
                     // input components in this modal
-                    width: '198',
-                    height: '34.13',
+                    width: '100%',
+                    minHeight: '34.13',
                     backgroundColor: theme => theme.palette.background.toolbar,
                     borderRadius: '8px',
                     padding: '4px 8px',

--- a/client/packages/system/src/Name/DetailModal/DetailModal.tsx
+++ b/client/packages/system/src/Name/DetailModal/DetailModal.tsx
@@ -68,16 +68,30 @@ export const DetailModal: FC<DetailModalProps> = ({ nameId }) => {
             <DetailInputWithLabelRow
               label={t('label.website')}
               inputProps={{ value: data?.website, disabled: isDisabled }}
+              inputAlignment="start"
               DisabledInput={
-                <>
-                  <MuiLink
-                    href={data.website ?? undefined}
-                    target="_blank"
-                    rel="noopener"
-                  >
-                    {data.website}
-                  </MuiLink>
-                </>
+                <MuiLink
+                  href={data.website ?? undefined}
+                  target="_blank"
+                  rel="noopener"
+                  sx={{
+                    // truncate long links
+                    overflow: 'hidden',
+                    textWrap: 'nowrap',
+                    textOverflow: 'ellipsis',
+                    // Make it look like another disabled text input consistence with other text
+                    // input components in this modal
+                    width: '198',
+                    height: '34.13',
+                    backgroundColor: theme => theme.palette.background.toolbar,
+                    borderRadius: '8px',
+                    padding: '4px 8px',
+                    // This is to match the width of BasicTextInput (from the required *):
+                    marginRight: '2',
+                  }}
+                >
+                  {data.website}
+                </MuiLink>
               }
             />
           </DetailSection>

--- a/client/packages/system/src/Name/DetailModal/DetailModal.tsx
+++ b/client/packages/system/src/Name/DetailModal/DetailModal.tsx
@@ -75,7 +75,7 @@ export const DetailModal: FC<DetailModalProps> = ({ nameId }) => {
                   target="_blank"
                   rel="noopener"
                   sx={{
-                    // Make it look like another disabled text input consistence with other text
+                    // Make it look like another disabled text input consistent with other text
                     // input components in this modal
                     width: '100%',
                     minHeight: '34.13',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3426

# 👩🏻‍💻 What does this PR do?

Make the supplier name website look like another, disabled text input

I tried to make it same with and height and same look as the other text inputs.

# Testing

There are three cases to consider:
- no website
- short website
- long website

![image](https://github.com/msupply-foundation/open-msupply/assets/88299195/b8d7dc3f-07b3-45d5-8a86-697b752c0051)

![image](https://github.com/msupply-foundation/open-msupply/assets/88299195/d9cd89fa-affa-4343-9ae4-e1b57293239e)

![image](https://github.com/msupply-foundation/open-msupply/assets/88299195/c4d31603-6f7a-49cf-b211-2bb006121d80)

