### PR TITLE
4466-integration-test-for-remote-omsupply-data

### DIFF
--- a/server/service/src/sync/test/integration/README.md
+++ b/server/service/src/sync/test/integration/README.md
@@ -107,7 +107,7 @@ For each step:
 - Completely Re Sync
 - Check IntegrationRecords in TestData against database
 
-## Open mSupply Central
+## Open mSupply Central (Central Data)
 
 For each step:
 
@@ -115,6 +115,19 @@ For each step:
 - Request and wait for sync of open mSupply central server (which will sync the central data we just created in original mSupply central server)
 - Perform graphql data mutations on open mSupply central server
 - Sync (remote site)
+- Check IntegrationRecords in TestData against database
+
+## Open mSupply Central (Remote Data)
+
+For each step:
+
+- Upsert central data specified in TestData
+- Request and wait for sync of open mSupply central server (which will sync the central data we just created in original mSupply central server)
+- Perform graphql data mutations on open mSupply central server
+- Sync (remote site)
+- Upsert/Delete (on remote server) IntegrationRecords in TestData 
+- Sync (remote site)
+- Completely Re Sync
 - Check IntegrationRecords in TestData against database
 
 # How do they work (Transfers)

--- a/server/service/src/sync/test/integration/central/unit_and_item.rs
+++ b/server/service/src/sync/test/integration/central/unit_and_item.rs
@@ -56,6 +56,8 @@ impl SyncRecordTester for UnitAndItemTester {
             default_pack_size: 1.0,
             is_active: true,
             is_vaccine: false,
+            strength: None,
+            ven_category: Default::default(),
         };
         let item_json1 = extend_base(json!({
             "ID": item_row1.id,
@@ -76,6 +78,8 @@ impl SyncRecordTester for UnitAndItemTester {
             default_pack_size: 1.0,
             is_active: true,
             is_vaccine: false,
+            strength: None,
+            ven_category: Default::default(),
         };
         let item_json2 = extend_base(json!({
             "ID": item_row2.id,
@@ -96,6 +100,8 @@ impl SyncRecordTester for UnitAndItemTester {
             default_pack_size: 1.0,
             is_active: true,
             is_vaccine: false,
+            strength: None,
+            ven_category: Default::default(),
         };
         let item_json3 = extend_base(json!({
             "ID": item_row3.id,

--- a/server/service/src/sync/test/integration/omsupply_central/asset.rs
+++ b/server/service/src/sync/test/integration/omsupply_central/asset.rs
@@ -1,0 +1,31 @@
+use crate::sync::{
+    test::integration::{
+        central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
+    },
+    translations::IntegrationOperation,
+};
+
+use repository::{asset_row::AssetRow, mock::mock_asset_a};
+
+use util::uuid::uuid;
+
+pub(crate) struct AssetTester;
+
+impl SyncRecordTester for AssetTester {
+    fn test_step_data(&self, site_properties: &NewSiteProperties) -> Vec<TestStepData> {
+        let mut result = Vec::new();
+
+        let asset_row = AssetRow {
+            id: uuid(),
+            store_id: Some(site_properties.store_id.clone()),
+            ..mock_asset_a()
+        };
+
+        result.push(TestStepData {
+            integration_records: vec![IntegrationOperation::upsert(asset_row.clone())],
+            ..Default::default()
+        });
+
+        result
+    }
+}

--- a/server/service/src/sync/test/integration/omsupply_central/mod.rs
+++ b/server/service/src/sync/test/integration/omsupply_central/mod.rs
@@ -1,10 +1,13 @@
+mod asset;
 mod pack_variant;
 mod test;
 
 use std::time::Duration;
 
+use repository::ChangelogRepository;
 use reqwest::Client;
 use url::Url;
+use util::assert_variant;
 
 use crate::sync::{
     test::{
@@ -14,11 +17,16 @@ use crate::sync::{
             init_test_context, SyncIntegrationContext,
         },
     },
+    translation_and_integration::integrate,
     CentralServerConfig,
 };
 
 use super::{GraphqlRequest, SyncRecordTester};
 
+/// For each test step:
+/// Upsert data to omSupply central via graphql
+/// Synchronise remote site
+/// Check integrated records exit
 async fn test_omsupply_central_records(identifier: &str, tester: &dyn SyncRecordTester) {
     // util::init_logger(util::LogLevel::Info);
     // Without re-initialisation
@@ -69,6 +77,86 @@ async fn test_omsupply_central_records(identifier: &str, tester: &dyn SyncRecord
 
         synchroniser.sync().await.unwrap();
         check_integrated(&connection, step_data.integration_records)
+    }
+}
+
+/// For each test step:
+/// Upsert data to database
+/// Push changes to central server
+/// Reinitialises from central server with a fresh database
+/// Check that pulled data matches previously upserted data
+async fn test_omsupply_central_remote_records(identifier: &str, tester: &dyn SyncRecordTester) {
+    // util::init_logger(util::LogLevel::Info);
+    // Without re-initialisation
+    println!("test_omsupply_central_remote_records{}_init", identifier);
+
+    let central_server_configurations = ConfigureCentralServer::from_env();
+    let SiteConfiguration {
+        new_site_properties,
+        sync_settings,
+    } = central_server_configurations
+        .create_sync_site(vec![])
+        .await
+        .expect("Problem creating sync site");
+
+    let SyncIntegrationContext {
+        connection,
+        synchroniser,
+        ..
+    } = init_test_context(&sync_settings, &identifier).await;
+
+    let steps_data = tester.test_step_data(&new_site_properties);
+    // First sync is required to get central server URL (before graphql queries are called)
+    synchroniser.sync().await.unwrap();
+
+    let central_server_url = assert_variant!(CentralServerConfig::get(), CentralServerConfig::CentralServerUrl(url) => url);
+
+    let mut previous_connection = connection;
+    let mut previous_synchroniser = synchroniser;
+
+    for (index, step_data) in steps_data.into_iter().enumerate() {
+        let inner_identifier = format!("{}_step_{}", identifier, index + 1);
+        println!("test_omsupply_central_remote_records_{}", inner_identifier);
+
+        central_server_configurations
+            .upsert_records(step_data.central_upsert)
+            .await
+            .expect("Problem inserting central data");
+
+        // Sync omSupply central server first
+        sync_omsupply_central(&central_server_url).await;
+        // Integrate omSupply central server records via graphql
+        for graphql_operation in step_data.om_supply_central_graphql_operations {
+            graphql(&central_server_url, graphql_operation).await;
+        }
+
+        previous_synchroniser.sync().await.unwrap();
+
+        let integration_records = step_data.integration_records;
+
+        // Integrate
+        {
+            let changelog_repo = ChangelogRepository::new(&previous_connection);
+            let cursor = changelog_repo.latest_cursor().unwrap();
+            integrate(&previous_connection, &integration_records, None).unwrap();
+            // Need to reset is_sync_update since we've inserted test data with sync methods
+            // they need to sync to central (if is_sync_update is set to true they will not sync to central)
+            changelog_repo.reset_is_sync_update(cursor).unwrap();
+        } // Extra scope is needed to drop changelog_repo since it has ref to mutable previous_connection
+          // Push integrated changes
+        previous_synchroniser.sync().await.unwrap();
+        // Re initialise
+        let SyncIntegrationContext {
+            connection,
+            synchroniser,
+            ..
+        } = init_test_context(&sync_settings, &inner_identifier).await;
+        previous_connection = connection;
+        previous_synchroniser = synchroniser;
+        previous_synchroniser.sync().await.unwrap();
+
+        // Confirm records have synced back correctly
+        check_integrated(&previous_connection, integration_records)
     }
 }
 

--- a/server/service/src/sync/test/integration/omsupply_central/test.rs
+++ b/server/service/src/sync/test/integration/omsupply_central/test.rs
@@ -1,11 +1,17 @@
 #[cfg(test)]
 mod tests {
     use crate::sync::test::integration::omsupply_central::{
-        pack_variant::PackVariantTester, test_omsupply_central_records,
+        asset::AssetTester, pack_variant::PackVariantTester, test_omsupply_central_records,
+        test_omsupply_central_remote_records,
     };
 
     #[actix_rt::test]
     async fn integration_sync_omsupply_central_sync_pack_variant() {
         test_omsupply_central_records("pack_variant", &PackVariantTester).await;
+    }
+
+    #[actix_rt::test]
+    async fn integration_sync_omsupply_central_sync_asset() {
+        test_omsupply_central_remote_records("asset", &AssetTester).await;
     }
 }

--- a/server/service/src/sync/test/integration/transfer/mod.rs
+++ b/server/service/src/sync/test/integration/transfer/mod.rs
@@ -31,7 +31,6 @@ struct SyncIntegrationTransferContext {
     item1: ItemRow,
     item2: ItemRow,
     service_item: ItemRow,
-    currency: CurrencyRow,
 }
 
 async fn initialise_transfer_sites(identifier: &str) -> SyncIntegrationTransferContext {

--- a/server/service/src/sync/test/integration/transfer/mod.rs
+++ b/server/service/src/sync/test/integration/transfer/mod.rs
@@ -76,7 +76,7 @@ async fn initialise_transfer_sites(identifier: &str) -> SyncIntegrationTransferC
         .await
         .expect("Problem inserting central data");
 
-    let (item1, item2, service_item, currency, central_data) = items_and_currency();
+    let (item1, item2, service_item, _currency, central_data) = items_and_currency();
     central_server_configurations
         .upsert_records(central_data)
         .await
@@ -108,7 +108,6 @@ async fn initialise_transfer_sites(identifier: &str) -> SyncIntegrationTransferC
         item1,
         item2,
         service_item,
-        currency,
     }
 }
 

--- a/server/service/src/sync/test/integration/transfer/requisition.rs
+++ b/server/service/src/sync/test/integration/transfer/requisition.rs
@@ -16,7 +16,6 @@ async fn integration_sync_requisition_transfers_normal() {
         item1,
         item2,
         service_item: _,
-        currency: _,
     } = initialise_transfer_sites("requisition_transfers_normal").await;
 
     let test = async move {
@@ -98,7 +97,6 @@ async fn integration_sync_requisition_transfers_initialisation() {
         item1,
         item2,
         service_item: _,
-        currency: _,
     } = initialise_transfer_sites(identifier).await;
 
     let test = async move {

--- a/server/service/src/sync/test/integration/transfer/returns.rs
+++ b/server/service/src/sync/test/integration/transfer/returns.rs
@@ -17,7 +17,6 @@ async fn integration_sync_return_transfers_normal() {
         item1,
         item2,
         service_item,
-        currency: _,
     } = initialise_transfer_sites("sync_return_transfers_normal").await;
 
     let test = async move {
@@ -178,7 +177,6 @@ async fn integration_sync_return_transfers_delete() {
         item1,
         item2,
         service_item,
-        currency: _,
     } = initialise_transfer_sites("return_transfers_delete").await;
 
     let test = async move {
@@ -286,7 +284,6 @@ async fn integration_sync_return_transfers_initialise() {
         item1,
         item2,
         service_item,
-        currency: _,
     } = initialise_transfer_sites(identifier).await;
 
     let test = async move {

--- a/server/service/src/sync/test/integration/transfer/shipments.rs
+++ b/server/service/src/sync/test/integration/transfer/shipments.rs
@@ -17,7 +17,6 @@ async fn integration_sync_shipment_transfers_normal() {
         item1,
         item2,
         service_item,
-        currency: _,
     } = initialise_transfer_sites("sync_shipment_transfers_normal").await;
 
     let test = async move {
@@ -158,7 +157,6 @@ async fn integration_sync_shipment_transfers_delete() {
         item1,
         item2,
         service_item,
-        currency: _,
     } = initialise_transfer_sites("shipment_transfers_delete").await;
 
     let test = async move {
@@ -245,7 +243,6 @@ async fn integration_sync_shipment_transfers_initialise() {
         item1,
         item2,
         service_item,
-        currency: _,
     } = initialise_transfer_sites(identifier).await;
 
     let test = async move {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Helper for validating #4466 in develop this test fails, but in the following PR it passes: https://github.com/msupply-foundation/open-msupply/pull/4463

# 👩🏻‍💻 What does this PR do?

Current omSuppy <-> omSupply central integration tests are limited to central data. Added remote data tester (basically a copy of existing [remote test for syncing with mSupply](https://github.com/msupply-foundation/open-msupply/blob/af61d89f9aa1541ed382e0d9d251e4bbd1f6605a/server/service/src/sync/test/integration/remote/mod.rs#L39-L107). Added one test case for asset row

## 💌 Any notes for the reviewer?

We talked with @jmbrunskill briefly, when do we add sync integration test ? For now have the following:

* At least one integration test should be added for a records type (i.e. for omSupply central data -> pack_variant one for omSupply remote data -> asset, transfers -> invoice/requisition transfer tests)
* When sync errors arise, replicate with integration test for that records type (if possible)

It would be great if we had sync integration tests for all records types, not sure if we can invest the time into doing this though

# 🧪 Testing

Please see automated test description in integration/README.md

# 📃 Documentation
