### PR TITLE
4497 Report args modal backdrop blackening

### DIFF
--- a/client/packages/reports/src/DetailView/DetailView.tsx
+++ b/client/packages/reports/src/DetailView/DetailView.tsx
@@ -128,6 +128,7 @@ const DetailViewInner = ({
         isPrinting={isPrinting}
       />
       <ReportArgumentsModal
+        key={report.id}
         report={reportWithArgs}
         onReset={() => setReportWithArgs(undefined)}
         onArgumentsSelected={generateReport}

--- a/client/packages/reports/src/ListView/ListView.tsx
+++ b/client/packages/reports/src/ListView/ListView.tsx
@@ -1,19 +1,28 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   Grid,
   ReportContext,
+  RouteBuilder,
   useAuthContext,
+  useNavigate,
   useTranslation,
 } from '@openmsupply-client/common';
 import { BarIcon, InvoiceIcon, TrendingDownIcon } from '@common/icons';
-import { useReportList, ReportRowFragment } from '@openmsupply-client/system';
+import {
+  useReportList,
+  ReportRowFragment,
+  ReportArgumentsModal,
+} from '@openmsupply-client/system';
 import { AppBarButtons } from './AppBarButton';
 import { SidePanel } from './SidePanel';
 import { ReportWidget } from '../components';
+import { JsonData } from 'packages/programs/src';
+import { AppRoute } from 'packages/config/src';
 
 export const ListView = () => {
   const t = useTranslation('reports');
   const { store } = useAuthContext();
+  const navigate = useNavigate();
   const { data } = useReportList({
     queryParams: {
       filterBy: {
@@ -43,6 +52,17 @@ export const ListView = () => {
     }
   };
 
+  const reportArgs = useCallback(
+    (report: ReportRowFragment, args: JsonData | undefined) => {
+      const stringifyArgs = JSON.stringify(args);
+      navigate(
+        RouteBuilder.create(AppRoute.Reports)
+          .addPart(`${report.id}?reportArgs=${stringifyArgs}`)
+          .build()
+      );
+    },
+    [navigate]
+  );
   return (
     <>
       <Grid
@@ -58,8 +78,6 @@ export const ListView = () => {
           Icon={BarIcon}
           reports={stockAndItemReports}
           onReportClick={onReportClick}
-          reportWithArgs={reportWithArgs}
-          setReportWithArgs={setReportWithArgs}
           hasReports={stockAndItemReports?.length !== 0}
         />
         <ReportWidget
@@ -67,8 +85,6 @@ export const ListView = () => {
           Icon={TrendingDownIcon}
           reports={expiringReports}
           onReportClick={onReportClick}
-          reportWithArgs={reportWithArgs}
-          setReportWithArgs={setReportWithArgs}
           hasReports={expiringReports?.length !== 0}
         />
         {store?.preferences?.omProgramModule && (
@@ -77,11 +93,14 @@ export const ListView = () => {
             Icon={InvoiceIcon}
             reports={programReports}
             onReportClick={onReportClick}
-            reportWithArgs={reportWithArgs}
-            setReportWithArgs={setReportWithArgs}
             hasReports={programReports?.length !== 0}
           />
         )}
+        <ReportArgumentsModal
+          report={reportWithArgs}
+          onReset={() => setReportWithArgs(undefined)}
+          onArgumentsSelected={reportArgs}
+        />
       </Grid>
 
       <AppBarButtons />

--- a/client/packages/reports/src/ListView/ListView.tsx
+++ b/client/packages/reports/src/ListView/ListView.tsx
@@ -97,6 +97,7 @@ export const ListView = () => {
           />
         )}
         <ReportArgumentsModal
+          key={reportWithArgs?.id}
           report={reportWithArgs}
           onReset={() => setReportWithArgs(undefined)}
           onArgumentsSelected={reportArgs}

--- a/client/packages/reports/src/components/ReportWidget.tsx
+++ b/client/packages/reports/src/components/ReportWidget.tsx
@@ -1,20 +1,15 @@
-import React, { PropsWithChildren, useCallback } from 'react';
+import React, { PropsWithChildren } from 'react';
 import { ChevronDownIcon, SvgIconProps } from '@common/icons';
-import {
-  ReportRowFragment,
-  ReportArgumentsModal,
-} from '@openmsupply-client/system';
+import { ReportRowFragment } from '@openmsupply-client/system';
 import {
   BasicSpinner,
   Link,
   RouteBuilder,
-  useNavigate,
   Card,
   Grid,
   Typography,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
-import { JsonData } from '@openmsupply-client/programs';
 
 interface ReportWidgetProps {
   height?: number | string;
@@ -23,8 +18,6 @@ interface ReportWidgetProps {
   Icon: (props: SvgIconProps & { stroke?: string }) => JSX.Element;
   reports: ReportRowFragment[] | undefined;
   onReportClick: (report: ReportRowFragment) => void;
-  reportWithArgs?: ReportRowFragment;
-  setReportWithArgs: (value: ReportRowFragment | undefined) => void;
   hasReports: boolean;
 }
 
@@ -35,24 +28,8 @@ export const ReportWidget: React.FC<PropsWithChildren<ReportWidgetProps>> = ({
   Icon,
   reports,
   onReportClick,
-  reportWithArgs,
-  setReportWithArgs,
   hasReports = false,
 }) => {
-  const navigate = useNavigate();
-
-  const reportArgs = useCallback(
-    (report: ReportRowFragment, args: JsonData | undefined) => {
-      const stringifyArgs = JSON.stringify(args);
-      navigate(
-        RouteBuilder.create(AppRoute.Reports)
-          .addPart(`${report.id}?reportArgs=${stringifyArgs}`)
-          .build()
-      );
-    },
-    [navigate]
-  );
-
   return (
     <>
       {hasReports ? (
@@ -144,11 +121,6 @@ export const ReportWidget: React.FC<PropsWithChildren<ReportWidgetProps>> = ({
                     </Link>
                   </React.Fragment>
                 ))}
-                <ReportArgumentsModal
-                  report={reportWithArgs}
-                  onReset={() => setReportWithArgs(undefined)}
-                  onArgumentsSelected={reportArgs}
-                />
               </Grid>
             )}
           </React.Suspense>

--- a/client/packages/reports/src/components/ReportWidget.tsx
+++ b/client/packages/reports/src/components/ReportWidget.tsx
@@ -142,13 +142,13 @@ export const ReportWidget: React.FC<PropsWithChildren<ReportWidgetProps>> = ({
                         />
                       </Grid>
                     </Link>
-                    <ReportArgumentsModal
-                      report={reportWithArgs}
-                      onReset={() => setReportWithArgs(undefined)}
-                      onArgumentsSelected={reportArgs}
-                    />
                   </React.Fragment>
                 ))}
+                <ReportArgumentsModal
+                  report={reportWithArgs}
+                  onReset={() => setReportWithArgs(undefined)}
+                  onArgumentsSelected={reportArgs}
+                />
               </Grid>
             )}
           </React.Suspense>

--- a/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
+++ b/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from 'react';
 
 import { JsonData, JsonForm } from '@openmsupply-client/programs';
 import { ReportRowFragment } from '../api';
-import { useDialog } from '@common/hooks';
+import { useDialog, useUrlQuery } from '@common/hooks';
 import { DialogButton } from '@common/components';
 import { useAuthContext } from '@openmsupply-client/common';
 
@@ -19,6 +19,7 @@ export const ReportArgumentsModal: FC<ReportArgumentsModalProps> = ({
   onArgumentsSelected,
 }) => {
   const { store } = useAuthContext();
+  const { urlQuery } = useUrlQuery();
 
   const {
     monthlyConsumptionLookBackPeriod,
@@ -32,12 +33,12 @@ export const ReportArgumentsModal: FC<ReportArgumentsModalProps> = ({
     monthsOverstock,
     monthsUnderstock,
     monthsItemsExpire,
+    ...JSON.parse((urlQuery?.['reportArgs'] ?? '{}') as string),
   });
   const [error, setError] = useState<string | false>(false);
 
   // clean up when modal is closed
   const cleanUp = () => {
-    setData({});
     onReset();
   };
 

--- a/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
+++ b/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
@@ -55,6 +55,7 @@ export const ReportArgumentsModal: FC<ReportArgumentsModalProps> = ({
       title="Report arguments"
       cancelButton={<DialogButton variant="cancel" onClick={cleanUp} />}
       slideAnimation={false}
+      width={500}
       okButton={
         <DialogButton
           variant="ok"

--- a/client/packages/system/src/Report/components/ReportSelector.tsx
+++ b/client/packages/system/src/Report/components/ReportSelector.tsx
@@ -140,6 +140,7 @@ export const ReportSelector: FC<PropsWithChildren<ReportSelectorProps>> = ({
       )}
 
       <ReportArgumentsModal
+        key={reportWithArgs?.id}
         report={reportWithArgs}
         onReset={() => setReportWithArgs(undefined)}
         onArgumentsSelected={onPrint}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4497

# 👩🏻‍💻 What does this PR do?
Move report args out of react fragment
![Screenshot 2024-08-05 at 9 30 58 AM](https://github.com/user-attachments/assets/e507f219-9e9a-416a-b59e-d9bf3927a55e)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Set up new reports from reports repo
- [ ] Click on a report to generate from the Report page
- [ ] The modal shouldn't be bugging anymore

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
