### PR TITLE
3947 stock line changes from stocktake not captured in activity log

### DIFF
--- a/client/packages/common/src/ui/icons/BarChart2.tsx
+++ b/client/packages/common/src/ui/icons/BarChart2.tsx
@@ -7,7 +7,7 @@ export const BarChart2Icon = (props: SvgIconProps): JSX.Element => {
       {...props}
       viewBox="0 0 24 24"
       stroke="currentColor"
-      stroke-width="2"
+      strokeWidth="2"
     >
       <line x1="18" y1="20" x2="18" y2="10"></line>
       <line x1="12" y1="20" x2="12" y2="4"></line>

--- a/server/service/src/demographic/insert_demographic_indicator.rs
+++ b/server/service/src/demographic/insert_demographic_indicator.rs
@@ -59,7 +59,7 @@ pub fn validate(
 ) -> Result<(), InsertDemographicIndicatorError> {
     match &input.name {
         Some(name) => {
-            if !check_year_name_combination_unique(&name, input.base_year, None, connection)? {
+            if !check_year_name_combination_unique(name, input.base_year, None, connection)? {
                 return Err(
                     InsertDemographicIndicatorError::DemographicIndicatorAlreadyExistsForThisYear,
                 );

--- a/server/service/src/stocktake/update.rs
+++ b/server/service/src/stocktake/update.rs
@@ -276,6 +276,8 @@ fn generate_stock_in_out_or_update(
         .sell_price_per_pack
         .unwrap_or(stock_line_row.sell_price_per_pack);
 
+    log_stock_changes(ctx, stock_line_row.clone(), row.clone())?;
+
     // If no change in stock quantity, we just update the stock line (no inventory adjustment)
     if delta == 0.0 {
         let updated_stock_line = StockLineRow {
@@ -304,8 +306,6 @@ fn generate_stock_in_out_or_update(
         invoice_line_id.clone(),
         row.inventory_adjustment_reason_id.clone(),
     );
-
-    log_stock_changes(ctx, stock_line_row.clone(), row.clone())?;
 
     let stock_in_or_out_line = if delta > 0.0 {
         StockChange::StockIn(InsertStockInLine {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3947

# 👩🏻‍💻 What does this PR do?
Logs stocktake changes to stock line... also found a couple bugs along the way. I did the changes on finalised since the stocktake lines get pruned when they are finalised and any changes to stock line that hasn't been counted will be reverted....

The stock line doesn't get invalidated when updating stocktake...

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a stocktake
- [ ] Change the details of a stock line (must count stock as well)
- [ ] Finalise
- [ ] Go to Stock Log (Should see changes have been logged)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
