### PR TITLE
Add fallback to loading indicator for lazy loads

### DIFF
--- a/client/packages/common/src/ui/layout/skeletons/DetailFormSkeleton.tsx
+++ b/client/packages/common/src/ui/layout/skeletons/DetailFormSkeleton.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Box, Skeleton, Stack } from '@mui/material';
 import { AppBarContentPortal, AppFooterPortal } from '../../components/portals';
 import { ButtonSkeleton } from './ButtonSkeleton';
+import { BasicSpinner } from '@common/components';
 
 const AppBarContent = () => (
   <Box display="flex" flexDirection="column" gap={1} width="100%">
@@ -86,6 +87,18 @@ export const DetailFormSkeleton = () => {
         <AppBarContent />
       </AppBarContentPortal>
       <DetailForm />
+      <AppFooterPortal Content={footerContent} />
+    </>
+  );
+};
+
+export const DetailLoadingSkeleton = () => {
+  return (
+    <>
+      <AppBarContentPortal sx={{ display: 'flex', flex: 1, marginBottom: 1 }}>
+        <AppBarContent />
+      </AppBarContentPortal>
+      <BasicSpinner />
       <AppFooterPortal Content={footerContent} />
     </>
   );

--- a/client/packages/host/src/Site.tsx
+++ b/client/packages/host/src/Site.tsx
@@ -17,6 +17,7 @@ import {
   useTranslation,
   SnackbarProvider,
   BarcodeScannerProvider,
+  DetailLoadingSkeleton,
 } from '@openmsupply-client/common';
 import { AppDrawer, AppBar, Footer, NotFound } from './components';
 import { CommandK } from './CommandK';
@@ -88,43 +89,71 @@ export const Site: FC = () => {
                       path={RouteBuilder.create(AppRoute.Dashboard)
                         .addWildCard()
                         .build()}
-                      element={<DashboardRouter />}
+                      element={
+                        <React.Suspense fallback={<DetailLoadingSkeleton />}>
+                          <DashboardRouter />
+                        </React.Suspense>
+                      }
                     />
                     <Route
                       path={RouteBuilder.create(AppRoute.Catalogue)
                         .addWildCard()
                         .build()}
-                      element={<CatalogueRouter />}
+                      element={
+                        <React.Suspense fallback={<DetailLoadingSkeleton />}>
+                          <CatalogueRouter />
+                        </React.Suspense>
+                      }
                     />
                     <Route
                       path={RouteBuilder.create(AppRoute.Distribution)
                         .addWildCard()
                         .build()}
-                      element={<DistributionRouter />}
+                      element={
+                        <React.Suspense fallback={<DetailLoadingSkeleton />}>
+                          <DistributionRouter />
+                        </React.Suspense>
+                      }
                     />
                     <Route
                       path={RouteBuilder.create(AppRoute.Replenishment)
                         .addWildCard()
                         .build()}
-                      element={<ReplenishmentRouter />}
+                      element={
+                        <React.Suspense fallback={<DetailLoadingSkeleton />}>
+                          <ReplenishmentRouter />
+                        </React.Suspense>
+                      }
                     />
                     <Route
                       path={RouteBuilder.create(AppRoute.Inventory)
                         .addWildCard()
                         .build()}
-                      element={<InventoryRouter />}
+                      element={
+                        <React.Suspense fallback={<DetailLoadingSkeleton />}>
+                          <InventoryRouter />
+                        </React.Suspense>
+                      }
                     />
                     <Route
                       path={RouteBuilder.create(AppRoute.Dispensary)
                         .addWildCard()
                         .build()}
-                      element={<DispensaryRouter />}
+                      element={
+                        <React.Suspense fallback={<DetailLoadingSkeleton />}>
+                          <DispensaryRouter />
+                        </React.Suspense>
+                      }
                     />
                     <Route
                       path={RouteBuilder.create(AppRoute.Coldchain)
                         .addWildCard()
                         .build()}
-                      element={<ColdChainRouter />}
+                      element={
+                        <React.Suspense fallback={<DetailLoadingSkeleton />}>
+                          <ColdChainRouter />
+                        </React.Suspense>
+                      }
                     />
                     <Route
                       path={RouteBuilder.create(AppRoute.Settings)
@@ -142,19 +171,31 @@ export const Site: FC = () => {
                       path={RouteBuilder.create(AppRoute.Manage)
                         .addWildCard()
                         .build()}
-                      element={<ManageRouter />}
+                      element={
+                        <React.Suspense fallback={<DetailLoadingSkeleton />}>
+                          <ManageRouter />
+                        </React.Suspense>
+                      }
                     />
                     <Route
                       path={RouteBuilder.create(AppRoute.Programs)
                         .addWildCard()
                         .build()}
-                      element={<ProgramsRouter />}
+                      element={
+                        <React.Suspense fallback={<DetailLoadingSkeleton />}>
+                          <ProgramsRouter />
+                        </React.Suspense>
+                      }
                     />
                     <Route
                       path={RouteBuilder.create(AppRoute.Reports)
                         .addWildCard()
                         .build()}
-                      element={<ReportsRouter />}
+                      element={
+                        <React.Suspense fallback={<DetailLoadingSkeleton />}>
+                          <ReportsRouter />
+                        </React.Suspense>
+                      }
                     />
                     <Route
                       path="/"


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4434

# 👩🏻‍💻 What does this PR do?

Adds fall back to lazy loading routers

Adds loading indicating skeleton which matches more closely the second loading of list views which is likely to occur with slower internet.

<!-- Explain the changes you made -->

You can test this by navigating to any of the changed routes with throttle enabled in dev tools

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
