### PR TITLE
Use a static LinkPatientModal to avoid recreating it on each render

### DIFF
--- a/client/packages/system/src/ContactTrace/DetailView/LinkPatientModal.tsx
+++ b/client/packages/system/src/ContactTrace/DetailView/LinkPatientModal.tsx
@@ -19,6 +19,7 @@ import {
   useRowStyle,
   AppSxProp,
   alpha,
+  ModalProps,
 } from '@openmsupply-client/common';
 import {
   ChipTableCell,
@@ -223,6 +224,56 @@ const ModalContent: FC<ModalContentProps> = ({
   );
 };
 
+const LinkPatientModal = ({
+  documentData,
+  Modal,
+  hideDialog,
+  onPatientLinked,
+}: {
+  documentData: ContactTrace;
+  Modal: FC<ModalProps>;
+  hideDialog: () => void;
+  onPatientLinked: (patientId?: string) => void;
+}) => {
+  const { filter, onChange } = useFilter(documentData);
+  const [linkedPatientId, setLinkedPatientId] = useState(
+    documentData?.contact?.id
+  );
+
+  return (
+    <TableProvider createStore={createTableStore}>
+      <Modal
+        sx={{
+          maxWidth: '90%',
+          minWidth: '65%',
+          height: '100%',
+        }}
+        title={''}
+        contentProps={{ sx: { padding: 0 } }}
+        cancelButton={<DialogButton variant="cancel" onClick={hideDialog} />}
+        okButton={
+          <DialogButton
+            variant="ok"
+            onClick={() => {
+              onPatientLinked(linkedPatientId);
+              hideDialog();
+            }}
+          />
+        }
+        slideAnimation={false}
+      >
+        <ModalContent
+          documentData={documentData}
+          linkedPatientId={linkedPatientId}
+          setLinkedPatientId={setLinkedPatientId}
+          onChangeFilter={onChange}
+          filter={filter}
+        />
+      </Modal>
+    </TableProvider>
+  );
+};
+
 export const useLinkPatientModal = (
   documentData: ContactTrace,
   onPatientLinked: (patientId?: string) => void
@@ -232,50 +283,18 @@ export const useLinkPatientModal = (
 
   LinkPatientModal: FC;
 } => {
-  const { filter, onChange } = useFilter(documentData);
   const { Modal, showDialog, hideDialog } = useDialog();
-  const [linkedPatientId, setLinkedPatientId] = useState(
-    documentData?.contact?.id
-  );
-
-  const LinkPatientModal: FC = () => {
-    return (
-      <TableProvider createStore={createTableStore}>
-        <Modal
-          sx={{
-            maxWidth: '90%',
-            minWidth: '65%',
-            height: '100%',
-          }}
-          title={''}
-          contentProps={{ sx: { padding: 0 } }}
-          cancelButton={<DialogButton variant="cancel" onClick={hideDialog} />}
-          okButton={
-            <DialogButton
-              variant="ok"
-              onClick={() => {
-                onPatientLinked(linkedPatientId);
-                hideDialog();
-              }}
-            />
-          }
-          slideAnimation={false}
-        >
-          <ModalContent
-            documentData={documentData}
-            linkedPatientId={linkedPatientId}
-            setLinkedPatientId={setLinkedPatientId}
-            onChangeFilter={onChange}
-            filter={filter}
-          />
-        </Modal>
-      </TableProvider>
-    );
-  };
 
   return {
     showDialog,
     hideDialog,
-    LinkPatientModal,
+    LinkPatientModal: () => (
+      <LinkPatientModal
+        documentData={documentData}
+        onPatientLinked={onPatientLinked}
+        Modal={Modal}
+        hideDialog={hideDialog}
+      />
+    ),
   };
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4106 

# 👩🏻‍💻 What does this PR do?

Use a static LinkPatientModal to avoid recreating it on each render

# 🧪 Testing

- Setup patient programs...
- Enter a name in the Family /partner information
- Click the link button to open the modal
- The previously entered name should now be prepopulated (this was broken as well)
- When typing in the filter input the Modal should not flicker
- You should also not lose focus on the current input field

# 📃 Documentation

@roxy-dao the video in the docs could be updated now...
