### PR TITLE
Drop consumption view in migration

### DIFF
--- a/server/repository/src/migrations/v2_01_00/ledger.rs
+++ b/server/repository/src/migrations/v2_01_00/ledger.rs
@@ -4,6 +4,7 @@ pub(crate) fn drop_ledger_views(connection: &StorageConnection) -> anyhow::Resul
     sql!(
         connection,
         r#"
+        DROP VIEW IF EXISTS consumption;
         DROP VIEW IF EXISTS stock_movement;
         DROP VIEW IF EXISTS outbound_shipment_stock_movement;
         DROP VIEW IF EXISTS inbound_shipment_stock_movement;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4185

# 👩🏻‍💻 What does this PR do?
Just drops the view so that `stock_movement` can be dropped, as per the script.
Only an issue if `consumption` was updated to be dependent on `stock_movement`, so not a big problem

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Try to run the `decimal_pack_size` migration manually on postgreSQL

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->

