### PR TITLE
#4152 Date filter label fix

### DIFF
--- a/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
@@ -2,7 +2,6 @@ import React, { FC, useEffect, useRef } from 'react';
 import {
   Box,
   StandardTextFieldProps,
-  SxProps,
   TextField,
   Typography,
 } from '@mui/material';

--- a/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
@@ -62,15 +62,13 @@ export const BasicTextInput: FC<BasicTextInputProps> = React.forwardRef(
           // object. So we're going to convert this input to a single array of
           // SX props here, which means it'll be safe regardless of the shape of
           // the incoming sx prop
-          sx={
-            [
-              {
-                '& .MuiInput-underline:before': { borderBottomWidth: 0 },
-                '& .MuiInput-input': { color: 'gray.dark', textAlign },
-              },
-              sx,
-            ].flat() as SxProps
-          }
+          sx={[
+            {
+              '& .MuiInput-underline:before': { borderBottomWidth: 0 },
+              '& .MuiInput-input': { color: 'gray.dark', textAlign },
+            },
+            sx ?? {},
+          ].flat()}
           variant="standard"
           size="small"
           InputProps={{

--- a/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
@@ -2,6 +2,7 @@ import React, { FC, useEffect, useRef } from 'react';
 import {
   Box,
   StandardTextFieldProps,
+  SxProps,
   TextField,
   Typography,
 } from '@mui/material';
@@ -56,11 +57,20 @@ export const BasicTextInput: FC<BasicTextInputProps> = React.forwardRef(
           ref={ref}
           inputRef={inputRef}
           color="secondary"
-          sx={{
-            '& .MuiInput-underline:before': { borderBottomWidth: 0 },
-            '& .MuiInput-input': { color: 'gray.dark', textAlign },
-            ...sx,
-          }}
+          // Sx props can be provided as an array of SxProp objects. In this
+          // case, it doesn't work to try and merge it as though it was an
+          // object. So we're going to convert this input to a single array of
+          // SX props here, which means it'll be safe regardless of the shape of
+          // the incoming sx prop
+          sx={
+            [
+              {
+                '& .MuiInput-underline:before': { borderBottomWidth: 0 },
+                '& .MuiInput-input': { color: 'gray.dark', textAlign },
+              },
+              sx,
+            ].flat() as SxProps
+          }
           variant="standard"
           size="small"
           InputProps={{


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4152

*PLEASE NOTE: I had a moment of dyslexia and mis-named my branch as `4125-`* 🙄

# 👩🏻‍💻 What does this PR do?

Quite a subtle problem here. Turns out that the Mui `sx` prop can actually be an *array* of SX objects as well as a single SX object. What was happening here is that the `sx` styles for the "textField" slotProps in the DateTimePickerInput were being converted to such an array before being passed down to the BasicTextInput component (presumably due to additional styles being injected internally by the Mui DateTimePicker component). And then, when we merged the `sx` objects, the resulting prop was not correct (I think it turned array indexes into object keys, which is why it never threw an error).

Solution here is to just put the SX object into a flattened array when merging, regardless, so that it doesn't matter if the incoming `sx` is already an array or an object.

## 💌 Any notes for the reviewer?

We're merging `sx` objects a lot throughout the app, so this could turn out to be a problem elsewhere. Something to be aware of, and maybe we should establish a convention for merging styles. Any thoughts, @mark-prins ?

# 🧪 Testing

Labels should show up correctly for the Date filters when initialised, and look basically the same as the Text filter:

![Screenshot 2024-06-21 at 11 42 47 AM](https://github.com/msupply-foundation/open-msupply/assets/5456533/205c965e-cf35-41b2-b13b-52c0a0661bc5)

