### PR TITLE
3994 Don't display foreign currency total if foreign currency id is the same as home currency

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/Tabs/StatusLogs.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/Tabs/StatusLogs.tsx
@@ -4,6 +4,7 @@ import {
   Box,
   Paper,
   SettingsCircleIcon,
+  UNDEFINED_STRING_VALUE,
   UserCircleIcon,
 } from '@openmsupply-client/common';
 import { useFormatDateTime, useIntlUtils, useTranslation } from '@common/intl';
@@ -40,7 +41,7 @@ const User = ({ user }: { user: ColdchainAssetLogFragment['user'] }) => {
   return (
     <Box display="flex" alignItems="flex-start">
       <Typography sx={{ fontWeight: 'bold', fontSize: '12px' }}>
-        {t('label.user')}: {user?.username ?? '-'}
+        {t('label.user')}: {user?.username ?? UNDEFINED_STRING_VALUE}
       </Typography>
       {!!fullName && <Divider />}
       {!!fullName && (
@@ -97,7 +98,7 @@ const StatusLog = ({
     >
       <Box flex={0} display="flex" flexDirection="column" alignItems="center">
         <Connector visible={!isFirst} />
-        <Icon username={log.user?.username ?? '-'} />
+        <Icon username={log.user?.username ?? UNDEFINED_STRING_VALUE} />
         <Connector visible={!isLast} />
       </Box>
       <Paper
@@ -123,11 +124,13 @@ const StatusLog = ({
           <User user={log.user} />
           <Box display="flex" alignItems="flex-start">
             <Typography sx={{ fontSize: '12px' }}>
-              <b>{t('label.reason')}:</b> {log.reason?.reason ?? '-'}
+              <b>{t('label.reason')}:</b>{' '}
+              {log.reason?.reason ?? UNDEFINED_STRING_VALUE}
             </Typography>
           </Box>
           <Typography sx={{ fontSize: '12px' }}>
-            <b>{t('label.observations')}:</b> {log.comment ?? '-'}
+            <b>{t('label.observations')}:</b>{' '}
+            {log.comment ?? UNDEFINED_STRING_VALUE}
           </Typography>
         </Box>
         <Box display="flex" flex={0.3}>

--- a/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
@@ -12,6 +12,7 @@ import {
   ArrayUtils,
   Box,
   Formatter,
+  UNDEFINED_STRING_VALUE,
   useAuthContext,
   useIsCentralServerApi,
 } from '@openmsupply-client/common';
@@ -277,7 +278,7 @@ export const Summary = ({ draft, onChange, locations }: SummaryProps) => {
           </Row>
           <Row label={t('label.reason')}>
             <BasicTextInput
-              value={draft.statusLog?.reason?.reason ?? '-'}
+              value={draft.statusLog?.reason?.reason ?? UNDEFINED_STRING_VALUE}
               disabled
               fullWidth
             />

--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/TemperatureChart.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/TemperatureChart.tsx
@@ -14,6 +14,7 @@ import {
   NothingHere,
   ResponsiveContainer,
   Typography,
+  UNDEFINED_STRING_VALUE,
   XAxis,
   YAxis,
   useTheme,
@@ -165,7 +166,7 @@ const Chart = ({
   const formatTemp = useFormatTemperature();
 
   const formatTemperature = (value: number | null | undefined) =>
-    !!value ? `${formatTemp(value)}` : '-';
+    !!value ? `${formatTemp(value)}` : UNDEFINED_STRING_VALUE;
 
   useEffect(() => {
     if (!urlQuery['datetime']) {

--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/TemperatureTooltip.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/TemperatureTooltip.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   TooltipProps,
   Typography,
+  UNDEFINED_STRING_VALUE,
   useFormatDateTime,
 } from '@openmsupply-client/common';
 import { useFormatTemperature } from '../../../common';
@@ -50,7 +51,7 @@ export const TemperatureTooltip = ({
   }
 
   const formatTemperature = (value: number | null | undefined) =>
-    !!value ? `${formatTemp(value)}` : '-';
+    !!value ? `${formatTemp(value)}` : UNDEFINED_STRING_VALUE;
   const entries: Entry[] = payload?.map(entry => {
     return {
       name: entry.name ?? '',

--- a/client/packages/coldchain/src/Sensor/Components/SensorLineForm.tsx
+++ b/client/packages/coldchain/src/Sensor/Components/SensorLineForm.tsx
@@ -7,6 +7,7 @@ import {
   Formatter,
   TextWithLabelRow,
   SensorNodeType,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { UseDraftSensorControl } from './SensorEditModal';
 import { isSensorNameEditDisabled } from '../utils';
@@ -54,7 +55,10 @@ export const SensorLineForm: FC<UseDraftSensorControl> = ({
       <TextWithLabelRow
         sx={textSx}
         label={t('label.cce')}
-        text={draft.assets?.nodes?.map(a => a.assetNumber).join(', ') || '-'}
+        text={
+          draft.assets?.nodes?.map(a => a.assetNumber).join(', ') ||
+          UNDEFINED_STRING_VALUE
+        }
       />
       <TextWithLabelRow
         sx={textSx}
@@ -64,7 +68,9 @@ export const SensorLineForm: FC<UseDraftSensorControl> = ({
       <TextWithLabelRow
         sx={textSx}
         label={t('label.battery-level')}
-        text={draft.batteryLevel ? `${draft.batteryLevel}%` : '-'}
+        text={
+          draft.batteryLevel ? `${draft.batteryLevel}%` : UNDEFINED_STRING_VALUE
+        }
       />
       <TextWithLabelRow
         sx={textSx}
@@ -75,7 +81,7 @@ export const SensorLineForm: FC<UseDraftSensorControl> = ({
             ? `${formatTemperature(
                 draft.latestTemperatureLog?.nodes[0]?.temperature
               )}`
-            : '-'
+            : UNDEFINED_STRING_VALUE
         }
       />
       <TextWithLabelRow

--- a/client/packages/coldchain/src/Sensor/ListView/ListView.tsx
+++ b/client/packages/coldchain/src/Sensor/ListView/ListView.tsx
@@ -11,6 +11,7 @@ import {
   useEditModal,
   useUrlQuery,
   SensorNodeType,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { useSensor, SensorFragment } from '../api';
 import { SensorEditModal } from '../Components';
@@ -57,7 +58,7 @@ export const SensorListView: FC = () => {
         accessor: ({ rowData }) => {
           const batteryLevel = rowData.batteryLevel;
 
-          return batteryLevel ? `${batteryLevel}%` : '-';
+          return batteryLevel ? `${batteryLevel}%` : UNDEFINED_STRING_VALUE;
         },
         sortable: false,
       },
@@ -69,7 +70,7 @@ export const SensorListView: FC = () => {
             ? `${formatTemperature(
                 rowData.latestTemperatureLog?.nodes[0]?.temperature
               )}`
-            : '-';
+            : UNDEFINED_STRING_VALUE;
         },
         sortable: false,
       },

--- a/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
@@ -102,7 +102,7 @@
 
 import React, { FC, useCallback, useEffect, useRef, useState } from 'react';
 import { BasicTextInput, BasicTextInputProps } from './BasicTextInput';
-import { NumUtils, RegexUtils } from '@common/utils';
+import { NumUtils, RegexUtils, UNDEFINED_STRING_VALUE } from '@common/utils';
 import { useFormatNumber, useCurrency } from '@common/intl';
 import { InputAdornment } from '@common/components';
 
@@ -218,7 +218,7 @@ export const NumericTextInput: FC<NumericTextInputProps> = React.forwardRef(
 
     const isInputIncomplete = useCallback(
       (value: string) => {
-        if (value === '-') return true;
+        if (value === UNDEFINED_STRING_VALUE) return true;
 
         return new RegExp(
           // Checks for a trailing `.` or a `0` (not necessarily immediately)

--- a/client/packages/common/src/utils/globalConst.ts
+++ b/client/packages/common/src/utils/globalConst.ts
@@ -1,0 +1,1 @@
+export const UNDEFINED_STRING_VALUE = '-';

--- a/client/packages/common/src/utils/index.ts
+++ b/client/packages/common/src/utils/index.ts
@@ -13,6 +13,7 @@ export * from './types';
 export * from './files';
 export * from './BarcodeScannerContext';
 export * from './item';
+export * from './globalConst';
 
 // having issues with tree shaking lodash
 // so we're just importing the functions we need

--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.tsx
@@ -15,6 +15,7 @@ import {
   useColumnUtils,
   NumberCell,
   ColumnDescription,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import {
   InventoryAdjustmentReasonRowFragment,
@@ -211,7 +212,9 @@ export const useStocktakeColumns = ({
       label: 'label.counted-num-of-packs',
       description: 'description.counted-num-of-packs',
       align: ColumnAlign.Right,
-      Cell: props => <NumberCell {...props} defaultValue={'-'} />,
+      Cell: props => (
+        <NumberCell {...props} defaultValue={UNDEFINED_STRING_VALUE} />
+      ),
       getIsError: row =>
         getLinesFromRow(row).some(
           r => getError(r)?.__typename === 'StockLineReducedBelowZero'

--- a/client/packages/inventory/src/Stocktake/DetailView/SidePanel.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/SidePanel.tsx
@@ -19,6 +19,7 @@ import {
   useFormatDateTime,
   useNavigate,
   RouteBuilder,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { useStocktake } from '../api';
 import { canDeleteStocktake } from '../../utils';
@@ -37,7 +38,7 @@ const AdditionalInfoSection: FC = () => {
       <Grid container gap={0.5} key="additional-info">
         <PanelRow>
           <PanelLabel>{t('label.entered-by')}</PanelLabel>
-          <PanelField>{user?.username ?? '-'}</PanelField>
+          <PanelField>{user?.username ?? UNDEFINED_STRING_VALUE}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user.email} /> : null}
         </PanelRow>
         <PanelRow>

--- a/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/AdditionalInfoSection.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/AdditionalInfoSection.tsx
@@ -11,6 +11,7 @@ import {
   useBufferState,
   InfoTooltipIcon,
   useFormatDateTime,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { useInbound } from '../../api';
 
@@ -32,7 +33,7 @@ export const AdditionalInfoSectionComponent = () => {
       <Grid container gap={0.5} key="additional-info">
         <PanelRow>
           <PanelLabel>{t('label.edited-by')}</PanelLabel>
-          <PanelField>{user?.username ?? '-'}</PanelField>
+          <PanelField>{user?.username ?? UNDEFINED_STRING_VALUE}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user?.email} /> : null}
         </PanelRow>
         <PanelRow>

--- a/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/PricingSection.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/PricingSection.tsx
@@ -46,6 +46,7 @@ export const PricingSectionComponent = () => {
   const { mutateAsync: updateTax } = useInbound.document.updateTax();
   const { c: foreignCurrency } = useCurrency(currency?.code as Currencies);
   const { store } = useAuthContext();
+  const isHomeCurrency = store?.homeCurrencyCode === currency?.code;
 
   const tax = PricingUtils.effectiveTax(
     pricing?.serviceTotalBeforeTax,
@@ -165,14 +166,16 @@ export const PricingSectionComponent = () => {
         </PanelRow>
         <PanelRow>
           <PanelLabel>{t('heading.rate')}</PanelLabel>
-          <PanelField>{currencyRate ?? 1}</PanelField>
+          <PanelField>{currencyRate === 0 ? 1 : currencyRate}</PanelField>
         </PanelRow>
         <PanelRow>
           <PanelLabel>{t('heading.total')}</PanelLabel>
           <PanelField>
-            {foreignCurrency(
-              pricing.foreignCurrencyTotalAfterTax ?? 0
-            ).format()}
+            {isHomeCurrency
+              ? '-'
+              : foreignCurrency(
+                  pricing.foreignCurrencyTotalAfterTax ?? 0
+                ).format()}
           </PanelField>
         </PanelRow>
         <PanelRow style={{ marginTop: 12 }}>

--- a/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/PricingSection.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/PricingSection.tsx
@@ -15,6 +15,7 @@ import {
   InvoiceLineNodeType,
   Currencies,
   useAuthContext,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { useInbound } from '../../api';
 import { InboundServiceLineEdit, TaxEdit } from '../modals';
@@ -172,7 +173,7 @@ export const PricingSectionComponent = () => {
           <PanelLabel>{t('heading.total')}</PanelLabel>
           <PanelField>
             {isHomeCurrency
-              ? '-'
+              ? UNDEFINED_STRING_VALUE
               : foreignCurrency(
                   pricing.foreignCurrencyTotalAfterTax ?? 0
                 ).format()}

--- a/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/RelatedDocumentsSection.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/RelatedDocumentsSection.tsx
@@ -10,6 +10,7 @@ import {
   Link,
   useFormatDateTime,
   RouteBuilder,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { useInbound } from '../../api';
@@ -26,7 +27,7 @@ export const RelatedDocumentsSectionComponent = () => {
       date: d(new Date(createdDatetime)),
     });
     tooltip += ` ${t('messages.by-user', {
-      username: user?.username ?? '-',
+      username: user?.username ?? UNDEFINED_STRING_VALUE,
     })}`;
   }
 

--- a/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/AdditionalInfoSection.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/AdditionalInfoSection.tsx
@@ -11,6 +11,7 @@ import {
   useBufferState,
   InfoTooltipIcon,
   useFormatDateTime,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { useOutbound } from '../../api';
 
@@ -33,7 +34,7 @@ export const AdditionalInfoSectionComponent: FC = () => {
       <Grid container gap={0.5} key="additional-info">
         <PanelRow>
           <PanelLabel>{t('label.entered-by')}</PanelLabel>
-          <PanelField>{user?.username ?? '-'}</PanelField>
+          <PanelField>{user?.username ?? UNDEFINED_STRING_VALUE}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user?.email} /> : null}
         </PanelRow>
         <PanelRow>

--- a/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/PricingSection.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/PricingSection.tsx
@@ -32,7 +32,7 @@ type CurrencyPricingProps = {
   pricing: PricingNode;
   currency?: CurrencyRowFragment | null;
   otherPartyIsInternal: boolean;
-  currencyRate?: number | null;
+  currencyRate: number;
   onChange: (value: CurrencyRowFragment | null) => void;
 };
 
@@ -159,6 +159,7 @@ export const ForeignCurrencyPrices = ({
   const t = useTranslation('distribution');
   const { store } = useAuthContext();
   const { c: foreignCurrency } = useCurrency(currency?.code as Currencies);
+  const isHomeCurrency = store?.homeCurrencyCode === currency?.code;
 
   return (
     <>
@@ -183,12 +184,16 @@ export const ForeignCurrencyPrices = ({
       </PanelRow>
       <PanelRow>
         <PanelLabel>{t('heading.rate')}</PanelLabel>
-        <PanelField>{currencyRate ?? 1}</PanelField>
+        <PanelField>{currencyRate === 0 ? 1 : currencyRate}</PanelField>
       </PanelRow>
       <PanelRow>
         <PanelLabel>{t('heading.total')}</PanelLabel>
         <PanelField>
-          {foreignCurrency(pricing.foreignCurrencyTotalAfterTax ?? 0).format()}
+          {isHomeCurrency
+            ? '-'
+            : foreignCurrency(
+                pricing.foreignCurrencyTotalAfterTax ?? 0
+              ).format()}
         </PanelField>
       </PanelRow>
     </>
@@ -215,12 +220,13 @@ export const PricingSectionComponent = () => {
   const t = useTranslation('distribution');
   const isDisabled = useOutbound.utils.isDisabled();
 
-  const { pricing, currency, otherParty, update, currencyRate } = useOutbound.document.fields([
-    'otherParty',
-    'currencyRate',
-    'pricing',
-    'currency',
-  ]);
+  const { pricing, currency, otherParty, update, currencyRate } =
+    useOutbound.document.fields([
+      'otherParty',
+      'currencyRate',
+      'pricing',
+      'currency',
+    ]);
 
   return (
     <DetailPanelSection title={t('heading.invoice-details')}>

--- a/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/PricingSection.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/PricingSection.tsx
@@ -17,6 +17,7 @@ import {
   useAuthContext,
   useCurrency,
   Currencies,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { useOutbound } from '../../api';
 import { OutboundServiceLineEdit } from '../OutboundServiceLineEdit';
@@ -190,7 +191,7 @@ export const ForeignCurrencyPrices = ({
         <PanelLabel>{t('heading.total')}</PanelLabel>
         <PanelField>
           {isHomeCurrency
-            ? '-'
+            ? UNDEFINED_STRING_VALUE
             : foreignCurrency(
                 pricing.foreignCurrencyTotalAfterTax ?? 0
               ).format()}

--- a/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/RelatedDocumentsSection.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/RelatedDocumentsSection.tsx
@@ -10,6 +10,7 @@ import {
   useFormatDateTime,
   RouteBuilder,
   Tooltip,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { useOutbound } from '../../api';
@@ -35,7 +36,7 @@ const RelatedDocumentsSectionComponent = () => {
           <Tooltip
             title={getTooltip(
               requisition.createdDatetime,
-              requisition.user?.username ?? '-'
+              requisition.user?.username ?? UNDEFINED_STRING_VALUE
             )}
           >
             <Grid item>

--- a/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/AdditionalInfoSection.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/AdditionalInfoSection.tsx
@@ -11,6 +11,7 @@ import {
   useBufferState,
   InfoTooltipIcon,
   useFormatDateTime,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { usePrescription } from '../../api';
 
@@ -33,7 +34,7 @@ export const AdditionalInfoSectionComponent: FC = () => {
       <Grid container gap={0.5} key="additional-info">
         <PanelRow>
           <PanelLabel>{t('label.entered-by')}</PanelLabel>
-          <PanelField>{user?.username ?? '-'}</PanelField>
+          <PanelField>{user?.username ?? UNDEFINED_STRING_VALUE}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user?.email} /> : null}
         </PanelRow>
         <PanelRow>

--- a/client/packages/invoices/src/Returns/InboundDetailView/SidePanel/AdditionalInfoSection.tsx
+++ b/client/packages/invoices/src/Returns/InboundDetailView/SidePanel/AdditionalInfoSection.tsx
@@ -9,6 +9,7 @@ import {
   InfoTooltipIcon,
   ColorSelectButton,
   BufferedTextArea,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { InboundReturnFragment, useReturns } from '../../api';
 
@@ -32,7 +33,7 @@ export const AdditionalInfoSectionComponent = () => {
       <Grid container gap={0.5} key="additional-info">
         <PanelRow>
           <PanelLabel>{t('label.edited-by')}</PanelLabel>
-          <PanelField>{user?.username ?? '-'}</PanelField>
+          <PanelField>{user?.username ?? UNDEFINED_STRING_VALUE}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user?.email} /> : null}
         </PanelRow>
 

--- a/client/packages/invoices/src/Returns/InboundDetailView/SidePanel/RelatedDocumentsSection.tsx
+++ b/client/packages/invoices/src/Returns/InboundDetailView/SidePanel/RelatedDocumentsSection.tsx
@@ -9,6 +9,7 @@ import {
   Link,
   useFormatDateTime,
   RouteBuilder,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { useReturns } from '../../api';
@@ -38,7 +39,7 @@ export const RelatedDocumentsSectionComponent = () => {
               <PanelLabel>
                 {getLabel(
                   originalShipment.createdDatetime,
-                  originalShipment.user?.username ?? '-'
+                  originalShipment.user?.username ?? UNDEFINED_STRING_VALUE
                 )}
               </PanelLabel>
               <PanelField>

--- a/client/packages/invoices/src/Returns/OutboundDetailView/SidePanel/AdditionalInfoSection.tsx
+++ b/client/packages/invoices/src/Returns/OutboundDetailView/SidePanel/AdditionalInfoSection.tsx
@@ -9,6 +9,7 @@ import {
   useTranslation,
   ColorSelectButton,
   InfoTooltipIcon,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { OutboundReturnFragment, useReturns } from '../../api';
 
@@ -33,7 +34,7 @@ export const AdditionalInfoSectionComponent: FC = () => {
       <Grid container gap={0.5} key="additional-info">
         <PanelRow>
           <PanelLabel>{t('label.entered-by')}</PanelLabel>
-          <PanelField>{user?.username ?? '-'}</PanelField>
+          <PanelField>{user?.username ?? UNDEFINED_STRING_VALUE}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user?.email} /> : null}
         </PanelRow>
 

--- a/client/packages/invoices/src/Returns/OutboundDetailView/SidePanel/RelatedDocumentsSection.tsx
+++ b/client/packages/invoices/src/Returns/OutboundDetailView/SidePanel/RelatedDocumentsSection.tsx
@@ -9,6 +9,7 @@ import {
   Link,
   useFormatDateTime,
   RouteBuilder,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { useReturns } from '../../api';
@@ -38,7 +39,7 @@ export const RelatedDocumentsSectionComponent = () => {
               <PanelLabel>
                 {getLabel(
                   originalShipment.createdDatetime,
-                  originalShipment.user?.username ?? '-'
+                  originalShipment.user?.username ?? UNDEFINED_STRING_VALUE
                 )}
               </PanelLabel>
               <PanelField>

--- a/client/packages/programs/src/JsonForms/components/EncounterLineChart.tsx
+++ b/client/packages/programs/src/JsonForms/components/EncounterLineChart.tsx
@@ -20,7 +20,7 @@ import {
 } from 'recharts';
 import { useEncounter } from '../../api';
 import { z } from 'zod';
-import { extractProperty } from '@common/utils';
+import { UNDEFINED_STRING_VALUE, extractProperty } from '@common/utils';
 
 export const encounterLineChartTester = rankWith(
   4,
@@ -172,7 +172,9 @@ const UIComponent = (props: ControlProps) => {
         />
         <YAxis domain={domain}>
           <Label
-            value={`${option.label ?? '-'} [${option.unit ?? '?'}]`}
+            value={`${option.label ?? UNDEFINED_STRING_VALUE} [${
+              option.unit ?? '?'
+            }]`}
             angle={-90}
             position={{ x: 0, y: 10 }}
           />
@@ -180,7 +182,7 @@ const UIComponent = (props: ControlProps) => {
         <Tooltip
           content={
             <DateTimeTooltip
-              name={option.label ?? '-'}
+              name={option.label ?? UNDEFINED_STRING_VALUE}
               unit={option.unit ?? '?'}
             />
           }

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
@@ -11,6 +11,7 @@ import {
   UserPermission,
   useIntlUtils,
   useDisabledNotificationToast,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { getNextRequestStatus, getStatusTranslation } from '../../../utils';
 import { useRequest } from '../../api';
@@ -100,8 +101,8 @@ const useStatusChangeButton = () => {
     return `${comment ? comment + '\n' : ''}${t('template.requisition-sent', {
       name,
       job,
-      phone: user?.phoneNumber ?? '-',
-      email: user?.email ?? '-',
+      phone: user?.phoneNumber ?? UNDEFINED_STRING_VALUE,
+      email: user?.email ?? UNDEFINED_STRING_VALUE,
     })}`;
   };
 

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/SidePanel.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/SidePanel.tsx
@@ -22,6 +22,7 @@ import {
   RequisitionNodeStatus,
   useDeleteConfirmation,
   useNavigate,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { useRequest } from '../api';
 import { AppRoute } from '@openmsupply-client/config';
@@ -44,7 +45,7 @@ const AdditionalInfoSection: FC = () => {
       <Grid container gap={0.5} key="additional-info">
         <PanelRow>
           <PanelLabel>{t('label.entered-by')}</PanelLabel>
-          <PanelField>{user?.username ?? '-'}</PanelField>
+          <PanelField>{user?.username ?? UNDEFINED_STRING_VALUE}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user?.email} /> : null}
         </PanelRow>
         <PanelRow>
@@ -112,7 +113,7 @@ const RelatedDocumentsSection: FC = () => {
             key={shipment.id}
             title={getTooltip(
               shipment.createdDatetime,
-              shipment.user?.username ?? '-'
+              shipment.user?.username ?? UNDEFINED_STRING_VALUE
             )}
           >
             <Grid item>

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/AdditionalInfoSection.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/AdditionalInfoSection.tsx
@@ -11,6 +11,7 @@ import {
   BufferedTextArea,
   InfoTooltipIcon,
   useFormatDateTime,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { useResponse } from '../api';
 
@@ -32,7 +33,7 @@ export const AdditionalInfoSection: FC = () => {
       <Grid container gap={0.5} key="additional-info">
         <PanelRow>
           <PanelLabel>{t('label.edited-by')}</PanelLabel>
-          <PanelField>{user?.username ?? '-'}</PanelField>
+          <PanelField>{user?.username ?? UNDEFINED_STRING_VALUE}</PanelField>
           {user?.email ? <InfoTooltipIcon title={user?.email} /> : null}
         </PanelRow>
         <PanelRow>

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/RelatedDocumentsSection.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/RelatedDocumentsSection.tsx
@@ -9,6 +9,7 @@ import {
   RouteBuilder,
   Link,
   Tooltip,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { useFormatDateTime } from '@common/intl';
 import { useResponse } from '../api';
@@ -50,7 +51,7 @@ export const RelatedDocumentsSection: FC = () => {
           <Tooltip
             title={getTooltip(
               shipment.createdDatetime,
-              shipment.user?.username ?? '-'
+              shipment.user?.username ?? UNDEFINED_STRING_VALUE
             )}
             key={shipment.id}
           >

--- a/client/packages/system/src/Encounter/DetailView/SidePanel.tsx
+++ b/client/packages/system/src/Encounter/DetailView/SidePanel.tsx
@@ -14,6 +14,7 @@ import {
   InlineSpinner,
   useAuthContext,
   BasicTextInput,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import {
   EncounterFragment,
@@ -39,7 +40,7 @@ export const SidePanel: FC<SidePanelProps> = ({ encounter, onChange }) => {
     encounter.document.data?.notes?.[0]?.text ?? ''
   );
   const [createdBy, setCreatedBy] = useState(
-    encounter?.document?.data?.createdBy?.username ?? '-'
+    encounter?.document?.data?.createdBy?.username ?? UNDEFINED_STRING_VALUE
   );
   const { user } = useAuthContext();
   const { localisedDate } = useFormatDateTime();

--- a/client/packages/system/src/Immunisation/ImmunisationProgramDetailView/ImmunisationProgramDetailView.tsx
+++ b/client/packages/system/src/Immunisation/ImmunisationProgramDetailView/ImmunisationProgramDetailView.tsx
@@ -19,6 +19,7 @@ import {
   useColumns,
   NothingHere,
   useEditModal,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { useImmunisationProgram } from '../api/hooks/useImmunisationProgram';
@@ -69,10 +70,9 @@ export const ProgramComponent: FC = () => {
 
         sortable: false,
         accessor: ({ rowData }) => {
-          if (!rowData?.demographicIndicator) {
-            return '-';
-          }
-          return rowData.demographicIndicator.name;
+          rowData?.demographicIndicator
+            ? rowData.demographicIndicator.name
+            : UNDEFINED_STRING_VALUE;
         },
       },
       { key: 'doses', label: 'label.doses' },

--- a/client/packages/system/src/Immunisation/ListView/ListView.tsx
+++ b/client/packages/system/src/Immunisation/ListView/ListView.tsx
@@ -11,6 +11,7 @@ import {
   createQueryParamsStore,
   useEditModal,
   InsertImmunisationProgramInput,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
@@ -57,10 +58,9 @@ const ImmunisationProgramListComponent: FC = () => {
         label: 'label.vaccine-courses',
         sortable: false,
         accessor: ({ rowData }) => {
-          if (rowData.vaccineCourses?.length === 0) {
-            return '-';
-          }
-          return rowData.vaccineCourses?.map(n => n.name).join(', ');
+          rowData?.vaccineCourses?.length === 0
+            ? UNDEFINED_STRING_VALUE
+            : rowData.vaccineCourses?.map(n => n.name).join(', ');
         },
       },
       'selection',

--- a/client/packages/system/src/Stock/Components/Repack/RepackEditForm.tsx
+++ b/client/packages/system/src/Stock/Components/Repack/RepackEditForm.tsx
@@ -5,6 +5,7 @@ import {
   InputWithLabelRow,
   NumericTextInput,
   TextWithLabelRow,
+  UNDEFINED_STRING_VALUE,
   useTranslation,
 } from '@openmsupply-client/common';
 import { LocationRowFragment, RepackDraft } from '@openmsupply-client/system';
@@ -70,7 +71,7 @@ export const RepackEditForm: FC<RepackEditFormProps> = ({
           />
           <TextWithLabelRow
             label={t('label.location')}
-            text={data?.locationName ?? '-'}
+            text={data?.locationName ?? UNDEFINED_STRING_VALUE}
             textProps={textProps}
             labelProps={labelProps}
           />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3994

# 👩🏻‍💻 What does this PR do?
Use '-' instead of foreign currency total in invoice if the foreign currency is home currency, also noticed that the rates were showing up as 0 in older invoices, so have handled that as well 👀 .... 
![Screenshot 2024-06-26 at 8 20 34 AM](https://github.com/msupply-foundation/open-msupply/assets/61820074/0698d46e-ee35-4ab2-88d3-631fc56b2f8f)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have `issue in foreign currency` store pref on
- [ ] Create an invoice for an external customer/supplier
- [ ] Add some lines with sell price
- [ ] See `-` for foreign currency total
- [ ] Change currency
- [ ] See total

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Screenshots with foreign currency 
  2.
