### PR TITLE
3887 Turn off installer Codesigning SSL

### DIFF
--- a/build/windows/omsupply_demo.suf
+++ b/build/windows/omsupply_demo.suf
@@ -3477,7 +3477,7 @@ g_HandleSystemReboot();
 <CustomSegSizeMode>0</CustomSegSizeMode>
 <Platform>1</Platform>
 <CollectLaunchUserInfo>0</CollectLaunchUserInfo>
-<CodeSignSetups>1</CodeSignSetups>
+<CodeSignSetups>0</CodeSignSetups>
 <CodeSignLocation>C:\Program Files (x86)\Windows Kits\8.0\bin\x64\signtool.exe</CodeSignLocation>
 <CodeSignWithSHA256>1</CodeSignWithSHA256>
 <CodeSignCertificateFileSHA256>C:\mSupply_installer_codesigning\mSupply_installer_code_signing.pfx</CodeSignCertificateFileSHA256>

--- a/build/windows/omsupply_desktop.suf
+++ b/build/windows/omsupply_desktop.suf
@@ -3244,7 +3244,7 @@ g_HandleSystemReboot();
 <CustomSegSizeMode>0</CustomSegSizeMode>
 <Platform>1</Platform>
 <CollectLaunchUserInfo>0</CollectLaunchUserInfo>
-<CodeSignSetups>1</CodeSignSetups>
+<CodeSignSetups>0</CodeSignSetups>
 <CodeSignLocation>C:\Program Files (x86)\Windows Kits\8.0\bin\x64\signtool.exe</CodeSignLocation>
 <CodeSignWithSHA256>1</CodeSignWithSHA256>
 <CodeSignCertificateFileSHA256>C:\mSupply_installer_codesigning\mSupply_installer_code_signing.pfx</CodeSignCertificateFileSHA256>

--- a/build/windows/omsupply_server.suf
+++ b/build/windows/omsupply_server.suf
@@ -4444,7 +4444,7 @@ g_HandleSystemReboot();
 <CustomSegSizeMode>0</CustomSegSizeMode>
 <Platform>1</Platform>
 <CollectLaunchUserInfo>0</CollectLaunchUserInfo>
-<CodeSignSetups>1</CodeSignSetups>
+<CodeSignSetups>0</CodeSignSetups>
 <CodeSignLocation>C:\Program Files (x86)\Windows Kits\8.0\bin\x64\signtool.exe</CodeSignLocation>
 <CodeSignWithSHA256>1</CodeSignWithSHA256>
 <CodeSignCertificateFileSHA256>C:\mSupply_installer_codesigning\mSupply_installer_code_signing.pfx</CodeSignCertificateFileSHA256>

--- a/build/windows/omsupply_standalone.suf
+++ b/build/windows/omsupply_standalone.suf
@@ -3527,7 +3527,7 @@ g_HandleSystemReboot();
 <CustomSegSizeMode>0</CustomSegSizeMode>
 <Platform>1</Platform>
 <CollectLaunchUserInfo>0</CollectLaunchUserInfo>
-<CodeSignSetups>1</CodeSignSetups>
+<CodeSignSetups>0</CodeSignSetups>
 <CodeSignLocation>C:\Program Files (x86)\Windows Kits\8.0\bin\x64\signtool.exe</CodeSignLocation>
 <CodeSignWithSHA256>1</CodeSignWithSHA256>
 <CodeSignCertificateFileSHA256>C:\mSupply_installer_codesigning\mSupply_installer_code_signing.pfx</CodeSignCertificateFileSHA256>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3887 

# 👩🏻‍💻 What does this PR do?
Turned off code signing in the setup factory files so that Jenkins build installers without any issues.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->
This is a temp fix in order to build installers for now. Will have to revert them back once we have proper code signing certs.