### PR TITLE
Fix graphql_get_names test

### DIFF
--- a/server/graphql/general/src/queries/tests/names.rs
+++ b/server/graphql/general/src/queries/tests/names.rs
@@ -185,6 +185,7 @@ mod graphql {
                 email,
                 is_patient: _,
                 is_donor,
+                code_or_name: _,
             } = filter.unwrap();
 
             assert_eq!(id, Some(EqualFilter::not_equal_to("id_not_equal_to")));


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes
```
error[E0027]: pattern does not mention field `code_or_name`
   --> graphql/general/src/queries/tests/names.rs:170:17
    |
170 |               let NameFilter {
    |  _________________^
171 | |                 id,
172 | |                 name,
173 | |                 code,
...   |
187 | |                 is_donor,
188 | |             } = filter.unwrap();
    | |_____________^ missing field `code_or_name`
    |
```

# 👩🏻‍💻 What does this PR do?

Fixes a test case

# 🧪 Testing

DEV ONLY no testing required
