### PR TITLE
Add the fifth year

### DIFF
--- a/client/packages/system/src/IndicatorsDemographics/DetailView/NameColumn.tsx
+++ b/client/packages/system/src/IndicatorsDemographics/DetailView/NameColumn.tsx
@@ -18,7 +18,7 @@ export const nameColumn = <
   setter: () => {
     if (process.env['NODE_ENV']) {
       throw new Error(
-        `The default setter of the NameAndColor column was called.
+        `The default setter of the Name column was called.
           Have you forgotten to provide a custom setter?
           When setting up your columns, you should provide a setter function
           const columns = useColumns([ percentageColumn(), { setter }])

--- a/client/packages/system/src/IndicatorsDemographics/DetailView/PercentageColumn.tsx
+++ b/client/packages/system/src/IndicatorsDemographics/DetailView/PercentageColumn.tsx
@@ -16,7 +16,7 @@ export const percentageColumn = <
   setter: () => {
     if (process.env['NODE_ENV']) {
       throw new Error(
-        `The default setter of the NameAndColor column was called.
+        `The default setter of the Percentage column was called.
         Have you forgotten to provide a custom setter?
         When setting up your columns, you should provide a setter function
         const columns = useColumns([ percentageColumn(), { setter }])

--- a/client/packages/system/src/IndicatorsDemographics/DetailView/PopulationColumn.tsx
+++ b/client/packages/system/src/IndicatorsDemographics/DetailView/PopulationColumn.tsx
@@ -16,7 +16,7 @@ export const populationColumn = <
   setter: () => {
     if (process.env['NODE_ENV']) {
       throw new Error(
-        `The default setter of the NameAndColor column was called.
+        `The default setter of the Population column was called.
         Have you forgotten to provide a custom setter?
         When setting up your columns, you should provide a setter function
         const columns = useColumns([ percentageColumn(), { setter }])

--- a/client/packages/system/src/IndicatorsDemographics/DetailView/utils.test.ts
+++ b/client/packages/system/src/IndicatorsDemographics/DetailView/utils.test.ts
@@ -22,6 +22,7 @@ describe('recursiveCalculate', () => {
       2: 202,
       3: 202,
       4: 202,
+      5: 202,
     };
     const indexValue = 1000;
     expect(recursiveCalculate(key, draftHeaders, row, indexValue)).toBe(200);

--- a/client/packages/system/src/IndicatorsDemographics/DetailView/utils.tsx
+++ b/client/packages/system/src/IndicatorsDemographics/DetailView/utils.tsx
@@ -14,11 +14,11 @@ export const toIndicatorFragment = (
     baseYear: row.baseYear,
     basePopulation: indexPopulation ?? row.basePopulation,
     populationPercentage: row.percentage ?? 0,
-    year1Projection: row[0],
-    year2Projection: row[1],
-    year3Projection: row[2],
-    year4Projection: row[3],
-    year5Projection: row[4],
+    year1Projection: row[1],
+    year2Projection: row[2],
+    year3Projection: row[3],
+    year4Projection: row[4],
+    year5Projection: row[5],
   };
 };
 
@@ -56,7 +56,6 @@ export const calculateAcrossRow = (
       !isNaN(parseFloat(key)) &&
       !(row.id === GENERAL_POPULATION_ID && parseFloat(key) == 0)
   );
-
   Object.values(rowNumberKeys).forEach(key => {
     const columnKey = parseInt(key);
     updatedRow = {
@@ -74,6 +73,5 @@ export const calculateAcrossRow = (
     updatedRow = { ...updatedRow, [0]: indexValue ?? 0 };
   }
   updatedRow = { ...updatedRow, basePopulation: indexValue ?? 0 };
-
   return updatedRow;
 };

--- a/client/packages/system/src/IndicatorsDemographics/api/hooks/document/useDemographicIndicators.ts
+++ b/client/packages/system/src/IndicatorsDemographics/api/hooks/document/useDemographicIndicators.ts
@@ -67,7 +67,7 @@ export const useDemographicIndicators = (headerData: HeaderValue[]) => {
     const nodesFiltered = uniqBy([generalRowCalculated, ...nodesAsRow], 'id');
     const draftRows = ArrayUtils.toObject(nodesFiltered);
     setDraft(draftRows);
-  }, [data, t]);
+  }, [data, headerData, t]);
 
   return { draft, setDraft, isLoading };
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4074

# 👩🏻‍💻 What does this PR do?
Adds the fifth year.

Also have fixed an issue where the base / general population was being zeroed when the %growth was adjusted.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
