### PR TITLE
Remove 1.2 Migration Warning

### DIFF
--- a/server/repository/src/migrations/v1_06_00/is_sync_update.rs
+++ b/server/repository/src/migrations/v1_06_00/is_sync_update.rs
@@ -210,12 +210,12 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
     )
     .is_err()
     {
-        println!("Database migration warning: Failed to add is_sync_update column to name, name_store_join, clinician and clinician_store_join as current version is < 1.2.00");
+        log::debug!("Database migration warning: Failed to add is_sync_update column to name, name_store_join, clinician and clinician_store_join as current version is < 1.2.00");
     }
 
     // these statements would have had the same problem
     if migrate_triggers(connection).is_err() {
-        println!("Database migration warning: Failed to add triggers for is_sync_update as version is < 1.2.00");
+        log::debug!("Database migration warning: Failed to add triggers for is_sync_update as version is < 1.2.00");
     }
 
     Ok(())


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3875

# 👩🏻‍💻 What does this PR do?

Changing warning to be a log::debug!

Shouldn't happen in production anymore, and is confusing seeing it in developer logs now and again...

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Test a failed migration doesn't show you an error? (Developer testing only)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
