### PR TITLE
#4496 Persist Report args

### DIFF
--- a/client/packages/reports/src/DetailView/DetailView.tsx
+++ b/client/packages/reports/src/DetailView/DetailView.tsx
@@ -128,6 +128,7 @@ const DetailViewInner = ({
         isPrinting={isPrinting}
       />
       <ReportArgumentsModal
+        key={report.id}
         report={reportWithArgs}
         onReset={() => setReportWithArgs(undefined)}
         onArgumentsSelected={generateReport}

--- a/client/packages/reports/src/ListView/ListView.tsx
+++ b/client/packages/reports/src/ListView/ListView.tsx
@@ -97,6 +97,7 @@ export const ListView = () => {
           />
         )}
         <ReportArgumentsModal
+          key={reportWithArgs?.id}
           report={reportWithArgs}
           onReset={() => setReportWithArgs(undefined)}
           onArgumentsSelected={reportArgs}

--- a/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
+++ b/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from 'react';
 
 import { JsonData, JsonForm } from '@openmsupply-client/programs';
 import { ReportRowFragment } from '../api';
-import { useDialog } from '@common/hooks';
+import { useDialog, useUrlQuery } from '@common/hooks';
 import { DialogButton } from '@common/components';
 import { useAuthContext } from '@openmsupply-client/common';
 
@@ -19,6 +19,7 @@ export const ReportArgumentsModal: FC<ReportArgumentsModalProps> = ({
   onArgumentsSelected,
 }) => {
   const { store } = useAuthContext();
+  const { urlQuery } = useUrlQuery();
 
   const {
     monthlyConsumptionLookBackPeriod,
@@ -32,12 +33,12 @@ export const ReportArgumentsModal: FC<ReportArgumentsModalProps> = ({
     monthsOverstock,
     monthsUnderstock,
     monthsItemsExpire,
+    ...JSON.parse((urlQuery?.['reportArgs'] ?? '{}') as string),
   });
   const [error, setError] = useState<string | false>(false);
 
   // clean up when modal is closed
   const cleanUp = () => {
-    setData({});
     onReset();
   };
 

--- a/client/packages/system/src/Report/components/ReportSelector.tsx
+++ b/client/packages/system/src/Report/components/ReportSelector.tsx
@@ -140,6 +140,7 @@ export const ReportSelector: FC<PropsWithChildren<ReportSelectorProps>> = ({
       )}
 
       <ReportArgumentsModal
+        key={reportWithArgs?.id}
         report={reportWithArgs}
         onReset={() => setReportWithArgs(undefined)}
         onArgumentsSelected={onPrint}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4496 

Have based on @mark-prins 's suggested branch for #4498 as that looks like it was dealing in the same area. So probably want to get that sorted before this one.

# 👩🏻‍💻 What does this PR do?

- makes sure any existing URL report args are included in modal data on load
- *don't* clear modal data on close
- add a "key" to the ReportArgsModal so that it'll force a remount (and therefore data reset) when the report type (id) changes

# 🧪 Testing

Follow the steps in the issue (#4496) and check that the problem has been fixed.

Also, if possible, try different reports and make sure args data is cleared when changing reports.