### PR TITLE
4086 add custom properties to cold chain equipment csv import

### DIFF
--- a/client/packages/coldchain/src/Equipment/ImportAsset/EquipmentImportModal.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/EquipmentImportModal.tsx
@@ -77,7 +77,7 @@ export const toInsertEquipmentInput = (
   store: row.store
     ? { ...row.store, __typename: 'StoreNode', storeName: '' }
     : null,
-  properties: JSON.stringify(row.properties),
+  parsedProperties: row.properties,
 });
 
 export const toExportEquipment = (

--- a/client/packages/coldchain/src/Equipment/ImportAsset/EquipmentImportModal.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/EquipmentImportModal.tsx
@@ -52,6 +52,7 @@ export type ImportRow = {
   errorMessage: string;
   warningMessage: string;
   store: StoreRowFragment | null | undefined;
+  properties: Record<string, string>;
 };
 
 export type LineNumber = {
@@ -76,6 +77,7 @@ export const toInsertEquipmentInput = (
   store: row.store
     ? { ...row.store, __typename: 'StoreNode', storeName: '' }
     : null,
+  properties: JSON.stringify(row.properties),
 });
 
 export const toExportEquipment = (
@@ -91,6 +93,7 @@ export const toExportEquipment = (
   lineNumber: index + 2,
   errorMessage: row.errorMessage,
   store: row.store,
+  properties: row.properties,
 });
 
 export const toUpdateEquipmentInput = (

--- a/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
@@ -261,7 +261,8 @@ export const EquipmentUploadTab: FC<ImportPanel & EquipmentUploadTabProps> = ({
         })
       ),
       t,
-      isCentralServer
+      isCentralServer,
+      properties ? properties.map(p => p.key) : []
     );
     FileUtils.exportCSV(csv, t('filename.cce'));
   };

--- a/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
@@ -23,13 +23,10 @@ import { ImportRow } from './EquipmentImportModal';
 import { importEquipmentToCsv } from '../utils';
 import {
   AssetCatalogueItemFragment,
+  processProperties,
   useStore,
 } from '@openmsupply-client/system';
-import {
-  AssetPropertyFragment,
-  useAssetData,
-} from '@openmsupply-client/system';
-
+import { useAssetData } from '@openmsupply-client/system';
 interface EquipmentUploadTabProps {
   setEquipment: React.Dispatch<React.SetStateAction<ImportRow[]>>;
   setErrorMessage: (value: React.SetStateAction<string>) => void;
@@ -171,59 +168,12 @@ function getImportHelpers<T, P>(
     addCell(key, localeKey, formatter);
   }
 
-  const processProperties = (
-    properties: undefined | AssetPropertyFragment[],
-    row: ParsedAsset,
-    importRow: ImportRow,
-    rowErrors: string[],
-    t: TypedTFunction<LocaleKey>
-  ) => {
-    properties?.forEach(property => {
-      const value = row[property.name] ?? row[property.key];
-      if (!!value?.trim()) {
-        if (!!property.allowedValues) {
-          const allowedValues = property.allowedValues.split(',');
-          if (allowedValues.every(v => v !== value)) {
-            rowErrors.push(
-              t('error.invalid-field-value', {
-                field: property.name,
-                value: value,
-              })
-            );
-          }
-        }
-        switch (property.valueType) {
-          case 'INTEGER':
-          case 'FLOAT':
-            if (Number.isNaN(Number(value))) {
-              rowErrors.push(
-                t('error.invalid-field-value', {
-                  field: property.name,
-                  value: value,
-                })
-              );
-            }
-            importRow.properties[property.key] = value;
-            break;
-          case 'BOOLEAN':
-            const isTrue =
-              value.toLowerCase() === 'true' || value.toLowerCase() === 'yes';
-            importRow.properties[property.key] = isTrue ? 'true' : 'false';
-            break;
-          default:
-            importRow.properties[property.key] = value;
-        }
-      }
-    });
-  };
-
   return {
     addLookup,
     addCell,
     addRequired,
     addSoftRequired,
     addUnique,
-    processProperties,
     importRow,
     rowErrors,
     rowWarnings,
@@ -313,7 +263,6 @@ export const EquipmentUploadTab: FC<ImportPanel & EquipmentUploadTabProps> = ({
         rowErrors,
         rowWarnings,
         addSoftRequired,
-        processProperties,
       } = getImportHelpers(row, rows, index, t);
       const lookupCode = (item: { code: string | null | undefined }) =>
         item.code;
@@ -342,7 +291,7 @@ export const EquipmentUploadTab: FC<ImportPanel & EquipmentUploadTabProps> = ({
         formatDate
       );
       addCell('serialNumber', 'label.serial');
-      processProperties(properties, row, importRow, rowErrors, t);
+      processProperties(properties ?? [], row, importRow, rowErrors, t);
       importRow.errorMessage = rowErrors.join(',');
       importRow.warningMessage = rowWarnings.join(',');
       hasErrors = hasErrors || rowErrors.length > 0;

--- a/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
@@ -247,19 +247,20 @@ export const EquipmentUploadTab: FC<ImportPanel & EquipmentUploadTabProps> = ({
   const { data: properties } = useAssetData.utils.properties();
 
   const csvExample = async () => {
-    const emptyRows: ImportRow[] = [];
+    const exampleRows: Partial<ImportRow>[] = [
+      {
+        id: '',
+        assetNumber: 'Asset Number',
+        catalogueItemCode: '',
+        store: undefined,
+        notes: '',
+        serialNumber: '',
+        installationDate: '',
+        properties: {},
+      },
+    ];
     const csv = importEquipmentToCsv(
-      emptyRows.map(
-        (_row: ImportRow): Partial<ImportRow> => ({
-          assetNumber: undefined,
-          catalogueItemCode: undefined,
-          store: undefined,
-          notes: undefined,
-          serialNumber: undefined,
-          installationDate: undefined,
-          properties: {},
-        })
-      ),
+      exampleRows,
       t,
       isCentralServer,
       properties ? properties.map(p => p.key) : []

--- a/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
@@ -28,7 +28,7 @@ import {
 import {
   AssetPropertyFragment,
   useAssetData,
-} from 'packages/system/src/Asset/api';
+} from '@openmsupply-client/system';
 
 interface EquipmentUploadTabProps {
   setEquipment: React.Dispatch<React.SetStateAction<ImportRow[]>>;

--- a/client/packages/common/src/intl/locales/ru/coldchain.json
+++ b/client/packages/common/src/intl/locales/ru/coldchain.json
@@ -71,5 +71,13 @@
     "heading.download-cce-documents": "Скачать документы Холодильного Оборудования",
     "heading.download-example": "Скачать шаблон.",
     "label.immunisation-name": "Название Курса Вакцин",
-    "label.vaccine-items": "Вакцинные Товары"
+    "label.vaccine-items": "Вакцинные Товары",
+    "label.cold-cumulative": "Накопительно Холодное",
+    "label.catalogue-item-code": "Код товара по каталогу",
+    "label.catalogue-item": "Товар каталога",
+    "label.asset-properties": "Свойства Ресурса",
+    "label.cce": "Холодильное Оборудование",
+    "label.chart": "Диаграмма",
+    "label.cold-consecutive": "Последовательно Холодное",
+    "label.catalogue-properties": "Свойства Каталога"
 }

--- a/client/packages/system/src/Asset/ImportCatalogueItem/UploadTab.tsx
+++ b/client/packages/system/src/Asset/ImportCatalogueItem/UploadTab.tsx
@@ -3,7 +3,7 @@ import Papa, { ParseResult } from 'papaparse';
 import { ImportPanel } from './ImportPanel';
 import { useNotification } from '@common/hooks';
 import { InlineProgress, Typography, Upload } from '@common/components';
-import { LocaleKey, TypedTFunction, useTranslation } from '@common/intl';
+import { useTranslation } from '@common/intl';
 import {
   Grid,
   Stack,
@@ -17,11 +17,8 @@ import {
 import * as AssetItemImportModal from './CatalogueItemImportModal';
 import { ImportRow } from './CatalogueItemImportModal';
 import { importRowToCsv } from '../utils';
-import {
-  useAssetData,
-  AssetCatalogueItemFragment,
-  AssetPropertyFragment,
-} from '../api';
+import { useAssetData, AssetCatalogueItemFragment } from '../api';
+import { processProperties } from '../../utils';
 
 interface AssetItemUploadTabProps {
   setAssetItem: React.Dispatch<React.SetStateAction<ImportRow[]>>;
@@ -56,52 +53,6 @@ const getCell = (row: ParsedImport, index: AssetColumn) => {
   const rowKeys = Object.keys(row);
   const key = rowKeys[index] ?? '';
   return row[key] ?? '';
-};
-
-const processProperties = (
-  properties: undefined | AssetPropertyFragment[],
-  row: ParsedImport,
-  importRow: ImportRow,
-  rowErrors: string[],
-  t: TypedTFunction<LocaleKey>
-) => {
-  properties?.forEach(property => {
-    const value = row[property.name] ?? row[property.key];
-    if (!!value?.trim()) {
-      if (!!property.allowedValues) {
-        const allowedValues = property.allowedValues.split(',');
-        if (allowedValues.every(v => v !== value)) {
-          rowErrors.push(
-            t('error.invalid-field-value', {
-              field: property.name,
-              value: value,
-            })
-          );
-        }
-      }
-      switch (property.valueType) {
-        case 'INTEGER':
-        case 'FLOAT':
-          if (Number.isNaN(Number(value))) {
-            rowErrors.push(
-              t('error.invalid-field-value', {
-                field: property.name,
-                value: value,
-              })
-            );
-          }
-          importRow.properties[property.key] = value;
-          break;
-        case 'BOOLEAN':
-          const isTrue =
-            value.toLowerCase() === 'true' || value.toLowerCase() === 'yes';
-          importRow.properties[property.key] = isTrue ? 'true' : 'false';
-          break;
-        default:
-          importRow.properties[property.key] = value;
-      }
-    }
-  });
 };
 
 export const AssetItemUploadTab: FC<ImportPanel & AssetItemUploadTabProps> = ({
@@ -302,7 +253,7 @@ export const AssetItemUploadTab: FC<ImportPanel & AssetItemUploadTabProps> = ({
       } else {
         importRow.model = model;
       }
-      processProperties(properties, row, importRow, rowErrors, t);
+      processProperties(properties ?? [], row, importRow, rowErrors, t);
       importRow.errorMessage = rowErrors.join(',');
       hasErrors = hasErrors || rowErrors.length > 0;
       rows.push(importRow);

--- a/client/packages/system/src/Asset/index.ts
+++ b/client/packages/system/src/Asset/index.ts
@@ -1,3 +1,7 @@
 export * from './ListView';
-export { AssetCatalogueItemFragment, useAssetData } from './api';
+export {
+  AssetCatalogueItemFragment,
+  AssetPropertyFragment,
+  useAssetData,
+} from './api';
 export { mapIdNameToOptions } from './utils';

--- a/client/packages/system/src/index.ts
+++ b/client/packages/system/src/index.ts
@@ -17,3 +17,4 @@ export * from './Log';
 export * from './ReturnReason';
 export * from './Currency';
 export * from './IndicatorsDemographics';
+export { processProperties } from './utils';

--- a/client/packages/system/src/utils.ts
+++ b/client/packages/system/src/utils.ts
@@ -1,6 +1,6 @@
 import { LocaleKey, TypedTFunction } from '@common/intl';
 import { Formatter } from '@common/utils';
-import { MasterListRowFragment } from '.';
+import { AssetPropertyFragment, MasterListRowFragment } from '.';
 import { LocationRowFragment } from './Location/api';
 import { StockLineRowFragment } from './Stock/api';
 
@@ -76,4 +76,57 @@ export const stockLinesToCsv = (
     node.supplierName,
   ]);
   return Formatter.csv({ fields, data });
+};
+
+interface ParsedRow {
+  id: string;
+  [key: string]: string | undefined;
+}
+
+export const processProperties = <
+  T extends { properties: Record<string, string> },
+>(
+  properties: AssetPropertyFragment[],
+  row: ParsedRow,
+  importRow: T,
+  rowErrors: string[],
+  t: TypedTFunction<LocaleKey>
+) => {
+  properties.forEach(property => {
+    const value = row[property.name] ?? row[property.key];
+    if (!!value?.trim()) {
+      if (!!property.allowedValues) {
+        const allowedValues = property.allowedValues.split(',');
+        if (allowedValues.every(v => v !== value)) {
+          rowErrors.push(
+            t('error.invalid-field-value', {
+              field: property.name,
+              value: value,
+            })
+          );
+        }
+      }
+      switch (property.valueType) {
+        case 'INTEGER':
+        case 'FLOAT':
+          if (Number.isNaN(Number(value))) {
+            rowErrors.push(
+              t('error.invalid-field-value', {
+                field: property.name,
+                value: value,
+              })
+            );
+          }
+          importRow.properties[property.key] = value;
+          break;
+        case 'BOOLEAN':
+          const isTrue =
+            value.toLowerCase() === 'true' || value.toLowerCase() === 'yes';
+          importRow.properties[property.key] = isTrue ? 'true' : 'false';
+          break;
+        default:
+          importRow.properties[property.key] = value;
+      }
+    }
+  });
 };


### PR DESCRIPTION
Fixes #4086 

# 👩🏻‍💻 What does this PR do?

Adds bulk import of custom fields to cold chain equipment

## 💌 Any notes for the reviewer?

You can try this out by importing new asset items.
Example csv should 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ]  Go to Cold Chain -> Equipment
- [ ] Click import
- [ ] See additional custom property fields for asset import
- [ ] Try adding asset property fields on bulk import
- [ ] See bulk imported custom fields in database

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
