### PR TITLE
swallow keep awake errors

### DIFF
--- a/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
+++ b/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
@@ -117,16 +117,22 @@ export const useNativeClient = ({
     // Currently only supported on native platforms via capacitor
     if (!Capacitor.isNativePlatform()) return;
 
-    const result = await KeepAwake.isSupported();
-    if (result.isSupported) await KeepAwake.allowSleep();
+    try {
+      const result = await KeepAwake.isSupported();
+      if (result.isSupported) await KeepAwake.allowSleep();
+      // If KeepAwake has errors, just swallow them
+    } catch {}
   };
 
   const keepAwake = async () => {
     // Currently only supported on native platforms via capacitor
     if (!Capacitor.isNativePlatform()) return;
 
-    const result = await KeepAwake.isSupported();
-    if (result.isSupported) await KeepAwake.keepAwake();
+    try {
+      const result = await KeepAwake.isSupported();
+      if (result.isSupported) await KeepAwake.keepAwake();
+      // If KeepAwake has errors, just swallow them
+    } catch {}
   };
 
   const saveFile = async (fileInfo: FileInfo) => {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4048 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Swallows KeepAwake errors if they arise, so initialisation screen can finish loading.

On initial load, KeepAwake was throwing a "not available" error, and so from the initialise hook, setIsInitialising(false) was never being called.

The form is disabled until isInitialising is set to false, so the form was never being enabled.

Seeing as the KeepAwake piece is helpful, but not critical to any workflow, I think the best solution is just to swallow the error and move on.


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

You can now type as expected:
<img width="426" alt="Screenshot 2024-06-06 at 12 17 36 PM" src="https://github.com/msupply-foundation/open-msupply/assets/55115239/49f980ee-32f7-4115-a7e2-e77182091f33">


## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

TBH I have no idea why keep awake is not available on initial load. It's available after refresh (i.e. I refreshed with dev tools, then everything worked fine), but you can't just refresh easily in android app.

It's working fine in main/2.0?? Wonder if there was a dependency upgrade somewhere, but I can't pinpoint right now and feel I've spent enough time on this already...

Probably worth investigating at some point? But I'd like to get this fix to the testers for Inv Adj testing 🙏 

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Build APK
- [ ] You can type in the inputs

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
