### PR TITLE
4229 assets with no store cant be edited

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/DetailView.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/DetailView.tsx
@@ -13,6 +13,8 @@ import {
   TableProvider,
   createTableStore,
   ObjUtils,
+  useAuthContext,
+  useIsCentralServerApi,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { Toolbar } from './Toolbar';
@@ -27,6 +29,9 @@ import { DraftAsset } from '../types';
 import { Details } from './Tabs/Details';
 
 export const EquipmentDetailView = () => {
+  const { storeId } = useAuthContext();
+  const isCentralServer = useIsCentralServerApi();
+
   const { data, isLoading } = useAssets.document.get();
   const { mutateAsync: update, isLoading: isSaving } =
     useAssets.document.update();
@@ -79,11 +84,15 @@ export const EquipmentDetailView = () => {
     const assetProperties = ObjUtils.parse(data.properties);
     const catalogProperties = ObjUtils.parse(data.catalogProperties);
 
+    const canEditLocationIds = !isCentralServer || draft?.storeId == storeId;
+
+    const locationIds = draft?.locationIds
+      ? draft.locationIds
+      : data.locations.nodes.map(location => location.id);
+
     setDraft({
       ...data,
-      locationIds: draft?.locationIds
-        ? draft.locationIds
-        : data.locations.nodes.map(location => location.id),
+      locationIds: canEditLocationIds ? locationIds : undefined,
       parsedProperties: assetProperties,
       parsedCatalogProperties: catalogProperties,
     });

--- a/client/packages/coldchain/src/Equipment/types.ts
+++ b/client/packages/coldchain/src/Equipment/types.ts
@@ -1,7 +1,7 @@
 import { AssetFragment } from './api';
 
 export interface LocationIds {
-  locationIds: string[];
+  locationIds: string[] | undefined;
 }
 
 export interface Properties {

--- a/client/packages/system/src/Store/api/api.ts
+++ b/client/packages/system/src/Store/api/api.ts
@@ -1,19 +1,11 @@
 import { FilterByWithBoolean } from '@openmsupply-client/common';
 import { Sdk } from './operations.generated';
 
-export type ListParams = {
-  filterBy: FilterByWithBoolean | null;
-  first: number;
-  offset: number;
-};
-
 export const getStoreQueries = (sdk: Sdk) => ({
   get: {
-    list: async ({ filterBy, first, offset }: ListParams) => {
+    list: async (filterBy: FilterByWithBoolean | null) => {
       const result = await sdk.stores({
         filter: filterBy,
-        first,
-        offset,
       });
 
       return result.stores;

--- a/client/packages/system/src/Store/api/hooks/document/useStores.ts
+++ b/client/packages/system/src/Store/api/hooks/document/useStores.ts
@@ -4,11 +4,10 @@ import { useStoreApi } from '../utils/useStoreApi';
 export const useStores = () => {
   const api = useStoreApi();
   const queryParams = useQueryParamsStore();
-  const { filter, pagination } = queryParams;
+  const { filter } = queryParams;
   const { filterBy } = filter;
-  const { first, offset } = pagination;
 
-  return useQuery(api.keys.paramList(queryParams.paramList()), async () =>
-    api.get.list({ filterBy, first, offset })
+  return useQuery(api.keys.paramList(filterBy), async () =>
+    api.get.list(filterBy)
   );
 };

--- a/client/packages/system/src/Store/api/hooks/utils/useStoreApi.ts
+++ b/client/packages/system/src/Store/api/hooks/utils/useStoreApi.ts
@@ -1,13 +1,14 @@
-import { useGql } from '@openmsupply-client/common';
+import { FilterByWithBoolean, useGql } from '@openmsupply-client/common';
 import { getSdk } from '../../operations.generated';
-import { getStoreQueries, ListParams } from '../../api';
+import { getStoreQueries } from '../../api';
 
 export const useStoreApi = () => {
   const keys = {
     base: () => ['store'] as const,
     detail: (id: string) => [...keys.base(), id] as const,
     list: () => [...keys.base(), 'list'] as const,
-    paramList: (params: ListParams) => [...keys.list(), params] as const,
+    paramList: (filterBy: FilterByWithBoolean | null) =>
+      [...keys.list(), filterBy] as const,
   };
 
   const { client } = useGql();


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4229

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Fixes ability to edit assets with no store on central server.

The error was a bit of a weird one, about locations - you need a store defined to set locations, and we were sending an empty array (Some) instead of undefined (None)

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] On central, Create asset with no store
- [ ] Edit it
- [ ] it saves!

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
