### PR TITLE
3797 move internal order toolbar content to side panel

### DIFF
--- a/client/packages/common/src/hooks/useDetailPanel/useDetailPanel.tsx
+++ b/client/packages/common/src/hooks/useDetailPanel/useDetailPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { create } from 'zustand';
 import { useTranslation } from '@common/intl';
 import { SidebarIcon, ButtonWithIcon } from '../../ui';
@@ -8,31 +8,43 @@ type DetailPanelController = {
   hasUserSet: boolean;
   isOpen: boolean;
   shouldPersist: boolean;
+  enabled: boolean;
   open: () => void;
   close: () => void;
+  setEnabled: (enabled: boolean) => void;
 };
 
 export const useDetailPanelStore = create<DetailPanelController>(set => {
   const initialValue = LocalStorage.getItem('/detailpanel/open');
 
   return {
+    enabled: false,
     hasUserSet: initialValue !== null,
     isOpen: false,
     shouldPersist: true,
     open: () =>
-      set(state => ({
-        ...state,
-        isOpen: true,
-        hasUserSet: true,
-        shouldPersist: true,
-      })),
+      set(state =>
+        state.enabled
+          ? {
+              ...state,
+              isOpen: true,
+              hasUserSet: true,
+              shouldPersist: true,
+            }
+          : state
+      ),
     close: () =>
-      set(state => ({
-        ...state,
-        isOpen: false,
-        hasUserSet: true,
-        shouldPersist: true,
-      })),
+      set(state =>
+        state.enabled
+          ? {
+              ...state,
+              isOpen: false,
+              hasUserSet: true,
+              shouldPersist: true,
+            }
+          : state
+      ),
+    setEnabled: (enabled: boolean) => set(state => ({ ...state, enabled })),
   };
 });
 
@@ -43,7 +55,7 @@ interface DetailPanel {
 }
 export const useDetailPanel = (): DetailPanel => {
   const t = useTranslation();
-  const { isOpen, open, close } = useDetailPanelStore();
+  const { isOpen, open, close, setEnabled } = useDetailPanelStore();
   const OpenButton = isOpen ? null : (
     <ButtonWithIcon
       Icon={<SidebarIcon />}
@@ -51,6 +63,11 @@ export const useDetailPanel = (): DetailPanel => {
       onClick={open}
     />
   );
+
+  useEffect(() => {
+    setEnabled(true);
+    return () => setEnabled(false);
+  }, []);
 
   return { OpenButton, open, close };
 };

--- a/client/packages/common/src/intl/locales/en/app.json
+++ b/client/packages/common/src/intl/locales/en/app.json
@@ -32,6 +32,8 @@
   "cmdk.goto-stock": "Go to: Stock",
   "cmdk.goto-stocktakes": "Go to: Stocktakes",
   "cmdk.goto-suppliers": "Go to: Suppliers",
+  "cmdk.more-info-close": "Close the more info panel",
+  "cmdk.more-info-open": "Open the more info panel",
   "cmdk.placeholder": "Type a command or search",
   "customer-requisition": "Requisitions",
   "customers": "Customers",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -127,7 +127,7 @@
   "heading.404": "Feeling lost?",
   "heading.actions": "Actions",
   "heading.add-item": "Add Item",
-  "heading.additional-info": "Additional Info",
+  "heading.additional-info": "Additional info",
   "heading.are-you-sure": "Are you sure?",
   "heading.barcode-scanners": "Barcode Scanners",
   "heading.comment": "Comment",

--- a/client/packages/common/src/intl/locales/en/replenishment.json
+++ b/client/packages/common/src/intl/locales/en/replenishment.json
@@ -36,6 +36,8 @@
   "heading.charges": "Charges",
   "heading.consumption-history": "Consumption History (monthly)",
   "heading.edit-tax-rate": "Edit tax rate percentage",
+  "heading.order-info": "Order info",
+  "heading.program-info": "Program info",
   "heading.related-documents": "Related documents",
   "heading.requested-to-suggested": "Request Suggested",
   "heading.return-items": "Return Items",

--- a/client/packages/common/src/intl/locales/en/replenishment.json
+++ b/client/packages/common/src/intl/locales/en/replenishment.json
@@ -50,7 +50,7 @@
   "heading.total": "Total",
   "info.automatic-shipment": "This shipment was created automatically, as the result of an Outbound Shipment in another store.",
   "info.automatic-shipment-no-edit": "You are unable to edit details until the status is confirmed as Delivered.",
-  "info.cannot-edit-program-requisition": "Cannot edit supplier, minimum MOS, maximum MOS or add items in a program requisition.",
+  "info.cannot-edit-program-requisition": "Cannot edit supplier, reorder threshold MOS, target MOS or add items in a program requisition.",
   "info.manual-shipment": "This shipment was created manually. The delivery status will not be automatically updated.",
   "label.add-batch": "Add batch",
   "label.add-charges": "Add charges",

--- a/client/packages/host/src/CommandK.tsx
+++ b/client/packages/host/src/CommandK.tsx
@@ -19,6 +19,7 @@ import {
   StoreModeNodeType,
   useRegisterActions,
   useConfirmationModal,
+  useDetailPanelStore,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { Action } from 'kbar/lib/types';
@@ -97,12 +98,13 @@ const Actions = () => {
     message: t('messages.logout-confirm'),
     title: t('heading.logout-confirm'),
   });
+  const { close, open } = useDetailPanelStore();
 
   const actions = [
     {
       id: 'navigation-drawer:toggle',
-      name: `${t('cmdk.drawer-toggle')} (m)`,
-      shortcut: ['m'],
+      name: `${t('cmdk.drawer-toggle')} (n)`,
+      shortcut: ['n'],
       keywords: 'drawer, close',
       perform: () => drawer.toggle(),
     },
@@ -303,6 +305,25 @@ const Actions = () => {
             .build()
         ),
     });
+
+    // if (enabled) {
+    actions.push(
+      {
+        id: 'action:more-open',
+        name: `${t('cmdk.more-info-close')} (m+o)`,
+        keywords: 'more open',
+        shortcut: ['m', 'o'],
+        perform: open,
+      },
+      {
+        id: 'action:more-close',
+        name: `${t('cmdk.more-info-close')} (m+c)`,
+        keywords: 'more close',
+        shortcut: ['m', 'c'],
+        perform: close,
+      }
+    );
+    // }
 
     if (store?.preferences.vaccineModule ?? false) {
       actions.push({

--- a/client/packages/host/src/CommandK.tsx
+++ b/client/packages/host/src/CommandK.tsx
@@ -306,7 +306,6 @@ const Actions = () => {
         ),
     });
 
-    // if (enabled) {
     actions.push(
       {
         id: 'action:more-open',
@@ -323,7 +322,6 @@ const Actions = () => {
         perform: close,
       }
     );
-    // }
 
     if (store?.preferences.vaccineModule ?? false) {
       actions.push({

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/OrderInfoSection.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/OrderInfoSection.tsx
@@ -1,23 +1,31 @@
 import React from 'react';
 import {
-  Switch,
   Grid,
   Autocomplete,
-  InputWithLabelRow,
   useTranslation,
   useConfirmationModal,
+  DetailPanelSection,
+  PanelRow,
+  PanelLabel,
+  PanelField,
 } from '@openmsupply-client/common';
-import { useRequest, useHideOverStocked } from '../../api';
+import { useRequest } from '../api';
+import { getApprovalStatusKey } from '../../utils';
 
 const months = [1, 2, 3, 4, 5, 6];
 
-export const ToolbarActions = () => {
-  const { on, toggle } = useHideOverStocked();
+export const OrderInfoSection = () => {
   const t = useTranslation('replenishment');
   const isDisabled = useRequest.utils.isDisabled();
   const isProgram = useRequest.utils.isProgram();
-  const { minMonthsOfStock, maxMonthsOfStock, update } =
-    useRequest.document.fields(['minMonthsOfStock', 'maxMonthsOfStock']);
+  const { minMonthsOfStock, maxMonthsOfStock, linkedRequisition, update } =
+    useRequest.document.fields([
+      'minMonthsOfStock',
+      'maxMonthsOfStock',
+      'programName',
+      'linkedRequisition',
+    ]);
+  const { usesRemoteAuthorisation } = useRequest.utils.isRemoteAuthorisation();
 
   const getMinMOSConfirmation = useConfirmationModal({
     title: t('heading.are-you-sure'),
@@ -35,12 +43,19 @@ export const ToolbarActions = () => {
   });
 
   return (
-    <Grid container gap={1} direction="column">
-      <Grid item>
-        <InputWithLabelRow
-          labelWidth="150px"
-          label={t('label.min-months-of-stock')}
-          Input={
+    <DetailPanelSection title={t('heading.order-info')}>
+      <Grid container gap={0.5} key="order-info">
+        {usesRemoteAuthorisation && (
+          <PanelRow>
+            <PanelLabel>{t('label.auth-status')}</PanelLabel>
+            <PanelField>
+              {t(getApprovalStatusKey(linkedRequisition?.approvalStatus))}
+            </PanelField>
+          </PanelRow>
+        )}
+        <PanelRow>
+          <PanelLabel>{t('label.min-months-of-stock')}</PanelLabel>
+          <PanelField>
             <Autocomplete
               disabled={isDisabled || isProgram}
               clearIcon={null}
@@ -78,14 +93,11 @@ export const ToolbarActions = () => {
               }}
               getOptionDisabled={option => option.value > maxMonthsOfStock}
             />
-          }
-        />
-      </Grid>
-      <Grid item>
-        <InputWithLabelRow
-          labelWidth="150px"
-          label={t('label.max-months-of-stock')}
-          Input={
+          </PanelField>
+        </PanelRow>
+        <PanelRow>
+          <PanelLabel>{t('label.max-months-of-stock')}</PanelLabel>
+          <PanelField>
             <Autocomplete
               disabled={isDisabled || isProgram}
               clearIcon={null}
@@ -107,23 +119,9 @@ export const ToolbarActions = () => {
               }
               getOptionDisabled={option => option.value < minMonthsOfStock}
             />
-          }
-        />
+          </PanelField>
+        </PanelRow>
       </Grid>
-      <Grid item>
-        <InputWithLabelRow
-          labelWidth="225px"
-          label={t('label.hide-stock-over-minimum')}
-          Input={
-            <Switch
-              onChange={toggle}
-              checked={on}
-              color="secondary"
-              size="small"
-            />
-          }
-        />
-      </Grid>
-    </Grid>
+    </DetailPanelSection>
   );
 };

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/SidePanel.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/SidePanel.tsx
@@ -26,6 +26,37 @@ import {
 } from '@openmsupply-client/common';
 import { useRequest } from '../api';
 import { AppRoute } from '@openmsupply-client/config';
+import { OrderInfoSection } from './OrderInfoSection';
+
+const ProgramInfoSection: FC = () => {
+  const { orderType, programName, period } = useRequest.document.fields([
+    'orderType',
+    'programName',
+    'period',
+  ]);
+  const t = useTranslation('replenishment');
+
+  return programName ? (
+    <DetailPanelSection title={t('heading.program-info')}>
+      <Grid container gap={0.5} key="program-info">
+        <PanelRow>
+          <PanelLabel>{t('label.order-type')}</PanelLabel>
+          <PanelField>{orderType ?? ''}</PanelField>
+        </PanelRow>
+        <PanelRow>
+          <PanelLabel>{t('label.program')}</PanelLabel>
+          <PanelField>{programName ?? ''}</PanelField>
+        </PanelRow>
+        <PanelRow>
+          <PanelLabel>{t('label.period')}</PanelLabel>
+          <PanelField>{period?.name ?? ''}</PanelField>
+        </PanelRow>
+      </Grid>
+    </DetailPanelSection>
+  ) : (
+    <></>
+  );
+};
 
 const AdditionalInfoSection: FC = () => {
   const isDisabled = useRequest.utils.isDisabled();
@@ -189,6 +220,8 @@ export const SidePanel: FC = () => {
         </>
       }
     >
+      <OrderInfoSection />
+      <ProgramInfoSection />
       <AdditionalInfoSection />
       <RelatedDocumentsSection />
     </DetailPanelPortal>

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
@@ -6,39 +6,22 @@ import {
   Grid,
   useTranslation,
   SearchBar,
-  Typography,
-  Box,
   Alert,
   Tooltip,
+  Switch,
 } from '@openmsupply-client/common';
 import { InternalSupplierSearchInput } from '@openmsupply-client/system';
-import { useRequest } from '../../api';
+import { useHideOverStocked, useRequest } from '../../api';
 import { ToolbarDropDown } from './ToolbarDropDown';
-import { ToolbarActions } from './ToolbarActions';
-import { getApprovalStatusKey } from '../../../utils';
 
 export const Toolbar: FC = () => {
+  const { on, toggle } = useHideOverStocked();
   const t = useTranslation('replenishment');
   const isDisabled = useRequest.utils.isDisabled();
   const isProgram = useRequest.utils.isProgram();
   const { itemFilter, setItemFilter } = useRequest.line.list();
-  const { usesRemoteAuthorisation } = useRequest.utils.isRemoteAuthorisation();
-  const {
-    linkedRequisition,
-    theirReference,
-    update,
-    otherParty,
-    orderType,
-    programName,
-    period,
-  } = useRequest.document.fields([
-    'theirReference',
-    'otherParty',
-    'linkedRequisition',
-    'programName',
-    'period',
-    'orderType',
-  ]);
+  const { theirReference, update, otherParty, programName } =
+    useRequest.document.fields(['theirReference', 'otherParty', 'programName']);
 
   return (
     <AppBarContentPortal
@@ -49,7 +32,7 @@ export const Toolbar: FC = () => {
         flexDirection: 'column',
       }}
     >
-      <Grid container>
+      <Grid container gap={2} flexWrap="nowrap">
         <Grid item display="flex" flex={1} flexDirection="column" gap={1}>
           {otherParty && (
             <InputWithLabelRow
@@ -77,51 +60,13 @@ export const Toolbar: FC = () => {
               </Tooltip>
             }
           />
-          {usesRemoteAuthorisation && (
-            <InputWithLabelRow
-              label={t('label.auth-status')}
-              Input={
-                <Typography>
-                  {t(getApprovalStatusKey(linkedRequisition?.approvalStatus))}
-                </Typography>
-              }
-            />
-          )}
-
-          {orderType && (
-            <InputWithLabelRow
-              label={t('label.order-type')}
-              Input={<Typography>{orderType ?? ''}</Typography>}
-            />
-          )}
-          {programName && (
-            <InputWithLabelRow
-              label={t('label.program')}
-              Input={<Typography>{programName ?? ''}</Typography>}
-            />
-          )}
-          {period && (
-            <InputWithLabelRow
-              label={t('label.period')}
-              Input={<Typography>{period?.name ?? ''}</Typography>}
-            />
-          )}
         </Grid>
-        {programName && (
-          <Box padding={2} style={{ maxWidth: 500 }}>
-            <Alert severity="info">
+        <Grid item>
+          {programName && (
+            <Alert severity="info" sx={{ marginTop: 1, maxWidth: '378px' }}>
               {t('info.cannot-edit-program-requisition')}
             </Alert>
-          </Box>
-        )}
-        <Grid
-          item
-          flexDirection="column"
-          alignItems="flex-end"
-          display="flex"
-          gap={2}
-        >
-          <ToolbarActions />
+          )}
         </Grid>
       </Grid>
       <Grid
@@ -130,17 +75,29 @@ export const Toolbar: FC = () => {
         gap={1}
         alignItems="flex-end"
         justifyContent="flex-end"
-        sx={{ marginTop: 2 }}
+        sx={{ marginTop: 1, flexWrap: 'wrap' }}
       >
-        <SearchBar
-          placeholder={t('placeholder.filter-items')}
-          value={itemFilter}
-          onChange={newValue => {
-            setItemFilter(newValue);
-          }}
-          debounceTime={0}
-        />
-        <ToolbarDropDown />
+        <Grid item>
+          <Switch
+            label={t('label.hide-stock-over-minimum')}
+            onChange={toggle}
+            checked={on}
+            color="secondary"
+            size="small"
+            labelSx={{ margin: '5px 0' }}
+          />
+        </Grid>
+        <Grid item display="flex" gap={1} alignItems="flex-end">
+          <SearchBar
+            placeholder={t('placeholder.filter-items')}
+            value={itemFilter}
+            onChange={newValue => {
+              setItemFilter(newValue);
+            }}
+            debounceTime={0}
+          />
+          <ToolbarDropDown />
+        </Grid>
       </Grid>
     </AppBarContentPortal>
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3797

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Removes some content from the toolbar, so it doesn't take up too much space on narrower screens:
![Screenshot 2024-08-27 at 2 35 02 PM](https://github.com/user-attachments/assets/1115d844-26ae-4564-81c0-35f92ddcd4e5)

And moves it to the side panel:

![Screenshot 2024-08-27 at 2 35 09 PM](https://github.com/user-attachments/assets/9b37ba39-c54f-4739-8196-4fa7bb39b95b)


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Had a brief play with the "show some kind of info popup the first time" side quest, but felt it was taking a bit long. Think we can do a separate issue for that if we find it to be a priority!

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

On tablet/small window:

- [ ] Check a regular
- [ ] And a program requisition
- [ ] You can see plenty of rows
- [ ] All the expected info is found in the side panel

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Internal order screenshots/where to find info should be updated
  2. Program requisitions as well
