### PR TITLE
4090 program event order

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -3411,7 +3411,7 @@ dependencies = [
  "serde_json",
  "time",
  "url",
- "uuid 1.8.0",
+ "uuid",
 ]
 
 [[package]]
@@ -4563,7 +4563,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "util",
- "uuid 0.8.2",
 ]
 
 [[package]]
@@ -6040,16 +6039,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror",
- "uuid 1.8.0",
-]
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom",
+ "uuid",
 ]
 
 [[package]]

--- a/server/repository/Cargo.toml
+++ b/server/repository/Cargo.toml
@@ -26,7 +26,6 @@ futures-util = "0.3.15"
 libsqlite3-sys = { version = "0.28.0", features = ["bundled"], optional = true }
 # 0.31.0 depends on libsqlite3-sys 0.28.0
 rusqlite = "0.31.0"
-uuid = { version = "0.8", features = ["v4"] }
 regex = "1.10.3"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.66"

--- a/server/service/src/programs/program_event.rs
+++ b/server/service/src/programs/program_event.rs
@@ -68,7 +68,7 @@ fn remove_event_stack(
         Pagination::one(),
         Some(event_target_filter(event_target).datetime(DatetimeFilter::equal_to(datetime))),
         Some(ProgramEventSort {
-            key: ProgramEventSortField::ActiveStartDatetime,
+            key: ProgramEventSortField::ActiveEndDatetime,
             desc: Some(true),
         }),
     )?;
@@ -91,7 +91,7 @@ fn remove_event_stack(
                     .active_end_datetime(DatetimeFilter::equal_to(datetime)),
             ),
             Some(ProgramEventSort {
-                key: ProgramEventSortField::ActiveStartDatetime,
+                key: ProgramEventSortField::ActiveEndDatetime,
                 desc: Some(true),
             }),
         )?
@@ -821,7 +821,7 @@ mod test {
         events.sort_by(|a, b| {
             a.datetime
                 .cmp(&b.datetime)
-                .then_with(|| a.active_start_datetime.cmp(&b.active_start_datetime))
+                .then_with(|| a.active_end_datetime.cmp(&b.active_end_datetime))
         });
 
         // init with first datetime
@@ -864,10 +864,16 @@ mod test {
                         event.data
                     );
                 }
-                assert!(event.active_end_datetime >= prev_event_end);
+                assert!(
+                    event.active_end_datetime >= prev_event_end,
+                    "event.active_end_datetime: {}, prev_event_end: {}",
+                    event.active_end_datetime,
+                    prev_event_end
+                );
                 prev_event_end = event.active_end_datetime;
             }
         }
+        assert_eq!(prev_event_end, max_datetime());
     }
 
     #[actix_rt::test]


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4090

# 👩🏻‍💻 What does this PR do?

An event stack can have events that all have the same  active_start_datetime. When picking the latest active_end_datetime from the stack we thus have to sort by active_end_datetime and not by active_start_datetime.

I noticed this sort order before but thought sorting by ActiveStartDatetime works as well, but it doesn't...

I tried to create test case for it but its a bit tricky because I couldn't easily trick the DB to give me the event in the wrong order. I also attempted to add a comment about it in the code, but the comment didn't make sense to me when reading it because in the context where I did the changes it is more logical to sort by ActiveEndDatetime  in the first place.

However, this is the test that failed when I inserted the event in reverse order into the DB and thus the DB gave me the event back in the reverse order:

```rust
#[actix_rt::test]
    async fn test_program_event_order_problem() {
        let (_, _, connection_manager, _) = setup_all(
            "test_program_event_order_problem",
            MockDataInserts::none().names().contexts(),
        )
        .await;

        let service_provider = ServiceProvider::new(connection_manager, "");
        let ctx = service_provider.basic_context().unwrap();

        let service = service_provider.program_event_service;

        // stack 1
        service
            .upsert_events(
                &ctx.connection,
                "patient2".to_string(),
                datetime_from_date(2023, 2, 3),
                &mock_program_a().context_id,
                vec![
                    event(datetime_from_date(2023, 1, 1), "G1_1"),
                    event(datetime_from_date(2023, 1, 2), "G1_2"),
                    event(datetime_from_date(2023, 2, 3), "G1_3"),
                ],
            )
            .unwrap();
        // stack 2
        service
            .upsert_events(
                &ctx.connection,
                "patient2".to_string(),
                datetime_from_date(2023, 1, 10),
                &mock_program_a().context_id,
                vec![
                    event(datetime_from_date(2023, 1, 2), "G2_1"),
                    event(datetime_from_date(2023, 1, 3), "G2_2"),
                    event(datetime_from_date(2023, 1, 4), "G2_3"),
                ],
            )
            .unwrap();

        // remove stack 1
        service
            .upsert_events(
                &ctx.connection,
                "patient2".to_string(),
                datetime_from_date(2023, 2, 3),
                &mock_program_a().context_id,
                vec![],
            )
            .unwrap();

        let result = service
            .events(&ctx, None, None, None, None)
            .unwrap()
            .rows
            .into_iter()
            .map(|row| row.program_event_row)
            .collect::<Vec<_>>();

        check_integrity(result);
    }
```

# 🧪 Testing

Just run the tests
