### PR TITLE
4271 customer-credit from OG should not be mapped as outbound-return

### DIFF
--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -184,7 +184,7 @@ pub struct LegacyTransactRow {
 }
 
 /// The mSupply central server will map outbound invoices from omSupply to "si" invoices for the
-/// receiving store.
+/// receiving store. Same for Inbound Returns.
 /// In the current version of mSupply all om_ fields get copied though.
 /// When receiving the transferred invoice on the omSupply store the "si" get translated to
 /// outbound shipments because the om_type will override to legacy type field.
@@ -204,6 +204,12 @@ fn sanitize_legacy_record(mut data: serde_json::Value) -> serde_json::Value {
         return data;
     };
     if legacy_type == LegacyTransactType::Si && om_type == InvoiceType::OutboundShipment {
+        let Some(obj) = data.as_object_mut() else {
+            return data;
+        };
+        obj.retain(|key, _| !key.starts_with("om_"));
+    }
+    if legacy_type == LegacyTransactType::Cc && om_type == InvoiceType::OutboundReturn {
         let Some(obj) = data.as_object_mut() else {
             return data;
         };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4271

# 👩🏻‍💻 What does this PR do?
Map new CC correctly

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have two setups in sync: one oms-storeA and one OG desktop-storeB
- [ ] From oms-storeA, create a outbound-return(supplier-credit) to desktop-storeB. Confirm shipped and sync
- [ ] In desktop-storeB, receive that as customer-credit(inbound-return).
- [ ] Do nothing. Don't finalise. Make sure everything is synced.
- [ ] Now migrate desktop-storeB to oms,
- [ ] Login to newly migrated oms-storeB
- [ ] Check Inbound returns(customer-credits)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
