### PR TITLE
4662 om supply backups

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1470,6 +1470,7 @@ dependencies = [
  "async-graphql",
  "chrono",
  "clap",
+ "copy_dir",
  "diesel",
  "graphql",
  "log",
@@ -1479,6 +1480,7 @@ dependencies = [
  "server",
  "service",
  "simple-log",
+ "thiserror",
  "tokio",
  "util",
 ]
@@ -1560,6 +1562,15 @@ dependencies = [
  "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "copy_dir"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "543d1dd138ef086e2ff05e3a48cf9da045da2033d16f8538fd76b86cd49b2ca3"
+dependencies = [
+ "walkdir",
 ]
 
 [[package]]

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1479,6 +1479,7 @@ dependencies = [
  "serde_json",
  "server",
  "service",
+ "shellexpand",
  "simple-log",
  "thiserror",
  "tokio",
@@ -1902,6 +1903,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1909,6 +1919,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4313,6 +4335,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-float"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5862,6 +5890,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]

--- a/server/README.md
+++ b/server/README.md
@@ -331,7 +331,12 @@ cargo run --bin remote_server_cli -- initialise-from-export -n 'export_name' -r
 cargo run --bin remote_server_cli -- initialise-from-central -u 'user1:password1'
 # attempt to refresh dates (advance them forward, see --help)
 cargo run --bin remote_server_cli -- refresh-dates
+# See README.md link below
+cargo run --bin remote_server_cli -- backup
+cargo run --bin remote_server_cli -- restore D2024_08_22T05_05_16 -s
 ```
+
+# [Backup and Restore](cli/src/backup/README.md)
 
 # Discovery
 

--- a/server/README.md
+++ b/server/README.md
@@ -333,7 +333,7 @@ cargo run --bin remote_server_cli -- initialise-from-central -u 'user1:password1
 cargo run --bin remote_server_cli -- refresh-dates
 # See README.md link below
 cargo run --bin remote_server_cli -- backup
-cargo run --bin remote_server_cli -- restore D2024_08_22T05_05_16 -s
+cargo run --bin remote_server_cli -- restore -b D2024_08_22T05_05_16 -s
 ```
 
 # [Backup and Restore](cli/src/backup/README.md)

--- a/server/android/src/android.rs
+++ b/server/android/src/android.rs
@@ -63,6 +63,7 @@ pub mod android {
                 LoggingSettings::new(LogMode::File, service::settings::Level::Info)
                     .with_directory(files_dir.to_string_lossy().to_string()),
             ),
+            backup: None,
         };
 
         logging_init(settings.logging.clone(), None);

--- a/server/cli/Cargo.toml
+++ b/server/cli/Cargo.toml
@@ -31,6 +31,7 @@ serde_json = { workspace = true }
 simple-log = { workspace = true }
 tokio = { version = "1.38.0", features = ["macros", "time", "rt-multi-thread"] }
 copy_dir = "0.1.3"
+shellexpand = "3.1.0"
 
 [dev-dependencies]
 actix-rt = { workspace = true }

--- a/server/cli/Cargo.toml
+++ b/server/cli/Cargo.toml
@@ -21,6 +21,7 @@ graphql = { path = "../graphql" }
 
 anyhow = { workspace = true }
 async-graphql = { workspace = true }
+thiserror = { workspace = true }
 clap = { workspace = true }
 chrono = { workspace = true }
 diesel = { version = "2.2.1", default-features = false, features = ["chrono"] }
@@ -29,6 +30,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 simple-log = { workspace = true }
 tokio = { version = "1.38.0", features = ["macros", "time", "rt-multi-thread"] }
+copy_dir = "0.1.3"
 
 [dev-dependencies]
 actix-rt = { workspace = true }

--- a/server/cli/src/backup/README.md
+++ b/server/cli/src/backup/README.md
@@ -2,6 +2,8 @@
 
 omSupply server can be backed up and restored via cli. 
 
+`NOTE` In production backups should only be done for omSupply central servers, remote sites are backed up via synchronisation
+
 ### Backup
 
 To backup simply run: 

--- a/server/cli/src/backup/README.md
+++ b/server/cli/src/backup/README.md
@@ -10,7 +10,7 @@ To backup simply run:
 
 **In development mode**
 
-`cargo run --bin remote service_cli -- backup`
+`cargo run --bin remote_server_cli -- backup` or for postgres `cargo run --bin remote_server_cli --features postgres -- backup`
 
 **In production**
 
@@ -26,7 +26,7 @@ To restore run:
 
 **In development mode**
 
-`cargo run --bin remote service_cli -- restore -b D2024_08_22T05_05_16 -s`
+`cargo run --bin remote_server_cli -- restore -b D2024_08_22T05_05_16 -s` or for postgres `cargo run --bin remote_server_cli --features postgres -- restore -b D2024_08_22T05_05_16 -s`
 
 **In production**
 

--- a/server/cli/src/backup/README.md
+++ b/server/cli/src/backup/README.md
@@ -1,0 +1,41 @@
+# Backup and Restore
+
+omSupply server can be backed up and restored via cli. 
+
+### Backup
+
+To backup simply run: 
+
+**In development mode**
+
+`cargo run --bin remote service_cli -- backup`
+
+**In production**
+
+`omSupply-cli backup`
+
+You will need to specify backup folder in configurations `.yaml` files see example.yaml. Each time backup runs a new folder will be created with this format `D2024_08_22T05_05_16`, a successful backup will print new backup name to console.
+
+Backup will contain a folder with all of the app_data (plugins, static files, etc..) and a folder with either sqlite files or postgres database dump. 
+
+### Restore
+
+To restore run: 
+
+**In development mode**
+
+`cargo run --bin remote service_cli -- restore -b D2024_08_22T05_05_16 -s`
+
+**In production**
+
+`omSupply-cli restore -b D2024_08_22T05_05_16`
+
+For full cli arguments list run `restore --help`
+
+Cli restore command will look for a backup folder specified with `-b` in backup folder specified by configurations `.yaml` files.
+
+App data folder will be cleared and replaced by the content of backup app_data. For postgres existing database will be dropped and replace by the backup database dump, and for sqlite, database files will be copied, after existing database sqlite files are wiped 
+
+### Extra 
+
+Configurations in `.yaml` files will be used in backup and restore, the base app folder, database name etc.. 

--- a/server/cli/src/backup/README.md
+++ b/server/cli/src/backup/README.md
@@ -4,17 +4,27 @@ omSupply server can be backed up and restored via cli.
 
 `NOTE` In production backups should only be done for omSupply central servers, remote sites are backed up via synchronisation
 
+For full cli arguments list and up to date description please run command with just `--help` argument
+
 ### Backup
 
 To backup simply run: 
 
 **In development mode**
 
-`cargo run --bin remote_server_cli -- backup` or for postgres `cargo run --bin remote_server_cli --features postgres -- backup`
+```
+cargo run --bin remote_server_cli -- backup
+``` 
+or for postgres 
+````
+cargo run --bin remote_server_cli --features postgres -- backup
+````
 
 **In production**
 
-`omSupply-cli backup`
+````
+omSupply-cli backup
+```
 
 You will need to specify a backup folder in the configuration `.yaml` files - to get started, see the `example.yaml`. Each time backup runs a new folder will be created with this format `D[YYYY]_[mm]_[dd]T[HH]_[MM]_[SS]` e.g. `D2024_08_22T05_05_16`. A successful backup will print new backup name to console.
 
@@ -26,13 +36,19 @@ To restore run:
 
 **In development mode**
 
-`cargo run --bin remote_server_cli -- restore -b D2024_08_22T05_05_16 -s` or for postgres `cargo run --bin remote_server_cli --features postgres -- restore -b D2024_08_22T05_05_16 -s`
+```
+cargo run --bin remote_server_cli -- restore -b D2024_08_22T05_05_16 -s
+``` 
+or for postgres 
+```
+cargo run --bin remote_server_cli --features postgres -- restore -b D2024_08_22T05_05_16 -s
+```
 
 **In production**
 
-`omSupply-cli restore -b D2024_08_22T05_05_16`
-
-For full cli arguments list run `restore --help`
+```
+omSupply-cli restore -b D2024_08_22T05_05_16
+```
 
 Cli restore command will look for a backup folder specified with `-b` in backup folder specified by configurations `.yaml` files.
 

--- a/server/cli/src/backup/README.md
+++ b/server/cli/src/backup/README.md
@@ -16,7 +16,7 @@ To backup simply run:
 
 `omSupply-cli backup`
 
-You will need to specify backup folder in configurations `.yaml` files see example.yaml. Each time backup runs a new folder will be created with this format `D2024_08_22T05_05_16`, a successful backup will print new backup name to console.
+You will need to specify a backup folder in the configuration `.yaml` files - to get started, see the `example.yaml`. Each time backup runs a new folder will be created with this format `D[YYYY]_[mm]_[dd]T[HH]_[MM]_[SS]` e.g. `D2024_08_22T05_05_16`. A successful backup will print new backup name to console.
 
 Backup will contain a folder with all of the app_data (plugins, static files, etc..) and a folder with either sqlite files or postgres database dump. 
 
@@ -36,8 +36,8 @@ For full cli arguments list run `restore --help`
 
 Cli restore command will look for a backup folder specified with `-b` in backup folder specified by configurations `.yaml` files.
 
-App data folder will be cleared and replaced by the content of backup app_data. For postgres existing database will be dropped and replace by the backup database dump, and for sqlite, database files will be copied, after existing database sqlite files are wiped 
+App data folder will be cleared and replaced by the content of backup app_data. For postgres existing database will be dropped and replaced by the backup database dump, and for sqlite, database files will be copied, after existing database sqlite files are wiped 
 
 ### Extra 
 
-Configurations in `.yaml` files will be used in backup and restore, the base app folder, database name etc.. 
+Configurations in `.yaml` files will be used in backup and restore, the base app folder, database name.

--- a/server/cli/src/backup/backup.rs
+++ b/server/cli/src/backup/backup.rs
@@ -25,7 +25,7 @@ pub(crate) fn backup(settings: &Settings) -> Result<(), BackupError> {
         copy_sqlite_files(settings, &database_dir)?;
     }
 
-    println!("{backup_name}");
+    println!("Backup completed in folder {backup_name}");
     Ok(())
 }
 

--- a/server/cli/src/backup/backup.rs
+++ b/server/cli/src/backup/backup.rs
@@ -1,17 +1,14 @@
 use super::*;
 use chrono::Utc;
 use copy_dir::copy_dir;
-use service::settings::{BackupSettings, Settings};
+use service::settings::Settings;
 use std::{fs, io, path::PathBuf, process::Command, str::FromStr};
 
 pub(crate) fn backup(settings: &Settings) -> Result<(), BackupError> {
-    let Some(BackupSettings {
+    let DirSettings {
         backup_dir,
         pg_bin_dir,
-    }) = settings.backup.clone()
-    else {
-        return Err(BackupError::BackupConfigurationMissing);
-    };
+    } = get_dirs_from_settings(settings)?;
 
     let Dirs {
         backup_name,
@@ -45,7 +42,7 @@ fn create_backup_dir(output_dir: String) -> Result<Dirs, BackupError> {
         .to_string();
 
     let base_dir = PathBuf::from_str(&output_dir)
-        .map_err(|_| BackupError::InvalidPath(output_dir.clone()))?
+        .map_err(|_| BackupError::InvalidPath(output_dir.to_string()))?
         .join(&backup_name);
 
     fs::create_dir_all(&base_dir)

--- a/server/cli/src/backup/backup.rs
+++ b/server/cli/src/backup/backup.rs
@@ -120,16 +120,7 @@ fn copy_sqlite_files(
     settings: &Settings,
     backup_database_dir: &PathBuf,
 ) -> Result<(), BackupError> {
-    let sqlite_files: Vec<PathBuf> = fs::read_dir("./")?
-        .into_iter()
-        .filter_map(Result::ok)
-        .map(|e| e.path())
-        .filter(|f| {
-            f.is_file()
-                && f.file_stem().map(|s| s.to_str()).flatten()
-                    == Some(settings.database.database_name.as_str())
-        })
-        .collect();
+    let sqlite_files = get_sqlite_files_paths(settings)?;
 
     if sqlite_files.is_empty() {
         return Err(BackupError::CannotFindSqliteBackup(

--- a/server/cli/src/backup/backup.rs
+++ b/server/cli/src/backup/backup.rs
@@ -1,0 +1,151 @@
+use super::*;
+use chrono::Utc;
+use copy_dir::copy_dir;
+use service::settings::{BackupSettings, Settings};
+use std::{fs, io, path::PathBuf, process::Command, str::FromStr};
+
+pub(crate) fn backup(settings: &Settings) -> Result<(), BackupError> {
+    let Some(BackupSettings {
+        backup_dir,
+        pg_bin_dir,
+    }) = settings.backup.clone()
+    else {
+        return Err(BackupError::BackupConfigurationMissing);
+    };
+
+    let Dirs {
+        backup_name,
+        file_dir,
+        database_dir,
+    } = create_backup_dir(backup_dir)?;
+
+    copy_files(settings, &file_dir)?;
+
+    // Backup database
+    if cfg!(feature = "postgres") {
+        dump_postgres_database(settings, &database_dir, pg_bin_dir)?;
+    } else {
+        copy_sqlite_files(settings, &database_dir)?;
+    }
+
+    println!("{backup_name}");
+    Ok(())
+}
+
+struct Dirs {
+    backup_name: String,
+    file_dir: PathBuf,
+    database_dir: PathBuf,
+}
+
+fn create_backup_dir(output_dir: String) -> Result<Dirs, BackupError> {
+    let backup_name = Utc::now()
+        .naive_local()
+        .format("D%Y_%m_%dT%H_%M_%S")
+        .to_string();
+
+    let base_dir = PathBuf::from_str(&output_dir)
+        .map_err(|_| BackupError::InvalidPath(output_dir.clone()))?
+        .join(&backup_name);
+
+    fs::create_dir_all(&base_dir)
+        .map_err(|e| BackupError::CannotCreateBackupFolder(e, base_dir.clone()))?;
+
+    let file_dir = base_dir.join(BACKUP_FILE_DIR);
+    fs::create_dir_all(&file_dir)
+        .map_err(|e| BackupError::CannotCreateBackupFolder(e, file_dir.clone()))?;
+
+    let database_dir = base_dir.join(BACKUP_DATABASE_DIR);
+    fs::create_dir_all(&database_dir)
+        .map_err(|e| BackupError::CannotCreateBackupFolder(e, database_dir.clone()))?;
+
+    Ok(Dirs {
+        backup_name,
+        file_dir,
+        database_dir,
+    })
+}
+
+fn copy_files(settings: &Settings, backup_file_dir: &PathBuf) -> Result<(), BackupError> {
+    // TODO should only copy sync_files and plugins
+    let file_dir = get_base_dir(settings)?;
+
+    for entry in fs::read_dir(file_dir)? {
+        let from_dir = entry?.path();
+
+        let (Some(folder_name), true) = (from_dir.file_name(), from_dir.is_dir()) else {
+            continue;
+        };
+
+        let to_dir = backup_file_dir.join(folder_name);
+        copy_dir(&from_dir, &to_dir)
+            .map_err(|e| BackupError::ProblemCopyingFolder(e, from_dir, to_dir))?;
+    }
+
+    Ok(())
+}
+
+fn dump_postgres_database(
+    settings: &Settings,
+    backup_database_dir: &PathBuf,
+    pg_bin_dir_opt: Option<String>,
+) -> Result<(), BackupError> {
+    let pg_bin_dir = pg_bin_dir_opt.clone().unwrap_or_default();
+
+    let command = PathBuf::from_str(&pg_bin_dir)
+        .map_err(|_| BackupError::InvalidPath(pg_bin_dir.clone()))?
+        .join("pg_dump");
+
+    let result = Command::new(command.to_str().unwrap())
+        .args([
+            "--file",
+            backup_database_dir.to_str().unwrap(),
+            "--format",
+            "d",
+            "--dbname",
+            &settings.database.connection_string(),
+        ])
+        .output()
+        .map_err(|e| match (e.kind(), pg_bin_dir_opt.is_some()) {
+            (io::ErrorKind::NotFound, true) => BackupError::PgCommandNotFoundInBinPath,
+            (io::ErrorKind::NotFound, false) => BackupError::PgCommandNotFoundInPath,
+            _ => e.into(),
+        })?;
+
+    if !result.status.success() {
+        return Err(BackupError::CommandLineError(result));
+    }
+
+    Ok(())
+}
+
+fn copy_sqlite_files(
+    settings: &Settings,
+    backup_database_dir: &PathBuf,
+) -> Result<(), BackupError> {
+    let sqlite_files: Vec<PathBuf> = fs::read_dir("./")?
+        .into_iter()
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|f| {
+            f.is_file()
+                && f.file_stem().map(|s| s.to_str()).flatten()
+                    == Some(settings.database.database_name.as_str())
+        })
+        .collect();
+
+    if sqlite_files.is_empty() {
+        return Err(BackupError::CannotFindSqliteBackup(
+            settings.database.database_name.clone(),
+        ));
+    }
+
+    for sqlite_filename in sqlite_files {
+        // Unwrap should be safe (would panic only if pathname terminates with '...')
+        let sqlite_filename = sqlite_filename.file_name().unwrap();
+
+        fs::copy(&sqlite_filename, &backup_database_dir.join(sqlite_filename))?;
+    }
+
+    Ok(())
+}

--- a/server/cli/src/backup/mod.rs
+++ b/server/cli/src/backup/mod.rs
@@ -1,0 +1,87 @@
+mod backup;
+pub(super) use self::backup::*;
+mod restore;
+pub(super) use self::restore::*;
+
+use std::fs;
+use std::str::FromStr;
+use std::{io, path::PathBuf};
+
+use repository::RepositoryError;
+use service::settings::Settings;
+use thiserror::Error;
+
+const BACKUP_FILE_DIR: &'static str = "files";
+
+#[cfg(feature = "postgres")]
+const BACKUP_DATABASE_DIR: &'static str = "postgres";
+#[cfg(not(feature = "postgres"))]
+const BACKUP_DATABASE_DIR: &'static str = "sqlite";
+
+#[derive(Error, Debug)]
+pub(super) enum BackupError {
+    #[error("Cannot find pg_dump or pg_restore executable in PATH, add it to PATH or specify Postgres bin directory via configurations")]
+    PgCommandNotFoundInPath,
+    #[error("Cannot find pg_dump or pg_restore executable in Postgres bin directory specified in configurations")]
+    PgCommandNotFoundInBinPath,
+    #[error("Problem create folder at path: {1}")]
+    CannotCreateBackupFolder(#[source] io::Error, PathBuf),
+    #[error("base_dir must be configured in configuration files")]
+    BaseDirNotSet,
+    #[error("Invalid path specified: {0}")]
+    InvalidPath(String),
+    #[error("Problem copying folder, from: {0} to {1}")]
+    ProblemCopyingFolder(#[source] io::Error, PathBuf, PathBuf),
+    #[error("Cannot find sqlite backup files with name {0}")]
+    CannotFindSqliteBackup(String),
+    #[error(transparent)]
+    StdIO(#[from] io::Error),
+    #[error("Error while executing command line: {0:#?}")]
+    CommandLineError(std::process::Output),
+    #[error("Invalid sqlite backup file: {0}")]
+    InvalidSqliteFile(PathBuf),
+    #[error("Failed to confirm restore")]
+    RestoreNotConfirmed,
+    #[error("Backup configurations needs to be specified in configuration files")]
+    BackupConfigurationMissing,
+    #[error("Issue opening backup folder {1}")]
+    BackupFolderNotExist(#[source] io::Error, PathBuf),
+    #[error(transparent)]
+    DatabaseError(#[from] RepositoryError),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+#[derive(clap::Parser, Debug)]
+pub(super) struct RestoreArguments {
+    /// Name of backup in directory specified by backup configurations
+    #[clap(short, long)]
+    backup_name: String,
+    /// In dev can specify this to skip confirmation
+    #[clap(short, long)]
+    skip_confirmation: bool,
+}
+
+fn get_base_dir(settings: &Settings) -> Result<PathBuf, BackupError> {
+    settings
+        .server
+        .base_dir
+        .as_ref()
+        .map(|dir| PathBuf::from_str(dir).map_err(|_| BackupError::InvalidPath(dir.to_string())))
+        .transpose()?
+        .ok_or(BackupError::BaseDirNotSet)
+}
+
+fn get_sqlite_files_paths(settings: &Settings) -> Result<Vec<PathBuf>, BackupError> {
+    let paths = fs::read_dir("./")?
+        .into_iter()
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|f| {
+            f.is_file()
+                && f.file_stem().map(|s| s.to_str()).flatten()
+                    == Some(settings.database.database_name.as_str())
+        })
+        .collect();
+
+    Ok(paths)
+}

--- a/server/cli/src/backup/mod.rs
+++ b/server/cli/src/backup/mod.rs
@@ -109,15 +109,16 @@ fn get_base_dir(settings: &Settings) -> Result<PathBuf, BackupError> {
 }
 
 fn get_sqlite_files_paths(settings: &Settings) -> Result<Vec<PathBuf>, BackupError> {
+    // omSupply database name can be specified with .sqlite extension, converting path and comparing file_stem()
+    // seems pretty easy way to deal with database_name discrepancy
+    let backup_name = PathBuf::from_str(&settings.database.database_name)
+        .map_err(|_| BackupError::InvalidPath(settings.database.database_name.to_string()))?;
+
     let paths = fs::read_dir("./")?
         .into_iter()
         .filter_map(Result::ok)
         .map(|e| e.path())
-        .filter(|f| {
-            f.is_file()
-                && f.file_stem().map(|s| s.to_str()).flatten()
-                    == Some(settings.database.database_name.as_str())
-        })
+        .filter(|f| f.is_file() && f.file_stem() == backup_name.file_stem())
         .collect();
 
     Ok(paths)

--- a/server/cli/src/backup/mod.rs
+++ b/server/cli/src/backup/mod.rs
@@ -23,7 +23,7 @@ const BACKUP_DATABASE_DIR: &'static str = "sqlite";
 
 #[derive(Error, Debug)]
 pub(super) enum BackupError {
-    #[error("Cannot find pg_dump or pg_restore executable in PATH, add it to PATH or specify Postgres bin directory via configurations")]
+    #[error("Cannot find pg_dump or pg_restore executable in PATH, add it to PATH or specify Postgres bin directory in the configuration file")]
     PgCommandNotFoundInPath,
     #[error("Cannot find pg_dump or pg_restore executable in Postgres bin directory specified in configurations")]
     PgCommandNotFoundInBinPath,

--- a/server/cli/src/backup/restore.rs
+++ b/server/cli/src/backup/restore.rs
@@ -34,6 +34,8 @@ pub(crate) fn restore(
         copy_sqlite_files(settings, &database_dir)?;
     }
 
+    println!("Restore completed");
+
     Ok(())
 }
 

--- a/server/cli/src/backup/restore.rs
+++ b/server/cli/src/backup/restore.rs
@@ -1,0 +1,194 @@
+use super::*;
+use copy_dir::copy_dir;
+use diesel::{Connection, RunQueryDsl};
+use repository::DBBackendConnection;
+use service::settings::{BackupSettings, Settings};
+use simple_log::is_debug;
+use std::{fs, io, path::PathBuf, process::Command, str::FromStr};
+
+pub(crate) fn restore(
+    settings: &Settings,
+    RestoreArguments {
+        skip_confirmation,
+        backup_name,
+    }: RestoreArguments,
+) -> Result<(), BackupError> {
+    let Some(BackupSettings {
+        backup_dir,
+        pg_bin_dir,
+    }) = settings.backup.clone()
+    else {
+        return Err(BackupError::BackupConfigurationMissing);
+    };
+
+    confirmation(skip_confirmation)?;
+
+    let Dirs {
+        file_dir,
+        database_dir,
+    } = get_backup_dir(backup_dir, backup_name)?;
+
+    copy_files(settings, &file_dir)?;
+
+    // Backup database
+    if cfg!(feature = "postgres") {
+        restore_postgres_database(settings, &database_dir, pg_bin_dir)?;
+    } else {
+        copy_sqlite_files(settings, &database_dir)?;
+    }
+
+    Ok(())
+}
+
+fn confirmation(skip_confirmation: bool) -> Result<(), BackupError> {
+    if is_debug() && skip_confirmation {
+        return Ok(());
+    }
+
+    // In production confirm restore
+    let confirmation = "I understand";
+    println!(
+        r#"This operation will completely wipe your omSupply database and other omSupply, are you sure (please type "{confirmation}" to continue): "#
+    );
+    let mut buffer = String::new();
+    io::stdin().read_line(&mut buffer)?;
+
+    if buffer.to_lowercase().trim() != confirmation.to_lowercase() {
+        return Err(BackupError::RestoreNotConfirmed);
+    }
+
+    Ok(())
+}
+
+struct Dirs {
+    file_dir: PathBuf,
+    database_dir: PathBuf,
+}
+
+fn get_backup_dir(input_dir: String, backup_name: String) -> Result<Dirs, BackupError> {
+    let base_dir = PathBuf::from_str(&input_dir)
+        .map_err(|_| BackupError::InvalidPath(input_dir.clone()))?
+        .join(backup_name);
+
+    let file_dir = base_dir.join(BACKUP_FILE_DIR);
+
+    let database_dir = base_dir.join(BACKUP_DATABASE_DIR);
+
+    Ok(Dirs {
+        file_dir,
+        database_dir,
+    })
+}
+
+fn copy_files(settings: &Settings, backup_file_dir: &PathBuf) -> Result<(), BackupError> {
+    let restore_file_dir = get_base_dir(settings)?;
+    // Wipe existing app_data (files folder) folder
+    let _ = fs::remove_dir_all(&restore_file_dir);
+    fs::create_dir_all(&restore_file_dir)
+        .map_err(|e| BackupError::CannotCreateBackupFolder(e, restore_file_dir.clone()))?;
+
+    for entry in fs::read_dir(backup_file_dir)
+        .map_err(|e| BackupError::BackupFolderNotExist(e, backup_file_dir.clone()))?
+    {
+        let from_dir = entry?.path();
+
+        let (Some(folder_name), true) = (from_dir.file_name(), from_dir.is_dir()) else {
+            continue;
+        };
+
+        let to_dir = restore_file_dir.join(folder_name);
+
+        copy_dir(&from_dir, &to_dir)
+            .map_err(|e| BackupError::ProblemCopyingFolder(e, from_dir, to_dir))?;
+    }
+
+    Ok(())
+}
+
+fn restore_postgres_database(
+    settings: &Settings,
+    backup_database_dir: &PathBuf,
+    pg_bin_dir_opt: Option<String>,
+) -> Result<(), BackupError> {
+    let pg_bin_dir = pg_bin_dir_opt.clone().unwrap_or_default();
+
+    let command = PathBuf::from_str(&pg_bin_dir)
+        .map_err(|_| BackupError::InvalidPath(pg_bin_dir.clone()))?
+        .join("pg_restore");
+
+    drop_and_create_database(settings)?;
+
+    // Pg restore into database
+    let result = Command::new(command.to_str().unwrap())
+        .args([
+            "--format",
+            "d",
+            "--dbname",
+            &settings.database.connection_string(),
+            backup_database_dir.to_str().unwrap(),
+        ])
+        .output()
+        .map_err(|e| match (e.kind(), pg_bin_dir_opt.is_some()) {
+            (io::ErrorKind::NotFound, true) => BackupError::PgCommandNotFoundInBinPath,
+            (io::ErrorKind::NotFound, false) => BackupError::PgCommandNotFoundInPath,
+            _ => e.into(),
+        })?;
+
+    if !result.status.success() {
+        return Err(BackupError::CommandLineError(result));
+    }
+
+    Ok(())
+}
+
+// TODO this should already be provided by repository error
+fn drop_and_create_database(settings: &Settings) -> Result<(), RepositoryError> {
+    let database_settings = &settings.database;
+
+    // Re-create database TODO this should use common method
+    #[cfg(feature = "postgres")]
+    let connection_string = &database_settings.connection_string_without_db();
+    #[cfg(not(feature = "postgres"))]
+    let connection_string = "unreachable";
+
+    let mut connection = DBBackendConnection::establish(connection_string).unwrap();
+
+    let database_name = &database_settings.database_name;
+    diesel::sql_query(format!(r#"DROP DATABASE IF EXISTS "{database_name}""#))
+        .execute(&mut connection)?;
+    diesel::sql_query(format!(r#"CREATE DATABASE "{database_name}""#)).execute(&mut connection)?;
+
+    Ok(())
+}
+
+fn copy_sqlite_files(
+    settings: &Settings,
+    backup_database_dir: &PathBuf,
+) -> Result<(), BackupError> {
+    // Remove database files
+    let sqlite_files = get_sqlite_files_paths(settings)?;
+
+    for sqlite_filename in sqlite_files {
+        // Unwrap should be safe (would panic only if pathname terminates with '...')
+        let sqlite_filename = sqlite_filename.file_name().unwrap();
+
+        fs::remove_file(&sqlite_filename)?;
+    }
+    let database_name = &settings.database.database_name;
+
+    // Move backup files
+    for sqlite_filename in fs::read_dir(backup_database_dir)
+        .map_err(|e| BackupError::BackupFolderNotExist(e, backup_database_dir.clone()))?
+    {
+        let from_file = sqlite_filename?.path();
+        let extension = from_file
+            .extension()
+            .map(|e| e.to_str())
+            .flatten()
+            .ok_or(BackupError::InvalidSqliteFile(from_file.clone()))?;
+        // Preserve database name
+        fs::copy(&from_file, format!("{database_name}.{extension}"))?;
+    }
+
+    Ok(())
+}

--- a/server/cli/src/backup/restore.rs
+++ b/server/cli/src/backup/restore.rs
@@ -162,7 +162,7 @@ fn copy_sqlite_files(
     settings: &Settings,
     backup_database_dir: &PathBuf,
 ) -> Result<(), BackupError> {
-    // Remove database files
+    // Remove current database files
     let sqlite_files = get_sqlite_files_paths(settings)?;
 
     for sqlite_filename in sqlite_files {
@@ -171,7 +171,13 @@ fn copy_sqlite_files(
 
         fs::remove_file(&sqlite_filename)?;
     }
-    let database_name = &settings.database.database_name;
+
+    // omSupply database name can be specified with .sqlite extension, remove it here
+    let database_name = settings
+        .database
+        .database_name
+        .clone()
+        .replace(".sqlite", "");
 
     // Move backup files
     for sqlite_filename in fs::read_dir(backup_database_dir)

--- a/server/cli/src/backup/restore.rs
+++ b/server/cli/src/backup/restore.rs
@@ -2,7 +2,7 @@ use super::*;
 use copy_dir::copy_dir;
 use diesel::{Connection, RunQueryDsl};
 use repository::DBBackendConnection;
-use service::settings::{BackupSettings, Settings};
+use service::settings::Settings;
 use simple_log::is_debug;
 use std::{fs, io, path::PathBuf, process::Command, str::FromStr};
 
@@ -13,13 +13,10 @@ pub(crate) fn restore(
         backup_name,
     }: RestoreArguments,
 ) -> Result<(), BackupError> {
-    let Some(BackupSettings {
+    let DirSettings {
         backup_dir,
         pg_bin_dir,
-    }) = settings.backup.clone()
-    else {
-        return Err(BackupError::BackupConfigurationMissing);
-    };
+    } = get_dirs_from_settings(settings)?;
 
     confirmation(skip_confirmation)?;
 

--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -33,6 +33,9 @@ use std::{
 };
 use util::inline_init;
 
+mod backup;
+use backup::*;
+
 const DATA_EXPORT_FOLDER: &str = "data";
 
 /// omSupply remote server cli
@@ -131,6 +134,8 @@ enum Action {
         #[clap(short, long)]
         sub_context: Option<String>,
     },
+    Backup,
+    Restore(RestoreArguments),
 }
 
 #[derive(Serialize, Deserialize)]
@@ -439,6 +444,12 @@ async fn main() -> anyhow::Result<()> {
             })?;
 
             info!("Report upserted");
+        }
+        Action::Backup => {
+            backup(&settings)?;
+        }
+        Action::Restore(arguments) => {
+            restore(&settings, arguments)?;
         }
     }
 

--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -134,6 +134,7 @@ enum Action {
         #[clap(short, long)]
         sub_context: Option<String>,
     },
+    /// Will back up database to a generated folder (the name of which will be returned). Folder will be generated in the backup directory specified by configuration file
     Backup,
     Restore(RestoreArguments),
 }

--- a/server/cli/src/lib.rs
+++ b/server/cli/src/lib.rs
@@ -1,4 +1,3 @@
 extern crate diesel;
-
 mod refresh_dates;
 pub use refresh_dates::*;

--- a/server/configuration/example.yaml
+++ b/server/configuration/example.yaml
@@ -37,4 +37,7 @@
 #   filename: remote_server.log
 #   max_file_count: 10
 #   max_file_size: 1
+# backup: # see cli backup/restore
+#   backup_dir: "~/Documents/omSupply_backup"
+#   pg_bin_dir: "/Applications/Postgres.app/Contents/Versions/16/bin"  # Optional
 

--- a/server/service/src/settings.rs
+++ b/server/service/src/settings.rs
@@ -10,6 +10,7 @@ pub struct Settings {
     pub database: DatabaseSettings,
     pub sync: Option<SyncSettings>,
     pub logging: Option<LoggingSettings>,
+    pub backup: Option<BackupSettings>,
 }
 
 #[derive(serde::Deserialize, Clone)]
@@ -38,6 +39,15 @@ impl ServerSettings {
     pub fn discovery_address(&self) -> String {
         format!("0.0.0.0:{}", self.port + 1)
     }
+}
+
+/// See backup cli for more details
+#[derive(serde::Deserialize, Clone)]
+pub struct BackupSettings {
+    // Root folder for backup
+    pub backup_dir: String,
+    // Directory containing postgres binaries (in case pg_dump and pg_restore are not in PATH)
+    pub pg_bin_dir: Option<String>,
 }
 
 pub fn is_develop() -> bool {

--- a/server/service/src/test_helpers.rs
+++ b/server/service/src/test_helpers.rs
@@ -50,6 +50,7 @@ pub(crate) async fn setup_all_with_data_and_service_provider(
         database: db_settings,
         sync: None,
         logging: None,
+        backup: None,
     });
     let (sync_trigger, _) = SynchroniserDriver::init(file_sync_trigger);
     let (site_is_initialise_trigger, _) = SiteIsInitialisedCallback::init();


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4662 

Original PR is here, please make sure all comments are address in that PR as well: https://github.com/msupply-foundation/open-msupply/pull/4664

# 👩🏻‍💻 What does this PR do?

Adds restore and backup cli scripts, please see [readme](https://github.com/msupply-foundation/open-msupply/blob/81092014a6efa0421953027cb011073969f446b2/server/cli/src/backup/README.md) for more details

I originally had backup folder and pg_bin_dir as cli arguments, after talking to Kahn we thought it would be best in configurations

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

There are bunch of carry overs and improvements that we should consider doing, i'll try to relocate to another issue:

There is `database_path` settings, which i think is not used (it's not used for sqlite i think, but makes more sense for sqlite?), if it's used for sqlite need to adjust cli -> It is used, so would be good for backup to respect that setting, not deemed high priority because central server is the only real use case for production backup and it should be running in postgres

Currently copying all folders in app_data, if there was an easier way to use the files service for this, i think it would be preferred, but would require a bit of refactor, I didn't want to touch it

Database drop and creation can be made to be re-usable, but i didn't want to touch core code

Would be great to specify configuration files when launching server or running backup script, this would make running central and remote server a bit easier.

Add some metadata to backup, is it sqlite or postgres, which version, what client/site etc.. 

I've noticed awhile ago that database errors formatting is not that great, I think we can improve on this by using this error on RepositoryError.

Auto zip backup

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->
For both sqlite and postgres versions:

- [ ] Backup (1)
- [ ] Make some changes (add invoice/requisition)
- [ ] Backup again (2)
- [ ] Delete some things (invoice/requisition)
- [ ] Backup again (3)
- [ ] Restore (1) make sure invoice/requisition does not exist, and creating new invoice has sequence number + 1
- [ ] Restore (2) make sure invoice/requisition exists, and creating new invoice has sequence number + 1
- [ ] Restore (3) make sure invoice/requisition does not exist, and creating new invoice has sequence number + 2

Check that files are also backed up (for best done I think with assets)

# 📃 Documentation

Does this need docs beyond docs in the repo ?
