### PR TITLE
4264 demographic growth rates not saving

### DIFF
--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -36,6 +36,7 @@ import {
   endOfWeek,
   setMilliseconds,
   addMilliseconds,
+  getYear,
 } from 'date-fns';
 import { getTimezoneOffset } from 'date-fns-tz';
 
@@ -139,6 +140,7 @@ export const DateUtils = {
   previousMonday,
   endOfWeek,
   setMilliseconds,
+  getCurrentYear: () => getYear(new Date()),
 
   /** Number of milliseconds in one second, i.e. SECOND = 1000*/
   SECOND,

--- a/client/packages/system/src/IndicatorsDemographics/DetailView/IndicatorsDemographics.tsx
+++ b/client/packages/system/src/IndicatorsDemographics/DetailView/IndicatorsDemographics.tsx
@@ -4,6 +4,7 @@ import {
   Box,
   ColumnAlign,
   DataTable,
+  DateUtils,
   RecordPatch,
   TableProvider,
   createTableStore,
@@ -46,7 +47,7 @@ const IndicatorsDemographicsComponent = () => {
   const t = useTranslation();
 
   const { draft, setDraft } = useDemographicData.indicator.list(headerDraft);
-  const baseYear = headerDraft?.baseYear ?? 2024;
+  const baseYear = headerDraft?.baseYear ?? DateUtils.getCurrentYear();
 
   const { data: projection, isLoading: isLoadingProjection } =
     useDemographicData.projection.get(baseYear);

--- a/client/packages/system/src/IndicatorsDemographics/DetailView/IndicatorsDemographics.tsx
+++ b/client/packages/system/src/IndicatorsDemographics/DetailView/IndicatorsDemographics.tsx
@@ -46,14 +46,25 @@ const IndicatorsDemographicsComponent = () => {
   const t = useTranslation();
 
   const { draft, setDraft } = useDemographicData.indicator.list(headerDraft);
-  const { data: projection, isLoading: isLoadingProjection } =
-    useDemographicData.projection.get(draft?.[0]?.baseYear ?? 2024);
+  const baseYear = headerDraft?.baseYear ?? 2024;
 
-  const { insertDemographicIndicator, invalidateQueries } =
-    useDemographicData.indicator.insert();
+  const { data: projection, isLoading: isLoadingProjection } =
+    useDemographicData.projection.get(baseYear);
+
+  const {
+    insertDemographicIndicator,
+    invalidateQueries: invalidateDemographicQueries,
+  } = useDemographicData.indicator.insert();
   const { mutateAsync: updateDemographicIndicator } =
     useDemographicData.indicator.update();
-  const upsertProjection = useDemographicData.projection.upsert();
+
+  const { upsertProjection, invalidateQueries: invalidateProjectionQueries } =
+    useDemographicData.projection.upsert();
+
+  const invalidateQueries = () => {
+    invalidateDemographicQueries();
+    invalidateProjectionQueries(baseYear);
+  };
 
   const handlePopulationChange = (patch: RecordPatch<Row>) => {
     setIsDirty(true);

--- a/client/packages/system/src/IndicatorsDemographics/api/hooks/document/useDemographicProjectionUpsert.ts
+++ b/client/packages/system/src/IndicatorsDemographics/api/hooks/document/useDemographicProjectionUpsert.ts
@@ -1,13 +1,21 @@
+import { useQueryClient } from '@openmsupply-client/common';
 import { DemographicProjectionFragment } from '../../operations.generated';
 import { useDemographicProjectionInsert } from './useDemographicProjectionInsert';
 import { useDemographicProjectionUpdate } from './useDemographicProjectionUpdate';
 import { FnUtils } from '@common/utils';
+import { useDemographicsApi } from '../utils/useDemographicApi';
 
 export const useDemographicProjectionUpsert = () => {
+  const queryClient = useQueryClient();
+  const api = useDemographicsApi();
+
   const { mutateAsync: insert } = useDemographicProjectionInsert();
   const { mutateAsync: update } = useDemographicProjectionUpdate();
 
-  return async (
+  const invalidateQueries = (baseYear: number) =>
+    queryClient.invalidateQueries(api.keys.projection(baseYear));
+
+  const upsertProjection = async (
     projection: Omit<DemographicProjectionFragment, '__typename'>
   ) => {
     if (!projection.id) {
@@ -20,5 +28,10 @@ export const useDemographicProjectionUpsert = () => {
       const result = await update(projection);
       return result;
     }
+  };
+
+  return {
+    upsertProjection,
+    invalidateQueries,
   };
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4264

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Demographics projections (growth rates) weren't being invalidated after save. On the first time you created the demographics, if you hit the save button twice or more before refreshing, it wouldn't know to update - it would try to do another insert (resulting in an error)

This PR invalidates the projections query after upsert of demographics, so second save does an update correctly!

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Reset DB/ensure `demographic_projection` table is empty
- [ ] On central server, go to manage > demographics
- [ ] edit growth rates/add some indicators/edit population - click save multiple times
- [ ] TEST: every save says saved successfully, you do not see the `DemographicProjectitonAlreadyExistsForBaseYear` error
- [ ] Refresh the page/navigate away and come back - indicators and growth rates are all still up to date

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
