### PR TITLE
gaps feature flag

### DIFF
--- a/client/packages/config/src/config.ts
+++ b/client/packages/config/src/config.ts
@@ -1,5 +1,6 @@
 declare const API_HOST: string;
 declare const FEATURE_PACK_VARIANTS: boolean;
+declare const FEATURE_GAPS: boolean;
 
 // For production, API is on the same domain/ip and port as web app, available through sub-route
 // i.e. web app is on https://my.openmsupply.com/, then graphql will be available https://my.openmsupply.com/graphql
@@ -44,6 +45,7 @@ export const Environment = {
     typeof FEATURE_PACK_VARIANTS === 'undefined'
       ? false
       : FEATURE_PACK_VARIANTS,
+  FEATURE_GAPS: typeof FEATURE_GAPS === 'undefined' ? false : FEATURE_GAPS,
 };
 
 export default Environment;

--- a/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -25,7 +25,7 @@ import {
   RouteBuilder,
   useConfirmationModal,
 } from '@openmsupply-client/common';
-import { AppRoute, ExternalURL } from '@openmsupply-client/config';
+import { AppRoute, Environment, ExternalURL } from '@openmsupply-client/config';
 import {
   CatalogueNav,
   DistributionNav,
@@ -218,7 +218,7 @@ export const AppDrawer: React.FC = () => {
           <InventoryNav />
           <DispensaryNav store={store} />
           <ColdChainNav store={store} />
-          <ManageNav />
+          {Environment.FEATURE_GAPS && <ManageNav />}
 
           {/* <AppNavLink
             to={AppRoute.Tools}

--- a/client/packages/host/webpack.config.js
+++ b/client/packages/host/webpack.config.js
@@ -145,6 +145,7 @@ module.exports = env => {
       new ReactRefreshWebpackPlugin(),
       new webpack.DefinePlugin({
         FEATURE_PACK_VARIANTS: env.FEATURE_PACK_VARIANTS,
+        FEATURE_GAPS: env.FEATURE_GAPS,
         API_HOST: JSON.stringify(env.API_HOST),
         LOCAL_PLUGINS: JSON.stringify(localPlugins()),
         LANG_VERSION: Date.now(),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->



# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Adds feature flag to hide GAPS `Manage` section/pages on central server.

Most other GAPS work is either pretty integrated into existing assets stuff (and probably fine to be there for a test build) or in a feature branch at this point.

<!-- why are the changes needed -->

This is just to hide in progress work from a test build for Inventory Adjustments, when time comes for RC build the feature toggle may be more fine grained!

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] `yarn start-local-features FEATURE_GAPS=true`
- [ ] You can see the Manage section in App Drawer when logged in on central server, and can navigate to the facilities page
- [ ] `yarn start`
- [ ] You CANNOT see the Manage section in App Drawer when logged in on central server

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
