### PR TITLE
4382 user permissions not working for inventory adjustment and repack

### DIFF
--- a/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
+++ b/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
@@ -20,6 +20,8 @@ import {
   useConfirmationModal,
   useNavigate,
   RouteBuilder,
+  useCallbackWithPermission,
+  UserPermission,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { PlusCircleIcon } from '@common/icons';
@@ -134,6 +136,11 @@ export const RepackModal: FC<RepackModalControlProps> = ({
     };
   };
 
+  const newRepack = useCallbackWithPermission(
+    UserPermission.CreateRepack,
+    onNewClick
+  );
+
   return (
     <Modal
       width={900}
@@ -226,7 +233,7 @@ export const RepackModal: FC<RepackModalControlProps> = ({
             <ButtonWithIcon
               label={t('label.new')}
               Icon={<PlusCircleIcon />}
-              onClick={onNewClick}
+              onClick={newRepack}
             />
           </Box>
         </Box>

--- a/client/packages/system/src/Stock/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Stock/DetailView/DetailView.tsx
@@ -14,6 +14,8 @@ import {
   useUrlQuery,
   useToggle,
   StockLineNode,
+  useCallbackWithPermission,
+  UserPermission,
 } from '@openmsupply-client/common';
 import { ActivityLogList } from '@openmsupply-client/system';
 import { AppBarButtons } from './AppBarButtons';
@@ -96,6 +98,10 @@ export const StockLineDetailView: React.FC = () => {
     title: t('heading.are-you-sure'),
   });
 
+  const openInventoryAdjustmentModal = useCallbackWithPermission(
+    UserPermission.InventoryAdjustmentMutate,
+    adjustmentModalController.toggleOn
+  );
   const tabs = [
     {
       Component: (
@@ -144,7 +150,7 @@ export const StockLineDetailView: React.FC = () => {
       )}
       <AppBarButtons
         openRepack={repackModalController.toggleOn}
-        openAdjust={adjustmentModalController.toggleOn}
+        openAdjust={openInventoryAdjustmentModal}
       />
       <TableProvider createStore={createTableStore}>
         <DetailTabs tabs={tabs} />

--- a/server/service/src/login.rs
+++ b/server/service/src/login.rs
@@ -389,9 +389,7 @@ fn permissions_to_domain(permissions: Vec<Permissions>) -> HashSet<PermissionTyp
                 output.insert(PermissionType::StocktakeMutate);
             }
             // inventory adjustments
-            Permissions::EnterInventoryAdjustments
-            | Permissions::EditInventoryAdjustments
-            | Permissions::FinaliseInventoryAdjustments => {
+            Permissions::EnterInventoryAdjustments => {
                 output.insert(PermissionType::InventoryAdjustmentMutate);
             }
             // customer invoices


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4382

# 👩🏻‍💻 What does this PR do?
Only using `Enter Inventory Adjustment` permissions for inventory adjustments like with how repacks uses `
Create Repack Or Split Stock` since we don't allow edits. The IAs and Repacks go from draft -> finalised.

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Try turning the `Edit`/`Finalised` permissions for Inventory Adjustments off
- [ ] Try to do an inventory adjustment (Stock -> Click on a line -> Adjust stock)
- [ ] Shouldn't be able to

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Update permissions page
  2.
