### PR TITLE
Avoid float precision problems when multiplying pack sizes

### DIFF
--- a/client/packages/common/src/utils/numbers/NumUtils.test.ts
+++ b/client/packages/common/src/utils/numbers/NumUtils.test.ts
@@ -20,4 +20,9 @@ describe('NumUtils', () => {
     expect(NumUtils.parseString('40', 1, 10)).toBe(10);
     expect(NumUtils.parseString('4.56')).toBe(4.56);
   });
+
+  it('floatMultiply', () => {
+    expect(NumUtils.floatMultiply(110.4, 29)).toBe(3201.6);
+    expect(NumUtils.floatMultiply(1.001, 1000)).toBe(1001);
+  });
 });

--- a/client/packages/common/src/utils/numbers/NumUtils.ts
+++ b/client/packages/common/src/utils/numbers/NumUtils.ts
@@ -19,10 +19,24 @@ export const NumUtils = {
 
     return constrain(parsed, min, max);
   },
+  /**
+   * Round a value to a given precision.
+   *
+   * For example, round(10.232, 2) gives 10.23
+   */
   round: (value: number, dp = 0): number => {
     if (dp === Infinity) return value;
     const multiplier = 10 ** dp;
     return Math.round(value * multiplier) / multiplier;
+  },
+  /**
+   * Multiplies two float numbers avoiding "float artefacts".
+   * For example: 110.4 * 29 = 3201.6000000000004
+   * while floatMultiply(110.4, 29) = 3201.6
+   */
+  floatMultiply: (left: number, right: number): number => {
+    // Use a hacky(?) correction factor of 10:
+    return (10 * left * right) / 10;
   },
   /**
    * This constant should be used for values that are potentially send to a backend API that expects

--- a/client/packages/common/src/utils/numbers/NumUtils.ts
+++ b/client/packages/common/src/utils/numbers/NumUtils.ts
@@ -35,8 +35,8 @@ export const NumUtils = {
    * while floatMultiply(110.4, 29) = 3201.6
    */
   floatMultiply: (left: number, right: number): number => {
-    // Use a hacky(?) correction factor of 10:
-    return (10 * left * right) / 10;
+    // Use a hacky(?) correction factor of 100:
+    return (100 * left * right) / 100;
   },
   /**
    * This constant should be used for values that are potentially send to a backend API that expects

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -11,6 +11,7 @@ import {
   useColumnUtils,
   CurrencyCell,
   ColumnDescription,
+  NumUtils,
 } from '@openmsupply-client/common';
 import {
   getPackVariantCell,
@@ -25,7 +26,7 @@ type InboundShipmentColumnDescription = ColumnDescription<
 >;
 
 const getUnitQuantity = (row: InboundLineFragment) =>
-  row.packSize * row.numberOfPacks;
+  NumUtils.floatMultiply(row.packSize, row.numberOfPacks);
 
 export const useInboundShipmentColumns = () => {
   const {

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -18,6 +18,7 @@ import {
   Currencies,
   useCurrencyCell,
   useAuthContext,
+  NumUtils,
 } from '@openmsupply-client/common';
 import { DraftInboundLine } from '../../../../types';
 import {
@@ -120,7 +121,8 @@ export const QuantityTableComponent: FC<
       [
         'unitQuantity',
         {
-          accessor: ({ rowData }) => rowData.numberOfPacks * rowData.packSize,
+          accessor: ({ rowData }) =>
+            NumUtils.floatMultiply(rowData.packSize, rowData.numberOfPacks),
         },
       ],
     ],

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
@@ -11,6 +11,7 @@ import {
   useCurrencyCell,
   Currencies,
   CurrencyCell,
+  NumUtils,
 } from '@openmsupply-client/common';
 import { DraftStockOutLine } from '../../../types';
 import { PackQuantityCell, StockOutLineFragment } from '../../../StockOut';
@@ -132,7 +133,8 @@ export const useOutboundLineEditColumns = ({
       {
         label: 'label.unit-quantity-issued',
         labelProps: { unit },
-        accessor: ({ rowData }) => rowData.numberOfPacks * rowData.packSize,
+        accessor: ({ rowData }) =>
+          NumUtils.floatMultiply(rowData.numberOfPacks, rowData.packSize),
         width: 90,
       },
     ],
@@ -196,7 +198,8 @@ export const useExpansionColumns = (): Column<StockOutLineFragment>[] => {
     [
       'unitQuantity',
       {
-        accessor: ({ rowData }) => rowData.packSize * rowData.numberOfPacks,
+        accessor: ({ rowData }) =>
+          NumUtils.floatMultiply(rowData.packSize, rowData.numberOfPacks),
       },
     ],
     [

--- a/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -13,6 +13,7 @@ import {
   NumberCell,
   CurrencyCell,
   ColumnDescription,
+  NumUtils,
 } from '@openmsupply-client/common';
 import {
   getPackVariantCell,
@@ -43,7 +44,9 @@ const getNumberOfPacks = (row: StockOutLineFragment) =>
   isDefaultPlaceholderRow(row) ? '' : row.numberOfPacks;
 
 const getUnitQuantity = (row: StockOutLineFragment) =>
-  isDefaultPlaceholderRow(row) ? '' : row.packSize * row.numberOfPacks;
+  isDefaultPlaceholderRow(row)
+    ? ''
+    : NumUtils.floatMultiply(row.packSize, row.numberOfPacks);
 
 export const useOutboundColumns = ({
   sortBy,

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/columns.ts
@@ -5,6 +5,7 @@ import {
   ColumnDescription,
   ExpiryDateCell,
   LocationCell,
+  NumUtils,
   NumberCell,
   useColumns,
 } from '@openmsupply-client/common';
@@ -94,7 +95,8 @@ export const usePrescriptionLineEditColumns = ({
       {
         label: 'label.unit-quantity-issued',
         labelProps: { unit },
-        accessor: ({ rowData }) => rowData.numberOfPacks * rowData.packSize,
+        accessor: ({ rowData }) =>
+          NumUtils.floatMultiply(rowData.numberOfPacks, rowData.packSize),
         width: 120,
       },
     ],
@@ -134,7 +136,8 @@ export const useExpansionColumns = (): Column<StockOutLineFragment>[] =>
     [
       'unitQuantity',
       {
-        accessor: ({ rowData }) => rowData.packSize * rowData.numberOfPacks,
+        accessor: ({ rowData }) =>
+          NumUtils.floatMultiply(rowData.packSize, rowData.numberOfPacks),
       },
     ],
   ]);

--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -12,6 +12,7 @@ import {
   NumberCell,
   CurrencyCell,
   ColumnDescription,
+  NumUtils,
 } from '@openmsupply-client/common';
 import {
   getPackVariantCell,
@@ -205,7 +206,10 @@ export const usePrescriptionColumn = ({
             const { lines } = rowData;
             return ArrayUtils.getUnitQuantity(lines);
           } else {
-            return rowData.packSize * rowData.numberOfPacks;
+            return NumUtils.floatMultiply(
+              rowData.packSize,
+              rowData.numberOfPacks
+            );
           }
         },
         getSortValue: rowData => {
@@ -213,7 +217,10 @@ export const usePrescriptionColumn = ({
             const { lines } = rowData;
             return ArrayUtils.getUnitQuantity(lines);
           } else {
-            return rowData.packSize * rowData.numberOfPacks;
+            return NumUtils.floatMultiply(
+              rowData.packSize,
+              rowData.numberOfPacks
+            );
           }
         },
       },

--- a/client/packages/invoices/src/Returns/InboundDetailView/columns.ts
+++ b/client/packages/invoices/src/Returns/InboundDetailView/columns.ts
@@ -10,6 +10,7 @@ import {
   getRowExpandColumn,
   ArrayUtils,
   ColumnDescription,
+  NumUtils,
 } from '@openmsupply-client/common';
 import { InboundReturnLineFragment } from '../api';
 import { InboundReturnItem } from '../../types';
@@ -32,7 +33,7 @@ const expansionColumn = getRowExpandColumn<
 // >();
 
 const getUnitQuantity = (row: InboundReturnLineFragment) =>
-  row.packSize * row.numberOfPacks;
+  NumUtils.floatMultiply(row.packSize, row.numberOfPacks);
 
 export const useInboundReturnColumns = ({
   sortBy,

--- a/client/packages/invoices/src/Returns/OutboundDetailView/columns.ts
+++ b/client/packages/invoices/src/Returns/OutboundDetailView/columns.ts
@@ -11,6 +11,7 @@ import {
   ArrayUtils,
   ColumnAlign,
   ColumnDescription,
+  NumUtils,
 } from '@openmsupply-client/common';
 import { OutboundReturnLineFragment } from '../api';
 import { OutboundReturnItem } from '../../types';
@@ -32,7 +33,7 @@ const expansionColumn = getRowExpandColumn<
 // >();
 
 const getUnitQuantity = (row: OutboundReturnLineFragment) =>
-  row.packSize * row.numberOfPacks;
+  NumUtils.floatMultiply(row.packSize, row.numberOfPacks);
 
 export const useOutboundReturnColumns = ({
   sortBy,

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -17,6 +17,7 @@ import {
   ColumnDescription,
   usePluginColumns,
   TooltipTextCell,
+  NumUtils,
 } from '@openmsupply-client/common';
 import { RepackModal, StockLineEditModal } from '../Components';
 import { StockLineRowFragment, useStock } from '../api';
@@ -168,7 +169,7 @@ const StockListComponent: FC = () => {
       'stockOnHand',
       {
         accessor: ({ rowData }) =>
-          rowData.totalNumberOfPacks * rowData.packSize,
+          NumUtils.floatMultiply(rowData.totalNumberOfPacks, rowData.packSize),
         label: 'label.soh',
         description: 'description.soh',
         sortable: false,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3705

# 👩🏻‍💻 What does this PR do?

Avoids some visual problems with pack_size being a float. For example, 110.4 * 29 = 3201.6000000000004 is displayed as 3201.6 now.

I didn't make the pack_size editable as a float though. Or do you think we should do it now?

# 🧪 Testing

Please have a look for other `pack_size: float` related issues in the UI that I might have missed.

To create a decimal pack size, create a stocktake in OG mSupply an edit an item to have decimal pack size. This stock line can then be sent to the omSupply site.