### PR TITLE
2780 requisition no bar graph shown if soh = 0

### DIFF
--- a/client/packages/common/src/intl/locales/en/distribution.json
+++ b/client/packages/common/src/intl/locales/en/distribution.json
@@ -100,6 +100,7 @@
   "messages.off-hold-confirmation": "This will re-enable status changes",
   "messages.on-hold-confirmation": "This will prevent any further status changes until the hold is removed",
   "messages.no-stock-available": "There is no stock available",
+  "messages.requisition-no-stock": "There is currently no stock available",
   "messages.cant-delete-requisitions": "Can only delete requisitions with a status of 'Draft'",
   "messages.cant-return-shipment": "Cannot process return of lines until the status is 'Shipped'",
   "messages.click-to-return-to-requisitions": "Unable to find a requisition with that ID. Click OK to return to the requisition list",

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ReponseStats/ResponseStoreStats.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ReponseStats/ResponseStoreStats.tsx
@@ -76,7 +76,6 @@ export const ResponseStoreStats: React.FC<ResponseStoreStatsProps> = ({
           </Box>
         )}
       </Box>
-
       <Box
         sx={{
           paddingLeft: 4,

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ReponseStats/ResponseStoreStats.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ReponseStats/ResponseStoreStats.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from '@common/intl';
-import { Box, ValueBar } from '@openmsupply-client/common';
+import { Box, Typography, ValueBar } from '@openmsupply-client/common';
 
 export interface ResponseStoreStatsProps {
   stockOnHand: number;
@@ -44,32 +44,39 @@ export const ResponseStoreStats: React.FC<ResponseStoreStatsProps> = ({
           paddingBottom: 2,
         }}
       >
-        <Box
-          display="flex"
-          alignItems="flex-start"
-          width={predictedStockPercent}
-        >
-          <ValueBar
-            value={stockOnHand}
-            total={predictedStockLevels}
-            label={t('label.stock-on-hand')}
-            colour="gray.dark"
-            startDivider
-          />
-          <ValueBar
-            value={incomingStock}
-            total={predictedStockLevels}
-            label={t('label.incoming-stock')}
-            colour="gray.main"
-          />
-          <ValueBar
-            value={stockOnOrder}
-            total={predictedStockLevels}
-            label={t('label.stock-on-order')}
-            colour="gray.light"
-          />
-        </Box>
+        {stockOnHand === 0 && incomingStock === 0 && stockOnOrder === 0 ? (
+          <Typography fontSize={14}>
+            {t('messages.no-stock-available')}
+          </Typography>
+        ) : (
+          <Box
+            display="flex"
+            alignItems="flex-start"
+            width={predictedStockPercent}
+          >
+            <ValueBar
+              value={stockOnHand}
+              total={predictedStockLevels}
+              label={t('label.stock-on-hand')}
+              colour="gray.dark"
+              startDivider
+            />
+            <ValueBar
+              value={incomingStock}
+              total={predictedStockLevels}
+              label={t('label.incoming-stock')}
+              colour="gray.main"
+            />
+            <ValueBar
+              value={stockOnOrder}
+              total={predictedStockLevels}
+              label={t('label.stock-on-order')}
+              colour="gray.light"
+            />
+          </Box>
+        )}
       </Box>
+
       <Box
         sx={{
           paddingLeft: 4,

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ReponseStats/ResponseStoreStats.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ReponseStats/ResponseStoreStats.tsx
@@ -45,8 +45,11 @@ export const ResponseStoreStats: React.FC<ResponseStoreStatsProps> = ({
         }}
       >
         {stockOnHand === 0 && incomingStock === 0 && stockOnOrder === 0 ? (
-          <Typography fontSize={14}>
-            {t('messages.no-stock-available')}
+          <Typography fontSize={14} style={{ textAlign: 'center' }}>
+            ⓘ
+            <span style={{ fontStyle: 'italic', paddingLeft: 4 }}>
+              {t('messages.requisition-no-stock')}
+            </span>
           </Typography>
         ) : (
           <Box


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2780

# 👩🏻‍💻 What does this PR do?
Show no stock available message if no SOH, incoming or stock on order. Have to check all conditions since the bar will show if one of those is not 0
![Screenshot 2024-06-24 at 10 53 27 PM](https://github.com/msupply-foundation/open-msupply/assets/61820074/9ec410bc-d020-4f9c-985a-8d2dcbc44594)

I toyed with the idea of making it red to pop up more... what do you think? 👀 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an Internal Order to a store that doesn't have that item on hand, being delivered or in an order
- [ ] Go to Store B
- [ ] Go to Requisitions
- [ ] Click on the Requisition and line
- [ ] See message

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Add to documentation
  2.
