### PR TITLE
Add useDebounce option to text input

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/Text.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Text.tsx
@@ -45,12 +45,7 @@ type Options = z.infer<typeof Options>;
 // Validates the option and parses the pattern into RegEx
 const useOptions = (
   options?: Record<string, unknown>
-): {
-  errors?: string;
-  options?: Options;
-  pattern?: RegExp;
-  useDebounce?: boolean;
-} => {
+): { errors?: string; options?: Options; pattern?: RegExp } => {
   const [regexError, setRegexErrors] = useState<string | undefined>();
   const { errors: zErrors, options: schemaOptions } = useZodOptionsValidation(
     Options,
@@ -102,7 +97,6 @@ const UIComponent = (props: ControlProps) => {
     errors: zErrors,
     options: schemaOptions,
     pattern,
-    useDebounce = true,
   } = useOptions(props.uischema.options);
   const customErrors = usePatternValidation(path, pattern, data);
   const error = !!errors || !!zErrors || !!customErrors;
@@ -133,6 +127,7 @@ const UIComponent = (props: ControlProps) => {
   const rows = schemaOptions?.rows;
 
   const width = schemaOptions?.width ?? '100%';
+  const useDebounce = schemaOptions?.useDebounce ?? true;
 
   return (
     <DetailInputWithLabelRow


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Partially Fixes #4464

# 👩🏻‍💻 What does this PR do?

Should fix issue for existing report, there is underlying issue in the debouncing of inputs and performance, please see linked issue. 

I've updated some reports to use this prop: https://github.com/msupply-foundation/open-msupply-reports/pull/79

## 💌 Any notes for the reviewer?

This shouldnt' close the issue, and issue can be changed to look at the debouncing overall, as we've been able to replicate it in the program module

# 🧪 Testing

Upsert one of the reports with ./upsert.sh script. Try to quickly item code or name and press OK. Filter should be respected in the report

# 📃 Documentation
