### PR TITLE
3738 transfer comment and reference updates

### DIFF
--- a/server/service/src/processors/transfer/invoice/common.rs
+++ b/server/service/src/processors/transfer/invoice/common.rs
@@ -58,6 +58,7 @@ pub(crate) fn generate_inbound_lines(
                     total_after_tax: (cost_price_per_pack * number_of_packs)
                         * (1.0 + tax_percentage.unwrap_or(0.0) / 100.0),
                     cost_price_per_pack,
+                    sell_price_per_pack,
                     r#type: match r#type {
                         InvoiceLineType::Service => InvoiceLineType::Service,
                         _ => InvoiceLineType::StockIn,
@@ -70,7 +71,6 @@ pub(crate) fn generate_inbound_lines(
                     // Default
                     stock_line_id: None,
                     location_id: None,
-                    sell_price_per_pack,
                     inventory_adjustment_reason_id: None,
                 }
             },
@@ -86,6 +86,10 @@ pub(crate) fn convert_invoice_line_to_single_pack(
     invoice_lines
         .into_iter()
         .map(|mut line| {
+            if line.r#type == InvoiceLineType::Service {
+                return line;
+            }
+
             line.number_of_packs *= line.pack_size;
             line.cost_price_per_pack /= line.pack_size;
             line.pack_size = 1.0;

--- a/server/service/src/processors/transfer/invoice/common.rs
+++ b/server/service/src/processors/transfer/invoice/common.rs
@@ -2,6 +2,8 @@ use repository::{EqualFilter, Invoice, InvoiceLineFilter, InvoiceLineRepository,
 use repository::{InvoiceLineRow, RepositoryError, StorageConnection};
 use util::uuid::uuid;
 
+use crate::invoice::common::calculate_total_after_tax;
+
 pub(crate) fn generate_inbound_lines(
     connection: &StorageConnection,
     inbound_invoice_id: &str,
@@ -60,8 +62,7 @@ pub(crate) fn generate_inbound_lines(
                     expiry_date,
                     pack_size,
                     total_before_tax,
-                    total_after_tax: total_before_tax
-                        * (1.0 + tax_percentage.unwrap_or(0.0) / 100.0),
+                    total_after_tax: calculate_total_after_tax(total_before_tax, tax_percentage),
                     cost_price_per_pack,
                     sell_price_per_pack,
                     r#type: match r#type {

--- a/server/service/src/processors/transfer/invoice/test.rs
+++ b/server/service/src/processors/transfer/invoice/test.rs
@@ -876,6 +876,7 @@ impl InvoiceTransferTester {
                 &ctx,
                 inline_init(|r: &mut UpdateOutboundShipment| {
                     r.id.clone_from(&self.outbound_shipment.id);
+                    r.their_reference = Some("some updated reference".to_string());
                     r.status = Some(UpdateOutboundShipmentStatus::Shipped);
                 }),
             )
@@ -896,6 +897,8 @@ impl InvoiceTransferTester {
             inline_edit(&inbound_shipment, |mut r| {
                 r.status = InvoiceStatus::Shipped;
                 r.shipped_datetime = self.outbound_shipment.shipped_datetime;
+                r.their_reference =
+                    Some("From invoice number: 20 (some updated reference)".to_string());
                 r
             })
         );

--- a/server/service/src/processors/transfer/invoice/test.rs
+++ b/server/service/src/processors/transfer/invoice/test.rs
@@ -59,6 +59,10 @@ async fn invoice_transfers() {
         r.id = uuid();
     });
 
+    let service_item = inline_init(|r: &mut ItemRow| {
+        r.id = uuid();
+    });
+
     let site_id_settings = inline_init(|r: &mut KeyValueStoreRow| {
         r.id = KeyType::SettingsSyncSiteId;
         r.value_int = Some(site_id);
@@ -79,7 +83,7 @@ async fn invoice_transfers() {
         inline_init(|r: &mut MockData| {
             r.names = vec![inbound_store_name.clone(), outbound_store_name.clone()];
             r.stores = vec![inbound_store.clone(), outbound_store.clone()];
-            r.items = vec![item1.clone(), item2.clone()];
+            r.items = vec![item1.clone(), item2.clone(), service_item.clone()];
             r.key_value_store_rows = vec![site_id_settings];
         }),
     )
@@ -93,6 +97,7 @@ async fn invoice_transfers() {
         outbound_store_name,
         item1,
         item2,
+        service_item,
     );
 
     let number_of_instances = 6;
@@ -109,6 +114,7 @@ async fn invoice_transfers() {
                 outbound_store_name,
                 item1,
                 item2,
+                service_item,
             ) = test_input;
 
             let ctx = service_provider.basic_context().unwrap();
@@ -121,6 +127,7 @@ async fn invoice_transfers() {
                 Some(&inbound_store_name),
                 &item1,
                 &item2,
+                &service_item,
             );
 
             tester.insert_request_requisition(&service_provider).await;
@@ -187,6 +194,7 @@ async fn invoice_transfers() {
                 Some(&inbound_store_name),
                 &item1,
                 &item2,
+                &service_item,
             );
 
             // Setup: create requisition
@@ -211,6 +219,7 @@ async fn invoice_transfers() {
                 Some(&inbound_store_name),
                 &item1,
                 &item2,
+                &service_item,
             );
             // Setup: create shipment
             tester.insert_request_requisition(&service_provider).await;
@@ -283,6 +292,10 @@ async fn invoice_transfers_with_merged_name() {
         r.id = uuid();
     });
 
+    let service_item = inline_init(|r: &mut ItemRow| {
+        r.id = uuid();
+    });
+
     let site_id_settings = inline_init(|r: &mut KeyValueStoreRow| {
         r.id = KeyType::SettingsSyncSiteId;
         r.value_int = Some(site_id);
@@ -307,7 +320,7 @@ async fn invoice_transfers_with_merged_name() {
                 merge_name.clone(),
             ];
             r.stores = vec![inbound_store.clone(), outbound_store.clone()];
-            r.items = vec![item1.clone(), item2.clone()];
+            r.items = vec![item1.clone(), item2.clone(), service_item.clone()];
             r.key_value_store_rows = vec![site_id_settings];
             r.name_links = vec![merge_name_link.clone()] // name_link is processed after the names. Updates the existing name link created for the name, effectively merging it.
         }),
@@ -322,6 +335,7 @@ async fn invoice_transfers_with_merged_name() {
         outbound_store_name,
         item1,
         item2,
+        service_item,
     );
     let number_of_instances = 6;
 
@@ -337,6 +351,7 @@ async fn invoice_transfers_with_merged_name() {
                 outbound_store_name,
                 item1,
                 item2,
+                service_item,
             ) = test_input;
 
             let ctx = service_provider.basic_context().unwrap();
@@ -349,6 +364,7 @@ async fn invoice_transfers_with_merged_name() {
                 Some(&merge_name),
                 &item1,
                 &item2,
+                &service_item,
             );
 
             // SHIPMENT
@@ -412,6 +428,7 @@ async fn invoice_transfers_with_merged_name() {
                 Some(&merge_name),
                 &item1,
                 &item2,
+                &service_item,
             );
 
             // Setup: create requisition
@@ -436,6 +453,7 @@ async fn invoice_transfers_with_merged_name() {
                 Some(&merge_name),
                 &item1,
                 &item2,
+                &service_item,
             );
 
             // Setup: create shipment
@@ -472,6 +490,7 @@ pub(crate) struct InvoiceTransferTester {
     outbound_shipment_line1: InvoiceLineRow,
     outbound_shipment_line2: InvoiceLineRow,
     outbound_shipment_unallocated_line: InvoiceLineRow,
+    outbound_shipment_service_line: InvoiceLineRow,
     outbound_return_line: InvoiceLineRow,
     outbound_return: InvoiceRow,
     outbound_shipment: InvoiceRow,
@@ -489,6 +508,7 @@ impl InvoiceTransferTester {
         inbound_name: Option<&NameRow>,
         item1: &ItemRow,
         item2: &ItemRow,
+        service_item: &ItemRow,
     ) -> InvoiceTransferTester {
         let request_requisition = inline_init(|r: &mut RequisitionRow| {
             r.id = uuid();
@@ -575,6 +595,19 @@ impl InvoiceTransferTester {
             // Location todo
         });
 
+        let outbound_shipment_service_line = inline_init(|r: &mut InvoiceLineRow| {
+            r.id = uuid();
+            r.invoice_id.clone_from(&outbound_shipment.id);
+            r.r#type = InvoiceLineType::Service;
+            r.item_link_id.clone_from(&service_item.id);
+            r.item_name.clone_from(&service_item.name);
+            r.item_code.clone_from(&service_item.code);
+            r.total_before_tax = 100.0;
+            r.total_after_tax = 110.0;
+            r.tax_percentage = Some(10.0);
+            // Location todo
+        });
+
         let outbound_shipment_unallocated_line = inline_init(|r: &mut InvoiceLineRow| {
             r.id = uuid();
             r.invoice_id.clone_from(&outbound_shipment.id);
@@ -626,6 +659,7 @@ impl InvoiceTransferTester {
             outbound_shipment_line1,
             outbound_shipment_line2,
             outbound_shipment_unallocated_line,
+            outbound_shipment_service_line,
             outbound_return_line,
             outbound_return,
             outbound_shipment,
@@ -687,6 +721,7 @@ impl InvoiceTransferTester {
                 r.invoice_lines = vec![
                     self.outbound_shipment_line1.clone(),
                     self.outbound_shipment_line2.clone(),
+                    self.outbound_shipment_service_line.clone(),
                 ]
             })
             .join(self.extra_mock_data.clone()),
@@ -782,7 +817,7 @@ impl InvoiceTransferTester {
                         .invoice_id(EqualFilter::equal_to(&inbound_shipment.id))
                 ))
                 .unwrap(),
-            2
+            3
         );
 
         check_line(
@@ -794,6 +829,11 @@ impl InvoiceTransferTester {
             connection,
             &inbound_shipment.id,
             &self.outbound_shipment_line2,
+        );
+        check_line(
+            connection,
+            &inbound_shipment.id,
+            &self.outbound_shipment_service_line,
         );
     }
 
@@ -910,13 +950,18 @@ impl InvoiceTransferTester {
                         .invoice_id(EqualFilter::equal_to(&inbound_shipment.id))
                 ))
                 .unwrap(),
-            1
+            2
         );
 
         check_line(
             connection,
             &inbound_shipment.id,
             &self.outbound_shipment_line2,
+        );
+        check_line(
+            connection,
+            &inbound_shipment.id,
+            &self.outbound_shipment_service_line,
         );
 
         self.inbound_shipment = Some(inbound_shipment)
@@ -1272,18 +1317,35 @@ fn check_line(connection: &StorageConnection, inbound_id: &str, outbound_line: &
     assert_eq!(inbound_line.pack_size, outbound_line.pack_size);
     assert_eq!(inbound_line.number_of_packs, outbound_line.number_of_packs);
     assert_eq!(inbound_line.note, outbound_line.note);
-    assert_eq!(inbound_line.r#type, InvoiceLineType::StockIn);
+
+    match outbound_line.r#type {
+        InvoiceLineType::Service => {
+            assert_eq!(inbound_line.r#type, InvoiceLineType::Service);
+            assert_eq!(
+                inbound_line.total_before_tax,
+                outbound_line.total_before_tax
+            );
+            assert_approx_eq::assert_approx_eq!(
+                inbound_line.total_after_tax,
+                outbound_line.total_after_tax
+            );
+        }
+        _ => {
+            assert_eq!(inbound_line.r#type, InvoiceLineType::StockIn);
+            assert_eq!(
+                inbound_line.total_before_tax,
+                outbound_line.sell_price_per_pack * outbound_line.number_of_packs
+            );
+            assert_eq!(
+                inbound_line.total_after_tax,
+                outbound_line.sell_price_per_pack * outbound_line.number_of_packs
+            );
+        }
+    }
+
     assert_eq!(
         inbound_line.cost_price_per_pack,
         outbound_line.sell_price_per_pack
-    );
-    assert_eq!(
-        inbound_line.total_before_tax,
-        outbound_line.sell_price_per_pack * outbound_line.number_of_packs
-    );
-    assert_eq!(
-        inbound_line.total_after_tax,
-        outbound_line.sell_price_per_pack * outbound_line.number_of_packs
     );
     assert_eq!(inbound_line.stock_line_id, None);
     assert_eq!(inbound_line.location_id, None);
@@ -1291,5 +1353,5 @@ fn check_line(connection: &StorageConnection, inbound_id: &str, outbound_line: &
         inbound_line.sell_price_per_pack,
         outbound_line.sell_price_per_pack
     );
-    assert_eq!(inbound_line.tax_percentage, None);
+    assert_eq!(inbound_line.tax_percentage, outbound_line.tax_percentage);
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3738

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Ended up fixing a few things!

The issue: comments/references weren't being transferred on update (only on insert). I.e. if you set these things before setting outbound to picked, they were transferred, but if you update them between picked and shipped, the changes do not map through. I also updated transport reference and tax percentage to transfer through on updates as well.

THEN I found a few bugs along the way, which honestly, I'm not sure how we didn't find them before??

- Service charge lines have no cost price per pack, nor pack size... so when running `convert_invoice_to_single_pack`, we would end up with a `NaN` and transfers stopped working completely?!
- Transferred service charge totals were showing as 0, becuase they were being calculated as `cost_price_per_pack * number_of_packs` ... both of which were 0 😁 

So added some logic around service lines 😅 

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

Would appreciate a double check on the logic/if I've transferred anything that we actually don't want to be? I don't think I have but 🙏 

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an outbound shipment
- [ ] Add a comment/reference/transport reference/some service charge etc
- [ ] Set to picked
- [ ] Log in to receiving store
- [x] All the above mapped through correctly
- [ ] Go back to sending store, update all those fields to something else
- [ ] Set to shipped
- [ ] Go back to receiving store
- [x] All your changes are reflected

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
