### PR TITLE
Pass front end language to report generation

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -5488,6 +5488,7 @@ export type QueriesGenerateCustomerReturnLinesArgs = {
 
 export type QueriesGenerateReportArgs = {
   arguments?: InputMaybe<Scalars['JSON']['input']>;
+  currentLanguage?: InputMaybe<Scalars['String']['input']>;
   dataId?: InputMaybe<Scalars['String']['input']>;
   format?: InputMaybe<PrintFormat>;
   reportId: Scalars['String']['input'];
@@ -5498,6 +5499,7 @@ export type QueriesGenerateReportArgs = {
 
 export type QueriesGenerateReportDefinitionArgs = {
   arguments?: InputMaybe<Scalars['JSON']['input']>;
+  currentLanguage?: InputMaybe<Scalars['String']['input']>;
   dataId?: InputMaybe<Scalars['String']['input']>;
   format?: InputMaybe<PrintFormat>;
   name?: InputMaybe<Scalars['String']['input']>;

--- a/client/packages/system/src/Report/api/hooks/useGenerateReport.ts
+++ b/client/packages/system/src/Report/api/hooks/useGenerateReport.ts
@@ -2,12 +2,14 @@ import { PrintFormat } from '@common/types';
 import { useReportGraphQL } from '../useReportGraphQL';
 import { GenerateReportParams } from './usePrintReport';
 import { useMutation } from '@openmsupply-client/common';
+import { useIntlUtils } from '@common/intl';
 
 export const useGenerateReport = () => {
   const { reportApi, storeId } = useReportGraphQL();
 
   const mutationFn = async (params: GenerateReportParams) => {
     const { dataId, reportId, args, sort, format = PrintFormat.Html } = params;
+    const {currentLanguage} = useIntlUtils();
 
     const result = await reportApi.generateReport({
       dataId,
@@ -16,6 +18,7 @@ export const useGenerateReport = () => {
       format,
       arguments: args,
       sort,
+      currentLanguage,
     });
     return result?.generateReport;
   };

--- a/client/packages/system/src/Report/api/operations.generated.ts
+++ b/client/packages/system/src/Report/api/operations.generated.ts
@@ -30,6 +30,7 @@ export type GenerateReportQueryVariables = Types.Exact<{
   arguments?: Types.InputMaybe<Types.Scalars['JSON']['input']>;
   format?: Types.InputMaybe<Types.PrintFormat>;
   sort?: Types.InputMaybe<Types.PrintReportSortInput>;
+  currentLanguage?: Types.InputMaybe<Types.Scalars['String']['input']>;
 }>;
 
 
@@ -70,7 +71,7 @@ export const ReportsDocument = gql`
 }
     ${ReportRowFragmentDoc}`;
 export const GenerateReportDocument = gql`
-    query generateReport($storeId: String!, $reportId: String!, $dataId: String, $arguments: JSON, $format: PrintFormat, $sort: PrintReportSortInput) {
+    query generateReport($storeId: String!, $reportId: String!, $dataId: String, $arguments: JSON, $format: PrintFormat, $sort: PrintReportSortInput, $currentLanguage: String) {
   generateReport(
     dataId: $dataId
     reportId: $reportId
@@ -78,6 +79,7 @@ export const GenerateReportDocument = gql`
     format: $format
     arguments: $arguments
     sort: $sort
+    currentLanguage: $currentLanguage
   ) {
     ... on PrintReportNode {
       __typename

--- a/client/packages/system/src/Report/api/operations.graphql
+++ b/client/packages/system/src/Report/api/operations.graphql
@@ -45,6 +45,7 @@ query generateReport(
   $arguments: JSON
   $format: PrintFormat
   $sort: PrintReportSortInput
+  $currentLanguage: String
 ) {
   generateReport(
     dataId: $dataId
@@ -53,6 +54,7 @@ query generateReport(
     format: $format
     arguments: $arguments
     sort: $sort
+    currentLanguage: $currentLanguage
   ) {
     ... on PrintReportNode {
       __typename

--- a/server/graphql/reports/src/lib.rs
+++ b/server/graphql/reports/src/lib.rs
@@ -60,8 +60,9 @@ impl ReportQueries {
         arguments: Option<serde_json::Value>,
         format: Option<PrintFormat>,
         sort: Option<PrintReportSortInput>,
+        current_language: Option<String>,
     ) -> Result<PrintReportResponse> {
-        generate_report(ctx, store_id, report_id, data_id, arguments, format, sort).await
+        generate_report(ctx, store_id, report_id, data_id, arguments, format, sort, current_language).await
     }
 
     /// Can be used when developing reports, e.g. to generate a report that is not already in the
@@ -74,9 +75,10 @@ impl ReportQueries {
         #[graphql(desc = "The report definition to be generated")] report: serde_json::Value,
         data_id: Option<String>,
         arguments: Option<serde_json::Value>,
-        format: Option<PrintFormat>,
+        format: Option<PrintFormat>,        
+        current_language: Option<String>,
     ) -> Result<PrintReportResponse> {
-        generate_report_definition(ctx, store_id, name, report, data_id, arguments, format).await
+        generate_report_definition(ctx, store_id, name, report, data_id, arguments, format, current_language).await
     }
 }
 

--- a/server/graphql/reports/src/print.rs
+++ b/server/graphql/reports/src/print.rs
@@ -63,6 +63,7 @@ pub async fn generate_report(
     arguments: Option<serde_json::Value>,
     format: Option<PrintFormat>,
     sort: Option<PrintReportSortInput>,
+    current_language: Option<String>,
 ) -> Result<PrintReportResponse> {
     let user = validate_auth(
         ctx,
@@ -118,6 +119,7 @@ pub async fn generate_report(
         arguments,
         format.map(PrintFormat::to_domain),
         translation_service,
+        current_language,
     ) {
         Ok(file_id) => file_id,
         Err(err) => {
@@ -140,6 +142,7 @@ pub async fn generate_report_definition(
     data_id: Option<String>,
     arguments: Option<serde_json::Value>,
     format: Option<PrintFormat>,
+    current_language: Option<String>,
 ) -> Result<PrintReportResponse> {
     let user = validate_auth(
         ctx,
@@ -200,6 +203,7 @@ pub async fn generate_report_definition(
         arguments,
         format.map(PrintFormat::to_domain),
         translation_service,
+        current_language,
     ) {
         Ok(file_id) => file_id,
         Err(err) => {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4720 

# 👩🏻‍💻 What does this PR do?
Adds front end language to report generation translation function

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
