### PR TITLE
1633 disable actions if invoice/requisition is uneditable

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
@@ -138,6 +138,7 @@ export const Toolbar: FC<{
             <DropdownMenuItem
               IconComponent={RewindIcon}
               onClick={onZeroQuantities}
+              disabled={isDisabled}
             >
               {t('button.zero-line-quantity')}
             </DropdownMenuItem>

--- a/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
@@ -103,10 +103,18 @@ export const Toolbar: FC<{
             />
           </Box>
           <DropdownMenu label={t('label.actions')}>
-            <DropdownMenuItem IconComponent={DeleteIcon} onClick={onDelete}>
+            <DropdownMenuItem
+              IconComponent={DeleteIcon}
+              onClick={onDelete}
+              disabled={isDisabled}
+            >
               {t('button.delete-lines')}
             </DropdownMenuItem>
-            <DropdownMenuItem IconComponent={ZapIcon} onClick={onAllocate}>
+            <DropdownMenuItem
+              IconComponent={ZapIcon}
+              onClick={onAllocate}
+              disabled={isDisabled}
+            >
               {t('button.allocate-lines')}
             </DropdownMenuItem>
 

--- a/client/packages/invoices/src/Prescriptions/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Footer/StatusChangeButton.tsx
@@ -139,20 +139,16 @@ export const StatusChangeButton = () => {
     lines?.totalCount === 0 ||
     lines?.nodes?.every(l => l.type === InvoiceLineNodeType.UnallocatedStock);
 
-  if (!selectedOption) return null;
-  if (isDisabled) return null;
-
   const noLinesNotification = useDisabledNotificationToast(
     t('messages.no-lines')
   );
-
-  if (!selectedOption) return null;
-  if (isDisabled) return null;
 
   const onStatusClick = () => {
     if (noLines) return noLinesNotification();
     return getConfirmation();
   };
+  if (!selectedOption) return null;
+  if (isDisabled) return null;
 
   return (
     <SplitButton

--- a/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
@@ -78,7 +78,11 @@ export const Toolbar: FC = () => {
           alignItems="center"
         >
           <DropdownMenu label={t('label.actions')}>
-            <DropdownMenuItem IconComponent={DeleteIcon} onClick={onDelete}>
+            <DropdownMenuItem
+              IconComponent={DeleteIcon}
+              onClick={onDelete}
+              disabled={isDisabled}
+            >
               {t('button.delete-lines')}
             </DropdownMenuItem>
           </DropdownMenu>

--- a/client/packages/invoices/src/Returns/CustomerDetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Returns/CustomerDetailView/Toolbar.tsx
@@ -103,7 +103,11 @@ export const Toolbar: FC = () => {
             />
           </Box>
           <DropdownMenu label={t('label.actions')}>
-            <DropdownMenuItem IconComponent={DeleteIcon} onClick={onDelete}>
+            <DropdownMenuItem
+              IconComponent={DeleteIcon}
+              onClick={onDelete}
+              disabled={isDisabled}
+            >
               {t('button.delete-lines')}
             </DropdownMenuItem>
           </DropdownMenu>

--- a/client/packages/invoices/src/Returns/SupplierDetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Returns/SupplierDetailView/Toolbar.tsx
@@ -97,7 +97,11 @@ export const Toolbar: FC = () => {
             />
           </Box>
           <DropdownMenu label={t('label.actions')}>
-            <DropdownMenuItem IconComponent={DeleteIcon} onClick={onDelete}>
+            <DropdownMenuItem
+              IconComponent={DeleteIcon}
+              onClick={onDelete}
+              disabled={isDisabled}
+            >
               {t('button.delete-lines')}
             </DropdownMenuItem>
           </DropdownMenu>

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
@@ -121,7 +121,7 @@ export const Toolbar: FC = () => {
           display="flex"
           gap={2}
         >
-          <ToolbarActions />
+          <ToolbarActions isDisabled={isDisabled} />
         </Grid>
       </Grid>
       <Grid
@@ -140,7 +140,7 @@ export const Toolbar: FC = () => {
           }}
           debounceTime={0}
         />
-        <ToolbarDropDown />
+        <ToolbarDropDown isDisabled={isDisabled} />
       </Grid>
     </AppBarContentPortal>
   );

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/ToolbarActions.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/ToolbarActions.tsx
@@ -9,12 +9,15 @@ import {
 } from '@openmsupply-client/common';
 import { useRequest, useHideOverStocked } from '../../api';
 
+interface ToolbarActionsProps {
+  isDisabled: boolean;
+}
+
 const months = [1, 2, 3, 4, 5, 6];
 
-export const ToolbarActions = () => {
+export const ToolbarActions = ({ isDisabled }: ToolbarActionsProps) => {
   const { on, toggle } = useHideOverStocked();
   const t = useTranslation('replenishment');
-  const isDisabled = useRequest.utils.isDisabled();
   const isProgram = useRequest.utils.isProgram();
   const { minMonthsOfStock, maxMonthsOfStock, update } =
     useRequest.document.fields(['minMonthsOfStock', 'maxMonthsOfStock']);

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/ToolbarDropDown.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/ToolbarDropDown.tsx
@@ -7,12 +7,21 @@ import {
 } from '@openmsupply-client/common';
 import { useRequest } from '../../api';
 
-export const ToolbarDropDown = () => {
+interface ToolbarDropDownProps {
+  isDisabled: boolean;
+}
+
+export const ToolbarDropDown = ({ isDisabled }: ToolbarDropDownProps) => {
   const t = useTranslation('replenishment');
   const onDelete = useRequest.line.delete();
+
   return (
     <DropdownMenu label={t('label.actions')}>
-      <DropdownMenuItem IconComponent={DeleteIcon} onClick={onDelete}>
+      <DropdownMenuItem
+        IconComponent={DeleteIcon}
+        onClick={onDelete}
+        disabled={isDisabled}
+      >
         {t('button.delete-lines', { ns: 'distribution' })}
       </DropdownMenuItem>
     </DropdownMenu>

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Toolbar.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Toolbar.tsx
@@ -134,7 +134,11 @@ export const Toolbar: FC = () => {
         />
 
         <DropdownMenu label={t('label.actions')}>
-          <DropdownMenuItem IconComponent={DeleteIcon} onClick={onDelete}>
+          <DropdownMenuItem
+            IconComponent={DeleteIcon}
+            onClick={onDelete}
+            disabled={isDisabled}
+          >
             {t('button.delete-lines', { ns: 'distribution' })}
           </DropdownMenuItem>
         </DropdownMenu>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1633

# 👩🏻‍💻 What does this PR do?
Disable actions that aren't available. Thought of disabling whole action bar if user can't interact with it, but we now have returns, so have decided to just disable the action for unification. Also fixed dup return in prescriptions

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have finalised Outbound/Inbound/Returns
- [ ] Click action
- [ ] See actions that aren't available with status disabled.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
