### PR TITLE
4587 basic reports error shows eternal loading indicator

### DIFF
--- a/client/packages/common/src/intl/locales/en/reports.json
+++ b/client/packages/common/src/intl/locales/en/reports.json
@@ -1,5 +1,7 @@
 {
     "description.notification-preferences": "By default, the system will tell you if you have more than 3 or 6 months of stock on the homepage dashboard.",
+    "error.failed-to-generate-report": "Failed to generate report",
+    "error.no-permission-report": "You do not have permission to view this report",
     "heading.expiring": "Expiring",
     "heading.notification-preferences": "Notification Preferences",
     "heading.stock-and-items": "Stock & Items",

--- a/client/packages/common/src/intl/locales/en/reports.json
+++ b/client/packages/common/src/intl/locales/en/reports.json
@@ -2,6 +2,7 @@
     "description.notification-preferences": "By default, the system will tell you if you have more than 3 or 6 months of stock on the homepage dashboard.",
     "error.failed-to-generate-report": "Failed to generate report",
     "error.no-permission-report": "You do not have permission to view this report",
+    "error.report-does-not-exist": "Report does not exist",
     "heading.expiring": "Expiring",
     "heading.notification-preferences": "Notification Preferences",
     "heading.stock-and-items": "Stock & Items",

--- a/client/packages/common/src/intl/locales/en/reports.json
+++ b/client/packages/common/src/intl/locales/en/reports.json
@@ -3,6 +3,7 @@
     "error.failed-to-generate-report": "Failed to generate report",
     "error.no-permission-report": "You do not have permission to view this report",
     "error.report-does-not-exist": "Report does not exist",
+    "error.failed-to-generate-excel": "Failed to generate Excel",
     "heading.expiring": "Expiring",
     "heading.notification-preferences": "Notification Preferences",
     "heading.stock-and-items": "Stock & Items",

--- a/client/packages/reports/src/DetailView/DetailView.tsx
+++ b/client/packages/reports/src/DetailView/DetailView.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
-  BasicSpinner,
   FileUtils,
+  LocaleKey,
   NothingHere,
   PrintFormat,
+  TypedTFunction,
   useBreadcrumbs,
   useParams,
   useTranslation,
@@ -23,6 +24,8 @@ import { JsonData } from '@openmsupply-client/programs';
 export const DetailView = () => {
   const { id } = useParams();
   const { data: report } = useReport(id ?? '');
+  const t = useTranslation('reports');
+
   const {
     urlQuery: { reportArgs: reportArgsJson },
   } = useUrlQuery({ skipParse: ['reportArgs'] });
@@ -31,22 +34,23 @@ export const DetailView = () => {
     (reportArgsJson && JSON.parse(reportArgsJson.toString())) || undefined;
 
   return !report?.id ? (
-    <BasicSpinner />
+    <NothingHere body={t('error.report-does-not-exist')} />
   ) : (
-    <DetailViewInner report={report} reportArgs={reportArgs} />
+    <DetailViewInner report={report} reportArgs={reportArgs} t={t} />
   );
 };
 
 const DetailViewInner = ({
   report,
   reportArgs,
+  t,
 }: {
   report: ReportRowFragment;
   reportArgs: JsonData;
+  t: TypedTFunction<LocaleKey>;
 }) => {
   const { setCustomBreadcrumbs } = useBreadcrumbs(['reports']);
   const [errorMessage, setErrorMessage] = useState('');
-  const t = useTranslation('reports');
   const { mutateAsync } = useGenerateReport(setErrorMessage, t);
   const [fileId, setFileId] = useState<string | undefined>();
   const { print, isPrinting } = usePrintReport();

--- a/client/packages/reports/src/DetailView/DetailView.tsx
+++ b/client/packages/reports/src/DetailView/DetailView.tsx
@@ -155,7 +155,7 @@ const DetailViewInner = ({
           if (errors[0].extensions?.details?.includes('permission')) {
             setErrorMessage(t('error.no-permission-report'));
           } else {
-            setErrorMessage(t('error.failed-to-generate-report'));
+            setErrorMessage(t('error.failed-to-generate-excel'));
           }
         } else {
           noOtherVariants(err.__typename);

--- a/client/packages/system/src/Report/api/hooks/useGenerateReport.ts
+++ b/client/packages/system/src/Report/api/hooks/useGenerateReport.ts
@@ -1,18 +1,9 @@
-import { Dispatch, SetStateAction } from 'react';
 import { PrintFormat } from '@common/types';
 import { useReportGraphQL } from '../useReportGraphQL';
 import { GenerateReportParams } from './usePrintReport';
-import {
-  LocaleKey,
-  noOtherVariants,
-  TypedTFunction,
-  useMutation,
-} from '@openmsupply-client/common';
+import { useMutation } from '@openmsupply-client/common';
 
-export const useGenerateReport = (
-  setErrorMessage: Dispatch<SetStateAction<string>>,
-  t: TypedTFunction<LocaleKey>
-) => {
+export const useGenerateReport = () => {
   const { reportApi, storeId } = useReportGraphQL();
 
   const mutationFn = async (params: GenerateReportParams) => {
@@ -26,27 +17,7 @@ export const useGenerateReport = (
       arguments: args,
       sort,
     });
-    if (result?.generateReport?.__typename === 'PrintReportNode') {
-      return result.generateReport.fileId;
-    }
-
-    if (result?.generateReport?.__typename === 'PrintReportError') {
-      const err = result?.generateReport.error;
-
-      if (err.__typename === 'FailedToFetchReportData') {
-        const errors = err.errors;
-
-        if (errors[0].extensions?.details?.includes('permission')) {
-          setErrorMessage(t('error.no-permission-report'));
-        } else {
-          setErrorMessage(t('error.failed-to-generate-report'));
-        }
-      } else {
-        noOtherVariants(err.__typename);
-      }
-    }
-
-    throw new Error(t('error.failed-to-generate-report'));
+    return result?.generateReport;
   };
 
   const { mutateAsync, isLoading } = useMutation({

--- a/client/packages/system/src/Report/api/hooks/useGenerateReport.ts
+++ b/client/packages/system/src/Report/api/hooks/useGenerateReport.ts
@@ -42,7 +42,7 @@ export const useGenerateReport = (
           setErrorMessage(t('error.failed-to-generate-report'));
         }
       } else {
-        noOtherVariants;
+        noOtherVariants(err.__typename);
       }
     }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4587 & #4589

# 👩🏻‍💻 What does this PR do?
Cover print structure error and change the spinner to a nothing here with the error message.
![Screenshot 2024-08-15 at 7 29 46 AM](https://github.com/user-attachments/assets/3789395d-6919-41b2-bdfc-84bfeffe6bbf)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Remove view item permissions in OG
- [ ] Load stock status report 
- [ ] Sync OMS 
- [ ] Try to view stock status report
- [ ] Should show Nothing here page with no permission message

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
