### PR TITLE
4464 Report filter doesn't filter if you type too fast

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/Text.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Text.tsx
@@ -111,7 +111,7 @@ const UIComponent = (props: ControlProps) => {
       ? t('error.json-bad-format-with-examples', {
           examples: examples.join('", "'),
         })
-      : zErrors ?? errors ?? customErrors;
+      : (zErrors ?? errors ?? customErrors);
 
   if (!props.visible) {
     return null;

--- a/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
+++ b/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from 'react';
 
 import { JsonData, JsonForm } from '@openmsupply-client/programs';
 import { ReportRowFragment } from '../api';
-import { useDialog } from '@common/hooks';
+import { useDebounceCallback, useDialog } from '@common/hooks';
 import { DialogButton } from '@common/components';
 import { useAuthContext } from '@openmsupply-client/common';
 
@@ -33,6 +33,14 @@ export const ReportArgumentsModal: FC<ReportArgumentsModalProps> = ({
     onClose: cleanUp,
   });
 
+  const onArgumentsSelectedDebounced = useDebounceCallback(
+    (report, data) => {
+      onArgumentsSelected(report, data);
+    },
+    [],
+    750
+  );
+
   if (!report?.argumentSchema) {
     return null;
   }
@@ -60,7 +68,7 @@ export const ReportArgumentsModal: FC<ReportArgumentsModalProps> = ({
           variant="ok"
           disabled={!!error}
           onClick={async () => {
-            onArgumentsSelected(report, data);
+            onArgumentsSelectedDebounced(report, data);
             cleanUp();
           }}
         />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4464

# 👩🏻‍💻 What does this PR do?
Debounce ok button for args...  Still a bit finicky depending on how fast you type then click.... but I just type/click super fast... so maybe just me... 

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Set up new reports (run upsert command in folder, or download and upload to OG with StockAndItems or Expiring for context)
- [ ] Sync
- [ ] Go to report page
- [ ] Click on the report
- [ ] Enter in something for item name or code
- [ ] Press Ok

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
