### PR TITLE
4588 Extend pagination on stock lines for reports

### DIFF
--- a/server/service/src/stock_line/query.rs
+++ b/server/service/src/stock_line/query.rs
@@ -6,7 +6,7 @@ use repository::{
     EqualFilter, PaginationOption, StockLine, StockLineFilter, StockLineRepository, StockLineSort,
 };
 
-pub const MAX_LIMIT: u32 = 1000;
+pub const MAX_LIMIT: u32 = 5000;
 pub const MIN_LIMIT: u32 = 1;
 
 pub fn get_stock_line(ctx: &ServiceContext, id: String) -> Result<StockLine, SingleRecordError> {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4588 

Requires for fix in report repo: https://github.com/msupply-foundation/open-msupply-reports/pull/87

# 👩🏻‍💻 What does this PR do?

Extend pagination for stock line

## 💌 Any notes for the reviewer?

Ideally we would have no pagination for reports or have a way to grab individual pages, added to reports epic to think about in the future.


# 🧪 Testing

Run  stock usage, stock detail, expiring items and stock status reports for data file where there are more then 100 items and stock lines, should see all rows.

Can add items with this (for sqlite):

```sql
WITH RECURSIVE
  cnt(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM cnt WHERE x<1000)
insert into item(id, code, name, type, legacy_record) select lower(hex(randomblob(16))), 'gen ' || lower(hex(randomblob(16))) , 'gen ' || lower(hex(randomblob(16))) , 'STOCK', ''  FROM cnt;

insert into item_link(id, item_id) select id, id from item where name like 'gen %';

insert into master_list_line(id, item_link_id, master_list_id)  select lower(hex(randomblob(16))), item.id, master_list.id from item join master_list where item.name like 'gen %';
```

# 📃 Documentation


