### PR TITLE
3981 fix $NaN currency display for outbound shipment placeholder lines

### DIFF
--- a/client/packages/common/src/ui/layout/tables/components/Cells/CurrencyCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/CurrencyCell.tsx
@@ -27,7 +27,7 @@ export const CurrencyCell = <T extends RecordWithId>({
   CellProps<T>
 > => {
   const { c } = useCurrency(currencyCode);
-  const price = Number(column.accessor({ rowData })) ?? 0;
+  const price = Number(column.accessor({ rowData }) ?? 0);
   // format prices > 1 with default precision
   const precision = price < 1 ? 10 : undefined;
   const fullText = c(price, precision).format();


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3981

# 👩🏻‍💻 What does this PR do?

Similar to #3975 (fixes $NaN in currency inputs) this fixes currency display cell:

![Screenshot 2024-05-23 at 10 33 58 AM](https://github.com/msupply-foundation/open-msupply/assets/55115239/253ee929-946e-4240-b566-e5828876bbf2)


<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create outbound shipment
- [ ] Add lines from master list (so placeholder lines created)
- [ ] TEST: Unit price shows $0.00

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
