### PR TITLE
Change to user price_per_unit rather than just price on master_list_l…

### DIFF
--- a/server/repository/src/db_diesel/master_list_line_row.rs
+++ b/server/repository/src/db_diesel/master_list_line_row.rs
@@ -12,7 +12,7 @@ table! {
         id -> Text,
         item_link_id -> Text,
         master_list_id -> Text,
-        price -> Nullable<Double>,
+        price_per_unit -> Nullable<Double>,
     }
 }
 
@@ -27,7 +27,7 @@ pub struct MasterListLineRow {
     pub id: String,
     pub item_link_id: String,
     pub master_list_id: String,
-    pub price: Option<f64>,
+    pub price_per_unit: Option<f64>,
 }
 
 pub struct MasterListLineRowRepository<'a> {

--- a/server/repository/src/migrations/v2_02_02/master_list_line.rs
+++ b/server/repository/src/migrations/v2_02_02/master_list_line.rs
@@ -5,14 +5,14 @@ pub(crate) struct Migrate;
 
 impl MigrationFragment for Migrate {
     fn identifier(&self) -> &'static str {
-        "master_list_line_price"
+        "master_list_line_price_per_unit"
     }
 
     fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
         sql!(
             connection,
             r#"
-            ALTER TABLE master_list_line ADD COLUMN price {DOUBLE};
+            ALTER TABLE master_list_line ADD COLUMN price_per_unit {DOUBLE};
             "#
         )?;
 

--- a/server/service/src/sync/test/test_data/master_list_line.rs
+++ b/server/service/src/sync/test/test_data/master_list_line.rs
@@ -35,7 +35,7 @@ fn master_list_line_a() -> TestSyncIncomingRecord {
             id: "9B02D0770B544BD1AC7DB99BB85FCDD5".to_string(),
             item_link_id: "item_a".to_string(),
             master_list_id: "item_query_test1".to_string(),
-            price: Some(3.14),
+            price_per_unit: Some(3.14),
         },
     )
 }

--- a/server/service/src/sync/translations/master_list_line.rs
+++ b/server/service/src/sync/translations/master_list_line.rs
@@ -67,7 +67,7 @@ impl SyncTranslation for MasterListLineTranslation {
             id: data.ID,
             item_link_id: data.item_ID,
             master_list_id: data.item_master_ID,
-            price: data.price,
+            price_per_unit: data.price,
         };
 
         Ok(PullTranslateResult::upsert(result))


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4703

# 👩🏻‍💻 What does this PR do?

Changes the price column in master list to clarify that it is `per_unit` would be nice if mSupply UI made this clear too...

![image](https://github.com/user-attachments/assets/a20957d5-98fd-4f26-9439-b750952cb264)


## 💌 Any notes for the reviewer?

Just been added to OMS so not used anywhere yet...

# 🧪 Testing

No testing required, will be tested as part of the pricing at issuance PRs.

# 📃 Documentation

- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
