### PR TITLE
4774 backlog prescription entry backdated stock levels service

### DIFF
--- a/server/repository/src/db_diesel/stock_movement.rs
+++ b/server/repository/src/db_diesel/stock_movement.rs
@@ -15,7 +15,7 @@ table! {
         store_id -> Text,
         quantity -> Double,
         datetime -> Timestamp,
-        stock_line_id -> Text,
+        stock_line_id -> Nullable<Text>,
     }
 }
 
@@ -26,7 +26,7 @@ pub struct StockMovementRow {
     pub store_id: String,
     pub quantity: f64,
     pub datetime: NaiveDateTime,
-    pub stock_line_id: String,
+    pub stock_line_id: Option<String>,
 }
 
 impl Default for StockMovementRow {
@@ -293,7 +293,7 @@ mod test {
                         .unwrap()
                         .and_hms_opt(0, 0, 0)
                         .unwrap(),
-                    stock_line_id: "NONE".to_string(),
+                    stock_line_id: None,
                 },
                 StockMovementRow {
                     id: "n/a".to_string(),
@@ -304,7 +304,7 @@ mod test {
                         .unwrap()
                         .and_hms_opt(0, 0, 0)
                         .unwrap(),
-                    stock_line_id: "NONE".to_string(),
+                    stock_line_id: None,
                 },
                 StockMovementRow {
                     id: "n/a".to_string(),
@@ -315,7 +315,7 @@ mod test {
                         .unwrap()
                         .and_hms_opt(0, 0, 0)
                         .unwrap(),
-                    stock_line_id: "NONE".to_string(),
+                    stock_line_id: None,
                 },
                 StockMovementRow {
                     id: "n/a".to_string(),
@@ -326,7 +326,7 @@ mod test {
                         .unwrap()
                         .and_hms_opt(0, 0, 0)
                         .unwrap(),
-                    stock_line_id: "NONE".to_string(),
+                    stock_line_id: None,
                 },
                 StockMovementRow {
                     id: "n/a".to_string(),
@@ -337,7 +337,7 @@ mod test {
                         .unwrap()
                         .and_hms_opt(0, 0, 0)
                         .unwrap(),
-                    stock_line_id: "NONE".to_string(),
+                    stock_line_id: None,
                 },
             ]
         )

--- a/server/repository/src/db_diesel/stock_movement.rs
+++ b/server/repository/src/db_diesel/stock_movement.rs
@@ -15,6 +15,7 @@ table! {
         store_id -> Text,
         quantity -> Double,
         datetime -> Timestamp,
+        stock_line_id -> Text,
     }
 }
 
@@ -25,6 +26,7 @@ pub struct StockMovementRow {
     pub store_id: String,
     pub quantity: f64,
     pub datetime: NaiveDateTime,
+    pub stock_line_id: String,
 }
 
 impl Default for StockMovementRow {
@@ -36,6 +38,7 @@ impl Default for StockMovementRow {
             item_id: Default::default(),
             store_id: Default::default(),
             quantity: Default::default(),
+            stock_line_id: Default::default(),
         }
     }
 }
@@ -45,6 +48,7 @@ pub struct StockMovementFilter {
     pub item_id: Option<EqualFilter<String>>,
     pub store_id: Option<EqualFilter<String>>,
     pub datetime: Option<DatetimeFilter>,
+    pub stock_line_id: Option<EqualFilter<String>>,
 }
 
 pub struct StockMovementRepository<'a> {
@@ -75,10 +79,12 @@ impl<'a> StockMovementRepository<'a> {
                 item_id,
                 datetime,
                 store_id,
+                stock_line_id,
             } = f;
 
             apply_equal_filter!(query, item_id, stock_movement_dsl::item_id);
             apply_equal_filter!(query, store_id, stock_movement_dsl::store_id);
+            apply_equal_filter!(query, stock_line_id, stock_movement_dsl::stock_line_id);
             apply_date_time_filter!(query, datetime, stock_movement_dsl::datetime);
         }
 
@@ -109,6 +115,11 @@ impl StockMovementFilter {
 
     pub fn datetime(mut self, filter: DatetimeFilter) -> Self {
         self.datetime = Some(filter);
+        self
+    }
+
+    pub fn stock_line_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.stock_line_id = Some(filter);
         self
     }
 }
@@ -257,6 +268,7 @@ mod test {
                 store_id: Some(EqualFilter::equal_to(&store().id)),
                 item_id: Some(EqualFilter::equal_to(&mock_item_a().id)),
                 datetime: None,
+                stock_line_id: None,
             }))
             .unwrap();
 
@@ -280,7 +292,8 @@ mod test {
                     datetime: NaiveDate::from_ymd_opt(2020, 11, 2)
                         .unwrap()
                         .and_hms_opt(0, 0, 0)
-                        .unwrap()
+                        .unwrap(),
+                    stock_line_id: "NONE".to_string(),
                 },
                 StockMovementRow {
                     id: "n/a".to_string(),
@@ -290,7 +303,8 @@ mod test {
                     datetime: NaiveDate::from_ymd_opt(2020, 11, 3)
                         .unwrap()
                         .and_hms_opt(0, 0, 0)
-                        .unwrap()
+                        .unwrap(),
+                    stock_line_id: "NONE".to_string(),
                 },
                 StockMovementRow {
                     id: "n/a".to_string(),
@@ -300,7 +314,8 @@ mod test {
                     datetime: NaiveDate::from_ymd_opt(2020, 12, 15)
                         .unwrap()
                         .and_hms_opt(0, 0, 0)
-                        .unwrap()
+                        .unwrap(),
+                    stock_line_id: "NONE".to_string(),
                 },
                 StockMovementRow {
                     id: "n/a".to_string(),
@@ -310,7 +325,8 @@ mod test {
                     datetime: NaiveDate::from_ymd_opt(2021, 1, 20)
                         .unwrap()
                         .and_hms_opt(0, 0, 0)
-                        .unwrap()
+                        .unwrap(),
+                    stock_line_id: "NONE".to_string(),
                 },
                 StockMovementRow {
                     id: "n/a".to_string(),
@@ -320,7 +336,8 @@ mod test {
                     datetime: NaiveDate::from_ymd_opt(2021, 2, 1)
                         .unwrap()
                         .and_hms_opt(0, 0, 0)
-                        .unwrap()
+                        .unwrap(),
+                    stock_line_id: "NONE".to_string(),
                 },
             ]
         )

--- a/server/service/src/stock_line/historical_stock.rs
+++ b/server/service/src/stock_line/historical_stock.rs
@@ -1,0 +1,47 @@
+use chrono::NaiveDateTime;
+use repository::{
+    DatetimeFilter, EqualFilter, StockLine, StockLineFilter, StockMovementFilter,
+    StockMovementRepository,
+};
+use util::date_now;
+
+use crate::{service_provider::ServiceContext, ListError, ListResult};
+
+use super::query::get_stock_lines;
+
+pub fn get_historical_stock_lines(
+    ctx: &ServiceContext,
+    store_id: String,
+    item_id: String,
+    datetime: NaiveDateTime,
+) -> Result<ListResult<StockLine>, ListError> {
+    // First get the current stock lines
+    let current_stock_lines = get_stock_lines(
+        ctx,
+        None,
+        Some(StockLineFilter::new().store_id(EqualFilter::equal_to(&store_id))),
+        None,
+        Some(store_id.clone()),
+    )?;
+
+    println!("current_stock_lines: {:?}", current_stock_lines);
+
+    let stock_line_ids: Vec<String> = current_stock_lines
+        .rows
+        .iter()
+        .map(|stock_line| stock_line.stock_line_row.id.clone())
+        .collect();
+
+    let filter = StockMovementFilter::new()
+        .store_id(EqualFilter::equal_to(&store_id))
+        .item_id(EqualFilter::equal_to(&item_id))
+        .datetime(DatetimeFilter::date_range(datetime, date_now().into()));
+    let stock_movements = StockMovementRepository::new(&ctx.connection).query(Some(filter))?;
+
+    println!("stock_movements: {:?}", stock_movements);
+
+    Ok(ListResult {
+        rows: vec![],
+        count: 0,
+    })
+}

--- a/server/service/src/stock_line/historical_stock.rs
+++ b/server/service/src/stock_line/historical_stock.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use chrono::NaiveDateTime;
 use repository::{
     DatetimeFilter, EqualFilter, StockLine, StockLineFilter, StockMovementFilter,
@@ -19,12 +21,15 @@ pub fn get_historical_stock_lines(
     let current_stock_lines = get_stock_lines(
         ctx,
         None,
-        Some(StockLineFilter::new().store_id(EqualFilter::equal_to(&store_id))),
+        Some(
+            StockLineFilter::new()
+                .store_id(EqualFilter::equal_to(&store_id))
+                .item_id(EqualFilter::equal_to(&item_id))
+                .is_available(true),
+        ),
         None,
         Some(store_id.clone()),
     )?;
-
-    println!("current_stock_lines: {:?}", current_stock_lines);
 
     let stock_line_ids: Vec<String> = current_stock_lines
         .rows
@@ -32,16 +37,46 @@ pub fn get_historical_stock_lines(
         .map(|stock_line| stock_line.stock_line_row.id.clone())
         .collect();
 
+    // Get all stock movements (aka changes) for the stock lines
     let filter = StockMovementFilter::new()
         .store_id(EqualFilter::equal_to(&store_id))
         .item_id(EqualFilter::equal_to(&item_id))
+        .stock_line_id(EqualFilter::equal_any(stock_line_ids))
         .datetime(DatetimeFilter::date_range(datetime, date_now().into()));
     let stock_movements = StockMovementRepository::new(&ctx.connection).query(Some(filter))?;
 
-    println!("stock_movements: {:?}", stock_movements);
+    // Calculate how much each stock line has been adjusted
+    let mut stock_line_adjustments: HashMap<String, f64> = HashMap::new();
+    for stock_movement in stock_movements {
+        let stock_line_id = stock_movement.stock_line_id.clone();
+        let quantity = stock_movement.quantity;
+        let adjustment = stock_line_adjustments.get(&stock_line_id).unwrap_or(&0.0) + quantity;
+        stock_line_adjustments.insert(stock_line_id, adjustment);
+    }
+
+    // Create the historical stock lines, adjusted by the stock available then and now
+    let mut historical_stock_lines: Vec<StockLine> = vec![];
+    for stock_line in current_stock_lines.rows {
+        let stock_line_id = stock_line.stock_line_row.id.clone();
+        let adjustment = stock_line_adjustments.get(&stock_line_id).unwrap_or(&0.0);
+        let historical_available_packs = stock_line.stock_line_row.available_number_of_packs
+            - adjustment / stock_line.stock_line_row.pack_size;
+
+        if historical_available_packs > 0.0 {
+            // There was stock available at this time, so we should create a historical stock line
+            let mut new_stock_line = stock_line.clone();
+            if historical_available_packs < stock_line.stock_line_row.available_number_of_packs {
+                // If we have less stock available now than we did then, we don't want to show it as available back then
+                new_stock_line.stock_line_row.available_number_of_packs =
+                    historical_available_packs;
+            }
+
+            historical_stock_lines.push(new_stock_line);
+        }
+    }
 
     Ok(ListResult {
-        rows: vec![],
-        count: 0,
+        count: historical_stock_lines.len() as u32,
+        rows: historical_stock_lines,
     })
 }

--- a/server/service/src/stock_line/mod.rs
+++ b/server/service/src/stock_line/mod.rs
@@ -2,8 +2,11 @@ use self::query::{get_stock_line, get_stock_lines};
 
 use super::{ListError, ListResult};
 use crate::{service_provider::ServiceContext, SingleRecordError};
+use chrono::NaiveDateTime;
+use historical_stock::get_historical_stock_lines;
 use repository::{PaginationOption, StockLine, StockLineFilter, StockLineSort};
 
+pub mod historical_stock;
 pub mod query;
 pub mod update;
 pub use self::update::*;
@@ -34,6 +37,16 @@ pub trait StockLineServiceTrait: Sync + Send {
         input: UpdateStockLine,
     ) -> Result<StockLine, UpdateStockLineError> {
         update_stock_line(ctx, input)
+    }
+
+    fn get_historical_stock_lines(
+        &self,
+        ctx: &ServiceContext,
+        store_id: String,
+        item_id: String,
+        datetime: NaiveDateTime,
+    ) -> Result<ListResult<StockLine>, ListError> {
+        get_historical_stock_lines(ctx, store_id, item_id, datetime)
     }
 }
 

--- a/server/service/src/stock_line/tests/historical_stock.rs
+++ b/server/service/src/stock_line/tests/historical_stock.rs
@@ -186,12 +186,12 @@ mod query {
             .unwrap();
 
         // Check there's no stock to start with, if there is some mocks might have slipped through?
-        // let result = service_provider
-        //     .stock_line_service
-        //     .get_historical_stock_lines(&ctx, store_id.clone(), item_id.clone(), date_now().into())
-        //     .unwrap();
+        let result = service_provider
+            .stock_line_service
+            .get_historical_stock_lines(&ctx, store_id.clone(), item_id.clone(), date_now().into())
+            .unwrap();
 
-        // assert!(result.rows.is_empty());
+        assert!(result.rows.is_empty());
 
         // Here's our test scenario
         // 3 stock lines, A, B, &C
@@ -277,12 +277,12 @@ mod query {
         adjust_test_stock(&ctx, stock_movements);
 
         // // Check we can see 2 stock lines now (stock line A is fully consumed)
-        // let result = service_provider
-        //     .stock_line_service
-        //     .get_historical_stock_lines(&ctx, store_id.clone(), item_id.clone(), date_now().into())
-        //     .unwrap();
+        let result = service_provider
+            .stock_line_service
+            .get_historical_stock_lines(&ctx, store_id.clone(), item_id.clone(), date_now().into())
+            .unwrap();
 
-        // assert_eq!(result.rows.len(), 2);
+        assert_eq!(result.rows.len(), 2);
 
         // +++ 2020-01-01
         let result = service_provider

--- a/server/service/src/stock_line/tests/historical_stock.rs
+++ b/server/service/src/stock_line/tests/historical_stock.rs
@@ -1,0 +1,269 @@
+#[cfg(test)]
+mod query {
+    use chrono::{NaiveDate, NaiveDateTime};
+    use repository::mock::{mock_item_a, mock_name_customer_a, mock_name_store_b, mock_store_a};
+    use repository::mock::{mock_user_account_a, MockDataInserts};
+    use repository::{
+        InvoiceLineRow, InvoiceLineType, InvoiceRow, InvoiceStatus, InvoiceType, StockLineRow,
+        StockLineRowRepository, Upsert,
+    };
+    use util::date_now;
+
+    use crate::service_provider::ServiceContext;
+    use crate::test_helpers::{setup_all_and_service_provider, ServiceTestContext};
+
+    static mut INVOICE_NUMBER: i64 = 0;
+
+    // These are all from default mock data
+    static ITEM_ID: &str = "item_a";
+    static STORE_ID: &str = "store_a";
+
+    static STOCK_LINE_A: &str = "stock_line_a";
+    static STOCK_LINE_B: &str = "stock_line_b";
+    static STOCK_LINE_C: &str = "stock_line_c";
+
+    fn next_invoice_number() -> i64 {
+        unsafe {
+            INVOICE_NUMBER += 1;
+            INVOICE_NUMBER
+        }
+    }
+
+    fn update_stock(
+        ctx: &ServiceContext,
+        datetime: NaiveDateTime,
+        stock_line_id: String,
+        pack_size: f64,
+        number_of_packs: f64,
+        batch: String,
+    ) -> () {
+        let invoice_type = if number_of_packs > 0.0 {
+            InvoiceType::InboundShipment
+        } else {
+            InvoiceType::OutboundShipment
+        };
+        let invoice_line_type = if number_of_packs > 0.0 {
+            InvoiceLineType::StockIn
+        } else {
+            InvoiceLineType::StockOut
+        };
+        let name = if number_of_packs > 0.0 {
+            mock_name_store_b().id // Supplier
+        } else {
+            mock_name_customer_a().id // Customer
+        };
+
+        let old_stock_line = StockLineRowRepository::new(&ctx.connection)
+            .find_one_by_id(&stock_line_id)
+            .unwrap()
+            .unwrap_or_default();
+        let new_number_of_packs = old_stock_line.total_number_of_packs + number_of_packs;
+
+        let invoice_number = next_invoice_number();
+        let invoice = InvoiceRow {
+            id: format!("invoice_{}", invoice_number),
+            invoice_number,
+            name_link_id: name.to_string(),
+            r#type: invoice_type,
+            store_id: STORE_ID.to_string(),
+            created_datetime: datetime.clone(),
+            verified_datetime: Some(datetime.clone()),
+            status: InvoiceStatus::Verified,
+            ..Default::default()
+        };
+
+        invoice.upsert(&ctx.connection).unwrap();
+
+        let stock_line = StockLineRow {
+            id: stock_line_id.clone(),
+            item_link_id: ITEM_ID.to_string(),
+            pack_size,
+            total_number_of_packs: new_number_of_packs,
+            store_id: STORE_ID.to_string(),
+            batch: Some(batch.clone()),
+            ..old_stock_line
+        };
+
+        stock_line.upsert(&ctx.connection).unwrap();
+
+        let invoice_line = InvoiceLineRow {
+            id: format!("invoice_line_{}", invoice_number),
+            invoice_id: invoice.id.clone(),
+            item_link_id: ITEM_ID.to_string(),
+            stock_line_id: Some(stock_line_id),
+            pack_size,
+            number_of_packs: number_of_packs.abs(),
+            batch: Some(batch.clone()),
+            r#type: invoice_line_type,
+            ..Default::default()
+        };
+
+        invoice_line.upsert(&ctx.connection).unwrap();
+    }
+
+    struct TestStockAdjustment {
+        date: NaiveDate,
+        stock_line_a: Option<f64>,
+        stock_line_b: Option<f64>,
+        stock_line_c: Option<f64>,
+    }
+
+    fn adjust_test_stock(ctx: &ServiceContext, adjustments: Vec<TestStockAdjustment>) {
+        for adjustment in adjustments {
+            if let Some(stock_line_a) = adjustment.stock_line_a {
+                update_stock(
+                    ctx,
+                    adjustment.date.and_hms_opt(0, 0, 0).unwrap(),
+                    STOCK_LINE_A.to_string(),
+                    1.0,
+                    stock_line_a,
+                    "batchA".to_string(),
+                );
+            }
+
+            if let Some(stock_line_b) = adjustment.stock_line_b {
+                update_stock(
+                    ctx,
+                    adjustment.date.and_hms_opt(0, 0, 0).unwrap(),
+                    STOCK_LINE_B.to_string(),
+                    10.0,
+                    stock_line_b,
+                    "batchB".to_string(),
+                );
+            }
+
+            if let Some(stock_line_c) = adjustment.stock_line_c {
+                update_stock(
+                    ctx,
+                    adjustment.date.and_hms_opt(0, 0, 0).unwrap(),
+                    STOCK_LINE_C.to_string(),
+                    100.0,
+                    stock_line_c,
+                    "batchC".to_string(),
+                );
+            }
+        }
+    }
+
+    #[actix_rt::test]
+    async fn historical_stock_lines() {
+        let ServiceTestContext {
+            service_provider, ..
+        } = setup_all_and_service_provider(
+            "historical_stock_lines",
+            MockDataInserts::none()
+                .names()
+                .stores()
+                .items()
+                .locations()
+                .numbers(),
+        )
+        .await;
+
+        let store_id = mock_store_a().id;
+        let item_id = mock_item_a().id;
+
+        // Service context needs correct store for stock line adjustments logic
+        let ctx = service_provider
+            .context(store_id.clone(), mock_user_account_a().id)
+            .unwrap();
+
+        // Check there's no stock now
+        let result = service_provider
+            .stock_line_service
+            .get_historical_stock_lines(&ctx, store_id.clone(), item_id.clone(), date_now().into())
+            .unwrap();
+
+        assert!(result.rows.is_empty());
+
+        // Here's our test scenario
+        // 3 stock lines, A, B, C C is introduced later
+        // Stock line A has been fully consumed (as per latest data) so it can't be allocated in the past
+        // Stock line B has some stock available at historical dates
+        // Stock line C is introduced later so it can't be allocated until it's introduced
+
+        /*
+        ## Stock Movements
+
+        | Date       | StockLine A | StockLine B | StockLine C |
+        |------------|-------------|-------------|-------------|
+        | 2020-01-01 | 100         | 1000        | None        |
+        | 2020-01-02 | -50         | -500        | None        |
+        | 2020-01-03 | -50         | None        | None        |
+        | 2020-01-04 | 100         | 100         | None        |
+        | 2020-01-05 | -100        | None        | None        |
+        | 2021-01-06 | None        | None        | 1000        |
+
+        ## Running Totals
+
+        | Date       | StockLine A | StockLine B | StockLine C |
+        |------------|-------------|-------------|-------------|
+        | 2020-01-01 | 100         | 1000        |             |
+        | 2020-01-02 | 50          | 500         | 0           |
+        | 2020-01-03 | 0           | 500         | 0           |
+        | 2020-01-04 | 100         | 600         | 0           |
+        | 2020-01-05 | 0           | 600         | 0           |
+        | 2021-01-06 | 0           | 600         | 1000        |
+
+        ## Expected Available Stock for backdated date
+
+        | Date       | StockLine A | StockLine B | StockLine C | Comment     |
+        |------------|-------------|-------------|-------------|         |
+        | 2020-01-01 | 0           | 600         | 0           |  # StockLine A has been all consumed the future, StockLine B has 1000 available stock at that date, but we only have 600 now, StockLine |C doesn't exist yet
+        | 2020-01-02 | 0           | 500         | 0           |  # StockLine A has been all consumed the future, StockLine B has 500 available at that date less than the 600 we have in future
+        | 2020-01-03 | 0           | 500         | 0           |  # StockLine A has been all consumed the future so extra consumption doesn't change anything, No change for StockLine B
+        | 2020-01-04 | 0           | 600         | 0           |  # StockLine A has been all consumed the future, StockLine B has 600 available at that date, it could be allocated from now
+        | 2020-01-05 | 0           | 600         | 0           |  # StockLine A has been all consumed the future so extra consumption doesn't change anything, StockLine B has 600 available at that date, it could be allocated from now
+        | 2021-01-06 | 0           | 600         | 1000        |  # StockLine A has been all consumed the future, StockLine B has 600 available at that date, it could be allocated from now, StockLine C is introduced
+        */
+
+        let stock_movements = vec![
+            TestStockAdjustment {
+                date: NaiveDate::from_ymd_opt(2020, 1, 1).unwrap(),
+                stock_line_a: Some(100.0),
+                stock_line_b: Some(1000.0),
+                stock_line_c: None,
+            },
+            TestStockAdjustment {
+                date: NaiveDate::from_ymd_opt(2020, 1, 2).unwrap(),
+                stock_line_a: Some(-50.0),
+                stock_line_b: Some(-500.0),
+                stock_line_c: None,
+            },
+            TestStockAdjustment {
+                date: NaiveDate::from_ymd_opt(2020, 1, 3).unwrap(),
+                stock_line_a: Some(-50.0),
+                stock_line_b: None,
+                stock_line_c: None,
+            },
+            TestStockAdjustment {
+                date: NaiveDate::from_ymd_opt(2020, 1, 4).unwrap(),
+                stock_line_a: Some(100.0),
+                stock_line_b: Some(100.0),
+                stock_line_c: None,
+            },
+            TestStockAdjustment {
+                date: NaiveDate::from_ymd_opt(2020, 1, 5).unwrap(),
+                stock_line_a: Some(-100.0),
+                stock_line_b: None,
+                stock_line_c: None,
+            },
+            TestStockAdjustment {
+                date: NaiveDate::from_ymd_opt(2020, 1, 6).unwrap(),
+                stock_line_a: None,
+                stock_line_b: None,
+                stock_line_c: Some(1000.0),
+            },
+        ];
+
+        adjust_test_stock(&ctx, stock_movements);
+
+        // Check we can see 2 stock lines now (stock line A is fully consumed)
+        let result = service_provider
+            .stock_line_service
+            .get_historical_stock_lines(&ctx, store_id.clone(), item_id.clone(), date_now().into())
+            .unwrap();
+
+        assert_eq!(result.rows.len(), 2);
+    }
+}

--- a/server/service/src/stock_line/tests/mod.rs
+++ b/server/service/src/stock_line/tests/mod.rs
@@ -1,3 +1,3 @@
-#[cfg(test)]
+mod historical_stock;
 mod query;
 mod update;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4474

# 👩🏻‍💻 What does this PR do?

New function `get_historical_stock_lines` and test case

## 💌 Any notes for the reviewer?

- I'm using the stock movement view, does that miss stock that's just allocated rather than actually picked/sent etc?
- Does inventory adjustments or stock takes mean we need to account for something differently?
- Are there any test cases/scenarios I've missed?
- Is it safe to just adjust available_packs as I'm doing? Do we need to do something with total packs too?
- Is the overall approach/math valid? What am I missing?

I think there is a potential for a temporary ledger issue with this approach.
We need to take the minimum stock level as the available amount (the latest stock level might not be the minimum)
Will update this in another PR...


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ]  Test cases are in the rust code. Please suggest any other scenarios to try...

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
