### PR TITLE
Change postgres type for name row type enum

### DIFF
--- a/server/repository/src/db_diesel/name_row.rs
+++ b/server/repository/src/db_diesel/name_row.rs
@@ -113,6 +113,7 @@ impl GenderType {
 #[derive(DbEnum, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[DbValueStyle = "SCREAMING_SNAKE_CASE"]
+#[PgType = "name_type"]
 pub enum NameRowType {
     Facility,
     Patient,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4516

# 👩🏻‍💻 What does this PR do?

Name row type enum was renamed, but database still treats it as name_type. This PR renames it via attribute 

## 💌 Any notes for the reviewer?

# 🧪 Testing

Unit tests with postgres feature would fail without this change

# 📃 Documentation
