### PR TITLE
3425 Column titles/headers truncated throughout app despite plenty of screen space

### DIFF
--- a/client/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
+++ b/client/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
@@ -140,7 +140,7 @@ const getColumnLookup = <T extends RecordWithId>(): Record<
     label: 'label.created',
     key: 'createdDatetime',
     format: ColumnFormat.Date,
-    width: 130,
+    width: 150,
   },
   stocktakeDate: {
     label: 'label.date',

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -130,6 +130,7 @@ export const useInboundShipmentColumns = () => {
               { path: ['lines', 'location', 'code'] },
               { path: ['location', 'code'], default: '' },
             ]),
+          width: 150,
         },
       ],
 

--- a/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
@@ -68,7 +68,7 @@ export const InboundListView: FC = () => {
             getStatusTranslator(t)(status as InvoiceNodeStatus),
         },
       ],
-      ['invoiceNumber', { maxWidth: 80 }],
+      ['invoiceNumber', { maxWidth: 100 }],
       'createdDatetime',
       'deliveredDatetime',
       ['comment', { width: 125, Cell: TooltipTextCell }],
@@ -76,6 +76,7 @@ export const InboundListView: FC = () => {
         'theirReference',
         {
           Cell: TooltipTextCell,
+          width: 125,
         },
       ],
       [

--- a/client/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/client/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -63,7 +63,7 @@ const OutboundShipmentListViewComponent: FC = () => {
       ],
       [
         'invoiceNumber',
-        { description: 'description.invoice-number', maxWidth: 110 },
+        { description: 'description.invoice-number', width: 150 },
       ],
       'createdDatetime',
       {
@@ -71,6 +71,7 @@ const OutboundShipmentListViewComponent: FC = () => {
         key: 'theirReference',
         label: 'label.reference',
         Cell: TooltipTextCell,
+        width: 175,
       },
       [
         'comment',
@@ -82,7 +83,7 @@ const OutboundShipmentListViewComponent: FC = () => {
         'totalAfterTax',
         {
           accessor: ({ rowData }) => rowData.pricing.totalAfterTax,
-          width: '100%',
+          width: 125,
         },
       ],
       'selection',

--- a/client/packages/invoices/src/Returns/InboundListView/ListView.tsx
+++ b/client/packages/invoices/src/Returns/InboundListView/ListView.tsx
@@ -71,14 +71,15 @@ const InboundReturnListViewComponent: FC = () => {
       ],
       [
         'invoiceNumber',
-        { description: 'description.invoice-number', maxWidth: 110 },
+        { description: 'description.invoice-number', width: 145 },
       ],
-      'createdDatetime',
+      ['createdDatetime', { width: 150 }],
       ['comment', { width: 125, Cell: TooltipTextCell }],
       [
         'theirReference',
         {
           Cell: TooltipTextCell,
+          width: 125,
         },
       ],
       'selection',

--- a/client/packages/invoices/src/Returns/OutboundListView/ListView.tsx
+++ b/client/packages/invoices/src/Returns/OutboundListView/ListView.tsx
@@ -71,7 +71,7 @@ const OutboundReturnListViewComponent: FC = () => {
       ],
       [
         'invoiceNumber',
-        { description: 'description.invoice-number', maxWidth: 110 },
+        { description: 'description.invoice-number', width: 150 },
       ],
       'createdDatetime',
       ['comment', { width: 125, Cell: TooltipTextCell }],

--- a/client/packages/invoices/src/Returns/OutboundListView/ListView.tsx
+++ b/client/packages/invoices/src/Returns/OutboundListView/ListView.tsx
@@ -79,6 +79,7 @@ const OutboundReturnListViewComponent: FC = () => {
         'theirReference',
         {
           Cell: TooltipTextCell,
+          width: 150,
         },
       ],
       'selection',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3425

# 👩🏻‍💻 What does this PR do?
Fix column widths so that the whole name shows for column

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Check Inbound Shipment (invoice) -> location
- [ ] Inbound Shipment (list) -> Invoice Number & Reference
- [ ] Inbound Returns -> invoice number & reference
- [ ] Outbound Returns -> Reference

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Check to see if any of the screenshots have cut off column names
  2.
