### PR TITLE
Add warnings for fields for fields if they fail to parse

### DIFF
--- a/client/packages/coldchain/src/Equipment/ImportAsset/EquipmentImportModal.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/EquipmentImportModal.tsx
@@ -50,6 +50,7 @@ export type ImportRow = {
   id: string;
   notes: string;
   errorMessage: string;
+  warningMessage: string;
   store: StoreRowFragment | null | undefined;
 };
 
@@ -118,6 +119,8 @@ export const EquipmentImportModal: FC<EquipmentImportModalProps> = ({
   const { Modal } = useDialog({ isOpen, onClose });
 
   const [errorMessage, setErrorMessage] = useState<string>(() => '');
+  const [warningMessage, setWarningMessage] = useState<string>(() => '');
+
   const [importProgress, setImportProgress] = useState(0);
   const [importErrorCount, setImportErrorCount] = useState(0);
   const {
@@ -243,6 +246,7 @@ export const EquipmentImportModal: FC<EquipmentImportModalProps> = ({
   const exportNotReady = !(
     bufferedEquipment.length >= 0 && errorMessage.length > 0
   );
+  const showWarnings = errorMessage.length == 0 && warningMessage.length > 0;
 
   const importSteps = [
     { label: t('label.upload'), description: '', clickable: true },
@@ -308,12 +312,14 @@ export const EquipmentImportModal: FC<EquipmentImportModalProps> = ({
                 catalogueItemData={catalogueItemData?.nodes}
                 setEquipment={setBufferedEquipment}
                 setErrorMessage={setErrorMessage}
+                setWarningMessage={setWarningMessage}
                 onUploadComplete={() => {
                   changeTab(Tabs.Review);
                 }}
               />
             </QueryParamsProvider>
             <EquipmentReviewTab
+              showWarnings={showWarnings}
               tab={Tabs.Review}
               uploadedRows={bufferedEquipment}
             />

--- a/client/packages/coldchain/src/Equipment/ImportAsset/ImportReviewDataTable.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/ImportReviewDataTable.tsx
@@ -15,9 +15,11 @@ import { ImportRow } from './EquipmentImportModal';
 
 interface ImportReviewDataTableProps {
   importRows: ImportRow[];
+  showWarnings: boolean;
 }
 export const ImportReviewDataTable: FC<ImportReviewDataTableProps> = ({
   importRows,
+  showWarnings,
 }) => {
   const t = useTranslation('coldchain');
   const isCentralServer = useIsCentralServerApi();
@@ -50,7 +52,6 @@ export const ImportReviewDataTable: FC<ImportReviewDataTableProps> = ({
       accessor: ({ rowData }) => rowData.store?.code,
     });
   }
-
   columnDescriptions.push({
     key: 'serialNumber',
     width: 100,
@@ -72,12 +73,21 @@ export const ImportReviewDataTable: FC<ImportReviewDataTableProps> = ({
     label: 'label.asset-notes',
     Cell: TooltipTextCell,
   });
-  columnDescriptions.push({
-    key: 'errorMessage',
-    label: 'label.error-message',
-    width: 150,
-    Cell: TooltipTextCell,
-  });
+  if (showWarnings) {
+    columnDescriptions.push({
+      key: 'warningMessage',
+      label: 'label.warning-message',
+      width: 150,
+      Cell: TooltipTextCell,
+    });
+  } else {
+    columnDescriptions.push({
+      key: 'errorMessage',
+      label: 'label.error-message',
+      width: 150,
+      Cell: TooltipTextCell,
+    });
+  }
 
   const columns = useColumns<ImportRow>(columnDescriptions, {}, []);
 

--- a/client/packages/coldchain/src/Equipment/ImportAsset/ReviewTab.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/ReviewTab.tsx
@@ -5,13 +5,18 @@ import { ImportReviewDataTable } from './ImportReviewDataTable';
 
 interface EquipmentReviewTabProps {
   uploadedRows: ImportRow[];
+  showWarnings: boolean;
 }
 
 export const EquipmentReviewTab: FC<ImportPanel & EquipmentReviewTabProps> = ({
+  showWarnings,
   tab,
   uploadedRows,
 }) => (
   <ImportPanel tab={tab}>
-    <ImportReviewDataTable importRows={uploadedRows} />
+    <ImportReviewDataTable
+      importRows={uploadedRows}
+      showWarnings={showWarnings}
+    />
   </ImportPanel>
 );

--- a/client/packages/common/src/intl/locales/en/coldchain.json
+++ b/client/packages/common/src/intl/locales/en/coldchain.json
@@ -68,6 +68,7 @@
   "label.current-status": "Current Status",
   "label.documents": "Documents",
   "label.error-message": "Error message",
+  "label.warning-message": "Warning",
   "label.hot-consecutive": "Hot Consecutive",
   "label.hot-cumulative": "Hot Cumulative",
   "label.import": "Import",
@@ -140,5 +141,7 @@
   "status.not-in-use": "Not in use",
   "title.new-sensor": "New sensor added",
   "title.sensor-details": "Sensor Details",
+  "warning.field-not-parsed": "{{field}} not parsed",
+  "messages.import-warning-on-upload": "Warning some values failed to parse. Please fix or these will be ignored on upload",
   "tooltip.import-fridge-tag": "Import Berlinger Fridge-tag and Q-tag log files. A sensor will be created, if necessary, for each log file imported."
 }

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -157,6 +157,7 @@
   "label.catalogue-item-code": "Catalogue item code",
   "label.asset-notes": "Notes",
   "label.error-message": "Error message",
+  "label.warning-message": "Warning",
   "label.app-version": "Version:",
   "label.approval-comment": "Approval Comment",
   "label.approved-packs": "Approved packs",


### PR DESCRIPTION
Fixes #3742 

# 👩🏻‍💻 What does this PR do?

Adds warnings for fields where they fail to parse

## 💌 Any notes for the reviewer?

Adds a warning column for cold chain equipment input for values which failed to parse but won't block the import
This is for non essential fields to flag to the user when they failed to parse.

I've also made this column optional only to only appear when there are no errors so as to not clog up the review table space.

Currently only installation date will flag warnings if it fails to parse.

Other text fields won't receive this warning because they don't require formatting.

# 🧪 Testing

Open open mSupply with vaccine module
Try importing some cold chain equipment where the date field is not a date such as this file:
[equipment upload template_2024-04-16 (1).csv](https://github.com/msupply-foundation/open-msupply/files/15257060/equipment.upload.template_2024-04-16.1.csv)

See warnings which don't prevent import (and resulting asset has no date value)
