### PR TITLE
Add commas to demographic numbers

### DIFF
--- a/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
@@ -25,6 +25,7 @@ export const NumberInputCell = <T extends RecordWithId>({
   allowNegative,
   id,
   TextInputProps,
+  width,
 }: CellProps<T> &
   NumericInputProps & {
     id?: string;
@@ -59,6 +60,7 @@ export const NumberInputCell = <T extends RecordWithId>({
       allowNegative={allowNegative}
       defaultValue={defaultValue}
       value={buffer as number | undefined}
+      width={width}
     />
   );
 };

--- a/client/packages/system/src/IndicatorsDemographics/DetailView/IndicatorsDemographics.tsx
+++ b/client/packages/system/src/IndicatorsDemographics/DetailView/IndicatorsDemographics.tsx
@@ -8,6 +8,7 @@ import {
   TableProvider,
   createTableStore,
   useColumns,
+  useFormatNumber,
   useNotification,
   useTranslation,
   useUrlQueryParams,
@@ -39,6 +40,7 @@ const IndicatorsDemographicsComponent = () => {
   const [headerDraft, setHeaderDraft] = useState<HeaderData>();
   const [indexPopulation, setIndexPopulation] = useState(0);
   const [isDirty, setIsDirty] = useState(false);
+  const formatNumber = useFormatNumber();
 
   const { error, success } = useNotification();
   const t = useTranslation();
@@ -178,11 +180,11 @@ const IndicatorsDemographicsComponent = () => {
       [nameColumn(), { setter }],
       [percentageColumn(), { setter }],
       [populationColumn(), { setter: handlePopulationChange }],
-      yearColumn(1),
-      yearColumn(2),
-      yearColumn(3),
-      yearColumn(4),
-      yearColumn(5),
+      yearColumn(1, formatNumber.format),
+      yearColumn(2, formatNumber.format),
+      yearColumn(3, formatNumber.format),
+      yearColumn(4, formatNumber.format),
+      yearColumn(5, formatNumber.format),
     ],
     { sortBy, onChangeSortBy: updateSortQuery },
     [draft, indexPopulation, sortBy]
@@ -235,11 +237,28 @@ export const IndicatorsDemographics = () => (
   </TableProvider>
 );
 
-const yearColumn = (year: number) => ({
+const yearColumn = (year: number, format: (n: number) => string) => ({
   key: String(year),
   width: 150,
   align: ColumnAlign.Right,
   label: undefined,
   labelProps: { defaultValue: currentYear + year },
   sortable: false,
+  accessor: ({ rowData }: { rowData: Row }) => {
+    // using a switch to appease typescript
+    switch (year) {
+      case 1:
+        return format(rowData[1]);
+      case 2:
+        return format(rowData[2]);
+      case 3:
+        return format(rowData[3]);
+      case 4:
+        return format(rowData[4]);
+      case 5:
+        return format(rowData[5]);
+      default:
+        return '';
+    }
+  },
 });

--- a/client/packages/system/src/IndicatorsDemographics/DetailView/PopulationColumn.tsx
+++ b/client/packages/system/src/IndicatorsDemographics/DetailView/PopulationColumn.tsx
@@ -11,6 +11,7 @@ const PopulationCell = (props: CellProps<Row>) => (
   <NumberInputCell
     {...props}
     decimalLimit={0}
+    width={100}
     isDisabled={props.isDisabled || props.rowData.id !== GENERAL_POPULATION_ID}
   />
 );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4263 #4265

# 👩🏻‍💻 What does this PR do?
Formats the numbers:

<img width="1539" alt="image" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/44c14dd2-6940-4b09-b8e5-366b9b704f93">

and makes the pop input wider. It now fits the max integer value we allow:

<img width="484" alt="image" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/a5fc31f3-2664-4dd4-9f59-1768a960629f">


<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Check that the numbers look ok

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
