### PR TITLE
3874 you can perform transactions on disabled oms store

### DIFF
--- a/client/packages/common/src/authentication/api/hooks/useLogin.ts
+++ b/client/packages/common/src/authentication/api/hooks/useLogin.ts
@@ -70,11 +70,15 @@ export const getStore = async (
     item => item.username.toLowerCase() === userDetails?.username?.toLowerCase()
   );
 
-  if (mru?.store && stores?.some(store => store.id === mru?.store?.id)) {
+  if (
+    mru?.store &&
+    !mru.store.isDisabled &&
+    stores?.some(store => store.id === mru?.store?.id)
+  ) {
     return stores.find(store => store.id === mru.store?.id) ?? mru.store;
   }
 
-  if (!!defaultStore) return defaultStore;
+  if (!!defaultStore && !defaultStore.isDisabled) return defaultStore;
 
   return !!stores && stores?.length > 0 ? stores?.[0] : undefined;
 };

--- a/client/packages/common/src/authentication/api/hooks/useLogin.ts
+++ b/client/packages/common/src/authentication/api/hooks/useLogin.ts
@@ -58,14 +58,13 @@ export const getMostRecentCredentials = (
   return [];
 };
 
-// returns MRU store, if set
-// or the first store in the list
+// returns MRU store, if set or the first store in the list
 export const getStore = async (
   userDetails?: Partial<UserNode>,
   mostRecentCredentials?: AuthenticationCredentials[]
 ) => {
   const defaultStore = userDetails?.defaultStore;
-  const stores = userDetails?.stores?.nodes;
+  const stores = userDetails?.stores?.nodes.filter(s => !s.isDisabled);
   const mru = mostRecentCredentials?.find(
     item => item.username.toLowerCase() === userDetails?.username?.toLowerCase()
   );
@@ -73,7 +72,7 @@ export const getStore = async (
   if (
     mru?.store &&
     !mru.store.isDisabled &&
-    stores?.some(store => store.id === mru?.store?.id)
+    stores?.some(store => store.id === mru?.store?.id && !store.isDisabled)
   ) {
     return stores.find(store => store.id === mru.store?.id) ?? mru.store;
   }

--- a/client/packages/common/src/authentication/api/hooks/useLogin.ts
+++ b/client/packages/common/src/authentication/api/hooks/useLogin.ts
@@ -71,7 +71,6 @@ export const getStore = async (
 
   if (
     mru?.store &&
-    !mru.store.isDisabled &&
     stores?.some(store => store.id === mru?.store?.id && !store.isDisabled)
   ) {
     return stores.find(store => store.id === mru.store?.id) ?? mru.store;

--- a/client/packages/common/src/authentication/api/operations.generated.ts
+++ b/client/packages/common/src/authentication/api/operations.generated.ts
@@ -4,7 +4,7 @@ import { GraphQLClient } from 'graphql-request';
 import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types';
 import gql from 'graphql-tag';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
-export type UserStoreNodeFragment = { __typename: 'UserStoreNode', code: string, id: string, nameId: string, name: string, storeMode: Types.StoreModeNodeType, createdDate?: string | null, homeCurrencyCode?: string | null, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean, omProgramModule: boolean, vaccineModule: boolean, issueInForeignCurrency: boolean } };
+export type UserStoreNodeFragment = { __typename: 'UserStoreNode', code: string, id: string, nameId: string, name: string, storeMode: Types.StoreModeNodeType, createdDate?: string | null, homeCurrencyCode?: string | null, isDisabled: boolean, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean, omProgramModule: boolean, vaccineModule: boolean, issueInForeignCurrency: boolean } };
 
 export type AuthTokenQueryVariables = Types.Exact<{
   username: Types.Scalars['String']['input'];
@@ -17,7 +17,7 @@ export type AuthTokenQuery = { __typename: 'Queries', authToken: { __typename: '
 export type MeQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type MeQuery = { __typename: 'Queries', me: { __typename: 'UserNode', email?: string | null, language: Types.LanguageType, username: string, userId: string, firstName?: string | null, lastName?: string | null, phoneNumber?: string | null, jobTitle?: string | null, defaultStore?: { __typename: 'UserStoreNode', code: string, id: string, nameId: string, name: string, storeMode: Types.StoreModeNodeType, createdDate?: string | null, homeCurrencyCode?: string | null, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean, omProgramModule: boolean, vaccineModule: boolean, issueInForeignCurrency: boolean } } | null, stores: { __typename: 'UserStoreConnector', totalCount: number, nodes: Array<{ __typename: 'UserStoreNode', code: string, id: string, nameId: string, name: string, storeMode: Types.StoreModeNodeType, createdDate?: string | null, homeCurrencyCode?: string | null, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean, omProgramModule: boolean, vaccineModule: boolean, issueInForeignCurrency: boolean } }> } } };
+export type MeQuery = { __typename: 'Queries', me: { __typename: 'UserNode', email?: string | null, language: Types.LanguageType, username: string, userId: string, firstName?: string | null, lastName?: string | null, phoneNumber?: string | null, jobTitle?: string | null, defaultStore?: { __typename: 'UserStoreNode', code: string, id: string, nameId: string, name: string, storeMode: Types.StoreModeNodeType, createdDate?: string | null, homeCurrencyCode?: string | null, isDisabled: boolean, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean, omProgramModule: boolean, vaccineModule: boolean, issueInForeignCurrency: boolean } } | null, stores: { __typename: 'UserStoreConnector', totalCount: number, nodes: Array<{ __typename: 'UserStoreNode', code: string, id: string, nameId: string, name: string, storeMode: Types.StoreModeNodeType, createdDate?: string | null, homeCurrencyCode?: string | null, isDisabled: boolean, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean, omProgramModule: boolean, vaccineModule: boolean, issueInForeignCurrency: boolean } }> } } };
 
 export type IsCentralServerQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
@@ -73,6 +73,7 @@ export const UserStoreNodeFragmentDoc = gql`
   }
   createdDate
   homeCurrencyCode
+  isDisabled
 }
     `;
 export const UpdateUserFragmentDoc = gql`

--- a/client/packages/common/src/authentication/api/operations.graphql
+++ b/client/packages/common/src/authentication/api/operations.graphql
@@ -15,6 +15,7 @@ fragment UserStoreNode on UserStoreNode {
   }
   createdDate
   homeCurrencyCode
+  isDisabled
 }
 
 query authToken($username: String!, $password: String!) {

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -3098,6 +3098,7 @@ export type InvoiceLineNode = {
   numberOfPacks: Scalars['Float']['output'];
   packSize: Scalars['Float']['output'];
   pricing: PricingNode;
+  returnReason?: Maybe<ReturnReasonNode>;
   returnReasonId?: Maybe<Scalars['String']['output']>;
   sellPricePerPack: Scalars['Float']['output'];
   stockLine?: Maybe<StockLineNode>;
@@ -7815,6 +7816,7 @@ export type UserStoreNode = {
   createdDate?: Maybe<Scalars['NaiveDate']['output']>;
   homeCurrencyCode?: Maybe<Scalars['String']['output']>;
   id: Scalars['String']['output'];
+  isDisabled: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
   nameId: Scalars['String']['output'];
   preferences: StorePreferenceNode;

--- a/client/packages/host/src/components/Footer/StoreSelector.tsx
+++ b/client/packages/host/src/components/Footer/StoreSelector.tsx
@@ -32,8 +32,8 @@ export const StoreSelector: FC<PropsWithChildrenOnly> = ({ children }) => {
 
   const storeButtons = stores.map(s => (
     <FlatButton
-      label={s.name}
-      disabled={s.id === store.id}
+      label={s.name + (s.isDisabled ? ` (${t('label.on-hold')})` : '')}
+      disabled={s.id === store.id || !!s.isDisabled}
       onClick={async () => {
         await setStore(s);
         hide();

--- a/server/graphql/types/src/types/user.rs
+++ b/server/graphql/types/src/types/user.rs
@@ -81,6 +81,10 @@ impl UserStoreNode {
             None => Ok(None),
         }
     }
+
+    pub async fn is_disabled(&self) -> bool {
+        self.user_store.store_row.is_disabled
+    }
 }
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq)]

--- a/server/repository/src/db_diesel/store_row.rs
+++ b/server/repository/src/db_diesel/store_row.rs
@@ -18,6 +18,7 @@ table! {
         logo -> Nullable<Text>,
         store_mode -> crate::db_diesel::store_row::StoreModeMapping,
         created_date -> Nullable<Date>,
+        is_disabled -> Bool,
     }
 }
 
@@ -44,6 +45,7 @@ pub struct StoreRow {
     pub logo: Option<String>,
     pub store_mode: StoreMode,
     pub created_date: Option<NaiveDate>,
+    pub is_disabled: bool,
 }
 
 pub struct StoreRowRepository<'a> {

--- a/server/repository/src/migrations/v2_01_00/mod.rs
+++ b/server/repository/src/migrations/v2_01_00/mod.rs
@@ -13,7 +13,7 @@ mod name_property;
 mod pg_enums;
 mod program;
 mod property;
-mod store_add_name_link_id;
+mod store_add_name_link_id_and_is_disabled;
 mod v6_sync_api_error_code;
 mod vaccine_course;
 
@@ -27,7 +27,7 @@ impl Migration for V2_01_00 {
     fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
         // Note, this migration deletes the consumption view which is recreated in decimal_pack_size
         // migration, i.e. this migration has to run first.
-        store_add_name_link_id::migrate(connection)?;
+        store_add_name_link_id_and_is_disabled::migrate(connection)?;
         activity_log::migrate(connection)?;
         // The ledger is migrated in decimal_pack_size because the same views needed to be
         // re-created

--- a/server/repository/src/migrations/v2_01_00/store_add_name_link_id_and_is_disabled.rs
+++ b/server/repository/src/migrations/v2_01_00/store_add_name_link_id_and_is_disabled.rs
@@ -21,6 +21,7 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
         -- Adding store.name_link_id
         DROP INDEX index_store_name_id_fkey;
         ALTER TABLE store ADD COLUMN name_link_id TEXT;
+        ALTER TABLE store ADD COLUMN is_disabled BOOLEAN DEFAULT FALSE NOT NULL;
         
         UPDATE store SET name_link_id = name_id;
 
@@ -40,10 +41,11 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
           site_id INTEGER NOT NULL,
           logo TEXT,
           store_mode TEXT DEFAULT 'STORE' NOT NULL,
-          created_date TEXT
+          created_date TEXT,
+          is_disabled BOOLEAN DEFAULT FALSE NOT NULL
         );
 
-        INSERT INTO store_new SELECT id, name_id, code, site_id, logo, store_mode, created_date FROM store;
+        INSERT INTO store_new SELECT id, name_id, code, site_id, logo, store_mode, created_date, false FROM store;
 
         PRAGMA foreign_keys=off;
         DROP TABLE store;

--- a/server/service/src/sync/translations/store.rs
+++ b/server/service/src/sync/translations/store.rs
@@ -33,6 +33,8 @@ pub struct LegacyStoreRow {
     #[serde(deserialize_with = "zero_date_as_option")]
     #[serde(serialize_with = "date_option_to_isostring")]
     pub created_date: Option<NaiveDate>,
+    #[serde(rename = "disabled")]
+    is_disabled: bool,
 }
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -88,6 +90,7 @@ impl SyncTranslation for StoreTranslation {
             logo: data.logo,
             store_mode,
             created_date: data.created_date,
+            is_disabled: data.is_disabled,
         };
 
         Ok(PullTranslateResult::upsert(result))


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3874

# 👩🏻‍💻 What does this PR do?
1. Migration to add `is_disabled` to store
2. In store selector at the bottom left of the screen: Disable store + add on hold text
![Screenshot 2024-06-21 at 7 28 44 PM](https://github.com/msupply-foundation/open-msupply/assets/61820074/6d9bae5e-07db-4525-906c-b4980bdb4e88)
3. Filter out disabled store from most recent credentials 

## 💌 Any notes for the reviewer?
Note for testers: Will need to delete database and reinitialise since there has been a migration change to store..


Sorry I accidentally merged develop into the branch and couldn't rebase cleanly again 👀 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] in mSupply: Disable store
- [ ] Sync to OMS
- [ ] See that disabled store is greyed out in Store Selector in bottom left 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Add a note about disabled stores
  4.
