### PR TITLE
Move prefer const to eslintrc

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -52,6 +52,13 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'warn',
     '@typescript-eslint/no-explicit-any': 'warn',
     'no-console': ['error', { allow: ['info', 'warn', 'error'] }],
+    'prefer-const': [
+      'error',
+      {
+        destructuring: 'any',
+        ignoreReadBeforeAssign: true,
+      },
+    ],
   },
   ignorePatterns: ['**/operations.generated.ts', '**/types/schema.ts'],
 };

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -2,21 +2,36 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@common/components": ["packages/common/src/ui/components"],
-      "@common/hooks": ["packages/common/src/hooks"],
-      "@common/icons": ["packages/common/src/ui/icons"],
-      "@common/intl": ["packages/common/src/intl"],
-      "@common/intl/*": ["packages/common/src/intl/*"],
-      "@common/styles": ["packages/common/src/styles"],
-      "@common/types": ["packages/common/src/types"],
-      "@common/utils": ["packages/common/src/utils"]
+      "@common/components": [
+        "packages/common/src/ui/components"
+      ],
+      "@common/hooks": [
+        "packages/common/src/hooks"
+      ],
+      "@common/icons": [
+        "packages/common/src/ui/icons"
+      ],
+      "@common/intl": [
+        "packages/common/src/intl"
+      ],
+      "@common/intl/*": [
+        "packages/common/src/intl/*"
+      ],
+      "@common/styles": [
+        "packages/common/src/styles"
+      ],
+      "@common/types": [
+        "packages/common/src/types"
+      ],
+      "@common/utils": [
+        "packages/common/src/utils"
+      ]
     },
     "resolveJsonModule": true,
     "target": "es2015",
     "module": "esnext",
     "moduleResolution": "node",
     "jsx": "react",
-
     "sourceMap": true,
     "outDir": "./dist",
     "rootDir": ".",
@@ -28,17 +43,17 @@
     "strictPropertyInitialization": true,
     "noImplicitThis": true,
     "alwaysStrict": true,
-
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
-
     "noPropertyAccessFromIndexSignature": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "typeRoots": ["./typings", "./node_modules/@types"]
+    "typeRoots": [
+      "./typings",
+      "./node_modules/@types"
+    ]
   }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes `../../tsconfig.json(31,5): error TS5023: Unknown compiler option 'prefer-const’`

# 👩🏻‍💻 What does this PR do?

It looks like this should have been an eslint rule not a compiler option?

## 💌 Any notes for the reviewer?
Does this still achieve the original goal?

DEV ONLY (no docs or testing required)
