### PR TITLE
4161 relocate gender input

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -1032,7 +1032,7 @@ export type ContactTraceFilterInput = {
   datetime?: InputMaybe<DatetimeFilterInput>;
   documentName?: InputMaybe<StringFilterInput>;
   firstName?: InputMaybe<StringFilterInput>;
-  gender?: InputMaybe<EqualFilterGenderInput>;
+  gender?: InputMaybe<EqualFilterGenderType>;
   id?: InputMaybe<EqualFilterStringInput>;
   lastName?: InputMaybe<StringFilterInput>;
   patientId?: InputMaybe<EqualFilterStringInput>;
@@ -1939,10 +1939,10 @@ export type EqualFilterEncounterStatusInput = {
   notEqualTo?: InputMaybe<EncounterNodeStatus>;
 };
 
-export type EqualFilterGenderInput = {
-  equalAny?: InputMaybe<Array<GenderInput>>;
-  equalTo?: InputMaybe<GenderInput>;
-  notEqualTo?: InputMaybe<GenderInput>;
+export type EqualFilterGenderType = {
+  equalAny?: InputMaybe<Array<GenderType>>;
+  equalTo?: InputMaybe<GenderType>;
+  notEqualTo?: InputMaybe<GenderType>;
 };
 
 export type EqualFilterInventoryAdjustmentReasonTypeInput = {
@@ -2118,19 +2118,6 @@ export type FullSyncStatusNode = {
   pushV6?: Maybe<SyncStatusWithProgressNode>;
   summary: SyncStatusNode;
 };
-
-export enum GenderInput {
-  Female = 'FEMALE',
-  Male = 'MALE',
-  NonBinary = 'NON_BINARY',
-  TransgenderFemale = 'TRANSGENDER_FEMALE',
-  TransgenderFemaleHormone = 'TRANSGENDER_FEMALE_HORMONE',
-  TransgenderFemaleSurgical = 'TRANSGENDER_FEMALE_SURGICAL',
-  TransgenderMale = 'TRANSGENDER_MALE',
-  TransgenderMaleHormone = 'TRANSGENDER_MALE_HORMONE',
-  TransgenderMaleSurgical = 'TRANSGENDER_MALE_SURGICAL',
-  Unknown = 'UNKNOWN'
-}
 
 export enum GenderType {
   Female = 'FEMALE',
@@ -2693,7 +2680,7 @@ export type InsertPatientInput = {
   dateOfBirth?: InputMaybe<Scalars['NaiveDate']['input']>;
   dateOfDeath?: InputMaybe<Scalars['NaiveDate']['input']>;
   firstName?: InputMaybe<Scalars['String']['input']>;
-  gender?: InputMaybe<GenderInput>;
+  gender?: InputMaybe<GenderType>;
   id: Scalars['String']['input'];
   isDeceased?: InputMaybe<Scalars['Boolean']['input']>;
   lastName?: InputMaybe<Scalars['String']['input']>;
@@ -4767,7 +4754,7 @@ export type PatientFilterInput = {
   dateOfDeath?: InputMaybe<DateFilterInput>;
   email?: InputMaybe<StringFilterInput>;
   firstName?: InputMaybe<StringFilterInput>;
-  gender?: InputMaybe<EqualFilterGenderInput>;
+  gender?: InputMaybe<EqualFilterGenderType>;
   id?: InputMaybe<EqualFilterStringInput>;
   identifier?: InputMaybe<StringFilterInput>;
   lastName?: InputMaybe<StringFilterInput>;
@@ -4840,7 +4827,7 @@ export type PatientSearchInput = {
   code2?: InputMaybe<Scalars['String']['input']>;
   dateOfBirth?: InputMaybe<Scalars['NaiveDate']['input']>;
   firstName?: InputMaybe<Scalars['String']['input']>;
-  gender?: InputMaybe<GenderInput>;
+  gender?: InputMaybe<GenderType>;
   identifier?: InputMaybe<Scalars['String']['input']>;
   lastName?: InputMaybe<Scalars['String']['input']>;
 };
@@ -7586,7 +7573,7 @@ export type UpdatePatientInput = {
   dateOfBirth?: InputMaybe<Scalars['NaiveDate']['input']>;
   dateOfDeath?: InputMaybe<Scalars['NaiveDate']['input']>;
   firstName?: InputMaybe<Scalars['String']['input']>;
-  gender?: InputMaybe<GenderInput>;
+  gender?: InputMaybe<GenderType>;
   id: Scalars['String']['input'];
   isDeceased?: InputMaybe<Scalars['Boolean']['input']>;
   lastName?: InputMaybe<Scalars['String']['input']>;

--- a/client/packages/programs/src/JsonForms/components/Search/SearchWithUserSource.tsx
+++ b/client/packages/programs/src/JsonForms/components/Search/SearchWithUserSource.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import {
-  GenderInput,
+  GenderType,
   PatientSearchInput,
   RegexUtils,
 } from '@openmsupply-client/common';
@@ -65,8 +65,8 @@ export const SearchWithUserSource = (
       return;
     }
     const newData = Object.fromEntries(
-      Object.entries(patient).filter(
-        ([key]) => (options.saveFields as string[])?.includes(key)
+      Object.entries(patient).filter(([key]) =>
+        (options.saveFields as string[])?.includes(key)
       )
     );
     handleChange(path, newData);
@@ -168,7 +168,7 @@ const createSearchFilter = (
       ? data['firstName']
       : undefined,
     gender: searchFields.includes('gender')
-      ? (data['gender'] as GenderInput)
+      ? (data['gender'] as GenderType)
       : undefined,
     lastName: searchFields.includes('lastName') ? data['lastName'] : undefined,
     identifier: searchFields.includes('identifier')

--- a/client/packages/system/src/Patient/CreatePatientModal/PatientResultsTab.tsx
+++ b/client/packages/system/src/Patient/CreatePatientModal/PatientResultsTab.tsx
@@ -4,7 +4,7 @@ import {
   Box,
   DataTable,
   DownloadIcon,
-  GenderInput,
+  GenderType,
   HomeIcon,
   InfoTooltipIcon,
   LoadingButton,
@@ -21,20 +21,20 @@ import { usePatient } from '../api';
 import { Gender, usePatientStore } from '@openmsupply-client/programs';
 import { CentralPatientSearchResponse } from '../api/api';
 
-const genderToGenderInput = (gender: Gender): GenderInput => {
+const genderToGenderType = (gender: Gender): GenderType => {
   switch (gender) {
     case Gender.MALE:
-      return GenderInput.Male;
+      return GenderType.Male;
     case Gender.FEMALE:
-      return GenderInput.Female;
+      return GenderType.Female;
     case Gender.TRANSGENDER_MALE:
-      return GenderInput.TransgenderMale;
+      return GenderType.TransgenderMale;
     case Gender.TRANSGENDER_FEMALE:
-      return GenderInput.TransgenderFemale;
+      return GenderType.TransgenderFemale;
     case Gender.UNKNOWN:
-      return GenderInput.Unknown;
+      return GenderType.Unknown;
     case Gender.NON_BINARY:
-      return GenderInput.NonBinary;
+      return GenderType.NonBinary;
     default:
       return noOtherVariants(gender);
   }
@@ -105,9 +105,7 @@ export const PatientResultsTab: FC<PatientPanel & { active: boolean }> = ({
       firstName: patient?.firstName,
       lastName: patient?.lastName,
       dateOfBirth: patient?.dateOfBirth,
-      gender: patient?.gender
-        ? genderToGenderInput(patient?.gender)
-        : undefined,
+      gender: patient?.gender ? genderToGenderType(patient?.gender) : undefined,
     }),
     [patient]
   );

--- a/client/packages/system/src/Patient/ListView/ListView.tsx
+++ b/client/packages/system/src/Patient/ListView/ListView.tsx
@@ -13,6 +13,7 @@ import {
   useAuthContext,
   useNavigate,
   ColumnDescription,
+  Formatter,
 } from '@openmsupply-client/common';
 import { usePatient, PatientRowFragment } from '../api';
 import { AppBarButtons } from './AppBarButtons';
@@ -92,12 +93,7 @@ const PatientListComponent: FC = () => {
     {
       key: 'gender',
       label: 'label.gender',
-    },
-    {
-      key: 'dateOfBirth',
-      label: 'label.date-of-birth',
-      formatter: dateString =>
-        dateString ? localisedDate((dateString as string) || '') : '',
+      formatter: gender =>Formatter.enumCase(gender as string ?? ''),
     },
   ];
 

--- a/client/packages/system/src/Patient/ListView/ListView.tsx
+++ b/client/packages/system/src/Patient/ListView/ListView.tsx
@@ -95,6 +95,12 @@ const PatientListComponent: FC = () => {
       label: 'label.gender',
       formatter: gender =>Formatter.enumCase(gender as string ?? ''),
     },
+    {
+      key: 'dateOfBirth',
+      label: 'label.date-of-birth',
+      formatter: dateString =>
+        dateString ? localisedDate((dateString as string) || '') : '',
+    },
   ];
 
   if (store?.preferences.omProgramModule) {

--- a/client/packages/system/src/Patient/PatientView/PatientSummary.tsx
+++ b/client/packages/system/src/Patient/PatientView/PatientSummary.tsx
@@ -59,7 +59,7 @@ export const PatientSummary: FC = () => {
         />
         <SummaryRow
           label="label.gender"
-          value={Formatter.sentenceCase(String(patient?.gender ?? ''))}
+          value={Formatter.enumCase(String(patient?.gender ?? ''))}
         />
         <SummaryRow
           label="label.date-of-birth"

--- a/server/graphql/programs/src/mutations/patient/insert.rs
+++ b/server/graphql/programs/src/mutations/patient/insert.rs
@@ -4,7 +4,7 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
-use graphql_types::types::patient::{GenderInput, PatientNode};
+use graphql_types::types::patient::{GenderType, PatientNode};
 use repository::NameType;
 use service::{
     auth::{Resource, ResourceAccessRequest},
@@ -18,7 +18,7 @@ pub struct InsertPatientInput {
     pub code_2: Option<String>,
     pub first_name: Option<String>,
     pub last_name: Option<String>,
-    pub gender: Option<GenderInput>,
+    pub gender: Option<GenderType>,
     pub date_of_birth: Option<NaiveDate>,
     pub address1: Option<String>,
     pub phone: Option<String>,

--- a/server/graphql/programs/src/mutations/patient/insert.rs
+++ b/server/graphql/programs/src/mutations/patient/insert.rs
@@ -4,7 +4,7 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
-use graphql_types::types::{patient::PatientNode, GenderInput};
+use graphql_types::types::patient::{GenderInput, PatientNode};
 use repository::NameType;
 use service::{
     auth::{Resource, ResourceAccessRequest},

--- a/server/graphql/programs/src/mutations/patient/update.rs
+++ b/server/graphql/programs/src/mutations/patient/update.rs
@@ -4,7 +4,7 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
-use graphql_types::types::{patient::PatientNode, GenderInput};
+use graphql_types::types::patient::{GenderInput, PatientNode};
 use service::{
     auth::{Resource, ResourceAccessRequest},
     programs::patient::{UpdatePatient, UpdatePatientError},

--- a/server/graphql/programs/src/mutations/patient/update.rs
+++ b/server/graphql/programs/src/mutations/patient/update.rs
@@ -4,7 +4,7 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
-use graphql_types::types::patient::{GenderInput, PatientNode};
+use graphql_types::types::patient::{GenderType, PatientNode};
 use service::{
     auth::{Resource, ResourceAccessRequest},
     programs::patient::{UpdatePatient, UpdatePatientError},
@@ -21,7 +21,7 @@ pub struct UpdatePatientInput {
     pub code_2: Option<String>,
     pub first_name: Option<String>,
     pub last_name: Option<String>,
-    pub gender: Option<GenderInput>,
+    pub gender: Option<GenderType>,
     pub date_of_birth: Option<NaiveDate>,
     pub address1: Option<String>,
     pub phone: Option<String>,

--- a/server/graphql/programs/src/queries/patient_search.rs
+++ b/server/graphql/programs/src/queries/patient_search.rs
@@ -1,7 +1,7 @@
 use async_graphql::*;
 use chrono::NaiveDate;
 use graphql_core::{standard_graphql_error::validate_auth, ContextExt};
-use graphql_types::types::patient::{GenderInput, PatientNode};
+use graphql_types::types::patient::{GenderType, PatientNode};
 use service::{
     auth::{Resource, ResourceAccessRequest},
     programs::patient::PatientSearch,
@@ -16,7 +16,7 @@ pub struct PatientSearchInput {
     first_name: Option<String>,
     last_name: Option<String>,
     date_of_birth: Option<NaiveDate>,
-    gender: Option<GenderInput>,
+    gender: Option<GenderType>,
     identifier: Option<String>,
 }
 

--- a/server/graphql/programs/src/queries/patient_search.rs
+++ b/server/graphql/programs/src/queries/patient_search.rs
@@ -1,7 +1,7 @@
 use async_graphql::*;
 use chrono::NaiveDate;
 use graphql_core::{standard_graphql_error::validate_auth, ContextExt};
-use graphql_types::types::{patient::PatientNode, GenderInput};
+use graphql_types::types::patient::{GenderInput, PatientNode};
 use service::{
     auth::{Resource, ResourceAccessRequest},
     programs::patient::PatientSearch,

--- a/server/graphql/types/src/types/clinician.rs
+++ b/server/graphql/types/src/types/clinician.rs
@@ -1,7 +1,7 @@
 use async_graphql::*;
 use repository::{Clinician, ClinicianRow};
 
-use super::GenderType;
+use crate::types::patient::GenderType;
 
 #[derive(PartialEq, Debug)]
 pub struct ClinicianNode {

--- a/server/graphql/types/src/types/name.rs
+++ b/server/graphql/types/src/types/name.rs
@@ -1,7 +1,7 @@
 use async_graphql::*;
 use chrono::{DateTime, NaiveDate, Utc};
 use dataloader::DataLoader;
-use repository::{GenderType as GenderRepo, Name, NameRow, NameType};
+use repository::{ Name, NameRow, NameType};
 
 use graphql_core::{
     loader::StoreByIdLoader, simple_generic_errors::NodeError,
@@ -9,46 +9,7 @@ use graphql_core::{
 };
 use serde::Serialize;
 
-use super::StoreNode;
-
-#[derive(Enum, Copy, Clone, PartialEq, Eq, Debug, Serialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")] // only needed to be comparable in tests
-pub enum GenderInput {
-    Female,
-    Male,
-    TransgenderMale,
-    TransgenderMaleHormone,
-    TransgenderMaleSurgical,
-    TransgenderFemale,
-    TransgenderFemaleHormone,
-    TransgenderFemaleSurgical,
-    Unknown,
-    NonBinary,
-}
-
-impl GenderInput {
-    pub fn to_domain(self) -> GenderRepo {
-        match self {
-            GenderInput::Female => GenderRepo::Female,
-            GenderInput::Male => GenderRepo::Male,
-            GenderInput::TransgenderMale => GenderRepo::TransgenderMale,
-            GenderInput::TransgenderMaleHormone => GenderRepo::TransgenderMaleHormone,
-            GenderInput::TransgenderMaleSurgical => GenderRepo::TransgenderMaleSurgical,
-            GenderInput::TransgenderFemale => GenderRepo::TransgenderFemale,
-            GenderInput::TransgenderFemaleHormone => GenderRepo::TransgenderFemaleHormone,
-            GenderInput::TransgenderFemaleSurgical => GenderRepo::TransgenderFemaleSurgical,
-            GenderInput::Unknown => GenderRepo::Unknown,
-            GenderInput::NonBinary => GenderRepo::NonBinary,
-        }
-    }
-}
-
-#[derive(InputObject, Clone)]
-pub struct EqualFilterGenderInput {
-    pub equal_to: Option<GenderInput>,
-    pub equal_any: Option<Vec<GenderInput>>,
-    pub not_equal_to: Option<GenderInput>,
-}
+use super::{patient::GenderType, StoreNode};
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq, Debug, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")] // only needed to be comparable in tests
@@ -85,38 +46,6 @@ impl NameNodeType {
     }
 }
 
-#[derive(Enum, Copy, Clone, PartialEq, Eq, Debug, Serialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")] // only needed to be comparable in tests
-pub enum GenderType {
-    Female,
-    Male,
-    Transgender,
-    TransgenderMale,
-    TransgenderMaleHormone,
-    TransgenderMaleSurgical,
-    TransgenderFemale,
-    TransgenderFemaleHormone,
-    TransgenderFemaleSurgical,
-    Unknown,
-    NonBinary,
-}
-impl GenderType {
-    pub fn from_domain(gender: &GenderRepo) -> Self {
-        match gender {
-            GenderRepo::Female => GenderType::Female,
-            GenderRepo::Male => GenderType::Male,
-            GenderRepo::Transgender => GenderType::Transgender,
-            GenderRepo::TransgenderMale => GenderType::TransgenderMale,
-            GenderRepo::TransgenderMaleHormone => GenderType::TransgenderMaleHormone,
-            GenderRepo::TransgenderMaleSurgical => GenderType::TransgenderMaleSurgical,
-            GenderRepo::TransgenderFemale => GenderType::TransgenderFemale,
-            GenderRepo::TransgenderFemaleHormone => GenderType::TransgenderFemaleHormone,
-            GenderRepo::TransgenderFemaleSurgical => GenderType::TransgenderFemaleSurgical,
-            GenderRepo::Unknown => GenderType::Unknown,
-            GenderRepo::NonBinary => GenderType::NonBinary,
-        }
-    }
-}
 
 #[Object]
 impl NameNode {
@@ -274,6 +203,7 @@ mod test {
     use repository::mock::MockDataInserts;
     use serde_json::json;
     use util::inline_init;
+    use repository::GenderType as GenderRepo;
 
     use super::*;
 

--- a/server/graphql/types/src/types/program/contact_trace.rs
+++ b/server/graphql/types/src/types/program/contact_trace.rs
@@ -15,10 +15,9 @@ use repository::{
     DateFilter, DatetimeFilter, EqualFilter, ProgramRow, StringFilter,
 };
 
-use crate::types::{EqualFilterGenderInput, GenderInput, GenderType};
 
 use super::{
-    document::DocumentNode, patient::PatientNode, program_enrolment::ProgramEnrolmentNode,
+    document::DocumentNode, patient::{EqualFilterGenderInput, GenderInput, PatientNode, GenderType}, program_enrolment::ProgramEnrolmentNode,
     program_node::ProgramNode,
 };
 

--- a/server/graphql/types/src/types/program/contact_trace.rs
+++ b/server/graphql/types/src/types/program/contact_trace.rs
@@ -15,9 +15,10 @@ use repository::{
     DateFilter, DatetimeFilter, EqualFilter, ProgramRow, StringFilter,
 };
 
-
 use super::{
-    document::DocumentNode, patient::{EqualFilterGenderInput, GenderInput, PatientNode, GenderType}, program_enrolment::ProgramEnrolmentNode,
+    document::DocumentNode,
+    patient::{EqualFilterGenderType, GenderType, PatientNode},
+    program_enrolment::ProgramEnrolmentNode,
     program_node::ProgramNode,
 };
 
@@ -87,7 +88,7 @@ pub struct ContactTraceFilterInput {
     pub contact_trace_id: Option<StringFilterInput>,
     pub first_name: Option<StringFilterInput>,
     pub last_name: Option<StringFilterInput>,
-    pub gender: Option<EqualFilterGenderInput>,
+    pub gender: Option<EqualFilterGenderType>,
     pub date_of_birth: Option<DateFilterInput>,
 }
 
@@ -119,7 +120,7 @@ impl ContactTraceFilterInput {
             last_name: last_name.map(StringFilter::from),
             patient_id: patient_id.map(EqualFilter::from),
             program_context_id: None,
-            gender: gender.map(|t| map_filter!(t, GenderInput::to_domain)),
+            gender: gender.map(|t| map_filter!(t, GenderType::to_domain)),
             date_of_birth: date_of_birth.map(DateFilter::from),
         }
     }

--- a/server/graphql/types/src/types/program/patient.rs
+++ b/server/graphql/types/src/types/program/patient.rs
@@ -9,15 +9,15 @@ use graphql_core::pagination::PaginationInput;
 use graphql_core::standard_graphql_error::StandardGraphqlError;
 use repository::{
     DateFilter, EqualFilter, Pagination, PaginationOption, Patient, PatientFilter,
-    ProgramEnrolmentFilter, StringFilter,
+    ProgramEnrolmentFilter, StringFilter, GenderType as GenderRepo
 };
+use serde::Serialize;
 use service::programs::patient::main_patient_doc_name;
 use service::programs::patient::patient_updated::patient_draft_document;
 use service::usize_to_u32;
 
 use crate::types::document::DocumentNode;
 use crate::types::program_enrolment::ProgramEnrolmentNode;
-use crate::types::{EqualFilterGenderInput, GenderInput, GenderType};
 
 use super::contact_trace::{
     ContactTraceConnector, ContactTraceFilterInput, ContactTraceNode, ContactTraceResponse,
@@ -26,6 +26,7 @@ use super::contact_trace::{
 use super::program_enrolment::{
     ProgramEnrolmentConnector, ProgramEnrolmentFilterInput, ProgramEnrolmentResponse,
 };
+
 
 #[derive(InputObject, Clone)]
 pub struct PatientFilterInput {
@@ -74,6 +75,78 @@ pub struct PatientNode {
     pub store_id: String,
     pub patient: Patient,
     pub allowed_ctx: Vec<String>,
+}
+
+#[derive(Enum, Copy, Clone, PartialEq, Eq, Debug, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")] // only needed to be comparable in tests
+pub enum GenderInput {
+    Female,
+    Male,
+    TransgenderMale,
+    TransgenderMaleHormone,
+    TransgenderMaleSurgical,
+    TransgenderFemale,
+    TransgenderFemaleHormone,
+    TransgenderFemaleSurgical,
+    Unknown,
+    NonBinary,
+}
+
+impl GenderInput {
+    pub fn to_domain(self) -> GenderRepo {
+        match self {
+            GenderInput::Female => GenderRepo::Female,
+            GenderInput::Male => GenderRepo::Male,
+            GenderInput::TransgenderMale => GenderRepo::TransgenderMale,
+            GenderInput::TransgenderMaleHormone => GenderRepo::TransgenderMaleHormone,
+            GenderInput::TransgenderMaleSurgical => GenderRepo::TransgenderMaleSurgical,
+            GenderInput::TransgenderFemale => GenderRepo::TransgenderFemale,
+            GenderInput::TransgenderFemaleHormone => GenderRepo::TransgenderFemaleHormone,
+            GenderInput::TransgenderFemaleSurgical => GenderRepo::TransgenderFemaleSurgical,
+            GenderInput::Unknown => GenderRepo::Unknown,
+            GenderInput::NonBinary => GenderRepo::NonBinary,
+        }
+    }
+}
+
+#[derive(InputObject, Clone)]
+pub struct EqualFilterGenderInput {
+    pub equal_to: Option<GenderInput>,
+    pub equal_any: Option<Vec<GenderInput>>,
+    pub not_equal_to: Option<GenderInput>,
+}
+
+#[derive(Enum, Copy, Clone, PartialEq, Eq, Debug, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")] // only needed to be comparable in tests
+pub enum GenderType {
+    Female,
+    Male,
+    Transgender,
+    TransgenderMale,
+    TransgenderMaleHormone,
+    TransgenderMaleSurgical,
+    TransgenderFemale,
+    TransgenderFemaleHormone,
+    TransgenderFemaleSurgical,
+    Unknown,
+    NonBinary,
+}
+impl GenderType {
+    pub fn from_domain(gender: &GenderRepo) -> Self {
+        match gender {
+            GenderRepo::Female => GenderType::Female,
+            GenderRepo::Male => GenderType::Male,
+            GenderRepo::Transgender => GenderType::Transgender,
+            GenderRepo::TransgenderMale => GenderType::TransgenderMale,
+            GenderRepo::TransgenderMaleHormone => GenderType::TransgenderMaleHormone,
+            GenderRepo::TransgenderMaleSurgical => GenderType::TransgenderMaleSurgical,
+            GenderRepo::TransgenderFemale => GenderType::TransgenderFemale,
+            GenderRepo::TransgenderFemaleHormone => GenderType::TransgenderFemaleHormone,
+            GenderRepo::TransgenderFemaleSurgical => GenderType::TransgenderFemaleSurgical,
+            GenderRepo::Unknown => GenderType::Unknown,
+            GenderRepo::NonBinary => GenderType::NonBinary,
+        }
+    }
 }
 
 #[Object]

--- a/server/graphql/types/src/types/program/patient.rs
+++ b/server/graphql/types/src/types/program/patient.rs
@@ -8,8 +8,8 @@ use graphql_core::{map_filter, ContextExt};
 use graphql_core::pagination::PaginationInput;
 use graphql_core::standard_graphql_error::StandardGraphqlError;
 use repository::{
-    DateFilter, EqualFilter, Pagination, PaginationOption, Patient, PatientFilter,
-    ProgramEnrolmentFilter, StringFilter, GenderType as GenderRepo
+    DateFilter, EqualFilter, GenderType as GenderRepo, Pagination, PaginationOption, Patient,
+    PatientFilter, ProgramEnrolmentFilter, StringFilter,
 };
 use serde::Serialize;
 use service::programs::patient::main_patient_doc_name;
@@ -27,7 +27,6 @@ use super::program_enrolment::{
     ProgramEnrolmentConnector, ProgramEnrolmentFilterInput, ProgramEnrolmentResponse,
 };
 
-
 #[derive(InputObject, Clone)]
 pub struct PatientFilterInput {
     pub id: Option<EqualFilterStringInput>,
@@ -36,7 +35,7 @@ pub struct PatientFilterInput {
     pub code_2: Option<StringFilterInput>,
     pub first_name: Option<StringFilterInput>,
     pub last_name: Option<StringFilterInput>,
-    pub gender: Option<EqualFilterGenderInput>,
+    pub gender: Option<EqualFilterGenderType>,
     pub date_of_birth: Option<DateFilterInput>,
     pub phone: Option<StringFilterInput>,
     pub address1: Option<StringFilterInput>,
@@ -57,7 +56,7 @@ impl From<PatientFilterInput> for PatientFilter {
             code_2: f.code_2.map(StringFilter::from),
             first_name: f.first_name.map(StringFilter::from),
             last_name: f.last_name.map(StringFilter::from),
-            gender: f.gender.map(|t| map_filter!(t, GenderInput::to_domain)),
+            gender: f.gender.map(|t| map_filter!(t, GenderType::to_domain)),
             date_of_birth: f.date_of_birth.map(DateFilter::from),
             phone: f.phone.map(StringFilter::from),
             address1: f.address1.map(StringFilter::from),
@@ -75,45 +74,6 @@ pub struct PatientNode {
     pub store_id: String,
     pub patient: Patient,
     pub allowed_ctx: Vec<String>,
-}
-
-#[derive(Enum, Copy, Clone, PartialEq, Eq, Debug, Serialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")] // only needed to be comparable in tests
-pub enum GenderInput {
-    Female,
-    Male,
-    TransgenderMale,
-    TransgenderMaleHormone,
-    TransgenderMaleSurgical,
-    TransgenderFemale,
-    TransgenderFemaleHormone,
-    TransgenderFemaleSurgical,
-    Unknown,
-    NonBinary,
-}
-
-impl GenderInput {
-    pub fn to_domain(self) -> GenderRepo {
-        match self {
-            GenderInput::Female => GenderRepo::Female,
-            GenderInput::Male => GenderRepo::Male,
-            GenderInput::TransgenderMale => GenderRepo::TransgenderMale,
-            GenderInput::TransgenderMaleHormone => GenderRepo::TransgenderMaleHormone,
-            GenderInput::TransgenderMaleSurgical => GenderRepo::TransgenderMaleSurgical,
-            GenderInput::TransgenderFemale => GenderRepo::TransgenderFemale,
-            GenderInput::TransgenderFemaleHormone => GenderRepo::TransgenderFemaleHormone,
-            GenderInput::TransgenderFemaleSurgical => GenderRepo::TransgenderFemaleSurgical,
-            GenderInput::Unknown => GenderRepo::Unknown,
-            GenderInput::NonBinary => GenderRepo::NonBinary,
-        }
-    }
-}
-
-#[derive(InputObject, Clone)]
-pub struct EqualFilterGenderInput {
-    pub equal_to: Option<GenderInput>,
-    pub equal_any: Option<Vec<GenderInput>>,
-    pub not_equal_to: Option<GenderInput>,
 }
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq, Debug, Serialize)]
@@ -147,6 +107,29 @@ impl GenderType {
             GenderRepo::NonBinary => GenderType::NonBinary,
         }
     }
+
+    pub fn to_domain(self) -> GenderRepo {
+        match self {
+            GenderType::Female => GenderRepo::Female,
+            GenderType::Male => GenderRepo::Male,
+            GenderType::TransgenderMale => GenderRepo::TransgenderMale,
+            GenderType::TransgenderMaleHormone => GenderRepo::TransgenderMaleHormone,
+            GenderType::TransgenderMaleSurgical => GenderRepo::TransgenderMaleSurgical,
+            GenderType::TransgenderFemale => GenderRepo::TransgenderFemale,
+            GenderType::TransgenderFemaleHormone => GenderRepo::TransgenderFemaleHormone,
+            GenderType::TransgenderFemaleSurgical => GenderRepo::TransgenderFemaleSurgical,
+            GenderType::Unknown => GenderRepo::Unknown,
+            GenderType::NonBinary => GenderRepo::NonBinary,
+            GenderType::Transgender => GenderRepo::Transgender,
+        }
+    }
+}
+
+#[derive(InputObject, Clone)]
+pub struct EqualFilterGenderType {
+    pub equal_to: Option<GenderType>,
+    pub equal_any: Option<Vec<GenderType>>,
+    pub not_equal_to: Option<GenderType>,
 }
 
 #[Object]


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4161

# 👩🏻‍💻 What does this PR do?
Move GenderInput/Type from name type to patient type and also formatted gender in frontend to remove the `_` (: 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Changing patient gender should still work
- [ ] Filtering by patient gender should work too

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
