### PR TITLE
4457 sync rr forms central server v6

### DIFF
--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -155,8 +155,8 @@ impl ChangelogTableName {
             ChangelogTableName::Property => ChangeLogSyncStyle::Central,
             ChangelogTableName::NameProperty => ChangeLogSyncStyle::Central,
             ChangelogTableName::NameOmsFields => ChangeLogSyncStyle::Central,
-            ChangelogTableName::RnrForm => ChangeLogSyncStyle::Central,
-            ChangelogTableName::RnrFormLine => ChangeLogSyncStyle::Central,
+            ChangelogTableName::RnrForm => ChangeLogSyncStyle::Remote,
+            ChangelogTableName::RnrFormLine => ChangeLogSyncStyle::Remote,
         }
     }
 }

--- a/server/repository/src/db_diesel/rnr_form_line_row.rs
+++ b/server/repository/src/db_diesel/rnr_form_line_row.rs
@@ -6,6 +6,7 @@ use crate::{
 
 use chrono::NaiveDate;
 use diesel::prelude::*;
+use serde::{Deserialize, Serialize};
 
 table! {
     rnr_form_line (id) {
@@ -34,7 +35,9 @@ joinable!(rnr_form_line -> item (item_id));
 allow_tables_to_appear_in_same_query!(rnr_form_line, rnr_form);
 allow_tables_to_appear_in_same_query!(rnr_form_line, item);
 
-#[derive(Clone, Insertable, Queryable, Debug, PartialEq, AsChangeset, Default)]
+#[derive(
+    Clone, Insertable, Queryable, Debug, PartialEq, AsChangeset, Serialize, Deserialize, Default,
+)]
 #[diesel(table_name = rnr_form_line)]
 #[diesel(treat_none_as_null = true)]
 pub struct RnRFormLineRow {

--- a/server/service/src/sync/api/common_records.rs
+++ b/server/service/src/sync/api/common_records.rs
@@ -108,8 +108,11 @@ impl CommonSyncRecord {
 
     pub(crate) fn to_buffer_rows(
         rows: Vec<CommonSyncRecord>,
+        source_site_id: Option<i32>,
     ) -> Result<Vec<SyncBufferRow>, ParsingSyncRecordError> {
-        rows.into_iter().map(|r| r.to_buffer_row(None)).collect()
+        rows.into_iter()
+            .map(|r| r.to_buffer_row(source_site_id))
+            .collect()
     }
 }
 
@@ -158,55 +161,58 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_common_records_to_sync_buffer_rows() {
-        let batch = CommonSyncRecord::to_buffer_rows(vec![
-            CommonSyncRecord {
-                table_name: "item".to_string(),
-                record_id: "itemA".to_string(),
-                action: SyncAction::Insert,
-                record_data: json!({
-                    "ID": "itemA",
-                    "item_name": "itemA",
-                    "code": "itemA",
-                    "unit_ID": "",
-                    "type_of": "general",
-                    "default_pack_size": 1,
-                }),
-            },
-            CommonSyncRecord {
-                table_name: "item".to_string(),
-                record_id: "itemA".to_string(),
-                action: SyncAction::Update,
-                record_data: json!({
-                    "ID": "itemA",
-                    "item_name": "itemA",
-                    "code": "itemA",
-                    "unit_ID": "",
-                    "type_of": "general",
-                    "default_pack_size": 1,
-                }),
-            },
-            CommonSyncRecord {
-                table_name: "item".to_string(),
-                record_id: "itemB".to_string(),
-                action: SyncAction::Insert,
-                record_data: json!({
-                    "ID": "itemB",
-                    "item_name": "itemB",
-                    "code": "itemB",
-                    "unit_ID": "",
-                    "type_of": "general",
-                    "default_pack_size": 1,
-                }),
-            },
-            CommonSyncRecord {
-                table_name: "item".to_string(),
-                record_id: "itemA".to_string(),
-                action: SyncAction::Merge,
-                record_data: json!({
-                    "mergeIdToKeep": "itemA", "mergeIdToDelete": "itemB"
-                }),
-            },
-        ])
+        let batch = CommonSyncRecord::to_buffer_rows(
+            vec![
+                CommonSyncRecord {
+                    table_name: "item".to_string(),
+                    record_id: "itemA".to_string(),
+                    action: SyncAction::Insert,
+                    record_data: json!({
+                        "ID": "itemA",
+                        "item_name": "itemA",
+                        "code": "itemA",
+                        "unit_ID": "",
+                        "type_of": "general",
+                        "default_pack_size": 1,
+                    }),
+                },
+                CommonSyncRecord {
+                    table_name: "item".to_string(),
+                    record_id: "itemA".to_string(),
+                    action: SyncAction::Update,
+                    record_data: json!({
+                        "ID": "itemA",
+                        "item_name": "itemA",
+                        "code": "itemA",
+                        "unit_ID": "",
+                        "type_of": "general",
+                        "default_pack_size": 1,
+                    }),
+                },
+                CommonSyncRecord {
+                    table_name: "item".to_string(),
+                    record_id: "itemB".to_string(),
+                    action: SyncAction::Insert,
+                    record_data: json!({
+                        "ID": "itemB",
+                        "item_name": "itemB",
+                        "code": "itemB",
+                        "unit_ID": "",
+                        "type_of": "general",
+                        "default_pack_size": 1,
+                    }),
+                },
+                CommonSyncRecord {
+                    table_name: "item".to_string(),
+                    record_id: "itemA".to_string(),
+                    action: SyncAction::Merge,
+                    record_data: json!({
+                        "mergeIdToKeep": "itemA", "mergeIdToDelete": "itemB"
+                    }),
+                },
+            ],
+            None, /* Source Site Id */
+        )
         .unwrap();
 
         let (_, connection, _, _) = setup_all(

--- a/server/service/src/sync/central_data_synchroniser.rs
+++ b/server/service/src/sync/central_data_synchroniser.rs
@@ -45,8 +45,10 @@ impl CentralDataSynchroniser {
             logger.progress(SyncStepProgress::PullCentral, max_cursor - start_cursor)?;
 
             let last_cursor_in_batch = data.last().map(|r| r.cursor).unwrap_or(start_cursor);
-            let sync_buffer_rows =
-                CommonSyncRecord::to_buffer_rows(data.into_iter().map(|r| r.record).collect())?;
+            let sync_buffer_rows = CommonSyncRecord::to_buffer_rows(
+                data.into_iter().map(|r| r.record).collect(),
+                None, // Everything from mSupply Central Server is considered to not have a source_site_id
+            )?;
 
             // Upsert sync buffer rows in a transaction together with cursor update
             connection

--- a/server/service/src/sync/central_data_synchroniser_v6.rs
+++ b/server/service/src/sync/central_data_synchroniser_v6.rs
@@ -110,8 +110,10 @@ impl SynchroniserV6 {
             logger.progress(SyncStepProgress::PullCentralV6, total_records)?;
 
             let last_cursor_in_batch = records.last().map(|r| r.cursor).unwrap_or(start_cursor);
-            let sync_buffer_rows =
-                CommonSyncRecord::to_buffer_rows(records.into_iter().map(|r| r.record).collect())?;
+            let sync_buffer_rows = CommonSyncRecord::to_buffer_rows(
+                records.into_iter().map(|r| r.record).collect(),
+                None, // Everything from open-mSupply Central Server is considered to not have a source_site_id
+            )?;
             // Upsert sync buffer rows in a transaction together with cursor update
             connection
                 .transaction_sync(|t_con| {

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -143,8 +143,10 @@ impl RemoteDataSynchroniser {
                 data,
             } = sync_batch;
 
-            let sync_buffer_rows =
-                CommonSyncRecord::to_buffer_rows(data.into_iter().map(|r| r.record).collect())?;
+            let sync_buffer_rows = CommonSyncRecord::to_buffer_rows(
+                data.into_iter().map(|r| r.record).collect(),
+                None, // Everything from mSupply Central Server is considered to not have a source_site_id
+            )?;
 
             let number_of_pulled_records = sync_buffer_rows.len() as u64;
 

--- a/server/service/src/sync/sync_on_central/mod.rs
+++ b/server/service/src/sync/sync_on_central/mod.rs
@@ -175,8 +175,10 @@ pub async fn push(
 
     let records_in_this_batch = records.len() as u64;
 
-    let sync_buffer_rows =
-        CommonSyncRecord::to_buffer_rows(records.into_iter().map(|r| r.record).collect())?;
+    let sync_buffer_rows = CommonSyncRecord::to_buffer_rows(
+        records.into_iter().map(|r| r.record).collect(),
+        Some(response.site_id),
+    )?;
 
     ctx.connection
         .transaction_sync(|t_con| {

--- a/server/service/src/sync/test/test_data/mod.rs
+++ b/server/service/src/sync/test/test_data/mod.rs
@@ -36,6 +36,7 @@ pub(crate) mod reason;
 pub(crate) mod report;
 pub(crate) mod requisition;
 pub(crate) mod requisition_line;
+pub(crate) mod rnr_form;
 pub(crate) mod sensor;
 pub(crate) mod special;
 pub(crate) mod stock_line;
@@ -85,6 +86,7 @@ pub(crate) fn get_all_pull_upsert_central_test_records() -> Vec<TestSyncIncoming
     test_records.append(&mut asset_property::test_pull_upsert_records());
     test_records.append(&mut property::test_pull_upsert_records());
     test_records.append(&mut name_property::test_pull_upsert_records());
+    test_records.append(&mut rnr_form::test_pull_upsert_records());
     test_records
 }
 
@@ -175,6 +177,7 @@ pub(crate) fn get_all_sync_v6_records() -> Vec<TestSyncOutgoingRecord> {
     test_records.append(&mut name_oms_fields::test_v6_central_push_records());
     test_records.append(&mut property::test_v6_central_push_records());
     test_records.append(&mut name_property::test_v6_central_push_records());
+    test_records.append(&mut rnr_form::test_v6_records());
 
     test_records
 }

--- a/server/service/src/sync/test/test_data/mod.rs
+++ b/server/service/src/sync/test/test_data/mod.rs
@@ -37,6 +37,7 @@ pub(crate) mod report;
 pub(crate) mod requisition;
 pub(crate) mod requisition_line;
 pub(crate) mod rnr_form;
+pub(crate) mod rnr_form_line;
 pub(crate) mod sensor;
 pub(crate) mod special;
 pub(crate) mod stock_line;
@@ -86,7 +87,7 @@ pub(crate) fn get_all_pull_upsert_central_test_records() -> Vec<TestSyncIncoming
     test_records.append(&mut asset_property::test_pull_upsert_records());
     test_records.append(&mut property::test_pull_upsert_records());
     test_records.append(&mut name_property::test_pull_upsert_records());
-    test_records.append(&mut rnr_form::test_pull_upsert_records());
+
     test_records
 }
 
@@ -110,6 +111,9 @@ pub(crate) fn get_all_pull_upsert_remote_test_records() -> Vec<TestSyncIncomingR
     test_records.append(&mut name_store_join::test_pull_upsert_records());
     test_records.append(&mut special::name_to_name_store_join::test_pull_upsert_records());
     test_records.append(&mut currency::test_pull_upsert_records());
+    test_records.append(&mut rnr_form::test_pull_upsert_records());
+    test_records.append(&mut rnr_form_line::test_pull_upsert_records());
+
     test_records
 }
 
@@ -125,6 +129,7 @@ pub(crate) fn get_all_pull_delete_central_test_records() -> Vec<TestSyncIncoming
     test_records.append(&mut unit::test_pull_delete_records());
     // Central but site specific
     test_records.append(&mut name_store_join::test_pull_delete_records());
+
     test_records
 }
 
@@ -178,6 +183,7 @@ pub(crate) fn get_all_sync_v6_records() -> Vec<TestSyncOutgoingRecord> {
     test_records.append(&mut property::test_v6_central_push_records());
     test_records.append(&mut name_property::test_v6_central_push_records());
     test_records.append(&mut rnr_form::test_v6_records());
+    test_records.append(&mut rnr_form_line::test_v6_records());
 
     test_records
 }

--- a/server/service/src/sync/test/test_data/rnr_form.rs
+++ b/server/service/src/sync/test/test_data/rnr_form.rs
@@ -1,0 +1,51 @@
+use repository::{rnr_form_row::RnRFormRow, RnRFormStatus};
+use serde_json::json;
+use util::Defaults;
+
+use super::{TestSyncIncomingRecord, TestSyncOutgoingRecord};
+
+const TABLE_NAME: &str = "rnr_form";
+
+const RNR_FORM1: (&str, &str) = (
+    "cfd578f8-c3d5-4a04-a466-0ac81dde2aab",
+    r#"{
+        "id":  "cfd578f8-c3d5-4a04-a466-0ac81dde2aab",
+        "store_id": "store_a",
+        "name_link_id": "",
+        "period_id": "period_1",
+        "program_id": "program_test",
+        "created_datetime": "2020-01-22T15:16:00",
+        "finalised_datetime": null,
+        "status": "DRAFT"
+    }"#,
+);
+
+fn rnr_form1() -> RnRFormRow {
+    RnRFormRow {
+        id: RNR_FORM1.0.to_string(),
+        store_id: "store_a".to_string(),
+        name_link_id: String::new(),
+        period_id: "period_1".to_string(),
+        program_id: "program_test".to_string(),
+        created_datetime: Defaults::naive_date_time(),
+        finalised_datetime: None,
+        status: RnRFormStatus::Draft,
+        linked_requisition_id: None,
+    }
+}
+
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_upsert(
+        TABLE_NAME,
+        RNR_FORM1,
+        rnr_form1(),
+    )]
+}
+
+pub(crate) fn test_v6_records() -> Vec<TestSyncOutgoingRecord> {
+    vec![TestSyncOutgoingRecord {
+        table_name: TABLE_NAME.to_string(),
+        record_id: RNR_FORM1.0.to_string(),
+        push_data: json!(rnr_form1()),
+    }]
+}

--- a/server/service/src/sync/test/test_data/rnr_form.rs
+++ b/server/service/src/sync/test/test_data/rnr_form.rs
@@ -11,7 +11,7 @@ const RNR_FORM1: (&str, &str) = (
     r#"{
         "id":  "cfd578f8-c3d5-4a04-a466-0ac81dde2aab",
         "store_id": "store_a",
-        "name_link_id": "",
+        "name_link_id": "1FB32324AF8049248D929CFB35F255BA",
         "period_id": "period_1",
         "program_id": "program_test",
         "created_datetime": "2020-01-22T15:16:00",
@@ -24,7 +24,7 @@ fn rnr_form1() -> RnRFormRow {
     RnRFormRow {
         id: RNR_FORM1.0.to_string(),
         store_id: "store_a".to_string(),
-        name_link_id: String::new(),
+        name_link_id: "1FB32324AF8049248D929CFB35F255BA".to_string(),
         period_id: "period_1".to_string(),
         program_id: "program_test".to_string(),
         created_datetime: Defaults::naive_date_time(),

--- a/server/service/src/sync/test/test_data/rnr_form_line.rs
+++ b/server/service/src/sync/test/test_data/rnr_form_line.rs
@@ -1,0 +1,65 @@
+use repository::RnRFormLineRow;
+use serde_json::json;
+
+use super::{TestSyncIncomingRecord, TestSyncOutgoingRecord};
+
+const TABLE_NAME: &str = "rnr_form_line";
+
+const RNR_FORM_LINE_1: (&str, &str) = (
+    "8524d61d-3f4d-43fd-9beb-326e6dcca16e",
+    r#"{
+        "id": "8524d61d-3f4d-43fd-9beb-326e6dcca16e",
+        "rnr_form_id":  "cfd578f8-c3d5-4a04-a466-0ac81dde2aab",
+        "item_id": "8F252B5884B74888AAB73A0D42C09E7A",
+        "average_monthly_consumption": 0.0,
+        "initial_balance": 0.0,
+        "quantity_received": 0.0,
+        "quantity_consumed": 0.0,
+        "adjusted_quantity_consumed": 0.0,
+        "adjustments": 0.0,
+        "stock_out_duration": 0,
+        "final_balance": 0.0,
+        "maximum_quantity": 0.0,
+        "expiry_date": null,
+        "requested_quantity": 0.0,
+        "comment": null,
+        "confirmed": false
+    }"#,
+);
+
+fn rnr_form_line_1() -> RnRFormLineRow {
+    RnRFormLineRow {
+        id: RNR_FORM_LINE_1.0.to_string(),
+        rnr_form_id: "cfd578f8-c3d5-4a04-a466-0ac81dde2aab".to_string(),
+        item_id: "8F252B5884B74888AAB73A0D42C09E7A".to_string(),
+        average_monthly_consumption: 0.0,
+        initial_balance: 0.0,
+        quantity_received: 0.0,
+        quantity_consumed: 0.0,
+        adjusted_quantity_consumed: 0.0,
+        adjustments: 0.0,
+        stock_out_duration: 0,
+        final_balance: 0.0,
+        maximum_quantity: 0.0,
+        expiry_date: None,
+        requested_quantity: 0.0,
+        comment: None,
+        confirmed: false,
+    }
+}
+
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_upsert(
+        TABLE_NAME,
+        RNR_FORM_LINE_1,
+        rnr_form_line_1(),
+    )]
+}
+
+pub(crate) fn test_v6_records() -> Vec<TestSyncOutgoingRecord> {
+    vec![TestSyncOutgoingRecord {
+        table_name: TABLE_NAME.to_string(),
+        record_id: RNR_FORM_LINE_1.0.to_string(),
+        push_data: json!(rnr_form_line_1()),
+    }]
+}

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -191,7 +191,6 @@ impl IntegrationOperation {
         connection: &StorageConnection,
         source_site_id: Option<i32>,
     ) -> Result<(), RepositoryError> {
-        log::info!("integrate: {:?}", source_site_id);
         match self {
             IntegrationOperation::Upsert(upsert) => {
                 let cursor_id = upsert.upsert(connection)?;

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -191,6 +191,7 @@ impl IntegrationOperation {
         connection: &StorageConnection,
         source_site_id: Option<i32>,
     ) -> Result<(), RepositoryError> {
+        log::info!("integrate: {:?}", source_site_id);
         match self {
             IntegrationOperation::Upsert(upsert) => {
                 let cursor_id = upsert.upsert(connection)?;

--- a/server/service/src/sync/translations/mod.rs
+++ b/server/service/src/sync/translations/mod.rs
@@ -37,6 +37,7 @@ pub(crate) mod reason;
 pub(crate) mod report;
 pub(crate) mod requisition;
 pub(crate) mod requisition_line;
+pub(crate) mod rnr_form;
 pub(crate) mod sensor;
 pub(crate) mod special;
 pub(crate) mod stock_line;
@@ -124,6 +125,7 @@ pub(crate) fn all_translators() -> SyncTranslators {
         asset_property::boxed(),
         //Sync file reference
         sync_file_reference::boxed(),
+        rnr_form::boxed(),
     ]
 }
 

--- a/server/service/src/sync/translations/mod.rs
+++ b/server/service/src/sync/translations/mod.rs
@@ -38,6 +38,7 @@ pub(crate) mod report;
 pub(crate) mod requisition;
 pub(crate) mod requisition_line;
 pub(crate) mod rnr_form;
+pub(crate) mod rnr_form_line;
 pub(crate) mod sensor;
 pub(crate) mod special;
 pub(crate) mod stock_line;
@@ -125,7 +126,9 @@ pub(crate) fn all_translators() -> SyncTranslators {
         asset_property::boxed(),
         //Sync file reference
         sync_file_reference::boxed(),
+        // RnR Form
         rnr_form::boxed(),
+        rnr_form_line::boxed(),
     ]
 }
 

--- a/server/service/src/sync/translations/rnr_form.rs
+++ b/server/service/src/sync/translations/rnr_form.rs
@@ -3,10 +3,10 @@ use repository::{
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
 };
 
-use crate::sync::translations::master_list::MasterListTranslation;
-use crate::sync::translations::name::NameTranslation;
-use crate::sync::translations::period::PeriodTranslation;
-use crate::sync::translations::store::StoreTranslation;
+use crate::sync::translations::{
+    master_list::MasterListTranslation, name::NameTranslation, period::PeriodTranslation,
+    program_requisition_settings::ProgramRequisitionSettingsTranslation, store::StoreTranslation,
+};
 
 use super::{
     PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
@@ -28,6 +28,7 @@ impl SyncTranslation for RnRFormTranslation {
     fn pull_dependencies(&self) -> Vec<&'static str> {
         vec![
             MasterListTranslation.table_name(),
+            ProgramRequisitionSettingsTranslation.table_name(),
             PeriodTranslation.table_name(),
             StoreTranslation.table_name(),
             NameTranslation.table_name(),

--- a/server/service/src/sync/translations/rnr_form.rs
+++ b/server/service/src/sync/translations/rnr_form.rs
@@ -1,0 +1,109 @@
+use repository::{
+    rnr_form_row::{RnRFormRow, RnRFormRowRepository},
+    ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+};
+
+use crate::sync::translations::master_list::MasterListTranslation;
+use crate::sync::translations::name::NameTranslation;
+use crate::sync::translations::period::PeriodTranslation;
+use crate::sync::translations::store::StoreTranslation;
+
+use super::{
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
+};
+
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(RnRFormTranslation)
+}
+
+pub(crate) struct RnRFormTranslation;
+
+impl SyncTranslation for RnRFormTranslation {
+    fn table_name(&self) -> &'static str {
+        "rnr_form"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![
+            MasterListTranslation.table_name(),
+            PeriodTranslation.table_name(),
+            StoreTranslation.table_name(),
+            NameTranslation.table_name(),
+        ]
+    }
+
+    fn try_translate_from_upsert_sync_record(
+        &self,
+        _: &StorageConnection,
+        sync_record: &SyncBufferRow,
+    ) -> Result<PullTranslateResult, anyhow::Error> {
+        Ok(PullTranslateResult::upsert(serde_json::from_str::<
+            RnRFormRow,
+        >(&sync_record.data)?))
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::RnrForm)
+    }
+
+    fn should_translate_to_sync_record(
+        &self,
+        row: &ChangelogRow,
+        r#type: &ToSyncRecordTranslationType,
+    ) -> bool {
+        match r#type {
+            ToSyncRecordTranslationType::PullFromOmSupplyCentral => {
+                self.change_log_type().as_ref() == Some(&row.table_name)
+            }
+            ToSyncRecordTranslationType::PushToOmSupplyCentral => {
+                self.change_log_type().as_ref() == Some(&row.table_name)
+            }
+            _ => false,
+        }
+    }
+
+    fn try_translate_to_upsert_sync_record(
+        &self,
+        connection: &StorageConnection,
+        changelog: &ChangelogRow,
+    ) -> Result<PushTranslateResult, anyhow::Error> {
+        let row = RnRFormRowRepository::new(connection)
+            .find_one_by_id(&changelog.record_id)?
+            .ok_or(anyhow::Error::msg(format!(
+                "RnRForm row ({}) not found",
+                changelog.record_id
+            )))?;
+
+        Ok(PushTranslateResult::upsert(
+            changelog,
+            self.table_name(),
+            serde_json::to_value(row)?,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use repository::{mock::MockDataInserts, test_db::setup_all};
+
+    #[actix_rt::test]
+    async fn test_rnrform_translation() {
+        use crate::sync::test::test_data::rnr_form as test_data;
+        let translator = RnRFormTranslation;
+
+        let (_, connection, _, _) =
+            setup_all("test_rnr_form_translation", MockDataInserts::all()).await;
+
+        for record in test_data::test_pull_upsert_records() {
+            assert!(translator.should_translate_from_sync_record(&record.sync_buffer_row));
+            let translation_result = translator
+                .try_translate_from_upsert_sync_record(&connection, &record.sync_buffer_row)
+                .unwrap();
+
+            assert_eq!(translation_result, record.translated_record);
+        }
+    }
+}

--- a/server/service/src/sync/translations/rnr_form_line.rs
+++ b/server/service/src/sync/translations/rnr_form_line.rs
@@ -3,7 +3,7 @@ use repository::{
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
 };
 
-use crate::sync::translations::rnr_form::RnRFormTranslation;
+use crate::sync::translations::{item::ItemTranslation, rnr_form::RnRFormTranslation};
 
 use super::{
     PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
@@ -23,7 +23,10 @@ impl SyncTranslation for RnRFormLineTranslation {
     }
 
     fn pull_dependencies(&self) -> Vec<&'static str> {
-        vec![RnRFormTranslation.table_name()]
+        vec![
+            RnRFormTranslation.table_name(),
+            ItemTranslation.table_name(),
+        ]
     }
 
     fn try_translate_from_upsert_sync_record(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4457

# 👩🏻‍💻 What does this PR do?

Syncs R&R Forms to OMS Central Server, doesn't do anything fancy like create response requisitions or transfers.

Both `rnr_form` and `rnr_form_line` are considered remote data.

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Central OMS Server with remote OMS server
- [ ] Create an R&R Form on remote server
- [ ] Check Central OMS Server database contains the new records after integration is completed (There's no central UI for reviewing R&R forms yet

# 📃 Documentation

- [X] **Part of an epic**: documentation will be completed for the feature as a whole
