### PR TITLE
3754 Cold Chain -> Equipment -> Store should be at the top in detail view of Asset Register

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
@@ -131,6 +131,17 @@ export const Summary = ({ draft, onChange, locations }: SummaryProps) => {
     <Box display="flex" flex={1}>
       <Container>
         <Section heading={t('heading.asset-identification')}>
+          {isCentralServer && (
+            <Row label={t('label.store')}>
+              <StoreSearchInput
+                clearable
+                fullWidth
+                value={draft?.store ?? undefined}
+                onChange={onStoreChange}
+                onInputChange={onStoreInputChange}
+              />
+            </Row>
+          )}
           <Row label={t('label.category')}>
             <BasicTextInput
               value={draft.assetCategory?.name ?? ''}
@@ -201,17 +212,6 @@ export const Summary = ({ draft, onChange, locations }: SummaryProps) => {
               />
             ) : null}
           </Row>
-          {isCentralServer && (
-            <Row label={t('label.store')}>
-              <StoreSearchInput
-                clearable
-                fullWidth
-                value={draft?.store ?? undefined}
-                onChange={onStoreChange}
-                onInputChange={onStoreInputChange}
-              />
-            </Row>
-          )}
         </Section>
       </Container>
       <Box


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3754

# 👩🏻‍💻 What does this PR do?
Feels kinda weird to move it to the top under `Asset Identification`... but as requested by @adamdewey have moved `Store` to the top of page.
<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Click on an `Equipment`
- [ ] Should see `Store` at the top in the detail view

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Update screenshots
  2.
