### PR TITLE
4349 Replenishment -> Inbound Shipment: Locations are not shown properly when the view is grouped by item 

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -279,7 +279,12 @@ export const useExpansionColumns = (): Column<InboundLineFragment>[] => {
   return useColumns<InboundLineFragment>([
     'batch',
     'expiryDate',
-    'location',
+    [
+      'location',
+      {
+        accessor: ({ rowData }) => rowData.location?.code,
+      },
+    ],
     ...(isPackVariantsEnabled
       ? [
           {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4349

# 👩🏻‍💻 What does this PR do?
Set location code when grouping by item
![Screenshot 2024-08-08 at 8 04 38 AM](https://github.com/user-attachments/assets/9b1606b2-0fdb-4524-8a80-22a2a41d6e56)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create Inbound Shipment 
- [ ] Add item with multiple batches 
- [ ] Set locations to those batches
- [ ] Group by item
- [ ] Expand to see all the batches for that item
- [ ] Location code should show up correctly

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
