### PR TITLE
4020 map sell prices through on invoice transfer

### DIFF
--- a/server/service/src/processors/transfer/invoice/common.rs
+++ b/server/service/src/processors/transfer/invoice/common.rs
@@ -70,7 +70,7 @@ pub(crate) fn generate_inbound_lines(
                     // Default
                     stock_line_id: None,
                     location_id: None,
-                    sell_price_per_pack: 0.0,
+                    sell_price_per_pack,
                     inventory_adjustment_reason_id: None,
                 }
             },

--- a/server/service/src/processors/transfer/invoice/test.rs
+++ b/server/service/src/processors/transfer/invoice/test.rs
@@ -1284,6 +1284,9 @@ fn check_line(connection: &StorageConnection, inbound_id: &str, outbound_line: &
     );
     assert_eq!(inbound_line.stock_line_id, None);
     assert_eq!(inbound_line.location_id, None);
-    assert_eq!(inbound_line.sell_price_per_pack, 0.0);
+    assert_eq!(
+        inbound_line.sell_price_per_pack,
+        outbound_line.sell_price_per_pack
+    );
     assert_eq!(inbound_line.tax_percentage, None);
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4020

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Applies the sell price from the outbound to the transferred inbound, to match functionality in mSupply:

<img width="155" alt="Screenshot 2024-06-24 at 2 27 03 PM" src="https://github.com/msupply-foundation/open-msupply/assets/55115239/0f28e1b3-239c-4bcc-957e-bb33492137db">


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create outbound shipment to another oms store
- [ ] Add a line which has a sell price
- [ ] Set to at least picked
- [ ] Switch to receiving store
- [ ] Go to the corresponding inbound shipment
- [ ] The sell price has been mapped through 🎉 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
