### PR TITLE
2663 Allow to enter decimal in issue quantity for Requisitions

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
@@ -265,6 +265,7 @@ export const RequestLineEditForm = ({
                       requestedQuantity / currentItem.defaultPackSize,
                       2
                     )}
+                    decimalLimit={2}
                     width={100}
                     onChange={quantity => {
                       update({


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2663

# 👩🏻‍💻 What does this PR do?
Allows decimal input if the line is being requested in packs instead of units. Currently set at 2 dp.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an Internal Order
- [ ] Add a line that has a default pack size other than 1
- [ ] Try order in decimal 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
