### PR TITLE
3642 patient search results display in created date order

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -4650,6 +4650,7 @@ export type PatientNode = {
   code2?: Maybe<Scalars['String']['output']>;
   contactTraces: ContactTraceResponse;
   country?: Maybe<Scalars['String']['output']>;
+  createdDatetime?: Maybe<Scalars['DateTime']['output']>;
   dateOfBirth?: Maybe<Scalars['NaiveDate']['output']>;
   dateOfDeath?: Maybe<Scalars['NaiveDate']['output']>;
   document?: Maybe<DocumentNode>;

--- a/client/packages/system/src/Patient/ListView/ListView.tsx
+++ b/client/packages/system/src/Patient/ListView/ListView.tsx
@@ -77,7 +77,6 @@ const PatientListComponent: FC = () => {
     {
       key: 'createdDatetime',
       label: 'label.created',
-      width: 175,
       formatter: dateString =>
         dateString ? localisedDate((dateString as string) || '') : '',
       sortable: true,
@@ -97,7 +96,6 @@ const PatientListComponent: FC = () => {
     {
       key: 'dateOfBirth',
       label: 'label.date-of-birth',
-      width: 175,
       formatter: dateString =>
         dateString ? localisedDate((dateString as string) || '') : '',
     },

--- a/client/packages/system/src/Patient/ListView/ListView.tsx
+++ b/client/packages/system/src/Patient/ListView/ListView.tsx
@@ -39,7 +39,7 @@ const PatientListComponent: FC = () => {
     filter,
     queryParams: { page, first, offset, sortBy, filterBy },
   } = useUrlQueryParams({
-    initialSort: { key: 'code', dir: 'asc' },
+    initialSort: { key: 'createdDatetime', dir: 'desc' },
     filters: [
       {
         key: 'dateOfBirth',
@@ -74,6 +74,14 @@ const PatientListComponent: FC = () => {
   const columnDefinitions: ColumnDescription<PatientRowFragment>[] = [
     { key: 'code', label: 'label.patient-id' },
     { key: 'code2', label: 'label.patient-nuic' },
+    {
+      key: 'createdDatetime',
+      label: 'label.created',
+      width: 175,
+      formatter: dateString =>
+        dateString ? localisedDate((dateString as string) || '') : '',
+      sortable: true,
+    },
     {
       key: 'firstName',
       label: 'label.first-name',

--- a/client/packages/system/src/Patient/api/operations.generated.ts
+++ b/client/packages/system/src/Patient/api/operations.generated.ts
@@ -4,9 +4,9 @@ import { GraphQLClient } from 'graphql-request';
 import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types';
 import gql from 'graphql-tag';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
-export type PatientRowFragment = { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', name: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } };
+export type PatientRowFragment = { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, createdDatetime?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', name: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } };
 
-export type ProgramPatientRowFragment = { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, documentDraft?: any | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } };
+export type ProgramPatientRowFragment = { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, createdDatetime?: string | null, documentDraft?: any | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } };
 
 export type PatientsQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -16,7 +16,7 @@ export type PatientsQueryVariables = Types.Exact<{
 }>;
 
 
-export type PatientsQuery = { __typename: 'Queries', patients: { __typename: 'PatientConnector', totalCount: number, nodes: Array<{ __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', name: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } }> } };
+export type PatientsQuery = { __typename: 'Queries', patients: { __typename: 'PatientConnector', totalCount: number, nodes: Array<{ __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, createdDatetime?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', name: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } }> } };
 
 export type PatientByIdQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -24,7 +24,7 @@ export type PatientByIdQueryVariables = Types.Exact<{
 }>;
 
 
-export type PatientByIdQuery = { __typename: 'Queries', patients: { __typename: 'PatientConnector', totalCount: number, nodes: Array<{ __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, documentDraft?: any | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } }> } };
+export type PatientByIdQuery = { __typename: 'Queries', patients: { __typename: 'PatientConnector', totalCount: number, nodes: Array<{ __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, createdDatetime?: string | null, documentDraft?: any | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } }> } };
 
 export type PatientSearchQueryVariables = Types.Exact<{
   input: Types.PatientSearchInput;
@@ -32,7 +32,7 @@ export type PatientSearchQueryVariables = Types.Exact<{
 }>;
 
 
-export type PatientSearchQuery = { __typename: 'Queries', patientSearch: { __typename: 'PatientSearchConnector', totalCount: number, nodes: Array<{ __typename: 'PatientSearchNode', score: number, patient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, documentDraft?: any | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } }> } };
+export type PatientSearchQuery = { __typename: 'Queries', patientSearch: { __typename: 'PatientSearchConnector', totalCount: number, nodes: Array<{ __typename: 'PatientSearchNode', score: number, patient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, createdDatetime?: string | null, documentDraft?: any | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } }> } };
 
 export type CentralPatientSearchQueryVariables = Types.Exact<{
   input: Types.CentralPatientSearchInput;
@@ -56,7 +56,7 @@ export type InsertProgramPatientMutationVariables = Types.Exact<{
 }>;
 
 
-export type InsertProgramPatientMutation = { __typename: 'Mutations', insertProgramPatient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, documentDraft?: any | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } };
+export type InsertProgramPatientMutation = { __typename: 'Mutations', insertProgramPatient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, createdDatetime?: string | null, documentDraft?: any | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } };
 
 export type UpdateProgramPatientMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -64,7 +64,7 @@ export type UpdateProgramPatientMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateProgramPatientMutation = { __typename: 'Mutations', updateProgramPatient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, documentDraft?: any | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } };
+export type UpdateProgramPatientMutation = { __typename: 'Mutations', updateProgramPatient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, createdDatetime?: string | null, documentDraft?: any | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } };
 
 export type InsertPatientMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -72,7 +72,7 @@ export type InsertPatientMutationVariables = Types.Exact<{
 }>;
 
 
-export type InsertPatientMutation = { __typename: 'Mutations', insertPatient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, documentDraft?: any | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } };
+export type InsertPatientMutation = { __typename: 'Mutations', insertPatient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, createdDatetime?: string | null, documentDraft?: any | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } };
 
 export type UpdatePatientMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -80,7 +80,7 @@ export type UpdatePatientMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdatePatientMutation = { __typename: 'Mutations', updatePatient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, documentDraft?: any | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } };
+export type UpdatePatientMutation = { __typename: 'Mutations', updatePatient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, createdDatetime?: string | null, documentDraft?: any | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } };
 
 export type LatestPatientEncounterQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -104,6 +104,7 @@ export const PatientRowFragmentDoc = gql`
   phone
   gender
   email
+  createdDatetime
   document {
     name
   }
@@ -138,6 +139,7 @@ export const ProgramPatientRowFragmentDoc = gql`
   phone
   gender
   email
+  createdDatetime
   document {
     id
     name

--- a/client/packages/system/src/Patient/api/operations.graphql
+++ b/client/packages/system/src/Patient/api/operations.graphql
@@ -10,6 +10,7 @@ fragment PatientRow on PatientNode {
   phone
   gender
   email
+  createdDatetime
   document {
     name
   }
@@ -43,6 +44,7 @@ fragment ProgramPatientRow on PatientNode {
   phone
   gender
   email
+  createdDatetime
   document {
     id
     name

--- a/server/graphql/programs/src/queries/patient.rs
+++ b/server/graphql/programs/src/queries/patient.rs
@@ -32,6 +32,7 @@ pub enum PatientSortFieldInput {
     Country,
     Email,
     DateOfDeath,
+    CreatedDatetime,
 }
 
 #[derive(InputObject)]
@@ -60,6 +61,7 @@ impl PatientSortInput {
                 PatientSortFieldInput::Country => PatientSortField::Country,
                 PatientSortFieldInput::Email => PatientSortField::Email,
                 PatientSortFieldInput::DateOfDeath => PatientSortField::DateOfDeath,
+                PatientSortFieldInput::CreatedDatetime => PatientSortField::CreatedDatetime,
             },
             desc: self.desc,
         }

--- a/server/graphql/reports/src/printing.rs
+++ b/server/graphql/reports/src/printing.rs
@@ -282,7 +282,7 @@ async fn fetch_data(
     }
     let mut data = if let Some(ResolvedReportQuery::GraphQlQuery(gql)) = graphql_query.get(0) {
         let variables = query_variables(store_id, &data_id, &arguments, &sort, &gql.variables);
-        let result = fetch_graphq_data(ctx, gql, variables).await?;
+        let result = fetch_graphql_data(ctx, gql, variables).await?;
         match result {
             FetchResult::Data(serde_json::Value::Object(data)) => data,
             FetchResult::Error(_) => return Ok(result),
@@ -333,7 +333,7 @@ fn fetch_sql_data(
     Ok(serde_json::Value::Array(data))
 }
 
-async fn fetch_graphq_data(
+async fn fetch_graphql_data(
     ctx: &Context<'_>,
     query: &GraphQlQuery,
     variables: serde_json::Map<String, serde_json::Value>,

--- a/server/graphql/types/src/types/program/patient.rs
+++ b/server/graphql/types/src/types/program/patient.rs
@@ -1,7 +1,9 @@
 use async_graphql::dataloader::DataLoader;
 use async_graphql::*;
-use chrono::{Local, NaiveDate};
-use graphql_core::generic_filters::{DateFilterInput, EqualFilterStringInput, StringFilterInput};
+use chrono::{DateTime, Local, NaiveDate, Utc};
+use graphql_core::generic_filters::{
+    DateFilterInput, DatetimeFilterInput, EqualFilterStringInput, StringFilterInput,
+};
 use graphql_core::loader::DocumentLoader;
 use graphql_core::{map_filter, ContextExt};
 
@@ -147,6 +149,12 @@ impl PatientNode {
 
     pub async fn date_of_death(&self) -> Option<NaiveDate> {
         self.patient.date_of_death
+    }
+
+    pub async fn created_datetime(&self) -> Option<DateTime<Utc>> {
+        self.patient.created_datetime.map(|created_datetime| {
+            DateTime::<Utc>::from_naive_utc_and_offset(created_datetime, Utc)
+        })
     }
 
     pub async fn document(&self, ctx: &Context<'_>) -> Result<Option<DocumentNode>> {

--- a/server/graphql/types/src/types/program/patient.rs
+++ b/server/graphql/types/src/types/program/patient.rs
@@ -1,9 +1,7 @@
 use async_graphql::dataloader::DataLoader;
 use async_graphql::*;
 use chrono::{DateTime, Local, NaiveDate, Utc};
-use graphql_core::generic_filters::{
-    DateFilterInput, DatetimeFilterInput, EqualFilterStringInput, StringFilterInput,
-};
+use graphql_core::generic_filters::{DateFilterInput, EqualFilterStringInput, StringFilterInput};
 use graphql_core::loader::DocumentLoader;
 use graphql_core::{map_filter, ContextExt};
 

--- a/server/graphql/types/src/types/user.rs
+++ b/server/graphql/types/src/types/user.rs
@@ -30,7 +30,7 @@ impl UserStoreNode {
     }
 
     pub async fn name_id(&self) -> &str {
-        &self.user_store.store_row.name_id
+        &self.user_store.store_row.name_link_id
     }
 
     pub async fn name(&self, ctx: &Context<'_>) -> Result<String> {

--- a/server/repository/src/db_diesel/patient.rs
+++ b/server/repository/src/db_diesel/patient.rs
@@ -61,6 +61,7 @@ pub enum PatientSortField {
     Country,
     Email,
     DateOfDeath,
+    CreatedDatetime,
 }
 
 pub type PatientSort = Sort<PatientSortField>;
@@ -137,6 +138,9 @@ impl<'a> PatientRepository<'a> {
                 }
                 PatientSortField::DateOfDeath => {
                     apply_sort_no_case!(query, sort, name_dsl::date_of_death)
+                }
+                PatientSortField::CreatedDatetime => {
+                    apply_sort_no_case!(query, sort, name_dsl::created_datetime)
                 }
             }
         } else {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3642

# 👩🏻‍💻 What does this PR do?
Adds `created date` column to patients and allow users to use this to sort patients (defaults: newest created patient -> oldest)

## 💌 Any notes for the reviewer?
Was unsure where to put the column... Didn't want it to be too right since it might be hidden on smaller screens...

Should the central search screen also return newest to oldest patients...?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have some patients with different created datetimes
- [ ] Go to `Patients` page
- [ ] See that newest patients are displayed first
- [ ] Click created date sorting, should sort correctly

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Screenshots showing the whole patients page
  2.
