### PR TITLE
Add tooltip to the select/unselect all column header

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -517,6 +517,7 @@
   "sync-status.push": "Push",
   "sync-status.push-v6": "Push V6",
   "table.show-columns": "Show / hide columns",
+  "table.select-unselect-all-columns": "Select / unselect all columns",
   "title.confirm-delete-encounter": "Delete encounter",
   "warning.caps-lock": "Warning: Caps lock is on",
   "error.record-already-exists": "A record with this id already exists",

--- a/client/packages/common/src/ui/layout/tables/columns/CheckboxSelectionColumn.tsx
+++ b/client/packages/common/src/ui/layout/tables/columns/CheckboxSelectionColumn.tsx
@@ -32,12 +32,13 @@ const useCheckbox = (rowId: string) => {
 };
 
 export const getCheckboxSelectionColumn = <
-  T extends RecordWithId
+  T extends RecordWithId,
 >(): ColumnDefinition<T> => ({
   key: GenericColumnKey.Selection,
   sortable: false,
   align: ColumnAlign.Right,
   width: 60,
+  label: 'table.select-unselect-all-columns',
   Header: () => {
     const { toggleAll, allSelected, someSelected } = useTableStore(state => {
       const allSelected =

--- a/client/packages/common/src/ui/layout/tables/components/Cells/TooltipTextCell/TooltipTextCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/TooltipTextCell/TooltipTextCell.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { CellProps, RecordWithId, Tooltip } from '@openmsupply-client/common';
+import { tooltipPlacement } from '../../tooltipPlacement';
 
 export const TooltipTextCell = <T extends RecordWithId>({
   column,
@@ -7,7 +8,7 @@ export const TooltipTextCell = <T extends RecordWithId>({
 }: CellProps<T>): React.ReactElement<CellProps<T>> => {
   const text = String(column.accessor({ rowData }) ?? '');
   return (
-    <Tooltip title={text} placement="bottom-start">
+    <Tooltip title={text} placement={tooltipPlacement(column.align)}>
       <div
         style={{
           overflow: 'hidden',

--- a/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -5,6 +5,7 @@ import { InfoOutlineIcon, SortDescIcon } from '@common/icons';
 import { RecordWithId } from '@common/types';
 import { useDebounceCallback } from '@common/hooks';
 import { useTranslation } from '@common/intl';
+import { tooltipPlacement } from '../tooltipPlacement';
 
 export const HeaderRow: FC<PropsWithChildren<{ dense?: boolean }>> = ({
   dense,
@@ -117,13 +118,6 @@ export const HeaderCell = <T extends RecordWithId>({
     child
   );
 
-  const tooltipPlacement =
-    align === 'left'
-      ? 'bottom-start'
-      : align === 'right'
-      ? 'bottom-end'
-      : 'bottom';
-
   return (
     <TableCell
       role="columnheader"
@@ -147,7 +141,7 @@ export const HeaderCell = <T extends RecordWithId>({
     >
       <Tooltip
         title={tooltip}
-        placement={tooltipPlacement}
+        placement={tooltipPlacement(align)}
         style={{ whiteSpace: 'pre-line' }}
       >
         {HeaderLabel}

--- a/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -64,19 +64,20 @@ export const HeaderCell = <T extends RecordWithId>({
 
   const columnLabel =
     column.label === '' ? '' : t(column.label, column.labelProps);
-  const tooltip = (
-    <>
-      {!!description && <div>{t(description)}</div>}
-      {sortable ? (
-        <div>
-          {t('label.click-to-sort')}
-          {` ${columnLabel}`}
-        </div>
-      ) : (
-        columnLabel
-      )}
-    </>
-  );
+  const tooltip =
+    !description && !sortable && !columnLabel ? null : (
+      <>
+        {!!description && <div>{t(description)}</div>}
+        {sortable ? (
+          <div>
+            {t('label.click-to-sort')}
+            {` ${columnLabel}`}
+          </div>
+        ) : (
+          columnLabel
+        )}
+      </>
+    );
 
   const infoIcon = !!description ? (
     <InfoOutlineIcon

--- a/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -117,6 +117,13 @@ export const HeaderCell = <T extends RecordWithId>({
     child
   );
 
+  const tooltipPlacement =
+    align === 'left'
+      ? 'bottom-start'
+      : align === 'right'
+      ? 'bottom-end'
+      : 'bottom';
+
   return (
     <TableCell
       role="columnheader"
@@ -140,7 +147,7 @@ export const HeaderCell = <T extends RecordWithId>({
     >
       <Tooltip
         title={tooltip}
-        placement="bottom"
+        placement={tooltipPlacement}
         style={{ whiteSpace: 'pre-line' }}
       >
         {HeaderLabel}

--- a/client/packages/common/src/ui/layout/tables/components/tooltipPlacement.ts
+++ b/client/packages/common/src/ui/layout/tables/components/tooltipPlacement.ts
@@ -1,0 +1,21 @@
+import { noOtherVariants } from '@common/utils';
+import { ColumnAlign } from '../columns';
+
+/**
+ * Returns tooltip placement depending on the column alignment, e.g. to have the tooltip on the
+ * correct side of the column.
+ */
+export const tooltipPlacement = (
+  align: ColumnAlign
+): 'bottom-end' | 'bottom-start' | 'bottom' => {
+  switch (align) {
+    case ColumnAlign.Left:
+      return 'bottom-start';
+    case ColumnAlign.Right:
+      return 'bottom-end';
+    case ColumnAlign.Center:
+      return 'bottom';
+    default:
+      return noOtherVariants(align);
+  }
+};


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3853 

# 👩🏻‍💻 What does this PR do?

Add a tooltip to avoid an empty tooltip to show up.

First I checked if we have data for a tool tip and if not set it to `null` (`packages/common/src/ui/layout/tables/components/Header/Header.tsx`)
However, thought having a tooltip is good solution as well...

# 🧪 Testing

- Go to a table and hover over the selection header checkbox
- Tooltip should show
