### PR TITLE
add vax card tab for immunisation program encounters

### DIFF
--- a/client/packages/common/src/intl/locales/en/dispensary.json
+++ b/client/packages/common/src/intl/locales/en/dispensary.json
@@ -45,6 +45,7 @@
   "label.program-enrolment": "Program Enrolment",
   "label.recorded-contact-differs": "Recorded Contact: {{recordedName}}",
   "label.search-results": "Search results",
+  "label.vaccinations": "Vaccinations",
   "label.visit-date": "Visit Date",
   "label.visit-end": "End",
   "label.visit-notes": "Notes",

--- a/client/packages/programs/src/api/api.ts
+++ b/client/packages/programs/src/api/api.ts
@@ -26,6 +26,7 @@ import {
   ContactTraceRowFragment,
   DocumentFragment,
   DocumentRegistryFragment,
+  EncounterByIdQuery,
   EncounterFieldsFragment,
   EncounterFragment,
   EncounterRowFragment,
@@ -115,7 +116,9 @@ export const getEncounterQueries = (sdk: Sdk, storeId: string) => ({
     }
     throw new Error('Error querying document');
   },
-  byId: async (encounterId: string): Promise<EncounterFragment> => {
+  byId: async (
+    encounterId: string
+  ): Promise<EncounterByIdQuery['encounters']['nodes'][number]> => {
     const result = await sdk.encounterById({ encounterId, storeId });
     const encounters = result?.encounters;
 

--- a/client/packages/programs/src/api/operations.generated.ts
+++ b/client/packages/programs/src/api/operations.generated.ts
@@ -98,7 +98,7 @@ export type EncounterByIdQueryVariables = Types.Exact<{
 }>;
 
 
-export type EncounterByIdQuery = { __typename: 'Queries', encounters: { __typename: 'EncounterConnector', totalCount: number, nodes: Array<{ __typename: 'EncounterNode', id: string, contextId: string, type: string, name: string, status?: Types.EncounterNodeStatus | null, createdDatetime: string, startDatetime: string, endDatetime?: string | null, patient: { __typename: 'PatientNode', id: string, firstName?: string | null, lastName?: string | null, code: string, code2?: string | null, name: string, dateOfBirth?: string | null }, clinician?: { __typename: 'ClinicianNode', id: string, firstName?: string | null, lastName: string } | null, document: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, timestamp: string, type: string, data: any, user?: { __typename: 'UserNode', userId: string, username: string, email?: string | null } | null, documentRegistry?: { __typename: 'DocumentRegistryNode', id: string, category: Types.DocumentRegistryCategoryNode, documentType: string, contextId: string, name?: string | null, formSchemaId: string, jsonSchema: any, uiSchemaType: string, uiSchema: any } | null } }> } };
+export type EncounterByIdQuery = { __typename: 'Queries', encounters: { __typename: 'EncounterConnector', totalCount: number, nodes: Array<{ __typename: 'EncounterNode', id: string, contextId: string, type: string, name: string, status?: Types.EncounterNodeStatus | null, createdDatetime: string, startDatetime: string, endDatetime?: string | null, programEnrolment?: { __typename: 'ProgramEnrolmentNode', isImmunisationProgram: boolean } | null, patient: { __typename: 'PatientNode', id: string, firstName?: string | null, lastName?: string | null, code: string, code2?: string | null, name: string, dateOfBirth?: string | null }, clinician?: { __typename: 'ClinicianNode', id: string, firstName?: string | null, lastName: string } | null, document: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, timestamp: string, type: string, data: any, user?: { __typename: 'UserNode', userId: string, username: string, email?: string | null } | null, documentRegistry?: { __typename: 'DocumentRegistryNode', id: string, category: Types.DocumentRegistryCategoryNode, documentType: string, contextId: string, name?: string | null, formSchemaId: string, jsonSchema: any, uiSchemaType: string, uiSchema: any } | null } }> } };
 
 export type EncounterByDocNameQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -720,6 +720,9 @@ export const EncounterByIdDocument = gql`
       __typename
       nodes {
         ...Encounter
+        programEnrolment {
+          isImmunisationProgram
+        }
       }
       totalCount
     }

--- a/client/packages/programs/src/api/operations.graphql
+++ b/client/packages/programs/src/api/operations.graphql
@@ -241,6 +241,9 @@ query encounterById($storeId: String!, $encounterId: String!) {
       __typename
       nodes {
         ...Encounter
+        programEnrolment {
+          isImmunisationProgram
+        }
       }
       totalCount
     }

--- a/client/packages/system/src/Encounter/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Encounter/DetailView/DetailView.tsx
@@ -15,6 +15,7 @@ import {
   DialogButton,
   ButtonWithIcon,
   SaveIcon,
+  DetailTabs,
 } from '@openmsupply-client/common';
 import {
   useEncounter,
@@ -259,16 +260,7 @@ export const DetailView: FC = () => {
     <React.Suspense fallback={<DetailViewSkeleton />}>
       <link rel="stylesheet" href="/medical-icons.css" media="all"></link>
       <AppBarButtons logicalStatus={logicalStatus} />
-      {encounter && (
-        <Toolbar
-          onChange={updateEncounter}
-          encounter={encounter}
-          onDelete={onDelete}
-        />
-      )}
-      {encounter ? (
-        JsonForm
-      ) : (
+      {!encounter ? (
         <AlertModal
           open={true}
           onOk={() =>
@@ -281,9 +273,26 @@ export const DetailView: FC = () => {
           title={t('error.encounter-not-found')}
           message={t('messages.click-to-return-to-encounters')}
         />
-      )}
-      {encounter && (
-        <SidePanel encounter={encounter} onChange={updateEncounter} />
+      ) : (
+        <>
+          <Toolbar
+            onChange={updateEncounter}
+            encounter={encounter}
+            onDelete={onDelete}
+          />
+          {encounter.programEnrolment?.isImmunisationProgram ? (
+            // If the encounter is for an immunisation program, show Vaccination card on first tab
+            <DetailTabs
+              tabs={[
+                { Component: <>VAX Card</>, value: t('label.vaccinations') },
+                { Component: JsonForm, value: t('label.encounter') },
+              ]}
+            />
+          ) : (
+            JsonForm
+          )}
+          <SidePanel encounter={encounter} onChange={updateEncounter} />
+        </>
       )}
       <SaveAsVisitedModal />
       <Footer


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4709

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Adds new tab to immunisation program encounters, to initially show the vaccine card (actually vaccine card to come 😉)

![Screenshot 2024-09-04 at 5 41 53 PM](https://github.com/user-attachments/assets/5856b926-daa8-4421-b58e-d928631acfe8)


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a patient enrolled in immunisation program
- [ ] Create an encounter
- [ ] See tabs with vaccination card tab as the default
- [ ] Create another encounter for non-immunisation program
- [ ] No tabs

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
