### PR TITLE
4437 Add some helpful message under 'Master List' tab of item details window for invisible items

### DIFF
--- a/client/packages/common/src/intl/locales/en/catalogue.json
+++ b/client/packages/common/src/intl/locales/en/catalogue.json
@@ -7,6 +7,7 @@
   "error.master-list-not-found": "Master list not found",
   "error.no-items": "No items to display.",
   "error.no-master-lists": "No Master Lists to display.",
+  "error.no-master-list": "This item is not assigned to a master list and therefore cannot be ordered, please contact your administrator if this is an error. Note that an item could be visible if there is stock on hand, even if the item isn't on a master list.",
   "error.no-pack-variants": "This item does not have any pack variants configured.",
   "error.pack-variant-exists": "Pack variant with the same pack size already exists for item",
   "filename.asset-categories": "Asset Categories",

--- a/client/packages/common/src/intl/locales/en/catalogue.json
+++ b/client/packages/common/src/intl/locales/en/catalogue.json
@@ -7,7 +7,7 @@
   "error.master-list-not-found": "Master list not found",
   "error.no-items": "No items to display.",
   "error.no-master-lists": "No Master Lists to display.",
-  "error.no-master-list": "This item is not assigned to a master list and therefore cannot be ordered, please contact your administrator if this is an error. Note that an item could be visible if there is stock on hand, even if the item isn't on a master list.",
+  "error.no-master-list": "This item is not assigned to a master list, please contact your administrator if this is an error. Note that an item could be visible if there is stock on hand, even if the item isn't on a master list.",
   "error.no-pack-variants": "This item does not have any pack variants configured.",
   "error.pack-variant-exists": "Pack variant with the same pack size already exists for item",
   "filename.asset-categories": "Asset Categories",

--- a/client/packages/system/src/Item/DetailView/Tabs/MasterLists.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/MasterLists.tsx
@@ -3,7 +3,7 @@ import {
   MasterListRowFragment,
   useMasterList,
 } from '@openmsupply-client/system';
-import { BasicSpinner } from '@common/components';
+import { BasicSpinner, NothingHere } from '@common/components';
 import {
   DataTable,
   TableProvider,
@@ -12,10 +12,12 @@ import {
   Box,
   createQueryParamsStore,
   TooltipTextCell,
+  useTranslation,
 } from '@openmsupply-client/common';
 
 const MasterListsTable: FC<{ itemId?: string }> = ({ itemId }) => {
   const { data, isLoading } = useMasterList.document.listByItemId(itemId ?? '');
+  const t = useTranslation('catalogue');
   const columns = useColumns<MasterListRowFragment>([
     ['code', { Cell: TooltipTextCell }],
     ['name', { width: 200, Cell: TooltipTextCell }],
@@ -25,7 +27,12 @@ const MasterListsTable: FC<{ itemId?: string }> = ({ itemId }) => {
   if (isLoading) return <BasicSpinner />;
 
   return (
-    <DataTable id="master-list-detail" data={data?.nodes} columns={columns} />
+    <DataTable
+      id="master-list-detail"
+      data={data?.nodes}
+      columns={columns}
+      noDataElement={<NothingHere body={t('error.no-master-list')} />}
+    />
   );
 };
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4437

# 👩🏻‍💻 What does this PR do?
Change message for item that isn't linked to master list 
![Screenshot 2024-08-20 at 6 40 32 AM](https://github.com/user-attachments/assets/40db8fc8-3621-40fb-8def-d73c5ef83cc7)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have an item that isn't linked to a master list but has stock in the store
- [ ] Go to Item 
- [ ] Press on item 
- [ ] Click on master list tab
- [ ] See new message

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Message for no master list linked to item
  2.
