### PR TITLE
Use correct condition for app nav's activeness

### DIFF
--- a/client/packages/host/src/components/Navigation/ColdChainNav.tsx
+++ b/client/packages/host/src/components/Navigation/ColdChainNav.tsx
@@ -33,12 +33,7 @@ export const ColdChainNav: FC<ColdChainNavProps> = ({ store }) => {
         text={t('cold-chain')}
         inactive
       />
-      <Collapse
-        in={isActive}
-        sx={{
-          marginBottom: 2,
-        }}
-      >
+      <Collapse in={isActive}>
         <List>
           <AppNavLink
             visible={visible}

--- a/client/packages/host/src/components/Navigation/ColdChainNav.tsx
+++ b/client/packages/host/src/components/Navigation/ColdChainNav.tsx
@@ -24,7 +24,7 @@ export const ColdChainNav: FC<ColdChainNavProps> = ({ store }) => {
   const visible = store?.preferences.vaccineModule ?? false;
 
   return (
-    <AppNavSection isActive={visible} to={AppRoute.Coldchain}>
+    <AppNavSection isActive={isActive} to={AppRoute.Coldchain}>
       <AppNavLink
         visible={visible}
         end={false}

--- a/client/packages/host/src/components/Navigation/DispensaryNav.tsx
+++ b/client/packages/host/src/components/Navigation/DispensaryNav.tsx
@@ -35,7 +35,7 @@ export const DispensaryNav: FC<DispensaryNavProps> = ({ store }) => {
         text={t('dispensary')}
         inactive
       />
-      <Collapse in={isActive} sx={{ marginBottom: 2 }}>
+      <Collapse in={isActive}>
         <List>
           <AppNavLink
             visible={visible}

--- a/client/packages/host/src/components/Navigation/DispensaryNav.tsx
+++ b/client/packages/host/src/components/Navigation/DispensaryNav.tsx
@@ -26,7 +26,7 @@ export const DispensaryNav: FC<DispensaryNavProps> = ({ store }) => {
   const isProgramModule = store?.preferences.omProgramModule;
 
   return (
-    <AppNavSection isActive={visible} to={AppRoute.Dispensary}>
+    <AppNavSection isActive={isActive} to={AppRoute.Dispensary}>
       <AppNavLink
         visible={visible}
         end={false}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3667

# 👩🏻‍💻 What does this PR do?
Use correct condition to to show if the dispensary or cold chain navs have been opened
![Screenshot 2024-05-08 at 10 26 50](https://github.com/msupply-foundation/open-msupply/assets/61820074/7445b5b1-855d-4d77-99d5-d34d9d9946a9)
![Screenshot 2024-05-08 at 10 26 43](https://github.com/msupply-foundation/open-msupply/assets/61820074/7c3a29a9-1119-4d17-ae7f-f1a81b440aa4)

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a dispensary
- [ ] See that the arrow for dispensary is > when closed and ⌄ when opened
- [ ] Make sure it is still hidden for stores that aren't dispensaries
- [ ] Reat 2 & 3 with cold chain (must have `uses vaccine module` store pref

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Maybe the GOTO part of coldchain and dispensary needs updating? 🤷🏻 
  2. Other GOTOs that show coldchain and dispensary?
