### PR TITLE
Facility list house icon

### DIFF
--- a/client/packages/system/src/IndicatorsDemographics/DetailView/GrowthRow.tsx
+++ b/client/packages/system/src/IndicatorsDemographics/DetailView/GrowthRow.tsx
@@ -143,7 +143,7 @@ const GrowthInput = ({
   return (
     <NumericTextInput
       value={buffer}
-      decimalLimit={2}
+      decimalLimit={4}
       decimalMin={1}
       allowNegative
       endAdornment="%"

--- a/client/packages/system/src/IndicatorsDemographics/DetailView/PercentageColumn.tsx
+++ b/client/packages/system/src/IndicatorsDemographics/DetailView/PercentageColumn.tsx
@@ -12,7 +12,7 @@ const PercentageCell = (props: CellProps<Row>) => (
   <NumberInputCell
     {...props}
     max={100}
-    decimalLimit={2}
+    decimalLimit={4}
     isDisabled={props.isDisabled || props.rowData.id === GENERAL_POPULATION_ID}
     TextInputProps={{
       InputProps: {

--- a/client/packages/system/src/Name/ListView/Facilities/ListView.tsx
+++ b/client/packages/system/src/Name/ListView/Facilities/ListView.tsx
@@ -9,9 +9,9 @@ import {
   DotCell,
   ColumnAlign,
   useEditModal,
+  TooltipTextCell,
 } from '@openmsupply-client/common';
 import { useName, NameRowFragment } from '../../api';
-import { NameRenderer } from '../../Components';
 import { Toolbar } from './Toolbar';
 import { FacilityEditModal } from './FacilityEditModal';
 
@@ -38,9 +38,7 @@ const FacilitiesListComponent = () => {
       {
         key: 'code',
         label: 'label.code',
-        Cell: ({ rowData }) => (
-          <NameRenderer label={rowData.code} isStore={!!rowData.store} />
-        ),
+        Cell: TooltipTextCell,
         width: 100,
       },
       'name',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4270

# 👩🏻‍💻 What does this PR do?
Removes the 'house' icon from the facility list - as all records in the list are stores, the icon simply adds confusion.

Offroad request: increase the number of decimal places in the demographic entry screen from 2 to 4 which might avoid one of the [numeric text input issues](https://github.com/msupply-foundation/open-msupply/issues/4213)

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] check that the facility list view looks ok
- [ ] try to enter values into the numeric text inputs on the demographic indicator page

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
