### PR TITLE
3992 unable to see full description of a master list in item   master list or in master list page

### DIFF
--- a/client/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
+++ b/client/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
@@ -180,6 +180,7 @@ const getColumnLookup = <T extends RecordWithId>(): Record<
     label: 'heading.description',
     key: 'description',
     width: 250,
+    Cell: TooltipTextCell,
   },
   selection: getCheckboxSelectionColumn(),
   code: {

--- a/client/packages/system/src/Item/DetailView/Tabs/MasterLists.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/MasterLists.tsx
@@ -11,14 +11,15 @@ import {
   createTableStore,
   Box,
   createQueryParamsStore,
+  TooltipTextCell,
 } from '@openmsupply-client/common';
 
 const MasterListsTable: FC<{ itemId?: string }> = ({ itemId }) => {
   const { data, isLoading } = useMasterList.document.listByItemId(itemId ?? '');
   const columns = useColumns<MasterListRowFragment>([
-    'code',
-    ['name', { width: 150 }],
-    'description',
+    ['code', { Cell: TooltipTextCell }],
+    ['name', { width: 200, Cell: TooltipTextCell }],
+    ['description', { minWidth: 100, Cell: TooltipTextCell }],
   ]);
 
   if (isLoading) return <BasicSpinner />;

--- a/client/packages/system/src/MasterList/ListView/ListView.tsx
+++ b/client/packages/system/src/MasterList/ListView/ListView.tsx
@@ -9,6 +9,7 @@ import {
   useTranslation,
   createQueryParamsStore,
   useUrlQueryParams,
+  TooltipTextCell,
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
@@ -26,7 +27,10 @@ const MasterListComponent: FC = () => {
   const navigate = useNavigate();
   const t = useTranslation('catalogue');
   const columns = useColumns<MasterListRowFragment>(
-    ['name', 'description'],
+    [
+      ['name', { width: 300, Cell: TooltipTextCell }],
+      ['description', { minWidth: 100, Cell: TooltipTextCell }],
+    ],
     {
       onChangeSortBy: updateSortQuery,
       sortBy,

--- a/server/repository/src/db_diesel/requisition_line/requisition_line_row.rs
+++ b/server/repository/src/db_diesel/requisition_line/requisition_line_row.rs
@@ -18,7 +18,7 @@ table! {
         requested_quantity -> Double,
         suggested_quantity -> Double,
         supply_quantity -> Double,
-        available_stock_on_hand -> Double ,
+        available_stock_on_hand -> Double,
         average_monthly_consumption -> Double,
         snapshot_datetime -> Nullable<Timestamp>,
         approved_quantity -> Double,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3992

# 👩🏻‍💻 What does this PR do?
Change row sizes for master list name/description + add tooltip

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create master lists with really long name and description
- [ ] Should be able to long press (on mobile) or hover (on desktop) to see tooltip

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
