### PR TITLE
4394 view service charges in more detail such as the types of service charged

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/PricingSection.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/PricingSection.tsx
@@ -17,6 +17,7 @@ import {
   useAuthContext,
   UNDEFINED_STRING_VALUE,
   TaxEdit,
+  Divider,
 } from '@openmsupply-client/common';
 import { useInbound } from '../../api';
 import { InboundServiceLineEdit } from '../modals';
@@ -134,6 +135,7 @@ export const PricingSectionComponent = () => {
                 </PanelRow>
               ))
             : null}
+          {serviceLines?.length !== 0 ? <Divider margin={2} /> : null}
         </PanelRow>
         <PanelRow>
           <PanelLabel>{t('heading.sub-total')}</PanelLabel>

--- a/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/PricingSection.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/PricingSection.tsx
@@ -121,6 +121,19 @@ export const PricingSectionComponent = () => {
               onClick={serviceLineModal.toggleOn}
             />
           </PanelField>
+          {serviceLines
+            ? serviceLines.map((line, index) => (
+                <PanelRow
+                  sx={{
+                    marginLeft: '10px',
+                    paddingBottom: index === serviceLines.length - 1 ? 2 : 0,
+                  }}
+                >
+                  <PanelLabel>{line.itemName}</PanelLabel>
+                  <PanelField>{c(line.totalBeforeTax).format()}</PanelField>
+                </PanelRow>
+              ))
+            : null}
         </PanelRow>
         <PanelRow>
           <PanelLabel>{t('heading.sub-total')}</PanelLabel>

--- a/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/PricingSection.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/PricingSection.tsx
@@ -19,6 +19,7 @@ import {
   Currencies,
   UNDEFINED_STRING_VALUE,
   TaxEdit,
+  Divider,
 } from '@openmsupply-client/common';
 import { useOutbound } from '../../api';
 import { OutboundServiceLineEdit } from '../OutboundServiceLineEdit';
@@ -95,6 +96,8 @@ const ServiceCharges = ({ pricing, isDisabled }: PricingGroupProps) => {
             </PanelRow>
           ))
         : null}
+      {serviceLines?.length !== 0 ? <Divider margin={2} /> : null}
+
       <PanelRow sx={{ marginLeft: '10px' }}>
         <PanelLabel>{t('heading.sub-total')}</PanelLabel>
         <PanelField>{c(serviceTotalBeforeTax)}</PanelField>

--- a/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/PricingSection.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/PricingSection.tsx
@@ -82,7 +82,19 @@ const ServiceCharges = ({ pricing, isDisabled }: PricingGroupProps) => {
           />
         </PanelField>
       </PanelRow>
-
+      {serviceLines
+        ? serviceLines.map((line, index) => (
+            <PanelRow
+              sx={{
+                marginLeft: '10px',
+                paddingBottom: index === serviceLines.length - 1 ? 2 : 0,
+              }}
+            >
+              <PanelLabel>{line.itemName}</PanelLabel>
+              <PanelField>{c(line.totalBeforeTax)}</PanelField>
+            </PanelRow>
+          ))
+        : null}
       <PanelRow sx={{ marginLeft: '10px' }}>
         <PanelLabel>{t('heading.sub-total')}</PanelLabel>
         <PanelField>{c(serviceTotalBeforeTax)}</PanelField>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4394

# 👩🏻‍💻 What does this PR do?
List service charges in the side panel
![Screenshot 2024-08-09 at 8 34 01 PM](https://github.com/user-attachments/assets/8dc18a91-a55f-4506-973f-7938d9c4ffe8)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have service charge in master list 
- [ ] Create an outbound with service charges
- [ ] Open side panel
- [ ] Should see it listed under service charge before pricing totals

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Could add a note about this in docs
  2.
