### PR TITLE
Check for undefined value in NumberCell

### DIFF
--- a/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberCell.tsx
@@ -15,9 +15,9 @@ export const NumberCell = <T extends RecordWithId>({
 }: CellProps<T> & {
   defaultValue?: string | number;
 }) => {
-  const value = column.accessor({ rowData }) as number;
-  const hasMoreThanTwoDp = (value * 100) % 1 !== 0;
-  const formattedValue = useFormatNumber().round(value, 2);
+  const value = column.accessor({ rowData }) as number | undefined | null;
+  const hasMoreThanTwoDp = (value ?? 0 * 100) % 1 !== 0;
+  const formattedValue = useFormatNumber().round(value ?? 0, 2);
 
   const displayValue =
     value === undefined || value === null ? defaultValue : formattedValue;

--- a/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberCell.tsx
@@ -31,7 +31,7 @@ export const NumberCell = <T extends RecordWithId>({
         padding: '4px 8px',
       }}
     >
-      <Tooltip title={value.toString()}>
+      <Tooltip title={value?.toString()}>
         <Typography
           style={{
             overflow: 'hidden',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4536

# 👩🏻‍💻 What does this PR do?
An innocuous change in #4403 - the value of a NumberCell can be undefined, but the tooltip is using `value.toString()`

The change is to account for undefined / null values.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a stocktake

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
