### PR TITLE
4194 increase stock by less than one

### DIFF
--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
@@ -324,7 +324,7 @@ mod test {
             Some(service_provider(test_service, &connection_manager))
         );
 
-        //NumberOfPacksBelowOne
+        //NumberOfPacksBelowZero
         let test_service = TestService(Box::new(|_| Err(ServiceError::NumberOfPacksBelowZero)));
         let expected_message = "Bad user input";
         assert_standard_graphql_error!(

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
@@ -146,7 +146,7 @@ fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
         ServiceError::NotThisStoreInvoice
         | ServiceError::LineAlreadyExists
         | ServiceError::NotAStockIn
-        | ServiceError::NumberOfPacksBelowOne
+        | ServiceError::NumberOfPacksBelowZero
         | ServiceError::PackSizeBelowOne
         | ServiceError::LocationDoesNotExist
         | ServiceError::ItemNotFound => BadUserInput(formatted_error),
@@ -325,7 +325,7 @@ mod test {
         );
 
         //NumberOfPacksBelowOne
-        let test_service = TestService(Box::new(|_| Err(ServiceError::NumberOfPacksBelowOne)));
+        let test_service = TestService(Box::new(|_| Err(ServiceError::NumberOfPacksBelowZero)));
         let expected_message = "Bad user input";
         assert_standard_graphql_error!(
             &settings,

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
@@ -158,7 +158,7 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
         // Standard Graphql Errors
         ServiceError::NotThisStoreInvoice
         | ServiceError::NotAStockIn
-        | ServiceError::NumberOfPacksBelowOne
+        | ServiceError::NumberOfPacksBelowZero
         | ServiceError::NotThisInvoiceLine(_)
         | ServiceError::PackSizeBelowOne
         | ServiceError::LocationDoesNotExist
@@ -361,7 +361,7 @@ mod test {
         );
 
         //NumberOfPacksBelowOne
-        let test_service = TestService(Box::new(|_| Err(ServiceError::NumberOfPacksBelowOne)));
+        let test_service = TestService(Box::new(|_| Err(ServiceError::NumberOfPacksBelowZero)));
         let expected_message = "Bad user input";
         assert_standard_graphql_error!(
             &settings,

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
@@ -360,7 +360,7 @@ mod test {
             Some(service_provider(test_service, &connection_manager))
         );
 
-        //NumberOfPacksBelowOne
+        //NumberOfPacksBelowZero
         let test_service = TestService(Box::new(|_| Err(ServiceError::NumberOfPacksBelowZero)));
         let expected_message = "Bad user input";
         assert_standard_graphql_error!(

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/update.rs
@@ -459,7 +459,7 @@ mod test {
             Some(service_provider(test_service, &connection_manager))
         );
 
-        //NumberOfPacksBelowOne
+        //NumberOfPacksBelowZero
         let test_service = TestService(Box::new(|_| Err(ServiceError::NumberOfPacksBelowZero)));
         let expected_message = "Bad user input";
         assert_standard_graphql_error!(

--- a/server/graphql/invoice_line/src/mutations/prescription_line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/prescription_line/update.rs
@@ -450,7 +450,7 @@ mod test {
             Some(service_provider(test_service, &connection_manager))
         );
 
-        //NumberOfPacksBelowOne
+        //NumberOfPacksBelowZero
         let test_service = TestService(Box::new(|_| Err(ServiceError::NumberOfPacksBelowZero)));
         let expected_message = "Bad user input";
         assert_standard_graphql_error!(

--- a/server/service/src/invoice_line/stock_in_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/mod.rs
@@ -191,7 +191,7 @@ mod test {
             Err(ServiceError::PackSizeBelowOne)
         );
 
-        // NumberOfPacksBelowOne
+        // NumberOfPacksBelowZero
         assert_eq!(
             insert_stock_in_line(
                 &context,

--- a/server/service/src/invoice_line/stock_in_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/mod.rs
@@ -93,7 +93,7 @@ pub enum InsertStockInLineError {
     LocationDoesNotExist,
     ItemNotFound,
     PackSizeBelowOne,
-    NumberOfPacksBelowOne,
+    NumberOfPacksBelowZero,
     NewlyCreatedLineDoesNotExist,
 }
 
@@ -201,7 +201,7 @@ mod test {
                     r.number_of_packs = 0.0;
                 }),
             ),
-            Err(ServiceError::NumberOfPacksBelowOne)
+            Err(ServiceError::NumberOfPacksBelowZero)
         );
 
         // ItemNotFound

--- a/server/service/src/invoice_line/stock_in_line/insert/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/validate.rs
@@ -2,7 +2,7 @@ use crate::{
     check_location_exists,
     invoice::{check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store},
     invoice_line::{
-        stock_in_line::check_pack_size,
+        stock_in_line::{check_number_of_packs, check_pack_size},
         validate::{check_item_exists, check_line_exists},
     },
 };
@@ -23,7 +23,7 @@ pub fn validate(
         return Err(PackSizeBelowOne);
     }
     if !check_number_of_packs(Some(input.number_of_packs)) {
-        return Err(NumberOfPacksBelowOne);
+        return Err(NumberOfPacksBelowZero);
     }
 
     let item = check_item_exists(connection, &input.item_id)?.ok_or(ItemNotFound)?;
@@ -47,13 +47,4 @@ pub fn validate(
     // TODO: LocationDoesNotBelongToCurrentStore
 
     Ok((item, invoice))
-}
-
-pub fn check_number_of_packs(number_of_packs_option: Option<f64>) -> bool {
-    if let Some(number_of_packs) = number_of_packs_option {
-        if number_of_packs < 1.0 {
-            return false;
-        }
-    }
-    true
 }

--- a/server/service/src/invoice_line/stock_in_line/update/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/mod.rs
@@ -209,7 +209,7 @@ mod test {
             Err(ServiceError::PackSizeBelowOne)
         );
 
-        // NumberOfPacksBelowOne
+        // NumberOfPacksBelowZero
         assert_eq!(
             update_stock_in_line(
                 &context,

--- a/server/service/src/invoice_line/stock_in_line/update/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/mod.rs
@@ -88,7 +88,7 @@ pub enum UpdateStockInLineError {
     LocationDoesNotExist,
     ItemNotFound,
     PackSizeBelowOne,
-    NumberOfPacksBelowOne,
+    NumberOfPacksBelowZero,
     BatchIsReserved,
     UpdatedLineDoesNotExist,
     NotThisInvoiceLine(String),
@@ -219,7 +219,7 @@ mod test {
                     r.number_of_packs = Some(0.0);
                 }),
             ),
-            Err(ServiceError::NumberOfPacksBelowOne)
+            Err(ServiceError::NumberOfPacksBelowZero)
         );
 
         // ItemNotFound

--- a/server/service/src/invoice_line/stock_in_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/validate.rs
@@ -2,7 +2,7 @@ use crate::{
     check_location_exists,
     invoice::{check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store},
     invoice_line::{
-        stock_in_line::{check_batch, check_pack_size},
+        stock_in_line::{check_batch, check_number_of_packs, check_pack_size},
         validate::{check_item_exists, check_line_belongs_to_invoice, check_line_exists},
     },
 };
@@ -24,7 +24,7 @@ pub fn validate(
         return Err(PackSizeBelowOne);
     }
     if !check_number_of_packs(input.number_of_packs) {
-        return Err(NumberOfPacksBelowOne);
+        return Err(NumberOfPacksBelowZero);
     }
 
     let item = check_item_option(&input.item_id, connection)?;
@@ -67,13 +67,4 @@ fn check_item_option(
     } else {
         Ok(None)
     }
-}
-
-fn check_number_of_packs(number_of_packs_option: Option<f64>) -> bool {
-    if let Some(number_of_packs) = number_of_packs_option {
-        if number_of_packs < 1.0 {
-            return false;
-        }
-    }
-    true
 }

--- a/server/service/src/invoice_line/stock_in_line/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/validate.rs
@@ -11,6 +11,15 @@ pub fn check_pack_size(pack_size_option: Option<f64>) -> bool {
     true
 }
 
+pub fn check_number_of_packs(number_of_packs_option: Option<f64>) -> bool {
+    if let Some(number_of_packs) = number_of_packs_option {
+        if number_of_packs <= 0.0 {
+            return false;
+        }
+    }
+    true
+}
+
 pub fn check_batch(
     line: &InvoiceLineRow,
     connection: &StorageConnection,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4194

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Allows stock in values greater than 0 (rather than greater than 1) 

Fixes stocktake issue where you couldn't increase by a decimal number of packs less than one (e.g. 0.5)

![Screenshot 2024-06-21 at 11 13 21 AM](https://github.com/msupply-foundation/open-msupply/assets/55115239/2b168bf7-d01a-4f74-9a3e-77df0afe67e9)

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a stocktake
- [ ] Add an item
- [ ] For a stockline for that item, increase the counted packs by 0.5
- [ ] Save the line
- [ ] TEST: you can finalise the stocktake

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
