### PR TITLE
3859 Upsert sync buffer in transaction

### DIFF
--- a/server/service/src/sync/api/common_records.rs
+++ b/server/service/src/sync/api/common_records.rs
@@ -67,7 +67,7 @@ pub(crate) struct ParsingSyncRecordError {
 }
 
 impl CommonSyncRecord {
-    pub(crate) fn to_buffer_row(
+    fn to_buffer_row(
         self,
         source_site_id: Option<i32>,
     ) -> Result<SyncBufferRow, ParsingSyncRecordError> {
@@ -100,18 +100,17 @@ impl CommonSyncRecord {
             source_site_id,
         })
     }
+
+    pub(crate) fn to_buffer_rows(
+        rows: Vec<CommonSyncRecord>,
+    ) -> Result<Vec<SyncBufferRow>, ParsingSyncRecordError> {
+        rows.into_iter().map(|r| r.to_buffer_row(None)).collect()
+    }
 }
 
 impl RemoteSyncBatchV5 {
     pub(crate) fn extract_sync_ids(&self) -> Vec<String> {
         self.data.iter().map(|r| r.sync_id.clone()).collect()
-    }
-
-    pub(crate) fn to_sync_buffer_rows(self) -> Result<Vec<SyncBufferRow>, ParsingSyncRecordError> {
-        self.data
-            .into_iter()
-            .map(|r| r.record.to_buffer_row(None))
-            .collect()
     }
 }
 
@@ -153,72 +152,56 @@ mod tests {
     }
 
     #[actix_rt::test]
-    async fn test_remote_sync_batch_v5_to_sync_buffer_rows() {
-        let batch = RemoteSyncBatchV5 {
-            queue_length: 0,
-            data: vec![
-                RemoteSyncRecordV5 {
-                    sync_id: "test1".to_string(),
-                    record: CommonSyncRecord {
-                        table_name: "item".to_string(),
-                        record_id: "itemA".to_string(),
-                        action: SyncAction::Insert,
-                        record_data: json!({
-                            "ID": "itemA",
-                            "item_name": "itemA",
-                            "code": "itemA",
-                            "unit_ID": "",
-                            "type_of": "general",
-                            "default_pack_size": 1,
-                        }),
-                    },
-                },
-                RemoteSyncRecordV5 {
-                    sync_id: "test2".to_string(),
-                    record: CommonSyncRecord {
-                        table_name: "item".to_string(),
-                        record_id: "itemA".to_string(),
-                        action: SyncAction::Update,
-                        record_data: json!({
-                            "ID": "itemA",
-                            "item_name": "itemA",
-                            "code": "itemA",
-                            "unit_ID": "",
-                            "type_of": "general",
-                            "default_pack_size": 1,
-                        }),
-                    },
-                },
-                RemoteSyncRecordV5 {
-                    sync_id: "test3".to_string(),
-                    record: CommonSyncRecord {
-                        table_name: "item".to_string(),
-                        record_id: "itemB".to_string(),
-                        action: SyncAction::Insert,
-                        record_data: json!({
-                            "ID": "itemB",
-                            "item_name": "itemB",
-                            "code": "itemB",
-                            "unit_ID": "",
-                            "type_of": "general",
-                            "default_pack_size": 1,
-                        }),
-                    },
-                },
-                RemoteSyncRecordV5 {
-                    sync_id: "test4".to_string(),
-                    record: CommonSyncRecord {
-                        table_name: "item".to_string(),
-                        record_id: "itemA".to_string(),
-                        action: SyncAction::Merge,
-                        record_data: json!({
-                            "mergeIdToKeep": "itemA", "mergeIdToDelete": "itemB"
-                        }),
-                    },
-                },
-            ],
-        }
-        .to_sync_buffer_rows()
+    async fn test_common_records_to_sync_buffer_rows() {
+        let batch = CommonSyncRecord::to_buffer_rows(vec![
+            CommonSyncRecord {
+                table_name: "item".to_string(),
+                record_id: "itemA".to_string(),
+                action: SyncAction::Insert,
+                record_data: json!({
+                    "ID": "itemA",
+                    "item_name": "itemA",
+                    "code": "itemA",
+                    "unit_ID": "",
+                    "type_of": "general",
+                    "default_pack_size": 1,
+                }),
+            },
+            CommonSyncRecord {
+                table_name: "item".to_string(),
+                record_id: "itemA".to_string(),
+                action: SyncAction::Update,
+                record_data: json!({
+                    "ID": "itemA",
+                    "item_name": "itemA",
+                    "code": "itemA",
+                    "unit_ID": "",
+                    "type_of": "general",
+                    "default_pack_size": 1,
+                }),
+            },
+            CommonSyncRecord {
+                table_name: "item".to_string(),
+                record_id: "itemB".to_string(),
+                action: SyncAction::Insert,
+                record_data: json!({
+                    "ID": "itemB",
+                    "item_name": "itemB",
+                    "code": "itemB",
+                    "unit_ID": "",
+                    "type_of": "general",
+                    "default_pack_size": 1,
+                }),
+            },
+            CommonSyncRecord {
+                table_name: "item".to_string(),
+                record_id: "itemA".to_string(),
+                action: SyncAction::Merge,
+                record_data: json!({
+                    "mergeIdToKeep": "itemA", "mergeIdToDelete": "itemB"
+                }),
+            },
+        ])
         .unwrap();
 
         let (_, connection, _, _) = setup_all(

--- a/server/service/src/sync/central_data_synchroniser_v6.rs
+++ b/server/service/src/sync/central_data_synchroniser_v6.rs
@@ -119,7 +119,7 @@ impl SynchroniserV6 {
                     cursor_controller.update(t_con, last_cursor_in_batch + 1)
                 })
                 .map_err(|e| e.to_inner_error())?;
-
+            // TODO it's likely that above update to cursor is redundant, this comment is to record this observation in a PR https://github.com/msupply-foundation/open-msupply/pull/4283/files/ac66350bc5aee585a10c2a8450e8d2abeffc527b#r1656344877
             cursor_controller.update(connection, end_cursor + 1)?;
 
             if is_last_batch {

--- a/server/service/src/sync/central_data_synchroniser_v6.rs
+++ b/server/service/src/sync/central_data_synchroniser_v6.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 use super::{
-    api::{ParsingSyncRecordError, SyncApiSettings},
+    api::{CommonSyncRecord, ParsingSyncRecordError, SyncApiSettings},
     api_v6::{SyncApiErrorV6, SyncApiV6, SyncApiV6CreatingError},
     get_sync_push_changelogs_filter,
     sync_status::logger::{SyncLogger, SyncLoggerError},
@@ -20,8 +20,7 @@ use super::{
 };
 
 use repository::{
-    ChangelogRepository, KeyType, RepositoryError, StorageConnection, SyncBufferRow,
-    SyncBufferRowRepository,
+    ChangelogRepository, KeyType, RepositoryError, StorageConnection, SyncBufferRowRepository,
 };
 use thiserror::Error;
 
@@ -96,25 +95,30 @@ impl SynchroniserV6 {
         let cursor_controller = CursorController::new(KeyType::SyncPullCursorV6);
         // TODO protection from infinite loop
         loop {
-            let cursor = cursor_controller.get(connection)?;
+            let start_cursor = cursor_controller.get(connection)?;
 
             let SyncBatchV6 {
                 end_cursor,
                 total_records,
-                records,
                 is_last_batch,
+                records,
             } = self
                 .sync_api_v6
-                .pull(cursor, batch_size, is_initialised)
+                .pull(start_cursor, batch_size, is_initialised)
                 .await?;
 
             logger.progress(SyncStepProgress::PullCentralV6, total_records)?;
 
-            for SyncRecordV6 { cursor, record } in records {
-                let buffer_row = record.to_buffer_row(None)?;
-
-                insert_one_and_update_cursor(connection, &cursor_controller, &buffer_row, cursor)?;
-            }
+            let last_cursor_in_batch = records.last().map(|r| r.cursor).unwrap_or(start_cursor);
+            let sync_buffer_rows =
+                CommonSyncRecord::to_buffer_rows(records.into_iter().map(|r| r.record).collect())?;
+            // Upsert sync buffer rows in a transaction together with cursor update
+            connection
+                .transaction_sync(|t_con| {
+                    SyncBufferRowRepository::new(t_con).upsert_many(&sync_buffer_rows)?;
+                    cursor_controller.update(t_con, last_cursor_in_batch + 1)
+                })
+                .map_err(|e| e.to_inner_error())?;
 
             cursor_controller.update(connection, end_cursor + 1)?;
 
@@ -217,18 +221,4 @@ impl SynchroniserV6 {
 
         Ok(())
     }
-}
-
-fn insert_one_and_update_cursor(
-    connection: &StorageConnection,
-    cursor_controller: &CursorController,
-    row: &SyncBufferRow,
-    cursor: u64,
-) -> Result<(), RepositoryError> {
-    connection
-        .transaction_sync(|con| {
-            SyncBufferRowRepository::new(con).upsert_one(row)?;
-            cursor_controller.update(con, cursor + 1)
-        })
-        .map_err(|e| e.to_inner_error())
 }

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -130,23 +130,32 @@ impl RemoteDataSynchroniser {
         logger: &mut SyncLogger<'a>,
     ) -> Result<(), RemotePullError> {
         let step_progress = SyncStepProgress::PullRemote;
-        let sync_buffer_repository = SyncBufferRowRepository::new(connection);
 
         loop {
             let sync_batch = self.sync_api_v5.get_queued_records(batch_size).await?;
 
             // queued_length is number of remote pull records awaiting acknowledgement
             // at this point it's number of records waiting to be pulled including records in this pull batch
-            let remaining = sync_batch.queue_length;
+
             let sync_ids = sync_batch.extract_sync_ids();
-            let sync_buffer_rows = sync_batch.to_sync_buffer_rows()?;
+            let RemoteSyncBatchV5 {
+                queue_length: remaining,
+                data,
+            } = sync_batch;
+
+            let sync_buffer_rows =
+                CommonSyncRecord::to_buffer_rows(data.into_iter().map(|r| r.record).collect())?;
 
             let number_of_pulled_records = sync_buffer_rows.len() as u64;
 
             logger.progress(step_progress.clone(), remaining)?;
 
             if number_of_pulled_records > 0 {
-                sync_buffer_repository.upsert_many(&sync_buffer_rows)?;
+                connection
+                    .transaction_sync(|t_con| {
+                        SyncBufferRowRepository::new(t_con).upsert_many(&sync_buffer_rows)
+                    })
+                    .map_err(|e| e.to_inner_error())?;
 
                 self.sync_api_v5.post_acknowledged_records(sync_ids).await?;
             } else {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3859 

# 👩🏻‍💻 What does this PR do?

Add transaction around all sync buffer upserts. 

I've been trying to test the speed of this, but my local og server is inconsistent (consecutive re-sync take anywhere from 50seconds to 3minutes, with both transaction and non transaction sync buffer upserts).

There was however some research done into this, and it was tested that transactions improve SQlite mutations quite a bit: 

https://github.com/msupply-foundation/open-msupply/blob/d60c38e945c07c70850740ea1a83d0cf7bd68bd1/server/service/src/sync/translation_and_integration.rs#L324C1-L327C71

## 💌 Any notes for the reviewer?

Sorry the change could have been smaller, but i deliberately changed the cursors naming from cursor (for both start and current) to start_cursor and end_cursor

# 🧪 Testing

Should be captured by unit tests and normal sync tests

# 📃 Documentation

No docs required