### PR TITLE
4386 Hide program related columns in Requisition

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
@@ -36,6 +36,7 @@ export const RequestRequisitionListView: FC = () => {
   const navigate = useNavigate();
   const t = useTranslation('replenishment');
   const modalController = useToggle();
+  const { data: programSettings } = useRequest.utils.programSettings();
 
   const { mutate: onUpdate } = useRequest.document.update();
   const {
@@ -65,27 +66,34 @@ export const RequestRequisitionListView: FC = () => {
       width: 90,
     },
     ['createdDatetime', { width: 150 }],
-    {
-      key: 'programName',
-      accessor: ({ rowData }) => rowData.programName,
-      label: 'label.program',
-      description: 'description.program',
-      sortable: true,
-      width: 150,
-    },
-    {
-      key: 'orderType',
-      accessor: ({ rowData }) => rowData.orderType,
-      label: 'label.order-type',
-      sortable: true,
-    },
+  ];
 
-    {
-      key: 'period',
-      accessor: ({ rowData }) => rowData.period?.name ?? '',
-      label: 'label.period',
-      sortable: true,
-    },
+  if (programSettings && programSettings.length > 0) {
+    columnDefinitions.push(
+      {
+        key: 'programName',
+        accessor: ({ rowData }) => rowData.programName,
+        label: 'label.program',
+        description: 'description.program',
+        sortable: true,
+        width: 150,
+      },
+      {
+        key: 'orderType',
+        accessor: ({ rowData }) => rowData.orderType,
+        label: 'label.order-type',
+        sortable: true,
+      },
+      {
+        key: 'period',
+        accessor: ({ rowData }) => rowData.period?.name ?? '',
+        label: 'label.period',
+        sortable: true,
+      }
+    );
+  }
+
+  columnDefinitions.push(
     [
       'status',
       {
@@ -94,8 +102,8 @@ export const RequestRequisitionListView: FC = () => {
           getRequisitionTranslator(t)(currentStatus as RequisitionNodeStatus),
       },
     ],
-    ['comment', { width: '100%', Cell: TooltipTextCell }],
-  ];
+    ['comment', { width: '100%', Cell: TooltipTextCell }]
+  );
 
   if (requireSupplierAuthorisation) {
     columnDefinitions.push({

--- a/client/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
@@ -62,6 +62,10 @@ export const ResponseRequisitionListView: FC = () => {
   const { data, isError, isLoading } = useResponse.document.list(queryParams);
   const { authoriseResponseRequisitions } = useResponse.utils.preferences();
   useDisableResponseRows(data?.nodes);
+  const program =
+    data?.nodes.some(row => row.programName) ||
+    data?.nodes.some(row => row.orderType) ||
+    data?.nodes.some(row => row.period);
 
   const columnDefinitions: ColumnDescription<ResponseRowFragment>[] = [
     [
@@ -88,27 +92,29 @@ export const ResponseRequisitionListView: FC = () => {
       description: 'description.number-of-shipments',
       accessor: ({ rowData }) => rowData?.shipments?.totalCount ?? 0,
     },
-    {
+  ];
+
+  if (program) {
+    columnDefinitions.push({
       key: 'programName',
       accessor: ({ rowData }) => rowData.programName,
       label: 'label.program',
       description: 'description.program',
       sortable: true,
-    },
-    {
+    });
+    columnDefinitions.push({
       key: 'orderType',
       accessor: ({ rowData }) => rowData.orderType,
       label: 'label.order-type',
       sortable: true,
-    },
-
-    {
+    });
+    columnDefinitions.push({
       key: 'period',
       accessor: ({ rowData }) => rowData.period?.name ?? '',
       label: 'label.period',
       sortable: true,
-    },
-  ];
+    });
+  }
 
   if (authoriseResponseRequisitions) {
     columnDefinitions.push({

--- a/client/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
@@ -95,25 +95,27 @@ export const ResponseRequisitionListView: FC = () => {
   ];
 
   if (program) {
-    columnDefinitions.push({
-      key: 'programName',
-      accessor: ({ rowData }) => rowData.programName,
-      label: 'label.program',
-      description: 'description.program',
-      sortable: true,
-    });
-    columnDefinitions.push({
-      key: 'orderType',
-      accessor: ({ rowData }) => rowData.orderType,
-      label: 'label.order-type',
-      sortable: true,
-    });
-    columnDefinitions.push({
-      key: 'period',
-      accessor: ({ rowData }) => rowData.period?.name ?? '',
-      label: 'label.period',
-      sortable: true,
-    });
+    columnDefinitions.push(
+      {
+        key: 'programName',
+        accessor: ({ rowData }) => rowData.programName,
+        label: 'label.program',
+        description: 'description.program',
+        sortable: true,
+      },
+      {
+        key: 'orderType',
+        accessor: ({ rowData }) => rowData.orderType,
+        label: 'label.order-type',
+        sortable: true,
+      },
+      {
+        key: 'period',
+        accessor: ({ rowData }) => rowData.period?.name ?? '',
+        label: 'label.period',
+        sortable: true,
+      }
+    );
   }
 
   if (authoriseResponseRequisitions) {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4386

# 👩🏻‍💻 What does this PR do?
Hides program requisition columns if program doesn't exist
![Screenshot 2024-08-05 at 8 32 29 PM](https://github.com/user-attachments/assets/501b346e-5d97-4c2a-b276-f1ae7bc3835a)
![Screenshot 2024-08-05 at 8 32 45 PM](https://github.com/user-attachments/assets/2330b437-7fce-43e7-976b-bbb52ba42dea)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Don't have programs set up
- [ ] Go to requisition/internal order
- [ ] Shouldn't see program related columns
- [ ] Set up programs
- [ ] Go to internal order -> See program related columns
- [ ] Send internal order
- [ ] Go to supplier store -> requisition
- [ ] See program related columns

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Screenshots for requisition list views
  2.
