### PR TITLE
4729 sync out vaccine course data

### DIFF
--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -101,6 +101,10 @@ pub enum ChangelogTableName {
     NameOmsFields,
     RnrForm,
     RnrFormLine,
+    DemographicIndicator,
+    VaccineCourse,
+    VaccineCourseItem,
+    VaccineCourseDose,
 }
 
 pub(crate) enum ChangeLogSyncStyle {
@@ -157,6 +161,10 @@ impl ChangelogTableName {
             ChangelogTableName::NameOmsFields => ChangeLogSyncStyle::Central,
             ChangelogTableName::RnrForm => ChangeLogSyncStyle::Remote,
             ChangelogTableName::RnrFormLine => ChangeLogSyncStyle::Remote,
+            ChangelogTableName::DemographicIndicator => ChangeLogSyncStyle::Central,
+            ChangelogTableName::VaccineCourse => ChangeLogSyncStyle::Central,
+            ChangelogTableName::VaccineCourseItem => ChangeLogSyncStyle::Central,
+            ChangelogTableName::VaccineCourseDose => ChangeLogSyncStyle::Central,
         }
     }
 }

--- a/server/repository/src/db_diesel/vaccine_course/vaccine_course_row.rs
+++ b/server/repository/src/db_diesel/vaccine_course/vaccine_course_row.rs
@@ -3,8 +3,10 @@ use super::vaccine_course_row::vaccine_course::dsl::*;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::RepositoryError;
-use crate::StorageConnection;
+use crate::{
+    ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RepositoryError, RowActionType,
+    StorageConnection, Upsert,
+};
 
 use diesel::prelude::*;
 
@@ -46,14 +48,33 @@ impl<'a> VaccineCourseRowRepository<'a> {
         VaccineCourseRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, vaccine_course_row: &VaccineCourseRow) -> Result<(), RepositoryError> {
+    pub fn upsert_one(
+        &self,
+        vaccine_course_row: &VaccineCourseRow,
+    ) -> Result<i64, RepositoryError> {
         diesel::insert_into(vaccine_course)
             .values(vaccine_course_row)
             .on_conflict(id)
             .do_update()
             .set(vaccine_course_row)
             .execute(self.connection.lock().connection())?;
-        Ok(())
+
+        self.insert_changelog(vaccine_course_row.id.to_owned(), RowActionType::Upsert)
+    }
+
+    fn insert_changelog(
+        &self,
+        row_id: String,
+        action: RowActionType,
+    ) -> Result<i64, RepositoryError> {
+        let row = ChangeLogInsertRow {
+            table_name: ChangelogTableName::VaccineCourse,
+            record_id: row_id,
+            row_action: action,
+            store_id: None,
+            ..Default::default()
+        };
+        ChangelogRepository::new(self.connection).insert(&row)
     }
 
     pub fn find_all(&mut self) -> Result<Vec<VaccineCourseRow>, RepositoryError> {
@@ -77,5 +98,20 @@ impl<'a> VaccineCourseRowRepository<'a> {
             .set(deleted_datetime.eq(Some(chrono::Utc::now().naive_utc())))
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+}
+
+impl Upsert for VaccineCourseRow {
+    fn upsert(&self, con: &StorageConnection) -> Result<Option<i64>, RepositoryError> {
+        let cursor_id = VaccineCourseRowRepository::new(con).upsert_one(self)?;
+        Ok(Some(cursor_id))
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            VaccineCourseRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/migrations/v2_03_00/add_vaccine_course_changelog_table_names.rs
+++ b/server/repository/src/migrations/v2_03_00/add_vaccine_course_changelog_table_names.rs
@@ -7,14 +7,15 @@ impl MigrationFragment for Migrate {
         "add_vaccine_course_changelog_table_names"
     }
 
+    #[cfg(feature = "postgres")]
     fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
         sql!(
             connection,
             r#"
-              ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'demographic_indicator';
-              ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'vaccine_course';
-              ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'vaccine_course_dose';
-              ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'vaccine_course_item';
+                ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'demographic_indicator';
+                ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'vaccine_course';
+                ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'vaccine_course_dose';
+                ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'vaccine_course_item';
             "#
         )?;
 

--- a/server/repository/src/migrations/v2_03_00/add_vaccine_course_changelog_table_names.rs
+++ b/server/repository/src/migrations/v2_03_00/add_vaccine_course_changelog_table_names.rs
@@ -1,0 +1,23 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_vaccine_course_changelog_table_names"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        sql!(
+            connection,
+            r#"
+              ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'demographic_indicator';
+              ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'vaccine_course';
+              ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'vaccine_course_dose';
+              ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'vaccine_course_item';
+            "#
+        )?;
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_03_00/mod.rs
+++ b/server/repository/src/migrations/v2_03_00/mod.rs
@@ -1,6 +1,7 @@
 use super::{version::Version, Migration, MigrationFragment};
 
 use crate::StorageConnection;
+mod add_vaccine_course_changelog_table_names;
 mod drop_program_deleted_datetime;
 mod remove_num_doses_from_vaccine_course;
 mod remove_vaccine_course_dose_dose_number;
@@ -25,6 +26,7 @@ impl Migration for V2_03_00 {
             Box::new(rename_vaccine_course_schedule_to_dose::Migrate),
             Box::new(remove_num_doses_from_vaccine_course::Migrate),
             Box::new(remove_vaccine_course_dose_dose_number::Migrate),
+            Box::new(add_vaccine_course_changelog_table_names::Migrate),
         ]
     }
 }

--- a/server/service/src/sync/test/test_data/demographic_indicator.rs
+++ b/server/service/src/sync/test/test_data/demographic_indicator.rs
@@ -1,0 +1,53 @@
+use repository::demographic_indicator_row::DemographicIndicatorRow;
+use serde_json::json;
+
+use super::{TestSyncIncomingRecord, TestSyncOutgoingRecord};
+
+const TABLE_NAME: &str = "demographic_indicator";
+
+const DEMOGRAPHIC_INDICATOR1: (&str, &str) = (
+    "test_demographic_indicator",
+    r#"{
+        "id":  "test_demographic_indicator",
+        "name": "test demographic".to_string(),
+        "base_year": 0,
+        "base_population": 0,
+        "population_percentage": 0.0,
+        "year_1_projection": 0,
+        "year_2_projection": 0,
+        "year_3_projection": 0,
+        "year_4_projection": 0,
+        "year_5_projection": 0
+    }"#,
+);
+
+fn demographic_indicator1() -> DemographicIndicatorRow {
+    DemographicIndicatorRow {
+        id: DEMOGRAPHIC_INDICATOR1.0.to_string(),
+        name: "test demographic".to_string(),
+        base_year: 0,
+        base_population: 0,
+        population_percentage: 0.0,
+        year_1_projection: 0,
+        year_2_projection: 0,
+        year_3_projection: 0,
+        year_4_projection: 0,
+        year_5_projection: 0,
+    }
+}
+
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_upsert(
+        TABLE_NAME,
+        DEMOGRAPHIC_INDICATOR1,
+        demographic_indicator1(),
+    )]
+}
+
+pub(crate) fn test_v6_records() -> Vec<TestSyncOutgoingRecord> {
+    vec![TestSyncOutgoingRecord {
+        table_name: TABLE_NAME.to_string(),
+        record_id: DEMOGRAPHIC_INDICATOR1.0.to_string(),
+        push_data: json!(demographic_indicator1()),
+    }]
+}

--- a/server/service/src/sync/test/test_data/demographic_indicator.rs
+++ b/server/service/src/sync/test/test_data/demographic_indicator.rs
@@ -9,7 +9,7 @@ const DEMOGRAPHIC_INDICATOR1: (&str, &str) = (
     "test_demographic_indicator",
     r#"{
         "id":  "test_demographic_indicator",
-        "name": "test demographic".to_string(),
+        "name": "test demographic",
         "base_year": 0,
         "base_population": 0,
         "population_percentage": 0.0,

--- a/server/service/src/sync/test/test_data/mod.rs
+++ b/server/service/src/sync/test/test_data/mod.rs
@@ -96,10 +96,6 @@ pub(crate) fn get_all_pull_upsert_central_test_records() -> Vec<TestSyncIncoming
     test_records.append(&mut vaccine_course_dose::test_pull_upsert_records());
     test_records.append(&mut vaccine_course_item::test_pull_upsert_records());
 
-    // should be below???
-    test_records.append(&mut rnr_form::test_pull_upsert_records());
-    test_records.append(&mut rnr_form_line::test_pull_upsert_records());
-
     test_records
 }
 
@@ -123,6 +119,10 @@ pub(crate) fn get_all_pull_upsert_remote_test_records() -> Vec<TestSyncIncomingR
     test_records.append(&mut name_store_join::test_pull_upsert_records());
     test_records.append(&mut special::name_to_name_store_join::test_pull_upsert_records());
     test_records.append(&mut currency::test_pull_upsert_records());
+
+    // Open mSupply central
+    test_records.append(&mut rnr_form::test_pull_upsert_records());
+    test_records.append(&mut rnr_form_line::test_pull_upsert_records());
 
     test_records
 }

--- a/server/service/src/sync/test/test_data/mod.rs
+++ b/server/service/src/sync/test/test_data/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod asset_property;
 pub(crate) mod asset_type;
 pub(crate) mod barcode;
 pub(crate) mod currency;
+pub(crate) mod demographic_indicator;
 pub(crate) mod invoice;
 pub(crate) mod invoice_line;
 pub(crate) mod item;
@@ -51,6 +52,9 @@ pub(crate) mod temperature_log;
 pub(crate) mod unit;
 pub(crate) mod user;
 pub(crate) mod user_permission;
+pub(crate) mod vaccine_course;
+pub(crate) mod vaccine_course_dose;
+pub(crate) mod vaccine_course_item;
 
 pub(crate) fn get_all_pull_upsert_central_test_records() -> Vec<TestSyncIncomingRecord> {
     let mut test_records = Vec::new();
@@ -87,6 +91,12 @@ pub(crate) fn get_all_pull_upsert_central_test_records() -> Vec<TestSyncIncoming
     test_records.append(&mut asset_property::test_pull_upsert_records());
     test_records.append(&mut property::test_pull_upsert_records());
     test_records.append(&mut name_property::test_pull_upsert_records());
+    test_records.append(&mut demographic_indicator::test_pull_upsert_records());
+    test_records.append(&mut vaccine_course::test_pull_upsert_records());
+    test_records.append(&mut vaccine_course_dose::test_pull_upsert_records());
+    test_records.append(&mut vaccine_course_item::test_pull_upsert_records());
+
+    // should be below???
     test_records.append(&mut rnr_form::test_pull_upsert_records());
     test_records.append(&mut rnr_form_line::test_pull_upsert_records());
 
@@ -184,6 +194,10 @@ pub(crate) fn get_all_sync_v6_records() -> Vec<TestSyncOutgoingRecord> {
     test_records.append(&mut name_property::test_v6_central_push_records());
     test_records.append(&mut rnr_form::test_v6_records());
     test_records.append(&mut rnr_form_line::test_v6_records());
+    test_records.append(&mut demographic_indicator::test_v6_records());
+    test_records.append(&mut vaccine_course::test_v6_records());
+    test_records.append(&mut vaccine_course_dose::test_v6_records());
+    test_records.append(&mut vaccine_course_item::test_v6_records());
 
     test_records
 }

--- a/server/service/src/sync/test/test_data/vaccine_course.rs
+++ b/server/service/src/sync/test/test_data/vaccine_course.rs
@@ -1,0 +1,47 @@
+use repository::vaccine_course::vaccine_course_row::VaccineCourseRow;
+use serde_json::json;
+
+use super::{TestSyncIncomingRecord, TestSyncOutgoingRecord};
+
+const TABLE_NAME: &str = "vaccine_course";
+
+const VACCINE_COURSE1: (&str, &str) = (
+    "test_vaccine_course",
+    r#"{
+        "id":  "test_vaccine_course",
+        "name": "test_course",
+        "program_id": "program_test",
+        "coverage_rate": 0.0,
+        "is_active": false,
+        "wastage_rate": 1.0
+    }"#,
+);
+
+fn vaccine_course1() -> VaccineCourseRow {
+    VaccineCourseRow {
+        id: VACCINE_COURSE1.0.to_string(),
+        program_id: "program_test".to_string(),
+        name: "test_course".to_string(),
+        demographic_indicator_id: None,
+        coverage_rate: 0.0,
+        is_active: false,
+        wastage_rate: 1.0,
+        deleted_datetime: None,
+    }
+}
+
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_upsert(
+        TABLE_NAME,
+        VACCINE_COURSE1,
+        vaccine_course1(),
+    )]
+}
+
+pub(crate) fn test_v6_records() -> Vec<TestSyncOutgoingRecord> {
+    vec![TestSyncOutgoingRecord {
+        table_name: TABLE_NAME.to_string(),
+        record_id: VACCINE_COURSE1.0.to_string(),
+        push_data: json!(vaccine_course1()),
+    }]
+}

--- a/server/service/src/sync/test/test_data/vaccine_course_dose.rs
+++ b/server/service/src/sync/test/test_data/vaccine_course_dose.rs
@@ -12,7 +12,7 @@ const VACCINE_COURSE_DOSE1: (&str, &str) = (
         "vaccine_course_id": "test_vaccine_course",
         "label": "test dose label",
         "min_age": 12.0,
-        "min_interval": 20
+        "min_interval_days": 20
     }"#,
 );
 

--- a/server/service/src/sync/test/test_data/vaccine_course_dose.rs
+++ b/server/service/src/sync/test/test_data/vaccine_course_dose.rs
@@ -1,0 +1,43 @@
+use repository::vaccine_course::vaccine_course_dose_row::VaccineCourseDoseRow;
+use serde_json::json;
+
+use super::{TestSyncIncomingRecord, TestSyncOutgoingRecord};
+
+const TABLE_NAME: &str = "vaccine_course_dose";
+
+const VACCINE_COURSE_DOSE1: (&str, &str) = (
+    "test_vaccine_course_dose",
+    r#"{
+        "id":  "test_vaccine_course_dose",
+        "vaccine_course_id": "test_vaccine_course",
+        "label": "test dose label",
+        "min_age": 12.0,
+        "min_interval": 20
+    }"#,
+);
+
+fn vaccine_course_dose1() -> VaccineCourseDoseRow {
+    VaccineCourseDoseRow {
+        id: VACCINE_COURSE_DOSE1.0.to_string(),
+        vaccine_course_id: "test_vaccine_course".to_string(),
+        label: "test dose label".to_string(),
+        min_age: 12.0,
+        min_interval_days: 20,
+    }
+}
+
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_upsert(
+        TABLE_NAME,
+        VACCINE_COURSE_DOSE1,
+        vaccine_course_dose1(),
+    )]
+}
+
+pub(crate) fn test_v6_records() -> Vec<TestSyncOutgoingRecord> {
+    vec![TestSyncOutgoingRecord {
+        table_name: TABLE_NAME.to_string(),
+        record_id: VACCINE_COURSE_DOSE1.0.to_string(),
+        push_data: json!(vaccine_course_dose1()),
+    }]
+}

--- a/server/service/src/sync/test/test_data/vaccine_course_item.rs
+++ b/server/service/src/sync/test/test_data/vaccine_course_item.rs
@@ -10,7 +10,7 @@ const VACCINE_COURSE_ITEM1: (&str, &str) = (
     r#"{
         "id":  "test_vaccine_course_item",
         "vaccine_course_id": "test_vaccine_course",
-        "item_id": "item_a"
+        "item_link_id": "item_a"
     }"#,
 );
 

--- a/server/service/src/sync/test/test_data/vaccine_course_item.rs
+++ b/server/service/src/sync/test/test_data/vaccine_course_item.rs
@@ -1,0 +1,39 @@
+use repository::vaccine_course::vaccine_course_item_row::VaccineCourseItemRow;
+use serde_json::json;
+
+use super::{TestSyncIncomingRecord, TestSyncOutgoingRecord};
+
+const TABLE_NAME: &str = "vaccine_course_item";
+
+const VACCINE_COURSE_ITEM1: (&str, &str) = (
+    "test_vaccine_course_item",
+    r#"{
+        "id":  "test_vaccine_course_item",
+        "vaccine_course_id": "test_vaccine_course",
+        "item_id": "item_a"
+    }"#,
+);
+
+fn vaccine_course_item1() -> VaccineCourseItemRow {
+    VaccineCourseItemRow {
+        id: VACCINE_COURSE_ITEM1.0.to_string(),
+        vaccine_course_id: "test_vaccine_course".to_string(),
+        item_link_id: "item_a".to_string(),
+    }
+}
+
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_upsert(
+        TABLE_NAME,
+        VACCINE_COURSE_ITEM1,
+        vaccine_course_item1(),
+    )]
+}
+
+pub(crate) fn test_v6_records() -> Vec<TestSyncOutgoingRecord> {
+    vec![TestSyncOutgoingRecord {
+        table_name: TABLE_NAME.to_string(),
+        record_id: VACCINE_COURSE_ITEM1.0.to_string(),
+        push_data: json!(vaccine_course_item1()),
+    }]
+}

--- a/server/service/src/sync/translations/demographic_indicator.rs
+++ b/server/service/src/sync/translations/demographic_indicator.rs
@@ -1,0 +1,102 @@
+use repository::{
+    demographic_indicator_row::{DemographicIndicatorRow, DemographicIndicatorRowRepository},
+    ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+};
+
+use super::{
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
+};
+
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(DemographicIndicatorTranslation)
+}
+
+pub(crate) struct DemographicIndicatorTranslation;
+
+impl SyncTranslation for DemographicIndicatorTranslation {
+    fn table_name(&self) -> &'static str {
+        "demographic_indicator"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![]
+    }
+
+    fn try_translate_from_upsert_sync_record(
+        &self,
+        _: &StorageConnection,
+        sync_record: &SyncBufferRow,
+    ) -> Result<PullTranslateResult, anyhow::Error> {
+        Ok(PullTranslateResult::upsert(serde_json::from_str::<
+            DemographicIndicatorRow,
+        >(&sync_record.data)?))
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::DemographicIndicator)
+    }
+
+    fn should_translate_to_sync_record(
+        &self,
+        row: &ChangelogRow,
+        r#type: &ToSyncRecordTranslationType,
+    ) -> bool {
+        match r#type {
+            ToSyncRecordTranslationType::PullFromOmSupplyCentral => {
+                self.change_log_type().as_ref() == Some(&row.table_name)
+            }
+            ToSyncRecordTranslationType::PushToOmSupplyCentral => {
+                self.change_log_type().as_ref() == Some(&row.table_name)
+            }
+            _ => false,
+        }
+    }
+
+    fn try_translate_to_upsert_sync_record(
+        &self,
+        connection: &StorageConnection,
+        changelog: &ChangelogRow,
+    ) -> Result<PushTranslateResult, anyhow::Error> {
+        let row = DemographicIndicatorRowRepository::new(connection)
+            .find_one_by_id(&changelog.record_id)?
+            .ok_or(anyhow::Error::msg(format!(
+                "DemographicIndicator row ({}) not found",
+                changelog.record_id
+            )))?;
+
+        Ok(PushTranslateResult::upsert(
+            changelog,
+            self.table_name(),
+            serde_json::to_value(row)?,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use repository::{mock::MockDataInserts, test_db::setup_all};
+
+    #[actix_rt::test]
+    async fn test_demographic_indicator_translation() {
+        use crate::sync::test::test_data::demographic_indicator as test_data;
+        let translator = DemographicIndicatorTranslation;
+
+        let (_, connection, _, _) = setup_all(
+            "test_demographic_indicator_translation",
+            MockDataInserts::none(),
+        )
+        .await;
+
+        for record in test_data::test_pull_upsert_records() {
+            assert!(translator.should_translate_from_sync_record(&record.sync_buffer_row));
+            let translation_result = translator
+                .try_translate_from_upsert_sync_record(&connection, &record.sync_buffer_row)
+                .unwrap();
+
+            assert_eq!(translation_result, record.translated_record);
+        }
+    }
+}

--- a/server/service/src/sync/translations/demographic_indicator.rs
+++ b/server/service/src/sync/translations/demographic_indicator.rs
@@ -47,9 +47,6 @@ impl SyncTranslation for DemographicIndicatorTranslation {
             ToSyncRecordTranslationType::PullFromOmSupplyCentral => {
                 self.change_log_type().as_ref() == Some(&row.table_name)
             }
-            ToSyncRecordTranslationType::PushToOmSupplyCentral => {
-                self.change_log_type().as_ref() == Some(&row.table_name)
-            }
             _ => false,
         }
     }

--- a/server/service/src/sync/translations/mod.rs
+++ b/server/service/src/sync/translations/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod barcode;
 pub(crate) mod clinician;
 pub(crate) mod clinician_store_join;
 pub(crate) mod currency;
+pub(crate) mod demographic_indicator;
 pub(crate) mod document;
 pub(crate) mod document_registry;
 pub(crate) mod form_schema;
@@ -53,6 +54,9 @@ pub(crate) mod unit;
 pub(crate) mod user;
 pub(crate) mod user_permission;
 pub(crate) mod utils;
+pub(crate) mod vaccine_course;
+pub(crate) mod vaccine_course_dose;
+pub(crate) mod vaccine_course_item;
 
 use repository::*;
 use thiserror::Error;
@@ -129,6 +133,11 @@ pub(crate) fn all_translators() -> SyncTranslators {
         // RnR Form
         rnr_form::boxed(),
         rnr_form_line::boxed(),
+        // Vaccine course
+        vaccine_course::boxed(),
+        vaccine_course_dose::boxed(),
+        vaccine_course_item::boxed(),
+        demographic_indicator::boxed(),
     ]
 }
 

--- a/server/service/src/sync/translations/vaccine_course.rs
+++ b/server/service/src/sync/translations/vaccine_course.rs
@@ -1,0 +1,108 @@
+use repository::{
+    vaccine_course::vaccine_course_row::{VaccineCourseRow, VaccineCourseRowRepository},
+    ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+};
+
+use crate::sync::translations::{
+    demographic_indicator::DemographicIndicatorTranslation, master_list::MasterListTranslation,
+    program_requisition_settings::ProgramRequisitionSettingsTranslation,
+};
+
+use super::{
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
+};
+
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(VaccineCourseTranslation)
+}
+
+pub(crate) struct VaccineCourseTranslation;
+
+impl SyncTranslation for VaccineCourseTranslation {
+    fn table_name(&self) -> &'static str {
+        "vaccine_course"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![
+            MasterListTranslation.table_name(),
+            ProgramRequisitionSettingsTranslation.table_name(),
+            DemographicIndicatorTranslation.table_name(),
+        ]
+    }
+
+    fn try_translate_from_upsert_sync_record(
+        &self,
+        _: &StorageConnection,
+        sync_record: &SyncBufferRow,
+    ) -> Result<PullTranslateResult, anyhow::Error> {
+        Ok(PullTranslateResult::upsert(serde_json::from_str::<
+            VaccineCourseRow,
+        >(&sync_record.data)?))
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::VaccineCourse)
+    }
+
+    fn should_translate_to_sync_record(
+        &self,
+        row: &ChangelogRow,
+        r#type: &ToSyncRecordTranslationType,
+    ) -> bool {
+        match r#type {
+            ToSyncRecordTranslationType::PullFromOmSupplyCentral => {
+                self.change_log_type().as_ref() == Some(&row.table_name)
+            }
+            ToSyncRecordTranslationType::PushToOmSupplyCentral => {
+                self.change_log_type().as_ref() == Some(&row.table_name)
+            }
+            _ => false,
+        }
+    }
+
+    fn try_translate_to_upsert_sync_record(
+        &self,
+        connection: &StorageConnection,
+        changelog: &ChangelogRow,
+    ) -> Result<PushTranslateResult, anyhow::Error> {
+        let row = VaccineCourseRowRepository::new(connection)
+            .find_one_by_id(&changelog.record_id)?
+            .ok_or(anyhow::Error::msg(format!(
+                "VaccineCourse row ({}) not found",
+                changelog.record_id
+            )))?;
+
+        Ok(PushTranslateResult::upsert(
+            changelog,
+            self.table_name(),
+            serde_json::to_value(row)?,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use repository::{mock::MockDataInserts, test_db::setup_all};
+
+    #[actix_rt::test]
+    async fn test_vaccine_course_translation() {
+        use crate::sync::test::test_data::vaccine_course as test_data;
+        let translator = VaccineCourseTranslation;
+
+        let (_, connection, _, _) =
+            setup_all("test_vaccine_course_translation", MockDataInserts::none()).await;
+
+        for record in test_data::test_pull_upsert_records() {
+            assert!(translator.should_translate_from_sync_record(&record.sync_buffer_row));
+            let translation_result = translator
+                .try_translate_from_upsert_sync_record(&connection, &record.sync_buffer_row)
+                .unwrap();
+
+            assert_eq!(translation_result, record.translated_record);
+        }
+    }
+}

--- a/server/service/src/sync/translations/vaccine_course.rs
+++ b/server/service/src/sync/translations/vaccine_course.rs
@@ -56,9 +56,6 @@ impl SyncTranslation for VaccineCourseTranslation {
             ToSyncRecordTranslationType::PullFromOmSupplyCentral => {
                 self.change_log_type().as_ref() == Some(&row.table_name)
             }
-            ToSyncRecordTranslationType::PushToOmSupplyCentral => {
-                self.change_log_type().as_ref() == Some(&row.table_name)
-            }
             _ => false,
         }
     }

--- a/server/service/src/sync/translations/vaccine_course_dose.rs
+++ b/server/service/src/sync/translations/vaccine_course_dose.rs
@@ -1,0 +1,106 @@
+use repository::{
+    vaccine_course::vaccine_course_dose_row::{
+        VaccineCourseDoseRow, VaccineCourseDoseRowRepository,
+    },
+    ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+};
+
+use crate::sync::translations::vaccine_course::VaccineCourseTranslation;
+
+use super::{
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
+};
+
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(VaccineCourseDoseTranslation)
+}
+
+pub(crate) struct VaccineCourseDoseTranslation;
+
+impl SyncTranslation for VaccineCourseDoseTranslation {
+    fn table_name(&self) -> &'static str {
+        "vaccine_course_dose"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![VaccineCourseTranslation.table_name()]
+    }
+
+    fn try_translate_from_upsert_sync_record(
+        &self,
+        _: &StorageConnection,
+        sync_record: &SyncBufferRow,
+    ) -> Result<PullTranslateResult, anyhow::Error> {
+        Ok(PullTranslateResult::upsert(serde_json::from_str::<
+            VaccineCourseDoseRow,
+        >(&sync_record.data)?))
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::VaccineCourseDose)
+    }
+
+    fn should_translate_to_sync_record(
+        &self,
+        row: &ChangelogRow,
+        r#type: &ToSyncRecordTranslationType,
+    ) -> bool {
+        match r#type {
+            ToSyncRecordTranslationType::PullFromOmSupplyCentral => {
+                self.change_log_type().as_ref() == Some(&row.table_name)
+            }
+            ToSyncRecordTranslationType::PushToOmSupplyCentral => {
+                self.change_log_type().as_ref() == Some(&row.table_name)
+            }
+            _ => false,
+        }
+    }
+
+    fn try_translate_to_upsert_sync_record(
+        &self,
+        connection: &StorageConnection,
+        changelog: &ChangelogRow,
+    ) -> Result<PushTranslateResult, anyhow::Error> {
+        let row = VaccineCourseDoseRowRepository::new(connection)
+            .find_one_by_id(&changelog.record_id)?
+            .ok_or(anyhow::Error::msg(format!(
+                "VaccineCourseDose row ({}) not found",
+                changelog.record_id
+            )))?;
+
+        Ok(PushTranslateResult::upsert(
+            changelog,
+            self.table_name(),
+            serde_json::to_value(row)?,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use repository::{mock::MockDataInserts, test_db::setup_all};
+
+    #[actix_rt::test]
+    async fn test_vaccine_course_dose_translation() {
+        use crate::sync::test::test_data::vaccine_course_dose as test_data;
+        let translator = VaccineCourseDoseTranslation;
+
+        let (_, connection, _, _) = setup_all(
+            "test_vaccine_course_dose_translation",
+            MockDataInserts::none(),
+        )
+        .await;
+
+        for record in test_data::test_pull_upsert_records() {
+            assert!(translator.should_translate_from_sync_record(&record.sync_buffer_row));
+            let translation_result = translator
+                .try_translate_from_upsert_sync_record(&connection, &record.sync_buffer_row)
+                .unwrap();
+
+            assert_eq!(translation_result, record.translated_record);
+        }
+    }
+}

--- a/server/service/src/sync/translations/vaccine_course_dose.rs
+++ b/server/service/src/sync/translations/vaccine_course_dose.rs
@@ -51,9 +51,6 @@ impl SyncTranslation for VaccineCourseDoseTranslation {
             ToSyncRecordTranslationType::PullFromOmSupplyCentral => {
                 self.change_log_type().as_ref() == Some(&row.table_name)
             }
-            ToSyncRecordTranslationType::PushToOmSupplyCentral => {
-                self.change_log_type().as_ref() == Some(&row.table_name)
-            }
             _ => false,
         }
     }

--- a/server/service/src/sync/translations/vaccine_course_item.rs
+++ b/server/service/src/sync/translations/vaccine_course_item.rs
@@ -1,0 +1,109 @@
+use repository::{
+    vaccine_course::vaccine_course_item_row::{
+        VaccineCourseItemRow, VaccineCourseItemRowRepository,
+    },
+    ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+};
+
+use crate::sync::translations::{item::ItemTranslation, vaccine_course::VaccineCourseTranslation};
+
+use super::{
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
+};
+
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(VaccineCourseItemTranslation)
+}
+
+pub(crate) struct VaccineCourseItemTranslation;
+
+impl SyncTranslation for VaccineCourseItemTranslation {
+    fn table_name(&self) -> &'static str {
+        "vaccine_course_item"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![
+            VaccineCourseTranslation.table_name(),
+            ItemTranslation.table_name(),
+        ]
+    }
+
+    fn try_translate_from_upsert_sync_record(
+        &self,
+        _: &StorageConnection,
+        sync_record: &SyncBufferRow,
+    ) -> Result<PullTranslateResult, anyhow::Error> {
+        Ok(PullTranslateResult::upsert(serde_json::from_str::<
+            VaccineCourseItemRow,
+        >(&sync_record.data)?))
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::VaccineCourseItem)
+    }
+
+    fn should_translate_to_sync_record(
+        &self,
+        row: &ChangelogRow,
+        r#type: &ToSyncRecordTranslationType,
+    ) -> bool {
+        match r#type {
+            ToSyncRecordTranslationType::PullFromOmSupplyCentral => {
+                self.change_log_type().as_ref() == Some(&row.table_name)
+            }
+            ToSyncRecordTranslationType::PushToOmSupplyCentral => {
+                self.change_log_type().as_ref() == Some(&row.table_name)
+            }
+            _ => false,
+        }
+    }
+
+    fn try_translate_to_upsert_sync_record(
+        &self,
+        connection: &StorageConnection,
+        changelog: &ChangelogRow,
+    ) -> Result<PushTranslateResult, anyhow::Error> {
+        let row = VaccineCourseItemRowRepository::new(connection)
+            .find_one_by_id(&changelog.record_id)?
+            .ok_or(anyhow::Error::msg(format!(
+                "VaccineCourseItem row ({}) not found",
+                changelog.record_id
+            )))?;
+
+        Ok(PushTranslateResult::upsert(
+            changelog,
+            self.table_name(),
+            serde_json::to_value(row)?,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use repository::{mock::MockDataInserts, test_db::setup_all};
+
+    #[actix_rt::test]
+    async fn test_vaccine_course_item_translation() {
+        use crate::sync::test::test_data::vaccine_course_item as test_data;
+        let translator = VaccineCourseItemTranslation;
+
+        let (_, connection, _, _) = setup_all(
+            "test_vaccine_course_item_translation",
+            MockDataInserts::none(),
+        )
+        .await;
+
+        for record in test_data::test_pull_upsert_records() {
+            assert!(translator.should_translate_from_sync_record(&record.sync_buffer_row));
+            let translation_result = translator
+                .try_translate_from_upsert_sync_record(&connection, &record.sync_buffer_row)
+                .unwrap();
+
+            assert_eq!(translation_result, record.translated_record);
+        }
+    }
+}

--- a/server/service/src/sync/translations/vaccine_course_item.rs
+++ b/server/service/src/sync/translations/vaccine_course_item.rs
@@ -54,9 +54,6 @@ impl SyncTranslation for VaccineCourseItemTranslation {
             ToSyncRecordTranslationType::PullFromOmSupplyCentral => {
                 self.change_log_type().as_ref() == Some(&row.table_name)
             }
-            ToSyncRecordTranslationType::PushToOmSupplyCentral => {
-                self.change_log_type().as_ref() == Some(&row.table_name)
-            }
             _ => false,
         }
     }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4729

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Adds vaccine course data to v6 sync so it is accessible for remote sites

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Configure some items as vaccine items (mSupply)
- [ ] Create at new demographic indicator (Central OMS, manage > demographics (you'll need the OMS manage central data permission))
- [ ] Create a new vaccine course on central server
- [ ] Add some vaccine items to it
- [ ] Add your demographic indicator to it
- [ ] Add some doses, save
- [ ] Sync remote site
- [ ] Vaccine course/dose/item and demographic indicator tables are populated accordingly

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole

