### PR TITLE
3934 Item name is cut off in requisition line edit modal

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEditForm.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEditForm.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import {
+  Box,
   Grid,
   InputWithLabelRow,
   NumericTextInput,
   TextArea,
+  Tooltip,
   Typography,
   useTranslation,
 } from '@openmsupply-client/common';
@@ -98,8 +100,11 @@ export const ResponseLineEditForm = ({
           <Typography variant="body1" fontWeight="bold">
             {t('heading.stock-details')}
           </Typography>
-
-          <InfoRow label={t('label.name')} value={item.name} />
+          <Tooltip title={item.name}>
+            <Box>
+              <InfoRow label={t('label.name')} value={item.name} />
+            </Box>
+          </Tooltip>
           <InfoRow label={t('label.code')} value={item.code} />
           {variantsControl ? (
             <InfoRow


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3934

# 👩🏻‍💻 What does this PR do?
Add tooltip to requisition item name
![Screenshot 2024-06-19 at 7 47 59 AM](https://github.com/msupply-foundation/open-msupply/assets/61820074/e25871ae-ac82-49bb-a104-84a92ae8d75f)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have an item with a very long item name
- [ ] From Store A: Create an Internal Order to Store B with that item
- [ ] Go to Store B: View Requisition
- [ ] Click on line
- [ ] Hover over item name

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
