### PR TITLE
4280 tax displays incorrectly on totals below $1 in outbound shipments

### DIFF
--- a/client/packages/common/src/utils/pricing/PricingUtils.ts
+++ b/client/packages/common/src/utils/pricing/PricingUtils.ts
@@ -5,8 +5,9 @@ export const PricingUtils = {
     return Math.max(total - subtotal, 0);
   },
   effectiveTax: (subtotal: number, total: number) => {
+    const taxAmount = PricingUtils.taxAmount(subtotal, total);
     return (
-      Math.round(((total - subtotal) / subtotal) * 100 * ROUNDING_PRECISION) /
+      Math.round((taxAmount / (subtotal || 1)) * 100 * ROUNDING_PRECISION) /
       ROUNDING_PRECISION
     );
   },

--- a/client/packages/common/src/utils/pricing/PricingUtils.ts
+++ b/client/packages/common/src/utils/pricing/PricingUtils.ts
@@ -5,11 +5,9 @@ export const PricingUtils = {
     return Math.max(total - subtotal, 0);
   },
   effectiveTax: (subtotal: number, total: number) => {
-    const taxAmount = PricingUtils.taxAmount(subtotal, total);
-    const x =
-      Math.round(
-        (taxAmount / Math.max(subtotal, 1)) * 100 * ROUNDING_PRECISION
-      ) / ROUNDING_PRECISION;
-    return x;
+    return (
+      Math.round(((total - subtotal) / subtotal) * 100 * ROUNDING_PRECISION) /
+      ROUNDING_PRECISION
+    );
   },
 };

--- a/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/PricingSection.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/PricingSection.tsx
@@ -49,7 +49,6 @@ const ServiceCharges = ({ pricing, isDisabled }: PricingGroupProps) => {
     serviceTotalBeforeTax,
     serviceTotalAfterTax
   );
-  console.log('tax: ', tax);
   const totalTax = PricingUtils.taxAmount(
     serviceTotalBeforeTax,
     serviceTotalAfterTax

--- a/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/PricingSection.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/PricingSection.tsx
@@ -26,6 +26,7 @@ import { CurrencyModal, CurrencyRowFragment } from '@openmsupply-client/system';
 
 type PricingGroupProps = {
   pricing: PricingNode;
+  taxPercentage?: number | null;
   isDisabled?: boolean;
 };
 
@@ -48,6 +49,7 @@ const ServiceCharges = ({ pricing, isDisabled }: PricingGroupProps) => {
     serviceTotalBeforeTax,
     serviceTotalAfterTax
   );
+  console.log('tax: ', tax);
   const totalTax = PricingUtils.taxAmount(
     serviceTotalBeforeTax,
     serviceTotalAfterTax
@@ -105,7 +107,11 @@ const ServiceCharges = ({ pricing, isDisabled }: PricingGroupProps) => {
   );
 };
 
-const ItemPrices = ({ pricing, isDisabled }: PricingGroupProps) => {
+const ItemPrices = ({
+  pricing,
+  isDisabled,
+  taxPercentage,
+}: PricingGroupProps) => {
   const t = useTranslation('distribution');
   const c = useFormatCurrency();
 
@@ -113,10 +119,6 @@ const ItemPrices = ({ pricing, isDisabled }: PricingGroupProps) => {
 
   const { stockTotalBeforeTax, stockTotalAfterTax } = pricing;
 
-  const tax = PricingUtils.effectiveTax(
-    stockTotalBeforeTax,
-    stockTotalAfterTax
-  );
   const totalTax = PricingUtils.taxAmount(
     stockTotalBeforeTax,
     stockTotalAfterTax
@@ -136,11 +138,13 @@ const ItemPrices = ({ pricing, isDisabled }: PricingGroupProps) => {
         <PanelField>{c(stockTotalBeforeTax)}</PanelField>
       </PanelRow>
       <PanelRow sx={{ marginLeft: '10px' }}>
-        <PanelLabel>{`${t('heading.tax')} ${Formatter.tax(tax)}`}</PanelLabel>
+        <PanelLabel>{`${t('heading.tax')} ${Formatter.tax(
+          taxPercentage ?? 0
+        )}`}</PanelLabel>
         <PanelField>
           <TaxEdit
             disabled={disableTax}
-            tax={tax}
+            tax={taxPercentage ?? 0}
             onChange={updateInvoiceTax}
           />
         </PanelField>
@@ -225,9 +229,10 @@ export const PricingSectionComponent = () => {
   const t = useTranslation('distribution');
   const isDisabled = useOutbound.utils.isDisabled();
 
-  const { pricing, currency, otherParty, update, currencyRate } =
+  const { pricing, taxPercentage, currency, otherParty, update, currencyRate } =
     useOutbound.document.fields([
       'otherParty',
+      'taxPercentage',
       'currencyRate',
       'pricing',
       'currency',
@@ -237,7 +242,11 @@ export const PricingSectionComponent = () => {
     <DetailPanelSection title={t('heading.invoice-details')}>
       <Grid container gap={0.5}>
         <ServiceCharges pricing={pricing} isDisabled={isDisabled} />
-        <ItemPrices pricing={pricing} isDisabled={isDisabled} />
+        <ItemPrices
+          pricing={pricing}
+          isDisabled={isDisabled}
+          taxPercentage={taxPercentage}
+        />
         <Totals pricing={pricing} />
         <ForeignCurrencyPrices
           pricing={pricing}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4280

# 👩🏻‍💻 What does this PR do?
Use tax percentage from invoice to calculate stock tax since we don't do stock tax by line... and also refactor effective tax to return correct tax percentage for service charges.
![Screenshot 2024-07-01 at 8 46 39 PM](https://github.com/msupply-foundation/open-msupply/assets/61820074/2d197b13-575b-4ad0-b591-8abc5c1a4f80)
![Screenshot 2024-07-01 at 8 46 23 PM](https://github.com/msupply-foundation/open-msupply/assets/61820074/2294424f-6ea6-40c9-b75e-e3f71f0a1d6f)


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an outbound shipment
- [ ] Add lines with sell price less than $1
- [ ] Add tax
- [ ] Should calculate tax correctly

- [ ] Have service line in master list for store
- [ ] Add multiple service charges with different tax percentages
- [ ] Tax percentage and total should calculate correctly

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
