### PR TITLE
4687 hotfix populate changelog store ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "2.2.00",
+  "version": "2.2.01",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/repository/src/migrations/mod.rs
+++ b/server/repository/src/migrations/mod.rs
@@ -21,6 +21,7 @@ mod v1_07_00;
 mod v2_00_00;
 mod v2_01_00;
 mod v2_02_00;
+mod v2_02_01;
 mod v2_03_00;
 mod version;
 mod views;
@@ -115,6 +116,7 @@ pub fn migrate(
         Box::new(v2_00_00::V2_00_00),
         Box::new(v2_01_00::V2_01_00),
         Box::new(v2_02_00::V2_02_00),
+        Box::new(v2_02_01::V2_02_01),
         // Box::new(v2_03_00::V2_03_00),
     ];
 

--- a/server/repository/src/migrations/v2_02_01/add_store_ids_to_existing_rnr_form_changelogs.rs
+++ b/server/repository/src/migrations/v2_02_01/add_store_ids_to_existing_rnr_form_changelogs.rs
@@ -1,0 +1,28 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_store_ids_to_existing_rnr_form_changelogs"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        sql!(
+            connection,
+            // Fix for https://github.com/msupply-foundation/open-msupply/issues/4687
+            r#"
+                UPDATE changelog
+                SET store_id = r.store_id
+                FROM rnr_form r
+                LEFT JOIN rnr_form_line rfl ON r.id = rfl.rnr_form_id
+                WHERE 
+                    (changelog.table_name = 'rnr_form' AND changelog.record_id = r.id)
+                OR 
+                    (changelog.table_name = 'rnr_form_line' AND changelog.record_id = rfl.id);
+            "#
+        )?;
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_02_01/mod.rs
+++ b/server/repository/src/migrations/v2_02_01/mod.rs
@@ -1,0 +1,135 @@
+use super::{version::Version, Migration, MigrationFragment};
+
+use crate::StorageConnection;
+
+mod add_store_ids_to_existing_rnr_form_changelogs;
+
+pub(crate) struct V2_02_01;
+
+impl Migration for V2_02_01 {
+    fn version(&self) -> Version {
+        Version::from_str("2.2.1")
+    }
+
+    fn migrate(&self, _connection: &StorageConnection) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn migrate_fragments(&self) -> Vec<Box<dyn MigrationFragment>> {
+        vec![Box::new(
+            add_store_ids_to_existing_rnr_form_changelogs::Migrate,
+        )]
+    }
+}
+
+#[cfg(test)]
+#[actix_rt::test]
+async fn migration_2_02_01() {
+    use v2_02_00::V2_02_00;
+
+    use crate::migrations::*;
+    use crate::test_db::*;
+
+    let previous_version = V2_02_00.version();
+    let version = V2_02_01.version();
+
+    let SetupResult { connection, .. } = setup_test(SetupOption {
+        db_name: &format!("migration_{version}"),
+        version: Some(previous_version.clone()),
+        ..Default::default()
+    })
+    .await;
+
+    add_rnr_form_changelogs_no_store_id(&connection).unwrap();
+
+    assert_eq!(check_changelogs_have_store_id(&connection), false);
+
+    // Run this migration
+    migrate(&connection, Some(version.clone())).unwrap();
+    assert_eq!(get_database_version(&connection), version);
+
+    assert_eq!(check_changelogs_have_store_id(&connection), true);
+}
+
+#[cfg(test)]
+fn check_changelogs_have_store_id(connection: &StorageConnection) -> bool {
+    use crate::{ChangelogFilter, ChangelogRepository, ChangelogTableName};
+
+    let mut changelogs = ChangelogRepository::new(connection)
+        .changelogs(
+            0,
+            1000,
+            Some(ChangelogFilter::new().table_name(ChangelogTableName::RnrForm.equal_to())),
+        )
+        .unwrap();
+
+    let rnr_form_line_changelogs = ChangelogRepository::new(connection)
+        .changelogs(
+            0,
+            1000,
+            Some(ChangelogFilter::new().table_name(ChangelogTableName::RnrFormLine.equal_to())),
+        )
+        .unwrap();
+
+    changelogs.extend(rnr_form_line_changelogs);
+
+    changelogs
+        .iter()
+        .all(|changelog| changelog.store_id.clone().unwrap_or("".to_string()) == "store1")
+}
+
+#[cfg(test)]
+fn add_rnr_form_changelogs_no_store_id(connection: &StorageConnection) -> anyhow::Result<()> {
+    use super::sql;
+    // Setup test data
+    sql!(
+        connection,
+        r#"
+        INSERT INTO item  (id, name, code, default_pack_size, type, legacy_record) VALUES  ('item1', 'item1name', 'item1code', 1, 'STOCK', '');
+        INSERT INTO item_link  (id, item_id) VALUES  ('item1', 'item1');
+
+        INSERT INTO name (id, name, code, is_customer, is_supplier, type, is_sync_update) VALUES ('name1', 'name1name', 'name1code', TRUE, FALSE, 'STORE', TRUE);
+        INSERT INTO name_link (id, name_id) VALUES ('name1', 'name1');
+
+        INSERT INTO store (id, name_link_id, code, site_id, store_mode) VALUES ('store1', 'name1', 'store1code', 1, 'STORE');
+
+        INSERT INTO period_schedule (id, name) VALUES ('schedule1', 'schedule1');
+        INSERT INTO period (id, period_schedule_id, name, start_date, end_date) VALUES ('period1', 'schedule1', 'period1', '2024-08-01', '2024-08-31');
+        "#
+    )
+    .unwrap();
+
+    // Insert rnr_form and an rnr_form_line
+    sql!(
+        connection,
+        r#"
+        INSERT INTO rnr_form 
+            ("id", "store_id", "name_link_id", "period_id", "program_id", "status", "created_datetime") 
+        VALUES
+            ('TEST_RNR_FORM_ID', 'store1', 'name1', 'period1', 'missing_program', 'DRAFT', '2024-08-27 23:34:55.380381');
+        "#,
+    )?;
+    sql!(
+        connection,
+        r#"
+        INSERT INTO rnr_form_line
+            ("id", "rnr_form_id", "item_link_id", "average_monthly_consumption", "previous_monthly_consumption_values", "initial_balance", "snapshot_quantity_received", "snapshot_quantity_consumed", "snapshot_adjustments", "adjusted_quantity_consumed", "stock_out_duration", "final_balance", "maximum_quantity", "calculated_requested_quantity") 
+        VALUES
+            ('TEST_RNR_FORM_LINE_ID', 'TEST_RNR_FORM_ID', 'item1', 0.0, "", 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0.0, 0.0, 0.0);
+        "#,
+    )?;
+
+    // Create changelog records for form and line - missing store_id
+    sql!(
+        connection,
+        r#"
+        INSERT INTO changelog
+            ("table_name", "record_id", "row_action", "store_id")
+        VALUES
+            ("rnr_form", "TEST_RNR_FORM_ID", "UPSERT", NULL),
+            ("rnr_form_line", "TEST_RNR_FORM_LINE_ID", "UPSERT", NULL);
+        "#,
+    )?;
+
+    Ok(())
+}

--- a/server/repository/src/migrations/v2_02_01/mod.rs
+++ b/server/repository/src/migrations/v2_02_01/mod.rs
@@ -113,7 +113,7 @@ fn add_rnr_form_changelogs_no_store_id(connection: &StorageConnection) -> anyhow
         INSERT INTO rnr_form_line
             ("id", "rnr_form_id", "item_link_id", "average_monthly_consumption", "previous_monthly_consumption_values", "initial_balance", "snapshot_quantity_received", "snapshot_quantity_consumed", "snapshot_adjustments", "adjusted_quantity_consumed", "stock_out_duration", "final_balance", "maximum_quantity", "calculated_requested_quantity") 
         VALUES
-            ('TEST_RNR_FORM_LINE_ID', 'TEST_RNR_FORM_ID', 'item1', 0.0, "", 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0.0, 0.0, 0.0);
+            ('TEST_RNR_FORM_LINE_ID', 'TEST_RNR_FORM_ID', 'item1', 0.0, '', 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0.0, 0.0, 0.0);
         "#,
     )?;
 
@@ -124,8 +124,8 @@ fn add_rnr_form_changelogs_no_store_id(connection: &StorageConnection) -> anyhow
         INSERT INTO changelog
             ("table_name", "record_id", "row_action", "store_id")
         VALUES
-            ("rnr_form", "TEST_RNR_FORM_ID", "UPSERT", NULL),
-            ("rnr_form_line", "TEST_RNR_FORM_LINE_ID", "UPSERT", NULL);
+            ('rnr_form', 'TEST_RNR_FORM_ID', 'UPSERT', NULL),
+            ('rnr_form_line', 'TEST_RNR_FORM_LINE_ID', 'UPSERT', NULL);
         "#,
     )?;
 

--- a/server/repository/src/migrations/v2_03_00/mod.rs
+++ b/server/repository/src/migrations/v2_03_00/mod.rs
@@ -17,12 +17,12 @@ impl Migration for V2_03_00 {
 #[cfg(test)]
 #[actix_rt::test]
 async fn migration_2_03_00() {
-    use v2_02_00::V2_02_00;
+    use v2_02_01::V2_02_01;
 
     use crate::migrations::*;
     use crate::test_db::*;
 
-    let previous_version = V2_02_00.version();
+    let previous_version = V2_02_01.version();
     let version = V2_03_00.version();
 
     let SetupResult { connection, .. } = setup_test(SetupOption {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4687

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Adds migration to populate rnr_form and rnr_form_line changelogs with store ID.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

There is a test in the migrations

- [ ] Install 2.2 RC5 and create at least one R&R form, OR against main, create an R&R form and then edit DB to delete store_id from the changelog entries
- [ ] Switch to this branch, run the migrations
- [ ] Check DB - you should now have store_id in the changelogs
- [ ] Reinitialise remote site that created the R&R form
- [ ] R&R forms come back

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
