### PR TITLE
# 3579 Fix Pagination bar side-scrolling

### DIFF
--- a/client/packages/common/src/ui/components/navigation/Tabs/DetailTab.tsx
+++ b/client/packages/common/src/ui/components/navigation/Tabs/DetailTab.tsx
@@ -11,6 +11,7 @@ const StyledTabPanel = styled(TabPanel)({
   height: '100%',
   flex: 1,
   padding: 0,
+  width: '100%',
 });
 
 const StyledTabContainer = styled(Box)(({ theme }) => ({

--- a/client/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -280,6 +280,7 @@ const DataTableComponent = <T extends RecordWithId>({
           display: 'flex',
           flexDirection: 'column',
           position: 'sticky',
+          left: 0,
           insetBlockEnd: 0,
           backgroundColor: 'white',
           justifyContent: 'flex-end',

--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/ContentArea.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/ContentArea.tsx
@@ -2,7 +2,6 @@ import React, { FC, useEffect } from 'react';
 import {
   DataTable,
   useTranslation,
-  Box,
   MiniTable,
   createQueryParamsStore,
   NothingHere,
@@ -105,25 +104,23 @@ export const ContentArea: FC<ContentAreaProps> = ({
   return isLoading ? (
     <BasicSpinner />
   ) : (
-    <Box flexDirection="column" flex={1} display="flex">
-      <DataTable<StocktakeSummaryItem | StocktakeLineFragment>
-        onRowClick={onRowClick}
-        ExpandContent={Expando}
-        isRowAnimated={true}
-        columns={columns}
-        data={rows}
-        id="stocktake-detail"
-        noDataElement={
-          <NothingHere
-            body={t('error.no-stocktake-items')}
-            onCreate={isDisabled ? undefined : onAddItem}
-            buttonText={t('button.add-item')}
-          />
-        }
-        enableColumnSelection
-        pagination={{ ...pagination, total: totalLineCount }}
-        onChangePage={updatePaginationQuery}
-      />
-    </Box>
+    <DataTable<StocktakeSummaryItem | StocktakeLineFragment>
+      onRowClick={onRowClick}
+      ExpandContent={Expando}
+      isRowAnimated={true}
+      columns={columns}
+      data={rows}
+      id="stocktake-detail"
+      noDataElement={
+        <NothingHere
+          body={t('error.no-stocktake-items')}
+          onCreate={isDisabled ? undefined : onAddItem}
+          buttonText={t('button.add-item')}
+        />
+      }
+      enableColumnSelection
+      pagination={{ ...pagination, total: totalLineCount }}
+      onChangePage={updatePaginationQuery}
+    />
   );
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3579

# 👩🏻‍💻 What does this PR do?

Literally a 1 line fix -- but took a while to figure it out 🙄

(This might be my smallest PR yet!)

# 🧪 Testing

Load a table that has more than 1 page of content and is wider than the available viewport.

Scroll to the side, confirm that the Pagination bar stays in place and doesn't scroll with it.