### PR TITLE
Remove seconds from DatePicker UI

### DIFF
--- a/client/packages/common/src/ui/components/inputs/DatePickers/DateTimePickerInput/DateTimePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/DateTimePickerInput/DateTimePickerInput.tsx
@@ -112,7 +112,7 @@ export const DateTimePickerInput: FC<
         },
         textField: {
           error: !isInitialEntry && (!!error || !!internalError),
-          helperText: !isInitialEntry ? error ?? internalError ?? '' : '',
+          helperText: !isInitialEntry ? (error ?? internalError ?? '') : '',
           onBlur: e => {
             handleDateInput(
               DateUtils.getDateOrNull(e.target.value, format, dateParseOptions)
@@ -132,7 +132,7 @@ export const DateTimePickerInput: FC<
       }}
       views={
         showTime
-          ? ['year', 'month', 'day', 'hours', 'minutes', 'seconds']
+          ? ['year', 'month', 'day', 'hours', 'minutes']
           : ['year', 'month', 'day']
       }
       minDate={minDate}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4628 

# 👩🏻‍💻 What does this PR do?
Removes the seconds from out date/time picker UI so that the time portion isn't so cluttered in the mobile aspect: 

![image](https://github.com/user-attachments/assets/39e7576b-798b-40ab-bb5c-44f3da300b49)


<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->
You can use inspect::change layout to mobile to view the mobile version

- [ ] Check that the datetime picker looks ok and still works

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
