### PR TITLE
4365 the decimal will get too long in outbound shipments

### DIFF
--- a/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberCell.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Tooltip, Typography } from '@mui/material';
 import { useFormatNumber } from '@common/intl';
 import { RecordWithId } from '@common/types';
 import { CellProps } from '../../../columns/types';
@@ -16,6 +16,7 @@ export const NumberCell = <T extends RecordWithId>({
   defaultValue?: string | number;
 }) => {
   const value = column.accessor({ rowData }) as number;
+  const hasMoreThanTwoDp = (value * 100) % 1 !== 0;
   const formattedValue = useFormatNumber().round(value, 2);
 
   const displayValue =
@@ -30,16 +31,18 @@ export const NumberCell = <T extends RecordWithId>({
         padding: '4px 8px',
       }}
     >
-      <Typography
-        style={{
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          textAlign: 'right',
-          fontSize: 'inherit',
-        }}
-      >
-        {displayValue}
-      </Typography>
+      <Tooltip title={value.toString()}>
+        <Typography
+          style={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            textAlign: 'right',
+            fontSize: 'inherit',
+          }}
+        >
+          {!!hasMoreThanTwoDp ? `${displayValue}...` : displayValue}
+        </Typography>
+      </Tooltip>
     </Box>
   );
 };

--- a/client/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
+++ b/client/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
@@ -237,6 +237,7 @@ const getColumnLookup = <T extends RecordWithId>(): Record<
     key: 'unitQuantity',
     width: 100,
     align: ColumnAlign.Right,
+    Cell: NumberCell,
   },
   itemUnit: {
     label: 'label.unit',
@@ -270,6 +271,7 @@ const getColumnLookup = <T extends RecordWithId>(): Record<
     key: 'availableStockOnHand',
     width: 100,
     align: ColumnAlign.Right,
+    Cell: NumberCell,
   },
   theirReference: {
     label: 'label.reference',

--- a/client/packages/common/src/utils/numbers/NumUtils.test.ts
+++ b/client/packages/common/src/utils/numbers/NumUtils.test.ts
@@ -20,9 +20,4 @@ describe('NumUtils', () => {
     expect(NumUtils.parseString('40', 1, 10)).toBe(10);
     expect(NumUtils.parseString('4.56')).toBe(4.56);
   });
-
-  it('floatMultiply', () => {
-    expect(NumUtils.floatMultiply(110.4, 29)).toBe(3201.6);
-    expect(NumUtils.floatMultiply(1.001, 1000)).toBe(1001);
-  });
 });

--- a/client/packages/common/src/utils/numbers/NumUtils.ts
+++ b/client/packages/common/src/utils/numbers/NumUtils.ts
@@ -30,15 +30,6 @@ export const NumUtils = {
     return Math.round(value * multiplier) / multiplier;
   },
   /**
-   * Multiplies two float numbers avoiding "float artefacts".
-   * For example: 110.4 * 29 = 3201.6000000000004
-   * while floatMultiply(110.4, 29) = 3201.6
-   */
-  floatMultiply: (left: number, right: number): number => {
-    // Use a hacky(?) correction factor of 100:
-    return (100 * left * right) / 100;
-  },
-  /**
    * This constant should be used for values that are potentially send to a backend API that expects
    * an unsigned 32 bit integer and thus would reject Number.MAX_SAFE_INTEGER.
    * For example, JS number max size is `2^53 - 1` while the Rust u32 size is `2^32 - 1`.

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -11,7 +11,6 @@ import {
   useColumnUtils,
   CurrencyCell,
   ColumnDescription,
-  NumUtils,
 } from '@openmsupply-client/common';
 import {
   getPackVariantCell,
@@ -26,7 +25,7 @@ type InboundShipmentColumnDescription = ColumnDescription<
 >;
 
 const getUnitQuantity = (row: InboundLineFragment) =>
-  NumUtils.floatMultiply(row.packSize, row.numberOfPacks);
+  row.packSize * row.numberOfPacks;
 
 export const useInboundShipmentColumns = () => {
   const {

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -18,7 +18,6 @@ import {
   Currencies,
   useCurrencyCell,
   useAuthContext,
-  NumUtils,
 } from '@openmsupply-client/common';
 import { DraftInboundLine } from '../../../../types';
 import {
@@ -121,8 +120,7 @@ export const QuantityTableComponent: FC<
       [
         'unitQuantity',
         {
-          accessor: ({ rowData }) =>
-            NumUtils.floatMultiply(rowData.packSize, rowData.numberOfPacks),
+          accessor: ({ rowData }) => rowData.packSize * rowData.numberOfPacks,
         },
       ],
     ],

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
@@ -11,7 +11,6 @@ import {
   useCurrencyCell,
   Currencies,
   CurrencyCell,
-  NumUtils,
 } from '@openmsupply-client/common';
 import { DraftStockOutLine } from '../../../types';
 import { PackQuantityCell, StockOutLineFragment } from '../../../StockOut';
@@ -133,8 +132,7 @@ export const useOutboundLineEditColumns = ({
       {
         label: 'label.unit-quantity-issued',
         labelProps: { unit },
-        accessor: ({ rowData }) =>
-          NumUtils.floatMultiply(rowData.numberOfPacks, rowData.packSize),
+        accessor: ({ rowData }) => rowData.numberOfPacks * rowData.packSize,
         width: 90,
       },
     ],
@@ -198,8 +196,7 @@ export const useExpansionColumns = (): Column<StockOutLineFragment>[] => {
     [
       'unitQuantity',
       {
-        accessor: ({ rowData }) =>
-          NumUtils.floatMultiply(rowData.packSize, rowData.numberOfPacks),
+        accessor: ({ rowData }) => rowData.packSize * rowData.numberOfPacks,
       },
     ],
     [

--- a/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -13,7 +13,6 @@ import {
   NumberCell,
   CurrencyCell,
   ColumnDescription,
-  NumUtils,
 } from '@openmsupply-client/common';
 import {
   getPackVariantCell,
@@ -44,9 +43,7 @@ const getNumberOfPacks = (row: StockOutLineFragment) =>
   isDefaultPlaceholderRow(row) ? '' : row.numberOfPacks;
 
 const getUnitQuantity = (row: StockOutLineFragment) =>
-  isDefaultPlaceholderRow(row)
-    ? ''
-    : NumUtils.floatMultiply(row.packSize, row.numberOfPacks);
+  isDefaultPlaceholderRow(row) ? '' : row.packSize * row.numberOfPacks;
 
 export const useOutboundColumns = ({
   sortBy,

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/columns.ts
@@ -5,7 +5,6 @@ import {
   ColumnDescription,
   ExpiryDateCell,
   LocationCell,
-  NumUtils,
   NumberCell,
   useColumns,
 } from '@openmsupply-client/common';
@@ -95,8 +94,7 @@ export const usePrescriptionLineEditColumns = ({
       {
         label: 'label.unit-quantity-issued',
         labelProps: { unit },
-        accessor: ({ rowData }) =>
-          NumUtils.floatMultiply(rowData.numberOfPacks, rowData.packSize),
+        accessor: ({ rowData }) => rowData.numberOfPacks * rowData.packSize,
         width: 120,
       },
     ],
@@ -136,8 +134,7 @@ export const useExpansionColumns = (): Column<StockOutLineFragment>[] =>
     [
       'unitQuantity',
       {
-        accessor: ({ rowData }) =>
-          NumUtils.floatMultiply(rowData.packSize, rowData.numberOfPacks),
+        accessor: ({ rowData }) => rowData.packSize * rowData.numberOfPacks,
       },
     ],
   ]);

--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -12,7 +12,6 @@ import {
   NumberCell,
   CurrencyCell,
   ColumnDescription,
-  NumUtils,
 } from '@openmsupply-client/common';
 import {
   getPackVariantCell,
@@ -207,10 +206,7 @@ export const usePrescriptionColumn = ({
             const { lines } = rowData;
             return ArrayUtils.getUnitQuantity(lines);
           } else {
-            return NumUtils.floatMultiply(
-              rowData.packSize,
-              rowData.numberOfPacks
-            );
+            return rowData.packSize * rowData.numberOfPacks;
           }
         },
         getSortValue: rowData => {
@@ -218,10 +214,7 @@ export const usePrescriptionColumn = ({
             const { lines } = rowData;
             return ArrayUtils.getUnitQuantity(lines);
           } else {
-            return NumUtils.floatMultiply(
-              rowData.packSize,
-              rowData.numberOfPacks
-            );
+            return rowData.packSize * rowData.numberOfPacks;
           }
         },
       },

--- a/client/packages/invoices/src/Returns/InboundDetailView/columns.ts
+++ b/client/packages/invoices/src/Returns/InboundDetailView/columns.ts
@@ -10,7 +10,6 @@ import {
   getRowExpandColumn,
   ArrayUtils,
   ColumnDescription,
-  NumUtils,
 } from '@openmsupply-client/common';
 import { InboundReturnLineFragment } from '../api';
 import { InboundReturnItem } from '../../types';
@@ -33,7 +32,7 @@ const expansionColumn = getRowExpandColumn<
 // >();
 
 const getUnitQuantity = (row: InboundReturnLineFragment) =>
-  NumUtils.floatMultiply(row.packSize, row.numberOfPacks);
+  row.packSize * row.numberOfPacks;
 
 export const useInboundReturnColumns = ({
   sortBy,

--- a/client/packages/invoices/src/Returns/OutboundDetailView/columns.ts
+++ b/client/packages/invoices/src/Returns/OutboundDetailView/columns.ts
@@ -11,7 +11,6 @@ import {
   ArrayUtils,
   ColumnAlign,
   ColumnDescription,
-  NumUtils,
 } from '@openmsupply-client/common';
 import { OutboundReturnLineFragment } from '../api';
 import { OutboundReturnItem } from '../../types';
@@ -33,7 +32,7 @@ const expansionColumn = getRowExpandColumn<
 // >();
 
 const getUnitQuantity = (row: OutboundReturnLineFragment) =>
-  NumUtils.floatMultiply(row.packSize, row.numberOfPacks);
+  row.packSize * row.numberOfPacks;
 
 export const useOutboundReturnColumns = ({
   sortBy,

--- a/client/packages/system/src/Item/Components/PackVariant/PackVariantQuantityCell.tsx
+++ b/client/packages/system/src/Item/Components/PackVariant/PackVariantQuantityCell.tsx
@@ -26,8 +26,7 @@ export const PackVariantQuantityCell =
     const formatNumber = useFormatNumber();
     const quantity = getQuantity(rowData);
     const packQuantity = numberOfPacksFromQuantity(quantity);
-    const hasMoreThanTwoDp =
-      packQuantity.toString().split('.')[1]?.length ?? 0 > 2;
+    const hasMoreThanTwoDp = (packQuantity * 100) % 1 !== 0;
     const roundedPackQuantity = formatNumber.round(packQuantity, 2);
 
     return (

--- a/client/packages/system/src/Item/ListView/ListView.tsx
+++ b/client/packages/system/src/Item/ListView/ListView.tsx
@@ -9,7 +9,6 @@ import {
   useTranslation,
   useUrlQueryParams,
   ColumnAlign,
-  NumUtils,
   TooltipTextCell,
 } from '@openmsupply-client/common';
 import { useItems, ItemsWithStatsFragment } from '../api';
@@ -57,7 +56,7 @@ const ItemListComponent: FC = () => {
         {
           Cell: PackVariantQuantityCell({
             getItemId: r => r.id,
-            getQuantity: r => NumUtils.round(r.stats.availableStockOnHand),
+            getQuantity: r => r.stats.availableStockOnHand,
           }),
           label: 'label.soh',
           description: 'description.soh',
@@ -70,8 +69,7 @@ const ItemListComponent: FC = () => {
         {
           Cell: PackVariantQuantityCell({
             getItemId: r => r.id,
-            getQuantity: r =>
-              NumUtils.round(r.stats.averageMonthlyConsumption, 2),
+            getQuantity: r => r.stats.averageMonthlyConsumption,
           }),
           align: ColumnAlign.Right,
           sortable: false,
@@ -81,8 +79,7 @@ const ItemListComponent: FC = () => {
       {
         Cell: PackVariantQuantityCell({
           getItemId: r => r.id,
-          getQuantity: r =>
-            NumUtils.round(r.stats.availableMonthsOfStockOnHand ?? 0, 2),
+          getQuantity: r => r.stats.availableMonthsOfStockOnHand ?? 0,
         }),
         align: ColumnAlign.Right,
         description: 'description.months-of-stock',

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -11,7 +11,6 @@ import {
   ColumnDescription,
   usePluginColumns,
   TooltipTextCell,
-  NumUtils,
   useNavigate,
   RouteBuilder,
 } from '@openmsupply-client/common';
@@ -125,7 +124,6 @@ const StockListComponent: FC = () => {
       'numberOfPacks',
       {
         accessor: ({ rowData }) => rowData.totalNumberOfPacks,
-        Cell: TooltipTextCell,
         width: 150,
       },
     ],
@@ -133,11 +131,10 @@ const StockListComponent: FC = () => {
       'stockOnHand',
       {
         accessor: ({ rowData }) =>
-          NumUtils.floatMultiply(rowData.totalNumberOfPacks, rowData.packSize),
+          rowData.totalNumberOfPacks * rowData.packSize,
         label: 'label.soh',
         description: 'description.soh',
         sortable: false,
-        Cell: TooltipTextCell,
         width: 125,
       },
     ],


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4365 

# 👩🏻‍💻 What does this PR do?
Only display values at 2 dp and hide longer decimal places with tooltip

![Screenshot 2024-07-12 at 6 47 23 PM](https://github.com/user-attachments/assets/31ea6334-bbbe-45ab-9f1e-c5f9a791c8bd)
![Screenshot 2024-07-12 at 6 47 41 PM](https://github.com/user-attachments/assets/d90807ca-81b9-4d45-8c83-923ce0e16789)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a item in mSupply with default packsize like 12.3565
- [ ] Receive Some items in decimal and send stocks to OMS store
- [ ] Receive items in OMS store, without altering the packsizes
- [ ] Create outbound shipments and enter values to pack quantity issued to 0.01
- [ ] Alternatively: Keep issuing an item in fraction
- [ ] Go to item/stock
- [ ] See decimal values for stock on hand/average monthly consumption/months of stock 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
