### PR TITLE
Include source site id sync buffer rows after v6 push to OMS Central

### DIFF
--- a/server/service/src/sync/api/common_records.rs
+++ b/server/service/src/sync/api/common_records.rs
@@ -108,8 +108,11 @@ impl CommonSyncRecord {
 
     pub(crate) fn to_buffer_rows(
         rows: Vec<CommonSyncRecord>,
+        source_site_id: Option<i32>,
     ) -> Result<Vec<SyncBufferRow>, ParsingSyncRecordError> {
-        rows.into_iter().map(|r| r.to_buffer_row(None)).collect()
+        rows.into_iter()
+            .map(|r| r.to_buffer_row(source_site_id))
+            .collect()
     }
 }
 
@@ -158,55 +161,58 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_common_records_to_sync_buffer_rows() {
-        let batch = CommonSyncRecord::to_buffer_rows(vec![
-            CommonSyncRecord {
-                table_name: "item".to_string(),
-                record_id: "itemA".to_string(),
-                action: SyncAction::Insert,
-                record_data: json!({
-                    "ID": "itemA",
-                    "item_name": "itemA",
-                    "code": "itemA",
-                    "unit_ID": "",
-                    "type_of": "general",
-                    "default_pack_size": 1,
-                }),
-            },
-            CommonSyncRecord {
-                table_name: "item".to_string(),
-                record_id: "itemA".to_string(),
-                action: SyncAction::Update,
-                record_data: json!({
-                    "ID": "itemA",
-                    "item_name": "itemA",
-                    "code": "itemA",
-                    "unit_ID": "",
-                    "type_of": "general",
-                    "default_pack_size": 1,
-                }),
-            },
-            CommonSyncRecord {
-                table_name: "item".to_string(),
-                record_id: "itemB".to_string(),
-                action: SyncAction::Insert,
-                record_data: json!({
-                    "ID": "itemB",
-                    "item_name": "itemB",
-                    "code": "itemB",
-                    "unit_ID": "",
-                    "type_of": "general",
-                    "default_pack_size": 1,
-                }),
-            },
-            CommonSyncRecord {
-                table_name: "item".to_string(),
-                record_id: "itemA".to_string(),
-                action: SyncAction::Merge,
-                record_data: json!({
-                    "mergeIdToKeep": "itemA", "mergeIdToDelete": "itemB"
-                }),
-            },
-        ])
+        let batch = CommonSyncRecord::to_buffer_rows(
+            vec![
+                CommonSyncRecord {
+                    table_name: "item".to_string(),
+                    record_id: "itemA".to_string(),
+                    action: SyncAction::Insert,
+                    record_data: json!({
+                        "ID": "itemA",
+                        "item_name": "itemA",
+                        "code": "itemA",
+                        "unit_ID": "",
+                        "type_of": "general",
+                        "default_pack_size": 1,
+                    }),
+                },
+                CommonSyncRecord {
+                    table_name: "item".to_string(),
+                    record_id: "itemA".to_string(),
+                    action: SyncAction::Update,
+                    record_data: json!({
+                        "ID": "itemA",
+                        "item_name": "itemA",
+                        "code": "itemA",
+                        "unit_ID": "",
+                        "type_of": "general",
+                        "default_pack_size": 1,
+                    }),
+                },
+                CommonSyncRecord {
+                    table_name: "item".to_string(),
+                    record_id: "itemB".to_string(),
+                    action: SyncAction::Insert,
+                    record_data: json!({
+                        "ID": "itemB",
+                        "item_name": "itemB",
+                        "code": "itemB",
+                        "unit_ID": "",
+                        "type_of": "general",
+                        "default_pack_size": 1,
+                    }),
+                },
+                CommonSyncRecord {
+                    table_name: "item".to_string(),
+                    record_id: "itemA".to_string(),
+                    action: SyncAction::Merge,
+                    record_data: json!({
+                        "mergeIdToKeep": "itemA", "mergeIdToDelete": "itemB"
+                    }),
+                },
+            ],
+            None, /* Source Site Id */
+        )
         .unwrap();
 
         let (_, connection, _, _) = setup_all(

--- a/server/service/src/sync/central_data_synchroniser.rs
+++ b/server/service/src/sync/central_data_synchroniser.rs
@@ -45,8 +45,10 @@ impl CentralDataSynchroniser {
             logger.progress(SyncStepProgress::PullCentral, max_cursor - start_cursor)?;
 
             let last_cursor_in_batch = data.last().map(|r| r.cursor).unwrap_or(start_cursor);
-            let sync_buffer_rows =
-                CommonSyncRecord::to_buffer_rows(data.into_iter().map(|r| r.record).collect())?;
+            let sync_buffer_rows = CommonSyncRecord::to_buffer_rows(
+                data.into_iter().map(|r| r.record).collect(),
+                None, // Everything from mSupply Central Server is considered to not have a source_site_id
+            )?;
 
             // Upsert sync buffer rows in a transaction together with cursor update
             connection

--- a/server/service/src/sync/central_data_synchroniser_v6.rs
+++ b/server/service/src/sync/central_data_synchroniser_v6.rs
@@ -110,8 +110,10 @@ impl SynchroniserV6 {
             logger.progress(SyncStepProgress::PullCentralV6, total_records)?;
 
             let last_cursor_in_batch = records.last().map(|r| r.cursor).unwrap_or(start_cursor);
-            let sync_buffer_rows =
-                CommonSyncRecord::to_buffer_rows(records.into_iter().map(|r| r.record).collect())?;
+            let sync_buffer_rows = CommonSyncRecord::to_buffer_rows(
+                records.into_iter().map(|r| r.record).collect(),
+                None, // Everything from open-mSupply Central Server is considered to not have a source_site_id
+            )?;
             // Upsert sync buffer rows in a transaction together with cursor update
             connection
                 .transaction_sync(|t_con| {

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -143,8 +143,10 @@ impl RemoteDataSynchroniser {
                 data,
             } = sync_batch;
 
-            let sync_buffer_rows =
-                CommonSyncRecord::to_buffer_rows(data.into_iter().map(|r| r.record).collect())?;
+            let sync_buffer_rows = CommonSyncRecord::to_buffer_rows(
+                data.into_iter().map(|r| r.record).collect(),
+                None, // Everything from mSupply Central Server is considered to not have a source_site_id
+            )?;
 
             let number_of_pulled_records = sync_buffer_rows.len() as u64;
 

--- a/server/service/src/sync/sync_on_central/mod.rs
+++ b/server/service/src/sync/sync_on_central/mod.rs
@@ -175,8 +175,10 @@ pub async fn push(
 
     let records_in_this_batch = records.len() as u64;
 
-    let sync_buffer_rows =
-        CommonSyncRecord::to_buffer_rows(records.into_iter().map(|r| r.record).collect())?;
+    let sync_buffer_rows = CommonSyncRecord::to_buffer_rows(
+        records.into_iter().map(|r| r.record).collect(),
+        Some(response.site_id),
+    )?;
 
     ctx.connection
         .transaction_sync(|t_con| {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4466

# 👩🏻‍💻 What does this PR do?

In a recent refactor we changed how we set the `source_site_id` on sync buffer rows. #4040
However, one function was hard coded to set this to none, resulting in incorrect setting of this source_site_id

## 💌 Any notes for the reviewer?

Anything else we might have missed?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a Cold Chain Equipment (or some other remote data on an OMS Site that syncs to OMS Central)
- [ ] Sync to OMS Central
- [ ] Check the records are integrated straight away (before would need to integrate)
- [ ] Re-initialise your remote server, check that newly create asset is downloaded correctly on re-initialisation

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
