### PR TITLE
Fix asset catalogue import with properties

### DIFF
--- a/client/packages/system/src/Asset/ImportCatalogueItem/UploadTab.tsx
+++ b/client/packages/system/src/Asset/ImportCatalogueItem/UploadTab.tsx
@@ -138,7 +138,7 @@ export const AssetItemUploadTab: FC<ImportPanel & AssetItemUploadTabProps> = ({
       exampleRows,
       t,
       false, // exclude errors
-      properties ? properties.map(p => p.name) : []
+      properties ? properties.map(p => p.key) : []
     );
     FileUtils.exportCSV(csv, t('filename.asset-import-example'));
   };
@@ -157,9 +157,10 @@ export const AssetItemUploadTab: FC<ImportPanel & AssetItemUploadTabProps> = ({
       setIsLoading(true);
       Papa.parse(csvFile, {
         delimiter: ',',
+        quoteChar: '"',
         header: true,
         worker: true,
-        skipEmptyLines: true,
+        skipEmptyLines: 'greedy',
         fastMode: false,
         chunkSize: 100 * 1024, // 100kb
         chunk: processUploadedDataChunk,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4012

# 👩🏻‍💻 What does this PR do?

Embarassingly easy fix in the end, I switched the example output to use the the property key instead of name, which fixes the issue.

Basically papaparse doesn't correctly parse csv header rows when they contain commas.
Was relying on a simple split on `,` the error was confusing though, as it appeared to suggest it couldn't find the right closing quote in an escape sequence. 

There's an issue in papaparse for this already.
https://github.com/mholt/PapaParse/issues/1052

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Central OMS Server
- [ ] Go to Catalogue -> Assets Import
- [ ] Download Example File
- [ ] Update this with real data
- [ ] Import
- [ ] Check that creating an asset inherits all the correct properties

# 📃 Documentation

- [X] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
