### PR TITLE
bump sync version (after item_name addition)

### DIFF
--- a/server/service/src/sync/settings.rs
+++ b/server/service/src/sync/settings.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 
 // See README.md for description of when this API version needs to be updated
-pub(crate) static SYNC_VERSION: u32 = 4;
+pub(crate) static SYNC_VERSION: u32 = 5;
 
 #[derive(Deserialize, Clone, Debug, PartialEq, Default)]
 pub struct SyncSettings {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->


# 👩🏻‍💻 What does this PR do?

> NOTE: should only be merged once mSupply PR https://github.com/msupply-foundation/msupply/pull/14649 is merged, or sync will break...

<!-- Explain the changes you made -->

Adding required field item_name is a breaking change for the sync API. We should therefore bump sync version to ensure compatibility with mSupply central. 

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] With mSupply >=v7.14.1, ensure that running sync gets a sync api not compatible error
- [ ] Currently...
  - [ ] Manually update maxVersion in the `syncV5API` method in mSupply to 5
  - [ ] Run sync - it should sync without errors
  - [ ] Though maybe by the time you review this, the sync version increase will be in the [mSupply PR](https://github.com/msupply-foundation/msupply/pull/14649) :)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
