### PR TITLE
Add baseYear to demographicIndicator graphql call for consistent display

### DIFF
--- a/client/packages/system/src/Immunisation/VaccineCourseView/VaccineCourseItemSelect.tsx
+++ b/client/packages/system/src/Immunisation/VaccineCourseView/VaccineCourseItemSelect.tsx
@@ -58,6 +58,7 @@ export const VaccineItemSelect = ({
 
   return (
     <AutocompleteMulti
+      sx={{ input: { textAlign: 'right' } }}
       isOptionEqualToValue={(option, value) => option.itemId === value.itemId}
       getOptionLabel={option => `${option.name}`}
       value={draft?.vaccineCourseItems ?? []}

--- a/client/packages/system/src/Immunisation/VaccineCourseView/VaccineCourseView.tsx
+++ b/client/packages/system/src/Immunisation/VaccineCourseView/VaccineCourseView.tsx
@@ -197,12 +197,20 @@ export const VaccineCourseView: FC = () => {
     return <BasicSpinner />;
   }
 
+  const defaultValue = {
+    value: draft.demographicIndicator?.name ?? '',
+    label: draft.demographicIndicator
+      ? `${draft.demographicIndicator?.name} ${draft.demographicIndicator?.baseYear}`
+      : '',
+  };
+
   return !!data ? (
     <Box display="flex" flex={1}>
       <Container>
         <Section heading={''}>
           <Row label={t('label.immunisation-name')}>
             <BasicTextInput
+              textAlign="right"
               value={draft?.name ?? ''}
               fullWidth
               onChange={e => updatePatch({ name: e.target.value })}
@@ -210,16 +218,14 @@ export const VaccineCourseView: FC = () => {
           </Row>
           <Row label={t('label.target-demographic')}>
             <Autocomplete
+              sx={{ input: { textAlign: 'right' } }}
               isOptionEqualToValue={option =>
                 option?.value === draft.demographicIndicatorId
               }
               onChange={(_e, selected) =>
                 updatePatch({ demographicIndicatorId: selected?.value })
               }
-              defaultValue={{
-                label: draft.demographicIndicator?.name ?? '',
-                value: draft.demographicIndicator?.id ?? '',
-              }}
+              defaultValue={defaultValue}
               placeholder={'demographic'}
               options={options}
             />

--- a/client/packages/system/src/Immunisation/api/operations.generated.ts
+++ b/client/packages/system/src/Immunisation/api/operations.generated.ts
@@ -38,7 +38,7 @@ export type UpdateImmunisationProgramMutationVariables = Types.Exact<{
 
 export type UpdateImmunisationProgramMutation = { __typename: 'Mutations', centralServer: { __typename: 'CentralServerMutationNode', program: { __typename: 'CentralProgramsMutations', updateImmunisationProgram: { __typename: 'ProgramNode', id: string, name: string, vaccineCourses?: Array<{ __typename: 'VaccineCourseNode', name: string }> | null } | { __typename: 'UpdateImmunisationProgramError', error: { __typename: 'DatabaseError', description: string } | { __typename: 'RecordAlreadyExist', description: string } | { __typename: 'UniqueValueViolation', field: Types.UniqueValueKey, description: string } } } } };
 
-export type VaccineCourseFragment = { __typename: 'VaccineCourseNode', id: string, name: string, programId: string, demographicIndicatorId?: string | null, doses: number, coverageRate: number, wastageRate: number, isActive: boolean, demographicIndicator?: { __typename: 'DemographicIndicatorNode', name: string, id: string } | null, vaccineCourseItems?: Array<{ __typename: 'VaccineCourseItemNode', id: string, itemId: string, name: string }> | null, vaccineCourseSchedules?: Array<{ __typename: 'VaccineCourseScheduleNode', id: string, doseNumber: number, label: string }> | null };
+export type VaccineCourseFragment = { __typename: 'VaccineCourseNode', id: string, name: string, programId: string, demographicIndicatorId?: string | null, doses: number, coverageRate: number, wastageRate: number, isActive: boolean, demographicIndicator?: { __typename: 'DemographicIndicatorNode', name: string, id: string, baseYear: number } | null, vaccineCourseItems?: Array<{ __typename: 'VaccineCourseItemNode', id: string, itemId: string, name: string }> | null, vaccineCourseSchedules?: Array<{ __typename: 'VaccineCourseScheduleNode', id: string, doseNumber: number, label: string }> | null };
 
 export type VaccineCoursesQueryVariables = Types.Exact<{
   first?: Types.InputMaybe<Types.Scalars['Int']['input']>;
@@ -49,7 +49,7 @@ export type VaccineCoursesQueryVariables = Types.Exact<{
 }>;
 
 
-export type VaccineCoursesQuery = { __typename: 'Queries', vaccineCourses: { __typename: 'VaccineCourseConnector', totalCount: number, nodes: Array<{ __typename: 'VaccineCourseNode', id: string, name: string, programId: string, demographicIndicatorId?: string | null, doses: number, coverageRate: number, wastageRate: number, isActive: boolean, demographicIndicator?: { __typename: 'DemographicIndicatorNode', name: string, id: string } | null, vaccineCourseItems?: Array<{ __typename: 'VaccineCourseItemNode', id: string, itemId: string, name: string }> | null, vaccineCourseSchedules?: Array<{ __typename: 'VaccineCourseScheduleNode', id: string, doseNumber: number, label: string }> | null }> } };
+export type VaccineCoursesQuery = { __typename: 'Queries', vaccineCourses: { __typename: 'VaccineCourseConnector', totalCount: number, nodes: Array<{ __typename: 'VaccineCourseNode', id: string, name: string, programId: string, demographicIndicatorId?: string | null, doses: number, coverageRate: number, wastageRate: number, isActive: boolean, demographicIndicator?: { __typename: 'DemographicIndicatorNode', name: string, id: string, baseYear: number } | null, vaccineCourseItems?: Array<{ __typename: 'VaccineCourseItemNode', id: string, itemId: string, name: string }> | null, vaccineCourseSchedules?: Array<{ __typename: 'VaccineCourseScheduleNode', id: string, doseNumber: number, label: string }> | null }> } };
 
 export type InsertVaccineCourseMutationVariables = Types.Exact<{
   input?: Types.InputMaybe<Types.InsertVaccineCourseInput>;
@@ -57,7 +57,7 @@ export type InsertVaccineCourseMutationVariables = Types.Exact<{
 }>;
 
 
-export type InsertVaccineCourseMutation = { __typename: 'Mutations', centralServer: { __typename: 'CentralServerMutationNode', vaccineCourse: { __typename: 'VaccineCourseMutations', insertVaccineCourse: { __typename: 'InsertVaccineCourseError', error: { __typename: 'RecordAlreadyExist', description: string } | { __typename: 'RecordProgramCombinationAlreadyExists', description: string } } | { __typename: 'VaccineCourseNode', id: string, name: string, programId: string, demographicIndicatorId?: string | null, doses: number, coverageRate: number, wastageRate: number, isActive: boolean, demographicIndicator?: { __typename: 'DemographicIndicatorNode', name: string, id: string } | null, vaccineCourseItems?: Array<{ __typename: 'VaccineCourseItemNode', id: string, itemId: string, name: string }> | null, vaccineCourseSchedules?: Array<{ __typename: 'VaccineCourseScheduleNode', id: string, doseNumber: number, label: string }> | null } } } };
+export type InsertVaccineCourseMutation = { __typename: 'Mutations', centralServer: { __typename: 'CentralServerMutationNode', vaccineCourse: { __typename: 'VaccineCourseMutations', insertVaccineCourse: { __typename: 'InsertVaccineCourseError', error: { __typename: 'RecordAlreadyExist', description: string } | { __typename: 'RecordProgramCombinationAlreadyExists', description: string } } | { __typename: 'VaccineCourseNode', id: string, name: string, programId: string, demographicIndicatorId?: string | null, doses: number, coverageRate: number, wastageRate: number, isActive: boolean, demographicIndicator?: { __typename: 'DemographicIndicatorNode', name: string, id: string, baseYear: number } | null, vaccineCourseItems?: Array<{ __typename: 'VaccineCourseItemNode', id: string, itemId: string, name: string }> | null, vaccineCourseSchedules?: Array<{ __typename: 'VaccineCourseScheduleNode', id: string, doseNumber: number, label: string }> | null } } } };
 
 export type UpdateVaccineCourseMutationVariables = Types.Exact<{
   input?: Types.InputMaybe<Types.UpdateVaccineCourseInput>;
@@ -65,7 +65,7 @@ export type UpdateVaccineCourseMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateVaccineCourseMutation = { __typename: 'Mutations', centralServer: { __typename: 'CentralServerMutationNode', vaccineCourse: { __typename: 'VaccineCourseMutations', updateVaccineCourse: { __typename: 'UpdateVaccineCourseError', error: { __typename: 'DatabaseError', description: string } | { __typename: 'RecordProgramCombinationAlreadyExists', description: string } } | { __typename: 'VaccineCourseNode', id: string, name: string, programId: string, demographicIndicatorId?: string | null, doses: number, coverageRate: number, wastageRate: number, isActive: boolean, demographicIndicator?: { __typename: 'DemographicIndicatorNode', name: string, id: string } | null, vaccineCourseItems?: Array<{ __typename: 'VaccineCourseItemNode', id: string, itemId: string, name: string }> | null, vaccineCourseSchedules?: Array<{ __typename: 'VaccineCourseScheduleNode', id: string, doseNumber: number, label: string }> | null } } } };
+export type UpdateVaccineCourseMutation = { __typename: 'Mutations', centralServer: { __typename: 'CentralServerMutationNode', vaccineCourse: { __typename: 'VaccineCourseMutations', updateVaccineCourse: { __typename: 'UpdateVaccineCourseError', error: { __typename: 'DatabaseError', description: string } | { __typename: 'RecordProgramCombinationAlreadyExists', description: string } } | { __typename: 'VaccineCourseNode', id: string, name: string, programId: string, demographicIndicatorId?: string | null, doses: number, coverageRate: number, wastageRate: number, isActive: boolean, demographicIndicator?: { __typename: 'DemographicIndicatorNode', name: string, id: string, baseYear: number } | null, vaccineCourseItems?: Array<{ __typename: 'VaccineCourseItemNode', id: string, itemId: string, name: string }> | null, vaccineCourseSchedules?: Array<{ __typename: 'VaccineCourseScheduleNode', id: string, doseNumber: number, label: string }> | null } } } };
 
 export const ImmunisationProgramFragmentDoc = gql`
     fragment ImmunisationProgram on ProgramNode {
@@ -103,6 +103,7 @@ export const VaccineCourseFragmentDoc = gql`
   demographicIndicator {
     name
     id
+    baseYear
   }
   vaccineCourseItems {
     ...VaccineCourseItem

--- a/client/packages/system/src/Immunisation/api/operations.graphql
+++ b/client/packages/system/src/Immunisation/api/operations.graphql
@@ -103,6 +103,7 @@ fragment VaccineCourse on VaccineCourseNode {
   demographicIndicator {
     name
     id
+    baseYear
   }
   vaccineCourseItems {
     ...VaccineCourseItem


### PR DESCRIPTION

Fixes #4109

# 👩🏻‍💻 What does this PR do?

Small UI changes to vaccine course detail view.

Added baseYear to vaccineCourse graphql call so that we can see baseYear in default display name in vaccineCourseDetailView.

Later might not be relevant when we refactor indicators to have different projections for different base years.

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
