### PR TITLE
4180 customer requisition doesn’t accept the decimal values that came form msupply sites via internal orders and remote auth

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
@@ -8,7 +8,6 @@ import {
   useFormatNumber,
   useUrlQueryParams,
   ColumnDescription,
-  NumUtils,
   ColumnDataAccessor,
   TooltipTextCell,
 } from '@openmsupply-client/common';
@@ -101,8 +100,7 @@ export const useRequestColumns = () => {
         align: ColumnAlign.Right,
         Cell: PackVariantQuantityCell({
           getItemId: r => r.itemId,
-          getQuantity: r =>
-            NumUtils.round(r.itemStats.averageMonthlyConsumption),
+          getQuantity: r => r.itemStats.averageMonthlyConsumption,
         }),
         getSortValue: rowData => rowData.itemStats.averageMonthlyConsumption,
       },
@@ -115,9 +113,7 @@ export const useRequestColumns = () => {
       Cell: PackVariantQuantityCell({
         getItemId: r => r.itemId,
         getQuantity: r =>
-          NumUtils.round(
-            r.itemStats.averageMonthlyConsumption * maxMonthsOfStock
-          ),
+          r.itemStats.averageMonthlyConsumption * maxMonthsOfStock,
       }),
       getSortValue: rowData =>
         rowData.itemStats.averageMonthlyConsumption * maxMonthsOfStock,
@@ -130,7 +126,7 @@ export const useRequestColumns = () => {
       width: 200,
       Cell: PackVariantQuantityCell({
         getItemId: r => r.itemId,
-        getQuantity: r => NumUtils.round(r.suggestedQuantity),
+        getQuantity: r => r.suggestedQuantity,
       }),
       getSortValue: rowData => rowData.suggestedQuantity,
     },
@@ -141,7 +137,7 @@ export const useRequestColumns = () => {
       width: 150,
       Cell: PackVariantQuantityCell({
         getItemId: r => r.itemId,
-        getQuantity: r => NumUtils.round(r.requestedQuantity),
+        getQuantity: r => r.requestedQuantity,
       }),
       getSortValue: rowData => rowData.requestedQuantity,
     },
@@ -154,8 +150,7 @@ export const useRequestColumns = () => {
       align: ColumnAlign.Right,
       Cell: PackVariantQuantityCell({
         getItemId: r => r.itemId,
-        getQuantity: r =>
-          NumUtils.round(r.linkedRequisitionLine?.approvedQuantity ?? 0, 2),
+        getQuantity: r => r.linkedRequisitionLine?.approvedQuantity ?? 0,
       }),
       sortable: false,
     });

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
@@ -6,7 +6,6 @@ import {
   getCommentPopoverColumn,
   useUrlQueryParams,
   ColumnDescription,
-  NumUtils,
   TooltipTextCell,
 } from '@openmsupply-client/common';
 import { ResponseLineFragment, useResponse } from './../api';
@@ -66,8 +65,7 @@ export const useResponseColumns = () => {
         sortable: false,
         Cell: PackVariantQuantityCell({
           getItemId: row => row.itemId,
-          getQuantity: row =>
-            NumUtils.round(row.itemStats.availableStockOnHand),
+          getQuantity: row => row.itemStats.availableStockOnHand,
         }),
       },
     ],
@@ -82,9 +80,7 @@ export const useResponseColumns = () => {
       Cell: PackVariantQuantityCell({
         getItemId: row => row.itemId,
         getQuantity: row =>
-          NumUtils.round(
-            row?.linkedRequisitionLine?.itemStats.availableStockOnHand ?? 0
-          ),
+          row?.linkedRequisitionLine?.itemStats.availableStockOnHand ?? 0,
       }),
     },
     [
@@ -93,7 +89,7 @@ export const useResponseColumns = () => {
         getSortValue: rowData => rowData.requestedQuantity,
         Cell: PackVariantQuantityCell({
           getItemId: row => row.itemId,
-          getQuantity: row => NumUtils.round(row.requestedQuantity ?? 0),
+          getQuantity: row => row.requestedQuantity ?? 0,
         }),
         width: 150,
       },
@@ -107,7 +103,7 @@ export const useResponseColumns = () => {
       sortable: false,
       Cell: PackVariantQuantityCell({
         getItemId: row => row.itemId,
-        getQuantity: row => NumUtils.round(row.approvedQuantity),
+        getQuantity: row => row.approvedQuantity,
       }),
     });
     columnDefinitions.push({
@@ -123,7 +119,7 @@ export const useResponseColumns = () => {
       getSortValue: rowData => rowData.supplyQuantity,
       Cell: PackVariantQuantityCell({
         getItemId: row => row.itemId,
-        getQuantity: row => NumUtils.round(row.supplyQuantity),
+        getQuantity: row => row.supplyQuantity,
       }),
     },
   ]);
@@ -136,7 +132,7 @@ export const useResponseColumns = () => {
     getSortValue: rowData => rowData.alreadyIssued,
     Cell: PackVariantQuantityCell({
       getItemId: row => row.itemId,
-      getQuantity: row => NumUtils.round(row.alreadyIssued),
+      getQuantity: row => row.alreadyIssued,
     }),
     width: 100,
   });
@@ -149,7 +145,7 @@ export const useResponseColumns = () => {
     getSortValue: rowData => rowData.remainingQuantityToSupply,
     Cell: PackVariantQuantityCell({
       getItemId: row => row.itemId,
-      getQuantity: row => NumUtils.round(row.remainingQuantityToSupply),
+      getQuantity: row => row.remainingQuantityToSupply,
     }),
   });
   columnDefinitions.push(GenericColumnKey.Selection);

--- a/client/packages/system/src/Item/Components/PackVariant/PackVariantQuantityCell.tsx
+++ b/client/packages/system/src/Item/Components/PackVariant/PackVariantQuantityCell.tsx
@@ -5,7 +5,7 @@ import {
   BasicCellLayout,
   Tooltip,
   Typography,
-  NumUtils,
+  useFormatNumber,
 } from '@openmsupply-client/common';
 import { usePackVariant } from '../../context';
 
@@ -23,12 +23,12 @@ export const PackVariantQuantityCell =
       getItemId(rowData),
       null
     );
-
+    const formatNumber = useFormatNumber();
     const quantity = getQuantity(rowData);
     const packQuantity = numberOfPacksFromQuantity(quantity);
     const hasMoreThanTwoDp =
       packQuantity.toString().split('.')[1]?.length ?? 0 > 2;
-    const roundedPackQuantity = NumUtils.round(packQuantity, 2);
+    const roundedPackQuantity = formatNumber.round(packQuantity, 2);
 
     return (
       <BasicCellLayout isError={isError}>

--- a/client/packages/system/src/Item/Components/PackVariant/PackVariantQuantityCell.tsx
+++ b/client/packages/system/src/Item/Components/PackVariant/PackVariantQuantityCell.tsx
@@ -3,6 +3,9 @@ import {
   RecordWithId,
   CellProps,
   BasicCellLayout,
+  Tooltip,
+  Typography,
+  NumUtils,
 } from '@openmsupply-client/common';
 import { usePackVariant } from '../../context';
 
@@ -26,7 +29,9 @@ export const PackVariantQuantityCell =
 
     return (
       <BasicCellLayout isError={isError}>
-        {String(packQuantity)}
+        <Tooltip title={String(quantity)}>
+          <Typography>{NumUtils.round(packQuantity, 2)}</Typography>
+        </Tooltip>
       </BasicCellLayout>
     );
   };

--- a/client/packages/system/src/Item/Components/PackVariant/PackVariantQuantityCell.tsx
+++ b/client/packages/system/src/Item/Components/PackVariant/PackVariantQuantityCell.tsx
@@ -26,11 +26,18 @@ export const PackVariantQuantityCell =
 
     const quantity = getQuantity(rowData);
     const packQuantity = numberOfPacksFromQuantity(quantity);
+    const hasMoreThanTwoDp =
+      packQuantity.toString().split('.')[1]?.length ?? 0 > 2;
+    const roundedPackQuantity = NumUtils.round(packQuantity, 2);
 
     return (
       <BasicCellLayout isError={isError}>
-        <Tooltip title={String(quantity)}>
-          <Typography>{NumUtils.round(packQuantity, 2)}</Typography>
+        <Tooltip title={String(packQuantity)}>
+          <Typography>
+            {hasMoreThanTwoDp
+              ? `${roundedPackQuantity}...`
+              : roundedPackQuantity}
+          </Typography>
         </Tooltip>
       </BasicCellLayout>
     );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4180

# 👩🏻‍💻 What does this PR do?
Allows `Requested`, `Supply`, `Issued` and `Remaining` to be displayed in 2 decimal places with ellipsis if there are more than 2 dp to indicate to users that there is a tooltip
![Screenshot 2024-07-09 at 8 45 50 AM](https://github.com/msupply-foundation/open-msupply/assets/61820074/13c16f54-2b45-4137-8c2c-0247ba505a0a)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have two sites (one OMS and one OG)
- [ ] Create an Internal Order in OG to send to OMS
- [ ] Enter some decimal in requested (e.g. 1.224131)
- [ ] Sync
- [ ] Go to OMS -> Requisitions
- [ ] Requested amount in requisition should be in decimals

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
