### PR TITLE
4287 Rename the necessary dropdown fields into 'Actions' instead of 'Select'

### DIFF
--- a/client/packages/invoices/src/Returns/InboundListView/Toolbar.tsx
+++ b/client/packages/invoices/src/Returns/InboundListView/Toolbar.tsx
@@ -53,7 +53,7 @@ export const Toolbar: FC<{ filter: FilterController }> = () => {
           ]}
         />
       </Box>
-      <DropdownMenu label="Select">
+      <DropdownMenu label={t('label.actions')}>
         <DropdownMenuItem IconComponent={DeleteIcon} onClick={onDelete}>
           {t('button.delete-lines')}
         </DropdownMenuItem>

--- a/client/packages/invoices/src/Returns/OutboundListView/Toolbar.tsx
+++ b/client/packages/invoices/src/Returns/OutboundListView/Toolbar.tsx
@@ -55,7 +55,7 @@ export const Toolbar: FC<{ filter: FilterController }> = () => {
           ]}
         />
       </Box>
-      <DropdownMenu label="Select">
+      <DropdownMenu label={t('label.actions')}>
         <DropdownMenuItem IconComponent={DeleteIcon} onClick={onDelete}>
           {t('button.delete-lines')}
         </DropdownMenuItem>

--- a/client/packages/system/src/Item/DetailView/Tabs/PackVariants.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/PackVariants.tsx
@@ -80,7 +80,7 @@ const PackVariantTable: FC<{ itemId: string }> = ({ itemId }) => {
           }
         />
         <DropdownMenu
-          label="Select"
+          label={t('label.actions')}
           sx={{ visibility: isEmpty ? 'hidden' : 'visible' }}
         >
           <DropdownMenuItem


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4287

# 👩🏻‍💻 What does this PR do?
Replace hardcoded select with translated actions in selection.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to returns (Inbound or outbound)
- [ ] See that Select now says Actions

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Return screenshots, maybe wording near those screenshots too? 
  2.
