### PR TITLE
DRAFT 4776 de techify new report modal

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -586,5 +586,7 @@
   "table.select-unselect-all-columns": "Select / unselect all columns",
   "table.show-columns": "Show / hide columns",
   "title.confirm-delete-encounter": "Delete encounter",
-  "warning.caps-lock": "Warning: Caps lock is on"
+  "warning.caps-lock": "Warning: Caps lock is on",
+  "message.arguments": "You can customize what is shown on the report by specifying some of the optional details below. Click OK to view the report.",
+  "label.report-filters": "Report Filters"
 }

--- a/client/packages/common/src/intl/locales/en/reports.json
+++ b/client/packages/common/src/intl/locales/en/reports.json
@@ -13,6 +13,5 @@
     "label.stocktake-frequency": "Stocktake frequency",
     "label.threshold-for-overstock": "Threshold for overstock",
     "label.threshold-for-understock": "Threshold for understock",
-    "message.contact-support": "Please contact support@msupply.foundation about configuring reports",
-    "message.arguments": "You can customize what is shown on the report by specifying some of the optional details below. Click OK to view the report."
+    "message.contact-support": "Please contact support@msupply.foundation about configuring reports"
 }

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -6828,6 +6828,8 @@ export type StringFilterInput = {
   equalTo?: InputMaybe<Scalars['String']['input']>;
   /** Search term must be included in search candidate (case insensitive) */
   like?: InputMaybe<Scalars['String']['input']>;
+  /** Search term must begin with (case insensitive) */
+  startsWith?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type Success = {

--- a/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
+++ b/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
@@ -20,7 +20,7 @@ export const ReportArgumentsModal: FC<ReportArgumentsModalProps> = ({
 }) => {
   const { store } = useAuthContext();
   const { urlQuery } = useUrlQuery();
-  const t = useTranslation('reports');
+  const t = useTranslation();
 
   const {
     monthlyConsumptionLookBackPeriod,
@@ -29,11 +29,15 @@ export const ReportArgumentsModal: FC<ReportArgumentsModalProps> = ({
     monthsItemsExpire,
   } = store?.preferences ?? {};
 
+  // default expiry date as now
+  const expiryDate = Date.now()
+
   const [data, setData] = useState<JsonData>({
     monthlyConsumptionLookBackPeriod,
     monthsOverstock,
     monthsUnderstock,
     monthsItemsExpire,
+    expiryDate,
     ...JSON.parse((urlQuery?.['reportArgs'] ?? '{}') as string),
   });
   const [error, setError] = useState<string | false>(false);
@@ -54,7 +58,7 @@ export const ReportArgumentsModal: FC<ReportArgumentsModalProps> = ({
 
   return (
     <Modal
-      title="Report arguments"
+      title={t("label.report-filters")}
       cancelButton={<DialogButton variant="cancel" onClick={cleanUp} />}
       slideAnimation={false}
       width={560}

--- a/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
+++ b/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
@@ -29,8 +29,8 @@ export const ReportArgumentsModal: FC<ReportArgumentsModalProps> = ({
     monthsItemsExpire,
   } = store?.preferences ?? {};
 
-  // default expiry date as now
-  const expiryDate = Date.now()
+  // default expiry date as now formatted to datepicker
+  const expiryDate = new Date().toISOString().slice(0, 10);
 
   const [data, setData] = useState<JsonData>({
     monthlyConsumptionLookBackPeriod,

--- a/server/graphql/core/src/generic_filters.rs
+++ b/server/graphql/core/src/generic_filters.rs
@@ -9,6 +9,8 @@ pub struct StringFilterInput {
     equal_to: Option<String>,
     /// Search term must be included in search candidate (case insensitive)
     like: Option<String>,
+    /// Search term must begin with (case insensitive)
+    starts_with: Option<String>,
 }
 
 impl From<StringFilterInput> for StringFilter {
@@ -19,8 +21,8 @@ impl From<StringFilterInput> for StringFilter {
             not_equal_to: None,
             equal_any: None,
             not_equal_all: None,
-            starts_with: None,
-            ends_with: None,
+            starts_with: f.starts_with,
+            ends_with: None, 
         }
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4776 

# 👩🏻‍💻 What does this PR do?

- Removes non configurable fields (This change comes with update reports from reports PR)
- Changes title wording
- Date defaults to today
- item search added starts_with for standard reports on name and/or code search

Works with changes made in omSupply reports PR https://github.com/msupply-foundation/open-msupply-reports/pull/93



<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

You can test this report by upserting the new reports from the [#4776 reports branch](https://github.com/msupply-foundation/open-msupply-reports/pull/93), and then generating a new report.

You will see the modal has changed and search for code or name on standard reports now runs by 'starts with' rather than 'contains'

# 📃 Documentation

- [x] **These areas should be updated or checked**: 
See new issue: https://github.com/msupply-foundation/msupply_docs/issues/88
<!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
