### PR TITLE
4559 Total/Available SoH number looks wrong after stocktake for existing lines whose packsize is greater than 1

### DIFF
--- a/server/service/src/invoice_line/stock_in_line/insert/generate.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/generate.rs
@@ -30,12 +30,11 @@ pub fn generate(
 ) -> Result<GenerateResult, RepositoryError> {
     let store_preferences = get_store_preferences(connection, &existing_invoice_row.store_id)?;
 
-    let new_line = generate_line(input.clone(), item_row, existing_invoice_row.clone());
+    let mut new_line = generate_line(input.clone(), item_row, existing_invoice_row.clone());
 
-    let mut new_line = match store_preferences.pack_to_one {
-        true => convert_invoice_line_to_single_pack(new_line),
-        false => new_line,
-    };
+    if StockInType::InventoryAddition != input.r#type && store_preferences.pack_to_one {
+        new_line = convert_invoice_line_to_single_pack(new_line);
+    }
 
     let barcode_option = generate_barcode(&input, connection)?;
 
@@ -59,12 +58,7 @@ pub fn generate(
         // If a new stock line has been created, update the stock_line_id on the invoice line
         new_line.stock_line_id = Some(batch.id.clone());
 
-        let new_batch = match store_preferences.pack_to_one {
-            true => convert_stock_line_to_single_pack(batch),
-            false => batch,
-        };
-
-        Some(new_batch)
+        Some(batch)
     } else {
         None
     };

--- a/server/service/src/invoice_line/stock_in_line/insert/generate.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/generate.rs
@@ -2,8 +2,7 @@ use crate::{
     barcode::{self, BarcodeInput},
     invoice::common::{calculate_total_after_tax, generate_invoice_user_id_update},
     invoice_line::stock_in_line::{
-        convert_invoice_line_to_single_pack, convert_stock_line_to_single_pack, generate_batch,
-        StockInType, StockLineInput,
+        convert_invoice_line_to_single_pack, generate_batch, StockInType, StockLineInput,
     },
     store_preference::get_store_preferences,
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4559

# 👩🏻‍💻 What does this PR do?
OG docs only talk about converting to 1 when receiving stock, so have removed this for Inventory Adjustments. 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Add stock with pack size greater than 1
- [ ] Do stocktake with that stock and add more stock
- [ ] Finalise stocktake
- [ ] Go back to stock view and make sure numbers are correct

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
