### PR TITLE
4365 The Decimal will get too long in outbound shipments

### DIFF
--- a/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberCell.tsx
@@ -16,7 +16,7 @@ export const NumberCell = <T extends RecordWithId>({
   defaultValue?: string | number;
 }) => {
   const value = column.accessor({ rowData }) as number | undefined | null;
-  const hasMoreThanTwoDp = (value ?? 0 * 100) % 1 !== 0;
+  const hasMoreThanTwoDp = ((value ?? 0) * 100) % 1 !== 0;
   const formattedValue = useFormatNumber().round(value ?? 0, 2);
 
   const displayValue =

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
@@ -6,6 +6,8 @@ import {
   useTranslation,
   TableCell,
   styled,
+  useFormatNumber,
+  Tooltip,
 } from '@openmsupply-client/common';
 import { DraftStockOutLine } from '../../../types';
 import { useOutboundLineEditRows } from './hooks';
@@ -46,6 +48,8 @@ const PlaceholderRow = ({ line }: { line?: DraftStockOutLine }) => {
   useEffect(() => {
     setPlaceholderBuffer(line?.numberOfPacks ?? 0);
   }, [line?.numberOfPacks]);
+  const formattedValue = useFormatNumber().round(placeholderBuffer, 2);
+  const hasMoreThanTwoDp = ((placeholderBuffer ?? 0) * 100) % 1 !== 0;
 
   return !line ? null : (
     <tr>
@@ -54,28 +58,34 @@ const PlaceholderRow = ({ line }: { line?: DraftStockOutLine }) => {
       </PlaceholderCell>
       <PlaceholderCell style={{ textAlign: 'right' }}>1</PlaceholderCell>
       <PlaceholderCell colSpan={4}></PlaceholderCell>
-      <PlaceholderCell style={{ textAlign: 'right' }}>
-        {placeholderBuffer}
-      </PlaceholderCell>
+      <Tooltip title={line?.numberOfPacks.toString()}>
+        <PlaceholderCell style={{ textAlign: 'right' }}>
+          {!!hasMoreThanTwoDp ? `${formattedValue}...` : formattedValue}
+        </PlaceholderCell>
+      </Tooltip>
     </tr>
   );
 };
 
 const TotalRow = ({ allocatedQuantity }: { allocatedQuantity: number }) => {
   const t = useTranslation('distribution');
+  const formattedValue = useFormatNumber().round(allocatedQuantity, 2);
+  const hasMoreThanTwoDp = ((allocatedQuantity ?? 0) * 100) % 1 !== 0;
 
   return (
     <tr>
       <TotalCell colSpan={3}>{t('label.total-quantity')}</TotalCell>
       <TotalCell colSpan={5}></TotalCell>
-      <TotalCell
-        style={{
-          textAlign: 'right',
-          paddingRight: 12,
-        }}
-      >
-        {allocatedQuantity}
-      </TotalCell>
+      <Tooltip title={allocatedQuantity.toString()}>
+        <TotalCell
+          style={{
+            textAlign: 'right',
+            paddingRight: 12,
+          }}
+        >
+          {!!hasMoreThanTwoDp ? `${formattedValue}...` : formattedValue}
+        </TotalCell>
+      </Tooltip>
     </tr>
   );
 };

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditTable.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditTable.tsx
@@ -6,6 +6,8 @@ import {
   useTranslation,
   TableCell,
   styled,
+  useFormatNumber,
+  Tooltip,
 } from '@openmsupply-client/common';
 import { DraftStockOutLine } from '../../../types';
 import { DraftItem } from '../../..';
@@ -60,19 +62,23 @@ const PlaceholderRow = ({ line }: { line?: DraftStockOutLine }) => {
 
 const TotalRow = ({ allocatedQuantity }: { allocatedQuantity: number }) => {
   const t = useTranslation('dispensary');
+  const formattedValue = useFormatNumber().round(allocatedQuantity, 2);
+  const hasMoreThanTwoDp = ((allocatedQuantity ?? 0) * 100) % 1 !== 0;
 
   return (
     <tr>
       <TotalCell colSpan={3}>{t('label.total-quantity')}</TotalCell>
       <TotalCell colSpan={5}></TotalCell>
-      <TotalCell
-        style={{
-          textAlign: 'right',
-          paddingRight: 12,
-        }}
-      >
-        {allocatedQuantity}
-      </TotalCell>
+      <Tooltip title={allocatedQuantity.toString()}>
+        <TotalCell
+          style={{
+            textAlign: 'right',
+            paddingRight: 12,
+          }}
+        >
+          {!!hasMoreThanTwoDp ? `${formattedValue}...` : formattedValue}
+        </TotalCell>
+      </Tooltip>
     </tr>
   );
 };

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditTable.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditTable.tsx
@@ -41,6 +41,8 @@ const PlaceholderRow = ({ line }: { line?: DraftStockOutLine }) => {
   const [placeholderBuffer, setPlaceholderBuffer] = useState(
     line?.numberOfPacks ?? 0
   );
+  const formattedValue = useFormatNumber().round(placeholderBuffer, 2);
+  const hasMoreThanTwoDp = ((placeholderBuffer ?? 0) * 100) % 1 !== 0;
 
   useEffect(() => {
     setPlaceholderBuffer(line?.numberOfPacks ?? 0);
@@ -53,9 +55,11 @@ const PlaceholderRow = ({ line }: { line?: DraftStockOutLine }) => {
       </PlaceholderCell>
       <PlaceholderCell style={{ textAlign: 'right' }}>1</PlaceholderCell>
       <PlaceholderCell colSpan={4}></PlaceholderCell>
-      <PlaceholderCell style={{ textAlign: 'right' }}>
-        {placeholderBuffer}
-      </PlaceholderCell>
+      <Tooltip title={line?.numberOfPacks.toString()}>
+        <PlaceholderCell style={{ textAlign: 'right' }}>
+          {!!hasMoreThanTwoDp ? `${formattedValue}...` : formattedValue}
+        </PlaceholderCell>
+      </Tooltip>
     </tr>
   );
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4365

# 👩🏻‍💻 What does this PR do?
Rounds placeholder and total lines and show ellipses to indicate number has more than 2dp with tooltip to display full value

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a placeholder line in Outbound Shipment with a lot of decimals 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
