### PR TITLE
4471 Equipment list not showing properly when reloading the page in browser

### DIFF
--- a/client/packages/coldchain/src/Equipment/api/hooks/document/useAssets.ts
+++ b/client/packages/coldchain/src/Equipment/api/hooks/document/useAssets.ts
@@ -1,13 +1,13 @@
 import {
   useAuthContext,
-  useIsCentralServerApi,
+  useCentralServerCallback,
   useQuery,
   useUrlQueryParams,
 } from '@openmsupply-client/common';
 import { useAssetApi } from '../utils/useAssetApi';
 
 export const useAssets = () => {
-  const isCentralServer = useIsCentralServerApi();
+  const isCentralServer = useCentralServerCallback();
   const { store } = useAuthContext();
 
   const { queryParams } = useUrlQueryParams({


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4471

# 👩🏻‍💻 What does this PR do?
Use callback to check if site is central server. 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Initialise OMS central server
- [ ] Create some equipments in different stores
- [ ] Go to equipment list view -> see all equipment regardless of store
- [ ] Press refresh button -> should still see all equipment regardless of store

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
