### PR TITLE
4161 Hardcode filtering out of patients from names query

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -2703,15 +2703,6 @@ export type InsertPluginDataInput = {
 
 export type InsertPluginDataResponse = PluginDataNode;
 
-export type InsertPrescriptionError = {
-  __typename: 'InsertPrescriptionError';
-  error: InsertPrescriptionErrorInterface;
-};
-
-export type InsertPrescriptionErrorInterface = {
-  description: Scalars['String']['output'];
-};
-
 export type InsertPrescriptionInput = {
   id: Scalars['String']['input'];
   patientId: Scalars['String']['input'];
@@ -2742,7 +2733,7 @@ export type InsertPrescriptionLineResponseWithId = {
   response: InsertPrescriptionLineResponse;
 };
 
-export type InsertPrescriptionResponse = InsertPrescriptionError | InvoiceNode;
+export type InsertPrescriptionResponse = InvoiceNode;
 
 export type InsertPrescriptionResponseWithId = {
   __typename: 'InsertPrescriptionResponseWithId';
@@ -4435,7 +4426,6 @@ export type NameFilterInput = {
   isCustomer?: InputMaybe<Scalars['Boolean']['input']>;
   /** Filter by donor property */
   isDonor?: InputMaybe<Scalars['Boolean']['input']>;
-  isPatient?: InputMaybe<Scalars['Boolean']['input']>;
   /** Is this name a store */
   isStore?: InputMaybe<Scalars['Boolean']['input']>;
   /** Filter by supplier property */
@@ -4494,7 +4484,6 @@ export enum NameNodeType {
   Facility = 'FACILITY',
   Invad = 'INVAD',
   Others = 'OTHERS',
-  Patient = 'PATIENT',
   Repack = 'REPACK',
   Store = 'STORE'
 }
@@ -4630,17 +4619,12 @@ export type OtherPartyNotACustomer = InsertErrorInterface & InsertInboundReturnE
   description: Scalars['String']['output'];
 };
 
-export type OtherPartyNotAPatient = InsertPrescriptionErrorInterface & UpdatePrescriptionErrorInterface & {
-  __typename: 'OtherPartyNotAPatient';
-  description: Scalars['String']['output'];
-};
-
 export type OtherPartyNotASupplier = InsertInboundShipmentErrorInterface & InsertOutboundReturnErrorInterface & InsertRequestRequisitionErrorInterface & UpdateInboundShipmentErrorInterface & UpdateRequestRequisitionErrorInterface & {
   __typename: 'OtherPartyNotASupplier';
   description: Scalars['String']['output'];
 };
 
-export type OtherPartyNotVisible = InsertErrorInterface & InsertInboundReturnErrorInterface & InsertInboundShipmentErrorInterface & InsertOutboundReturnErrorInterface & InsertPrescriptionErrorInterface & InsertRequestRequisitionErrorInterface & UpdateInboundShipmentErrorInterface & UpdateNameErrorInterface & UpdatePrescriptionErrorInterface & UpdateRequestRequisitionErrorInterface & {
+export type OtherPartyNotVisible = InsertErrorInterface & InsertInboundReturnErrorInterface & InsertInboundShipmentErrorInterface & InsertOutboundReturnErrorInterface & InsertRequestRequisitionErrorInterface & UpdateInboundShipmentErrorInterface & UpdateNameErrorInterface & UpdateRequestRequisitionErrorInterface & {
   __typename: 'OtherPartyNotVisible';
   description: Scalars['String']['output'];
 };

--- a/client/packages/invoices/src/Prescriptions/api/operations.generated.ts
+++ b/client/packages/invoices/src/Prescriptions/api/operations.generated.ts
@@ -33,7 +33,7 @@ export type InsertPrescriptionMutationVariables = Types.Exact<{
 }>;
 
 
-export type InsertPrescriptionMutation = { __typename: 'Mutations', insertPrescription: { __typename: 'InsertPrescriptionError', error: { __typename: 'OtherPartyNotAPatient', description: string } | { __typename: 'OtherPartyNotVisible', description: string } } | { __typename: 'InvoiceNode', id: string, invoiceNumber: number } };
+export type InsertPrescriptionMutation = { __typename: 'Mutations', insertPrescription: { __typename: 'InvoiceNode', id: string, invoiceNumber: number } };
 
 export type UpsertPrescriptionMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -41,7 +41,7 @@ export type UpsertPrescriptionMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpsertPrescriptionMutation = { __typename: 'Mutations', batchPrescription: { __typename: 'BatchPrescriptionResponse', deletePrescriptionLines?: Array<{ __typename: 'DeletePrescriptionLineResponseWithId', id: string, response: { __typename: 'DeletePrescriptionLineError', error: { __typename: 'CannotEditInvoice', description: string } | { __typename: 'ForeignKeyError', description: string, key: Types.ForeignKey } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'DeleteResponse', id: string } }> | null, deletePrescriptions?: Array<{ __typename: 'DeletePrescriptionResponseWithId', id: string, response: { __typename: 'DeletePrescriptionError', error: { __typename: 'CannotDeleteInvoiceWithLines', description: string } | { __typename: 'CannotEditInvoice', description: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'DeleteResponse', id: string } }> | null, insertPrescriptionLines?: Array<{ __typename: 'InsertPrescriptionLineResponseWithId', id: string, response: { __typename: 'InsertPrescriptionLineError', error: { __typename: 'CannotEditInvoice', description: string } | { __typename: 'ForeignKeyError', description: string } | { __typename: 'LocationIsOnHold', description: string } | { __typename: 'LocationNotFound', description: string } | { __typename: 'NotEnoughStockForReduction', description: string } | { __typename: 'StockLineAlreadyExistsInInvoice', description: string } | { __typename: 'StockLineIsOnHold', description: string } } | { __typename: 'InvoiceLineNode' } }> | null, insertPrescriptions?: Array<{ __typename: 'InsertPrescriptionResponseWithId', id: string, response: { __typename: 'InsertPrescriptionError', error: { __typename: 'OtherPartyNotAPatient', description: string } | { __typename: 'OtherPartyNotVisible', description: string } } | { __typename: 'InvoiceNode' } }> | null, updatePrescriptionLines?: Array<{ __typename: 'UpdatePrescriptionLineResponseWithId', id: string, response: { __typename: 'InvoiceLineNode' } | { __typename: 'UpdatePrescriptionLineError', error: { __typename: 'CannotEditInvoice', description: string } | { __typename: 'ForeignKeyError', description: string, key: Types.ForeignKey } | { __typename: 'LocationIsOnHold', description: string } | { __typename: 'LocationNotFound', description: string } | { __typename: 'NotEnoughStockForReduction', description: string, batch: { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'StockLineNode' } } | { __typename: 'RecordNotFound', description: string } | { __typename: 'StockLineAlreadyExistsInInvoice', description: string } | { __typename: 'StockLineIsOnHold', description: string } } }> | null, updatePrescriptions?: Array<{ __typename: 'UpdatePrescriptionResponseWithId', id: string, response: { __typename: 'InvoiceNode' } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'UpdatePrescriptionError', error: { __typename: 'CanOnlyChangeToPickedWhenNoUnallocatedLines', description: string } | { __typename: 'CannotReverseInvoiceStatus', description: string } | { __typename: 'InvoiceIsNotEditable', description: string } | { __typename: 'OtherPartyNotAPatient', description: string } | { __typename: 'OtherPartyNotVisible', description: string } | { __typename: 'RecordNotFound', description: string } } }> | null } };
+export type UpsertPrescriptionMutation = { __typename: 'Mutations', batchPrescription: { __typename: 'BatchPrescriptionResponse', deletePrescriptionLines?: Array<{ __typename: 'DeletePrescriptionLineResponseWithId', id: string, response: { __typename: 'DeletePrescriptionLineError', error: { __typename: 'CannotEditInvoice', description: string } | { __typename: 'ForeignKeyError', description: string, key: Types.ForeignKey } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'DeleteResponse', id: string } }> | null, deletePrescriptions?: Array<{ __typename: 'DeletePrescriptionResponseWithId', id: string, response: { __typename: 'DeletePrescriptionError', error: { __typename: 'CannotDeleteInvoiceWithLines', description: string } | { __typename: 'CannotEditInvoice', description: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'DeleteResponse', id: string } }> | null, insertPrescriptionLines?: Array<{ __typename: 'InsertPrescriptionLineResponseWithId', id: string, response: { __typename: 'InsertPrescriptionLineError', error: { __typename: 'CannotEditInvoice', description: string } | { __typename: 'ForeignKeyError', description: string } | { __typename: 'LocationIsOnHold', description: string } | { __typename: 'LocationNotFound', description: string } | { __typename: 'NotEnoughStockForReduction', description: string } | { __typename: 'StockLineAlreadyExistsInInvoice', description: string } | { __typename: 'StockLineIsOnHold', description: string } } | { __typename: 'InvoiceLineNode' } }> | null, insertPrescriptions?: Array<{ __typename: 'InsertPrescriptionResponseWithId', id: string }> | null, updatePrescriptionLines?: Array<{ __typename: 'UpdatePrescriptionLineResponseWithId', id: string, response: { __typename: 'InvoiceLineNode' } | { __typename: 'UpdatePrescriptionLineError', error: { __typename: 'CannotEditInvoice', description: string } | { __typename: 'ForeignKeyError', description: string, key: Types.ForeignKey } | { __typename: 'LocationIsOnHold', description: string } | { __typename: 'LocationNotFound', description: string } | { __typename: 'NotEnoughStockForReduction', description: string, batch: { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'StockLineNode' } } | { __typename: 'RecordNotFound', description: string } | { __typename: 'StockLineAlreadyExistsInInvoice', description: string } | { __typename: 'StockLineIsOnHold', description: string } } }> | null, updatePrescriptions?: Array<{ __typename: 'UpdatePrescriptionResponseWithId', id: string, response: { __typename: 'InvoiceNode' } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'UpdatePrescriptionError', error: { __typename: 'CanOnlyChangeToPickedWhenNoUnallocatedLines', description: string } | { __typename: 'CannotReverseInvoiceStatus', description: string } | { __typename: 'InvoiceIsNotEditable', description: string } | { __typename: 'RecordNotFound', description: string } } }> | null } };
 
 export type DeletePrescriptionsMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -173,21 +173,6 @@ export const InsertPrescriptionDocument = gql`
       id
       invoiceNumber
     }
-    ... on InsertPrescriptionError {
-      __typename
-      error {
-        description
-        ... on OtherPartyNotVisible {
-          __typename
-          description
-        }
-        ... on OtherPartyNotAPatient {
-          __typename
-          description
-        }
-        description
-      }
-    }
   }
 }
     `;
@@ -261,14 +246,6 @@ export const UpsertPrescriptionDocument = gql`
     }
     insertPrescriptions {
       id
-      response {
-        ... on InsertPrescriptionError {
-          __typename
-          error {
-            description
-          }
-        }
-      }
     }
     updatePrescriptionLines {
       id

--- a/client/packages/invoices/src/Prescriptions/api/operations.graphql
+++ b/client/packages/invoices/src/Prescriptions/api/operations.graphql
@@ -128,21 +128,6 @@ mutation insertPrescription(
       id
       invoiceNumber
     }
-    ... on InsertPrescriptionError {
-      __typename
-      error {
-        description
-        ... on OtherPartyNotVisible {
-          __typename
-          description
-        }
-        ... on OtherPartyNotAPatient {
-          __typename
-          description
-        }
-        description
-      }
-    }
   }
 }
 
@@ -218,14 +203,6 @@ mutation upsertPrescription(
     }
     insertPrescriptions {
       id
-      response {
-        ... on InsertPrescriptionError {
-          __typename
-          error {
-            description
-          }
-        }
-      }
     }
     updatePrescriptionLines {
       id

--- a/server/graphql/general/src/queries/names.rs
+++ b/server/graphql/general/src/queries/names.rs
@@ -51,7 +51,6 @@ pub struct NameFilterInput {
     pub is_supplier: Option<bool>,
     /// Filter by donor property
     pub is_donor: Option<bool>,
-    pub is_patient: Option<bool>,
     /// Is this name a store
     pub is_store: Option<bool>,
     /// Code of the store if store is linked to name
@@ -146,7 +145,6 @@ impl NameFilterInput {
             address2,
             country,
             email,
-            is_patient,
             code_or_name,
         } = self;
 
@@ -168,7 +166,6 @@ impl NameFilterInput {
             address2: address2.map(StringFilter::from),
             country: country.map(StringFilter::from),
             email: email.map(StringFilter::from),
-            is_patient,
         }
     }
 }

--- a/server/graphql/general/src/queries/tests/names.rs
+++ b/server/graphql/general/src/queries/tests/names.rs
@@ -184,7 +184,6 @@ mod graphql {
                 address2,
                 country,
                 email,
-                is_patient: _,
                 is_donor,
                 code_or_name: _,
             } = filter.unwrap();

--- a/server/graphql/invoice/src/mutations/prescription/insert.rs
+++ b/server/graphql/invoice/src/mutations/prescription/insert.rs
@@ -1,6 +1,5 @@
 use async_graphql::*;
 
-use graphql_core::simple_generic_errors::{OtherPartyNotAPatient, OtherPartyNotVisible};
 use graphql_core::standard_graphql_error::{validate_auth, StandardGraphqlError};
 use graphql_core::ContextExt;
 use graphql_types::types::InvoiceNode;
@@ -17,16 +16,9 @@ pub struct InsertInput {
     pub patient_id: String,
 }
 
-#[derive(SimpleObject)]
-#[graphql(name = "InsertPrescriptionError")]
-pub struct InsertError {
-    pub error: InsertErrorInterface,
-}
-
 #[derive(Union)]
 #[graphql(name = "InsertPrescriptionResponse")]
 pub enum InsertResponse {
-    Error(InsertError),
     Response(InvoiceNode),
 }
 
@@ -49,14 +41,6 @@ pub fn insert(ctx: &Context<'_>, store_id: &str, input: InsertInput) -> Result<I
     )
 }
 
-#[derive(Interface)]
-#[graphql(name = "InsertPrescriptionErrorInterface")]
-#[graphql(field(name = "description", ty = "&str"))]
-pub enum InsertErrorInterface {
-    OtherPartyNotVisible(OtherPartyNotVisible),
-    OtherPartyNotAPatient(OtherPartyNotAPatient),
-}
-
 impl InsertInput {
     pub fn to_domain(self) -> ServiceInput {
         let InsertInput { id, patient_id } = self;
@@ -68,34 +52,21 @@ impl InsertInput {
 pub fn map_response(from: Result<Invoice, ServiceError>) -> Result<InsertResponse> {
     let result = match from {
         Ok(invoice) => InsertResponse::Response(InvoiceNode::from_domain(invoice)),
-        Err(error) => InsertResponse::Error(InsertError {
-            error: map_error(error)?,
-        }),
+        Err(error) => return map_error(error),
     };
 
     Ok(result)
 }
 
-fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
+fn map_error(error: ServiceError) -> Result<InsertResponse> {
     use StandardGraphqlError::*;
     let formatted_error = format!("{:#?}", error);
 
     let graphql_error = match error {
-        // Structured Errors
-        ServiceError::OtherPartyNotAPatient => {
-            return Ok(InsertErrorInterface::OtherPartyNotAPatient(
-                OtherPartyNotAPatient,
-            ))
-        }
-        ServiceError::OtherPartyNotVisible => {
-            return Ok(InsertErrorInterface::OtherPartyNotVisible(
-                OtherPartyNotVisible,
-            ))
-        }
         // Standard Graphql Errors
-        ServiceError::NotAPerscription
+        ServiceError::NotAPrescription
         | ServiceError::InvoiceAlreadyExists
-        | ServiceError::OtherPartyDoesNotExist => BadUserInput(formatted_error),
+        | ServiceError::PatientDoesNotExist => BadUserInput(formatted_error),
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
         ServiceError::NewlyCreatedInvoiceDoesNotExist => InternalError(formatted_error),
     };
@@ -172,54 +143,12 @@ mod test {
         let mutation = r#"
         mutation ($input: InsertPrescriptionInput!, $storeId: String) {
             insertPrescription(storeId: $storeId, input: $input) {
-              ... on InsertPrescriptionError {
-                error {
-                  __typename
+                ... on InvoiceNode {
+                    id
                 }
-              }
             }
           }
         "#;
-
-        // OtherPartyNotASupplier
-        let test_service = TestService(Box::new(|_| Err(ServiceError::OtherPartyNotAPatient)));
-
-        let expected = json!({
-            "insertPrescription": {
-              "error": {
-                "__typename": "OtherPartyNotAPatient"
-              }
-            }
-          }
-        );
-
-        assert_graphql_query!(
-            &settings,
-            mutation,
-            &Some(empty_variables()),
-            &expected,
-            Some(service_provider(test_service, &connection_manager))
-        );
-
-        // OtherPartyNotVisible
-        let test_service = TestService(Box::new(|_| Err(ServiceError::OtherPartyNotVisible)));
-
-        let expected = json!({
-            "insertPrescription": {
-              "error": {
-                "__typename": "OtherPartyNotVisible"
-              }
-            }
-          }
-        );
-
-        assert_graphql_query!(
-            &settings,
-            mutation,
-            &Some(empty_variables()),
-            &expected,
-            Some(service_provider(test_service, &connection_manager))
-        );
 
         // InvoiceAlreadyExists
         let test_service = TestService(Box::new(|_| Err(ServiceError::InvoiceAlreadyExists)));
@@ -233,8 +162,8 @@ mod test {
             Some(service_provider(test_service, &connection_manager))
         );
 
-        //OtherPartyDoesNotExist
-        let test_service = TestService(Box::new(|_| Err(ServiceError::OtherPartyDoesNotExist)));
+        //PatientDoesNotExist
+        let test_service = TestService(Box::new(|_| Err(ServiceError::PatientDoesNotExist)));
         let expected_message = "Bad user input";
         assert_standard_graphql_error!(
             &settings,

--- a/server/graphql/invoice/src/mutations/prescription/update.rs
+++ b/server/graphql/invoice/src/mutations/prescription/update.rs
@@ -1,8 +1,5 @@
 use async_graphql::*;
-use graphql_core::simple_generic_errors::{
-    CannotReverseInvoiceStatus, NodeError, OtherPartyNotAPatient, OtherPartyNotVisible,
-    RecordNotFound,
-};
+use graphql_core::simple_generic_errors::{CannotReverseInvoiceStatus, NodeError, RecordNotFound};
 use graphql_core::standard_graphql_error::{validate_auth, StandardGraphqlError};
 use graphql_core::ContextExt;
 use graphql_types::types::{InvoiceLineConnector, InvoiceNode};
@@ -83,8 +80,6 @@ pub enum UpdatePrescriptionErrorInterface {
     InvoiceDoesNotExist(RecordNotFound),
     CannotReverseInvoiceStatus(CannotReverseInvoiceStatus),
     InvoiceIsNotEditable(InvoiceIsNotEditable),
-    OtherPartyNotVisible(OtherPartyNotVisible),
-    OtherPartyNotAPatient(OtherPartyNotAPatient),
     CanOnlyChangeToPickedWhenNoUnallocatedLines(CanOnlyChangeToPickedWhenNoUnallocatedLines),
 }
 
@@ -128,21 +123,11 @@ fn map_error(error: ServiceError) -> Result<UpdatePrescriptionErrorInterface> {
             ))
         }
 
-        ServiceError::OtherPartyNotAPatient => {
-            return Ok(UpdatePrescriptionErrorInterface::OtherPartyNotAPatient(
-                OtherPartyNotAPatient,
-            ))
-        }
-        ServiceError::OtherPartyNotVisible => {
-            return Ok(UpdatePrescriptionErrorInterface::OtherPartyNotVisible(
-                OtherPartyNotVisible,
-            ))
-        }
         // Standard Graphql Errors
         ServiceError::NotAPrescriptionInvoice
         | ServiceError::ClinicianDoesNotExist
         | ServiceError::NotThisStoreInvoice
-        | ServiceError::OtherPartyDoesNotExist => BadUserInput(formatted_error),
+        | ServiceError::PatientDoesNotExist => BadUserInput(formatted_error),
         ServiceError::DatabaseError(_)
         | ServiceError::InvoiceLineHasNoStockLine(_)
         | ServiceError::UpdatedInvoiceDoesNotExist => InternalError(formatted_error),
@@ -274,44 +259,6 @@ mod test {
             Some(service_provider(test_service, &connection_manager))
         );
 
-        //OtherPartyNotASupplier
-        let test_service = TestService(Box::new(|_| Err(ServiceError::OtherPartyNotAPatient)));
-
-        let expected = json!({
-            "updatePrescription" : {
-                "error": {
-                    "__typename": "OtherPartyNotAPatient"
-                }
-            }
-        });
-
-        assert_graphql_query!(
-            &settings,
-            mutation,
-            &Some(empty_variables()),
-            &expected,
-            Some(service_provider(test_service, &connection_manager))
-        );
-
-        // OtherPartyNotVisible
-        let test_service = TestService(Box::new(|_| Err(ServiceError::OtherPartyNotVisible)));
-
-        let expected = json!({
-            "updatePrescription" : {
-                "error": {
-                    "__typename": "OtherPartyNotVisible"
-                }
-            }
-        });
-
-        assert_graphql_query!(
-            &settings,
-            mutation,
-            &Some(empty_variables()),
-            &expected,
-            Some(service_provider(test_service, &connection_manager))
-        );
-
         //NotThisStoreInvoice
         let test_service = TestService(Box::new(|_| Err(ServiceError::NotThisStoreInvoice)));
         let expected_message = "Bad user input";
@@ -336,8 +283,8 @@ mod test {
             Some(service_provider(test_service, &connection_manager))
         );
 
-        //OtherPartyDoesNotExist
-        let test_service = TestService(Box::new(|_| Err(ServiceError::OtherPartyDoesNotExist)));
+        //PatientDoesNotExist
+        let test_service = TestService(Box::new(|_| Err(ServiceError::PatientDoesNotExist)));
         let expected_message = "Bad user input";
         assert_standard_graphql_error!(
             &settings,

--- a/server/graphql/types/src/types/name.rs
+++ b/server/graphql/types/src/types/name.rs
@@ -54,7 +54,6 @@ pub struct EqualFilterGenderInput {
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")] // only needed to be comparable in tests
 pub enum NameNodeType {
     Facility,
-    Patient,
     Build,
     Invad,
     Repack,
@@ -65,7 +64,8 @@ impl NameNodeType {
     pub fn from_domain(name_type: &NameType) -> Self {
         match name_type {
             NameType::Facility => NameNodeType::Facility,
-            NameType::Patient => NameNodeType::Patient,
+            // Shouldn't show up since patients have been filtered out at repo layer
+            NameType::Patient => NameNodeType::Others,
             NameType::Build => NameNodeType::Build,
             NameType::Invad => NameNodeType::Invad,
             NameType::Repack => NameNodeType::Repack,
@@ -76,7 +76,6 @@ impl NameNodeType {
     pub fn to_domain(self) -> NameType {
         match self {
             NameNodeType::Facility => NameType::Facility,
-            NameNodeType::Patient => NameType::Patient,
             NameNodeType::Build => NameType::Build,
             NameNodeType::Invad => NameType::Invad,
             NameNodeType::Repack => NameType::Repack,
@@ -297,7 +296,7 @@ mod test {
                 NameNode {
                     name: Name {
                         name_row: inline_init(|r: &mut NameRow| {
-                            r.r#type = NameType::Patient;
+                            r.r#type = NameType::Store;
                             r.code = "some code".to_string();
                             r.first_name = Some("first_name".to_string());
                             r.last_name = Some("last_name".to_string());
@@ -333,7 +332,7 @@ mod test {
         let expected = json!({
             "testQuery": {
                 "__typename": "NameNode",
-                "type": "PATIENT",
+                "type": "STORE",
                 "code": "some code",
                 "firstName": "first_name",
                 "lastName": "last_name",

--- a/server/repository/src/db_diesel/name.rs
+++ b/server/repository/src/db_diesel/name.rs
@@ -40,7 +40,6 @@ pub struct NameFilter {
     pub is_customer: Option<bool>,
     pub is_supplier: Option<bool>,
     pub is_donor: Option<bool>,
-    pub is_patient: Option<bool>,
     pub is_store: Option<bool>,
     pub store_code: Option<StringFilter>,
     pub is_visible: Option<bool>,
@@ -197,7 +196,6 @@ impl<'a> NameRepository<'a> {
                 address2,
                 country,
                 email,
-                is_patient,
                 code_or_name,
             } = f;
 
@@ -229,12 +227,6 @@ impl<'a> NameRepository<'a> {
 
             query = match is_donor {
                 Some(bool) => query.filter(name_dsl::is_donor.eq(bool)),
-                None => query,
-            };
-
-            query = match is_patient {
-                Some(true) => query.filter(name_dsl::type_.eq(NameType::Patient)),
-                Some(false) => query.filter(name_dsl::type_.ne(NameType::Patient)),
                 None => query,
             };
 
@@ -353,11 +345,6 @@ impl NameFilter {
         self
     }
 
-    pub fn is_patient(mut self, value: bool) -> Self {
-        self.is_patient = Some(value);
-        self
-    }
-
     pub fn r#type(mut self, filter: EqualFilter<NameType>) -> Self {
         self.r#type = Some(filter);
         self
@@ -382,10 +369,6 @@ impl Name {
             .as_ref()
             .map(|name_store_join_row| name_store_join_row.name_is_supplier)
             .unwrap_or(false)
-    }
-
-    pub fn is_patient(&self) -> bool {
-        self.name_row.r#type == NameType::Patient
     }
 
     pub fn is_visible(&self) -> bool {

--- a/server/repository/src/db_diesel/name.rs
+++ b/server/repository/src/db_diesel/name.rs
@@ -176,6 +176,7 @@ impl<'a> NameRepository<'a> {
                     .left_join(store_dsl::store),
             )
             .inner_join(name_oms_fields_alias)
+            .filter(name_dsl::type_.ne(NameType::Patient))
             .into_boxed();
 
         if let Some(f) = filter {

--- a/server/service/src/invoice/prescription/insert/mod.rs
+++ b/server/service/src/invoice/prescription/insert/mod.rs
@@ -19,11 +19,8 @@ pub struct InsertPrescription {
 #[derive(Debug, PartialEq)]
 pub enum InsertPrescriptionError {
     InvoiceAlreadyExists,
-    NotAPerscription,
-    // Name validation
-    OtherPartyDoesNotExist,
-    OtherPartyNotVisible,
-    OtherPartyNotAPatient,
+    NotAPrescription,
+    PatientDoesNotExist,
     // Internal error
     NewlyCreatedInvoiceDoesNotExist,
     DatabaseError(RepositoryError),
@@ -38,7 +35,7 @@ pub fn insert_prescription(
     let invoice = ctx
         .connection
         .transaction_sync(|connection| {
-            validate(connection, &ctx.store_id, &input)?;
+            validate(connection, &input)?;
             let new_invoice = generate(connection, &ctx.store_id, &ctx.user_id, input)?;
             InvoiceRowRepository::new(connection).upsert_one(&new_invoice)?;
 
@@ -145,7 +142,7 @@ mod test {
             ),
             Err(ServiceError::InvoiceAlreadyExists)
         );
-        // OtherPartyDoesNotExist
+        // PatientDoesNotExist
         assert_eq!(
             service.insert_prescription(
                 &context,
@@ -154,29 +151,7 @@ mod test {
                     r.patient_id = "invalid".to_string();
                 })
             ),
-            Err(ServiceError::OtherPartyDoesNotExist)
-        );
-        // OtherPartyNotVisible
-        assert_eq!(
-            service.insert_prescription(
-                &context,
-                inline_init(|r: &mut InsertPrescription| {
-                    r.id = "new_id".to_string();
-                    r.patient_id = not_visible().id;
-                })
-            ),
-            Err(ServiceError::OtherPartyNotVisible)
-        );
-        // OtherPartyNotAPatient
-        assert_eq!(
-            service.insert_prescription(
-                &context,
-                inline_init(|r: &mut InsertPrescription| {
-                    r.id = "new_id".to_string();
-                    r.patient_id = not_a_patient().id;
-                })
-            ),
-            Err(ServiceError::OtherPartyNotAPatient)
+            Err(ServiceError::PatientDoesNotExist)
         );
     }
 

--- a/server/service/src/invoice/prescription/insert/validate.rs
+++ b/server/service/src/invoice/prescription/insert/validate.rs
@@ -1,14 +1,10 @@
-use crate::{
-    invoice::check_invoice_exists,
-    validate::{check_other_party, CheckOtherPartyType, OtherPartyErrors},
-};
+use crate::{invoice::check_invoice_exists, validate::check_patient_exists};
 use repository::StorageConnection;
 
 use super::{InsertPrescription, InsertPrescriptionError};
 
 pub fn validate(
     connection: &StorageConnection,
-    store_id: &str,
     input: &InsertPrescription,
 ) -> Result<(), InsertPrescriptionError> {
     use InsertPrescriptionError::*;
@@ -16,20 +12,9 @@ pub fn validate(
         return Err(InvoiceAlreadyExists);
     }
 
-    check_other_party(
-        connection,
-        store_id,
-        &input.patient_id,
-        CheckOtherPartyType::Patient,
-    )
-    .map_err(|e| match e {
-        OtherPartyErrors::OtherPartyDoesNotExist => OtherPartyDoesNotExist {},
-        // kept this in for match but added condition so that it won't trigger for patients
-        // since you should be allowed to prescribe to a patient as long as they're on the site
-        OtherPartyErrors::OtherPartyNotVisible => OtherPartyNotVisible,
-        OtherPartyErrors::TypeMismatched => OtherPartyNotAPatient,
-        OtherPartyErrors::DatabaseError(repository_error) => DatabaseError(repository_error),
-    })?;
+    if check_patient_exists(connection, &input.patient_id)?.is_none() {
+        return Err(PatientDoesNotExist);
+    }
 
     Ok(())
 }

--- a/server/service/src/invoice/prescription/update/mod.rs
+++ b/server/service/src/invoice/prescription/update/mod.rs
@@ -39,10 +39,7 @@ pub enum UpdatePrescriptionError {
     NotAPrescriptionInvoice,
     NotThisStoreInvoice,
     ClinicianDoesNotExist,
-    // Name validation
-    OtherPartyDoesNotExist,
-    OtherPartyNotVisible,
-    OtherPartyNotAPatient,
+    PatientDoesNotExist,
     // Internal
     UpdatedInvoiceDoesNotExist,
     DatabaseError(RepositoryError),

--- a/server/service/src/name/query.rs
+++ b/server/service/src/name/query.rs
@@ -1,5 +1,4 @@
 use repository::NameRepository;
-use repository::NameType;
 use repository::PaginationOption;
 use repository::{Name, NameFilter, NameSort};
 
@@ -20,12 +19,8 @@ pub fn get_names(
     let pagination = get_default_pagination(pagination, MAX_LIMIT, MIN_LIMIT)?;
     let repository = NameRepository::new(&ctx.connection);
 
-    let filter = filter
-        .unwrap_or_default()
-        .r#type(NameType::Patient.not_equal_to());
-
     Ok(ListResult {
-        rows: repository.query(store_id, pagination, Some(filter.clone()), sort)?,
-        count: i64_to_u32(repository.count(store_id, Some(filter))?),
+        rows: repository.query(store_id, pagination, filter.clone(), sort)?,
+        count: i64_to_u32(repository.count(store_id, filter)?),
     })
 }

--- a/server/service/src/validate.rs
+++ b/server/service/src/validate.rs
@@ -1,7 +1,7 @@
 use repository::{
     property::{PropertyFilter, PropertyRepository},
-    EqualFilter, Name, NameFilter, NameRepository, RepositoryError, StorageConnection,
-    StoreRowRepository, StringFilter,
+    EqualFilter, Name, NameFilter, NameRepository, Patient, PatientFilter, PatientRepository,
+    RepositoryError, StorageConnection, StoreRowRepository, StringFilter,
 };
 
 pub fn check_store_id_matches(store_id_a: &str, store_id_b: &str) -> bool {
@@ -27,7 +27,6 @@ pub enum OtherPartyErrors {
 pub enum CheckOtherPartyType {
     Customer,
     Supplier,
-    Patient,
 }
 
 pub fn get_other_party(
@@ -41,6 +40,16 @@ pub fn get_other_party(
     )
 }
 
+pub fn check_patient_exists(
+    connection: &StorageConnection,
+    patient_id: &str,
+) -> Result<Option<Patient>, RepositoryError> {
+    PatientRepository::new(connection).query_one(
+        PatientFilter::new().id(EqualFilter::equal_to(patient_id)),
+        None,
+    )
+}
+
 pub fn check_other_party(
     connection: &StorageConnection,
     store_id: &str,
@@ -50,9 +59,7 @@ pub fn check_other_party(
     let other_party = get_other_party(connection, store_id, other_party_id)?
         .ok_or(OtherPartyErrors::OtherPartyDoesNotExist)?;
 
-    // Error will only happen if other party is not a patient since you can prescribe
-    // to patients on the same site.
-    if !other_party.is_visible() && !other_party.is_patient() {
+    if !other_party.is_visible() {
         return Err(OtherPartyErrors::OtherPartyNotVisible);
     }
 
@@ -65,12 +72,6 @@ pub fn check_other_party(
 
         CheckOtherPartyType::Supplier => {
             if !other_party.is_supplier() {
-                return Err(OtherPartyErrors::TypeMismatched);
-            }
-        }
-
-        CheckOtherPartyType::Patient => {
-            if !other_party.is_patient() {
                 return Err(OtherPartyErrors::TypeMismatched);
             }
         }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4161

# 👩🏻‍💻 What does this PR do?
Removes hardcoded patient filtering from the name service layer and have moved this to the repository layer, and remove is_patient filter and Patient from NameNodeType. 

Prescription insert/update now use a `check_patient_exists` for patient validation instead of the `check_other_party` function.

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Make sure suppliers/customers are still loaded correctly
- [ ] Make sure that prescriptions can still be created
- [ ] (dev) Call name API with graphql. Patients shouldn't show at all even without filtering.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
