### PR TITLE
4499 expiring items report UI review 

### DIFF
--- a/client/packages/common/src/intl/locales/en/reports.json
+++ b/client/packages/common/src/intl/locales/en/reports.json
@@ -9,5 +9,6 @@
     "label.stocktake-frequency": "Stocktake frequency",
     "label.threshold-for-overstock": "Threshold for overstock",
     "label.threshold-for-understock": "Threshold for understock",
-    "message.contact-support": "Please contact support@msupply.foundation about configuring reports"
+    "message.contact-support": "Please contact support@msupply.foundation about configuring reports",
+    "message.arguments": "You can customize what is shown on the report by specifying some of the optional details below. Click OK to view the report."
 }

--- a/client/packages/common/src/ui/forms/Detail/InputWithLabelRow.tsx
+++ b/client/packages/common/src/ui/forms/Detail/InputWithLabelRow.tsx
@@ -17,6 +17,7 @@ interface InputWithLabelRowProps {
   labelWidthPercentage?: number;
   labelProps?: FormLabelProps;
   inputProps?: StandardTextFieldProps;
+  inputSx?: SxProps<Theme>;
   /** flex-{$inputAlignment} alignment of the input field  */
   inputAlignment?: 'start' | 'end';
 }
@@ -30,6 +31,7 @@ export const DetailInputWithLabelRow: FC<InputWithLabelRowProps> = ({
   Input = <BasicTextInput fullWidth {...inputProps} />,
   DisabledInput = <BasicTextInput fullWidth {...inputProps} />,
   labelProps,
+  inputSx,
 }) => {
   const { sx: labelSx, ...labelPropsRest } = labelProps || {};
   const isDisabled = inputProps?.disabled;
@@ -51,7 +53,12 @@ export const DetailInputWithLabelRow: FC<InputWithLabelRowProps> = ({
           {labelWithPunctuation(label)}
         </FormLabel>
       </Box>
-      <Box flexBasis={inputFlexBasis} justifyContent={justify} display="flex">
+      <Box
+        flexBasis={inputFlexBasis}
+        justifyContent={justify}
+        display="flex"
+        sx={{ ...inputSx }}
+      >
         {!isDisabled ? Input : DisabledInput}
       </Box>
     </Box>

--- a/client/packages/programs/src/JsonForms/common/JsonForm.tsx
+++ b/client/packages/programs/src/JsonForms/common/JsonForm.tsx
@@ -247,6 +247,7 @@ export const JsonForm: FC<
         '& .input-with-label-row': {
           alignItems: 'flex-start',
           maxWidth: FORM_COLUMN_MAX_WIDTH,
+          whiteSpace: 'nowrap',
         },
         '& h1, h2, h3, h4, h5, h6': {
           width: FORM_LABEL_COLUMN_WIDTH,

--- a/client/packages/programs/src/JsonForms/common/components/Date.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Date.tsx
@@ -39,11 +39,18 @@ const UIComponent = (props: ControlProps) => {
   return (
     <DetailInputWithLabelRow
       sx={DefaultFormRowSx}
+      inputSx={{
+        '& > .MuiBox-root': {
+          flexBasis: '90%',
+          width: '100%',
+        },
+      }}
       label={label}
       labelWidthPercentage={FORM_LABEL_WIDTH}
       inputAlignment="start"
       Input={
         <BaseDatePickerInput
+          sx={{ width: '100%' }}
           // undefined is displayed as "now" and null as unset
           value={formatDateTime.getLocalDate(data)}
           onChange={e => {

--- a/client/packages/programs/src/JsonForms/common/components/Date.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Date.tsx
@@ -6,7 +6,7 @@ import {
   useFormatDateTime,
   BaseDatePickerInput,
 } from '@openmsupply-client/common';
-import { FORM_LABEL_WIDTH } from '../styleConstants';
+import { DefaultFormRowSx, FORM_LABEL_WIDTH } from '../styleConstants';
 import { z } from 'zod';
 import { useZodOptionsValidation } from '../hooks/useZodOptionsValidation';
 import { useJSONFormsCustomError } from '../hooks/useJSONFormsCustomError';
@@ -38,12 +38,7 @@ const UIComponent = (props: ControlProps) => {
 
   return (
     <DetailInputWithLabelRow
-      sx={{
-        marginTop: 0.5,
-        gap: 2,
-        minWidth: '300px',
-        justifyContent: 'space-around',
-      }}
+      sx={DefaultFormRowSx}
       label={label}
       labelWidthPercentage={FORM_LABEL_WIDTH}
       inputAlignment="start"

--- a/client/packages/programs/src/JsonForms/common/components/Number.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Number.tsx
@@ -50,7 +50,7 @@ const UIComponent = (props: ControlProps) => {
     },
     disabled: !props.enabled,
     error: error,
-    helperText: errors,
+    helperText: errors || zErrors,
     value: localData,
   };
 

--- a/client/packages/programs/src/JsonForms/common/components/Number.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Number.tsx
@@ -8,17 +8,32 @@ import {
   useDebounceCallback,
 } from '@openmsupply-client/common';
 import { FORM_LABEL_WIDTH, DefaultFormRowSx } from '../styleConstants';
+import { z } from 'zod';
+import { useZodOptionsValidation } from '../hooks/useZodOptionsValidation';
 
 export const numberTester = rankWith(3, schemaTypeIs('number'));
 
+const Options = z
+  .object({
+    inputAlignment: z.enum(['start', 'end']).optional(),
+    paddingRight: z.number().optional(),
+  })
+  .optional();
+
+type Options = z.infer<typeof Options>;
+
 const UIComponent = (props: ControlProps) => {
-  const { data, handleChange, label, path, errors, schema } = props;
+  const { data, handleChange, label, path, errors, schema, uischema } = props;
   const [localData, setLocalData] = useState<number | undefined>(data);
   const onChange = useDebounceCallback(
     (value: number | undefined) => handleChange(path, value),
     [path]
   );
-  const error = !!errors;
+  const { errors: zErrors, options } = useZodOptionsValidation(
+    Options,
+    uischema.options
+  );
+  const error = !!errors || !!zErrors;
 
   if (!props.visible) {
     return null;
@@ -38,12 +53,17 @@ const UIComponent = (props: ControlProps) => {
     helperText: errors,
     value: localData,
   };
+
+  const inputAlignment = options?.inputAlignment ?? 'start';
+  const paddingRight = options?.paddingRight ?? 0;
+
   return (
     <DetailInputWithLabelRow
       sx={DefaultFormRowSx}
       label={label}
       labelWidthPercentage={FORM_LABEL_WIDTH}
-      inputAlignment="start"
+      inputAlignment={inputAlignment}
+      inputSx={{ paddingRight: `${paddingRight}px` }}
       Input={
         <NumericTextInput
           {...inputProps}

--- a/client/packages/programs/src/JsonForms/common/components/Text.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Text.tsx
@@ -22,6 +22,7 @@ const Options = z
      */
     examples: z.array(z.string()).optional(),
     width: z.string().optional(),
+    flexBasis: z.string().optional(),
     /**
      * If true, text input will expand to multiple lines if required (default:
      * true)
@@ -127,6 +128,7 @@ const UIComponent = (props: ControlProps) => {
   const rows = schemaOptions?.rows;
 
   const width = schemaOptions?.width ?? '100%';
+  const flexBasis = schemaOptions?.flexBasis ?? '100%';
   const useDebounce = schemaOptions?.useDebounce ?? true;
 
   return (
@@ -136,7 +138,7 @@ const UIComponent = (props: ControlProps) => {
       inputProps={{
         value: text ?? '',
         sx: { width },
-        style: { flexBasis: '100%' },
+        style: { flexBasis },
         onChange: e =>
           useDebounce
             ? onDebounceChange(e.target.value ?? '')

--- a/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
+++ b/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
@@ -3,8 +3,8 @@ import React, { FC, useState } from 'react';
 import { JsonData, JsonForm } from '@openmsupply-client/programs';
 import { ReportRowFragment } from '../api';
 import { useDialog, useUrlQuery } from '@common/hooks';
-import { DialogButton } from '@common/components';
-import { useAuthContext } from '@openmsupply-client/common';
+import { DialogButton, Typography } from '@common/components';
+import { useAuthContext, useTranslation } from '@openmsupply-client/common';
 
 export type ReportArgumentsModalProps = {
   /** Modal is shown if there is an argument schema present */
@@ -20,6 +20,7 @@ export const ReportArgumentsModal: FC<ReportArgumentsModalProps> = ({
 }) => {
   const { store } = useAuthContext();
   const { urlQuery } = useUrlQuery();
+  const t = useTranslation('reports');
 
   const {
     monthlyConsumptionLookBackPeriod,
@@ -68,17 +69,25 @@ export const ReportArgumentsModal: FC<ReportArgumentsModalProps> = ({
         />
       }
     >
-      <JsonForm
-        data={data}
-        jsonSchema={report.argumentSchema.jsonSchema}
-        uiSchema={report.argumentSchema.uiSchema}
-        isError={false}
-        isLoading={false}
-        setError={err => setError(err)}
-        updateData={(newData: JsonData) => {
-          setData(newData);
-        }}
-      />
+      <>
+        <Typography
+          variant="body1"
+          sx={{ mb: 2, maxWidth: 500, padding: '0 5px' }}
+        >
+          {t('message.arguments')}
+        </Typography>
+        <JsonForm
+          data={data}
+          jsonSchema={report.argumentSchema.jsonSchema}
+          uiSchema={report.argumentSchema.uiSchema}
+          isError={false}
+          isLoading={false}
+          setError={err => setError(err)}
+          updateData={(newData: JsonData) => {
+            setData(newData);
+          }}
+        />
+      </>
     </Modal>
   );
 };

--- a/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
+++ b/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
@@ -56,7 +56,7 @@ export const ReportArgumentsModal: FC<ReportArgumentsModalProps> = ({
       title="Report arguments"
       cancelButton={<DialogButton variant="cancel" onClick={cleanUp} />}
       slideAnimation={false}
-      width={500}
+      width={560}
       okButton={
         <DialogButton
           variant="ok"

--- a/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
+++ b/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
@@ -70,10 +70,7 @@ export const ReportArgumentsModal: FC<ReportArgumentsModalProps> = ({
       }
     >
       <>
-        <Typography
-          variant="body1"
-          sx={{ mb: 2, maxWidth: 500, padding: '0 5px' }}
-        >
+        <Typography sx={{ mb: 2, maxWidth: 500 }}>
           {t('message.arguments')}
         </Typography>
         <JsonForm


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4499

# 👩🏻‍💻 What does this PR do?
Added some css props to the numbers and text input to get the args modal for expiring items looking nicely without effecting other areas using the same component... The rest of the fixes asked for in the latter half of the issue has been fixed already.

![Screenshot 2024-08-14 at 9 14 09 AM](https://github.com/user-attachments/assets/343135fc-e938-4078-a222-326a556ea0c6)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have expiring reports set up (https://github.com/msupply-foundation/open-msupply-reports/pull/83)
- [ ] Click on it 
- [ ] Argument modal should look pretty now

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
