### PR TITLE
3767 Cold Chain -> Equipment -> most useful filters not shown by default

### DIFF
--- a/client/packages/coldchain/src/Equipment/ListView/Toolbar.tsx
+++ b/client/packages/coldchain/src/Equipment/ListView/Toolbar.tsx
@@ -105,7 +105,6 @@ export const Toolbar = () => {
       name: t('label.type'),
       urlParameter: 'typeId',
       options: mapIdNameToOptions(types),
-      isDefault: true,
     },
     {
       type: 'text',
@@ -133,6 +132,7 @@ export const Toolbar = () => {
       type: 'text',
       name: t('label.serial'),
       urlParameter: 'serialNumber',
+      isDefault: true,
     },
   ];
 
@@ -141,6 +141,7 @@ export const Toolbar = () => {
       type: 'text',
       name: t('label.store'),
       urlParameter: 'store',
+      isDefault: true,
     });
 
   return (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3767

# 👩🏻‍💻 What does this PR do?
As requested by @adamdewey 

Default filters for equipment: 
- Store
- Category
- Functional status
- Asset number
- Serial number

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to equipment page
- [ ] see above default filters

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Default filters for equipment? 
  2.
