### PR TITLE
#4233 Fix filter layout ordering

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Filters/FilterMenu.tsx
+++ b/client/packages/common/src/ui/components/inputs/Filters/FilterMenu.tsx
@@ -90,12 +90,7 @@ export const FilterMenu: FC<FilterDefinitions> = ({ filters }) => {
   // i.e. choosing a filter option in one filter changes the options in another
   useEffect(() => {
     setActiveFilters(
-      flattenFilterDefinitions(filters).filter(
-        fil =>
-          Object.keys(urlQuery).includes(fil.urlParameter) ||
-          fil.isDefault ||
-          activeFilters.some(f => f.name === fil.name)
-      )
+      updateFilters(filters, activeFilters, Object.keys(urlQuery))
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filters]);
@@ -161,15 +156,28 @@ const getFilterOptions = (
     }));
 };
 
-const flattenFilterDefinitions = (
-  filters: (FilterDefinition | GroupFilterDefinition)[]
+// Updates the active filter list based on the URL, but doesn't remove already
+// active filters and preserves the current order
+const updateFilters = (
+  filters: (FilterDefinition | GroupFilterDefinition)[],
+  activeFilters: FilterDefinition[],
+  urlKeys: string[]
 ) => {
   const flattened: FilterDefinition[] = [];
   filters.forEach(fil => {
     if ('urlParameter' in fil) flattened.push(fil);
     else flattened.push(...fil.elements);
   });
-  return flattened;
+
+  const newFilters = [...activeFilters];
+  flattened.forEach(fil => {
+    if (
+      activeFilters.every(active => active.name !== fil.name) &&
+      (fil.isDefault || urlKeys.includes(fil.urlParameter))
+    )
+      newFilters.push(fil);
+  });
+  return newFilters;
 };
 
 const getFilterComponent = (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4233

# 👩🏻‍💻 What does this PR do?

Prevents the ordering of active filters being changed when they are updated

<!-- Explain the changes you made -->

The problem was in the `useEffect` that runs when the filters are changed -- they were being recreated using the overall filter definitions list and following that ordering (it's the order they show up in the Filter Menu), and if the user had instantiated the filters in a different order, this would be overwritten.

Solution is to check the existing "activeFilters" and only add new filters (if they're in the URL) if not already active.

# 🧪 Testing

- Follow the steps in the [original issue](#4233) to see the the problem. However, note that the problem occurs whenever you load the filters in a different order to how they are listed in the menu, not just with the "range" filters as suggested in the issue.
- Switch to this branch and ensure the problem goes away.