### PR TITLE
3964 Tax Edit modal value is not updated if you edit tax percentage from service line edit modal

### DIFF
--- a/client/packages/common/src/ui/components/inputs/TextInput/TaxEdit.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/TaxEdit.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   useTranslation,
   InputModal,
@@ -19,6 +19,10 @@ export const TaxEdit = ({ disabled = false, tax, onChange }: TaxEditProps) => {
   const t = useTranslation('replenishment');
   const [val, setVal] = useState<number | undefined>(tax);
 
+  useEffect(() => {
+    setVal(tax);
+  }, [tax]);
+
   return (
     <>
       <IconButton
@@ -27,7 +31,6 @@ export const TaxEdit = ({ disabled = false, tax, onChange }: TaxEditProps) => {
         label={t('heading.edit-tax-rate')}
         onClick={modalController.toggleOn}
       />
-      {/* Unmount when closing to reset state */}
       {modalController.isOn && (
         <InputModal
           isOpen={modalController.isOn}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3964

# 👩🏻‍💻 What does this PR do?
Val wasn't being updated when tax was updated, so have used useEffect to prompt change.


https://github.com/msupply-foundation/open-msupply/assets/61820074/29fb9e66-0036-4dfb-b28a-25375c345b06



# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have service item in master list
- [ ] Go to an Outbound shipment
- [ ] Add a service charge
- [ ] Set a tax percentage
- [ ] Then open tax edit modal

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
