### PR TITLE
Disable centralPatientSearch query if the input params object is empty

### DIFF
--- a/client/packages/system/src/Patient/api/hooks/utils/useCentralPatientSearch.ts
+++ b/client/packages/system/src/Patient/api/hooks/utils/useCentralPatientSearch.ts
@@ -13,7 +13,7 @@ export const useCentralPatientSearch = (
     ...useQuery(
       api.keys.centralSearch(params),
       () => api.get.centralSearch(params),
-      { enabled }
+      { enabled: enabled && JSON.stringify(params) !== '{}' }
     ),
   };
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4087 

# 👩🏻‍💻 What does this PR do?
Checks if the input object is empty, i.e. has no keys like `first: undefined`.

Could have also added the check on the server but was easier to do in js...

# 🧪 Testing

Think it requires the png programs module to be configure to be able to select the NUIC.

- Search only by NUIC or now input params at all
- The returned list should not include central server results