### PR TITLE
default lang version to app version if not defined

### DIFF
--- a/client/packages/common/src/intl/context/IntlContext.tsx
+++ b/client/packages/common/src/intl/context/IntlContext.tsx
@@ -7,8 +7,12 @@ import { I18nextProviderProps, initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { browserLanguageDetector } from './browserLanguageDetector';
 import { createRegisteredContext } from 'react-singleton-context';
+const appVersion = require('../../../../../../package.json').version; // eslint-disable-line @typescript-eslint/no-var-requires
 
-declare const LANG_VERSION: string; // Created by webpack DefinePlugin see webpack.config.js
+// Created by webpack DefinePlugin see webpack.config.js
+// Only for web, otherwise default to app version
+declare const LANG_VERSION: string;
+
 const defaultNS = 'common';
 
 type IntlProviderProps = PropsWithChildren<{ isElectron?: boolean }>;
@@ -34,6 +38,9 @@ export const IntlProvider: FC<IntlProviderProps> = ({
       ? 0
       : 7 * 24 * 60 * minuteInMilliseconds; // Cache for 7 days, on rebuild we should get a new language version so we can use a reasonably long cache
 
+    const languageVersion =
+      typeof LANG_VERSION === 'undefined' ? appVersion : LANG_VERSION;
+
     // Electron `main` window translations should be served with relative path
     const loadPath = `${!!isElectron ? '.' : ''}/locales/{{lng}}/{{ns}}.json`;
 
@@ -52,7 +59,9 @@ export const IntlProvider: FC<IntlProviderProps> = ({
               /* options for primary backend */
               expirationTime,
               defaultVersion: 'v0.1',
-              versions: { en: LANG_VERSION },
+              versions: {
+                en: languageVersion,
+              },
             },
             {
               /* options for secondary backend */


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3995

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Default the language version to appVersion if LANG_VERSION not available

Honestly maybe just using app version would be fine?? Looks like this was introduced by @mark-prins, maybe you have thoughts?

This felt like the quickest way to get something going...

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] yarn electron:start
- [ ] app runs

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
