### PR TITLE
Line totals migration

### DIFF
--- a/server/service/src/sync/translations/invoice_line.rs
+++ b/server/service/src/sync/translations/invoice_line.rs
@@ -155,8 +155,11 @@ impl SyncTranslation for InvoiceLineTranslation {
             }
         };
 
-        let (item_code, tax_percentage, total_before_tax, total_after_tax) = match item_code {
-            Some(item_code) => {
+        let item_code = item_code.unwrap_or("".to_string());
+        let (item_code, tax_percentage, total_before_tax, total_after_tax) = match item_code
+            .is_empty()
+        {
+            false => {
                 // use new om_* fields
                 (
                     item_code,
@@ -165,7 +168,7 @@ impl SyncTranslation for InvoiceLineTranslation {
                     total_after_tax.unwrap_or(0.0),
                 )
             }
-            None => {
+            true => {
                 let item = match ItemRowRepository::new(connection).find_active_by_id(&item_id)? {
                     Some(item) => item,
                     None => {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4273 

# 👩🏻‍💻 What does this PR do?
The `item_code` was coming through, not as `None` but as an empty string.
I've handled the `None` and `is_empty()` as equivalent, and requiring calculation. Would be nice to have some sort of serde deserialize [empty_as_none](https://docs.rs/serde_with/1.4.0/serde_with/rust/string_empty_as_none/index.html) to handle this. surprised it hasn't come up before?

The result is this: the translation handles the new invoice as a new invoice and the pricing works:

<img width="262" alt="image" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/64a1e6e3-ecb8-417e-bfd8-359bdfbc41fd">


<img width="914" alt="Screenshot 2024-07-02 at 12 42 51 PM" src="https://github.com/msupply-foundation/open-msupply/assets/9192912/043ba667-efbd-417f-86d6-7b2305698874">




<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] as per the issue - migrate the `test3` site and check outbound shipment #2

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
