### PR TITLE
3801 Internal Order Page has misaligned "Filter Items" searchbox and "Actions" drop down

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
@@ -129,7 +129,7 @@ export const Toolbar: FC = () => {
         display="flex"
         gap={1}
         justifyContent="flex-end"
-        sx={{ marginTop: 2 }}
+        sx={{ marginTop: 2, height: 37 }}
       >
         <SearchBar
           placeholder={t('placeholder.filter-items')}

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
@@ -128,8 +128,9 @@ export const Toolbar: FC = () => {
         item
         display="flex"
         gap={1}
+        alignItems="flex-end"
         justifyContent="flex-end"
-        sx={{ marginTop: 2, height: 37 }}
+        sx={{ marginTop: 2 }}
       >
         <SearchBar
           placeholder={t('placeholder.filter-items')}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3801

# 👩🏻‍💻 What does this PR do?
Forces height on grid so that the filter and actions align 👀 
![Screenshot 2024-05-08 at 11 41 40](https://github.com/msupply-foundation/open-msupply/assets/61820074/5c2d757d-313a-4194-b782-21b61a84913d)

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Internal Order
- [ ] Create a new Internal Order
- [ ] See they should be aligned on tool bar 👀 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Maybe screenshots if they're misaligned
  2.
