### PR TITLE
filter report contexts for r&r forms

### DIFF
--- a/client/packages/programs/src/RnRForms/DetailView/AppBarButtons.tsx
+++ b/client/packages/programs/src/RnRForms/DetailView/AppBarButtons.tsx
@@ -44,6 +44,7 @@ export const AppBarButtonsComponent = () => {
       <Grid container gap={1}>
         <ReportSelector
           context={ReportContext.Requisition}
+          subContext="R&R"
           onPrint={printReport}
         >
           <LoadingButton

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
@@ -59,6 +59,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
         <ReportSelector
           context={ReportContext.Requisition}
           onPrint={printReport}
+          // Filters out reports that have a subContext (i.e. `R&R`)
           queryParams={{ filterBy: { subContext: { equalAnyOrNull: [] } } }}
         >
           <LoadingButton

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
@@ -59,6 +59,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
         <ReportSelector
           context={ReportContext.Requisition}
           onPrint={printReport}
+          queryParams={{ filterBy: { subContext: { equalAnyOrNull: [] } } }}
         >
           <LoadingButton
             variant="outlined"

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
@@ -38,6 +38,7 @@ export const AppBarButtonsComponent = () => {
         <ReportSelector
           context={ReportContext.Requisition}
           onPrint={printReport}
+          queryParams={{ filterBy: { subContext: { equalAnyOrNull: [] } } }}
         >
           <LoadingButton
             variant="outlined"

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
@@ -38,6 +38,7 @@ export const AppBarButtonsComponent = () => {
         <ReportSelector
           context={ReportContext.Requisition}
           onPrint={printReport}
+          // Filters out reports that have a subContext (i.e. `R&R`)
           queryParams={{ filterBy: { subContext: { equalAnyOrNull: [] } } }}
         >
           <LoadingButton

--- a/client/packages/system/src/Report/api/hooks/useReportList.ts
+++ b/client/packages/system/src/Report/api/hooks/useReportList.ts
@@ -11,8 +11,8 @@ import { LIST, REPORT } from './keys';
 
 export type ReportListParams = {
   filterBy: ReportFilterInput | null;
-  sortBy: SortBy<ReportRowFragment>;
-  offset: number;
+  sortBy?: SortBy<ReportRowFragment>;
+  offset?: number;
 };
 
 export const useReportList = ({
@@ -39,15 +39,12 @@ export const useReportList = ({
     nodes: ReportRowFragment[];
     totalCount: number;
   }> => {
-    const filter =
-      context || subContext
-        ? {
-            context: context ? { equalTo: context } : null,
-            subContext: subContext ? { equalTo: subContext } : null,
-          }
-        : null;
     const query = await reportApi.reports({
-      filter: { ...filterBy, ...filter },
+      filter: {
+        ...filterBy,
+        ...(context ? { context: { equalTo: context } } : null),
+        ...(subContext ? { subContext: { equalTo: subContext } } : null),
+      },
       key: sortBy.key as ReportSortFieldInput,
       desc: sortBy.isDesc,
       storeId,

--- a/client/packages/system/src/Report/components/ReportSelector.tsx
+++ b/client/packages/system/src/Report/components/ReportSelector.tsx
@@ -10,7 +10,7 @@ import {
 } from '@common/components';
 import { ReportArgumentsModal } from './ReportArgumentsModal';
 import { JsonData } from '@openmsupply-client/programs';
-import { useReportList } from '../api/hooks';
+import { ReportListParams, useReportList } from '../api/hooks';
 import { ReportRowFragment } from '../api';
 
 interface ReportSelectorProps {
@@ -18,6 +18,7 @@ interface ReportSelectorProps {
   subContext?: string;
   onPrint: (report: ReportRowFragment, args: JsonData | undefined) => void;
   disabled?: boolean;
+  queryParams?: ReportListParams;
 }
 
 const NoReports = ({ hasPermission }: { hasPermission: boolean }) => {
@@ -44,9 +45,14 @@ export const ReportSelector: FC<PropsWithChildren<ReportSelectorProps>> = ({
   children,
   onPrint,
   disabled,
+  queryParams,
 }) => {
   const { hide, PaperClickPopover } = usePaperClickPopover();
-  const { data, isLoading } = useReportList({ context, subContext });
+  const { data, isLoading } = useReportList({
+    context,
+    subContext,
+    queryParams,
+  });
   const t = useTranslation('app');
   const [reportWithArgs, setReportWithArgs] = useState<
     ReportRowFragment | undefined


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4415 


# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

R&R report PR [here](https://github.com/msupply-foundation/open-msupply-reports/pull/76) - use the upsert script there to insert the report and test this PR.

This PR adds filtering of Requisition subcontexts, so only R&R report shows on R&R page, and it doesn't show on other requisition pages.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Upsert the R&R report
- [ ] Go to an R&R form
- [ ] Click Print - report is generated and print window opens immediately
- [ ] Only Internal Order and Requisition pages, there is no option to print an R&R report

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
