### PR TITLE
4235 non-central stores should only see their assets

### DIFF
--- a/client/packages/coldchain/src/Equipment/api/api.ts
+++ b/client/packages/coldchain/src/Equipment/api/api.ts
@@ -97,19 +97,21 @@ export const getAssetQueries = (sdk: Sdk, storeId: string) => ({
 
       throw new Error('Asset not found');
     },
-    list: async ({
-      first,
-      offset,
-      sortBy,
-      filterBy,
-    }: ListParams<AssetFragment>) => {
+    list: async (
+      { first, offset, sortBy, filterBy }: ListParams<AssetFragment>,
+      storeCode?: string
+    ) => {
       const result = await sdk.assets({
         first,
         offset,
         key: assetParsers.toSortField(sortBy),
         desc: sortBy.isDesc,
         storeId,
-        filter: { ...filterBy, classId: { equalTo: CCE_CLASS_ID } },
+        filter: {
+          ...filterBy,
+          ...(storeCode ? { store: { equalTo: storeCode } } : {}),
+          classId: { equalTo: CCE_CLASS_ID },
+        },
       });
 
       const items = result?.assets;

--- a/client/packages/coldchain/src/Equipment/api/hooks/document/useAssets.ts
+++ b/client/packages/coldchain/src/Equipment/api/hooks/document/useAssets.ts
@@ -1,7 +1,15 @@
-import { useQuery, useUrlQueryParams } from '@openmsupply-client/common';
+import {
+  useAuthContext,
+  useIsCentralServerApi,
+  useQuery,
+  useUrlQueryParams,
+} from '@openmsupply-client/common';
 import { useAssetApi } from '../utils/useAssetApi';
 
 export const useAssets = () => {
+  const isCentralServer = useIsCentralServerApi();
+  const { store } = useAuthContext();
+
   const { queryParams } = useUrlQueryParams({
     filters: [
       { key: 'notes' },
@@ -17,8 +25,11 @@ export const useAssets = () => {
       { key: 'functionalStatus', condition: 'equalTo' },
     ],
   });
+
+  const storeCodeFilter = isCentralServer ? undefined : store?.code;
+
   const api = useAssetApi();
   return useQuery(api.keys.paramList(queryParams), () =>
-    api.get.list(queryParams)
+    api.get.list(queryParams, storeCodeFilter)
   );
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4235

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

On remote sites, you could see assets for all the stores at that site.

This fix restricts that to only the store you are logged in to.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a remote site with at least two stores (both with vaccine module enabled)
- [ ] On one store, add some cold chain assets
- [ ] log in to the other store 
- [ ] You CANNOT see the assets from the first store
- [ ] Log into central
- [ ] You can still see the assets for all stores

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
