### PR TITLE
Adjust translation namespace calls

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/AppBarButtons.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/AppBarButtons.tsx
@@ -25,7 +25,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   onAddItem,
 }) => {
   const { OpenButton } = useDetailPanel();
-  const t = useTranslation();
+  const t = useTranslation('reports'); // note: using 'reports' due to issue #4616
   const { print, isPrinting } = usePrintReport();
   const { data } = useStocktake.document.get();
   const isDisabled = !data || isStocktakeDisabled(data);

--- a/client/packages/invoices/src/InboundShipment/DetailView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/AppBarButtons.tsx
@@ -31,7 +31,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   const isDisabled = useInbound.utils.isDisabled();
   const { data } = useInbound.document.get();
   const { OpenButton } = useDetailPanel();
-  const t = useTranslation();
+  const t = useTranslation('reports'); // note: using 'reports' due to issue #4616
   const { print, isPrinting } = usePrintReport();
   const {
     queryParams: { sortBy },

--- a/client/packages/invoices/src/OutboundShipment/DetailView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/AppBarButtons.tsx
@@ -32,7 +32,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   const isDisabled = useOutbound.utils.isDisabled();
   const { data } = useOutbound.document.get();
   const { OpenButton } = useDetailPanel();
-  const t = useTranslation();
+  const t = useTranslation('reports'); // note: using 'reports' due to issue #4616
   const { print, isPrinting } = usePrintReport();
   const {
     queryParams: { sortBy },

--- a/client/packages/invoices/src/Returns/InboundDetailView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/Returns/InboundDetailView/AppBarButtons.tsx
@@ -30,7 +30,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   const isDisabled = useReturns.utils.inboundIsDisabled();
   const { data } = useReturns.document.inboundReturn();
   const { OpenButton } = useDetailPanel();
-  const t = useTranslation('common');
+  const t = useTranslation('reports'); // note: using 'reports' due to issue #4616
   const { print, isPrinting } = usePrintReport();
   const {
     queryParams: { sortBy },

--- a/client/packages/invoices/src/Returns/OutboundDetailView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/Returns/OutboundDetailView/AppBarButtons.tsx
@@ -30,7 +30,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   const isDisabled = useReturns.utils.outboundIsDisabled();
   const { data } = useReturns.document.outboundReturn();
   const { OpenButton } = useDetailPanel();
-  const t = useTranslation('common');
+  const t = useTranslation('reports'); // note: using 'reports' due to issue #4616
   const { print, isPrinting } = usePrintReport();
   const {
     queryParams: { sortBy },

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
@@ -31,7 +31,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   const isDisabled = useRequest.utils.isDisabled();
   const isProgram = useRequest.utils.isProgram();
   const { OpenButton } = useDetailPanel();
-  const t = useTranslation('distribution');
+  const t = useTranslation('reports'); // note: using 'reports' due to issue #4616
   const { data } = useRequest.document.get();
   const { print, isPrinting } = usePrintReport();
 

--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/utils/useAddFromMasterList.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/utils/useAddFromMasterList.ts
@@ -22,7 +22,7 @@ export const useAddFromMasterList = () => {
       queryClient.invalidateQueries(api.keys.detail(String(requisitionNumber))),
   });
 
-  const t = useTranslation('distribution');
+  const t = useTranslation('replenishment');
   const getConfirmation = useConfirmationModal({
     title: t('heading.are-you-sure'),
     message: t('messages.confirm-add-from-master-list'),

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
@@ -21,7 +21,7 @@ export const AppBarButtonsComponent = () => {
   const { OpenButton } = useDetailPanel();
   const { data } = useResponse.document.get();
   const { print, isPrinting } = usePrintReport();
-  const t = useTranslation();
+  const t = useTranslation('reports'); // note: using 'reports' due to issue #4616
 
   const printReport = (
     report: ReportRowFragment,

--- a/client/packages/requisitions/src/RnRForms/DetailView/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/AppBarButtons.tsx
@@ -26,7 +26,7 @@ export const AppBarButtonsComponent = () => {
     query: { data },
   } = useRnRForm({ rnrFormId: id });
   const { print, isPrinting } = usePrintReport();
-  const t = useTranslation();
+  const t = useTranslation('reports'); // note: using 'reports' due to issue #4616
 
   const printReport =
     (format: PrintFormat) =>

--- a/client/packages/system/src/Patient/PatientView/AppBarButtons.tsx
+++ b/client/packages/system/src/Patient/PatientView/AppBarButtons.tsx
@@ -21,7 +21,7 @@ export const AppBarButtons: FC<{
   disabled: boolean;
   store?: UserStoreNodeFragment;
 }> = ({ disabled, store }) => {
-  const t = useTranslation();
+  const t = useTranslation('reports'); // note: using 'reports' due to issue #4616
   const { print, isPrinting } = usePrintReport();
   const patientId = usePatient.utils.id();
   const printReport = (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4616

# 👩🏻‍💻 What does this PR do?
I tracked this as far as the call to `useTranslation('reports')` which then causes the reports namespace to be loaded - but due to the timing / placement in the DOM of the ReportArgumentsModal this is loaded after the app bar portal is rendered:

![Screenshot 2024-08-19 at 5 18 00 PM](https://github.com/user-attachments/assets/d0025879-1c29-4e5a-b1a3-de95ddd0342a)

which means that you get a ref for the portal, and then, without the div being unloaded, the ref is `null` 🤷 

a simple fix is to load the reports namespace earlier, so I've lifted that and used it in the appbar components.

A similar problem with internal orders, where the `distribution` namespace was being used, for a component which is in the `replenishment` section; a new namespace is loaded and the portal refs disappear.

So, no conclusive understanding of what's gone wrong - this at least will fix the problem.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->
Check the following pages, navigate to them and refresh: should look ok
- [ ] R&R forms detail view
- [ ] Requisition detail view
- [ ] Internal order detail view
- [ ] Stocktake detail view

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
