### PR TITLE
Fix opening balance for first R&R Form when stock is reserved.

### DIFF
--- a/server/repository/src/db_diesel/stock_on_hand.rs
+++ b/server/repository/src/db_diesel/stock_on_hand.rs
@@ -10,6 +10,7 @@ table! {
         item_name -> Text,
         store_id -> Text,
         available_stock_on_hand -> Double,
+        total_stock_on_hand -> Double,
     }
 }
 
@@ -20,6 +21,7 @@ pub struct StockOnHandRow {
     pub item_name: String,
     pub store_id: String,
     pub available_stock_on_hand: f64,
+    pub total_stock_on_hand: f64,
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]

--- a/server/repository/src/migrations/v2_02_00/mod.rs
+++ b/server/repository/src/migrations/v2_02_00/mod.rs
@@ -10,6 +10,7 @@ mod item_ven;
 mod remove_changelog_triggers;
 mod report_add_report_context;
 mod rnr_form;
+mod stock_on_hand_add_total_stock;
 mod store_preferences_for_reports;
 mod sync;
 
@@ -31,6 +32,7 @@ impl Migration for V2_02_00 {
         item_ven::migrate(connection)?;
         consumption_and_replenishment_views::migrate(connection)?;
         sync::migrate(connection)?;
+        stock_on_hand_add_total_stock::migrate(connection)?;
         Ok(())
     }
 }

--- a/server/repository/src/migrations/v2_02_00/stock_on_hand_add_total_stock.rs
+++ b/server/repository/src/migrations/v2_02_00/stock_on_hand_add_total_stock.rs
@@ -5,7 +5,13 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
     sql!(
         connection,
         r#"
+        DROP VIEW IF EXISTS stock_on_hand;
         DROP VIEW IF EXISTS store_items;
+        "#,
+    )?;
+    sql!(
+        connection,
+        r#"
         CREATE VIEW store_items AS
         SELECT i.id as item_id, sl.store_id, sl.pack_size, sl.available_number_of_packs, sl.total_number_of_packs
         FROM
@@ -18,8 +24,6 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
     sql!(
         connection,
         r#"
-        DROP VIEW stock_on_hand;
-
         CREATE VIEW stock_on_hand AS
         SELECT
           'n/a' AS id,

--- a/server/repository/src/migrations/v2_02_00/stock_on_hand_add_total_stock.rs
+++ b/server/repository/src/migrations/v2_02_00/stock_on_hand_add_total_stock.rs
@@ -1,0 +1,60 @@
+use crate::{migrations::sql, StorageConnection};
+
+pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
+    // re-create stock_on_hand and store_items
+    sql!(
+        connection,
+        r#"
+        DROP VIEW IF EXISTS store_items;
+        CREATE VIEW store_items AS
+        SELECT i.id as item_id, sl.store_id, sl.pack_size, sl.available_number_of_packs, sl.total_number_of_packs
+        FROM
+          item i
+          LEFT JOIN item_link il ON il.item_id = i.id
+          LEFT JOIN stock_line sl ON sl.item_link_id = il.id
+          LEFT JOIN store s ON s.id = sl.store_id
+        "#,
+    )?;
+    sql!(
+        connection,
+        r#"
+        DROP VIEW stock_on_hand;
+
+        CREATE VIEW stock_on_hand AS
+        SELECT
+          'n/a' AS id,
+          items_and_stores.item_id AS item_id,
+          items_and_stores.item_name AS item_name,
+          items_and_stores.store_id AS store_id,
+          COALESCE(stock.available_stock_on_hand, 0) AS available_stock_on_hand,
+          COALESCE(stock.total_stock_on_hand, 0) AS total_stock_on_hand
+        FROM
+          (
+            SELECT
+              item.id AS item_id,
+              item.name AS item_name,
+              store.id AS store_id
+            FROM
+              item,
+              store
+          ) AS items_and_stores
+          LEFT OUTER JOIN (
+            SELECT
+              item_id,
+              store_id,
+              SUM(pack_size * available_number_of_packs) AS available_stock_on_hand,
+              SUM(pack_size * total_number_of_packs) AS total_stock_on_hand
+            FROM
+              store_items
+            WHERE
+              store_items.available_number_of_packs > 0 OR store_items.total_number_of_packs > 0
+            GROUP BY
+              item_id,
+              store_id
+          ) AS stock ON stock.item_id = items_and_stores.item_id
+          AND stock.store_id = items_and_stores.store_id
+     "#
+    )?;
+
+    Ok(())
+}

--- a/server/service/src/rnr_form/generate_rnr_form_lines.rs
+++ b/server/service/src/rnr_form/generate_rnr_form_lines.rs
@@ -272,7 +272,7 @@ pub fn get_opening_balance(
                 .store_id(EqualFilter::equal_to(store_id))
                 .item_id(EqualFilter::equal_to(item_id)),
         )?
-        .map(|row| row.available_stock_on_hand)
+        .map(|row| row.total_stock_on_hand)
         .unwrap_or(0.0);
 
     Ok(stock_on_hand_now - total_movements_since_start_date)

--- a/server/service/src/rnr_form/tests/finalise.rs
+++ b/server/service/src/rnr_form/tests/finalise.rs
@@ -71,11 +71,6 @@ mod finalise {
             .context(mock_store_a().id, "".to_string())
             .unwrap();
 
-        let last_requisition_number = RequisitionRowRepository::new(&context.connection)
-            .find_max_requisition_number(repository::RequisitionType::Request, &mock_store_a().id)
-            .unwrap()
-            .unwrap_or_default();
-
         let _result = service_provider
             .rnr_form_service
             .finalise_rnr_form(

--- a/server/service/src/rnr_form/tests/finalise.rs
+++ b/server/service/src/rnr_form/tests/finalise.rs
@@ -5,8 +5,8 @@ mod finalise {
     use repository::test_db::setup_all;
     use repository::{
         EqualFilter, RequisitionFilter, RequisitionLineFilter, RequisitionLineRepository,
-        RequisitionRepository, RequisitionRowRepository, RequisitionStatus,
-        RnRFormLineRowRepository, RnRFormRowRepository, RnRFormStatus,
+        RequisitionRepository, RequisitionStatus, RnRFormLineRowRepository, RnRFormRowRepository,
+        RnRFormStatus,
     };
 
     use crate::rnr_form::finalise::{FinaliseRnRForm, FinaliseRnRFormError};

--- a/server/service/src/sync/test/test_data/rnr_form_line.rs
+++ b/server/service/src/sync/test/test_data/rnr_form_line.rs
@@ -23,7 +23,8 @@ const RNR_FORM_LINE_1: (&str, &str) = (
         "expiry_date": null,
         "requested_quantity": 0.0,
         "comment": null,
-        "confirmed": false
+        "confirmed": false,
+        previous_average_monthly_consumption: 0.0
     }"#,
 );
 
@@ -48,6 +49,7 @@ fn rnr_form_line_1() -> RnRFormLineRow {
         requested_quantity: 0.0,
         comment: None,
         confirmed: false,
+        previous_average_monthly_consumption: 0.0,
     }
 }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4472

# 👩🏻‍💻 What does this PR do?

Adds total_stock_on_hand to stock_on_hand view
Changes RnR Form logic to use total_stock_on_hand

## 💌 Any notes for the reviewer?

Also fixed an RnR Form test.
There's another unrelated test failing though.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Setup for testing R&R forms (see: https://github.com/msupply-foundation/open-msupply/issues/4405)
- [ ] Create a stockline that will be part of your RnR Form with less available stock, than total stock. (This can be done by creating an outbound shipment, with a stock stock assigned, but leave the outbound shipment status as `Allocated` (Don't confirm `Picked`)
- [ ] Check the opening `stock on hand` is calculated correctly when the R&R form is created for that item.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
