### PR TITLE
3111 oms central sync versioning

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
@@ -268,7 +268,6 @@ export const Summary = ({ draft, onChange, locations }: SummaryProps) => {
           <Section heading={t('label.asset-properties')}>
             {Object.entries(draft.parsedProperties).map(([key, value]) => (
               <Row key={key} label={`${value}`}>
-              >
                 <BasicTextInput
                   value={draft.parsedProperties[key]}
                   disabled

--- a/client/packages/common/src/intl/locales/en/app.json
+++ b/client/packages/common/src/intl/locales/en/app.json
@@ -46,6 +46,8 @@
   "equipment": "Equipment",
   "error.sync-api-incompatible": "Sync API version is not compatible",
   "error.sync-api-incompatible-hint": "The mSupply Central Server needs to be upgraded to a newer version before you can connect - please contact support@msupply.org.nz",
+  "error.sync-v6-api-incompatible": "Sync V6 API version is not compatible",
+  "error.sync-v6-api-incompatible-hint": "The Open mSupply Central Server needs to be upgraded to a newer version before you can connect - please contact support@msupply.org.nz",
   "error.authentication-error": "The server has returned an error",
   "error.connection-error": "Unable to connect to server",
   "error.connection-error-hint": "Check your network connection",

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -6357,7 +6357,8 @@ export enum SyncErrorVariant {
   SiteHasNoStore = 'SITE_HAS_NO_STORE',
   SiteNameNotFound = 'SITE_NAME_NOT_FOUND',
   SiteUuidIsBeingChanged = 'SITE_UUID_IS_BEING_CHANGED',
-  Unknown = 'UNKNOWN'
+  Unknown = 'UNKNOWN',
+  V6ApiVersionIncompatible = 'V6_API_VERSION_INCOMPATIBLE'
 }
 
 export type SyncFileReferenceConnector = {

--- a/client/packages/system/src/Sync/api/api.ts
+++ b/client/packages/system/src/Sync/api/api.ts
@@ -66,6 +66,8 @@ export function mapSyncError(
     [SyncErrorVariant.InvalidUrl]: 'error.invalid-url',
     [SyncErrorVariant.ApiVersionIncompatible]: 'error.sync-api-incompatible',
     [SyncErrorVariant.CentralV6NotConfigured]: 'error.v6-server-not-configured',
+    [SyncErrorVariant.V6ApiVersionIncompatible]:
+      'error.sync-v6-api-incompatible',
     [SyncErrorVariant.IntegrationError]: 'error.internal-error',
     [SyncErrorVariant.Unknown]: defaultKey || 'error.unknown-sync-error',
   };
@@ -76,6 +78,8 @@ export function mapSyncError(
         return t('error.sync-api-incompatible-hint');
       case SyncErrorVariant.CentralV6NotConfigured:
         return t('error.v6-server-not-configured-hint');
+      case SyncErrorVariant.V6ApiVersionIncompatible:
+        return t('error.sync-v6-api-incompatible-hint');
       default:
         return undefined;
     }

--- a/server/graphql/general/src/sync_api_error.rs
+++ b/server/graphql/general/src/sync_api_error.rs
@@ -30,6 +30,7 @@ pub enum Variant {
     Unknown,
     ApiVersionIncompatible,
     CentralV6NotConfigured,
+    V6ApiVersionIncompatible,
     IntegrationError,
 }
 
@@ -123,6 +124,7 @@ impl SyncErrorNode {
             from::IntegrationTimeoutReached => to::IntegrationTimeoutReached,
             from::ApiVersionIncompatible => to::ApiVersionIncompatible,
             from::CentralV6NotConfigured => to::CentralV6NotConfigured,
+            from::V6ApiVersionIncompatible => to::V6ApiVersionIncompatible,
             from::IntegrationError => to::IntegrationError,
         };
 

--- a/server/repository/src/db_diesel/sync_log_row.rs
+++ b/server/repository/src/db_diesel/sync_log_row.rs
@@ -21,6 +21,7 @@ pub enum SyncApiErrorCode {
     IntegrationError,
     ApiVersionIncompatible,
     CentralV6NotConfigured,
+    V6ApiVersionIncompatible,
 }
 
 table! {

--- a/server/repository/src/migrations/v2_01_00/mod.rs
+++ b/server/repository/src/migrations/v2_01_00/mod.rs
@@ -5,6 +5,7 @@ use crate::StorageConnection;
 mod assets;
 mod ledger;
 mod pg_enums;
+mod v6_sync_api_error_code;
 
 pub(crate) struct V2_01_00;
 
@@ -17,6 +18,7 @@ impl Migration for V2_01_00 {
         ledger::migrate(connection)?;
         pg_enums::migrate(connection)?;
         assets::migrate_assets(connection)?;
+        v6_sync_api_error_code::migrate(connection)?;
         Ok(())
     }
 }

--- a/server/repository/src/migrations/v2_01_00/v6_sync_api_error_code.rs
+++ b/server/repository/src/migrations/v2_01_00/v6_sync_api_error_code.rs
@@ -1,0 +1,14 @@
+use crate::migrations::*;
+
+pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
+    if cfg!(feature = "postgres") {
+        sql!(
+            connection,
+            r#"
+            ALTER TYPE sync_api_error_code ADD VALUE IF NOT EXISTS 'V6_API_VERSION_INCOMPATIBLE';
+        "#
+        )?;
+    }
+
+    Ok(())
+}

--- a/server/service/src/sync/README.md
+++ b/server/service/src/sync/README.md
@@ -158,3 +158,7 @@ When change allows for previous version to still work without logical or syntax 
 - adding a new optional field or a field where default value can be deduced
 - adding a new table
 - adding new optional header
+
+### V6 Versioning
+
+The same versioning pattern also applies to the V6 sync (syncing with Open mSupply Central). The V6 sync version of the remote site is set in [settings.rs](./settings.rs), and checked in [sync_on_central](./sync_on_central/mod.rs)

--- a/server/service/src/sync/api/core.rs
+++ b/server/service/src/sync/api/core.rs
@@ -91,7 +91,7 @@ impl SyncApiV5 {
 
     #[cfg(test)]
     pub(crate) fn new_test(url: &str, site_name: &str, password: &str, hardware_id: &str) -> Self {
-        use crate::sync::settings::SYNC_VERSION;
+        use crate::sync::settings::SYNC_V5_VERSION;
         use util::hash::sha256;
 
         SyncApiV5 {
@@ -101,7 +101,7 @@ impl SyncApiV5 {
                 username: site_name.to_string(),
                 password_sha256: sha256(&password),
                 site_uuid: hardware_id.to_string(),
-                sync_version: SYNC_VERSION.to_string(),
+                sync_version: SYNC_V5_VERSION.to_string(),
                 app_version: Version::from_package_json().to_string(),
                 app_name: APP_NAME.to_string(),
             },

--- a/server/service/src/sync/api_v6/core.rs
+++ b/server/service/src/sync/api_v6/core.rs
@@ -8,6 +8,7 @@ use super::*;
 pub(crate) struct SyncApiV6 {
     pub(crate) url: Url,
     pub(crate) sync_v5_settings: SyncApiSettings,
+    pub(crate) sync_v6_version: u32,
 }
 
 #[derive(Error, Debug)]
@@ -22,6 +23,7 @@ impl SyncApiV6 {
     pub fn new(
         url: &str,
         sync_v5_settings: &SyncApiSettings,
+        sync_v6_version: u32,
     ) -> Result<Self, SyncApiV6CreatingError> {
         let mut url = Url::parse(url)
             .map_err(|error| SyncApiV6CreatingError::CannotParseSyncUrl(url.to_string(), error))?;
@@ -31,6 +33,7 @@ impl SyncApiV6 {
         Ok(Self {
             url,
             sync_v5_settings: sync_v5_settings.clone(),
+            sync_v6_version,
         })
     }
 
@@ -43,6 +46,7 @@ impl SyncApiV6 {
         let Self {
             sync_v5_settings,
             url,
+            sync_v6_version,
         } = self;
 
         let route = "pull";
@@ -53,6 +57,7 @@ impl SyncApiV6 {
             batch_size,
             sync_v5_settings: sync_v5_settings.clone(),
             is_initialised,
+            sync_v6_version: sync_v6_version.clone(),
         };
 
         let result = Client::new().post(url.clone()).json(&request).send().await;
@@ -74,6 +79,7 @@ impl SyncApiV6 {
         let Self {
             sync_v5_settings,
             url,
+            sync_v6_version,
         } = self;
 
         let route = "push";
@@ -82,6 +88,7 @@ impl SyncApiV6 {
         let request = SyncPushRequestV6 {
             batch,
             sync_v5_settings: sync_v5_settings.clone(),
+            sync_v6_version: sync_v6_version.clone(),
         };
 
         let result = Client::new().post(url.clone()).json(&request).send().await;
@@ -103,6 +110,7 @@ impl SyncApiV6 {
         let Self {
             sync_v5_settings,
             url,
+            sync_v6_version,
         } = self;
 
         let route = "site_status";
@@ -110,6 +118,7 @@ impl SyncApiV6 {
 
         let request = SiteStatusRequestV6 {
             sync_v5_settings: sync_v5_settings.clone(),
+            sync_v6_version: sync_v6_version.clone(),
         };
 
         let result = Client::new().post(url.clone()).json(&request).send().await;

--- a/server/service/src/sync/api_v6/download_file.rs
+++ b/server/service/src/sync/api_v6/download_file.rs
@@ -12,6 +12,7 @@ impl SyncApiV6 {
         let Self {
             sync_v5_settings,
             url,
+            sync_v6_version,
         } = self;
 
         let route = "download_file";
@@ -22,6 +23,7 @@ impl SyncApiV6 {
             table_name: sync_file.table_name.clone(),
             record_id: sync_file.record_id.clone(),
             sync_v5_settings: sync_v5_settings.clone(),
+            sync_v6_version: sync_v6_version.clone(),
         };
 
         let request = Client::new().post(url.clone()).json(&request);

--- a/server/service/src/sync/api_v6/mod.rs
+++ b/server/service/src/sync/api_v6/mod.rs
@@ -39,6 +39,8 @@ pub enum SyncParsedErrorV6 {
     IntegrationInProgress,
     #[error("Sync file not found, file_id: {0}")]
     SyncFileNotFound(String),
+    #[error("Sync API version not compatible, maxVersion: {0}, minVersion: {1}, received: {2}")]
+    SyncVersionMismatch(u32, u32, u32),
 }
 
 impl From<anyhow::Error> for SyncParsedErrorV6 {
@@ -157,6 +159,7 @@ pub struct SyncPullRequestV6 {
     pub(crate) batch_size: u32,
     pub(crate) sync_v5_settings: SyncApiSettings,
     pub(crate) is_initialised: bool,
+    pub(crate) sync_v6_version: u32,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -164,12 +167,14 @@ pub struct SyncPullRequestV6 {
 pub struct SyncPushRequestV6 {
     pub(crate) batch: SyncBatchV6,
     pub(crate) sync_v5_settings: SyncApiSettings,
+    pub(crate) sync_v6_version: u32,
 }
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SiteStatusRequestV6 {
     pub(crate) sync_v5_settings: SyncApiSettings,
+    pub(crate) sync_v6_version: u32,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -184,12 +189,14 @@ pub struct SyncDownloadFileRequestV6 {
     pub(crate) record_id: String,
     pub(crate) id: String,
     pub(crate) sync_v5_settings: SyncApiSettings,
+    pub(crate) sync_v6_version: u32,
 }
 
 #[derive(Deserialize, Debug, Serialize)]
 pub struct SyncUploadFileRequestV6 {
     pub file_id: String,
     pub sync_v5_settings: SyncApiSettings,
+    pub(crate) sync_v6_version: u32,
 }
 
 #[derive(Deserialize, Debug, Serialize)]

--- a/server/service/src/sync/api_v6/mod.rs
+++ b/server/service/src/sync/api_v6/mod.rs
@@ -39,7 +39,7 @@ pub enum SyncParsedErrorV6 {
     IntegrationInProgress,
     #[error("Sync file not found, file_id: {0}")]
     SyncFileNotFound(String),
-    #[error("Sync API version not compatible, maxVersion: {0}, minVersion: {1}, received: {2}")]
+    #[error("Sync V6 API version not compatible, maxVersion: {0}, minVersion: {1}, received: {2}")]
     SyncVersionMismatch(u32, u32, u32),
 }
 

--- a/server/service/src/sync/api_v6/mod.rs
+++ b/server/service/src/sync/api_v6/mod.rs
@@ -39,7 +39,7 @@ pub enum SyncParsedErrorV6 {
     IntegrationInProgress,
     #[error("Sync file not found, file_id: {0}")]
     SyncFileNotFound(String),
-    #[error("Sync V6 API version not compatible, maxVersion: {0}, minVersion: {1}, received: {2}")]
+    #[error("Sync V6 API version not compatible, minVersion: {0}, maxVersion: {1}, received: {2}")]
     SyncVersionMismatch(u32, u32, u32),
 }
 

--- a/server/service/src/sync/api_v6/mod.rs
+++ b/server/service/src/sync/api_v6/mod.rs
@@ -152,6 +152,11 @@ impl From<PushSyncRecord> for SyncRecordV6 {
         }
     }
 }
+
+fn default_sync_v6_version() -> u32 {
+    1
+}
+
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SyncPullRequestV6 {
@@ -159,6 +164,7 @@ pub struct SyncPullRequestV6 {
     pub(crate) batch_size: u32,
     pub(crate) sync_v5_settings: SyncApiSettings,
     pub(crate) is_initialised: bool,
+    #[serde(default = "default_sync_v6_version")]
     pub(crate) sync_v6_version: u32,
 }
 
@@ -167,6 +173,7 @@ pub struct SyncPullRequestV6 {
 pub struct SyncPushRequestV6 {
     pub(crate) batch: SyncBatchV6,
     pub(crate) sync_v5_settings: SyncApiSettings,
+    #[serde(default = "default_sync_v6_version")]
     pub(crate) sync_v6_version: u32,
 }
 
@@ -174,6 +181,7 @@ pub struct SyncPushRequestV6 {
 #[serde(rename_all = "camelCase")]
 pub struct SiteStatusRequestV6 {
     pub(crate) sync_v5_settings: SyncApiSettings,
+    #[serde(default = "default_sync_v6_version")]
     pub(crate) sync_v6_version: u32,
 }
 
@@ -189,6 +197,7 @@ pub struct SyncDownloadFileRequestV6 {
     pub(crate) record_id: String,
     pub(crate) id: String,
     pub(crate) sync_v5_settings: SyncApiSettings,
+    #[serde(default = "default_sync_v6_version")]
     pub(crate) sync_v6_version: u32,
 }
 
@@ -196,6 +205,7 @@ pub struct SyncDownloadFileRequestV6 {
 pub struct SyncUploadFileRequestV6 {
     pub file_id: String,
     pub sync_v5_settings: SyncApiSettings,
+    #[serde(default = "default_sync_v6_version")]
     pub(crate) sync_v6_version: u32,
 }
 

--- a/server/service/src/sync/api_v6/mod.rs
+++ b/server/service/src/sync/api_v6/mod.rs
@@ -153,10 +153,6 @@ impl From<PushSyncRecord> for SyncRecordV6 {
     }
 }
 
-fn default_sync_v6_version() -> u32 {
-    1
-}
-
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SyncPullRequestV6 {
@@ -164,7 +160,7 @@ pub struct SyncPullRequestV6 {
     pub(crate) batch_size: u32,
     pub(crate) sync_v5_settings: SyncApiSettings,
     pub(crate) is_initialised: bool,
-    #[serde(default = "default_sync_v6_version")]
+    #[serde(default)]
     pub(crate) sync_v6_version: u32,
 }
 
@@ -173,7 +169,7 @@ pub struct SyncPullRequestV6 {
 pub struct SyncPushRequestV6 {
     pub(crate) batch: SyncBatchV6,
     pub(crate) sync_v5_settings: SyncApiSettings,
-    #[serde(default = "default_sync_v6_version")]
+    #[serde(default)]
     pub(crate) sync_v6_version: u32,
 }
 
@@ -181,7 +177,7 @@ pub struct SyncPushRequestV6 {
 #[serde(rename_all = "camelCase")]
 pub struct SiteStatusRequestV6 {
     pub(crate) sync_v5_settings: SyncApiSettings,
-    #[serde(default = "default_sync_v6_version")]
+    #[serde(default)]
     pub(crate) sync_v6_version: u32,
 }
 
@@ -197,7 +193,7 @@ pub struct SyncDownloadFileRequestV6 {
     pub(crate) record_id: String,
     pub(crate) id: String,
     pub(crate) sync_v5_settings: SyncApiSettings,
-    #[serde(default = "default_sync_v6_version")]
+    #[serde(default)]
     pub(crate) sync_v6_version: u32,
 }
 
@@ -205,7 +201,7 @@ pub struct SyncDownloadFileRequestV6 {
 pub struct SyncUploadFileRequestV6 {
     pub file_id: String,
     pub sync_v5_settings: SyncApiSettings,
-    #[serde(default = "default_sync_v6_version")]
+    #[serde(default)]
     pub(crate) sync_v6_version: u32,
 }
 

--- a/server/service/src/sync/api_v6/upload_file.rs
+++ b/server/service/src/sync/api_v6/upload_file.rs
@@ -15,6 +15,7 @@ impl SyncApiV6 {
         let Self {
             sync_v5_settings,
             url,
+            sync_v6_version,
         } = self;
 
         let route = "upload_file";
@@ -33,6 +34,7 @@ impl SyncApiV6 {
         let json_request = SyncUploadFileRequestV6 {
             file_id: sync_file_reference_row.id.clone(),
             sync_v5_settings: sync_v5_settings.clone(),
+            sync_v6_version: sync_v6_version.clone(),
         };
 
         let request = client.put(url.clone()).multipart(

--- a/server/service/src/sync/central_data_synchroniser_v6.rs
+++ b/server/service/src/sync/central_data_synchroniser_v6.rs
@@ -67,9 +67,10 @@ impl SynchroniserV6 {
     pub(crate) fn new(
         url: &str,
         sync_v5_settings: &SyncApiSettings,
+        sync_v6_version: u32,
     ) -> Result<Self, SyncApiV6CreatingError> {
         Ok(Self {
-            sync_api_v6: SyncApiV6::new(url, sync_v5_settings)?,
+            sync_api_v6: SyncApiV6::new(url, sync_v5_settings, sync_v6_version)?,
         })
     }
 

--- a/server/service/src/sync/file_synchroniser.rs
+++ b/server/service/src/sync/file_synchroniser.rs
@@ -17,11 +17,14 @@ use crate::sync::api_v6::SyncApiV6;
 use crate::sync::settings::SYNC_V5_VERSION;
 use crate::{service_provider::ServiceProvider, static_files::StaticFileService};
 
-use super::api_v6::{SyncApiErrorV6, SyncApiV6CreatingError};
 use super::settings::SyncSettings;
 use super::{
     api::SyncApiV5CreatingError,
     api_v6::{SyncApiErrorVariantV6, SyncParsedErrorV6},
+};
+use super::{
+    api_v6::{SyncApiErrorV6, SyncApiV6CreatingError},
+    settings::SYNC_V6_VERSION,
 };
 
 pub static MAX_UPLOAD_ATTEMPTS: i32 = 7 * 24; // 7 days * 24 hours Retry sending for up to for 1 week before giving up
@@ -72,7 +75,7 @@ impl FileSynchroniser {
         // Create SyncApiV6 instance
         let sync_v5_settings =
             SyncApiV5::new_settings(&settings, &service_provider, SYNC_V5_VERSION)?;
-        let sync_api_v6 = SyncApiV6::new(sync_v6_url, &sync_v5_settings)?;
+        let sync_api_v6 = SyncApiV6::new(sync_v6_url, &sync_v5_settings, SYNC_V6_VERSION)?;
 
         Ok(Self {
             sync_api_v6,

--- a/server/service/src/sync/file_synchroniser.rs
+++ b/server/service/src/sync/file_synchroniser.rs
@@ -14,7 +14,7 @@ use repository::{
 use crate::static_files::{StaticFile, StaticFileCategory};
 use crate::sync::api::SyncApiV5;
 use crate::sync::api_v6::SyncApiV6;
-use crate::sync::settings::SYNC_VERSION;
+use crate::sync::settings::SYNC_V5_VERSION;
 use crate::{service_provider::ServiceProvider, static_files::StaticFileService};
 
 use super::api_v6::{SyncApiErrorV6, SyncApiV6CreatingError};
@@ -70,7 +70,8 @@ impl FileSynchroniser {
         static_file_service: Arc<StaticFileService>,
     ) -> anyhow::Result<Self> {
         // Create SyncApiV6 instance
-        let sync_v5_settings = SyncApiV5::new_settings(&settings, &service_provider, SYNC_VERSION)?;
+        let sync_v5_settings =
+            SyncApiV5::new_settings(&settings, &service_provider, SYNC_V5_VERSION)?;
         let sync_api_v6 = SyncApiV6::new(sync_v6_url, &sync_v5_settings)?;
 
         Ok(Self {

--- a/server/service/src/sync/settings.rs
+++ b/server/service/src/sync/settings.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 
 // See README.md for description of when this API version needs to be updated
 pub(crate) static SYNC_V5_VERSION: u32 = 5;
+pub(crate) static SYNC_V6_VERSION: u32 = 2;
 
 #[derive(Deserialize, Clone, Debug, PartialEq, Default)]
 pub struct SyncSettings {

--- a/server/service/src/sync/settings.rs
+++ b/server/service/src/sync/settings.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 
 // See README.md for description of when this API version needs to be updated
-pub(crate) static SYNC_VERSION: u32 = 5;
+pub(crate) static SYNC_V5_VERSION: u32 = 5;
 
 #[derive(Deserialize, Clone, Debug, PartialEq, Default)]
 pub struct SyncSettings {

--- a/server/service/src/sync/settings.rs
+++ b/server/service/src/sync/settings.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 
 // See README.md for description of when this API version needs to be updated
 pub(crate) static SYNC_V5_VERSION: u32 = 5;
-pub(crate) static SYNC_V6_VERSION: u32 = 2;
+pub(crate) static SYNC_V6_VERSION: u32 = 1;
 
 #[derive(Deserialize, Clone, Debug, PartialEq, Default)]
 pub struct SyncSettings {

--- a/server/service/src/sync/site_info.rs
+++ b/server/service/src/sync/site_info.rs
@@ -8,7 +8,7 @@ use crate::{
     service_provider::{ServiceContext, ServiceProvider},
     sync::{
         api::{SiteInfoV5, SyncApiV5},
-        settings::{SyncSettings, SYNC_VERSION},
+        settings::{SyncSettings, SYNC_V5_VERSION},
     },
 };
 
@@ -58,7 +58,7 @@ impl SiteInfoTrait for SiteInfoService {
         let sync_api_v5 = SyncApiV5::new(SyncApiV5::new_settings(
             &settings,
             &service_provider,
-            SYNC_VERSION,
+            SYNC_V5_VERSION,
         )?)?;
         let ctx = service_provider.basic_context()?;
 

--- a/server/service/src/sync/sync_on_central/mod.rs
+++ b/server/service/src/sync/sync_on_central/mod.rs
@@ -30,7 +30,7 @@ use super::{
 };
 
 // See ../README.md for when to increment versions!
-static MIN_VERSION: u32 = 1;
+static MIN_VERSION: u32 = 0;
 static MAX_VERSION: u32 = 1;
 
 /// Send Records to a remote open-mSupply Server

--- a/server/service/src/sync/sync_on_central/mod.rs
+++ b/server/service/src/sync/sync_on_central/mod.rs
@@ -29,6 +29,9 @@ use super::{
     translations::translate_changelogs_to_sync_records,
 };
 
+static MIN_VERSION: u32 = 1;
+static MAX_VERSION: u32 = 1;
+
 /// Send Records to a remote open-mSupply Server
 pub async fn pull(
     service_provider: &ServiceProvider,
@@ -37,6 +40,7 @@ pub async fn pull(
         batch_size,
         sync_v5_settings,
         is_initialised,
+        sync_v6_version,
     }: SyncPullRequestV6,
 ) -> Result<SyncBatchV6, SyncParsedErrorV6> {
     use SyncParsedErrorV6 as Error;
@@ -44,6 +48,15 @@ pub async fn pull(
     if !CentralServerConfig::is_central_server() {
         return Err(Error::NotACentralServer);
     }
+
+    if !is_sync_version_compatible(sync_v6_version) {
+        return Err(Error::SyncVersionMismatch(
+            MIN_VERSION,
+            MAX_VERSION,
+            sync_v6_version,
+        ));
+    }
+
     // Check credentials again mSupply central server
     let response = SyncApiV5::new(sync_v5_settings)
         .map_err(|e| Error::OtherServerError(format_error(&e)))?
@@ -111,6 +124,7 @@ pub async fn push(
     SyncPushRequestV6 {
         batch,
         sync_v5_settings,
+        sync_v6_version,
     }: SyncPushRequestV6,
 ) -> Result<SyncPushSuccessV6, SyncParsedErrorV6> {
     use SyncParsedErrorV6 as Error;
@@ -118,6 +132,15 @@ pub async fn push(
     if !CentralServerConfig::is_central_server() {
         return Err(Error::NotACentralServer);
     }
+
+    if !is_sync_version_compatible(sync_v6_version) {
+        return Err(Error::SyncVersionMismatch(
+            MIN_VERSION,
+            MAX_VERSION,
+            sync_v6_version,
+        ));
+    }
+
     // Check credentials again mSupply central server
     let response = SyncApiV5::new(sync_v5_settings)
         .map_err(|e| Error::OtherServerError(format_error(&e)))?
@@ -164,12 +187,23 @@ pub async fn push(
 }
 
 pub async fn get_site_status(
-    SiteStatusRequestV6 { sync_v5_settings }: SiteStatusRequestV6,
+    SiteStatusRequestV6 {
+        sync_v5_settings,
+        sync_v6_version,
+    }: SiteStatusRequestV6,
 ) -> Result<SiteStatusV6, SyncParsedErrorV6> {
     use SyncParsedErrorV6 as Error;
 
     if !CentralServerConfig::is_central_server() {
         return Err(Error::NotACentralServer);
+    }
+
+    if !is_sync_version_compatible(sync_v6_version) {
+        return Err(Error::SyncVersionMismatch(
+            MIN_VERSION,
+            MAX_VERSION,
+            sync_v6_version,
+        ));
     }
 
     let response = SyncApiV5::new(sync_v5_settings)
@@ -216,6 +250,7 @@ pub async fn download_file(
         table_name,
         record_id,
         sync_v5_settings,
+        sync_v6_version,
     }: SyncDownloadFileRequestV6,
 ) -> Result<(actix_files::NamedFile, StaticFile), SyncParsedErrorV6> {
     use SyncParsedErrorV6 as Error;
@@ -230,6 +265,15 @@ pub async fn download_file(
     if !CentralServerConfig::is_central_server() {
         return Err(Error::NotACentralServer);
     }
+
+    if !is_sync_version_compatible(sync_v6_version) {
+        return Err(Error::SyncVersionMismatch(
+            MIN_VERSION,
+            MAX_VERSION,
+            sync_v6_version,
+        ));
+    }
+
     // Check credentials again mSupply central server
     let _ = SyncApiV5::new(sync_v5_settings)
         .map_err(|e| Error::OtherServerError(format_error(&e)))?
@@ -258,6 +302,7 @@ pub async fn upload_file(
     SyncUploadFileRequestV6 {
         file_id,
         sync_v5_settings,
+        sync_v6_version,
     }: SyncUploadFileRequestV6,
     file_part: TempFile,
 ) -> Result<(), SyncParsedErrorV6> {
@@ -268,6 +313,15 @@ pub async fn upload_file(
     if !CentralServerConfig::is_central_server() {
         return Err(Error::NotACentralServer);
     }
+
+    if !is_sync_version_compatible(sync_v6_version) {
+        return Err(Error::SyncVersionMismatch(
+            MIN_VERSION,
+            MAX_VERSION,
+            sync_v6_version,
+        ));
+    }
+
     // Check credentials again mSupply central server
     let _ = SyncApiV5::new(sync_v5_settings)
         .map_err(|e| Error::OtherServerError(format_error(&e)))?
@@ -317,4 +371,8 @@ fn set_integrating(site_id: i32, is_integrating: bool) {
     } else {
         sites_being_integrated.retain(|id| *id != site_id);
     }
+}
+
+fn is_sync_version_compatible(sync_v6_version: u32) -> bool {
+    MIN_VERSION <= sync_v6_version && sync_v6_version <= MAX_VERSION
 }

--- a/server/service/src/sync/sync_on_central/mod.rs
+++ b/server/service/src/sync/sync_on_central/mod.rs
@@ -29,6 +29,7 @@ use super::{
     translations::translate_changelogs_to_sync_records,
 };
 
+// See ../README.md for when to increment versions!
 static MIN_VERSION: u32 = 1;
 static MAX_VERSION: u32 = 1;
 

--- a/server/service/src/sync/sync_status/logger.rs
+++ b/server/service/src/sync/sync_status/logger.rs
@@ -357,6 +357,10 @@ impl SyncLogError {
                 SyncParsedErrorV6::LegacyServerError(source),
             )) => &source.code,
 
+            SyncApiErrorVariant::V6(SyncApiErrorVariantV6::ParsedError(
+                SyncParsedErrorV6::SyncVersionMismatch(_, _, _),
+            )) => return Self::new(SyncApiErrorCode::V6ApiVersionIncompatible, sync_error),
+
             // map connection errors
             SyncApiErrorVariant::V6(SyncApiErrorVariantV6::ConnectionError(_))
             | SyncApiErrorVariant::V5(SyncApiErrorVariantV5::ConnectionError { .. }) => {

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -20,7 +20,7 @@ use super::{
         PostInitialisationError, RemoteDataSynchroniser, RemotePullError, RemotePushError,
         WaitForSyncOperationError,
     },
-    settings::{SyncSettings, SYNC_VERSION},
+    settings::{SyncSettings, SYNC_V5_VERSION},
     sync_buffer::SyncBuffer,
     sync_status::logger::{SyncLogger, SyncLoggerError},
     translation_and_integration::{TranslationAndIntegration, TranslationAndIntegrationResults},
@@ -107,7 +107,7 @@ impl Synchroniser {
         settings: SyncSettings,
         service_provider: Arc<ServiceProvider>,
     ) -> anyhow::Result<Self> {
-        Self::new_with_version(settings, service_provider, SYNC_VERSION)
+        Self::new_with_version(settings, service_provider, SYNC_V5_VERSION)
     }
 
     pub(crate) fn new_with_version(

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -20,7 +20,7 @@ use super::{
         PostInitialisationError, RemoteDataSynchroniser, RemotePullError, RemotePushError,
         WaitForSyncOperationError,
     },
-    settings::{SyncSettings, SYNC_V5_VERSION},
+    settings::{SyncSettings, SYNC_V5_VERSION, SYNC_V6_VERSION},
     sync_buffer::SyncBuffer,
     sync_status::logger::{SyncLogger, SyncLoggerError},
     translation_and_integration::{TranslationAndIntegration, TranslationAndIntegrationResults},
@@ -35,6 +35,7 @@ pub struct Synchroniser {
     central: CentralDataSynchroniser,
     sync_v5_settings: SyncApiSettings,
     remote: RemoteDataSynchroniser,
+    sync_v6_version: u32,
 }
 
 #[derive(Error)]
@@ -107,13 +108,14 @@ impl Synchroniser {
         settings: SyncSettings,
         service_provider: Arc<ServiceProvider>,
     ) -> anyhow::Result<Self> {
-        Self::new_with_version(settings, service_provider, SYNC_V5_VERSION)
+        Self::new_with_version(settings, service_provider, SYNC_V5_VERSION, SYNC_V6_VERSION)
     }
 
     pub(crate) fn new_with_version(
         settings: SyncSettings,
         service_provider: Arc<ServiceProvider>,
         sync_version: u32,
+        sync_v6_version: u32,
     ) -> anyhow::Result<Self> {
         let sync_v5_settings = SyncApiV5::new_settings(&settings, &service_provider, sync_version)?;
         let sync_api_v5 = SyncApiV5::new(sync_v5_settings.clone())?;
@@ -125,6 +127,7 @@ impl Synchroniser {
             service_provider,
             central: CentralDataSynchroniser { sync_api_v5 },
             sync_v5_settings,
+            sync_v6_version,
         })
     }
 
@@ -186,7 +189,8 @@ impl Synchroniser {
             CentralServerConfig::NotConfigured => return Err(SyncError::V6NotConfigured),
             CentralServerConfig::IsCentralServer => None,
             CentralServerConfig::CentralServerUrl(url) => {
-                let v6_sync = SynchroniserV6::new(&url, &self.sync_v5_settings)?;
+                let v6_sync =
+                    SynchroniserV6::new(&url, &self.sync_v5_settings, self.sync_v6_version)?;
                 Some(v6_sync)
             }
         };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3111

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Adds version check for V6 sync API:

![Screenshot 2024-05-21 at 10 48 16 AM](https://github.com/msupply-foundation/open-msupply/assets/55115239/4f44f945-08cd-452f-b580-36772e2de109)



<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

Also will create a PR in the docs repo for the new version matrix!

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Start OMS central server and OMS remote server
- [ ] Run sync for remote site
- [ ] Sync runs successfully
- [ ] In `service/src/sync/setting.rs`, increment the v6 sync version
- [ ] Restart remote server
- [ ] Run sync for remote site
- [ ] See the V6 sync incompatible error

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Version matrix
  2.
