### PR TITLE
3893 correctly map repack times and status

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -149,6 +149,7 @@ export const useOutboundColumns = ({
             { path: ['lines', 'location', 'code'] },
             { path: ['location', 'code'], default: '' },
           ]),
+        width: 100,
       },
     ],
   ];

--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -125,6 +125,7 @@ export const usePrescriptionColumn = ({
     [
       'location',
       {
+        width: 100,
         getSortValue: row =>
           getColumnPropertyAsString(row, [
             { path: ['lines', 'location', 'code'] },

--- a/client/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
@@ -62,7 +62,7 @@ export const RequestRequisitionListView: FC = () => {
     {
       key: 'requisitionNumber',
       label: 'label.number',
-      width: 75,
+      width: 90,
     },
     ['createdDatetime', { width: 150 }],
     {

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -566,9 +566,6 @@ fn map_legacy(invoice_type: &InvoiceType, data: &LegacyTransactRow) -> LegacyMap
             _ => {}
         },
         InvoiceType::Repack => match data.status {
-            LegacyTransactStatus::Cn => {
-                mapping.verified_datetime = confirm_datetime;
-            }
             LegacyTransactStatus::Fn => {
                 mapping.verified_datetime = confirm_datetime;
             }
@@ -632,15 +629,17 @@ fn invoice_status(invoice_type: &InvoiceType, data: &LegacyTransactRow) -> Optio
             LegacyTransactStatus::Fn => InvoiceStatus::Verified,
             _ => return None,
         },
-        InvoiceType::InventoryAddition | InvoiceType::InventoryReduction | InvoiceType::Repack => {
-            match data.status {
-                LegacyTransactStatus::Nw => InvoiceStatus::New,
-                LegacyTransactStatus::Sg => InvoiceStatus::New,
-                LegacyTransactStatus::Cn => InvoiceStatus::Verified,
-                LegacyTransactStatus::Fn => InvoiceStatus::Verified,
-                _ => return None,
-            }
-        }
+        InvoiceType::InventoryAddition | InvoiceType::InventoryReduction => match data.status {
+            LegacyTransactStatus::Nw => InvoiceStatus::New,
+            LegacyTransactStatus::Sg => InvoiceStatus::New,
+            LegacyTransactStatus::Cn => InvoiceStatus::Verified,
+            LegacyTransactStatus::Fn => InvoiceStatus::Verified,
+            _ => return None,
+        },
+        InvoiceType::Repack => match data.status {
+            LegacyTransactStatus::Fn => InvoiceStatus::Verified,
+            _ => return None,
+        },
     };
     Some(status)
 }

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -636,6 +636,8 @@ fn invoice_status(invoice_type: &InvoiceType, data: &LegacyTransactRow) -> Optio
             LegacyTransactStatus::Fn => InvoiceStatus::Verified,
             _ => return None,
         },
+        // mSupply will alert users to finalise any repacks if they have un-finalised repacks
+        // before they migrate to Open mSupply.
         InvoiceType::Repack => match data.status {
             LegacyTransactStatus::Fn => InvoiceStatus::Verified,
             _ => return None,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3893

# 👩🏻‍💻 What does this PR do?
Correctly map repack status and confirmed datetime. Nw and sg repacks should be handled by OG
<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
