### PR TITLE
#3641 (2) Fix default patient schema DOB component

### DIFF
--- a/client/packages/system/src/Patient/PatientView/DefaultPatientUISchema.json
+++ b/client/packages/system/src/Patient/PatientView/DefaultPatientUISchema.json
@@ -45,12 +45,9 @@
           "label": "Last Name"
         },
         {
-          "type": "Control",
+          "type": "DateOfBirth",
           "label": "Date of Birth",
-          "scope": "#/properties/dateOfBirth",
-          "options": {
-            "disableFuture": true
-          }
+          "scope": "#"
         },
         {
           "type": "Control",


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3641 (again 🙄)

# 👩🏻‍💻 What does this PR do?

Updated the default (fallback) Patient UI schema to use the proper "Date of birth" component rather than generic date picker.

# 🧪 Testing

If you have an existing Programs schema installed (eg PNG), you won't see the default one (hence why we missed this the first time). In order to test/confirm, go to `PatientView.tsx` and change line 112 temporarily to:
```ts
  const patientRegistry = DEFAULT_SCHEMA;
```
