### PR TITLE
3834 clear number inputs to 0

### DIFF
--- a/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
@@ -168,9 +168,13 @@ export const NumericTextInput: FC<NumericTextInputProps> = React.forwardRef(
           onChange(newNum);
         }}
         onBlur={() => {
+          const defaultVal = min === 0 ? undefined : min;
+
           const parsed = parse(textValue ?? '');
-          onChange(Number.isNaN(parsed) ? undefined : parsed);
-          setTextValue(formatValue(value));
+          const val = Number.isNaN(parsed) ? defaultVal : parsed;
+
+          onChange(val);
+          setTextValue(formatValue(val));
         }}
         onFocus={e => e.target.select()}
         {...props}

--- a/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
@@ -168,10 +168,8 @@ export const NumericTextInput: FC<NumericTextInputProps> = React.forwardRef(
           onChange(newNum);
         }}
         onBlur={() => {
-          const defaultVal = min === 0 ? undefined : min;
-
           const parsed = parse(textValue ?? '');
-          const val = Number.isNaN(parsed) ? defaultVal : parsed;
+          const val = Number.isNaN(parsed) ? defaultValue : parsed;
 
           onChange(val);
           setTextValue(formatValue(val));

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -75,6 +75,7 @@ const NumberOfPacksCell: React.FC<CellProps<DraftInboundLine>> = ({
 }) => (
   <NumberInputCell
     {...props}
+    min={0}
     isRequired={rowData.numberOfPacks === 0}
     rowData={rowData}
   />

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
@@ -267,10 +267,9 @@ export const RequestLineEditForm = ({
                     )}
                     width={100}
                     onChange={quantity => {
-                      if (quantity === undefined) return;
                       update({
                         requestedQuantity:
-                          quantity * currentItem.defaultPackSize,
+                          (quantity ?? 0) * currentItem.defaultPackSize,
                       });
                     }}
                   />

--- a/client/packages/system/src/Item/Components/PackVariant/PackVariantEntryCell.tsx
+++ b/client/packages/system/src/Item/Components/PackVariant/PackVariantEntryCell.tsx
@@ -36,7 +36,7 @@ export const PackVariantEntryCell =
     const t = useTranslation();
     const [isEnterPackSize, setIsEnterPackSize] = useState(false);
     const [shouldFocusInput, setShouldFocusInput] = useState(false);
-    const [packSize, setPackSize] = useState(
+    const [packSize, setPackSize] = useState<number | undefined>(
       Number(column.accessor({ rowData }))
     );
 
@@ -49,7 +49,14 @@ export const PackVariantEntryCell =
       }
     }, []);
 
-    const updater = useDebounceCallback(column.setter, [column.setter], 250);
+    const updater = useDebounceCallback(
+      (newValue: number) => {
+        setPackSize(newValue);
+        column.setter({ ...rowData, [column.key]: newValue });
+      },
+      [column.setter],
+      500
+    );
     const disabled = isDisabled || getIsDisabled?.(rowData) || false;
 
     // Make sure manual pack size is auto selected on load if packSize does not
@@ -67,8 +74,12 @@ export const PackVariantEntryCell =
           focusOnRender={shouldFocusInput}
           value={packSize}
           onChange={newValue => {
-            setPackSize(newValue || 1);
-            updater({ ...rowData, [column.key]: newValue });
+            // newValue could be undefined. Here we (briefly) set packSize to the newValue
+            // regardless of if it is undefined, to allow e.g. changing 1 to 2
+            setPackSize(newValue);
+
+            // Updater is debounced, but will set an undefined packSize back to 1
+            updater(newValue || 1);
           }}
           disabled={disabled}
         />
@@ -115,7 +126,7 @@ export const PackVariantEntryCell =
             setPackSize(newPackSize);
             setIsEnterPackSize(isEnterPackSizeSelected);
             setShouldFocusInput(isEnterPackSizeSelected);
-            updater({ ...rowData, [column.key]: newPackSize });
+            updater(newPackSize);
           }}
           disabled={disabled}
         />

--- a/client/packages/system/src/Item/Components/PackVariant/PackVariantEntryCell.tsx
+++ b/client/packages/system/src/Item/Components/PackVariant/PackVariantEntryCell.tsx
@@ -68,8 +68,13 @@ export const PackVariantEntryCell =
           min={1}
           value={packSize}
           onChange={newValue => {
+            // newValue could be undefined, while the user is inputting
+            // (e.g. they clear the field to enter a new pack size)
+            // In that case, we temporarily update the column value to 0 (so we don't have any `NaN`s)
+
+            // NumericTextInput onBlur will reset the value to our min (1) if the field is empty!
             setPackSize(newValue);
-            updater({ ...rowData, [column.key]: newValue || 1 });
+            updater({ ...rowData, [column.key]: newValue || 0 });
           }}
           disabled={disabled}
         />

--- a/client/packages/system/src/Item/Components/PackVariant/PackVariantEntryCell.tsx
+++ b/client/packages/system/src/Item/Components/PackVariant/PackVariantEntryCell.tsx
@@ -66,15 +66,17 @@ export const PackVariantEntryCell =
         <NumericTextInput
           focusOnRender={shouldFocusInput}
           min={1}
+          defaultValue={1}
           value={packSize}
           onChange={newValue => {
             // newValue could be undefined, while the user is inputting
             // (e.g. they clear the field to enter a new pack size)
-            // In that case, we temporarily update the column value to 0 (so we don't have any `NaN`s)
+            // In that case, we keep the packSize local state as undefined
+            // but set the row value to 1 (so we always have valid state to save)
 
-            // NumericTextInput onBlur will reset the value to our min (1) if the field is empty!
+            // NumericTextInput will reset to our default (1) on blur if the field is empty!
             setPackSize(newValue);
-            updater({ ...rowData, [column.key]: newValue || 0 });
+            updater({ ...rowData, [column.key]: newValue ?? 1 });
           }}
           disabled={disabled}
         />

--- a/client/packages/system/src/Item/Components/PackVariant/PackVariantEntryCell.tsx
+++ b/client/packages/system/src/Item/Components/PackVariant/PackVariantEntryCell.tsx
@@ -49,14 +49,7 @@ export const PackVariantEntryCell =
       }
     }, []);
 
-    const updater = useDebounceCallback(
-      (newValue: number) => {
-        setPackSize(newValue);
-        column.setter({ ...rowData, [column.key]: newValue });
-      },
-      [column.setter],
-      500
-    );
+    const updater = useDebounceCallback(column.setter, [column.setter], 250);
     const disabled = isDisabled || getIsDisabled?.(rowData) || false;
 
     // Make sure manual pack size is auto selected on load if packSize does not
@@ -72,14 +65,11 @@ export const PackVariantEntryCell =
       return (
         <NumericTextInput
           focusOnRender={shouldFocusInput}
+          min={1}
           value={packSize}
           onChange={newValue => {
-            // newValue could be undefined. Here we (briefly) set packSize to the newValue
-            // regardless of if it is undefined, to allow e.g. changing 1 to 2
             setPackSize(newValue);
-
-            // Updater is debounced, but will set an undefined packSize back to 1
-            updater(newValue || 1);
+            updater({ ...rowData, [column.key]: newValue || 1 });
           }}
           disabled={disabled}
         />
@@ -126,7 +116,7 @@ export const PackVariantEntryCell =
             setPackSize(newPackSize);
             setIsEnterPackSize(isEnterPackSizeSelected);
             setShouldFocusInput(isEnterPackSizeSelected);
-            updater(newPackSize);
+            updater({ ...rowData, [column.key]: newPackSize });
           }}
           disabled={disabled}
         />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3834

# 👩🏻‍💻 What does this PR do?

Updates:
- Internal order requested quantity to allow for 0 quantity input
- Updates pack size input (PackVariantEntryCell) for Inbound Shipment and Inbound Return, to allow clearing the value while typing, and then reset to the min value (e.g. 1) on blur
- Allows pack quantity field to be set to 0 in inbound shipments (you can't save the modal, but at least you can clear the input in order to change e.g. 1 to 2!)

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an Internal Order
- [ ] Add an item
- [ ] Enter a requested quantity
- [ ] TEST: you should be able to backspace the quantity to 0
- [ ] Create an inbound shipment
- [ ] Add an item
- [ ] Enter a pack quantity
- [ ] TEST: you should be able to backspace the quantity to 0
- [ ] Backspace the pack size
- [ ] TEST: it should clear
- [ ] Click off the pack size field, so it loses focus
- [ ] TEST: it should reset to 1
- [ ] Create an inbound return
- [ ] Add an item
- [ ] Backspace the pack size
- [ ] TEST: it should clear
- [ ] Click off the pack size field, so it loses focus
- [ ] TEST: it should reset to 1

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
