### PR TITLE
Disable inserting/updating inbound lines when invoice is on hold

### DIFF
--- a/client/packages/invoices/src/utils.ts
+++ b/client/packages/invoices/src/utils.ts
@@ -129,6 +129,9 @@ export const isOutboundDisabled = (outbound: OutboundRowFragment): boolean => {
 };
 
 export const isInboundDisabled = (inbound: InboundRowFragment): boolean => {
+  if (inbound.onHold) {
+    return true;
+  }
   const isManuallyCreated = !inbound.linkedShipment?.id;
   return isManuallyCreated
     ? inbound.status === InvoiceNodeStatus.Verified

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
@@ -143,6 +143,7 @@ fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
         ServiceError::NumberOfPacksBelowOne => BadUserInput(formatted_error),
         ServiceError::PackSizeBelowOne => BadUserInput(formatted_error),
         ServiceError::LocationDoesNotExist => BadUserInput(formatted_error),
+        ServiceError::InvoiceOnHold => BadUserInput(formatted_error),
         ServiceError::ItemNotFound => BadUserInput(formatted_error),
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
         ServiceError::NewlyCreatedLineDoesNotExist => InternalError(formatted_error),

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
@@ -162,6 +162,7 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
         ServiceError::PackSizeBelowOne => BadUserInput(formatted_error),
         ServiceError::LocationDoesNotExist => BadUserInput(formatted_error),
         ServiceError::ItemNotFound => BadUserInput(formatted_error),
+        ServiceError::InvoiceOnHold => BadUserInput(formatted_error),
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
         ServiceError::UpdatedLineDoesNotExist => InternalError(formatted_error),
     };

--- a/server/service/src/invoice_line/inbound_shipment_line/insert/mod.rs
+++ b/server/service/src/invoice_line/inbound_shipment_line/insert/mod.rs
@@ -73,6 +73,7 @@ pub enum InsertInboundShipmentLineError {
     PackSizeBelowOne,
     NumberOfPacksBelowOne,
     NewlyCreatedLineDoesNotExist,
+    InvoiceOnHold,
 }
 
 impl From<RepositoryError> for InsertInboundShipmentLineError {

--- a/server/service/src/invoice_line/inbound_shipment_line/insert/validate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_line/insert/validate.rs
@@ -3,7 +3,10 @@ use crate::{
     invoice_line::{
         check_location_exists,
         inbound_shipment_line::check_pack_size,
-        validate::{check_item_exists, check_line_does_not_exist, check_number_of_packs},
+        validate::{
+            check_invoice_not_on_hold, check_item_exists, check_line_does_not_exist,
+            check_number_of_packs,
+        },
     },
 };
 use repository::{InvoiceRow, InvoiceRowType, ItemRow, StorageConnection};
@@ -45,6 +48,9 @@ pub fn validate(
     }
     if !check_invoice_is_editable(&invoice) {
         return Err(CannotEditFinalised);
+    }
+    if !check_invoice_not_on_hold(&invoice) {
+        return Err(InvoiceOnHold);
     }
 
     // TODO: StockLineDoesNotBelongToCurrentStore

--- a/server/service/src/invoice_line/inbound_shipment_line/update/mod.rs
+++ b/server/service/src/invoice_line/inbound_shipment_line/update/mod.rs
@@ -84,6 +84,7 @@ pub enum UpdateInboundShipmentLineError {
     BatchIsReserved,
     UpdatedLineDoesNotExist,
     NotThisInvoiceLine(String),
+    InvoiceOnHold,
 }
 
 impl From<RepositoryError> for UpdateInboundShipmentLineError {

--- a/server/service/src/invoice_line/inbound_shipment_line/update/validate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_line/update/validate.rs
@@ -3,8 +3,8 @@ use crate::{
     invoice_line::{
         check_batch, check_location_exists, check_pack_size,
         validate::{
-            check_item_exists, check_line_belongs_to_invoice, check_line_exists_option,
-            check_number_of_packs,
+            check_invoice_not_on_hold, check_item_exists, check_line_belongs_to_invoice,
+            check_line_exists_option, check_number_of_packs,
         },
     },
 };
@@ -41,6 +41,9 @@ pub fn validate(
     }
     if !check_store(&invoice, store_id) {
         return Err(NotThisStoreInvoice);
+    }
+    if !check_invoice_not_on_hold(&invoice) {
+        return Err(InvoiceOnHold);
     }
 
     if !check_batch(line_row, connection)? {

--- a/server/service/src/invoice_line/validate.rs
+++ b/server/service/src/invoice_line/validate.rs
@@ -26,6 +26,10 @@ pub fn check_number_of_packs(number_of_packs_option: Option<f64>) -> bool {
     return true;
 }
 
+pub fn check_invoice_not_on_hold(invoice: &InvoiceRow) -> bool {
+    !invoice.on_hold
+}
+
 pub fn check_item_exists(
     connection: &StorageConnection,
     id: &str,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3526

# 👩🏻‍💻 What does this PR do?

Hotfix for an (old) issues that has been revealed by fixing 3526.

- Add backend on_hold check when inserting and updating inbound lines
- Add fe check to disable UI when invoice is on hold

# 🧪 Testing
- Create inbound shipment
- set on hold and try to edit/ update lines

