### PR TITLE
#3968 Stocktake pricing fix

### DIFF
--- a/client/packages/common/src/ui/layout/tables/components/Cells/CurrencyInputCell/CurrencyInputCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/CurrencyInputCell/CurrencyInputCell.tsx
@@ -20,7 +20,7 @@ export const CurrencyInputCell = <T extends RecordWithId>({
       disabled={isDisabled}
       autoFocus={autoFocus}
       maxWidth={column.width}
-      defaultValue={String(column.accessor({ rowData }))}
+      defaultValue={String(column.accessor({ rowData }) ?? 0)}
       onChangeNumber={newValue =>
         updater({ ...rowData, [column.key]: newValue })
       }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fix #3968

# 👩🏻‍💻 What does this PR do?

Fix the pricing display for zero-stock items in Stocktake batch pricing tab

<!-- Explain the changes you made -->

A simple one-liner. The `CurrencyInput` can't handle a `null` value, so have just added a fallback to `0`.

## 💌 Any notes for the reviewer?

No point going much further with this for now, would like to re-factor Currency input properly at some point: #3959 

# 🧪 Testing

- Start a new stocktake from a master list (all items probably)
- Find a stock line that has a "Snapshot Packs" value of 0
- Open it, go to pricing tab
- Should display `$0.00` for both prices
