### PR TITLE
4541 trying to increase the issue quan in prescription window shows wrong available(packs) and thus can't increase the quan despite the stocks available

### DIFF
--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/hooks/useDraftPrescriptionLines.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/hooks/useDraftPrescriptionLines.tsx
@@ -11,7 +11,6 @@ import { usePrescription } from '../../../api';
 import { DraftItem } from '../../../..';
 import { DraftStockOutLine } from '../../../../types';
 import {
-  DraftStockOutLineSeeds,
   UseDraftStockOutLinesControl,
   createDraftStockOutLine,
   createDraftStockOutLineFromStockLine,
@@ -23,17 +22,6 @@ export interface UseDraftPrescriptionLinesControl
   extends UseDraftStockOutLinesControl {
   updateNotes: (note: string) => void;
 }
-
-// Not using createDraftStockOutLine here since availableNumberOfPacks is reduced
-// when prescription's status is >= Picked and we do not want to add back the numberOfPacks from
-// invoice line for display in UI
-export const createDraftPrescriptionLine = ({
-  invoiceLine,
-}: DraftStockOutLineSeeds): DraftStockOutLine => ({
-  isCreated: !invoiceLine,
-  isUpdated: false,
-  ...invoiceLine,
-});
 
 export const useDraftPrescriptionLines = (
   item: DraftItem | null
@@ -66,7 +54,7 @@ export const useDraftPrescriptionLines = (
             ({ stockLine }) => stockLine?.id === batch.id
           );
           if (invoiceLine) {
-            return createDraftPrescriptionLine({
+            return createDraftStockOutLine({
               invoiceLine,
               invoiceId,
             });


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4541

# 👩🏻‍💻 What does this PR do?
Show all available packs in picked status and also show batch if they have all been issued.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have an item with 10 (or so) stock on hand. 
- [ ] Go to prescriptions
- [ ] Issue 3 to patient
- [ ] You should still have 10 available stock to issue.

2.
- [ ] Try issue all the item to the patient
- [ ] Batch shouldn't disappear and you should still be able to edit batch.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
