### PR TITLE
Change translation from status log to status history

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/DetailView.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/DetailView.tsx
@@ -111,7 +111,7 @@ export const EquipmentDetailView = () => {
     },
     {
       Component: draft === undefined ? null : <StatusLogs assetId={draft.id} />,
-      value: 'StatusLogs',
+      value: 'StatusHistory',
     },
     {
       Component: draft === undefined ? null : <Documents draft={draft} />,

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -375,7 +375,7 @@
   "label.soh": "SOH",
   "label.start-datetime": "Start date / time",
   "label.status": "Status",
-  "label.statuslogs": "Status Logs",
+  "label.statushistory": "Status History",
   "label.stock-on-hand": "SoH (Est. remaining)",
   "label.stocktake-comment": "Comment",
   "label.store": "Store",

--- a/client/packages/common/src/intl/locales/fr/common.json
+++ b/client/packages/common/src/intl/locales/fr/common.json
@@ -396,7 +396,6 @@
   "label.from-datetime": "A partir de la date/heure",
   "label.from-start-datetime": "À partir de la date/heure de début",
   "label.last-name": "Nom",
-  "label.statuslogs": "Journal des statuts",
   "messages.no": "Non",
   "title.confirm-delete-encounter": "Supprimer la visite",
   "label.available-quantity-for-return": "Quantité disponible pour le retour",


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4045

# 👩🏻‍💻 What does this PR do?
Change translation to Status History. Thought it would be nice to get in before users start asking why the tab changed XD

<img width="1186" alt="Screenshot 2024-06-10 at 6 50 43 PM" src="https://github.com/msupply-foundation/open-msupply/assets/61820074/8ff517f4-c2b3-44c0-93ae-420e69fb2057">

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Click on an `Equipment` in the list view
- [ ] See that `Status Log` has been changed to `Status History`

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Any screenshot that shows the status log in equipment page
  2.
