### PR TITLE
4567 Catalogue -> Assets -> the count does not update when deleting assets

### DIFF
--- a/server/repository/src/db_diesel/assets/asset_catalogue_item.rs
+++ b/server/repository/src/db_diesel/assets/asset_catalogue_item.rs
@@ -115,7 +115,9 @@ pub fn to_domain(asset_catalogue_item_row: AssetCatalogueItemRow) -> AssetCatalo
 }
 
 fn create_filtered_query(filter: Option<AssetCatalogueItemFilter>) -> BoxedAssetCatalogueItemQuery {
-    let mut query = asset_catalogue_item_dsl::asset_catalogue_item.into_boxed();
+    let mut query = asset_catalogue_item_dsl::asset_catalogue_item
+        .filter(asset_catalogue_item_dsl::deleted_datetime.is_null())
+        .into_boxed();
 
     if let Some(f) = filter {
         let AssetCatalogueItemFilter {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4567

# 👩🏻‍💻 What does this PR do?
Filter out deleted assets

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to assets
- [ ] Delete some assets
- [ ] Total count at the bottom of the table should update accordingly

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
