### PR TITLE
3696 remove caching of reasons

### DIFF
--- a/client/packages/system/src/InventoryAdjustmentReason/api/hooks/document/useInventoryAdjustmentReason.ts
+++ b/client/packages/system/src/InventoryAdjustmentReason/api/hooks/document/useInventoryAdjustmentReason.ts
@@ -6,12 +6,8 @@ export const useInventoryAdjustmentReason = (
   sortBy?: SortBy<InventoryAdjustmentReasonRowFragment>
 ) => {
   const api = useInventoryAdjustmentReasonApi();
-  const result = useQuery(
-    api.keys.sortedList(sortBy),
-    () => api.get.listAllActive({ sortBy }),
-    {
-      staleTime: 5 * 60 * 1000,
-    }
+  const result = useQuery(api.keys.sortedList(sortBy), () =>
+    api.get.listAllActive({ sortBy })
   );
 
   return { ...result };

--- a/client/packages/system/src/ReturnReason/api/hooks/document/useReturnReasons.ts
+++ b/client/packages/system/src/ReturnReason/api/hooks/document/useReturnReasons.ts
@@ -3,8 +3,6 @@ import { useReturnReasonApi } from '../utils/useReturnReasonApi';
 
 export const useReturnReasons = () => {
   const api = useReturnReasonApi();
-  const result = useQuery(api.keys.list(), () => api.get.listAllActive(), {
-    staleTime: 5 * 60 * 1000,
-  });
+  const result = useQuery(api.keys.list(), () => api.get.listAllActive());
   return { ...result };
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3696

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Removes caching of return/inventory adjustment reasons, so that they update after sync

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to view stock -> a stock line -> adjust
- [ ] Check inv adj reasons
- [ ] In mSupply prefs -> options, set some more reasons to active/inactive
- [ ] Sync 
- [ ] Go back to your stock line, adjustment reasons should have updated (without needing to refresh the page etc.)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
