### PR TITLE
allow export of R&R form to excel

### DIFF
--- a/client/packages/programs/src/RnRForms/DetailView/AppBarButtons.tsx
+++ b/client/packages/programs/src/RnRForms/DetailView/AppBarButtons.tsx
@@ -7,6 +7,7 @@ import {
   LoadingButton,
   Platform,
   PrinterIcon,
+  PrintFormat,
   ReportContext,
   useParams,
   useTranslation,
@@ -27,17 +28,17 @@ export const AppBarButtonsComponent = () => {
   const { print, isPrinting } = usePrintReport();
   const t = useTranslation();
 
-  const printReport = (
-    report: ReportRowFragment,
-    args: JsonData | undefined
-  ) => {
-    if (!data) return;
-    print({
-      reportId: report.id,
-      dataId: data?.id,
-      args,
-    });
-  };
+  const printReport =
+    (format: PrintFormat) =>
+    (report: ReportRowFragment, args: JsonData | undefined) => {
+      if (!data) return;
+      print({
+        reportId: report.id,
+        dataId: data?.id,
+        args,
+        format,
+      });
+    };
 
   return (
     <AppBarButtonsPortal>
@@ -45,7 +46,7 @@ export const AppBarButtonsComponent = () => {
         <ReportSelector
           context={ReportContext.Requisition}
           subContext="R&R"
-          onPrint={printReport}
+          onPrint={printReport(PrintFormat.Html)}
         >
           <LoadingButton
             variant="outlined"
@@ -55,15 +56,21 @@ export const AppBarButtonsComponent = () => {
             {t('button.print')}
           </LoadingButton>
         </ReportSelector>
-        <LoadingButton
-          startIcon={<DownloadIcon />}
-          variant="outlined"
-          onClick={() => {}}
-          disabled={EnvUtils.platform === Platform.Android}
-          isLoading={false}
+
+        <ReportSelector
+          context={ReportContext.Requisition}
+          subContext="R&R"
+          onPrint={printReport(PrintFormat.Excel)}
         >
-          {t('button.export')}
-        </LoadingButton>
+          <LoadingButton
+            startIcon={<DownloadIcon />}
+            variant="outlined"
+            disabled={EnvUtils.platform === Platform.Android}
+            isLoading={isPrinting}
+          >
+            {t('button.export')}
+          </LoadingButton>
+        </ReportSelector>
       </Grid>
     </AppBarButtonsPortal>
   );

--- a/client/packages/system/src/Report/api/hooks/usePrintReport.ts
+++ b/client/packages/system/src/Report/api/hooks/usePrintReport.ts
@@ -66,13 +66,19 @@ export const usePrintReport = () => {
   const { error } = useNotification();
 
   const mutationFn = async (params: GenerateReportParams) => {
-    const { dataId, reportId, args, sort } = params;
+    const {
+      dataId,
+      reportId,
+      args,
+      sort,
+      format = EnvUtils.printFormat,
+    } = params;
 
     const result = await reportApi.generateReport({
       dataId,
       reportId,
       storeId,
-      format: EnvUtils.printFormat,
+      format,
       arguments: args,
       sort,
     });
@@ -85,10 +91,10 @@ export const usePrintReport = () => {
 
   const { mutate, isLoading } = useMutation({
     mutationFn,
-    onSuccess: fileId => {
+    onSuccess: (fileId, { format = EnvUtils.printFormat }) => {
       if (!fileId) throw new Error('Error printing report');
       const url = `${Environment.FILE_URL}${fileId}`;
-      if (EnvUtils.printFormat === PrintFormat.Html) {
+      if (format === PrintFormat.Html) {
         printPage(url);
       } else {
         FileUtils.downloadFile(url);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4416

# 👩🏻‍💻 What does this PR do?

Implements Export button on R&R form page, to export the data to Excel.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

You'll need this version of the report: https://github.com/msupply-foundation/open-msupply-reports/pull/78 ... plz also review 🙏 

- [ ] Create an R&R form
- [ ] Click the Export button
- [ ] An Excel file should be downloaded, with the same data as the R&R form table

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
