### PR TITLE
remove selection column for remote sites

### DIFF
--- a/client/packages/system/src/Asset/ListView/ListView.tsx
+++ b/client/packages/system/src/Asset/ListView/ListView.tsx
@@ -9,6 +9,8 @@ import {
   useUrlQueryParams,
   TooltipTextCell,
   useToggle,
+  useIsCentralServerApi,
+  ColumnDescription,
 } from '@openmsupply-client/common';
 import { AssetCatalogueItemFragment, useAssetData } from '../api';
 import { Toolbar } from './Toolbar';
@@ -16,6 +18,8 @@ import { AppBarButtons } from './AppBarButtons';
 import { AssetCatalogueItemImportModal } from '../ImportCatalogueItem';
 
 const AssetListComponent: FC = () => {
+  const isCentralServer = useIsCentralServerApi();
+
   const {
     updateSortQuery,
     updatePaginationQuery,
@@ -36,47 +40,50 @@ const AssetListComponent: FC = () => {
   const t = useTranslation('catalogue');
   const importModalController = useToggle();
 
+  const columnDescriptions: ColumnDescription<AssetCatalogueItemFragment>[] = [
+    {
+      key: 'subCatalogue',
+      label: 'label.sub-catalogue',
+      sortable: true,
+      width: 165,
+    },
+    ['code', { width: 150 }],
+    {
+      key: 'type',
+      label: 'label.type',
+      sortable: false,
+      accessor: ({ rowData }) => rowData.assetType?.name,
+    },
+    {
+      key: 'manufacturer',
+      Cell: TooltipTextCell,
+      width: 300,
+      label: 'label.manufacturer',
+    },
+    {
+      Cell: TooltipTextCell,
+      key: 'model',
+      label: 'label.model',
+      width: 200,
+    },
+    {
+      key: 'class',
+      label: 'label.class',
+      sortable: false,
+      accessor: ({ rowData }) => rowData.assetClass?.name,
+    },
+    {
+      key: 'category',
+      label: 'label.category',
+      sortable: false,
+      accessor: ({ rowData }) => rowData.assetCategory?.name,
+    },
+  ];
+
+  if (isCentralServer) columnDescriptions.push('selection');
+
   const columns = useColumns<AssetCatalogueItemFragment>(
-    [
-      {
-        key: 'subCatalogue',
-        label: 'label.sub-catalogue',
-        sortable: true,
-        width: 165,
-      },
-      ['code', { width: 150 }],
-      {
-        key: 'type',
-        label: 'label.type',
-        sortable: false,
-        accessor: ({ rowData }) => rowData.assetType?.name,
-      },
-      {
-        key: 'manufacturer',
-        Cell: TooltipTextCell,
-        width: 300,
-        label: 'label.manufacturer',
-      },
-      {
-        Cell: TooltipTextCell,
-        key: 'model',
-        label: 'label.model',
-        width: 200,
-      },
-      {
-        key: 'class',
-        label: 'label.class',
-        sortable: false,
-        accessor: ({ rowData }) => rowData.assetClass?.name,
-      },
-      {
-        key: 'category',
-        label: 'label.category',
-        sortable: false,
-        accessor: ({ rowData }) => rowData.assetCategory?.name,
-      },
-      'selection',
-    ],
+    columnDescriptions,
     {
       sortBy,
       onChangeSortBy: updateSortQuery,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4286

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

For all sites except central server, hide the select column in asset catalogue: 

<img width="1710" alt="Screenshot 2024-06-26 at 6 12 52 PM" src="https://github.com/msupply-foundation/open-msupply/assets/55115239/4750a10b-4260-4cbb-a965-391a52bccbd0">


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] On central server, catalogue > assets, you can see the select column
- [ ] On remote site, catalogue > assets, you CANNOT see the select column

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
