### PR TITLE
Add backup cleanup to backup script

### DIFF
--- a/server/cli/src/backup/README.md
+++ b/server/cli/src/backup/README.md
@@ -30,6 +30,8 @@ You will need to specify a backup folder in the configuration `.yaml` files - to
 
 Backup will contain a folder with all of the app_data (plugins, static files, etc..) and a folder with either sqlite files or postgres database dump. 
 
+`max_number_of_backups` in configuration `.yaml` file can be used to limit number of backups that will be kept in backup folder, this will be checked during each backup and extra backup folder will be deleted
+
 ### Restore
 
 To restore run: 

--- a/server/cli/src/backup/backup.rs
+++ b/server/cli/src/backup/backup.rs
@@ -167,10 +167,14 @@ fn cleanup_backups(
 
     paths.sort();
 
-    for path in paths
-        .iter()
-        .take(paths.len() - *max_number_of_backups as usize)
-    {
+    let max_number_of_backups = *max_number_of_backups as usize;
+    let number_of_backups_to_delete = if paths.len() <= max_number_of_backups {
+        0
+    } else {
+        paths.len() - max_number_of_backups
+    };
+
+    for path in paths.iter().take(number_of_backups_to_delete) {
         println!("Deleting old backup: {:?}", path);
         let _ = fs::remove_dir_all(path);
     }

--- a/server/cli/src/backup/mod.rs
+++ b/server/cli/src/backup/mod.rs
@@ -75,6 +75,7 @@ fn get_dirs_from_settings(settings: &Settings) -> Result<DirSettings, BackupErro
     let Some(BackupSettings {
         backup_dir,
         pg_bin_dir,
+        ..
     }) = settings.backup.clone()
     else {
         return Err(BackupError::BackupConfigurationMissing);

--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -134,7 +134,9 @@ enum Action {
         #[clap(short, long)]
         sub_context: Option<String>,
     },
-    /// Will back up database to a generated folder (the name of which will be returned). Folder will be generated in the backup directory specified by configuration file
+    /// Will back up database to a generated folder (the name of which will be returned).
+    /// Folder will be generated in the backup directory specified by configuration file.
+    /// User can specify max number of backup to keep, see example configuration file
     Backup,
     Restore(RestoreArguments),
 }

--- a/server/configuration/example.yaml
+++ b/server/configuration/example.yaml
@@ -40,4 +40,4 @@
 # backup: # see cli backup/restore
 #   backup_dir: "~/Documents/omSupply_backup"
 #   pg_bin_dir: "/Applications/Postgres.app/Contents/Versions/16/bin"  # Optional
-
+#   max_number_of_backups: 10  # Optional, defaults to unlimited 

--- a/server/service/src/settings.rs
+++ b/server/service/src/settings.rs
@@ -48,6 +48,8 @@ pub struct BackupSettings {
     pub backup_dir: String,
     // Directory containing postgres binaries (in case pg_dump and pg_restore are not in PATH)
     pub pg_bin_dir: Option<String>,
+    // Number of backups to keep
+    pub max_number_of_backups: Option<u32>,
 }
 
 pub fn is_develop() -> bool {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4696

# 👩🏻‍💻 What does this PR do?

Add max_number_of_backups to configuration file and uses it in backup script, please see additions to README.md + cli docs 

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

Do a few backups.
Set max_number_of_backups in configuration file to something low
Do a few more backups and check that only specified number of backups remain (in chronological order)
Make sure to check use case where max_number_of_backups is higher then current number of backups

# 📃 Documentation


