### PR TITLE
4175 Can't enter exact decimal value under 'Pack Qty Issued' column in item-line in Outbounds

### DIFF
--- a/client/packages/invoices/src/StockOut/utils.tsx
+++ b/client/packages/invoices/src/StockOut/utils.tsx
@@ -344,6 +344,8 @@ export const PackQuantityCell = (props: CellProps<DraftStockOutLine>) => (
     {...props}
     max={props.rowData.stockLine?.availableNumberOfPacks}
     id={getPackQuantityCellId(props.rowData.stockLine?.batch)}
+    decimalLimit={2}
+    min={0}
   />
 );
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4175

# 👩🏻‍💻 What does this PR do?
Allow decimal inputs for Outbound Shipments + Prescriptions

## 💌 Any notes for the reviewer?
Do we want to display available number of packs in decimals in the search bar?
Also, still don't get why pack size of 1 can have decimal packs? Probably want to change this in stocktake too, so have left this up for discussion.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have some item with fractional packs
- [ ] Create `Outbound Shipment` with this item
- [ ] Enter some decimals

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
