### PR TITLE
3739 remove foreign key for user

### DIFF
--- a/server/repository/src/migrations/v2_00_00/assets/asset_log.rs
+++ b/server/repository/src/migrations/v2_00_00/assets/asset_log.rs
@@ -28,7 +28,7 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
         CREATE TABLE asset_log (
             id TEXT NOT NULL PRIMARY KEY,
             asset_id TEXT NOT NULL REFERENCES asset(id),
-            user_id TEXT NOT NULL REFERENCES user_account(id),
+            user_id TEXT NOT NULL,
             status {ASSET_LOG_STATUS_ENUM_TYPE},
             reason_id TEXT REFERENCES asset_log_reason(id),
             comment TEXT,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3739 

# 👩🏻‍💻 What does this PR do?
Removes foreign key from `asset_log` to `user_account` so if a user isn't available on central OMS it doesn't prevent sync from happening.

![image](https://github.com/msupply-foundation/open-msupply/assets/8287373/c99b849a-1615-43be-9861-0aa7d865e40b)


## 💌 Any notes for the reviewer?

Roxy's PR https://github.com/msupply-foundation/open-msupply/pull/3431 to sync user information could potentially solve this? But doesn't appear to be working for me.

This PR msupply suggests that changes to user account might not trigger sync?
https://github.com/msupply-foundation/msupply/pull/14538

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] OMS Central Sync server with an OMS remote site running this PR
- [ ] Login to OMS Remote with user that hasn't logged into Central
- [ ] Create an asset
- [ ] Create a status log
- [ ] Sync to Central
- [ ] Login to Central with different user
- [ ] Check that the asset and status both synced correctly.

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
