### PR TITLE
Create empty plugin folder if doesn't exist on expected path

### DIFF
--- a/server/service/src/plugin/plugin_files.rs
+++ b/server/service/src/plugin/plugin_files.rs
@@ -50,6 +50,7 @@ impl PluginFileService {
     ) -> anyhow::Result<Vec<PluginFile>> {
         let mut files = Vec::new();
         let plugin_base_dir = get_plugin_dir(base_dir)?;
+        validate_dir_or_create(plugin_base_dir.clone())?;
         let paths = fs::read_dir(plugin_base_dir)?;
 
         for plugin_dir in paths {
@@ -89,6 +90,14 @@ fn get_plugin_dir(base_dir: &Option<String>) -> Result<PathBuf, anyhow::Error> {
         Some(file_dir) => PathBuf::from_str(file_dir)?.join(PLUGIN_FILE_DIR),
         None => PathBuf::from_str(PLUGIN_FILE_DIR)?,
     })
+}
+
+fn validate_dir_or_create(dir_path: PathBuf) -> Result<(), anyhow::Error> {
+    if let Ok(false) = dir_path.try_exists() {
+        println!("Creating new dir...");
+        fs::create_dir(dir_path)?;
+    }
+    Ok(())
 }
 
 fn read_plugin_file(


### PR DESCRIPTION
Fixes #3873 

# 👩🏻‍💻 What does this PR do?

Creates a new empty plugin folder if this doesn't exist in the expected plugins folder location.

## 💌 Any notes for the reviewer?

You can test this by deleting the plugin folder from app_data (or wherever you're saving plugins), and refreshing the web page. 

OMS will not longer throw errors due to no plugin folder, and will create an empty folder.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
