### PR TITLE
3806 Cold chain: Rename mSupply sensor type

### DIFF
--- a/client/packages/common/src/intl/locales/en/coldchain.json
+++ b/client/packages/common/src/intl/locales/en/coldchain.json
@@ -104,7 +104,7 @@
   "label.observations": "Observations",
   "label.reason": "Reason",
   "label.review": "Review",
-  "label.rtmd": "mSupply RTMD",
+  "label.rtmd": "mSupply",
   "label.unacknowledged": "Unacknowledged",
   "label.upload": "Upload",
   "label.upload-files": "Upload files",


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3806

# 👩🏻‍💻 What does this PR do?
Remote RTMD from translation for BlueMaestro

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have vaccine module on
- [ ] Have BlueMaestro sensor
- [ ] Go to Sensor page
- [ ] Should only say `mSupply` instead of `mSupply RTMD`

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Update any screenshots that say mSupply RTMD for sensors
  2.
