### PR TITLE
4024 stock lines not included in search

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -3098,6 +3098,7 @@ export type InvoiceLineNode = {
   numberOfPacks: Scalars['Float']['output'];
   packSize: Scalars['Float']['output'];
   pricing: PricingNode;
+  returnReason?: Maybe<ReturnReasonNode>;
   returnReasonId?: Maybe<Scalars['String']['output']>;
   sellPricePerPack: Scalars['Float']['output'];
   stockLine?: Maybe<StockLineNode>;
@@ -3269,6 +3270,7 @@ export type ItemCountsResponse = {
 export type ItemFilterInput = {
   code?: InputMaybe<StringFilterInput>;
   codeOrName?: InputMaybe<StringFilterInput>;
+  hasStockOnHand?: InputMaybe<Scalars['Boolean']['input']>;
   id?: InputMaybe<EqualFilterStringInput>;
   isActive?: InputMaybe<Scalars['Boolean']['input']>;
   isVaccine?: InputMaybe<Scalars['Boolean']['input']>;

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -3270,11 +3270,13 @@ export type ItemCountsResponse = {
 export type ItemFilterInput = {
   code?: InputMaybe<StringFilterInput>;
   codeOrName?: InputMaybe<StringFilterInput>;
-  hasStockOnHand?: InputMaybe<Scalars['Boolean']['input']>;
   id?: InputMaybe<EqualFilterStringInput>;
   isActive?: InputMaybe<Scalars['Boolean']['input']>;
   isVaccine?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Items that are visible in this store. This filter is void if `is_visible_or_on_hand` is true */
   isVisible?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Items that are visible in this store OR there is available stock of that item in this store */
+  isVisibleOrOnHand?: InputMaybe<Scalars['Boolean']['input']>;
   name?: InputMaybe<StringFilterInput>;
   type?: InputMaybe<EqualFilterItemTypeInput>;
 };

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
@@ -41,6 +41,7 @@ export const StocktakeLineEditForm: FC<StocktakeLineEditProps> = ({
             disabled={disabled}
             currentItemId={item?.id}
             onChange={onChangeItem}
+            includeNonVisibleWithStockOnHand
             extraFilter={
               disabled
                 ? undefined

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -179,6 +179,7 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
             disabled={disabled}
             currentItemId={item?.id}
             onChange={onChangeItem}
+            includeNonVisibleWithStockOnHand
             extraFilter={
               disabled
                 ? undefined

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
@@ -189,6 +189,7 @@ export const PrescriptionLineEditForm: React.FC<
             disabled={disabled}
             currentItemId={item?.id}
             onChange={onChangeItem}
+            includeNonVisibleWithStockOnHand
             extraFilter={
               disabled
                 ? undefined

--- a/client/packages/invoices/src/Returns/modals/OutboundReturn/ItemSelector.tsx
+++ b/client/packages/invoices/src/Returns/modals/OutboundReturn/ItemSelector.tsx
@@ -40,6 +40,7 @@ export const ItemSelector: FC<ItemSelectorProps> = ({
             disabled={disabled}
             currentItemId={itemId}
             onChange={newItem => newItem && onChangeItemId(newItem.id)}
+            includeNonVisibleWithStockOnHand
             extraFilter={
               disabled
                 ? undefined

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
@@ -28,6 +28,7 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
   width,
   autoFocus = false,
   openOnFocus,
+  includeNonVisibleWithStockOnHand = false,
 }) => {
   const [items, setItems] = useState<ItemStockOnHandFragment[]>([]);
   const { pagination, onPageChange } = usePagination();
@@ -36,6 +37,7 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
   const { data, isLoading } = useItemStockOnHand({
     pagination,
     filter,
+    includeNonVisibleWithStockOnHand,
   });
   // changed from useStockLines even though that is more appropriate
   // when viewing a stocktake, you may have a stocktake line which has no stock lines.

--- a/client/packages/system/src/Item/api/api.ts
+++ b/client/packages/system/src/Item/api/api.ts
@@ -100,9 +100,10 @@ export const getItemQueries = (sdk: Sdk, storeId: string) => ({
         filter: {
           ...filterBy,
           type: { equalTo: ItemNodeType.Stock },
-          isVisible: true,
+          [includeNonVisibleWithStockOnHand
+            ? 'isVisibleOrOnHand'
+            : 'isVisible']: true,
           isActive: true,
-          hasStockOnHand: includeNonVisibleWithStockOnHand,
         },
       });
 
@@ -155,10 +156,9 @@ export const getItemQueries = (sdk: Sdk, storeId: string) => ({
         // because service items don't have SOH & AMC so it's odd to show them alongside stock items
         filter: {
           ...filterBy,
-          isVisible: true,
-          isActive: true,
           // includes non-visible items that have stock on hand
-          hasStockOnHand: true,
+          isVisibleOrOnHand: true,
+          isActive: true,
         },
       });
 

--- a/client/packages/system/src/Item/api/api.ts
+++ b/client/packages/system/src/Item/api/api.ts
@@ -87,7 +87,10 @@ export const getItemQueries = (sdk: Sdk, storeId: string) => ({
       first,
       offset,
       sortBy,
-    }: ListParams<ItemRowFragment>) => {
+      includeNonVisibleWithStockOnHand,
+    }: ListParams<ItemRowFragment> & {
+      includeNonVisibleWithStockOnHand?: boolean;
+    }) => {
       const result = await sdk.itemStockOnHand({
         key: itemParsers.toSortField(sortBy),
         first,
@@ -99,6 +102,7 @@ export const getItemQueries = (sdk: Sdk, storeId: string) => ({
           type: { equalTo: ItemNodeType.Stock },
           isVisible: true,
           isActive: true,
+          hasStockOnHand: includeNonVisibleWithStockOnHand,
         },
       });
 
@@ -153,6 +157,8 @@ export const getItemQueries = (sdk: Sdk, storeId: string) => ({
           ...filterBy,
           isVisible: true,
           isActive: true,
+          // includes non-visible items that have stock on hand
+          hasStockOnHand: true,
         },
       });
 

--- a/client/packages/system/src/Item/api/hooks/useItemStockOnHand/useItemStockOnHand.tsx
+++ b/client/packages/system/src/Item/api/hooks/useItemStockOnHand/useItemStockOnHand.tsx
@@ -5,16 +5,19 @@ type UseItemStockOnHandParams = {
   pagination: { first: number; offset: number };
   filter: { [key: string]: { like: string } };
   preload?: boolean;
+  includeNonVisibleWithStockOnHand?: boolean;
 };
 
 export const useItemStockOnHand = ({
   pagination,
   filter,
+  includeNonVisibleWithStockOnHand,
 }: UseItemStockOnHandParams) => {
   const queryParams = {
     ...pagination,
     filterBy: filter,
     sortBy: { key: 'name', isDesc: false, direction: 'asc' as 'asc' | 'desc' },
+    includeNonVisibleWithStockOnHand,
   };
 
   const api = useItemApi();

--- a/client/packages/system/src/Item/utils.ts
+++ b/client/packages/system/src/Item/utils.ts
@@ -36,6 +36,7 @@ export interface StockItemSearchInputProps
   extends GenericStockItemSearchInputProps {
   onChange: (item: ItemStockOnHandFragment | null) => void;
   extraFilter?: (item: ItemStockOnHandFragment) => boolean;
+  includeNonVisibleWithStockOnHand?: boolean;
 }
 
 export interface StockItemSearchInputWithStatsProps

--- a/server/graphql/general/src/queries/item.rs
+++ b/server/graphql/general/src/queries/item.rs
@@ -45,11 +45,13 @@ pub struct ItemFilterInput {
     pub name: Option<StringFilterInput>,
     pub r#type: Option<EqualFilterItemTypeInput>,
     pub code: Option<StringFilterInput>,
+    /// Items that are visible in this store OR there is available stock of that item in this store
+    pub is_visible_or_on_hand: Option<bool>,
+    /// Items that are visible in this store. This filter is void if `is_visible_or_on_hand` is true
     pub is_visible: Option<bool>,
     pub code_or_name: Option<StringFilterInput>,
     pub is_active: Option<bool>,
     pub is_vaccine: Option<bool>,
-    pub has_stock_on_hand: Option<bool>,
 }
 
 #[derive(Union)]
@@ -98,7 +100,7 @@ impl ItemFilterInput {
             code_or_name,
             is_active,
             is_vaccine,
-            has_stock_on_hand,
+            is_visible_or_on_hand,
         } = self;
 
         ItemFilter {
@@ -110,7 +112,7 @@ impl ItemFilterInput {
             code_or_name: code_or_name.map(StringFilter::from),
             is_active,
             is_vaccine,
-            has_stock_on_hand,
+            is_visible_or_on_hand,
         }
     }
 }

--- a/server/graphql/general/src/queries/item.rs
+++ b/server/graphql/general/src/queries/item.rs
@@ -49,6 +49,7 @@ pub struct ItemFilterInput {
     pub code_or_name: Option<StringFilterInput>,
     pub is_active: Option<bool>,
     pub is_vaccine: Option<bool>,
+    pub has_stock_on_hand: Option<bool>,
 }
 
 #[derive(Union)]
@@ -97,6 +98,7 @@ impl ItemFilterInput {
             code_or_name,
             is_active,
             is_vaccine,
+            has_stock_on_hand,
         } = self;
 
         ItemFilter {
@@ -108,6 +110,7 @@ impl ItemFilterInput {
             code_or_name: code_or_name.map(StringFilter::from),
             is_active,
             is_vaccine,
+            has_stock_on_hand,
         }
     }
 }

--- a/server/repository/src/db_diesel/item.rs
+++ b/server/repository/src/db_diesel/item.rs
@@ -249,8 +249,6 @@ fn create_filtered_query(store_id: String, filter: Option<ItemFilter>) -> BoxedI
             .group_by(item_link_dsl::item_id)
             .into_boxed();
 
-        // MORNING - add me to frontend filters and test me everywhere!
-
         query = match (is_visible, has_stock_on_hand) {
             // visible items AND non-visible items with stock on hand
             (Some(true), Some(true)) => query.filter(

--- a/server/repository/src/db_diesel/stock_line.rs
+++ b/server/repository/src/db_diesel/stock_line.rs
@@ -229,7 +229,6 @@ fn apply_item_filter(
         if let Some(item_code_or_name) = &f.item_code_or_name {
             let mut item_filter = ItemFilter::new();
             item_filter.code_or_name = Some(item_code_or_name.clone());
-            item_filter.is_visible = Some(true);
             item_filter.is_active = Some(true);
             let items = ItemRepository::new(connection)
                 .query_by_filter(item_filter, Some(store_id))

--- a/server/repository/src/db_diesel/stock_on_hand.rs
+++ b/server/repository/src/db_diesel/stock_on_hand.rs
@@ -1,6 +1,6 @@
 use super::{stock_on_hand::stock_on_hand::dsl as stock_on_hand_dsl, StorageConnection};
 
-use crate::{diesel_macros::apply_equal_filter, EqualFilter, RepositoryError};
+use crate::{diesel_macros::apply_equal_filter, item_link, EqualFilter, RepositoryError};
 use diesel::prelude::*;
 
 table! {
@@ -12,6 +12,9 @@ table! {
         available_stock_on_hand -> Double,
     }
 }
+
+joinable!(stock_on_hand -> item_link (item_id));
+allow_tables_to_appear_in_same_query!(item_link, stock_on_hand);
 
 #[derive(Clone, Queryable, Debug, PartialEq)]
 pub struct StockOnHandRow {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4024

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Makes non-visible items available in various places if you have some stock on hand for that item.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

Honestly uncertain about the composition of the filters - typically the filter object is composed as an AND filter, so its a bit funky here to use it as an OR... especially because I can imagine wanting an AND version in future (give me the visible items that have stock on hand.) I tried to make it clear what was happening with comments/naming, but could I do something different?

Per [this comment](https://github.com/msupply-foundation/open-msupply/issues/4024#issuecomment-2185564264) in the issue, I'm not 100% sure where we should/shouldn't include the "invisible items with stock" throughout the app, hasn't been clarified yet, but thought I'd get the implementation in place, using/removing should be trivial. Let me know if you have thoughts on where these items should be seen?

i.e. maybe you actually shouldn't be able to issue items that are invisible to you? But you can see them in stock list/stock take? should you be able to see them in the item list (because you have them) or not because its more of a catalogue list than current state?

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have two stores using two different master lists, with some different items in those master lists
- [ ] From one store, make an Outbound Shipment to the other store, including an item that is not in the master list for that other store (i.e. not visible in the other store)
- [ ] Receive that Inbound Shipment of the invisible item in the receiving store
- [x] Item List: you can now see that item
- [x] View stock: you can now see that stock line - also test that you can still see that item when you use the `item name or code` search! (this was the original bug)
- [x] Outbound shipment: you can issue the item
- [ ] Prescription: you can issue the item
- [x] Outbound return: you can return the item
- [x] Stocktake: you can add this item in your stocktakes
- [ ] internal order: you cannot request this item
- [x] Inbound return: you cannot add this item to an inbound return
- [x] Inbound shipment: you cannot add this item to an inbound shipment


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
