### PR TITLE
add needs daily triage label to bug report issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,13 +2,13 @@
 name: Bug report
 about: Create a report for a bug or to help us improve
 title: A brief clear title describing the bug from a user's perspective
-labels: bug, needs triage
-assignees: ''
-
+labels: bug, needs triage, needs daily triage
+assignees: ""
 ---
 
 ## What went wrong? 😲
-<!-- Provide a clear and concise description of what the bug is. Screenshots are helpful! --> 
+
+<!-- Provide a clear and concise description of what the bug is. Screenshots are helpful! -->
 
 ## Expected behaviour 🤔
 
@@ -22,7 +22,9 @@ Steps to reproduce the behaviour:
 4. See error
 
 ## Your environment 🌱
+
 <!-- e.g. 1.2.3 -->
+
 - Open mSupply Version:
 - Legacy mSupply Central Server Version:
 <!-- e.g. android, browser (extra points if you tell us which one), desktop (windows), desktop (macOS), server (windows) -->


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->


# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Adds new `needs daily triage` label to bug report issue template.

This allows the release management team to know which newly reported bugs need to be triaged each day. Especially if this responsibility is shared, will help to stop people doubling up on work.

Any hotfix bugs (and high severity?) can then be assigned immediately, while others can wait for usual weekly triage.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
