### PR TITLE
3877 introduce stock when set straight to verified

### DIFF
--- a/server/service/src/invoice/inbound_return/update/generate.rs
+++ b/server/service/src/invoice/inbound_return/update/generate.rs
@@ -88,9 +88,9 @@ pub fn should_create_batches(
 
     match (existing_status, new_status) {
         (
-            // From New/Picked/Shipped to Delivered
+            // From New/Picked/Shipped to Delivered/Verified
             InvoiceRowStatus::New | InvoiceRowStatus::Picked | InvoiceRowStatus::Shipped,
-            UpdateInboundReturnStatus::Delivered,
+            UpdateInboundReturnStatus::Delivered | UpdateInboundReturnStatus::Verified,
         ) => true,
         _ => false,
     }

--- a/server/service/src/invoice/inbound_return/update/mod.rs
+++ b/server/service/src/invoice/inbound_return/update/mod.rs
@@ -389,4 +389,76 @@ mod test {
         // Stock line has not changed
         assert_eq!(stock_line_delivered, stock_line_verified);
     }
+
+    #[actix_rt::test]
+    async fn update_inbound_return_success_new_to_verified() {
+        let (_, connection, connection_manager, _) = setup_all(
+            "update_inbound_return_success_new_to_verified",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let context = service_provider
+            .context(mock_store_b().id, mock_user_account_a().id)
+            .unwrap();
+        let service = service_provider.invoice_service;
+
+        let invoice_id = mock_inbound_return_b().id;
+
+        /* -------
+         * Setting NEW inbound return to VERIFIED
+         */
+        let return_line_filter =
+            InvoiceLineFilter::new().invoice_id(EqualFilter::equal_to(&mock_inbound_return_b().id));
+
+        let invoice_line_repo = InvoiceLineRepository::new(&connection);
+
+        let invoice_lines = invoice_line_repo
+            .query_by_filter(return_line_filter.clone())
+            .unwrap();
+
+        // Inbound return currently in NEW status, should have no stock lines
+        assert!(invoice_lines
+            .iter()
+            .all(|l| l.invoice_line_row.stock_line_id == None));
+
+        let updated_return = service
+            .update_inbound_return(
+                &context,
+                inline_init(|r: &mut UpdateInboundReturn| {
+                    r.id = invoice_id.clone();
+                    r.status = Some(UpdateInboundReturnStatus::Verified);
+                }),
+            )
+            .unwrap();
+
+        let return_row = updated_return.invoice_row;
+        // Status has been updated
+        assert_eq!(return_row.status, InvoiceRowStatus::Verified);
+        assert!(return_row.verified_datetime.is_some());
+
+        let invoice_lines = invoice_line_repo
+            .query_by_filter(return_line_filter.clone())
+            .unwrap();
+
+        assert_eq!(invoice_lines.len(), 1);
+
+        let stock_line_id = invoice_lines[0]
+            .invoice_line_row
+            .stock_line_id
+            .clone()
+            .unwrap();
+
+        // check stock line was introduced
+        let stock_line = StockLineRowRepository::new(&connection)
+            .find_one_by_id(&stock_line_id)
+            .unwrap();
+
+        // data from invoice line was added to the new stock line
+        assert_eq!(
+            stock_line.batch,
+            mock_inbound_return_b_invoice_line_a().batch
+        );
+    }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3877

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Introduces stock when an inbound return status is updated from `New`/`Picked`/`Shipped`, straight to `Verified`.

(It was only being introduced when changed to Delivered!)

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an Inbound Return
- [ ] Add at least one line
- [ ] Set the return straight to verified
- [ ] Check the View Stock page
- [ ] TEST: your stock line is there

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
