### PR TITLE
Add is_default_price_list and discount to master list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "2.2.01",
+  "version": "2.2.02",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/graphql/general/src/queries/tests/master_lists.rs
+++ b/server/graphql/general/src/queries/tests/master_lists.rs
@@ -83,6 +83,8 @@ mod graphql {
                     code: "test_code".to_owned(),
                     description: "test_description".to_owned(),
                     is_active: true,
+                    is_default_price_list: false,
+                    discount: None,
                 }],
                 count: 1,
             })

--- a/server/repository/src/db_diesel/item.rs
+++ b/server/repository/src/db_diesel/item.rs
@@ -548,6 +548,7 @@ mod tests {
                 code: "".to_string(),
                 description: "".to_string(),
                 is_active: true,
+                ..Default::default()
             },
             MasterListRow {
                 id: "master_list2".to_string(),
@@ -555,6 +556,7 @@ mod tests {
                 code: "".to_string(),
                 description: "".to_string(),
                 is_active: true,
+                ..Default::default()
             },
         ];
 

--- a/server/repository/src/db_diesel/master_list_row.rs
+++ b/server/repository/src/db_diesel/master_list_row.rs
@@ -14,10 +14,12 @@ table! {
         code -> Text,
         description -> Text,
         is_active -> Bool,
+        is_default_price_list -> Bool,
+        discount -> Nullable<Double>,
     }
 }
 
-#[derive(Clone, Insertable, Queryable, Debug, PartialEq, Eq, AsChangeset, Default)]
+#[derive(Clone, Insertable, Queryable, Debug, PartialEq, AsChangeset, Default)]
 #[diesel(table_name = master_list)]
 pub struct MasterListRow {
     pub id: String,
@@ -25,6 +27,8 @@ pub struct MasterListRow {
     pub code: String,
     pub description: String,
     pub is_active: bool,
+    pub is_default_price_list: bool,
+    pub discount: Option<f64>,
 }
 
 allow_tables_to_appear_in_same_query!(master_list, item_link);

--- a/server/repository/src/migrations/mod.rs
+++ b/server/repository/src/migrations/mod.rs
@@ -22,6 +22,7 @@ mod v2_00_00;
 mod v2_01_00;
 mod v2_02_00;
 mod v2_02_01;
+mod v2_02_02;
 mod v2_03_00;
 mod version;
 mod views;
@@ -117,6 +118,7 @@ pub fn migrate(
         Box::new(v2_01_00::V2_01_00),
         Box::new(v2_02_00::V2_02_00),
         Box::new(v2_02_01::V2_02_01),
+        Box::new(v2_02_02::V2_02_02),
         // Box::new(v2_03_00::V2_03_00),
     ];
 

--- a/server/repository/src/migrations/v2_02_02/master_list.rs
+++ b/server/repository/src/migrations/v2_02_02/master_list.rs
@@ -1,0 +1,24 @@
+use crate::migrations::DOUBLE;
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "master_list_default_price_list"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        sql!(
+            connection,
+            r#"
+            ALTER TABLE master_list
+            ADD COLUMN is_default_price_list BOOLEAN DEFAULT FALSE;
+            ALTER TABLE master_list
+            ADD COLUMN discount {DOUBLE};
+            "#
+        )?;
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_02_02/master_list.rs
+++ b/server/repository/src/migrations/v2_02_02/master_list.rs
@@ -23,7 +23,7 @@ impl MigrationFragment for Migrate {
         sql!(
             connection,
             r#"
-            UPDATE sync_buffer SET integration_datetime = NULL WHERE table_name = 'master_list';
+            UPDATE sync_buffer SET integration_datetime = NULL WHERE table_name = 'list_master';
         "#,
         )?;
 

--- a/server/repository/src/migrations/v2_02_02/master_list.rs
+++ b/server/repository/src/migrations/v2_02_02/master_list.rs
@@ -19,6 +19,14 @@ impl MigrationFragment for Migrate {
             "#
         )?;
 
+        // Retranslate all master lists on the next, in case they already had the new fields added before upgrade happens here.
+        sql!(
+            connection,
+            r#"
+            UPDATE sync_buffer SET integration_datetime = NULL WHERE table_name = 'master_list';
+        "#,
+        )?;
+
         Ok(())
     }
 }

--- a/server/repository/src/migrations/v2_02_02/master_list.rs
+++ b/server/repository/src/migrations/v2_02_02/master_list.rs
@@ -19,7 +19,7 @@ impl MigrationFragment for Migrate {
             "#
         )?;
 
-        // Retranslate all master lists on the next, in case they already had the new fields added before upgrade happens here.
+        // Retranslate all master lists on the next sync, in case they already had the new fields added before upgrade happens here.
         sql!(
             connection,
             r#"

--- a/server/repository/src/migrations/v2_02_02/mod.rs
+++ b/server/repository/src/migrations/v2_02_02/mod.rs
@@ -1,7 +1,6 @@
 use super::{version::Version, Migration, MigrationFragment};
 
 use crate::StorageConnection;
-use diesel::prelude::*;
 
 mod master_list;
 
@@ -24,12 +23,12 @@ impl Migration for V2_02_02 {
 #[cfg(test)]
 #[actix_rt::test]
 async fn migration_2_02_02() {
-    use v2_02_00::V2_02_00;
+    use v2_02_01::V2_02_01;
 
     use crate::migrations::*;
     use crate::test_db::*;
 
-    let previous_version = V2_02_00.version();
+    let previous_version = V2_02_01.version();
     let version = V2_02_02.version();
 
     let SetupResult { connection, .. } = setup_test(SetupOption {
@@ -39,93 +38,7 @@ async fn migration_2_02_02() {
     })
     .await;
 
-    add_rnr_form_changelogs_no_store_id(&connection).unwrap();
-
-    assert_eq!(check_changelogs_have_store_id(&connection), false);
-
     // Run this migration
     migrate(&connection, Some(version.clone())).unwrap();
     assert_eq!(get_database_version(&connection), version);
-
-    assert_eq!(check_changelogs_have_store_id(&connection), true);
-}
-
-// Temp table definition for testing for changelog schema at this point in time
-table! {
-    changelog (cursor) {
-        cursor -> BigInt,
-        record_id -> Text,
-        store_id -> Nullable<Text>,
-    }
-}
-
-#[cfg(test)]
-fn check_changelogs_have_store_id(connection: &StorageConnection) -> bool {
-    use changelog::dsl as changelog_dsl;
-
-    let changelog_store_ids: Vec<Option<String>> = changelog_dsl::changelog
-        .select(changelog::store_id)
-        .filter(changelog::record_id.eq_any(vec!["TEST_RNR_FORM_ID", "TEST_RNR_FORM_LINE_ID"]))
-        .load::<Option<String>>(connection.lock().connection())
-        .unwrap();
-
-    changelog_store_ids
-        .iter()
-        .all(|store_id| store_id.clone().unwrap_or("".to_string()) == "store1")
-}
-
-#[cfg(test)]
-fn add_rnr_form_changelogs_no_store_id(connection: &StorageConnection) -> anyhow::Result<()> {
-    use super::sql;
-    // Setup test data
-    sql!(
-        connection,
-        r#"
-        INSERT INTO item  (id, name, code, default_pack_size, type, legacy_record) VALUES  ('item1', 'item1name', 'item1code', 1, 'STOCK', '');
-        INSERT INTO item_link  (id, item_id) VALUES  ('item1', 'item1');
-
-        INSERT INTO name (id, name, code, is_customer, is_supplier, type, is_sync_update) VALUES ('name1', 'name1name', 'name1code', TRUE, FALSE, 'STORE', TRUE);
-        INSERT INTO name_link (id, name_id) VALUES ('name1', 'name1');
-
-        INSERT INTO store (id, name_link_id, code, site_id, store_mode) VALUES ('store1', 'name1', 'store1code', 1, 'STORE');
-
-        INSERT INTO period_schedule (id, name) VALUES ('schedule1', 'schedule1');
-        INSERT INTO period (id, period_schedule_id, name, start_date, end_date) VALUES ('period1', 'schedule1', 'period1', '2024-08-01', '2024-08-31');
-        "#
-    )
-    .unwrap();
-
-    // Insert rnr_form and an rnr_form_line
-    sql!(
-        connection,
-        r#"
-        INSERT INTO rnr_form 
-            ("id", "store_id", "name_link_id", "period_id", "program_id", "status", "created_datetime") 
-        VALUES
-            ('TEST_RNR_FORM_ID', 'store1', 'name1', 'period1', 'missing_program', 'DRAFT', '2024-08-27 23:34:55.380381');
-        "#,
-    )?;
-    sql!(
-        connection,
-        r#"
-        INSERT INTO rnr_form_line
-            ("id", "rnr_form_id", "item_link_id", "average_monthly_consumption", "previous_monthly_consumption_values", "initial_balance", "snapshot_quantity_received", "snapshot_quantity_consumed", "snapshot_adjustments", "adjusted_quantity_consumed", "stock_out_duration", "final_balance", "maximum_quantity", "calculated_requested_quantity") 
-        VALUES
-            ('TEST_RNR_FORM_LINE_ID', 'TEST_RNR_FORM_ID', 'item1', 0.0, '', 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0.0, 0.0, 0.0);
-        "#,
-    )?;
-
-    // Create changelog records for form and line - missing store_id
-    sql!(
-        connection,
-        r#"
-        INSERT INTO changelog
-            ("table_name", "record_id", "row_action", "store_id")
-        VALUES
-            ('rnr_form', 'TEST_RNR_FORM_ID', 'UPSERT', NULL),
-            ('rnr_form_line', 'TEST_RNR_FORM_LINE_ID', 'UPSERT', NULL);
-        "#,
-    )?;
-
-    Ok(())
 }

--- a/server/repository/src/migrations/v2_02_02/mod.rs
+++ b/server/repository/src/migrations/v2_02_02/mod.rs
@@ -1,0 +1,131 @@
+use super::{version::Version, Migration, MigrationFragment};
+
+use crate::StorageConnection;
+use diesel::prelude::*;
+
+mod master_list;
+
+pub(crate) struct V2_02_02;
+
+impl Migration for V2_02_02 {
+    fn version(&self) -> Version {
+        Version::from_str("2.2.2")
+    }
+
+    fn migrate(&self, _connection: &StorageConnection) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn migrate_fragments(&self) -> Vec<Box<dyn MigrationFragment>> {
+        vec![Box::new(master_list::Migrate)]
+    }
+}
+
+#[cfg(test)]
+#[actix_rt::test]
+async fn migration_2_02_02() {
+    use v2_02_00::V2_02_00;
+
+    use crate::migrations::*;
+    use crate::test_db::*;
+
+    let previous_version = V2_02_00.version();
+    let version = V2_02_02.version();
+
+    let SetupResult { connection, .. } = setup_test(SetupOption {
+        db_name: &format!("migration_{version}"),
+        version: Some(previous_version.clone()),
+        ..Default::default()
+    })
+    .await;
+
+    add_rnr_form_changelogs_no_store_id(&connection).unwrap();
+
+    assert_eq!(check_changelogs_have_store_id(&connection), false);
+
+    // Run this migration
+    migrate(&connection, Some(version.clone())).unwrap();
+    assert_eq!(get_database_version(&connection), version);
+
+    assert_eq!(check_changelogs_have_store_id(&connection), true);
+}
+
+// Temp table definition for testing for changelog schema at this point in time
+table! {
+    changelog (cursor) {
+        cursor -> BigInt,
+        record_id -> Text,
+        store_id -> Nullable<Text>,
+    }
+}
+
+#[cfg(test)]
+fn check_changelogs_have_store_id(connection: &StorageConnection) -> bool {
+    use changelog::dsl as changelog_dsl;
+
+    let changelog_store_ids: Vec<Option<String>> = changelog_dsl::changelog
+        .select(changelog::store_id)
+        .filter(changelog::record_id.eq_any(vec!["TEST_RNR_FORM_ID", "TEST_RNR_FORM_LINE_ID"]))
+        .load::<Option<String>>(connection.lock().connection())
+        .unwrap();
+
+    changelog_store_ids
+        .iter()
+        .all(|store_id| store_id.clone().unwrap_or("".to_string()) == "store1")
+}
+
+#[cfg(test)]
+fn add_rnr_form_changelogs_no_store_id(connection: &StorageConnection) -> anyhow::Result<()> {
+    use super::sql;
+    // Setup test data
+    sql!(
+        connection,
+        r#"
+        INSERT INTO item  (id, name, code, default_pack_size, type, legacy_record) VALUES  ('item1', 'item1name', 'item1code', 1, 'STOCK', '');
+        INSERT INTO item_link  (id, item_id) VALUES  ('item1', 'item1');
+
+        INSERT INTO name (id, name, code, is_customer, is_supplier, type, is_sync_update) VALUES ('name1', 'name1name', 'name1code', TRUE, FALSE, 'STORE', TRUE);
+        INSERT INTO name_link (id, name_id) VALUES ('name1', 'name1');
+
+        INSERT INTO store (id, name_link_id, code, site_id, store_mode) VALUES ('store1', 'name1', 'store1code', 1, 'STORE');
+
+        INSERT INTO period_schedule (id, name) VALUES ('schedule1', 'schedule1');
+        INSERT INTO period (id, period_schedule_id, name, start_date, end_date) VALUES ('period1', 'schedule1', 'period1', '2024-08-01', '2024-08-31');
+        "#
+    )
+    .unwrap();
+
+    // Insert rnr_form and an rnr_form_line
+    sql!(
+        connection,
+        r#"
+        INSERT INTO rnr_form 
+            ("id", "store_id", "name_link_id", "period_id", "program_id", "status", "created_datetime") 
+        VALUES
+            ('TEST_RNR_FORM_ID', 'store1', 'name1', 'period1', 'missing_program', 'DRAFT', '2024-08-27 23:34:55.380381');
+        "#,
+    )?;
+    sql!(
+        connection,
+        r#"
+        INSERT INTO rnr_form_line
+            ("id", "rnr_form_id", "item_link_id", "average_monthly_consumption", "previous_monthly_consumption_values", "initial_balance", "snapshot_quantity_received", "snapshot_quantity_consumed", "snapshot_adjustments", "adjusted_quantity_consumed", "stock_out_duration", "final_balance", "maximum_quantity", "calculated_requested_quantity") 
+        VALUES
+            ('TEST_RNR_FORM_LINE_ID', 'TEST_RNR_FORM_ID', 'item1', 0.0, '', 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0.0, 0.0, 0.0);
+        "#,
+    )?;
+
+    // Create changelog records for form and line - missing store_id
+    sql!(
+        connection,
+        r#"
+        INSERT INTO changelog
+            ("table_name", "record_id", "row_action", "store_id")
+        VALUES
+            ('rnr_form', 'TEST_RNR_FORM_ID', 'UPSERT', NULL),
+            ('rnr_form_line', 'TEST_RNR_FORM_LINE_ID', 'UPSERT', NULL);
+        "#,
+    )?;
+
+    Ok(())
+}

--- a/server/repository/src/migrations/v2_03_00/mod.rs
+++ b/server/repository/src/migrations/v2_03_00/mod.rs
@@ -17,12 +17,12 @@ impl Migration for V2_03_00 {
 #[cfg(test)]
 #[actix_rt::test]
 async fn migration_2_03_00() {
-    use v2_02_01::V2_02_01;
+    use v2_02_02::V2_02_02;
 
     use crate::migrations::*;
     use crate::test_db::*;
 
-    let previous_version = V2_02_01.version();
+    let previous_version = V2_02_02.version();
     let version = V2_03_00.version();
 
     let SetupResult { connection, .. } = setup_test(SetupOption {

--- a/server/repository/src/mock/full_master_list.rs
+++ b/server/repository/src/mock/full_master_list.rs
@@ -21,6 +21,7 @@ pub fn mock_master_list_item_query_test1() -> FullMockMasterList {
             code: "code_item_query_test1".to_owned(),
             description: "description_item_query_test1".to_owned(),
             is_active: true,
+            ..Default::default()
         },
         joins: vec![MasterListNameJoinRow {
             id: "item_query_test1".to_owned(),
@@ -43,6 +44,7 @@ pub fn mock_master_list_master_list_filter_test() -> FullMockMasterList {
             code: "code_master_list_filter_test".to_owned(),
             description: "description_master_list_filter_test".to_owned(),
             is_active: true,
+            ..Default::default()
         },
         joins: vec![MasterListNameJoinRow {
             id: "master_list_filter_test".to_owned(),
@@ -61,6 +63,7 @@ pub fn mock_master_list_program() -> FullMockMasterList {
             code: "master_list_program_code".to_owned(),
             description: "master_list_program_description".to_owned(),
             is_active: true,
+            ..Default::default()
         },
         joins: vec![
             MasterListNameJoinRow {
@@ -90,6 +93,7 @@ pub fn mock_master_list_program_b() -> FullMockMasterList {
             code: "master_list_program_b_code".to_owned(),
             description: "master_list_program_b_description".to_owned(),
             is_active: true,
+            ..Default::default()
         },
         joins: vec![
             MasterListNameJoinRow {
@@ -119,6 +123,7 @@ pub fn mock_master_list_master_list_line_filter_test() -> FullMockMasterList {
             code: "code_master_list_master_list_line_filter_test".to_owned(),
             description: "description_master_list_master_list_line_filter_test".to_owned(),
             is_active: true,
+            ..Default::default()
         },
         joins: Vec::new(),
         lines: vec![

--- a/server/repository/src/mock/test_master_list_repository.rs
+++ b/server/repository/src/mock/test_master_list_repository.rs
@@ -76,6 +76,7 @@ pub fn mock_test_master_list_name_filter1() -> FullMockMasterList {
             code: id.clone(),
             description: id.clone(),
             is_active: true,
+            ..Default::default()
         },
         joins: vec![
             MasterListNameJoinRow {
@@ -106,6 +107,7 @@ pub fn mock_test_master_list_name_filter2() -> FullMockMasterList {
             code: id.clone(),
             description: id.clone(),
             is_active: true,
+            ..Default::default()
         },
         joins: vec![
             MasterListNameJoinRow {
@@ -136,6 +138,7 @@ pub fn mock_test_master_list_name_filter3() -> FullMockMasterList {
             code: id.clone(),
             description: id.clone(),
             is_active: true,
+            ..Default::default()
         },
         joins: vec![
             MasterListNameJoinRow {

--- a/server/repository/src/mock/test_requisition_service.rs
+++ b/server/repository/src/mock/test_requisition_service.rs
@@ -300,6 +300,7 @@ pub fn mock_test_not_store_a_master_list() -> FullMockMasterList {
             code: id.clone(),
             description: id.clone(),
             is_active: true,
+            ..Default::default()
         },
         joins: vec![],
         lines: vec![],

--- a/server/repository/src/tests.rs
+++ b/server/repository/src/tests.rs
@@ -76,6 +76,7 @@ mod repository_test {
                 code: "ML Code 1".to_string(),
                 description: "ML Description 1".to_string(),
                 is_active: true,
+                ..Default::default()
             }
         }
 
@@ -86,6 +87,7 @@ mod repository_test {
                 code: "ML Code 1".to_string(),
                 description: "ML Description 1".to_string(),
                 is_active: true,
+                ..Default::default()
             }
         }
 

--- a/server/service/src/dashboard/item_count.rs
+++ b/server/service/src/dashboard/item_count.rs
@@ -134,6 +134,7 @@ mod item_count_service_test {
                         code: String::new(),
                         description: String::new(),
                         is_active: true,
+                        ..Default::default()
                     },
                     joins: vec![MasterListNameJoinRow {
                         id: "join1".to_string(),
@@ -215,6 +216,7 @@ mod item_count_service_test {
                         code: String::new(),
                         description: String::new(),
                         is_active: true,
+                        ..Default::default()
                     },
                     joins: vec![MasterListNameJoinRow {
                         id: "join1".to_string(),
@@ -363,6 +365,7 @@ mod item_count_service_test {
                         code: String::new(),
                         description: String::new(),
                         is_active: true,
+                        ..Default::default()
                     },
                     joins: vec![MasterListNameJoinRow {
                         id: "join1".to_string(),

--- a/server/service/src/invoice/inbound_shipment/add_from_master_list.rs
+++ b/server/service/src/invoice/inbound_shipment/add_from_master_list.rs
@@ -217,6 +217,7 @@ mod test {
                     code: id.clone(),
                     description: id.clone(),
                     is_active: true,
+                    ..Default::default()
                 },
                 joins: vec![MasterListNameJoinRow {
                     id: join1,

--- a/server/service/src/invoice/outbound_shipment/add_from_master_list.rs
+++ b/server/service/src/invoice/outbound_shipment/add_from_master_list.rs
@@ -228,6 +228,7 @@ mod test {
                     code: id.clone(),
                     description: id.clone(),
                     is_active: true,
+                    ..Default::default()
                 },
                 joins: vec![MasterListNameJoinRow {
                     id: join1,

--- a/server/service/src/requisition/request_requisition/add_from_master_list.rs
+++ b/server/service/src/requisition/request_requisition/add_from_master_list.rs
@@ -257,6 +257,7 @@ mod test {
                     code: id.clone(),
                     description: id.clone(),
                     is_active: true,
+                    ..Default::default()
                 },
                 joins: vec![MasterListNameJoinRow {
                     id: join1,

--- a/server/service/src/stock_line/tests/query.rs
+++ b/server/service/src/stock_line/tests/query.rs
@@ -22,14 +22,14 @@ mod query {
             service.get_stock_lines(
                 &context,
                 Some(PaginationOption {
-                    limit: Some(2000),
+                    limit: Some(6000),
                     offset: None
                 }),
                 None,
                 None,
                 None,
             ),
-            Err(ListError::LimitAboveMax(1000))
+            Err(ListError::LimitAboveMax(5000))
         );
 
         assert_eq!(

--- a/server/service/src/sync/test/test_data/master_list.rs
+++ b/server/service/src/sync/test/test_data/master_list.rs
@@ -44,6 +44,50 @@ const MASTER_LIST_2: (&str, &str) = (
 }"#,
 );
 
+const DEFAULT_PRICE_LIST: (&str, &str) = (
+    "4d9a615e-eebb-42ad-a806-e3854f7733ae",
+    r#"{
+    "ID": "4d9a615e-eebb-42ad-a806-e3854f7733ae",
+    "description": "Default Price List",
+    "date_created": "2017-08-17",
+    "created_by_user_ID": "0763E2E3053D4C478E1E6B6B03FEC207",
+    "note": "National Price List",
+    "gets_new_items": false,
+    "tags": null,
+    "isProgram": false,
+    "programSettings": null,
+    "code": "",
+    "isPatientList": false,
+    "is_hiv": false,
+    "isSupplierHubCatalog": false,
+    "inactive": false,
+    "is_default_price_list": true,
+    "discount": 0.0
+}"#,
+);
+
+const DISCOUNT_LIST: (&str, &str) = (
+    "4d9a615e-eebb-42ad-a806-e3854f7733a1",
+    r#"{
+    "ID": "4d9a615e-eebb-42ad-a806-e3854f7733a1",
+    "description": "Discount List",
+    "date_created": "2017-08-17",
+    "created_by_user_ID": "0763E2E3053D4C478E1E6B6B03FEC207",
+    "note": "National Price List Store Discounts",
+    "gets_new_items": false,
+    "tags": null,
+    "isProgram": false,
+    "programSettings": null,
+    "code": "",
+    "isPatientList": false,
+    "is_hiv": false,
+    "isSupplierHubCatalog": false,
+    "inactive": false,
+    "is_default_price_list": false,
+    "discount": 0.2
+}"#,
+);
+
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
         TestSyncIncomingRecord::new_pull_upsert(
@@ -55,6 +99,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
                 code: "".to_owned(),
                 description: "note 1".to_owned(),
                 is_active: false,
+                is_default_price_list: false,
+                discount: None,
             },
         ),
         TestSyncIncomingRecord::new_pull_upsert(
@@ -66,6 +112,34 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
                 code: "".to_owned(),
                 description: "note 2".to_owned(),
                 is_active: true,
+                is_default_price_list: false,
+                discount: None,
+            },
+        ),
+        TestSyncIncomingRecord::new_pull_upsert(
+            TABLE_NAME,
+            DEFAULT_PRICE_LIST,
+            MasterListRow {
+                id: DEFAULT_PRICE_LIST.0.to_owned(),
+                name: "Default Price List".to_owned(),
+                code: "".to_owned(),
+                description: "National Price List".to_owned(),
+                is_active: true,
+                is_default_price_list: true,
+                discount: Some(0.0),
+            },
+        ),
+        TestSyncIncomingRecord::new_pull_upsert(
+            TABLE_NAME,
+            DISCOUNT_LIST,
+            MasterListRow {
+                id: DISCOUNT_LIST.0.to_owned(),
+                name: "Discount List".to_owned(),
+                code: "".to_owned(),
+                description: "National Price List Store Discounts".to_owned(),
+                is_active: true,
+                is_default_price_list: false,
+                discount: Some(0.2),
             },
         ),
     ]

--- a/server/service/src/sync/translations/master_list.rs
+++ b/server/service/src/sync/translations/master_list.rs
@@ -16,6 +16,8 @@ pub struct LegacyListMasterRow {
     code: String,
     note: String,
     inactive: Option<bool>,
+    is_default_price_list: Option<bool>,
+    discount: Option<f64>,
 }
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -47,6 +49,8 @@ impl SyncTranslation for MasterListTranslation {
             description: data.note,
             // By default if inactive = null, or missing, it should mean is_active = true
             is_active: !data.inactive.unwrap_or(true),
+            is_default_price_list: data.is_default_price_list.unwrap_or(false),
+            discount: data.discount,
         };
         Ok(PullTranslateResult::upsert(result))
     }
@@ -71,6 +75,8 @@ impl SyncTranslation for MasterListTranslation {
                 code: master_list.code,
                 description: master_list.description,
                 is_active: false,
+                is_default_price_list: master_list.is_default_price_list,
+                discount: master_list.discount,
             };
             return Ok(PullTranslateResult::upsert(result));
         }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4703 (Part 1)

# 👩🏻‍💻 What does this PR do?

Adds two new fields to `master_list`

- [ ] is_default_price_list
- [ ] discount

Adds translation tests for new fields (using the same names are in mSupply when it is updated)
Updates test cases to use default values for master list fields.

## 💌 Any notes for the reviewer?

Using these new fields will be in the next PR... 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Update mSupply to include a PR for this ISSUE -> https://github.com/msupply-foundation/msupply/issues/15108 (doesn't exist yet)
- [ ] Add a master list with is_default_price_list set
- [ ] Add a masterlist with a discount set
- [ ] Sync open-mSupply
- [ ] Check the fields are set correctly....
- [ ] Check legacy mSupply master lists still sync correctly as well

# 📃 Documentation
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
