### PR TITLE
4647 GAPS: Store Properties are saved but doesn't show up

### DIFF
--- a/client/packages/system/src/Name/ListView/Facilities/FacilityEditModal.tsx
+++ b/client/packages/system/src/Name/ListView/Facilities/FacilityEditModal.tsx
@@ -13,7 +13,6 @@ import {
   InputWithLabelRow,
   ObjUtils,
   useIsCentralServerApi,
-  NamePropertyNode,
 } from '@openmsupply-client/common';
 import { useName } from '../../api';
 import { NameRenderer } from '../..';
@@ -23,8 +22,6 @@ interface FacilityEditModalProps {
   isOpen: boolean;
   onClose: () => void;
   setNextFacility?: (nameId: string) => void;
-  properties?: NamePropertyNode[] | undefined;
-  propertiesLoading?: boolean;
 }
 
 const useDraftFacilityProperties = (initialProperties?: string | null) => {
@@ -49,11 +46,11 @@ export const FacilityEditModal: FC<FacilityEditModalProps> = ({
   isOpen,
   onClose,
   setNextFacility,
-  properties,
-  propertiesLoading,
 }) => {
   const t = useTranslation();
   const isCentralServer = useIsCentralServerApi();
+  const { data: properties, isLoading: propertiesLoading } =
+    useName.document.properties();
 
   const { data, isLoading } = useName.document.get(nameId);
 

--- a/client/packages/system/src/Name/ListView/Facilities/ListView.tsx
+++ b/client/packages/system/src/Name/ListView/Facilities/ListView.tsx
@@ -99,8 +99,6 @@ const FacilitiesListComponent = () => {
           nameId={selectedId}
           onClose={onClose}
           setNextFacility={setSelectedId}
-          properties={properties}
-          propertiesLoading={propertiesLoading}
         />
       )}
       <DataTable


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4647

# 👩🏻‍💻 What does this PR do?
Move properties hook to modal since it needs to be used when clicking edit in footer and when editing from listview.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Be an OMS central server
- [ ] Initialise store properties in settings
- [ ] Click `Edit` in the footer
- [ ] Should show up with store properties to edit 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
