### PR TITLE
4250 Status set as cancelled but pop up for save encountered as visited appears

### DIFF
--- a/client/packages/system/src/Encounter/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Encounter/DetailView/DetailView.tsx
@@ -213,9 +213,13 @@ export const DetailView: FC = () => {
       data as unknown as EncounterSchema,
       updateEncounter
     );
+  const dataStatus = data
+    ? (data as Record<string, JsonData>)['status']
+    : undefined;
   const suggestSaveWithStatusVisited = encounter
     ? new Date(encounter.startDatetime).getTime() < Date.now() &&
-      encounter.status === EncounterNodeStatus.Pending
+      encounter.status === EncounterNodeStatus.Pending &&
+      dataStatus === EncounterNodeStatus.Pending
     : false;
 
   useEffect(() => {
@@ -234,10 +238,9 @@ export const DetailView: FC = () => {
             >
               {getPatientBreadcrumbSuffix(encounter, getLocalisedFullName)}
             </Breadcrumb>
-            <span>{` / ${encounter.document.documentRegistry
-              ?.name} - ${dateFormat.localisedDate(
-              encounter.startDatetime
-            )}`}</span>
+            <span>{` / ${
+              encounter.document.documentRegistry?.name
+            } - ${dateFormat.localisedDate(encounter.startDatetime)}`}</span>
           </>
         ),
       });


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4250

# 👩🏻‍💻 What does this PR do?
Check jsonData status as well since status doesn't get changed until the `Save` button is pressed. Thing the modal prompt was implemented to remind users to tick off pass encounters as visited, so have kept it as is and not displaying any modal for cancelled appointments.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have patient programs set up
- [ ] Enrol a patient into a program
- [ ] Add an encounter for today or in the past 
- [ ] Change status to `Cancelled`
- [ ] Click `Save`
- [ ] Shouldn't see prompt and encounter is cancelled

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
