### PR TITLE
3903 no error trying to reduce stock line below available

### DIFF
--- a/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
+++ b/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
@@ -25,7 +25,7 @@ export const InventoryAdjustmentModal: FC<InventoryAdjustmentModalProps> = ({
   onClose,
 }) => {
   const t = useTranslation('inventory');
-  const { success } = useNotification();
+  const { success, error } = useNotification();
   const { Modal } = useDialog({ isOpen, onClose });
 
   const { draft, setDraft, create } = useInventoryAdjustment(stockLine);
@@ -40,12 +40,19 @@ export const InventoryAdjustmentModal: FC<InventoryAdjustmentModalProps> = ({
 
   const save = async () => {
     try {
-      await create();
-      const successSnack = success(t('messages.inventory-adjustment-saved'));
-      successSnack();
-      onClose();
+      const result = await create();
+
+      if (result === undefined) {
+        const successSnack = success(t('messages.inventory-adjustment-saved'));
+        successSnack();
+        onClose();
+        return;
+      }
+
+      const errorSnack = error(t(result));
+      errorSnack();
     } catch {
-      // TODO: handle error if no reason selected when reasons required
+      //     // TODO: handle error if no reason selected when reasons required
     }
   };
 

--- a/client/packages/system/src/Stock/api/hooks/useInventoryAdjustment.ts
+++ b/client/packages/system/src/Stock/api/hooks/useInventoryAdjustment.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import { AdjustmentTypeInput, useMutation } from '@openmsupply-client/common';
 import {
   InventoryAdjustmentReasonRowFragment,
@@ -19,17 +19,26 @@ export function useInventoryAdjustment(stockLine: StockLineRowFragment) {
     adjustment: 0,
     adjustmentType: AdjustmentTypeInput.Addition,
   });
-
   const { mutateAsync: createMutation } = useCreate(stockLine.id);
 
-  const create = useCallback(async () => {
-    await createMutation(draft);
-    setDraft({
-      reason: null,
-      adjustment: 0,
-      adjustmentType: AdjustmentTypeInput.Addition,
-    });
-  }, [draft, createMutation]);
+  const create = async () => {
+    const result = await createMutation(draft);
+
+    if (result.createInventoryAdjustment.__typename === 'InvoiceNode') {
+      setDraft({
+        reason: null,
+        adjustment: 0,
+        adjustmentType: AdjustmentTypeInput.Addition,
+      });
+      return;
+    }
+
+    const { error: adjustmentError } = result.createInventoryAdjustment;
+
+    if (adjustmentError.__typename === 'StockLineReducedBelowZero') {
+      return 'error.stocktake-has-stock-reduced-below-zero';
+    }
+  };
 
   return {
     draft,

--- a/client/packages/system/src/Stock/api/operations.generated.ts
+++ b/client/packages/system/src/Stock/api/operations.generated.ts
@@ -83,7 +83,7 @@ export type CreateInventoryAdjustmentMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateInventoryAdjustmentMutation = { __typename: 'Mutations', createInventoryAdjustment: { __typename: 'CreateInventoryAdjustmentError' } | { __typename: 'InvoiceNode', id: string } };
+export type CreateInventoryAdjustmentMutation = { __typename: 'Mutations', createInventoryAdjustment: { __typename: 'CreateInventoryAdjustmentError', error: { __typename: 'StockLineReducedBelowZero', description: string } } | { __typename: 'InvoiceNode', id: string } };
 
 export type InsertStockLineMutationVariables = Types.Exact<{
   input: Types.InsertStockLineInput;
@@ -266,9 +266,20 @@ export const InsertRepackDocument = gql`
 export const CreateInventoryAdjustmentDocument = gql`
     mutation createInventoryAdjustment($input: CreateInventoryAdjustmentInput!, $storeId: String!) {
   createInventoryAdjustment(input: $input, storeId: $storeId) {
+    __typename
     ... on InvoiceNode {
       __typename
       ...InvoiceRow
+    }
+    ... on CreateInventoryAdjustmentError {
+      __typename
+      error {
+        description
+        ... on StockLineReducedBelowZero {
+          __typename
+          description
+        }
+      }
     }
   }
 }

--- a/client/packages/system/src/Stock/api/operations.graphql
+++ b/client/packages/system/src/Stock/api/operations.graphql
@@ -178,9 +178,20 @@ mutation createInventoryAdjustment(
   $storeId: String!
 ) {
   createInventoryAdjustment(input: $input, storeId: $storeId) {
+    __typename
     ... on InvoiceNode {
       __typename
       ...InvoiceRow
+    }
+    ... on CreateInventoryAdjustmentError {
+      __typename
+      error {
+        description
+        ... on StockLineReducedBelowZero {
+          __typename
+          description
+        }
+      }
     }
   }
 }

--- a/server/service/src/program/delete_immunisation.rs
+++ b/server/service/src/program/delete_immunisation.rs
@@ -35,7 +35,7 @@ pub fn delete_immunisation_program(
 
             for id in courses_to_delete.iter() {
                 vaccine_course_row_repo
-                    .mark_deleted(&id)
+                    .mark_deleted(id)
                     .map_err(DeleteImmunisationProgramError::from)?;
             }
 
@@ -68,7 +68,7 @@ fn generate(
     id: &str,
 ) -> Result<Vec<String>, DeleteImmunisationProgramError> {
     let vaccine_courses = VaccineCourseRepository::new(connection)
-        .query_by_filter(VaccineCourseFilter::new().program_id(EqualFilter::equal_to(&id)))?;
+        .query_by_filter(VaccineCourseFilter::new().program_id(EqualFilter::equal_to(id)))?;
 
     let vaccine_course_ids_to_delete = vaccine_courses.into_iter().map(|v| v.id).collect();
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3903 
Error snack if stock line has been reduced below zero for inventory adjustments
![Screenshot 2024-06-20 at 10 52 20 PM](https://github.com/msupply-foundation/open-msupply/assets/61820074/57863127-94d3-4cad-a084-0d0e282910c7)

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a stock line with say 10 stock
- [ ] Issue 5 of those in an Outbound Shipment
- [ ] Go to Stock page and click on stock line
- [ ] Click adjustment
- [ ] Try reduce all packs
- [ ] See error snack

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
