### PR TITLE
4067 view stock 'cancel/close' button disabled

### DIFF
--- a/client/packages/common/src/ui/components/buttons/standard/DialogButton.tsx
+++ b/client/packages/common/src/ui/components/buttons/standard/DialogButton.tsx
@@ -20,7 +20,8 @@ type DialogButtonVariant =
   | 'save'
   | 'copy'
   | 'delete'
-  | 'export';
+  | 'export'
+  | 'close';
 
 interface DialogButtonProps {
   disabled?: boolean;
@@ -91,6 +92,12 @@ const getButtonProps = (
         icon: <DownloadIcon />,
         labelKey: 'button.export',
         variant: 'contained',
+      };
+    case 'close':
+      return {
+        icon: <XCircleIcon />,
+        labelKey: 'button.close',
+        variant: 'outlined',
       };
   }
 };

--- a/client/packages/system/src/Stock/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Stock/DetailView/DetailView.tsx
@@ -119,6 +119,7 @@ export const StockLineDetailView: React.FC = () => {
     showSaveConfirmation,
     showCancelConfirmation,
     disabled: !isDirty && !hasPluginChanged,
+    isDirty,
   };
 
   return (

--- a/client/packages/system/src/Stock/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Stock/DetailView/DetailView.tsx
@@ -41,7 +41,7 @@ export const StockLineDetailView: React.FC = () => {
   } = useUrlQuery();
   const { success, error } = useNotification();
   const t = useTranslation('inventory');
-  const { setSuffix } = useBreadcrumbs();
+  const { setSuffix, navigateUpOne } = useBreadcrumbs();
 
   const repackModalController = useToggle();
   const adjustmentModalController = useToggle();
@@ -86,8 +86,13 @@ export const StockLineDetailView: React.FC = () => {
     title: t('heading.are-you-sure'),
   });
 
+  const onCancel = () => {
+    resetDraft();
+    navigateUpOne();
+  };
+
   const showCancelConfirmation = useConfirmationModal({
-    onConfirm: resetDraft,
+    onConfirm: onCancel,
     message: t('messages.confirm-cancel-generic'),
     title: t('heading.are-you-sure'),
   });

--- a/client/packages/system/src/Stock/DetailView/Footer.tsx
+++ b/client/packages/system/src/Stock/DetailView/Footer.tsx
@@ -5,6 +5,7 @@ import {
   AppFooterPortal,
   DialogButton,
   LoadingButton,
+  useBreadcrumbs,
 } from '@openmsupply-client/common';
 import { FormInputData } from '@openmsupply-client/programs';
 
@@ -15,6 +16,7 @@ interface FooterProps {
   inputData?: FormInputData;
   showSaveConfirmation: () => void;
   showCancelConfirmation: () => void;
+  isDirty: boolean;
 }
 
 export const Footer: FC<FooterProps> = ({
@@ -23,8 +25,10 @@ export const Footer: FC<FooterProps> = ({
   inputData,
   showSaveConfirmation,
   showCancelConfirmation,
+  isDirty,
 }) => {
   const t = useTranslation();
+  const { navigateUpOne } = useBreadcrumbs();
 
   return (
     <AppFooterPortal
@@ -44,9 +48,10 @@ export const Footer: FC<FooterProps> = ({
             marginLeft="auto"
           >
             <DialogButton
-              variant="cancel"
-              disabled={disabled}
-              onClick={() => showCancelConfirmation()}
+              variant="close"
+              onClick={() =>
+                isDirty ? showCancelConfirmation() : navigateUpOne()
+              }
             />
             <LoadingButton
               color="secondary"


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4067

# 👩🏻‍💻 What does this PR do?
Change button to `Close`. If stock line has been edited, prompt user that they will lose all their data if they continue or redirect back to Stock page.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to `Stock`
- [ ] Click on stock line
- [ ] Click close -> Should redirect back
- [ ] Follow step 1 & 2
- [ ] Edit stock line
- [ ] Click Close
- [ ] See prompt

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Screenshots for Stock page
  2.
