### PR TITLE
3829 inbound delivery date updated when verified

### DIFF
--- a/server/repository/src/mock/invoice.rs
+++ b/server/repository/src/mock/invoice.rs
@@ -246,6 +246,9 @@ pub fn mock_inbound_shipment_a() -> InvoiceRow {
             .unwrap()
             .and_hms_milli_opt(20, 30, 0, 0)
             .unwrap();
+        r.delivered_datetime = NaiveDate::from_ymd_opt(1970, 1, 3)
+            .unwrap()
+            .and_hms_milli_opt(21, 30, 0, 0);
     })
 }
 

--- a/server/service/src/invoice/inbound_return/update/generate.rs
+++ b/server/service/src/invoice/inbound_return/update/generate.rs
@@ -110,14 +110,16 @@ fn set_new_status_datetime(inbound_return: &mut InvoiceRow, patch: &UpdateInboun
             inbound_return.delivered_datetime = Some(current_datetime);
         }
 
-        // From New/Picked/Shipped/Delivered to Verified
+        // From New/Picked/Shipped to Verified
         (
-            InvoiceStatus::New
-            | InvoiceStatus::Picked
-            | InvoiceStatus::Shipped
-            | InvoiceStatus::Delivered,
+            InvoiceStatus::New | InvoiceStatus::Picked | InvoiceStatus::Shipped,
             UpdateInboundReturnStatus::Verified,
         ) => {
+            inbound_return.delivered_datetime = Some(current_datetime);
+            inbound_return.verified_datetime = Some(current_datetime);
+        }
+        // From Delivered to Verified
+        (InvoiceStatus::Delivered, UpdateInboundReturnStatus::Verified) => {
             inbound_return.verified_datetime = Some(current_datetime);
         }
         _ => {}

--- a/server/service/src/invoice/inbound_shipment/update/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/update/generate.rs
@@ -246,14 +246,16 @@ fn set_new_status_datetime(invoice: &mut InvoiceRow, patch: &UpdateInboundShipme
             invoice.delivered_datetime = Some(current_datetime);
         }
 
-        // From New/Picked/Shipped/Delivered to Verified
+        // From New/Picked/Shipped to Verified
         (
-            InvoiceStatus::New
-            | InvoiceStatus::Picked
-            | InvoiceStatus::Shipped
-            | InvoiceStatus::Delivered,
+            InvoiceStatus::New | InvoiceStatus::Picked | InvoiceStatus::Shipped,
             UpdateInboundShipmentStatus::Verified,
         ) => {
+            invoice.delivered_datetime = Some(current_datetime);
+            invoice.verified_datetime = Some(current_datetime);
+        }
+        // From Delivered to Verified
+        (InvoiceStatus::Delivered, UpdateInboundShipmentStatus::Verified) => {
             invoice.verified_datetime = Some(current_datetime);
         }
         _ => {}

--- a/server/service/src/invoice/inbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/update/mod.rs
@@ -865,7 +865,10 @@ mod test {
             .unwrap();
 
         // Ensure delivered time not updated by status change to verified
-        assert_eq!(invoice.delivered_datetime, None);
+        assert_eq!(
+            invoice.delivered_datetime,
+            mock_inbound_shipment_a().delivered_datetime
+        );
 
         assert!(invoice.verified_datetime.unwrap() > now);
         assert!(invoice.verified_datetime.unwrap() < end_time);

--- a/server/service/src/invoice/inbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/update/mod.rs
@@ -864,6 +864,9 @@ mod test {
             .find_one_by_id(&stock_line_id)
             .unwrap();
 
+        // Ensure delivered time not updated by status change to verified
+        assert_eq!(invoice.delivered_datetime, None);
+
         assert!(invoice.verified_datetime.unwrap() > now);
         assert!(invoice.verified_datetime.unwrap() < end_time);
         assert_eq!(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3829

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Issue was that the delivered_datetime was being overwritten on Delivered -> Verified.

- Uses `match` statement rather than status index to determine whether to update delivered/verified datetime.
  - This makes the status change logic more readable, and prevents the delivered_datetime being updated when setting to `Verified`

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

I've seen both in different places... should `delivered_datetime` be set if we go straight from `New` to `Verified`?

If not, we need to update the ledger query to handle this possibility! Currently we get no ledger line if we go straight to verified 👀 

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an inbound shipment, add a line, and set it to delivered
- [ ] In view stock, check the timestamp in the ledger tab of your newly introduced stock line
- [ ] Wait at least a minute 😅 
- [ ] Set your inbound shipment to Verified
- [ ] Check the ledger tab again - the timestamp should NOT have changed

Or can check by going to the inbound shipment detail view, look in dev tools at the `inboundByNumber` query, check the timestamps on the inbound shipment: 

![Screenshot 2024-05-14 at 10 26 22 AM](https://github.com/msupply-foundation/open-msupply/assets/55115239/fafe55e6-7767-4c72-847c-a417ac9b6a93)




# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
