### PR TITLE
Display RC version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "2.1.00",
+  "version": "2.1.00-rc1",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/repository/src/migrations/version.rs
+++ b/server/repository/src/migrations/version.rs
@@ -22,7 +22,11 @@ impl PackageJsonAsset {
         let package_json = PackageJsonAsset::get("").expect("Embedded package json not found");
         let package: PackageJson = serde_json::from_slice(&package_json.data)
             .expect("Embedded package json cannot be parsed");
-        package.version
+        // strip out the -rc1 or -test detail from the version
+        let re = regex::Regex::new(r"\-.*").unwrap();
+        let version = re.replace(&package.version, "").to_string();
+
+        version
     }
 }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4217

# 👩🏻‍💻 What does this PR do?
A somewhat exploratory PR for an issue that is technically still asking for triage love. 


<!-- Explain the changes you made -->
The problem with having the semantically versioned rc in the `package.json` is that the version is used to update the database and run migrations. 

My suggestion here is to simply strip that final section from the semver in package.json, such that `2.10.00-rc1` is displayed on the front end unaltered, but interpreted by the API as `2.1.00`

This gives the following:
_login screen_
<img width="223" alt="Screenshot 2024-06-21 at 2 11 01 PM" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/500f064c-ba7e-4028-a599-5faad7d1e020">

_settings screen_
<img width="217" alt="Screenshot 2024-06-21 at 2 10 53 PM" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/19bd6072-380c-4d7f-836f-d60f5cea31cd">


<!-- why are the changes needed -->
Why is this required? It allows testers to know which version they are running.

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
