### PR TITLE
Add zero dose and Penta 3

### DIFF
--- a/client/packages/host/src/api/hooks/settings/namePropertyData.ts
+++ b/client/packages/host/src/api/hooks/settings/namePropertyData.ts
@@ -90,5 +90,23 @@ export const gapsNameProperties: {
       allowedValues: null,
       remoteEditable: true,
     },
+    {
+      id: '86cb041d-96d3-40f1-874e-4189f4796790',
+      propertyId: 'penta_3',
+      key: 'penta_3',
+      name: 'Penta-3 Coverage',
+      valueType: PropertyNodeValueType.String,
+      allowedValues: 'High,Medium,Low,Unknown',
+      remoteEditable: true,
+    },
+    {
+      id: '9cc3ac59-061e-4e3f-af13-d2b6d9a52dea',
+      propertyId: 'zero_dose',
+      key: 'zero_dose',
+      name: 'Zero Dose Coverage',
+      valueType: PropertyNodeValueType.String,
+      allowedValues: 'High,Medium,Low,Unknown',
+      remoteEditable: true,
+    },
   ],
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3700

# 👩🏻‍💻 What does this PR do?

Adds Zero Dose and Penta 3 as name properties

![image](https://github.com/msupply-foundation/open-msupply/assets/8287373/1900169c-3dc6-43f6-8f88-56cf92696feb)


## 💌 Any notes for the reviewer?

What is this for or what does it mean? Sorry I'm not sure :)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Initialise GAPS Properties
- [ ] Check you can set appropriate values in the name/store properties editor

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
