### PR TITLE
4506 Reports page is blank if the reports aren't configured

### DIFF
--- a/client/packages/common/src/intl/locales/en/reports.json
+++ b/client/packages/common/src/intl/locales/en/reports.json
@@ -9,5 +9,5 @@
     "label.stocktake-frequency": "Stocktake frequency",
     "label.threshold-for-overstock": "Threshold for overstock",
     "label.threshold-for-understock": "Threshold for understock",
-    "message.contact-support": "Please contact support at support@msupply.foundation about configuring reports."
+    "message.contact-support": "Please contact support@msupply.foundation about configuring reports"
 }

--- a/client/packages/common/src/intl/locales/en/reports.json
+++ b/client/packages/common/src/intl/locales/en/reports.json
@@ -8,5 +8,6 @@
     "label.monthly-consumption-look-back-period": "Monthly consumption look back period",
     "label.stocktake-frequency": "Stocktake frequency",
     "label.threshold-for-overstock": "Threshold for overstock",
-    "label.threshold-for-understock": "Threshold for understock"
+    "label.threshold-for-understock": "Threshold for understock",
+    "message.contact-support": "Please contact support at support@msupply.foundation about configuring reports."
 }

--- a/client/packages/reports/src/ListView/ListView.tsx
+++ b/client/packages/reports/src/ListView/ListView.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import {
   Grid,
+  NothingHere,
   ReportContext,
   RouteBuilder,
   useAuthContext,
@@ -63,6 +64,15 @@ export const ListView = () => {
     },
     [navigate]
   );
+
+  if (
+    !store?.preferences?.omProgramModule ||
+    !stockAndItemReports?.length ||
+    !expiringReports?.length
+  ) {
+    return <NothingHere body={t('message.contact-support')} />;
+  }
+
   return (
     <>
       <Grid

--- a/client/packages/reports/src/ListView/ListView.tsx
+++ b/client/packages/reports/src/ListView/ListView.tsx
@@ -65,11 +65,7 @@ export const ListView = () => {
     [navigate]
   );
 
-  if (
-    !store?.preferences?.omProgramModule ||
-    !stockAndItemReports?.length ||
-    !expiringReports?.length
-  ) {
+  if (!stockAndItemReports?.length && !expiringReports?.length) {
     return <NothingHere body={t('message.contact-support')} />;
   }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4506

# 👩🏻‍💻 What does this PR do?
Add Nothing here with a message to contact support about setting up reports if there are no reports.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Don't have any reports set up (not even program reports)
- [ ] Go to report page
- [ ] See message

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
