### PR TITLE
make min=0 the default for number input cell

### DIFF
--- a/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
@@ -14,9 +14,9 @@ export const NumberInputCell = <T extends RecordWithId>({
   rowIndex,
   columnIndex,
   isDisabled = false,
-  // Make the default min=1 as this is the typical implementation
+  // Make the default min=0 as this is the typical implementation
   // in Data Tables
-  min = 1,
+  min = 0,
   max,
   decimalLimit,
   step,

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -75,7 +75,6 @@ const NumberOfPacksCell: React.FC<CellProps<DraftInboundLine>> = ({
 }) => (
   <NumberInputCell
     {...props}
-    min={0}
     isRequired={rowData.numberOfPacks === 0}
     rowData={rowData}
   />

--- a/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/InboundReturn/ReturnQuantitiesTable.tsx
@@ -127,7 +127,6 @@ const NumberOfPacksReturnedInputCell: React.FC<
     {...props}
     isRequired
     max={props.rowData.numberOfPacksIssued ?? undefined}
-    min={0}
   />
 );
 const expiryInputColumn =

--- a/client/packages/invoices/src/Returns/modals/OutboundReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/OutboundReturn/ReturnQuantitiesTable.tsx
@@ -101,7 +101,6 @@ const NumberOfPacksToReturnReturnInputCell: React.FC<
     {...props}
     isRequired
     max={props.rowData.availableNumberOfPacks}
-    min={0}
   />
 );
 

--- a/client/packages/invoices/src/StockOut/utils.tsx
+++ b/client/packages/invoices/src/StockOut/utils.tsx
@@ -344,7 +344,6 @@ export const PackQuantityCell = (props: CellProps<DraftStockOutLine>) => (
     {...props}
     max={props.rowData.stockLine?.availableNumberOfPacks}
     id={getPackQuantityCellId(props.rowData.stockLine?.batch)}
-    min={0}
   />
 );
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3950

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Backspace to 0 now works for tax input in the two service charge modals:

https://github.com/msupply-foundation/open-msupply/assets/55115239/f383cdfa-28c2-419d-8b76-ebfd5023ff17


Removes the default min=1 on the NumberInputCell, because everywhere except the service charge tax cells, we were explicitly setting min=0, and we actually don't want a min of 1 for service charge tax either 😅 


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->


<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] In an Inbound Shipment, add a service charge
- [ ] Enter a value in `tax` field, then backspace, you should be able to reset to 0
- [ ] In an Outbound Shipment, add a service charge
- [ ] Enter a value in `tax` field, then backspace, you should be able to reset to 0
- [ ] In inbound/outbound returns & shipments, and prescriptions, validate still can clear all inputs back to 0

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
