### PR TITLE
4592 Add store id to item visibility stock on hand filter

### DIFF
--- a/server/repository/src/db_diesel/item.rs
+++ b/server/repository/src/db_diesel/item.rs
@@ -251,7 +251,11 @@ fn create_filtered_query(store_id: String, filter: Option<ItemFilter>) -> BoxedI
         let item_ids_with_stock_on_hand = item_link_dsl::item_link
             .select(item_link_dsl::item_id)
             .inner_join(stock_on_hand_dsl::stock_on_hand)
-            .filter(stock_on_hand_dsl::available_stock_on_hand.gt(0.0))
+            .filter(
+                stock_on_hand_dsl::available_stock_on_hand
+                    .gt(0.0)
+                    .and(stock_on_hand_dsl::store_id.eq(store_id.clone())),
+            )
             .group_by(item_link_dsl::item_id)
             .into_boxed();
 
@@ -694,6 +698,18 @@ mod tests {
                 .collect::<Vec<String>>(),
             vec!["item1", "item2", "item3"]
         );
+
+        // Make sure stock on hand filter applies to only one store
+        let results = ItemRepository::new(&storage_connection)
+            .query(
+                Pagination::new(),
+                Some(ItemFilter::new().has_stock_on_hand(true)),
+                None,
+                Some("some other store".to_string()),
+            )
+            .unwrap();
+
+        assert_eq!(results.len(), 0);
     }
 
     #[actix_rt::test]


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4592 

# 👩🏻‍💻 What does this PR do?

Looks like we needed extra filter by store id for item stock on hand visibility check

## 💌 Any notes for the reviewer?

I added extra test that fails without this change

# 🧪 Testing

Have two stores on the same site, add extra item and new master list to one of the stores, check that it is not shown for second store. Now add some stock for that item in the store, item should remain invisible in second store

# 📃 Documentation


