### PR TITLE
4306 4305 Fix transfer migrations from mobile

### DIFF
--- a/server/graphql/invoice/src/mutations/outbound_shipment/insert.rs
+++ b/server/graphql/invoice/src/mutations/outbound_shipment/insert.rs
@@ -243,6 +243,7 @@ mod graphql {
         // make sure item has been inserted
         InvoiceRowRepository::new(&connection)
             .find_one_by_id("ci_insert_1")
+            .unwrap()
             .unwrap();
 
         // Test succeeding insert on_hold and their_reference

--- a/server/repository/src/db_diesel/requisition/requisition_row.rs
+++ b/server/repository/src/db_diesel/requisition/requisition_row.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 use super::requisition_row::requisition::dsl as requisition_dsl;
 
 use crate::db_diesel::{
@@ -249,6 +251,10 @@ impl Upsert for RequisitionRow {
             RequisitionRowRepository::new(con).find_one_by_id(&self.id),
             Ok(Some(self.clone()))
         )
+    }
+
+    fn as_mut_any(&mut self) -> Option<&mut dyn Any> {
+        Some(self)
     }
 }
 

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -247,9 +247,7 @@ impl SyncTranslation for InvoiceTranslation {
         let data = serde_json::from_value::<LegacyTransactRow>(data)?;
 
         let name = NameRowRepository::new(connection)
-            .find_one_by_id(&data.name_ID)
-            .ok()
-            .flatten()
+            .find_one_by_id(&data.name_ID)?
             .ok_or(anyhow::Error::msg(format!(
                 "Missing name: {}",
                 data.name_ID

--- a/server/service/src/sync/translations/invoice_line.rs
+++ b/server/service/src/sync/translations/invoice_line.rs
@@ -198,8 +198,8 @@ impl SyncTranslation for InvoiceLineTranslation {
         // Currently a uuid is assigned by central for the stock_line id which causes a foreign key constraint violation
         let is_stock_line_valid = match stock_line_id {
             Some(ref stock_line_id) => StockLineRowRepository::new(connection)
-                .find_one_by_id(stock_line_id)
-                .is_ok(),
+                .find_one_by_id(stock_line_id)?
+                .is_some(),
             None => true,
         };
 

--- a/server/util/src/test_helpers.rs
+++ b/server/util/src/test_helpers.rs
@@ -9,3 +9,13 @@ macro_rules! assert_matches {
         )
     }};
 }
+
+#[macro_export]
+macro_rules! assert_variant {
+    ($e:expr, $matches:pat => $result:expr) => {
+         match $e {
+            $matches=> $result,
+            _ => panic!("expected {}", stringify!($matches:pat => $result:expr))
+        }
+    }
+}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4306 
Fixes #4305 

# 👩🏻‍💻 What does this PR do?

Both fixes are relate to existing transfers being migrated to omSupply (inbound shipment and response requisition from existing mSupply mobile store to omSupply store)

There is a check during integration of invoice lines that stock line exists, and if it doesn't we ignore it. Stock line is only added to invoice line in omSupply when inbound shipment is delivered, but in mobile placeholder stock line is id added (either in mobile or during inbound shipment generation in mSupply central). Actually this check was already added but during find_one_by_id refactor it was missed (I went through all of the find_one_by_id and made sure this is not a problem somewhere else, you'll see some minor changes due to this). So added is_some() check on top of is_ok()

For requisition being not editable, when mSupply creates supplier invoice or response, it will copy everything from that original record, this was noted as issue previously for invoices and sanitisation was added, same added here in this PR for requisition

I added an extra macro to help with tests, to be able to assert and extract a variant.

## 💌 Any notes for the reviewer?

Looks like the stock_line will be cleared on invoice line regardless of invoice type and status, I think this could be an issue down the road, would expect sync to guarantee some sort of data integrity so we don't get runtime errors down the track, only noticed this when writing PR description. Do you think i should change that now, is it ok to query for invoice on every invoice line integration ?

# 🧪 Testing

You can use this data file:

[43054306.4DD.zip](https://github.com/user-attachments/files/16060893/43054306.4DD.zip)

Use config user to register etc.. Use wasmobile site and test user, first initialise pre this change you will see that requisition is not editable and invoice line is missing from inbound shipment. 

When using the fixed version you will see that requisition is editable and line is present in inbound shipment.

To start test form scratch please see issue test case or just have a mobile store/site to which you send internal order and outbound shipment, sync mobile site to make sure those are received. Then convert that site to omSupply site, and check both invoice and requisition

