### PR TITLE
3729 Returns: if there is no 'Reason' configured on mSupply, you still can type to search

### DIFF
--- a/client/packages/system/src/ReturnReason/Components/ReturnReasonSearchInput.tsx
+++ b/client/packages/system/src/ReturnReason/Components/ReturnReasonSearchInput.tsx
@@ -33,7 +33,7 @@ export const ReturnReasonSearchInput: FC<ReturnReasonSearchInputProps> = ({
       <Autocomplete
         fullWidth
         autoFocus={autoFocus}
-        disabled={isDisabled || data?.nodes.length === 0}
+        disabled={isDisabled || reasons.length === 0}
         clearable={false}
         value={
           value

--- a/client/packages/system/src/ReturnReason/Components/ReturnReasonSearchInput.tsx
+++ b/client/packages/system/src/ReturnReason/Components/ReturnReasonSearchInput.tsx
@@ -33,7 +33,7 @@ export const ReturnReasonSearchInput: FC<ReturnReasonSearchInputProps> = ({
       <Autocomplete
         fullWidth
         autoFocus={autoFocus}
-        disabled={isDisabled}
+        disabled={isDisabled || data?.nodes.length === 0}
         clearable={false}
         value={
           value


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3729

# 👩🏻‍💻 What does this PR do?
Disables return reason if no reason is configured
![Screenshot 2024-06-19 at 2 53 18 AM](https://github.com/msupply-foundation/open-msupply/assets/61820074/d41783aa-73c7-45db-a014-ffafd7b751cd)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have no return reasons set up
- [ ] Go to `Inbound Returns`
- [ ] Create a new return and add a line
- [ ] Put in a quantity and go to next step
- [ ] See that reason should be disabled

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
