### PR TITLE
3485 When creating a new stocktake with `Items with stock` checked ON, the counted packs should be equal to the snapshot packs instead of 0

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.tsx
@@ -223,21 +223,13 @@ export const useStocktakeColumns = ({
       accessor: ({ rowData }) => {
         if ('lines' in rowData) {
           const { lines } = rowData;
-          if (
-            lines.every(
-              line =>
-                line.countedNumberOfPacks === null ||
-                line.countedNumberOfPacks === undefined
-            )
-          ) {
-            return null;
-          }
-          return (
-            lines.reduce(
-              (total, line) => total + (line.countedNumberOfPacks ?? 0),
-              0
-            ) ?? 0
-          ).toString();
+          let countedLines = lines.flatMap(
+            ({ countedNumberOfPacks: counted }) =>
+              typeof counted === 'number' ? [counted] : []
+          );
+          // No counted lines
+          if (countedLines.length === 0) return null;
+          return countedLines.reduce((total, counted) => total + counted, 0);
         } else {
           return rowData.countedNumberOfPacks;
         }

--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.tsx
@@ -223,6 +223,15 @@ export const useStocktakeColumns = ({
       accessor: ({ rowData }) => {
         if ('lines' in rowData) {
           const { lines } = rowData;
+          if (
+            lines.every(
+              line =>
+                line.countedNumberOfPacks === null ||
+                line.countedNumberOfPacks === undefined
+            )
+          ) {
+            return null;
+          }
           return (
             lines.reduce(
               (total, line) => total + (line.countedNumberOfPacks ?? 0),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3485

# 👩🏻‍💻 What does this PR do?
Counted number of packs was still showing 0 for me since the line totals always have some number or 0. So the `-` for uncounted packs was only showing up when you didn't group stocktake by item.

Now checking that every line is either null or undefined to allow `-` to show up for uncounted rows.

![Screenshot 2024-07-09 at 7 05 57 AM](https://github.com/msupply-foundation/open-msupply/assets/61820074/d9bc85f1-5f28-442f-84f5-365a28c2dd26)


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a stocktake with master list or one of the filters with a few items
- [ ] Make sure `group by item` toggle is on
- [ ] Uncounted should show as `-`

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Done
  2.
