### PR TITLE
Add unit and allow decimals to vaccine course view fields

### DIFF
--- a/.github/workflows/client-tests.yaml
+++ b/.github/workflows/client-tests.yaml
@@ -1,0 +1,25 @@
+name: Client tests
+
+on:
+  pull_request:
+    paths:
+      - 'client/**'
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.base_ref }}
+
+      - name: Install dependencies
+        run: cd ./client && rm -rf node_modules && yarn install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.TOKEN_REPO}}
+
+      - name: Run tests
+        run: cd ./client && yarn test

--- a/client/packages/coldchain/src/Equipment/ImportAsset/EquipmentImportModal.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/EquipmentImportModal.tsx
@@ -77,7 +77,7 @@ export const toInsertEquipmentInput = (
   store: row.store
     ? { ...row.store, __typename: 'StoreNode', storeName: '' }
     : null,
-  properties: JSON.stringify(row.properties),
+  parsedProperties: row.properties,
 });
 
 export const toExportEquipment = (

--- a/client/packages/coldchain/src/Equipment/ImportAsset/EquipmentImportModal.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/EquipmentImportModal.tsx
@@ -52,6 +52,7 @@ export type ImportRow = {
   errorMessage: string;
   warningMessage: string;
   store: StoreRowFragment | null | undefined;
+  properties: Record<string, string>;
 };
 
 export type LineNumber = {
@@ -76,6 +77,7 @@ export const toInsertEquipmentInput = (
   store: row.store
     ? { ...row.store, __typename: 'StoreNode', storeName: '' }
     : null,
+  properties: JSON.stringify(row.properties),
 });
 
 export const toExportEquipment = (
@@ -91,6 +93,7 @@ export const toExportEquipment = (
   lineNumber: index + 2,
   errorMessage: row.errorMessage,
   store: row.store,
+  properties: row.properties,
 });
 
 export const toUpdateEquipmentInput = (

--- a/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
@@ -23,6 +23,7 @@ import { ImportRow } from './EquipmentImportModal';
 import { importEquipmentToCsv } from '../utils';
 import {
   AssetCatalogueItemFragment,
+  processProperties,
   useStore,
 } from '@openmsupply-client/system';
 import {
@@ -171,59 +172,12 @@ function getImportHelpers<T, P>(
     addCell(key, localeKey, formatter);
   }
 
-  const processProperties = (
-    properties: undefined | AssetPropertyFragment[],
-    row: ParsedAsset,
-    importRow: ImportRow,
-    rowErrors: string[],
-    t: TypedTFunction<LocaleKey>
-  ) => {
-    properties?.forEach(property => {
-      const value = row[property.name] ?? row[property.key];
-      if (!!value?.trim()) {
-        if (!!property.allowedValues) {
-          const allowedValues = property.allowedValues.split(',');
-          if (allowedValues.every(v => v !== value)) {
-            rowErrors.push(
-              t('error.invalid-field-value', {
-                field: property.name,
-                value: value,
-              })
-            );
-          }
-        }
-        switch (property.valueType) {
-          case 'INTEGER':
-          case 'FLOAT':
-            if (Number.isNaN(Number(value))) {
-              rowErrors.push(
-                t('error.invalid-field-value', {
-                  field: property.name,
-                  value: value,
-                })
-              );
-            }
-            importRow.properties[property.key] = value;
-            break;
-          case 'BOOLEAN':
-            const isTrue =
-              value.toLowerCase() === 'true' || value.toLowerCase() === 'yes';
-            importRow.properties[property.key] = isTrue ? 'true' : 'false';
-            break;
-          default:
-            importRow.properties[property.key] = value;
-        }
-      }
-    });
-  };
-
   return {
     addLookup,
     addCell,
     addRequired,
     addSoftRequired,
     addUnique,
-    processProperties,
     importRow,
     rowErrors,
     rowWarnings,
@@ -313,7 +267,6 @@ export const EquipmentUploadTab: FC<ImportPanel & EquipmentUploadTabProps> = ({
         rowErrors,
         rowWarnings,
         addSoftRequired,
-        processProperties,
       } = getImportHelpers(row, rows, index, t);
       const lookupCode = (item: { code: string | null | undefined }) =>
         item.code;
@@ -342,7 +295,7 @@ export const EquipmentUploadTab: FC<ImportPanel & EquipmentUploadTabProps> = ({
         formatDate
       );
       addCell('serialNumber', 'label.serial');
-      processProperties(properties, row, importRow, rowErrors, t);
+      processProperties(properties ?? [], row, importRow, rowErrors, t);
       importRow.errorMessage = rowErrors.join(',');
       importRow.warningMessage = rowWarnings.join(',');
       hasErrors = hasErrors || rowErrors.length > 0;

--- a/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
@@ -261,7 +261,8 @@ export const EquipmentUploadTab: FC<ImportPanel & EquipmentUploadTabProps> = ({
         })
       ),
       t,
-      isCentralServer
+      isCentralServer,
+      properties ? properties.map(p => p.key) : []
     );
     FileUtils.exportCSV(csv, t('filename.cce'));
   };

--- a/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
@@ -247,19 +247,20 @@ export const EquipmentUploadTab: FC<ImportPanel & EquipmentUploadTabProps> = ({
   const { data: properties } = useAssetData.utils.properties();
 
   const csvExample = async () => {
-    const emptyRows: ImportRow[] = [];
+    const exampleRows: Partial<ImportRow>[] = [
+      {
+        id: '',
+        assetNumber: 'Asset Number',
+        catalogueItemCode: '',
+        store: undefined,
+        notes: '',
+        serialNumber: '',
+        installationDate: '',
+        properties: {},
+      },
+    ];
     const csv = importEquipmentToCsv(
-      emptyRows.map(
-        (_row: ImportRow): Partial<ImportRow> => ({
-          assetNumber: undefined,
-          catalogueItemCode: undefined,
-          store: undefined,
-          notes: undefined,
-          serialNumber: undefined,
-          installationDate: undefined,
-          properties: {},
-        })
-      ),
+      exampleRows,
       t,
       isCentralServer,
       properties ? properties.map(p => p.key) : []

--- a/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
@@ -28,7 +28,7 @@ import {
 import {
   AssetPropertyFragment,
   useAssetData,
-} from 'packages/system/src/Asset/api';
+} from '@openmsupply-client/system';
 
 interface EquipmentUploadTabProps {
   setEquipment: React.Dispatch<React.SetStateAction<ImportRow[]>>;

--- a/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
@@ -104,6 +104,7 @@ import React, { FC, useCallback, useEffect, useRef, useState } from 'react';
 import { BasicTextInput, BasicTextInputProps } from './BasicTextInput';
 import { NumUtils, RegexUtils } from '@common/utils';
 import { useFormatNumber, useCurrency } from '@common/intl';
+import { InputAdornment } from '@common/components';
 
 export interface NumericInputProps {
   /**
@@ -167,6 +168,7 @@ export interface NumericInputProps {
 export type NumericTextInputProps = NumericInputProps &
   Omit<BasicTextInputProps, 'onChange'> & {
     onChange?: (value: number | undefined) => void;
+    endAdornment?: string;
   };
 
 export const DEFAULT_NUMERIC_TEXT_INPUT_WIDTH = 75;
@@ -189,6 +191,7 @@ export const NumericTextInput: FC<NumericTextInputProps> = React.forwardRef(
       value,
       noFormatting = false,
       fullWidth,
+      endAdornment,
       ...props
     },
     ref
@@ -268,7 +271,14 @@ export const NumericTextInput: FC<NumericTextInputProps> = React.forwardRef(
           ...sx,
         }}
         inputMode="numeric"
-        InputProps={InputProps}
+        InputProps={{
+          endAdornment: endAdornment ? (
+            <InputAdornment position="end" sx={{ paddingBottom: '2px' }}>
+              {endAdornment}
+            </InputAdornment>
+          ) : undefined,
+          ...InputProps,
+        }}
         onChange={e => {
           if (!isDirty) setIsDirty(true);
 

--- a/client/packages/system/src/Asset/index.ts
+++ b/client/packages/system/src/Asset/index.ts
@@ -1,3 +1,7 @@
 export * from './ListView';
-export { AssetCatalogueItemFragment, useAssetData } from './api';
+export {
+  AssetCatalogueItemFragment,
+  AssetPropertyFragment,
+  useAssetData,
+} from './api';
 export { mapIdNameToOptions } from './utils';

--- a/client/packages/system/src/Immunisation/VaccineCourseView/VaccineCourseView.tsx
+++ b/client/packages/system/src/Immunisation/VaccineCourseView/VaccineCourseView.tsx
@@ -6,7 +6,6 @@ import {
   Checkbox,
   Container,
   DemographicIndicatorNode,
-  InputAdornment,
   InputWithLabelRow,
   NothingHere,
   NumericTextInput,
@@ -228,9 +227,7 @@ export const VaccineCourseView: FC = () => {
               value={draft?.coverageRate ?? 1}
               fullWidth
               onChange={value => updatePatch({ coverageRate: value })}
-              InputProps={{
-                endAdornment: <InputAdornment position="end">%</InputAdornment>,
-              }}
+              endAdornment="%"
               decimalLimit={1}
             />
           </Row>
@@ -239,9 +236,7 @@ export const VaccineCourseView: FC = () => {
               value={draft?.wastageRate ?? 1}
               fullWidth
               onChange={value => updatePatch({ wastageRate: value })}
-              InputProps={{
-                endAdornment: <InputAdornment position="end">%</InputAdornment>,
-              }}
+              endAdornment="%"
               decimalLimit={1}
             />
           </Row>

--- a/client/packages/system/src/Immunisation/VaccineCourseView/VaccineCourseView.tsx
+++ b/client/packages/system/src/Immunisation/VaccineCourseView/VaccineCourseView.tsx
@@ -6,6 +6,7 @@ import {
   Checkbox,
   Container,
   DemographicIndicatorNode,
+  InputAdornment,
   InputWithLabelRow,
   NothingHere,
   NumericTextInput,
@@ -227,6 +228,10 @@ export const VaccineCourseView: FC = () => {
               value={draft?.coverageRate ?? 1}
               fullWidth
               onChange={value => updatePatch({ coverageRate: value })}
+              InputProps={{
+                endAdornment: <InputAdornment position="end">%</InputAdornment>,
+              }}
+              decimalLimit={1}
             />
           </Row>
           <Row label={t('label.wastage-rate')}>
@@ -234,6 +239,10 @@ export const VaccineCourseView: FC = () => {
               value={draft?.wastageRate ?? 1}
               fullWidth
               onChange={value => updatePatch({ wastageRate: value })}
+              InputProps={{
+                endAdornment: <InputAdornment position="end">%</InputAdornment>,
+              }}
+              decimalLimit={1}
             />
           </Row>
           <Row label={t('label.vaccine-items')}>

--- a/client/packages/system/src/IndicatorsDemographics/DetailView/GrowthRow.tsx
+++ b/client/packages/system/src/IndicatorsDemographics/DetailView/GrowthRow.tsx
@@ -10,7 +10,6 @@ import {
   Table as MuiTable,
   InlineSpinner,
   NumericTextInput,
-  InputAdornment,
   useTranslation,
   useBufferState,
 } from '@openmsupply-client/common';
@@ -147,10 +146,7 @@ const GrowthInput = ({
       decimalLimit={2}
       decimalMin={1}
       allowNegative
-      InputProps={{
-        inputProps: { sx: { padding: '2px 0' } },
-        endAdornment: <InputAdornment position="end">%</InputAdornment>,
-      }}
+      endAdornment="%"
       onChange={newValue => {
         setBuffer(newValue);
         if (newValue !== undefined) setValue(newValue);

--- a/client/packages/system/src/index.ts
+++ b/client/packages/system/src/index.ts
@@ -17,3 +17,4 @@ export * from './Log';
 export * from './ReturnReason';
 export * from './Currency';
 export * from './IndicatorsDemographics';
+export { processProperties } from './utils';

--- a/client/packages/system/src/utils.ts
+++ b/client/packages/system/src/utils.ts
@@ -1,6 +1,6 @@
 import { LocaleKey, TypedTFunction } from '@common/intl';
 import { Formatter } from '@common/utils';
-import { MasterListRowFragment } from '.';
+import { AssetPropertyFragment, MasterListRowFragment } from '.';
 import { LocationRowFragment } from './Location/api';
 import { StockLineRowFragment } from './Stock/api';
 
@@ -76,4 +76,57 @@ export const stockLinesToCsv = (
     node.supplierName,
   ]);
   return Formatter.csv({ fields, data });
+};
+
+interface ParsedRow {
+  id: string;
+  [key: string]: string | undefined;
+}
+
+export const processProperties = <
+  T extends { properties: Record<string, string> },
+>(
+  properties: AssetPropertyFragment[],
+  row: ParsedRow,
+  importRow: T,
+  rowErrors: string[],
+  t: TypedTFunction<LocaleKey>
+) => {
+  properties.forEach(property => {
+    const value = row[property.name] ?? row[property.key];
+    if (!!value?.trim()) {
+      if (!!property.allowedValues) {
+        const allowedValues = property.allowedValues.split(',');
+        if (allowedValues.every(v => v !== value)) {
+          rowErrors.push(
+            t('error.invalid-field-value', {
+              field: property.name,
+              value: value,
+            })
+          );
+        }
+      }
+      switch (property.valueType) {
+        case 'INTEGER':
+        case 'FLOAT':
+          if (Number.isNaN(Number(value))) {
+            rowErrors.push(
+              t('error.invalid-field-value', {
+                field: property.name,
+                value: value,
+              })
+            );
+          }
+          importRow.properties[property.key] = value;
+          break;
+        case 'BOOLEAN':
+          const isTrue =
+            value.toLowerCase() === 'true' || value.toLowerCase() === 'yes';
+          importRow.properties[property.key] = isTrue ? 'true' : 'false';
+          break;
+        default:
+          importRow.properties[property.key] = value;
+      }
+    }
+  });
 };


### PR DESCRIPTION
Fixes #4219

# 👩🏻‍💻 What does this PR do?

Allows decimal inputs to wastage rate and coverage rate
These already allowed floats in the backend, so just changed mui props.

Also add % unit inline for these fields

## 💌 Any notes for the reviewer?

You can view these changes in Immunisations -> program -> vaccine course -> 
Then look at coverage rate and wastage rate fields

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
