### PR TITLE
3910 Post migration from desktop, previous 'sg' stocktakes have missing lines

### DIFF
--- a/server/service/src/sync/translations/stocktake_line.rs
+++ b/server/service/src/sync/translations/stocktake_line.rs
@@ -128,7 +128,10 @@ impl SyncTranslation for StocktakeLineTranslation {
         let result = StocktakeLineRow {
             id: ID,
             stocktake_id: stock_take_ID,
-            stock_line_id: item_line_ID,
+            stock_line_id: match is_stock_line_valid {
+                true => item_line_ID,
+                false => None,
+            },
             location_id,
             comment,
             snapshot_number_of_packs: snapshot_qty,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3910

# 👩🏻‍💻 What does this PR do?
mSupply creates UUID for stock line in stocktakes if new batches are added, so null stock line id for stocktake line if it doesn't exist. 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have Store in mSupply
- [ ] Create stocktake with new batches
- [ ] Migrate Store to OMS site
- [ ] Integrate
- [ ] Stocktake should migrate without problem

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
