### PR TITLE
2389 Carry customer reference field through from requisition to outbound shipment

### DIFF
--- a/server/service/src/requisition/response_requisition/create_requisition_shipment/generate.rs
+++ b/server/service/src/requisition/response_requisition/create_requisition_shipment/generate.rs
@@ -38,13 +38,13 @@ pub fn generate(
         status: InvoiceStatus::New,
         created_datetime: Utc::now().naive_utc(),
         requisition_id: Some(requisition_row.id),
+        their_reference: requisition_row.their_reference,
 
         // Default
         currency_id: Some(currency.currency_row.id),
         currency_rate: 1.0,
         on_hold: false,
         comment: None,
-        their_reference: None,
         transport_reference: None,
         allocated_datetime: None,
         picked_datetime: None,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2389

# 👩🏻‍💻 What does this PR do?
Carry over response requisition reference to outbound

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a requisition
- [ ] Type some reference or keep as since pre-populates with `From internal order X`
- [ ] Supply some stock
- [ ] Click `Create Shipment`
- [ ] See reference has been carried through

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
