### PR TITLE
Download excel report export via iframe

### DIFF
--- a/client/packages/common/src/utils/files/FileUtils.ts
+++ b/client/packages/common/src/utils/files/FileUtils.ts
@@ -25,6 +25,8 @@ const exportFile = (data: string, type: string, title?: string) => {
   }
 };
 
+// TODO this causes electron app to navigate to this url (at the same time as opening dialog box)
+// however for temp files, this causes Static file not found error as the temp file is delete after first request
 const downloadFile = async (url: string) => {
   const res = await fetch(url);
   const data = await res.blob();

--- a/client/packages/reports/src/DetailView/DetailView.tsx
+++ b/client/packages/reports/src/DetailView/DetailView.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
-  FileUtils,
   LocaleKey,
   noOtherVariants,
   NothingHere,
@@ -143,6 +142,7 @@ const DetailViewInner = ({
         format: PrintFormat.Excel,
       });
       if (result?.__typename === 'PrintReportNode') {
+        // Setting iframe url with response != html disposition, causes iframe to 'download' this file
         setFileId(result.fileId);
       }
 
@@ -164,8 +164,6 @@ const DetailViewInner = ({
     } catch (error) {
       console.error(error);
     }
-    const url = `${Environment.FILE_URL}${fileId}`;
-    FileUtils.downloadFile(url);
   }, [reportArgs]);
 
   const url = `${Environment.FILE_URL}${fileId}`;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4686

# 👩🏻‍💻 What does this PR do?

See comments/descriptions in commit

## 💌 Any notes for the reviewer?

downloadFile is also used in PDF download, which is actually never used, we should delete that at some point.

reportArgs is a dependency to useCallback, but it's an object, was tempted to refactor.

I wonder if iframe can solve the issue we had with file download on android ¯\_(ツ)_/¯ 

# 🧪 Testing

Try to export a report in electron app (omSupply client), chrome and firefox, all should work.

For dev test, this issue is replicable if you run `yarn electron:start`, you would need to re-build front end `yarn build` and then restart server

# 📃 Documentation

