### PR TITLE
Update server-tests.yaml

### DIFF
--- a/.github/workflows/server-tests.yaml
+++ b/.github/workflows/server-tests.yaml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clean
+          args: --manifest-path server/Cargo.toml
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/server-tests.yaml
+++ b/.github/workflows/server-tests.yaml
@@ -28,5 +28,8 @@ jobs:
           workspaces: server
       - uses: actions-rs/cargo@v1
         with:
+          command: clean
+      - uses: actions-rs/cargo@v1
+        with:
           command: test
           args: --features=sqlite --manifest-path server/Cargo.toml

--- a/.github/workflows/server-tests.yaml
+++ b/.github/workflows/server-tests.yaml
@@ -26,10 +26,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: server
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clean
-          args: --manifest-path server/Cargo.toml
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/server/repository/src/db_diesel/item.rs
+++ b/server/repository/src/db_diesel/item.rs
@@ -174,6 +174,7 @@ impl<'a> ItemRepository<'a> {
             .limit(pagination.limit as i64);
 
         // Debug diesel query
+        //
         // println!(
         //    "{}",
         //     diesel::debug_query::<DBType, _>(&final_query).to_string()


### PR DESCRIPTION
Crudely seeing if cargo clean will clear out some space. That said, I'd assume it's a fresh ubuntu runner anyway and would be starting from nothing. So this is a stab in the dark...

Other things to look at:

https://github.com/actions/runner-images/issues/2840
https://github.com/actions/runner-images/issues/2875 (leads to https://github.com/marketplace/actions/free-disk-space-ubuntu)
https://stackoverflow.com/questions/75536771/github-runner-out-of-disk-space-after-building-docker-image
