### PR TITLE
3760 Catalogue -> Assets -> Log Reasons -> swap Reason and Status around

### DIFF
--- a/client/packages/system/src/Asset/AssetLogReasons/ListView.tsx
+++ b/client/packages/system/src/Asset/AssetLogReasons/ListView.tsx
@@ -35,15 +35,15 @@ const AssetListComponent: FC = () => {
   const columns = useColumns<AssetLogReasonFragment>(
     [
       {
-        key: 'reason',
-        label: 'label.reason',
-        sortable: false,
-      },
-      {
         key: 'status',
         label: 'label.status',
         sortable: false,
         accessor: ({ rowData }) => parseStatus(rowData.assetLogStatus, t),
+      },
+      {
+        key: 'reason',
+        label: 'label.reason',
+        sortable: false,
       },
       'selection',
     ],


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3760

# 👩🏻‍💻 What does this PR do?
Swap Reason <-> Status in log reasons
<img width="1196" alt="Screenshot 2024-05-09 at 11 53 49" src="https://github.com/msupply-foundation/open-msupply/assets/61820074/c9a4df2b-575c-4a2c-b308-fc64aaaba8e0">

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to `Asset` page
- [ ] Click on `Manage asset reason` button
- [ ] See that columns have been swapped

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Screenshots for asset reasons
  2.
