### PR TITLE
Reports UI

### DIFF
--- a/client/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.tsx
+++ b/client/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.tsx
@@ -41,11 +41,6 @@ export const Breadcrumbs = ({
       ? t('breadcrumb.item', { id: part.value })
       : t(part.key);
 
-  // Removes the first element if it is a top level path to get correct breadcrumbs
-  if (topLevelPaths.includes(urlParts[0]?.value ?? '') && urlParts.length > 1) {
-    urlParts.shift();
-  }
-
   const crumbs = urlParts.map((part, index) => {
     const customCrumb = customBreadcrumbs[index];
 

--- a/client/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.tsx
+++ b/client/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.tsx
@@ -41,6 +41,11 @@ export const Breadcrumbs = ({
       ? t('breadcrumb.item', { id: part.value })
       : t(part.key);
 
+  // Removes the first element if it is a top level path to get correct breadcrumbs
+  if (topLevelPaths.includes(urlParts[0]?.value ?? '') && urlParts.length > 1) {
+    urlParts.shift();
+  }
+
   const crumbs = urlParts.map((part, index) => {
     const customCrumb = customBreadcrumbs[index];
 

--- a/client/packages/host/src/CommandK.tsx
+++ b/client/packages/host/src/CommandK.tsx
@@ -107,6 +107,13 @@ const Actions = () => {
       perform: () => drawer.toggle(),
     },
     {
+      id: 'navigation-drawer:report',
+      name: `${t('cmdk.goto-reports')} (g+r)`,
+      shortcut: ['g', 'r'],
+      keywords: 'report',
+      perform: () => navigate(RouteBuilder.create(AppRoute.Reports).build()),
+    },
+    {
       id: 'navigation:outbound-shipment',
       name: `${t('cmdk.goto-outbound')} (o)`,
       shortcut: ['o'],

--- a/client/packages/reports/src/DetailView/DetailView.tsx
+++ b/client/packages/reports/src/DetailView/DetailView.tsx
@@ -134,7 +134,11 @@ const DetailViewInner = ({
         onArgumentsSelected={generateReport}
       />
 
-      {!fileId ? <BasicSpinner /> : <iframe src={url} width="100%" />}
+      {!fileId ? (
+        <BasicSpinner />
+      ) : (
+        <iframe src={url} width="100%" style={{ borderWidth: 0 }} />
+      )}
     </>
   );
 };

--- a/client/packages/reports/src/DetailView/DetailView.tsx
+++ b/client/packages/reports/src/DetailView/DetailView.tsx
@@ -42,7 +42,7 @@ const DetailViewInner = ({
   report: ReportRowFragment;
   reportArgs: JsonData;
 }) => {
-  const { setCustomBreadcrumbs } = useBreadcrumbs();
+  const { setCustomBreadcrumbs } = useBreadcrumbs(['reports']);
   const { mutateAsync } = useGenerateReport();
   const [fileId, setFileId] = useState<string | undefined>();
   const { print, isPrinting } = usePrintReport();
@@ -54,7 +54,7 @@ const DetailViewInner = ({
   >();
 
   useEffect(() => {
-    setCustomBreadcrumbs({ 0: report.name ?? '' });
+    setCustomBreadcrumbs({ 1: report.name ?? '' });
 
     // Initial report generation
     if (!report.argumentSchema) {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4494

# 👩🏻‍💻 What does this PR do?

Removed topLevel from urlParts if there are more than 1 element in urlParts... if we want Report/{Report Name} probably best to move reports out of top level? But it's easy enough to get to reports from Nav, so probably fine? 
![Screenshot 2024-08-12 at 8 23 32 AM](https://github.com/user-attachments/assets/ecf9f6d4-8b08-4c40-b14e-502d353b0bdf)

Also added shortcut for reports (g+r) and removed border from iframe

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have reports set up
- [ ] Press g+r to navigate to reports with shortcut
- [ ] Click on a report
- [ ] Breadcrumb should show as above (with only report name)

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
