### PR TITLE
3948 asset donor field name lookup

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
@@ -288,7 +288,7 @@ export const Summary = ({ draft, onChange, locations }: SummaryProps) => {
         <Section heading={t('label.donor')}>
           <Row label={t('label.donor')}>
             <DonorSearchInput
-              value={draft.donor as NameRowFragment} // TODO: Fix this?
+              value={draft.donor as NameRowFragment} // Using as NameRowFragment is ok, because the comparison function is based on the id
               onChange={e => onChange({ donor: e, donorNameId: e?.id })}
             />
           </Row>

--- a/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
@@ -15,7 +15,12 @@ import {
   useIsCentralServerApi,
 } from '@openmsupply-client/common';
 import { Status } from '../../Components';
-import { StoreRowFragment, StoreSearchInput } from '@openmsupply-client/system';
+import {
+  DonorSearchInput,
+  NameRowFragment,
+  StoreRowFragment,
+  StoreSearchInput,
+} from '@openmsupply-client/system';
 import { DraftAsset } from '../../types';
 interface SummaryProps {
   draft?: DraftAsset;
@@ -277,6 +282,14 @@ export const Summary = ({ draft, onChange, locations }: SummaryProps) => {
               fullWidth
               multiline
               rows={4}
+            />
+          </Row>
+        </Section>
+        <Section heading={t('label.donor')}>
+          <Row label={t('label.donor')}>
+            <DonorSearchInput
+              value={draft.donor as NameRowFragment} // TODO: Fix this?
+              onChange={e => onChange({ donor: e })}
             />
           </Row>
         </Section>

--- a/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
@@ -289,7 +289,7 @@ export const Summary = ({ draft, onChange, locations }: SummaryProps) => {
           <Row label={t('label.donor')}>
             <DonorSearchInput
               value={draft.donor as NameRowFragment} // TODO: Fix this?
-              onChange={e => onChange({ donor: e })}
+              onChange={e => onChange({ donor: e, donorNameId: e?.id })}
             />
           </Row>
         </Section>

--- a/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
@@ -133,6 +133,14 @@ export const Summary = ({ draft, onChange, locations }: SummaryProps) => {
     if (reason === 'clear') onChange({ store: null });
   };
 
+  const onDonorInputChange = (
+    _event: React.SyntheticEvent<Element, Event>,
+    _value: string,
+    reason: string
+  ) => {
+    if (reason === 'clear') onChange({ donor: null, donorNameId: null });
+  };
+
   return (
     <Box display="flex" flex={1}>
       <Container>
@@ -290,6 +298,8 @@ export const Summary = ({ draft, onChange, locations }: SummaryProps) => {
             <DonorSearchInput
               value={draft.donor as NameRowFragment} // Using as NameRowFragment is ok, because the comparison function is based on the id
               onChange={e => onChange({ donor: e, donorNameId: e?.id })}
+              onInputChange={onDonorInputChange}
+              clearable
             />
           </Row>
         </Section>

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -4194,6 +4194,8 @@ export type NameFilterInput = {
   id?: InputMaybe<EqualFilterStringInput>;
   /** Filter by customer property */
   isCustomer?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Filter by donor property */
+  isDonor?: InputMaybe<Scalars['Boolean']['input']>;
   isPatient?: InputMaybe<Scalars['Boolean']['input']>;
   /** Is this name a store */
   isStore?: InputMaybe<Scalars['Boolean']['input']>;

--- a/client/packages/system/src/Name/Components/DonorSearchInput/DonorSearchInput.tsx
+++ b/client/packages/system/src/Name/Components/DonorSearchInput/DonorSearchInput.tsx
@@ -1,0 +1,47 @@
+import React, { FC } from 'react';
+import {
+  Autocomplete,
+  useBufferState,
+  useTranslation,
+} from '@openmsupply-client/common';
+import { NameRowFragment, useName } from '../../api';
+import {
+  basicFilterOptions,
+  filterByNameAndCode,
+  NameSearchInputProps,
+} from '../../utils';
+import { getNameOptionRenderer } from '../NameOptionRenderer';
+
+export const DonorSearchInput: FC<NameSearchInputProps> = ({
+  onChange,
+  width = 250,
+  value,
+  disabled = false,
+}) => {
+  const { data, isLoading } = useName.document.donors();
+  const [buffer, setBuffer] = useBufferState(value);
+  const t = useTranslation();
+  const NameOptionRenderer = getNameOptionRenderer(t('label.on-hold'));
+
+  return (
+    <Autocomplete
+      disabled={disabled}
+      clearable={false}
+      value={buffer && { ...buffer, label: buffer.name }}
+      filterOptionConfig={basicFilterOptions}
+      loading={isLoading}
+      onChange={(_, name) => {
+        setBuffer(name);
+        name && onChange(name);
+      }}
+      options={data?.nodes ?? []}
+      renderOption={NameOptionRenderer}
+      getOptionLabel={(option: NameRowFragment) => option.name}
+      filterOptions={filterByNameAndCode}
+      width={`${width}px`}
+      popperMinWidth={width}
+      isOptionEqualToValue={(option, value) => option?.id === value?.id}
+      getOptionDisabled={option => option.isOnHold}
+    />
+  );
+};

--- a/client/packages/system/src/Name/Components/DonorSearchInput/DonorSearchInput.tsx
+++ b/client/packages/system/src/Name/Components/DonorSearchInput/DonorSearchInput.tsx
@@ -14,9 +14,11 @@ import { getNameOptionRenderer } from '../NameOptionRenderer';
 
 export const DonorSearchInput: FC<NameSearchInputProps> = ({
   onChange,
+  onInputChange,
   width = 250,
   value,
   disabled = false,
+  clearable = false,
 }) => {
   const { data, isLoading } = useName.document.donors();
   const [buffer, setBuffer] = useBufferState(value);
@@ -26,7 +28,7 @@ export const DonorSearchInput: FC<NameSearchInputProps> = ({
   return (
     <Autocomplete
       disabled={disabled}
-      clearable={false}
+      clearable={clearable}
       value={buffer && { ...buffer, label: buffer.name }}
       filterOptionConfig={basicFilterOptions}
       loading={isLoading}
@@ -34,6 +36,7 @@ export const DonorSearchInput: FC<NameSearchInputProps> = ({
         setBuffer(name);
         name && onChange(name);
       }}
+      onInputChange={onInputChange}
       options={data?.nodes ?? []}
       renderOption={NameOptionRenderer}
       getOptionLabel={(option: NameRowFragment) => option.name}

--- a/client/packages/system/src/Name/Components/DonorSearchInput/index.ts
+++ b/client/packages/system/src/Name/Components/DonorSearchInput/index.ts
@@ -1,0 +1,1 @@
+export * from './DonorSearchInput';

--- a/client/packages/system/src/Name/Components/index.ts
+++ b/client/packages/system/src/Name/Components/index.ts
@@ -1,3 +1,4 @@
+export * from './DonorSearchInput';
 export * from './SupplierSearchInput';
 export * from './SupplierSearchModal';
 export * from './CustomerSearchInput';

--- a/client/packages/system/src/Name/api/api.ts
+++ b/client/packages/system/src/Name/api/api.ts
@@ -46,12 +46,10 @@ export const getNameQueries = (sdk: Sdk, storeId: string) => ({
 
       return result?.names;
     },
-    donors: async ({ sortBy }: ListParams) => {
-      const key = nameParsers.toSort(sortBy?.key ?? '');
-
+    donors: async () => {
       const result = await sdk.names({
-        key,
-        desc: !!sortBy?.isDesc,
+        key: NameSortFieldInput.Name,
+        desc: false,
         storeId,
         filter: { isDonor: true },
         first: 1000,

--- a/client/packages/system/src/Name/api/api.ts
+++ b/client/packages/system/src/Name/api/api.ts
@@ -46,6 +46,19 @@ export const getNameQueries = (sdk: Sdk, storeId: string) => ({
 
       return result?.names;
     },
+    donors: async ({ sortBy }: ListParams) => {
+      const key = nameParsers.toSort(sortBy?.key ?? '');
+
+      const result = await sdk.names({
+        key,
+        desc: !!sortBy?.isDesc,
+        storeId,
+        filter: { isDonor: true },
+        first: 1000,
+      });
+
+      return result?.names;
+    },
     suppliers: async ({ sortBy }: ListParams) => {
       const key = nameParsers.toSort(sortBy?.key ?? '');
 

--- a/client/packages/system/src/Name/api/hooks/document/index.ts
+++ b/client/packages/system/src/Name/api/hooks/document/index.ts
@@ -3,6 +3,7 @@ import { useSuppliers } from './useSuppliers';
 import { useInternalSuppliers } from './useInternalSuppliers';
 import { useName } from './useName';
 import { useNames } from './useNames';
+import { useDonors } from './useDonors';
 
 export const Document = {
   useCustomers,
@@ -10,4 +11,5 @@ export const Document = {
   useInternalSuppliers,
   useName,
   useNames,
+  useDonors,
 };

--- a/client/packages/system/src/Name/api/hooks/document/useDonors.ts
+++ b/client/packages/system/src/Name/api/hooks/document/useDonors.ts
@@ -1,0 +1,8 @@
+import { useQuery } from '@openmsupply-client/common';
+import { useNameApi } from '../utils/useNameApi';
+
+export const useDonors = () => {
+  const api = useNameApi();
+
+  return useQuery(api.keys.donors(), () => api.get.donors());
+};

--- a/client/packages/system/src/Name/api/hooks/index.ts
+++ b/client/packages/system/src/Name/api/hooks/index.ts
@@ -9,5 +9,6 @@ export const useName = {
     internalSuppliers: Document.useInternalSuppliers,
     list: Document.useNames,
     suppliers: Document.useSuppliers,
+    donors: Document.useDonors,
   },
 };

--- a/client/packages/system/src/Name/api/hooks/utils/useNameApi.ts
+++ b/client/packages/system/src/Name/api/hooks/utils/useNameApi.ts
@@ -9,6 +9,7 @@ export const useNameApi = () => {
     detail: (id: string) => [...keys.base(), storeId, id] as const,
     list: () => [...keys.base(), storeId, 'list'] as const,
     paramList: (params: ListParams) => [...keys.list(), params] as const,
+    donors: () => [...keys.base(), storeId, 'donors'] as const,
   };
   const { client } = useGql();
   const queries = getNameQueries(getSdk(client), storeId);

--- a/client/packages/system/src/Name/utils.ts
+++ b/client/packages/system/src/Name/utils.ts
@@ -16,9 +16,15 @@ interface NameSearchListProps {
 
 export interface NameSearchInputProps {
   onChange: (name: NameRowFragment) => void;
+  onInputChange?: (
+    event: React.SyntheticEvent,
+    value: string,
+    reason: string
+  ) => void;
   width?: number;
   value: NameRowFragment | null;
   disabled?: boolean;
+  clearable?: boolean;
 }
 
 export const basicFilterOptions = {

--- a/server/graphql/general/src/queries/names.rs
+++ b/server/graphql/general/src/queries/names.rs
@@ -49,6 +49,8 @@ pub struct NameFilterInput {
     pub is_customer: Option<bool>,
     /// Filter by supplier property
     pub is_supplier: Option<bool>,
+    /// Filter by donor property
+    pub is_donor: Option<bool>,
     pub is_patient: Option<bool>,
     /// Is this name a store
     pub is_store: Option<bool>,
@@ -130,6 +132,7 @@ impl NameFilterInput {
             code,
             is_customer,
             is_supplier,
+            is_donor,
             is_store,
             store_code,
             is_visible,
@@ -150,6 +153,7 @@ impl NameFilterInput {
             store_code: store_code.map(StringFilter::from),
             is_customer,
             is_supplier,
+            is_donor,
             is_store,
             is_visible,
             is_system_name: is_system_name.or(Some(false)),

--- a/server/graphql/general/src/queries/tests/names.rs
+++ b/server/graphql/general/src/queries/tests/names.rs
@@ -193,6 +193,7 @@ mod graphql {
 
             assert_eq!(is_customer, Some(true));
             assert_eq!(is_supplier, Some(false));
+            assert_eq!(is_donor, None);
             assert_eq!(is_store, Some(true));
             assert_eq!(store_code, Some(StringFilter::like("store code like")));
             assert_eq!(is_visible, Some(false));

--- a/server/graphql/general/src/queries/tests/names.rs
+++ b/server/graphql/general/src/queries/tests/names.rs
@@ -178,13 +178,13 @@ mod graphql {
                 is_visible,
                 is_system_name,
                 r#type,
-
                 phone,
                 address1,
                 address2,
                 country,
                 email,
                 is_patient: _,
+                is_donor,
             } = filter.unwrap();
 
             assert_eq!(id, Some(EqualFilter::not_equal_to("id_not_equal_to")));

--- a/server/repository/src/db_diesel/name.rs
+++ b/server/repository/src/db_diesel/name.rs
@@ -33,6 +33,7 @@ pub struct NameFilter {
     pub code: Option<StringFilter>,
     pub is_customer: Option<bool>,
     pub is_supplier: Option<bool>,
+    pub is_donor: Option<bool>,
     pub is_patient: Option<bool>,
     pub is_store: Option<bool>,
     pub store_code: Option<StringFilter>,
@@ -174,6 +175,7 @@ impl<'a> NameRepository<'a> {
                 code,
                 is_customer,
                 is_supplier,
+                is_donor,
                 is_store,
                 store_code,
                 is_visible,
@@ -206,6 +208,11 @@ impl<'a> NameRepository<'a> {
             if let Some(is_supplier) = is_supplier {
                 query = query.filter(name_store_join_dsl::name_is_supplier.eq(is_supplier));
             }
+
+            query = match is_donor {
+                Some(bool) => query.filter(name_dsl::is_donor.eq(bool)),
+                None => query,
+            };
 
             query = match is_patient {
                 Some(true) => query.filter(name_dsl::type_.eq(NameType::Patient)),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3948

# 👩🏻‍💻 What does this PR do?

Adds a Donor selection for each asset, stored as a nameId against the record.

(See issue if you need help setting up donors in mSupply)

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

![image](https://github.com/msupply-foundation/open-msupply/assets/8287373/51e87bf7-185d-449e-8dc7-13febff5f001)


## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->




# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a donor in Legacy mSupply (needs preference turned on)
- [ ] Try to assign a donor to an asset

# 📃 Documentation

- [X] **Part of an epic**: documentation will be completed for the feature as a whole