### PR TITLE
Mount capacitor js to web view onLoadResource

### DIFF
--- a/client/packages/android/app/src/main/java/org/openmsupply/client/ExtendedWebViewClient.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/ExtendedWebViewClient.java
@@ -29,7 +29,7 @@ public class ExtendedWebViewClient extends BridgeWebViewClient {
     // and plugin definitions etc is not injected
 
     // Using onLoadResource vs onPageStarted because sometimes onPageStarted is too late
-    // but with onLoadResource we need to make sure that injection happens only one in a web view
+    // but with onLoadResource we need to make sure that injection happens only once in a web view
     @Override
     public void onLoadResource(WebView webView, 
             String url) {
@@ -79,7 +79,7 @@ public class ExtendedWebViewClient extends BridgeWebViewClient {
 
             // .post to run on UI thread
             webView.post(() -> {
-                // To only run once on a page we check for existence ot nativeBridge
+                // To only run once on a page we check for existence of nativeBridge
                 // which is instantiated by above scripts
                 webView.evaluateJavascript("typeof nativeBridge", new ValueCallback<String>() {
                     @Override

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/ExtendedWebViewClient.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/ExtendedWebViewClient.java
@@ -1,6 +1,7 @@
 package org.openmsupply.client;
 
 import android.graphics.Bitmap;
+import android.webkit.ValueCallback;
 import android.webkit.WebView;
 
 import com.getcapacitor.Bridge;
@@ -26,10 +27,14 @@ public class ExtendedWebViewClient extends BridgeWebViewClient {
     // but since it manually uses net.URL to fetch the content of request, this
     // fails for self signed certificates
     // and plugin definitions etc is not injected
+
+    // Using onLoadResource vs onPageStarted because sometimes onPageStarted is too late
+    // but with onLoadResource we need to make sure that injection happens only one in a web view
     @Override
-    public void onPageStarted(WebView webView,
-            String url,
-            Bitmap favicon) {
+    public void onLoadResource(WebView webView, 
+            String url) {
+        super.onLoadResource(webView, url);
+
         // TODO make sure this is only injected for pages in native bundle
         // There is no way to get the full list of plugins from bridge, use 'debug' and
         // see what plugins to add
@@ -56,6 +61,7 @@ public class ExtendedWebViewClient extends BridgeWebViewClient {
             // This would mean getServerUrl wouldn't work correctly (we are not using it)
             String localUrlJS = "window.WEBVIEW_SERVER_URL = '';";
 
+            // From JSInjector.getScriptString()
             String fullScript = globalJS +
                     " \n\n" +
                     localUrlJS +
@@ -71,9 +77,20 @@ public class ExtendedWebViewClient extends BridgeWebViewClient {
                     cordovaPluginsJS +
                     "\n\n";
 
-            // From JSInjector.getScriptString()
             // .post to run on UI thread
-            webView.post(() -> webView.evaluateJavascript(fullScript, null));
+            webView.post(() -> {
+                // To only run once on a page we check for existence ot nativeBridge
+                // which is instantiated by above scripts
+                webView.evaluateJavascript("typeof nativeBridge", new ValueCallback<String>() {
+                    @Override
+                    public void onReceiveValue(String s) {
+                        if (s.trim().equals("\"undefined\"")) {
+                            webView.evaluateJavascript(fullScript, null);
+                        }
+                    }
+                });
+            });
+
         } catch (Exception ex) {
             Logger.error("Unable to export Capacitor JS. App will not function!", ex);
         }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4373

# 👩🏻‍💻 What does this PR do?

I found that native capacitor plugins were not always available, sometimes they were there and sometimes not. On tablet with dev options on and usb debugging plugged in I could inspect app while it was running with chrome using 'chrome://inspect'. Managed to see a pattern, when adding [console.log here](https://github.com/msupply-foundation/open-msupply/blob/f8dacaf0164d5e8c3442ff54067870ae40ecf19d/client/packages/android/app/src/main/java/org/openmsupply/client/ExtendedWebViewClient.java#L66), and it seem when the log was showing after bugsnag was mounted, web app was not able to recognise native functionality, but when the log was showing before bugsnag mounted log, native functionality worked as expected. This lead me to thing that capacitor JS injection was happening late, which was confirmed by the fix.

No 100% happy about it all, can discuss future improvement on this front a bit later, but I think this change is safe (relative to what is currently happening

## 💌 Any notes for the reviewer?

We had to move to using evaluateJavascript because existing capacitor 'injection', that happens here:

https://github.com/ionic-team/capacitor/blob/f4e7f19f186e334404b2cd0decc3205e57bf4469/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java#L372-L381

Relies on below method which fails on self signed certs:

https://github.com/ionic-team/capacitor/blob/f4e7f19f186e334404b2cd0decc3205e57bf4469/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java#L348

Some extra material: https://github.com/ionic-team/capacitor/discussions/6166

# 🧪 Testing

On tablet open stock view for one batch, next to barcode you should see a scan icon. This icon is sometimes missing (if you restart and start app multiple times you should see it, for me it happens quite oftern)


