### PR TITLE
4079 facilities list should only include stores

### DIFF
--- a/client/packages/system/src/Name/api/api.ts
+++ b/client/packages/system/src/Name/api/api.ts
@@ -118,7 +118,7 @@ export const getNameQueries = (sdk: Sdk, storeId: string) => ({
         storeId,
         filter: {
           ...filterBy,
-          type: { equalAny: [NameNodeType.Facility, NameNodeType.Store] },
+          type: { equalTo: NameNodeType.Store },
         },
       });
 

--- a/client/packages/system/src/Name/api/api.ts
+++ b/client/packages/system/src/Name/api/api.ts
@@ -118,7 +118,7 @@ export const getNameQueries = (sdk: Sdk, storeId: string) => ({
         storeId,
         filter: {
           ...filterBy,
-          type: { equalTo: NameNodeType.Store },
+          isStore: true,
         },
       });
 

--- a/server/service/src/name/query.rs
+++ b/server/service/src/name/query.rs
@@ -1,6 +1,7 @@
-use repository::{
-    EqualFilter, Name, NameFilter, NameRepository, NameSort, NameType, PaginationOption,
-};
+use repository::NameRepository;
+use repository::NameType;
+use repository::PaginationOption;
+use repository::{Name, NameFilter, NameSort};
 
 use crate::{
     get_default_pagination, i64_to_u32, service_provider::ServiceContext, ListError, ListResult,
@@ -19,17 +20,9 @@ pub fn get_names(
     let pagination = get_default_pagination(pagination, MAX_LIMIT, MIN_LIMIT)?;
     let repository = NameRepository::new(&ctx.connection);
 
-    let filter = filter.unwrap_or_default();
-
-    let type_filter = match filter.r#type.clone() {
-        Some(filter_input) => EqualFilter::<NameType> {
-            not_equal_to: Some(NameType::Patient),
-            ..filter_input
-        },
-        None => NameType::Patient.not_equal_to(),
-    };
-
-    let filter = filter.r#type(type_filter);
+    let filter = filter
+        .unwrap_or_default()
+        .r#type(NameType::Patient.not_equal_to());
 
     Ok(ListResult {
         rows: repository.query(store_id, pagination, Some(filter.clone()), sort)?,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4079

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Filters the facilities list to only include stores.

Turns out the names query was overwriting the `type` to filter out patients - fixed this compose the two filters instead 😅 

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

There are actually two store filters on name...

1. `isStore` - this checks whether we have a store for that name, via the `name_store_join`
2. `NameType` of `STORE` - name type from mSupply (i.e. as opposed to Facility, Patient...)

Currently I'm using option 2, would you say this is correct?

In the datafile that I'm using, it doesn't seem to matter, like there aren't any names with the `NameType` of `STORE` that don't have a linked store. Or facilities that DO have a linked store. But wanted to check if that is possible?

Though the little store icon on the left hand side is derived from `isStore`... so maybe I should be using that?? 🤷‍♀️ 

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Manage > Facilities
- [ ] The list should only contain stores (all have the house icon on the left hand side)

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  