### PR TITLE
3993 Can't see Supplier/Customer's full address

### DIFF
--- a/client/packages/system/src/Name/DetailModal/DetailModal.tsx
+++ b/client/packages/system/src/Name/DetailModal/DetailModal.tsx
@@ -37,15 +37,6 @@ export const DetailModal: FC<DetailModalProps> = ({ nameId }) => {
         <Grid container flex={1} flexDirection="row" gap={4}>
           <DetailSection title="">
             <DetailInputWithLabelRow
-              label={t('label.address')}
-              inputProps={{
-                value: [data?.address1, data?.address2]
-                  .filter(a => !!a)
-                  .join(', '),
-                disabled: isDisabled,
-              }}
-            />
-            <DetailInputWithLabelRow
               label={t('label.code')}
               inputProps={{ value: data?.code, disabled: isDisabled }}
             />
@@ -119,6 +110,17 @@ export const DetailModal: FC<DetailModalProps> = ({ nameId }) => {
               Input={
                 <Checkbox disabled={isDisabled} checked={data?.isOnHold} />
               }
+            />
+            <DetailInputWithLabelRow
+              label={t('label.address')}
+              inputProps={{
+                value: [data?.address1, data?.address2]
+                  .filter(a => !!a)
+                  .join(', '),
+                disabled: isDisabled,
+                maxRows: 3,
+                multiline: true,
+              }}
             />
           </DetailSection>
         </Grid>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3993

# 👩🏻‍💻 What does this PR do?
Allows users to see the full address of a supplier or customer. Had to limit the amount of rows to display because of a sizing error (which apparently is safe to ignore) but thought to play it safe 🤷🏻 . 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Enter a really long address for a supplier or customer in OG
- [ ] Go to either Supplier or Customer depending on which one you inputted
- [ ] See that `Address` is now in bottom right
- [ ] The user should be able to see the full address

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Update supplier + customer modal screenshots
  2.
