### PR TITLE
3674 assets locations dont show on central server

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
@@ -11,6 +11,7 @@ import {
   ArrayUtils,
   Box,
   Formatter,
+  useAuthContext,
   useIsCentralServerApi,
 } from '@openmsupply-client/common';
 import { Status } from '../../Components';
@@ -99,6 +100,7 @@ const Row = ({
 export const Summary = ({ draft, onChange, locations }: SummaryProps) => {
   const t = useTranslation('coldchain');
   const { localisedDate } = useFormatDateTime();
+  const { storeId } = useAuthContext();
   const isCentralServer = useIsCentralServerApi();
 
   if (!draft) return null;
@@ -184,35 +186,37 @@ export const Summary = ({ draft, onChange, locations }: SummaryProps) => {
             />
           </Row>
         </Section>
-        <Section heading={t('heading.cold-chain')}>
-          <Row label={t('label.cold-storage-location')}>
-            {locations ? (
-              <AutocompleteMulti
-                isOptionEqualToValue={(option, value) =>
-                  option.value === value.value
-                }
-                defaultValue={defaultLocations}
-                filterSelectedOptions
-                getOptionLabel={option => option.label}
-                inputProps={{ fullWidth: true }}
-                onChange={(
-                  _event,
-                  newSelectedLocations: {
-                    label: string;
-                    value: string;
-                  }[]
-                ) => {
-                  onChange({
-                    locationIds: ArrayUtils.dedupe(
-                      newSelectedLocations.map(location => location.value)
-                    ),
-                  });
-                }}
-                options={locations}
-              />
-            ) : null}
-          </Row>
-        </Section>
+        {(!isCentralServer || draft.storeId == storeId) && (
+          <Section heading={t('heading.cold-chain')}>
+            <Row label={t('label.cold-storage-location')}>
+              {locations ? (
+                <AutocompleteMulti
+                  isOptionEqualToValue={(option, value) =>
+                    option.value === value.value
+                  }
+                  defaultValue={defaultLocations}
+                  filterSelectedOptions
+                  getOptionLabel={option => option.label}
+                  inputProps={{ fullWidth: true }}
+                  onChange={(
+                    _event,
+                    newSelectedLocations: {
+                      label: string;
+                      value: string;
+                    }[]
+                  ) => {
+                    onChange({
+                      locationIds: ArrayUtils.dedupe(
+                        newSelectedLocations.map(location => location.value)
+                      ),
+                    });
+                  }}
+                  options={locations}
+                />
+              ) : null}
+            </Row>
+          </Section>
+        )}
       </Container>
       <Box
         marginTop={4}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3674

# 👩🏻‍💻 What does this PR do?

Since all locations aren't available on Central Server, we hid the Location section of the Assets on central server, unless they relate to the currently logged in store.

Central Server - Logged in Store
![image](https://github.com/msupply-foundation/open-msupply/assets/8287373/f3f5a1ca-a93e-4df8-8bff-e5e54174df69)

Central Server - Other store

![image](https://github.com/msupply-foundation/open-msupply/assets/8287373/cb14fdc0-6b40-42c7-9878-1a1dd2fa162a)


## 💌 Any notes for the reviewer?


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] OMS Central Server
- [ ] 1 Asset assigned to Central Store
- [ ] 1 Asset assigned to another store
- [ ] Check that the asset from the remote store doesn't show any location section
- [ ] Check that the asset from the central store does show the location section.

# 📃 Documentation
- [ ] **No documentation required**: Technically we could update the docs to say the section won't show up but I don't think it's critical.

