### PR TITLE
Prevent R&R line rerenders

### DIFF
--- a/client/packages/common/src/intl/locales/en/replenishment.json
+++ b/client/packages/common/src/intl/locales/en/replenishment.json
@@ -178,6 +178,7 @@
   "messages.select-rows-to-delete-them": "Select rows to delete them",
   "messages.select-rows-to-return": "Select rows to return them",
   "messages.shipment-saved": "Shipment saved 🥳",
+  "messages.all-changes-must-be-confirmed": "You have some lines with unsaved changes. Mark these lines as confirmed to finalise.",
   "messages.unassign-min-mos": "This will remove the stock reorder threshold. Reorder threshold will now default to be the same as target months of stock.",
   "messages.zero-line-quantities_few": "The quantity of {{count}} lines has been set to 0",
   "messages.zero-line-quantities_many": "The quantity of {{count}} lines has been set to 0",

--- a/client/packages/common/src/intl/locales/en/replenishment.json
+++ b/client/packages/common/src/intl/locales/en/replenishment.json
@@ -105,7 +105,6 @@
   "label.supplier-name": "Supplier Name",
   "label.supplier-ref": "Reference",
   "messages.alert-zero-return-quantity": "Please add some quantities to return before proceeding to the next step",
-  "messages.all-changes-must-be-confirmed": "You have some lines with unsaved changes. Mark these lines as confirmed to finalise.",
   "messages.by-user": "by {{username}}",
   "messages.cant-delete-requisitions": "Can only delete requisitions with a status of 'Draft'",
   "messages.cant-return-shipment": "Cannot return lines until the status is 'Delivered'",

--- a/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
@@ -74,6 +74,7 @@ export const BasicTextInput = React.forwardRef<
           variant="standard"
           size="small"
           InputProps={{
+            disableInjectingGlobalStyles: true,
             disableUnderline: error ? true : false,
             ...InputProps,
             sx: {

--- a/client/packages/common/src/ui/layout/tables/index.ts
+++ b/client/packages/common/src/ui/layout/tables/index.ts
@@ -1,4 +1,5 @@
 import { AppSxProp } from '@common/styles';
+import { ViewportList } from 'react-viewport-list';
 import {
   Table,
   TableBody,
@@ -17,6 +18,7 @@ export {
   TableContainer,
   TableHead,
   TableRow,
+  ViewportList,
 };
 export * from './hooks';
 export * from './DataTable';

--- a/client/packages/requisitions/src/RnRForms/DetailView/ContentArea.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/ContentArea.tsx
@@ -22,19 +22,22 @@ interface ContentAreaProps {
 interface HeaderCellProps {
   label: LocaleKey;
   tooltip?: LocaleKey;
+  width?: number;
 }
 
-const HeaderCell = ({ label, tooltip }: HeaderCellProps) => {
+const HeaderCell = ({ label, tooltip, width }: HeaderCellProps) => {
   const t = useTranslation('replenishment');
 
-  return tooltip === undefined ? (
-    <th>{t(label)}</th>
-  ) : (
-    <th>
-      <Box display="flex">
-        {t(label)}
-        <InfoTooltipIcon title={t(tooltip)} />
-      </Box>
+  return (
+    <th style={{ minWidth: width }}>
+      {tooltip === undefined ? (
+        t(label)
+      ) : (
+        <Box display="flex">
+          {t(label)}
+          <InfoTooltipIcon title={t(tooltip)} />
+        </Box>
+      )}
     </th>
   );
 };
@@ -114,9 +117,9 @@ export const ContentArea = ({
           <tr>
             <th className="sticky-column first-column">{t('label.code')}</th>
             <th className="sticky-column second-column">{t('label.name')}</th>
-            <HeaderCell label="label.strength" />
-            <HeaderCell label="label.unit" />
-            <HeaderCell label="label.ven" />
+            <HeaderCell label="label.strength" width={85} />
+            <HeaderCell label="label.unit" width={80} />
+            <HeaderCell label="label.ven" width={55} />
             <HeaderCell
               label="label.rnr-initial-balance"
               tooltip="description.rnr-initial-balance"

--- a/client/packages/requisitions/src/RnRForms/DetailView/ContentArea.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/ContentArea.tsx
@@ -14,7 +14,6 @@ import { RnRFormLine } from './RnRFormLine';
 interface ContentAreaProps {
   data: RnRFormLineFragment[];
   saveLine: (line: RnRFormLineFragment) => Promise<void>;
-  markDirty: (id: string) => void;
   periodLength: number;
   disabled: boolean;
 }
@@ -42,7 +41,6 @@ const HeaderCell = ({ label, tooltip }: HeaderCellProps) => {
 export const ContentArea = ({
   data,
   saveLine,
-  markDirty,
   periodLength,
   disabled,
 }: ContentAreaProps) => {
@@ -150,7 +148,6 @@ export const ContentArea = ({
               line={line}
               periodLength={periodLength}
               saveLine={saveLine}
-              markDirty={markDirty}
               disabled={disabled}
             />
           ))}

--- a/client/packages/requisitions/src/RnRForms/DetailView/ContentArea.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/ContentArea.tsx
@@ -58,7 +58,6 @@ export const ContentArea = ({
   ) : (
     <Box
       flex={1}
-      padding={2}
       style={{
         display: 'flex',
         flexDirection: 'column',
@@ -70,21 +69,27 @@ export const ContentArea = ({
     >
       <GlobalStyles
         styles={{
+          thead: {
+            position: 'sticky',
+            top: 0,
+            backgroundColor: '#fff',
+            zIndex: 999,
+          },
           '.sticky-column': {
             backgroundColor: '#fff',
             position: 'sticky',
             zIndex: 99,
           },
           '.first-column': {
+            left: 0,
             position: '-webkit-sticky',
-            left: 16,
             width: 80,
           },
           '.second-column': {
-            position: '-webkit-sticky',
-            left: 88,
-            minWidth: '300px',
             borderRight: '1px solid blue',
+            left: 72,
+            minWidth: '300px',
+            position: '-webkit-sticky',
           },
         }}
       />
@@ -156,6 +161,17 @@ export const ContentArea = ({
               tooltip="description.rnr-approved-quantity"
             />
           </tr>
+          <tr>
+            <td colSpan={20} style={{ borderWidth: 0, padding: 0 }}>
+              <Box
+                sx={{
+                  backgroundColor: 'gray.light',
+                  height: '1px',
+                  width: '100%',
+                }}
+              ></Box>
+            </td>
+          </tr>
         </thead>
 
         <tbody>
@@ -163,7 +179,6 @@ export const ContentArea = ({
             viewportRef={ref}
             items={lines}
             axis="y"
-            // itemSize={40}
             renderSpacer={({ ref, style }) => <tr ref={ref} style={style} />}
             initialDelay={1}
           >

--- a/client/packages/requisitions/src/RnRForms/DetailView/ContentArea.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/ContentArea.tsx
@@ -15,7 +15,6 @@ import { RnRFormLine } from './RnRFormLine';
 interface ContentAreaProps {
   data: RnRFormLineFragment[];
   saveLine: (line: RnRFormLineFragment) => Promise<void>;
-  markDirty: (id: string) => void;
   periodLength: number;
   disabled: boolean;
 }
@@ -43,7 +42,6 @@ const HeaderCell = ({ label, tooltip }: HeaderCellProps) => {
 export const ContentArea = ({
   data,
   saveLine,
-  markDirty,
   periodLength,
   disabled,
 }: ContentAreaProps) => {
@@ -87,7 +85,7 @@ export const ContentArea = ({
           },
           '.second-column': {
             borderRight: '1px solid blue',
-            left: 72,
+            left: 79,
             minWidth: '300px',
             position: '-webkit-sticky',
           },
@@ -96,6 +94,7 @@ export const ContentArea = ({
       <Table
         sx={{
           height: '500px',
+          borderCollapse: 'separate',
           overflowY: 'scroll',
           '& th': {
             textAlign: 'left',
@@ -161,17 +160,6 @@ export const ContentArea = ({
               tooltip="description.rnr-approved-quantity"
             />
           </tr>
-          <tr>
-            <td colSpan={20} style={{ borderWidth: 0, padding: 0 }}>
-              <Box
-                sx={{
-                  backgroundColor: 'gray.light',
-                  height: '1px',
-                  width: '100%',
-                }}
-              ></Box>
-            </td>
-          </tr>
         </thead>
 
         <tbody>
@@ -185,10 +173,9 @@ export const ContentArea = ({
             {line => (
               <RnRFormLine
                 key={line.id}
-                line={line}
+                id={line.id}
                 periodLength={periodLength}
                 saveLine={saveLine}
-                markDirty={markDirty}
                 disabled={disabled}
               />
             )}

--- a/client/packages/requisitions/src/RnRForms/DetailView/DetailView.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/DetailView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import {
   DetailViewSkeleton,
   useNavigate,
@@ -60,30 +60,14 @@ const RnRFormDetailViewComponent = ({
   const t = useTranslation('replenishment');
   const { setCustomBreadcrumbs } = useBreadcrumbs();
 
-  const [dirtyLines, setDirtyLines] = useState<string[]>([]);
-
-  const saveLine = useCallback(
-    async (line: RnRFormLineFragment) => {
-      setDirtyLines(lines => lines.filter(id => id !== line.id));
-      updateLine(line);
-    },
-    [updateLine]
-  );
-
-  const markDirty = useCallback(
-    (id: string) => setDirtyLines(lines => [...lines, id]),
-    [setDirtyLines]
-  );
-
   const tabs = [
     {
       Component: (
         <ContentArea
           periodLength={data.periodLength}
           data={data.lines}
-          saveLine={saveLine}
+          saveLine={updateLine}
           disabled={data.status === RnRFormNodeStatus.Finalised}
-          markDirty={markDirty}
         />
       ),
       value: t('label.details'),
@@ -107,11 +91,7 @@ const RnRFormDetailViewComponent = ({
         <DetailTabs tabs={tabs} />
       </TableProvider>
 
-      <Footer
-        rnrFormId={data.id}
-        unsavedChanges={dirtyLines.length > 0}
-        linesUnconfirmed={linesUnconfirmed}
-      />
+      <Footer rnrFormId={data.id} linesUnconfirmed={linesUnconfirmed} />
     </>
   );
 };

--- a/client/packages/requisitions/src/RnRForms/DetailView/DetailView.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/DetailView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   DetailViewSkeleton,
   useNavigate,
@@ -65,14 +65,18 @@ const RnRFormDetailViewComponent = ({
 
   useConfirmOnLeaving(dirtyLines.length > 0);
 
-  const saveLine = async (line: RnRFormLineFragment) => {
-    setDirtyLines(lines => lines.filter(id => id !== line.id));
-    updateLine(line);
-  };
+  const saveLine = useCallback(
+    async (line: RnRFormLineFragment) => {
+      setDirtyLines(lines => lines.filter(id => id !== line.id));
+      updateLine(line);
+    },
+    [updateLine]
+  );
 
-  const markDirty = (id: string) => {
-    if (!dirtyLines.includes(id)) setDirtyLines(lines => [...lines, id]);
-  };
+  const markDirty = useCallback(
+    () => (id: string) => setDirtyLines(lines => [...lines, id]),
+    [setDirtyLines]
+  );
 
   const tabs = [
     {

--- a/client/packages/requisitions/src/RnRForms/DetailView/DetailView.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/DetailView.tsx
@@ -11,7 +11,6 @@ import {
   TableProvider,
   createTableStore,
   RnRFormNodeStatus,
-  useConfirmOnLeaving,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { ActivityLogList } from '@openmsupply-client/system';
@@ -63,8 +62,6 @@ const RnRFormDetailViewComponent = ({
 
   const [dirtyLines, setDirtyLines] = useState<string[]>([]);
 
-  useConfirmOnLeaving(dirtyLines.length > 0);
-
   const saveLine = useCallback(
     async (line: RnRFormLineFragment) => {
       setDirtyLines(lines => lines.filter(id => id !== line.id));
@@ -74,7 +71,7 @@ const RnRFormDetailViewComponent = ({
   );
 
   const markDirty = useCallback(
-    () => (id: string) => setDirtyLines(lines => [...lines, id]),
+    (id: string) => setDirtyLines(lines => [...lines, id]),
     [setDirtyLines]
   );
 

--- a/client/packages/requisitions/src/RnRForms/DetailView/Footer.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/Footer.tsx
@@ -14,13 +14,15 @@ import { useRnRForm } from '../api';
 export const Footer = ({
   rnrFormId,
   linesUnconfirmed,
+  unsavedChanges,
 }: {
   rnrFormId: string;
   linesUnconfirmed: boolean;
+  unsavedChanges: boolean;
 }) => {
   const t = useTranslation('replenishment');
   const { navigateUpOne } = useBreadcrumbs();
-  const { error, success } = useNotification();
+  const { error, info, success } = useNotification();
   const {
     query: { data },
     finalise: { finalise, isFinalising },
@@ -45,6 +47,14 @@ export const Footer = ({
     title: t('heading.are-you-sure'),
   });
 
+  const onFinalise = async () => {
+    if (unsavedChanges) {
+      info(t('messages.all-changes-must-be-confirmed'))();
+      return;
+    }
+    showFinaliseConfirmation();
+  };
+
   return (
     <AppFooterPortal
       Content={
@@ -62,7 +72,7 @@ export const Footer = ({
                 disabled={
                   isFinalising || data.status === RnRFormNodeStatus.Finalised
                 }
-                onClick={() => showFinaliseConfirmation()}
+                onClick={onFinalise}
                 variant={'ok'}
                 customLabel={
                   data.status === RnRFormNodeStatus.Finalised

--- a/client/packages/requisitions/src/RnRForms/DetailView/Footer.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/Footer.tsx
@@ -8,6 +8,7 @@ import {
   RnRFormNodeStatus,
   useNotification,
   useConfirmationModal,
+  useConfirmOnLeaving,
 } from '@openmsupply-client/common';
 import { useRnRForm } from '../api';
 
@@ -28,6 +29,8 @@ export const Footer = ({
     finalise: { finalise, isFinalising },
     confirmRemainingLines,
   } = useRnRForm({ rnrFormId });
+
+  useConfirmOnLeaving(unsavedChanges);
 
   const showFinaliseConfirmation = useConfirmationModal({
     onConfirm: async () => {

--- a/client/packages/requisitions/src/RnRForms/DetailView/Footer.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/Footer.tsx
@@ -8,7 +8,6 @@ import {
   RnRFormNodeStatus,
   useNotification,
   useConfirmationModal,
-  useConfirmOnLeaving,
 } from '@openmsupply-client/common';
 import { useRnRForm } from '../api';
 
@@ -27,8 +26,6 @@ export const Footer = ({
     finalise: { finalise, isFinalising },
     confirmRemainingLines,
   } = useRnRForm({ rnrFormId });
-
-  useConfirmOnLeaving(linesUnconfirmed);
 
   const showFinaliseConfirmation = useConfirmationModal({
     onConfirm: async () => {

--- a/client/packages/requisitions/src/RnRForms/DetailView/Footer.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/Footer.tsx
@@ -15,22 +15,20 @@ import { useRnRForm } from '../api';
 export const Footer = ({
   rnrFormId,
   linesUnconfirmed,
-  unsavedChanges,
 }: {
   rnrFormId: string;
   linesUnconfirmed: boolean;
-  unsavedChanges: boolean;
 }) => {
   const t = useTranslation('replenishment');
   const { navigateUpOne } = useBreadcrumbs();
-  const { error, info, success } = useNotification();
+  const { error, success } = useNotification();
   const {
     query: { data },
     finalise: { finalise, isFinalising },
     confirmRemainingLines,
   } = useRnRForm({ rnrFormId });
 
-  useConfirmOnLeaving(unsavedChanges);
+  useConfirmOnLeaving(linesUnconfirmed);
 
   const showFinaliseConfirmation = useConfirmationModal({
     onConfirm: async () => {
@@ -50,14 +48,6 @@ export const Footer = ({
     title: t('heading.are-you-sure'),
   });
 
-  const onFinalise = async () => {
-    if (unsavedChanges) {
-      info(t('messages.all-changes-must-be-confirmed'))();
-      return;
-    }
-    showFinaliseConfirmation();
-  };
-
   return (
     <AppFooterPortal
       Content={
@@ -75,7 +65,7 @@ export const Footer = ({
                 disabled={
                   isFinalising || data.status === RnRFormNodeStatus.Finalised
                 }
-                onClick={onFinalise}
+                onClick={() => showFinaliseConfirmation()}
                 variant={'ok'}
                 customLabel={
                   data.status === RnRFormNodeStatus.Finalised

--- a/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
@@ -11,7 +11,6 @@ import {
   NumericTextInput,
   NumUtils,
   useBufferState,
-  useConfirmOnLeaving,
   useNotification,
   useTheme,
   VenCategoryType,
@@ -21,11 +20,13 @@ import { getLowStockStatus, getAmc } from './helpers';
 
 export const RnRFormLine = ({
   line,
+  markDirty,
   saveLine,
   periodLength,
   disabled,
 }: {
   line: RnRFormLineFragment;
+  markDirty: (id: string) => void;
   periodLength: number;
   saveLine: (line: RnRFormLineFragment) => Promise<void>;
   disabled: boolean;
@@ -35,8 +36,6 @@ export const RnRFormLine = ({
   const [patch, setPatch] = useState<Partial<RnRFormLineFragment> | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const draft = { ...line, ...patch };
-
-  useConfirmOnLeaving(patch !== null);
 
   const updateDraft = (update: Partial<RnRFormLineFragment>) => {
     const newPatch = {
@@ -87,6 +86,7 @@ export const RnRFormLine = ({
       calculatedRequestedQuantity,
       lowStock,
     });
+    markDirty(draft.id);
   };
 
   const venCategory =

--- a/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
@@ -257,6 +257,7 @@ export const RnRFormLine = ({
                   setIsLoading(false);
                 } catch (e) {
                   error((e as Error).message)();
+                  setIsLoading(false);
                 }
               }}
               disabled={disabled}

--- a/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
@@ -20,14 +20,12 @@ import { getLowStockStatus, getAmc } from './helpers';
 export const RnRFormLine = ({
   line,
   saveLine,
-  markDirty,
   periodLength,
   disabled,
 }: {
   line: RnRFormLineFragment;
   periodLength: number;
   saveLine: (line: RnRFormLineFragment) => Promise<void>;
-  markDirty: (id: string) => void;
   disabled: boolean;
 }) => {
   const theme = useTheme();
@@ -85,7 +83,6 @@ export const RnRFormLine = ({
       calculatedRequestedQuantity,
       lowStock,
     });
-    markDirty(draft.id);
   };
 
   const venCategory =

--- a/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
@@ -4,6 +4,7 @@ import {
   BasicTextInput,
   Checkbox,
   CircleIcon,
+  CircularProgress,
   DatePicker,
   Formatter,
   LowStockStatus,
@@ -32,6 +33,7 @@ export const RnRFormLine = ({
   const { error } = useNotification();
 
   const [patch, setPatch] = useState<Partial<RnRFormLineFragment> | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
   const draft = { ...line, ...patch };
 
   const updateDraft = (update: Partial<RnRFormLineFragment>) => {
@@ -232,27 +234,35 @@ export const RnRFormLine = ({
 
       {/* Confirm the line */}
       <td style={{ textAlign: 'center' }}>
-        <Checkbox
-          checked={!!draft.confirmed}
-          size="medium"
-          onClick={async () => {
-            try {
-              await saveLine({ ...draft, confirmed: !draft.confirmed });
-              setPatch(null);
-            } catch (e) {
-              error((e as Error).message)();
-            }
-          }}
-          disabled={disabled}
-          sx={{ marginLeft: '10px' }}
-        />
-        <CircleIcon
-          sx={{
-            width: '10px',
-            visibility: patch === null ? 'hidden' : 'visible',
-            color: 'secondary.main',
-          }}
-        />
+        {isLoading ? (
+          <CircularProgress size={20} />
+        ) : (
+          <>
+            <Checkbox
+              checked={!!draft.confirmed}
+              size="medium"
+              onClick={async () => {
+                try {
+                  setIsLoading(true);
+                  await saveLine({ ...draft, confirmed: !draft.confirmed });
+                  setPatch(null);
+                  setIsLoading(false);
+                } catch (e) {
+                  error((e as Error).message)();
+                }
+              }}
+              disabled={disabled}
+              sx={{ marginLeft: '10px' }}
+            />
+            <CircleIcon
+              sx={{
+                width: '10px',
+                visibility: patch === null ? 'hidden' : 'visible',
+                color: 'secondary.main',
+              }}
+            />
+          </>
+        )}
       </td>
       {/* Readonly - populated from Response Requisition */}
       <RnRNumberCell

--- a/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
@@ -11,6 +11,7 @@ import {
   NumericTextInput,
   NumUtils,
   useBufferState,
+  useConfirmOnLeaving,
   useNotification,
   useTheme,
   VenCategoryType,
@@ -31,10 +32,11 @@ export const RnRFormLine = ({
 }) => {
   const theme = useTheme();
   const { error } = useNotification();
-
   const [patch, setPatch] = useState<Partial<RnRFormLineFragment> | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const draft = { ...line, ...patch };
+
+  useConfirmOnLeaving(patch !== null);
 
   const updateDraft = (update: Partial<RnRFormLineFragment>) => {
     const newPatch = {

--- a/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
@@ -17,30 +17,33 @@ import {
 } from '@openmsupply-client/common';
 import { RnRFormLineFragment } from '../api/operations.generated';
 import { getLowStockStatus, getAmc } from './helpers';
+import { useRnRFormContext } from '../api';
 
 export const RnRFormLine = ({
-  line,
-  markDirty,
+  id,
   saveLine,
   periodLength,
   disabled,
 }: {
-  line: RnRFormLineFragment;
-  markDirty: (id: string) => void;
+  id: string;
   periodLength: number;
   saveLine: (line: RnRFormLineFragment) => Promise<void>;
   disabled: boolean;
 }) => {
   const theme = useTheme();
   const { error } = useNotification();
-  const [patch, setPatch] = useState<Partial<RnRFormLineFragment> | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const draft = { ...line, ...patch };
+  const line = useRnRFormContext(state => state.lines[id]);
+
+  if (!line) return null;
+
+  const setLine = useRnRFormContext(state => state.setLine);
 
   const updateDraft = (update: Partial<RnRFormLineFragment>) => {
     const newPatch = {
-      ...patch,
+      ...line,
       confirmed: false,
+      isDirty: true,
       ...update,
     };
 
@@ -51,7 +54,7 @@ export const RnRFormLine = ({
       adjustments,
       stockOutDuration,
       previousMonthlyConsumptionValues,
-    } = { ...draft, ...newPatch };
+    } = { ...newPatch };
 
     const finalBalance =
       initialBalance + quantityReceived - quantityConsumed + adjustments;
@@ -77,7 +80,7 @@ export const RnRFormLine = ({
 
     const lowStock = getLowStockStatus(finalBalance, maximumQuantity);
 
-    setPatch({
+    setLine({
       ...newPatch,
       finalBalance,
       adjustedQuantityConsumed,
@@ -86,16 +89,15 @@ export const RnRFormLine = ({
       calculatedRequestedQuantity,
       lowStock,
     });
-    markDirty(draft.id);
   };
 
   const venCategory =
-    draft.item.venCategory === VenCategoryType.NotAssigned
+    line.item.venCategory === VenCategoryType.NotAssigned
       ? ''
-      : draft.item.venCategory;
+      : line.item.venCategory;
 
   const textColor =
-    disabled || draft.confirmed
+    disabled || line.confirmed
       ? theme.palette.text.disabled
       : theme.palette.text.primary;
 
@@ -109,30 +111,30 @@ export const RnRFormLine = ({
     <tr>
       {/* Read only Item data */}
       <td className="sticky-column first-column" style={readOnlyColumn}>
-        {draft.item.code}
+        {line.item.code}
       </td>
       <td style={readOnlyColumn} className="sticky-column second-column">
-        {draft.item.name}
+        {line.item.name}
       </td>
-      <td style={readOnlyColumn}>{draft.item.strength}</td>
-      <td style={readOnlyColumn}>{draft.item.unitName}</td>
+      <td style={readOnlyColumn}>{line.item.strength}</td>
+      <td style={readOnlyColumn}>{line.item.unitName}</td>
       <td style={{ ...readOnlyColumn, textAlign: 'center' }}>{venCategory}</td>
 
       {/* Enterable consumption data */}
       <RnRNumberCell
-        value={draft.initialBalance}
+        value={line.initialBalance}
         onChange={val => updateDraft({ initialBalance: val })}
         textColor={textColor}
         disabled={disabled}
       />
       <RnRNumberCell
-        value={draft.quantityReceived}
+        value={line.quantityReceived}
         onChange={val => updateDraft({ quantityReceived: val })}
         textColor={textColor}
         disabled={disabled}
       />
       <RnRNumberCell
-        value={draft.quantityConsumed}
+        value={line.quantityConsumed}
         onChange={val => updateDraft({ quantityConsumed: val })}
         textColor={textColor}
         disabled={disabled}
@@ -142,20 +144,20 @@ export const RnRFormLine = ({
       <RnRNumberCell
         readOnly
         textColor={textColor}
-        value={draft.adjustedQuantityConsumed}
+        value={line.adjustedQuantityConsumed}
         onChange={() => {}}
       />
 
       {/* Losses/adjustments and stock out */}
       <RnRNumberCell
-        value={draft.adjustments}
+        value={line.adjustments}
         onChange={val => updateDraft({ adjustments: val })}
         textColor={textColor}
         allowNegative
         disabled={disabled}
       />
       <RnRNumberCell
-        value={draft.stockOutDuration}
+        value={line.stockOutDuration}
         textColor={textColor}
         onChange={val => updateDraft({ stockOutDuration: val })}
         max={periodLength}
@@ -165,19 +167,19 @@ export const RnRFormLine = ({
       {/* Readonly calculated values */}
       <RnRNumberCell
         readOnly
-        value={draft.finalBalance}
+        value={line.finalBalance}
         textColor={textColor}
         onChange={() => {}}
       />
       <RnRNumberCell
         readOnly
-        value={draft.averageMonthlyConsumption}
+        value={line.averageMonthlyConsumption}
         onChange={() => {}}
         textColor={textColor}
       />
       <RnRNumberCell
         readOnly
-        value={draft.maximumQuantity}
+        value={line.maximumQuantity}
         onChange={() => {}}
         textColor={textColor}
       />
@@ -190,7 +192,7 @@ export const RnRFormLine = ({
             '& fieldset': { border: 'none' },
             '& input': { color: textColor },
           }}
-          value={draft.expiryDate ? new Date(draft.expiryDate) : null}
+          value={line.expiryDate ? new Date(line.expiryDate) : null}
           onChange={date =>
             updateDraft({ expiryDate: Formatter.naiveDate(date) })
           }
@@ -199,19 +201,19 @@ export const RnRFormLine = ({
       </td>
       <RnRNumberCell
         value={
-          draft.enteredRequestedQuantity ?? draft.calculatedRequestedQuantity
+          line.enteredRequestedQuantity ?? line.calculatedRequestedQuantity
         }
         onChange={val => updateDraft({ enteredRequestedQuantity: val })}
         textColor={textColor}
         disabled={disabled}
       />
       <td style={{ ...readOnlyColumn, textAlign: 'center' }}>
-        {draft.lowStock !== LowStockStatus.Ok && (
+        {line.lowStock !== LowStockStatus.Ok && (
           <AlertIcon
-            double={draft.lowStock === LowStockStatus.BelowQuarter}
+            double={line.lowStock === LowStockStatus.BelowQuarter}
             sx={{
               color:
-                draft.lowStock === LowStockStatus.BelowQuarter
+                line.lowStock === LowStockStatus.BelowQuarter
                   ? 'error.main'
                   : 'primary.light',
             }}
@@ -228,7 +230,7 @@ export const RnRFormLine = ({
               '& .MuiInput-input': { color: textColor },
             },
           }}
-          value={draft.comment ?? ''}
+          value={line.comment ?? ''}
           onChange={e => updateDraft({ comment: e.target.value })}
           disabled={disabled}
         />
@@ -241,13 +243,17 @@ export const RnRFormLine = ({
         ) : (
           <>
             <Checkbox
-              checked={!!draft.confirmed}
+              checked={!!line.confirmed}
               size="medium"
               onClick={async () => {
                 try {
                   setIsLoading(true);
-                  await saveLine({ ...draft, confirmed: !draft.confirmed });
-                  setPatch(null);
+                  await saveLine({ ...line, confirmed: !line.confirmed });
+                  setLine({
+                    ...line,
+                    confirmed: !line.confirmed,
+                    isDirty: false,
+                  });
                   setIsLoading(false);
                 } catch (e) {
                   error((e as Error).message)();
@@ -259,7 +265,7 @@ export const RnRFormLine = ({
             <CircleIcon
               sx={{
                 width: '10px',
-                visibility: patch === null ? 'hidden' : 'visible',
+                visibility: line.isDirty ? 'visible' : 'hidden',
                 color: 'secondary.main',
               }}
             />
@@ -269,7 +275,7 @@ export const RnRFormLine = ({
       {/* Readonly - populated from Response Requisition */}
       <RnRNumberCell
         readOnly
-        value={draft.approvedQuantity ?? 0}
+        value={line.approvedQuantity ?? 0}
         textColor={textColor}
         onChange={() => {}}
       />

--- a/client/packages/requisitions/src/RnRForms/api/hooks/index.ts
+++ b/client/packages/requisitions/src/RnRForms/api/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useRnRForm';
+export * from './useRnRFormContext';
 export * from './useRnRFormList';
 export * from './useSchedulesAndPeriods';
 export * from './useCreateRnRForm';

--- a/client/packages/requisitions/src/RnRForms/api/hooks/useRnRForm.ts
+++ b/client/packages/requisitions/src/RnRForms/api/hooks/useRnRForm.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import {
   isEmpty,
   UpdateRnRFormLineInput,
@@ -40,7 +41,10 @@ export const useRnRForm = ({ rnrFormId }: { rnrFormId: string }) => {
 
   const query = useQuery({ queryKey, queryFn });
 
-  const updateLine = async (line: RnRFormLineFragment) => updateLines([line]);
+  const updateLine = useCallback(
+    async (line: RnRFormLineFragment) => updateLines([line]),
+    []
+  );
 
   const confirmRemainingLines = async () => {
     if (!query.data) return;

--- a/client/packages/requisitions/src/RnRForms/api/hooks/useRnRForm.ts
+++ b/client/packages/requisitions/src/RnRForms/api/hooks/useRnRForm.ts
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import {
   isEmpty,
   UpdateRnRFormLineInput,
@@ -41,10 +40,7 @@ export const useRnRForm = ({ rnrFormId }: { rnrFormId: string }) => {
 
   const query = useQuery({ queryKey, queryFn });
 
-  const updateLine = useCallback(
-    async (line: RnRFormLineFragment) => updateLines([line]),
-    []
-  );
+  const updateLine = async (line: RnRFormLineFragment) => updateLines([line]);
 
   const confirmRemainingLines = async () => {
     if (!query.data) return;

--- a/client/packages/requisitions/src/RnRForms/api/hooks/useRnRFormContext.ts
+++ b/client/packages/requisitions/src/RnRForms/api/hooks/useRnRFormContext.ts
@@ -1,0 +1,55 @@
+import { RnRFormNodeStatus } from '@common/types';
+import { RnRFormLineFragment } from '../operations.generated';
+import { ArrayUtils, create } from '@openmsupply-client/common';
+
+export interface RnRForm {
+  id: string;
+  periodLength: number;
+  periodName: string;
+  status: RnRFormNodeStatus;
+  lineIds: string[];
+}
+
+export interface RnRFormLine extends RnRFormLineFragment {
+  isDirty?: boolean;
+  error?: string;
+}
+
+interface RnRFormContext {
+  isLoading: boolean;
+  form: RnRForm | undefined;
+  lines: Record<string, RnRFormLine>;
+  setForm: (form: RnRForm) => void;
+  setIsLoading: (isLoading: boolean) => void;
+  setLine: (line: RnRFormLine) => void;
+  setLines: (lines: RnRFormLineFragment[]) => void;
+  setError: (lineId: string, error: string) => void;
+}
+
+export const useRnRFormContext = create<RnRFormContext>(set => ({
+  isLoading: true,
+  form: undefined,
+  lines: {},
+  setForm: (form: RnRForm) =>
+    set(state => ({ ...state, form, isLoading: false })),
+  setIsLoading: (isLoading: boolean) => set(state => ({ ...state, isLoading })),
+  setLine: (line: RnRFormLine) =>
+    set(state => ({
+      ...state,
+      lines: { ...state.lines, [line.id]: line },
+    })),
+  setLines: (lines: RnRFormLineFragment[]) =>
+    set(state => ({ ...state, lines: ArrayUtils.toObject(lines) })),
+  setError: (lineId: string, error: string) =>
+    set(state => {
+      const line = state.lines[lineId];
+      if (line === undefined) return state;
+      return {
+        ...state,
+        lines: {
+          ...state.lines,
+          [lineId]: { ...line, error },
+        },
+      };
+    }),
+}));

--- a/client/packages/requisitions/src/RnRForms/api/hooks/useRnRFormContext.ts
+++ b/client/packages/requisitions/src/RnRForms/api/hooks/useRnRFormContext.ts
@@ -12,7 +12,6 @@ export interface RnRForm {
 
 export interface RnRFormLine extends RnRFormLineFragment {
   isDirty?: boolean;
-  error?: string;
 }
 
 interface RnRFormContext {
@@ -23,7 +22,6 @@ interface RnRFormContext {
   setIsLoading: (isLoading: boolean) => void;
   setLine: (line: RnRFormLine) => void;
   setLines: (lines: RnRFormLineFragment[]) => void;
-  setError: (lineId: string, error: string) => void;
 }
 
 export const useRnRFormContext = create<RnRFormContext>(set => ({
@@ -40,16 +38,4 @@ export const useRnRFormContext = create<RnRFormContext>(set => ({
     })),
   setLines: (lines: RnRFormLineFragment[]) =>
     set(state => ({ ...state, lines: ArrayUtils.toObject(lines) })),
-  setError: (lineId: string, error: string) =>
-    set(state => {
-      const line = state.lines[lineId];
-      if (line === undefined) return state;
-      return {
-        ...state,
-        lines: {
-          ...state.lines,
-          [lineId]: { ...line, error },
-        },
-      };
-    }),
 }));


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4568

# 👩🏻‍💻 What does this PR do?
The `RnRFormLine` component is rendered 3x for every row, on every update.
This is sluggish on android and increasingly so the more lines you have.

I've hobbled the dirty state, as this contributes a render cycle - now the blue dot shows, but there's no global state, so there's no info snack telling you to update. I figure that if you are editing, then the row isn't confirmed and so the finalise button will still prompt.

I had also moved the `useConfirmOnLeaving` hook into the footer as this adds a render cycle when it updates. This is now on every row, and while I'm worried that this adds overhead, it seems to run ok.

Have added the loading indicator to the row. 

With the changes, when you edit a row the row itself renders - previously all rows were re-rendered. 
When you confirm, there are 2 renders for every row, so there's an improvement, even if not ideal.

Here's my old lenovo coping with 50 rows:

https://github.com/user-attachments/assets/91fbc589-6744-457b-ab9e-71991cc3ebf6



<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] try editing a medium/large form and get the vibes
- [ ] does it prompt if you navigate away after editing?
- [ ] does it warn you when finalising, if you have un-committed rows?

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
