### PR TITLE
3895 Username no longer being displayed in sidepanels

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/Tabs/StatusLogs.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/Tabs/StatusLogs.tsx
@@ -40,7 +40,7 @@ const User = ({ user }: { user: ColdchainAssetLogFragment['user'] }) => {
   return (
     <Box display="flex" alignItems="flex-start">
       <Typography sx={{ fontWeight: 'bold', fontSize: '12px' }}>
-        {t('label.user')}: {user?.username}
+        {t('label.user')}: {user?.username ?? '-'}
       </Typography>
       {!!fullName && <Divider />}
       {!!fullName && (
@@ -97,7 +97,7 @@ const StatusLog = ({
     >
       <Box flex={0} display="flex" flexDirection="column" alignItems="center">
         <Connector visible={!isFirst} />
-        <Icon username={log.user?.username} />
+        <Icon username={log.user?.username ?? '-'} />
         <Connector visible={!isLast} />
       </Box>
       <Paper

--- a/client/packages/inventory/src/Stocktake/DetailView/SidePanel.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/SidePanel.tsx
@@ -37,7 +37,7 @@ const AdditionalInfoSection: FC = () => {
       <Grid container gap={0.5} key="additional-info">
         <PanelRow>
           <PanelLabel>{t('label.entered-by')}</PanelLabel>
-          <PanelField>{user?.username}</PanelField>
+          <PanelField>{user?.username ?? '-'}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user.email} /> : null}
         </PanelRow>
         <PanelRow>

--- a/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/AdditionalInfoSection.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/AdditionalInfoSection.tsx
@@ -32,7 +32,7 @@ export const AdditionalInfoSectionComponent = () => {
       <Grid container gap={0.5} key="additional-info">
         <PanelRow>
           <PanelLabel>{t('label.edited-by')}</PanelLabel>
-          <PanelField>{user?.username}</PanelField>
+          <PanelField>{user?.username ?? '-'}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user?.email} /> : null}
         </PanelRow>
         <PanelRow>

--- a/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/RelatedDocumentsSection.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/RelatedDocumentsSection.tsx
@@ -25,11 +25,9 @@ export const RelatedDocumentsSectionComponent = () => {
     tooltip = t('messages.internal-order-created-on', {
       date: d(new Date(createdDatetime)),
     });
-    if (user?.username && user.username !== 'unknown') {
-      tooltip += ` ${t('messages.by-user', {
-        username: user?.username,
-      })}`;
-    }
+    tooltip += ` ${t('messages.by-user', {
+      username: user?.username ?? '-',
+    })}`;
   }
 
   return (

--- a/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/AdditionalInfoSection.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/AdditionalInfoSection.tsx
@@ -33,7 +33,7 @@ export const AdditionalInfoSectionComponent: FC = () => {
       <Grid container gap={0.5} key="additional-info">
         <PanelRow>
           <PanelLabel>{t('label.entered-by')}</PanelLabel>
-          <PanelField>{user?.username}</PanelField>
+          <PanelField>{user?.username ?? '-'}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user?.email} /> : null}
         </PanelRow>
         <PanelRow>

--- a/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/RelatedDocumentsSection.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/RelatedDocumentsSection.tsx
@@ -23,7 +23,7 @@ const RelatedDocumentsSectionComponent = () => {
     let tooltip = t('messages.customer-requisition-created-on', {
       date: d(createdDatetime),
     });
-    if (username && username !== 'unknown') {
+    if (username) {
       tooltip += ` ${t('messages.by-user', { username })}`;
     }
 
@@ -36,7 +36,12 @@ const RelatedDocumentsSectionComponent = () => {
         {!requisition ? (
           <PanelLabel>{t('messages.no-related-documents')}</PanelLabel>
         ) : (
-          <Tooltip title={getTooltip(requisition.createdDatetime, requisition.user?.username)}>
+          <Tooltip
+            title={getTooltip(
+              requisition.createdDatetime,
+              requisition.user?.username ?? '-'
+            )}
+          >
             <Grid item>
               <PanelRow>
                 <PanelLabel>{t('label.requisition')}</PanelLabel>

--- a/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/RelatedDocumentsSection.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/RelatedDocumentsSection.tsx
@@ -23,11 +23,7 @@ const RelatedDocumentsSectionComponent = () => {
     let tooltip = t('messages.customer-requisition-created-on', {
       date: d(createdDatetime),
     });
-    if (username) {
-      tooltip += ` ${t('messages.by-user', { username })}`;
-    }
-
-    return tooltip;
+    return (tooltip += ` ${t('messages.by-user', { username })}`);
   };
 
   return (

--- a/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/AdditionalInfoSection.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/AdditionalInfoSection.tsx
@@ -33,7 +33,7 @@ export const AdditionalInfoSectionComponent: FC = () => {
       <Grid container gap={0.5} key="additional-info">
         <PanelRow>
           <PanelLabel>{t('label.entered-by')}</PanelLabel>
-          <PanelField>{user?.username}</PanelField>
+          <PanelField>{user?.username ?? '-'}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user?.email} /> : null}
         </PanelRow>
         <PanelRow>

--- a/client/packages/invoices/src/Returns/InboundDetailView/SidePanel/AdditionalInfoSection.tsx
+++ b/client/packages/invoices/src/Returns/InboundDetailView/SidePanel/AdditionalInfoSection.tsx
@@ -32,7 +32,7 @@ export const AdditionalInfoSectionComponent = () => {
       <Grid container gap={0.5} key="additional-info">
         <PanelRow>
           <PanelLabel>{t('label.edited-by')}</PanelLabel>
-          <PanelField>{user?.username}</PanelField>
+          <PanelField>{user?.username ?? '-'}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user?.email} /> : null}
         </PanelRow>
 

--- a/client/packages/invoices/src/Returns/InboundDetailView/SidePanel/RelatedDocumentsSection.tsx
+++ b/client/packages/invoices/src/Returns/InboundDetailView/SidePanel/RelatedDocumentsSection.tsx
@@ -24,9 +24,7 @@ export const RelatedDocumentsSectionComponent = () => {
       date: d(new Date(createdDatetime)),
     });
 
-    return username && username !== 'unknown'
-      ? `${label} ${t('messages.by-user', { username })}`
-      : label;
+    return `${label} ${t('messages.by-user', { username })}`;
   };
 
   return (
@@ -40,7 +38,7 @@ export const RelatedDocumentsSectionComponent = () => {
               <PanelLabel>
                 {getLabel(
                   originalShipment.createdDatetime,
-                  originalShipment.user?.username
+                  originalShipment.user?.username ?? '-'
                 )}
               </PanelLabel>
               <PanelField>

--- a/client/packages/invoices/src/Returns/OutboundDetailView/SidePanel/AdditionalInfoSection.tsx
+++ b/client/packages/invoices/src/Returns/OutboundDetailView/SidePanel/AdditionalInfoSection.tsx
@@ -33,7 +33,7 @@ export const AdditionalInfoSectionComponent: FC = () => {
       <Grid container gap={0.5} key="additional-info">
         <PanelRow>
           <PanelLabel>{t('label.entered-by')}</PanelLabel>
-          <PanelField>{user?.username}</PanelField>
+          <PanelField>{user?.username ?? '-'}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user?.email} /> : null}
         </PanelRow>
 

--- a/client/packages/invoices/src/Returns/OutboundDetailView/SidePanel/RelatedDocumentsSection.tsx
+++ b/client/packages/invoices/src/Returns/OutboundDetailView/SidePanel/RelatedDocumentsSection.tsx
@@ -24,9 +24,7 @@ export const RelatedDocumentsSectionComponent = () => {
       date: d(new Date(createdDatetime)),
     });
 
-    return username && username !== 'unknown'
-      ? `${label} ${t('messages.by-user', { username })}`
-      : label;
+    return `${label} ${t('messages.by-user', { username })}`;
   };
 
   return (
@@ -40,7 +38,7 @@ export const RelatedDocumentsSectionComponent = () => {
               <PanelLabel>
                 {getLabel(
                   originalShipment.createdDatetime,
-                  originalShipment.user?.username
+                  originalShipment.user?.username ?? '-'
                 )}
               </PanelLabel>
               <PanelField>

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/SidePanel.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/SidePanel.tsx
@@ -44,7 +44,7 @@ const AdditionalInfoSection: FC = () => {
       <Grid container gap={0.5} key="additional-info">
         <PanelRow>
           <PanelLabel>{t('label.entered-by')}</PanelLabel>
-          <PanelField>{user?.username}</PanelField>
+          <PanelField>{user?.username ?? '-'}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user?.email} /> : null}
         </PanelRow>
         <PanelRow>
@@ -98,11 +98,7 @@ const RelatedDocumentsSection: FC = () => {
       date: d(new Date(createdDatetime)),
     });
 
-    if (username && username !== 'unknown') {
-      tooltip += ` ${t('messages.by-user', { username })}`;
-    }
-
-    return tooltip;
+    return (tooltip += ` ${t('messages.by-user', { username })}`);
   };
 
   return (
@@ -116,7 +112,7 @@ const RelatedDocumentsSection: FC = () => {
             key={shipment.id}
             title={getTooltip(
               shipment.createdDatetime,
-              shipment.user?.username
+              shipment.user?.username ?? '-'
             )}
           >
             <Grid item>

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/AdditionalInfoSection.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/AdditionalInfoSection.tsx
@@ -32,7 +32,7 @@ export const AdditionalInfoSection: FC = () => {
       <Grid container gap={0.5} key="additional-info">
         <PanelRow>
           <PanelLabel>{t('label.edited-by')}</PanelLabel>
-          <PanelField>{user?.username}</PanelField>
+          <PanelField>{user?.username ?? '-'}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user?.email} /> : null}
         </PanelRow>
         <PanelRow>

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/RelatedDocumentsSection.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/RelatedDocumentsSection.tsx
@@ -37,11 +37,7 @@ export const RelatedDocumentsSection: FC = () => {
       date: d(createdDatetime),
     });
 
-    if (username && username !== 'unknown') {
-      tooltip += ` ${t('messages.by-user', { username })}`;
-    }
-
-    return tooltip;
+    return (tooltip += ` ${t('messages.by-user', { username })}`);
   };
 
   return (
@@ -54,7 +50,7 @@ export const RelatedDocumentsSection: FC = () => {
           <Tooltip
             title={getTooltip(
               shipment.createdDatetime,
-              shipment.user?.username
+              shipment.user?.username ?? '-'
             )}
             key={shipment.id}
           >

--- a/client/packages/system/src/Encounter/DetailView/SidePanel.tsx
+++ b/client/packages/system/src/Encounter/DetailView/SidePanel.tsx
@@ -39,7 +39,7 @@ export const SidePanel: FC<SidePanelProps> = ({ encounter, onChange }) => {
     encounter.document.data?.notes?.[0]?.text ?? ''
   );
   const [createdBy, setCreatedBy] = useState(
-    encounter?.document?.data?.createdBy?.username ?? ''
+    encounter?.document?.data?.createdBy?.username ?? '-'
   );
   const { user } = useAuthContext();
   const { localisedDate } = useFormatDateTime();


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3895

# 👩🏻‍💻 What does this PR do?
Users can be unknown if they are new users since they don't get synced back to Open mSupply. It is also possible to migrate existing data with no user_ID saved in the table. 

This PR shows a dash if the username is unknown. This has been made consistent throughout the app 
<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Need an existing datafile
- [ ] Go to any invoice
- [ ] Open side panel
- [ ] If user is not known, dash should be shown

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Maybe the side panel screenshots if they show unknown user
  2.
