### PR TITLE
Fix the zebra tester 🦓 ✅ 

### DIFF
--- a/server/server/src/print/label.rs
+++ b/server/server/src/print/label.rs
@@ -142,7 +142,7 @@ impl HostResponse {
             label_length: 0,
         };
         let lines: Vec<&str> = data.split('\n').collect();
-        if lines.len() != 3 {
+        if lines.len() < 3 {
             return invalid_response;
         }
         let line1_parts: Vec<&str> = lines[0].split(',').collect();

--- a/server/service/src/print/jetdirect.rs
+++ b/server/service/src/print/jetdirect.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use std::{io::Write, net::SocketAddr};
 use telnet::{Event, Telnet};
 
-const PRINTER_COMMAND_TIMEOUT: Duration = Duration::new(0, 500);
+const PRINTER_COMMAND_TIMEOUT: Duration = Duration::new(1, 0);
 const PRINTER_CONNECTION_TIMEOUT: Duration = Duration::new(5, 0);
 
 // Note: this file is mostly taken from https://github.com/fearful-symmetry/zebrasend/blob/main/src/cmd/jetdirect.rs
@@ -62,7 +62,6 @@ impl Jetdirect {
                 }
             }
         }
-
         Ok(response)
     }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3849

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
Two issues with the printer response:
* The printer was timing out on the initial telnet connection
* There is now an additional linebreak at the end of the response i.e. 
```
"\u{2}030,0,0,0290,000,0,0,0,000,0,0,0\u{3}\r\n\u{2}001,0,0,0,1,2,4,0,00000000,1,000\u{3}\r\n\u{2}1234,0\u{3}\r\n"
```

the validation was checking for exactly 3 lines of response. I've changed that to fail if less than 3.
Increased the timeout from 500ms to 1s

<img width="1252" alt="Screenshot 2024-05-09 at 5 16 05 PM" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/402cb25e-4479-4442-8dcb-ad6d0b23a92a">


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Press the test button!
# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
