### PR TITLE
Set R&R line stock out duration to 0 if no transactions

### DIFF
--- a/server/service/src/rnr_form/generate_rnr_form_lines.rs
+++ b/server/service/src/rnr_form/generate_rnr_form_lines.rs
@@ -313,9 +313,14 @@ pub fn get_stock_out_duration(
         .historic_stock
         .into_iter()
         .filter(|point| point.quantity == 0.0)
-        .count();
+        .count() as i32;
 
-    Ok(days_out_of_stock as i32)
+    if days_out_of_stock == days_in_period as i32 {
+        // If there was no consumption data, we'll set stock out duration to 0 and let the user input this
+        Ok(0)
+    } else {
+        Ok(days_out_of_stock)
+    }
 }
 
 // If stock had been available for the entire period, this is the quantity that 'would' have been consumed

--- a/server/service/src/rnr_form/tests/generate_rnr_form_lines.rs
+++ b/server/service/src/rnr_form/tests/generate_rnr_form_lines.rs
@@ -230,6 +230,19 @@ mod generate_rnr_form_lines {
         .unwrap();
 
         assert_eq!(result, 8);
+
+        // If no transactions, stock out duration is 0
+        let result = get_stock_out_duration(
+            &connection,
+            &mock_store_a().id,
+            &mock_item_a().id, // different item, which we have no transactions for
+            NaiveDate::from_ymd_opt(2024, 1, 31).unwrap(),
+            31,
+            0.0, // closing balance
+        )
+        .unwrap();
+
+        assert_eq!(result, 0);
     }
 
     #[actix_rt::test]


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4509 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

If there is no transaction data for the period, and the closing balance is 0, we were setting stock out duration to be the length of the period... 

However for the current use case, R&R forms are used without consumption data tracked in OMS, so we should default this duration to 0 and let the user input the duration.


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

Feels like a future improvement, but wondered about checking whether there were _any_ transactions in the period, for any item, rather than by item... can imagine that if you _were_ tracking transactions, and you had some items with no transactions, then you _would_ want the stock out duration to be set 🤷‍♀️ 

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create the first R&R form for a program, with an item that had a closing balance of 0.0 and no transactions in the period
- [ ] See stock out duration - it should be 0

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
