### PR TITLE
3885 fix catalogue item autocomplete duplicates

### DIFF
--- a/client/packages/coldchain/src/Equipment/ListView/CreateAssetModal.tsx
+++ b/client/packages/coldchain/src/Equipment/ListView/CreateAssetModal.tsx
@@ -41,6 +41,7 @@ interface CreateAssetModalProps {
 const mapCatalogueItem = (catalogueItem: AssetCatalogueItemFragment) => ({
   label: `${catalogueItem.code} ${catalogueItem.assetType?.name} ${catalogueItem.manufacturer} ${catalogueItem.model}`,
   value: catalogueItem.id,
+  id: catalogueItem.id,
 });
 
 const mapCatalogueItems = (catalogueItems: AssetCatalogueItemFragment[]) =>
@@ -175,8 +176,8 @@ export const CreateAssetModal = ({
 
   // when the pagination changes, fetch the next page
   useEffect(() => {
-    fetchNextPage({ pageParam: pagination });
-  }, [fetchNextPage, pagination]);
+    fetchNextPage({ pageParam: pagination.page });
+  }, [fetchNextPage, pagination.page]);
 
   // reset the catalogue item pagination when the category changes
   useEffect(() => {
@@ -231,7 +232,7 @@ export const CreateAssetModal = ({
                     typeId: '',
                   });
                 }}
-                value={draft.categoryId}
+                value={draft.categoryId ?? ''}
               />
             }
           />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3885

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Before, entering some search value in the catalogue item input, backspacing and then entering again, caused duplicates like this:

<img width="569" alt="Screenshot 2024-06-24 at 1 10 57 PM" src="https://github.com/msupply-foundation/open-msupply/assets/55115239/e235b20c-b665-48b8-8ef7-9b5a25b1c8a7">

Working now:

<img width="556" alt="Screenshot 2024-06-24 at 1 12 15 PM" src="https://github.com/msupply-foundation/open-msupply/assets/55115239/d12172da-b9ab-44ab-8f8a-b93e01e82997">


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create new equipment/CCE asset
- [ ] Search in the autocomplete input for catalogue item
- [ ] Backspace
- [ ] retype same input
- [ ] Repeat
- [ ] Still the same number of search results, all unique

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
