### PR TITLE
4763 cleanup pricing discounts

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -2585,7 +2585,6 @@ export type InsertOutboundShipmentLineInput = {
   numberOfPacks: Scalars['Float']['input'];
   stockLineId: Scalars['String']['input'];
   taxPercentage?: InputMaybe<Scalars['Float']['input']>;
-  totalBeforeTax?: InputMaybe<Scalars['Float']['input']>;
 };
 
 export type InsertOutboundShipmentLineResponse = InsertOutboundShipmentLineError | InvoiceLineNode;

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
@@ -202,7 +202,7 @@ export const useExpansionColumns = (): Column<StockOutLineFragment>[] => {
     [
       'sellPricePerUnit',
       {
-        accessor: ({ rowData }) => rowData.sellPricePerPack,
+        accessor: ({ rowData }) => rowData.sellPricePerPack / rowData.packSize,
       },
     ]
   );

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
@@ -107,7 +107,7 @@ export const useDraftOutboundLines = (
 
       return rows;
     });
-  }, [data, lines, item, invoiceId, itemPrice]);
+  }, [data, lines, item, invoiceId, itemPrice, priceFetched]);
 
   const onChangeRowQuantity = useCallback(
     (batchId: string, value: number) => {

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
@@ -107,7 +107,7 @@ export const useDraftOutboundLines = (
 
       return rows;
     });
-  }, [data, lines, item, invoiceId]);
+  }, [data, lines, item, invoiceId, itemPrice]);
 
   const onChangeRowQuantity = useCallback(
     (batchId: string, value: number) => {

--- a/client/packages/invoices/src/OutboundShipment/api/api.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/api.ts
@@ -19,7 +19,7 @@ import {
   DeleteOutboundShipmentServiceLineInput,
 } from '@openmsupply-client/common';
 import { DraftStockOutLine } from '../../types';
-import { get, isA } from '../../utils';
+import { isA } from '../../utils';
 import {
   OutboundRowFragment,
   OutboundFragment,
@@ -109,7 +109,6 @@ const outboundParsers = {
       numberOfPacks: line.numberOfPacks,
       stockLineId: line.stockLine?.id ?? '',
       invoiceId: line.invoiceId,
-      totalBeforeTax: get.invoiceLineSubtotal(line),
     };
   },
   toUpdateLine: (line: DraftStockOutLine): UpdateOutboundShipmentLineInput => {
@@ -117,7 +116,6 @@ const outboundParsers = {
       id: line.id,
       numberOfPacks: line.numberOfPacks,
       stockLineId: line.stockLine?.id ?? '',
-      totalBeforeTax: get.invoiceLineSubtotal(line),
     };
   },
   toDeleteLine: (line: { id: string }): DeleteOutboundShipmentLineInput => ({

--- a/client/packages/invoices/src/utils.ts
+++ b/client/packages/invoices/src/utils.ts
@@ -14,7 +14,7 @@ import {
 } from '@openmsupply-client/common';
 import { OutboundFragment, OutboundRowFragment } from './OutboundShipment/api';
 import { InboundLineFragment } from './InboundShipment/api';
-import { DraftStockOutLine, InboundItem } from './types';
+import { InboundItem } from './types';
 import { PrescriptionRowFragment } from './Prescriptions/api';
 import {
   InboundReturnFragment,
@@ -308,13 +308,6 @@ export const isA = {
     line.type === InvoiceLineNodeType.Service,
   placeholderLine: (line: { type: InvoiceLineNodeType }) =>
     line.type === InvoiceLineNodeType.UnallocatedStock,
-};
-
-export const get = {
-  stockLineSubtotal: (line: DraftStockOutLine) =>
-    line.numberOfPacks * (line.stockLine?.sellPricePerPack ?? 0),
-  invoiceLineSubtotal: (line: DraftStockOutLine) =>
-    line.sellPricePerPack * line.numberOfPacks,
 };
 
 export const outboundsToCsv = (

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/insert.rs
@@ -23,7 +23,6 @@ pub struct InsertInput {
     pub invoice_id: String,
     pub stock_line_id: String,
     pub number_of_packs: f64,
-    pub total_before_tax: Option<f64>,
     pub tax_percentage: Option<f64>,
 }
 
@@ -90,7 +89,6 @@ impl InsertInput {
             invoice_id,
             stock_line_id,
             number_of_packs,
-            total_before_tax,
             tax_percentage,
         } = self;
 
@@ -100,7 +98,7 @@ impl InsertInput {
             invoice_id,
             stock_line_id,
             number_of_packs,
-            total_before_tax,
+            total_before_tax: None,
             tax_percentage,
             // Default
             note: None,

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/update.rs
@@ -26,7 +26,6 @@ pub struct UpdateInput {
     pub id: String,
     stock_line_id: Option<String>,
     number_of_packs: Option<f64>,
-    total_before_tax: Option<f64>,
     tax: Option<TaxInput>,
 }
 
@@ -93,7 +92,6 @@ impl UpdateInput {
             id,
             stock_line_id,
             number_of_packs,
-            total_before_tax,
             tax,
         } = self;
         ServiceInput {
@@ -101,7 +99,7 @@ impl UpdateInput {
             r#type: Some(StockOutType::OutboundShipment),
             stock_line_id,
             number_of_packs,
-            total_before_tax,
+            total_before_tax: None,
             tax: tax.map(|tax| ShipmentTaxUpdate {
                 percentage: tax.percentage,
             }),

--- a/server/service/src/invoice_line/stock_out_line/insert/generate.rs
+++ b/server/service/src/invoice_line/stock_out_line/insert/generate.rs
@@ -6,18 +6,22 @@ use repository::{
 use crate::{
     invoice::common::{calculate_foreign_currency_total, calculate_total_after_tax},
     invoice_line::StockOutType,
-    pricing::{calculate_sell_price::calculate_sell_price, item_price::ItemPrice},
+    item,
+    pricing::{
+        calculate_sell_price::calculate_sell_price,
+        item_price::{get_pricing_for_item, ItemPrice, ItemPriceLookup},
+    },
+    service_provider::ServiceContext,
 };
 
 use super::{InsertStockOutLine, InsertStockOutLineError};
 
 pub fn generate(
-    connection: &StorageConnection,
+    ctx: &ServiceContext,
     input: InsertStockOutLine,
     item_row: ItemRow,
     batch: StockLine,
     invoice: InvoiceRow,
-    pricing: ItemPrice,
 ) -> Result<(InvoiceLineRow, StockLineRow), InsertStockOutLineError> {
     let adjust_total_number_of_packs =
         should_adjust_total_number_of_packs(invoice.status.clone(), &input.r#type);
@@ -27,8 +31,17 @@ pub fn generate(
         batch.stock_line_row.clone(),
         adjust_total_number_of_packs,
     );
+
+    // Check if we need to override the pricing with a default
+    let pricing = get_pricing_for_item(
+        ctx,
+        ItemPriceLookup {
+            item_id: item_row.id.clone(),
+            customer_name_id: Some(invoice.name_link_id.clone()),
+        },
+    )?;
     let new_line = generate_line(
-        connection,
+        &ctx.connection,
         input,
         item_row,
         update_batch.clone(),

--- a/server/service/src/invoice_line/stock_out_line/insert/generate.rs
+++ b/server/service/src/invoice_line/stock_out_line/insert/generate.rs
@@ -6,7 +6,6 @@ use repository::{
 use crate::{
     invoice::common::{calculate_foreign_currency_total, calculate_total_after_tax},
     invoice_line::StockOutType,
-    item,
     pricing::{
         calculate_sell_price::calculate_sell_price,
         item_price::{get_pricing_for_item, ItemPrice, ItemPriceLookup},

--- a/server/service/src/invoice_line/stock_out_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_out_line/insert/mod.rs
@@ -1,9 +1,4 @@
-use crate::{
-    invoice_line::query::get_invoice_line,
-    pricing::item_price::{get_pricing_for_item, ItemPriceLookup},
-    service_provider::ServiceContext,
-    WithDBError,
-};
+use crate::{invoice_line::query::get_invoice_line, service_provider::ServiceContext, WithDBError};
 use chrono::NaiveDate;
 use repository::{InvoiceLine, InvoiceLineRowRepository, RepositoryError, StockLineRowRepository};
 

--- a/server/service/src/invoice_line/stock_out_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_out_line/insert/mod.rs
@@ -78,17 +78,7 @@ pub fn insert_stock_out_line(
         .connection
         .transaction_sync(|connection| {
             let (item, invoice, batch) = validate(&input, &ctx.store_id, connection)?;
-
-            // Check if we need to override the pricing with a default
-            let pricing = get_pricing_for_item(
-                ctx,
-                ItemPriceLookup {
-                    item_id: item.id.clone(),
-                    customer_name_id: Some(invoice.name_link_id.clone()),
-                },
-            )?;
-            let (new_line, update_batch) =
-                generate(connection, input, item, batch, invoice, pricing)?;
+            let (new_line, update_batch) = generate(ctx, input, item, batch, invoice)?;
             InvoiceLineRowRepository::new(connection).upsert_one(&new_line)?;
             StockLineRowRepository::new(connection).upsert_one(&update_batch)?;
             get_invoice_line(ctx, &new_line.id)


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4763

# 👩🏻‍💻 What does this PR do?

- [x] remove `totalBeforeTax` from batch invoice line mutation (it's not actually used from frontend which is confusing)
- [x] remove `invoiceLineSubtotal`: (line: DraftStockOutLine) =>
- [x] Fix usage of `unitPrice` vs `pricePerPack`? https://github.com/msupply-foundation/open-msupply/blob/a25c8630cd9024645d6f953f58f9c7052f9e09c1/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts#L202-L207
- [x] Move let pricing = get_pricing_for_item() in server/service/src/invoice_line/stock_out_line/insert/mod.rs to generate method
- [x] Use existing sell price in update line, instead of re-querying 
- [x] Adds pricing dependancies to useEffect in Outboundshipment

## 💌 Any notes for the reviewer?

I think this covers off the important things from earlier code reviews, let me know if I missed something.
Didn't do the test `with_service_provider` refactor for now, might be good to create a refactor issue for that, and go through doing a big update, so people tend to copy the new pattern instead of the old?

Two new issues raised from my testing, not sure if we go through triage first?

- [ ] #4765
- [ ] #4764


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a default price list and discount price list
- [ ] Check the correct prices and discounts are applied as per issue https://github.com/msupply-foundation/open-msupply/issues/4703
- [ ] Try things like updating existing lines, adding new lines, having multiple different prices and discounts applying in the same outbound shipment for example.
- [ ] Test prescriptions
- [ ] Make sure everything sync correctly to mSupply and we aren't missing prices in reports?

# 📃 Documentation

- [X] **Part of an epic**: documentation will be completed for the feature as a whole
