### PR TITLE
4014 You can query patient data without View Patients permission (via name query)

### DIFF
--- a/server/repository/src/db_diesel/name.rs
+++ b/server/repository/src/db_diesel/name.rs
@@ -395,15 +395,12 @@ impl Name {
 }
 
 impl NameType {
-    pub fn equal_to(&self) -> EqualFilter<NameType> {
-        EqualFilter {
-            equal_to: Some(self.clone()),
-            not_equal_to: None,
-            equal_any: None,
-            not_equal_all: None,
-            equal_any_or_null: None,
-            is_null: None,
-        }
+    pub fn equal_to(&self) -> EqualFilter<Self> {
+        inline_init(|r: &mut EqualFilter<Self>| r.equal_to = Some(self.clone()))
+    }
+
+    pub fn not_equal_to(&self) -> EqualFilter<Self> {
+        inline_init(|r: &mut EqualFilter<Self>| r.not_equal_to = Some(self.clone()))
     }
 }
 

--- a/server/service/src/name.rs
+++ b/server/service/src/name.rs
@@ -1,4 +1,5 @@
 use repository::NameRepository;
+use repository::NameType;
 use repository::PaginationOption;
 use repository::{Name, NameFilter, NameSort};
 
@@ -19,8 +20,12 @@ pub fn get_names(
     let pagination = get_default_pagination(pagination, MAX_LIMIT, MIN_LIMIT)?;
     let repository = NameRepository::new(&ctx.connection);
 
+    let filter = filter
+        .unwrap_or_default()
+        .r#type(NameType::Patient.not_equal_to());
+
     Ok(ListResult {
-        rows: repository.query(store_id, pagination, filter.clone(), sort)?,
-        count: i64_to_u32(repository.count(store_id, filter)?),
+        rows: repository.query(store_id, pagination, Some(filter.clone()), sort)?,
+        count: i64_to_u32(repository.count(store_id, Some(filter))?),
     })
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4014

# 👩🏻‍💻 What does this PR do?
Filters all patients out for names by default since there's a separate endpoint to get patients

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Call names endpoints with Type.Patient
- [ ] Shouldn't see any patients

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
