### PR TITLE
3858 CCEI module: No details in error message when creating CCE with duplicate asset numbers

### DIFF
--- a/client/packages/coldchain/src/Equipment/ListView/CreateAssetModal.tsx
+++ b/client/packages/coldchain/src/Equipment/ListView/CreateAssetModal.tsx
@@ -70,10 +70,11 @@ const InputRow = ({
 const parseInsertError = (e: unknown) => {
   const message = (e as Error).message;
   if (
-    message.includes('DatabaseError(') &&
-    message.includes('UniqueViolation(') &&
-    message.includes('asset_asset_number_key') &&
-    message.includes('duplicate key')
+    message.includes('DatabaseError(') ||
+    message.includes('UniqueViolation(') ||
+    message.includes('asset_asset_number_key') ||
+    message.includes('duplicate key') ||
+    message.includes('AssetNumberAlreadyExists')
   ) {
     return 'error.cce-asset-number-already-used';
   }

--- a/client/packages/coldchain/src/Equipment/ListView/CreateAssetModal.tsx
+++ b/client/packages/coldchain/src/Equipment/ListView/CreateAssetModal.tsx
@@ -69,13 +69,7 @@ const InputRow = ({
 
 const parseInsertError = (e: unknown) => {
   const message = (e as Error).message;
-  if (
-    message.includes('DatabaseError(') ||
-    message.includes('UniqueViolation(') ||
-    message.includes('asset_asset_number_key') ||
-    message.includes('duplicate key') ||
-    message.includes('AssetNumberAlreadyExists')
-  ) {
+  if (message.includes('AssetNumberAlreadyExists')) {
     return 'error.cce-asset-number-already-used';
   }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3858

# 👩🏻‍💻 What does this PR do?
Show correct error if asset number already exists
![Screenshot 2024-05-13 at 17 03 17](https://github.com/msupply-foundation/open-msupply/assets/61820074/cf015d65-06b0-431c-95d7-a2e049a62e95)

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an equipment with asset number = 1
- [ ] Try create another equipment with asset number = 1
- [ ] See error

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
