### PR TITLE
3442 collapse drawers on secondary click

### DIFF
--- a/client/packages/common/src/hooks/useDrawer/useDrawer.ts
+++ b/client/packages/common/src/hooks/useDrawer/useDrawer.ts
@@ -35,9 +35,14 @@ export const useDrawer = create<DrawerController>(set => {
         }
         return state;
       }),
-    onExpand: (clickedNavPath?: string) =>
+    onExpand: (newClickedNavPath?: string) =>
       set(state => {
         const hoverOpen = state.isOpen ? state.hoverOpen : true;
+        // reset expansion if clicked again
+        const clickedNavPath =
+          newClickedNavPath === state.clickedNavPath
+            ? undefined
+            : newClickedNavPath;
         return { ...state, hoverOpen, clickedNavPath, isOpen: true };
       }),
   };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3442

# 👩🏻‍💻 What does this PR do?

Collapse non-active nav sections when clicked a second time:
https://github.com/msupply-foundation/open-msupply/assets/55115239/e06a8eba-f19d-41a7-936a-f4bf4f25d6ed



<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Open the app drawer
- [ ] Click on a section that you are not currently active on (e.g. if on Distribution > Outbound Shipment, click on Inventory)
- [ ] Inventory nav opens
- [ ] Click on Inventory again
- [ ] Inventory Nav closes

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
