### PR TITLE
4578 Catalogue -> Master List Lines: Code sorting does not work

### DIFF
--- a/client/packages/system/src/MasterList/DetailView/ContentArea.tsx
+++ b/client/packages/system/src/MasterList/DetailView/ContentArea.tsx
@@ -42,7 +42,6 @@ export const ContentArea = () => {
         'itemUnit',
         {
           accessor: ({ rowData }) => rowData.item.unitName,
-          getSortValue: rowData => rowData.item.unitName ?? '',
           sortable: false,
         },
       ],

--- a/client/packages/system/src/MasterList/api/api.ts
+++ b/client/packages/system/src/MasterList/api/api.ts
@@ -28,8 +28,8 @@ export type LinesParams = {
 
 const masterListParser = {
   toSort: (sortBy: SortBy<MasterListRowFragment>): MasterListSortFieldInput => {
-    if (sortBy.key === 'name') return MasterListSortFieldInput.Name;
-    if (sortBy.key === 'code') return MasterListSortFieldInput.Code;
+    if (sortBy.key === 'itemName') return MasterListSortFieldInput.Name;
+    if (sortBy.key === 'itemCode') return MasterListSortFieldInput.Code;
     return MasterListSortFieldInput.Description;
   },
 };
@@ -38,7 +38,7 @@ const masterListLineParser = {
   toSort: (
     sortBy: SortBy<MasterListLineFragment>
   ): MasterListLineSortFieldInput => {
-    if (sortBy.key === 'code') return MasterListLineSortFieldInput.Code;
+    if (sortBy.key === 'itemCode') return MasterListLineSortFieldInput.Code;
     return MasterListLineSortFieldInput.Name;
   },
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4578

# 👩🏻‍💻 What does this PR do?
Allow sorting by master list line code


https://github.com/user-attachments/assets/a2d353ff-6e6a-44f6-879e-bc493289e6b5


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Click on Master List
- [ ] Click on a line
- [ ] Try sort by code

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
