### PR TITLE
Populate internal order sent date

### DIFF
--- a/server/service/src/rnr_form/finalise.rs
+++ b/server/service/src/rnr_form/finalise.rs
@@ -127,7 +127,7 @@ fn generate(
         r#type: RequisitionType::Request,
         status: RequisitionStatus::Sent,
         created_datetime: Utc::now().naive_utc(),
-        sent_datetime: None,
+        sent_datetime: Some(Utc::now().naive_utc()),
         finalised_datetime: None,
         expected_delivery_date: None,
         colour: None,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4641

# 👩🏻‍💻 What does this PR do?
Populates the sent date of the generated internal order

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] create an R&R form and finalise. View the internal order : the sent date should be the same as the created date

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
