### PR TITLE
4013 Ignore orphaned master list lines

### DIFF
--- a/client/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
+++ b/client/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
@@ -185,7 +185,7 @@ const getColumnLookup = <T extends RecordWithId>(): Record<
   code: {
     label: 'label.code',
     key: 'code',
-    width: 20,
+    width: 100,
     Cell: TooltipTextCell,
   },
   packSize: {

--- a/server/graphql/general/src/queries/tests/names.rs
+++ b/server/graphql/general/src/queries/tests/names.rs
@@ -185,6 +185,7 @@ mod graphql {
                 email,
                 is_patient: _,
                 is_donor,
+                code_or_name: _,
             } = filter.unwrap();
 
             assert_eq!(id, Some(EqualFilter::not_equal_to("id_not_equal_to")));

--- a/server/service/src/sync/test/test_data/master_list_line.rs
+++ b/server/service/src/sync/test/test_data/master_list_line.rs
@@ -1,12 +1,25 @@
-use repository::MasterListLineRow;
+use repository::{MasterListLineRow, SyncBufferRow};
+use util::inline_init;
 
-use crate::sync::test::TestSyncIncomingRecord;
+use crate::sync::{test::TestSyncIncomingRecord, translations::PullTranslateResult};
 
 const MASTER_LIST_LINE_1: (&str, &str) = (
     "9B02D0770B544BD1AC7DB99BB85FCDD5",
     r#"{
     "ID": "9B02D0770B544BD1AC7DB99BB85FCDD5",
     "item_master_ID": "item_query_test1",
+    "item_ID": "item_a",
+    "imprest_quan": 0,
+    "order_number": 1,
+    "price": 0
+  }"#,
+);
+
+const MASTER_LIST_LINE_2: (&str, &str) = (
+    "orphan",
+    r#"{
+    "ID": "9B02D0770B544BD1AC7DB99BB85FCDD5",
+    "item_master_ID": "orphan",
     "item_ID": "8F252B5884B74888AAB73A0D42C09E7F",
     "imprest_quan": 0,
     "order_number": 1,
@@ -14,14 +27,30 @@ const MASTER_LIST_LINE_1: (&str, &str) = (
   }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
-    vec![TestSyncIncomingRecord::new_pull_upsert(
+fn master_list_line_a() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         "list_master_line",
         MASTER_LIST_LINE_1,
         MasterListLineRow {
             id: "9B02D0770B544BD1AC7DB99BB85FCDD5".to_owned(),
-            item_link_id: "8F252B5884B74888AAB73A0D42C09E7F".to_owned(),
+            item_link_id: "item_a".to_owned(),
             master_list_id: "item_query_test1".to_owned(),
         },
-    )]
+    )
+}
+
+fn master_list_line_b() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord {
+        translated_record: PullTranslateResult::Ignored("Missing master list".to_string()),
+        sync_buffer_row: inline_init(|r: &mut SyncBufferRow| {
+            r.table_name = "list_master_line".to_owned();
+            r.record_id = MASTER_LIST_LINE_2.0.to_owned();
+            r.data = MASTER_LIST_LINE_2.1.to_owned();
+        }),
+        extra_data: None,
+    }
+}
+
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
+    vec![master_list_line_a(), master_list_line_b()]
 }

--- a/server/service/src/sync/test/test_data/master_list_line.rs
+++ b/server/service/src/sync/test/test_data/master_list_line.rs
@@ -6,7 +6,7 @@ const MASTER_LIST_LINE_1: (&str, &str) = (
     "9B02D0770B544BD1AC7DB99BB85FCDD5",
     r#"{
     "ID": "9B02D0770B544BD1AC7DB99BB85FCDD5",
-    "item_master_ID": "87027C44835B48E6989376F42A58F7E3",
+    "item_master_ID": "item_query_test1",
     "item_ID": "8F252B5884B74888AAB73A0D42C09E7F",
     "imprest_quan": 0,
     "order_number": 1,
@@ -21,7 +21,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
         MasterListLineRow {
             id: "9B02D0770B544BD1AC7DB99BB85FCDD5".to_owned(),
             item_link_id: "8F252B5884B74888AAB73A0D42C09E7F".to_owned(),
-            master_list_id: "87027C44835B48E6989376F42A58F7E3".to_owned(),
+            master_list_id: "item_query_test1".to_owned(),
         },
     )]
 }

--- a/server/service/src/sync/translations/master_list_line.rs
+++ b/server/service/src/sync/translations/master_list_line.rs
@@ -56,7 +56,6 @@ impl SyncTranslation for MasterListLineTranslation {
         let data = serde_json::from_str::<LegacyListMasterLineRow>(&sync_record.data)?;
         let master_list =
             MasterListRowRepository::new(connection).find_one_by_id(&data.item_master_ID)?;
-
         if master_list.is_none() {
             return Ok(PullTranslateResult::Ignored(
                 "Missing master list".to_string(),
@@ -83,6 +82,7 @@ mod tests {
         use crate::sync::test::test_data::master_list_line as test_data;
         let translator = MasterListLineTranslation {};
 
+        // Using all() because pull_upserts requires master_list from mock data
         let (_, connection, _, _) =
             setup_all("test_master_list_line_translation", MockDataInserts::all()).await;
 

--- a/server/service/src/sync/translations/master_list_line.rs
+++ b/server/service/src/sync/translations/master_list_line.rs
@@ -82,7 +82,7 @@ mod tests {
         let translator = MasterListLineTranslation {};
 
         let (_, connection, _, _) =
-            setup_all("test_master_list_line_translation", MockDataInserts::none()).await;
+            setup_all("test_master_list_line_translation", MockDataInserts::all()).await;
 
         for record in test_data::test_pull_upsert_records() {
             assert!(translator.should_translate_from_sync_record(&record.sync_buffer_row));

--- a/server/service/src/sync/translations/master_list_line.rs
+++ b/server/service/src/sync/translations/master_list_line.rs
@@ -58,7 +58,9 @@ impl SyncTranslation for MasterListLineTranslation {
             MasterListRowRepository::new(connection).find_one_by_id(&data.item_master_ID)?;
 
         if master_list.is_none() {
-            return Ok(PullTranslateResult::Ignored("Orphaned line".to_string()));
+            return Ok(PullTranslateResult::Ignored(
+                "Missing master list".to_string(),
+            ));
         }
 
         let result = MasterListLineRow {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4013

# 👩🏻‍💻 What does this PR do?
Ignore orphaned master list lines

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
