### PR TITLE
3527 You can confirm outbound shipments with only placeholder lines

### DIFF
--- a/client/packages/common/src/intl/locales/en/replenishment.json
+++ b/client/packages/common/src/intl/locales/en/replenishment.json
@@ -83,6 +83,7 @@
   "messages.inbound-shipment-created-on": "Inbound shipment created on {{date}}",
   "messages.internal-order-created-on": "Internal order created on {{date}}",
   "messages.off-hold-confirmation": "This will re-enable status changes",
+  "messages.cant-send-order": "Cannot change the status because there are no lines or because there are only placeholder lines",
   "messages.on-hold-confirmation": "This will prevent any further status changes until the hold is removed",
   "messages.cant-delete-requisitions": "Can only delete requisitions with a status of 'Draft'",
   "messages.cant-return-shipment": "Cannot return lines until the status is 'Delivered'",

--- a/client/packages/common/src/intl/locales/en/replenishment.json
+++ b/client/packages/common/src/intl/locales/en/replenishment.json
@@ -83,7 +83,7 @@
   "messages.inbound-shipment-created-on": "Inbound shipment created on {{date}}",
   "messages.internal-order-created-on": "Internal order created on {{date}}",
   "messages.off-hold-confirmation": "This will re-enable status changes",
-  "messages.cant-send-order": "Cannot change the status because there are no lines or because there are only placeholder lines",
+  "messages.cant-send-order": "Cannot send Internal Order because there are no lines or because there are only placeholder lines",
   "messages.on-hold-confirmation": "This will prevent any further status changes until the hold is removed",
   "messages.cant-delete-requisitions": "Can only delete requisitions with a status of 'Draft'",
   "messages.cant-return-shipment": "Cannot return lines until the status is 'Delivered'",

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
@@ -141,13 +141,17 @@ export const StatusChangeButton = () => {
   const { selectedOption, getConfirmation, lines } = useStatusChangeButton();
   const isDisabled = useRequest.utils.isDisabled();
   const { userHasPermission } = useAuthContext();
-  const t = useTranslation('app');
-  const noLines = lines?.totalCount === 0;
+  const t = useTranslation(['app', 'replenishment']);
+  const cantSend =
+    lines?.totalCount === 0 ||
+    lines?.nodes.some(line => line.requestedQuantity === 0);
 
   const showPermissionDenied = useDisabledNotificationToast(
     t('auth.permission-denied')
   );
-  const showNoLines = useDisabledNotificationToast(t('messages.no-lines'));
+  const showCantSend = useDisabledNotificationToast(
+    t('messages.cant-send-order', { ns: 'replenishment' })
+  );
 
   if (!selectedOption) return null;
   if (isDisabled) return null;
@@ -159,7 +163,7 @@ export const StatusChangeButton = () => {
 
   const onClick = () => {
     if (!hasPermission) return showPermissionDenied();
-    if (noLines) return showNoLines();
+    if (cantSend) return showCantSend();
 
     getConfirmation();
   };

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
@@ -144,7 +144,7 @@ export const StatusChangeButton = () => {
   const t = useTranslation(['app', 'replenishment']);
   const cantSend =
     lines?.totalCount === 0 ||
-    lines?.nodes.some(line => line.requestedQuantity === 0);
+    lines?.nodes.every(line => line.requestedQuantity === 0);
 
   const showPermissionDenied = useDisabledNotificationToast(
     t('auth.permission-denied')


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3527

# 👩🏻‍💻 What does this PR do?
Don't allow users to send Internal Orders if there are only placeholder lines or if there are no lines

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an `Internal Order`
- [ ] Try send without lines
- [ ] See message
- [ ] Add lines from masterlist or just add one line
- [ ] Don't put anything in for requested quantity (should be 0)
- [ ] Try to send
- [ ] See message

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
