### PR TITLE
Plugin Suggested Quantity. via API call example

### DIFF
--- a/server/amc/amc.js
+++ b/server/amc/amc.js
@@ -2,7 +2,7 @@ const { sql } = Host.getFunctions();
 
 // Would need to install extism-js: https://github.com/extism/js-pdk?tab=readme-ov-file#linux-macos
 // To build (from this dir): extism-js ./amc.js -i amc.d.ts -o amc.wasm
-// To upload to server (from this dir): curl --form files='@amc.wasm' "config={};type=application/json" 'http://localhost:8000/plugin?plugin-type=AMC'
+// To upload to server (from this dir): curl --form files='@amc.wasm' --form "config={};type=application/json" 'http://localhost:8000/plugin?plugin-type=AMC'
 
 // TODO type sharing
 // TODO build scripts to use typescript (as per extism js)

--- a/server/amc/amc.js
+++ b/server/amc/amc.js
@@ -2,10 +2,10 @@ const { sql } = Host.getFunctions();
 
 // Would need to install extism-js: https://github.com/extism/js-pdk?tab=readme-ov-file#linux-macos
 // To build (from this dir): extism-js ./amc.js -i amc.d.ts -o amc.wasm
-// To upload to server (from this dir): curl --form files='@amc.wasm' http://localhost:8000/plugin
+// To upload to server (from this dir): curl --form files='@amc.wasm' "config={};type=application/json" 'http://localhost:8000/plugin?plugin-type=AMC'
 
 // TODO type sharing
-// TODO build scripts to use typescript (as per extism js std)
+// TODO build scripts to use typescript (as per extism js)
 
 // TODO Should come from settings
 const DAY_LOOKBACK = 800;

--- a/server/repository/src/db_diesel/requisition/requisition_row.rs
+++ b/server/repository/src/db_diesel/requisition/requisition_row.rs
@@ -52,7 +52,7 @@ joinable!(requisition -> program (program_id));
 allow_tables_to_appear_in_same_query!(requisition, name_link);
 allow_tables_to_appear_in_same_query!(requisition, item_link);
 
-#[derive(DbEnum, Debug, Clone, PartialEq, Eq)]
+#[derive(DbEnum, Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[DbValueStyle = "SCREAMING_SNAKE_CASE"]
 pub enum RequisitionType {
     Request,
@@ -67,7 +67,7 @@ pub enum RequisitionStatus {
     Sent,
     Finalised,
 }
-#[derive(DbEnum, Debug, Clone, PartialEq, Eq)]
+#[derive(DbEnum, Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[cfg_attr(test, derive(strum::EnumIter))]
 #[DbValueStyle = "SCREAMING_SNAKE_CASE"]
 pub enum ApprovalStatusType {
@@ -80,7 +80,7 @@ pub enum ApprovalStatusType {
     DeniedByAnother,
 }
 
-#[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq)]
+#[derive(Clone, Queryable, Insertable, AsChangeset, Deserialize, Serialize, Debug, PartialEq)]
 #[diesel(treat_none_as_null = true)]
 #[diesel(table_name = requisition)]
 pub struct RequisitionRow {

--- a/server/server/src/upload_plugin.rs
+++ b/server/server/src/upload_plugin.rs
@@ -1,27 +1,41 @@
-use actix_multipart::form::MultipartForm;
+use actix_multipart::form::{tempfile::TempFile, MultipartForm};
 use actix_web::{
     post,
     web::{self, Data},
     HttpResponse,
 };
 
+use serde::Deserialize;
 use serde_json::json;
 use service::{
     bind_plugin,
     service_provider::ServiceProvider,
     settings::Settings,
     static_files::{StaticFileCategory, StaticFileService},
+    PluginConfig, PluginType,
 };
-
-use crate::static_files::UploadForm;
 
 pub fn config_upload_plugin(cfg: &mut web::ServiceConfig) {
     cfg.service(plugin);
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct UrlParams {
+    plugin_type: PluginType,
+}
+
+#[derive(MultipartForm)]
+pub struct UploadPlugin {
+    #[multipart(rename = "files")]
+    pub file: TempFile,
+    pub config: actix_multipart::form::json::Json<PluginConfig>,
+}
+
 #[post("/plugin")]
 async fn plugin(
-    MultipartForm(UploadForm { file }): MultipartForm<UploadForm>,
+    MultipartForm(UploadPlugin { file, config }): MultipartForm<UploadPlugin>,
+    url_params: web::Query<UrlParams>,
     settings: Data<Settings>,
     service_provider: Data<ServiceProvider>,
 ) -> HttpResponse {
@@ -31,7 +45,12 @@ async fn plugin(
         .move_temp_file(file, &StaticFileCategory::Temporary, None)
         .unwrap();
 
-    bind_plugin(service_provider.clone(), static_file.to_path_buf());
+    bind_plugin(
+        service_provider.clone(),
+        static_file.to_path_buf(),
+        &url_params.plugin_type,
+        config.clone(),
+    );
 
     HttpResponse::Ok().json(json!({"ok": "all good"}))
 }

--- a/server/service/src/requisition/request_requisition/mod.rs
+++ b/server/service/src/requisition/request_requisition/mod.rs
@@ -21,3 +21,6 @@ pub use self::use_suggested_quantity::*;
 
 mod add_from_master_list;
 pub use self::add_from_master_list::*;
+
+mod suggested_quantity;
+pub use self::suggested_quantity::*;

--- a/server/service/src/requisition/request_requisition/suggested_quantity.rs
+++ b/server/service/src/requisition/request_requisition/suggested_quantity.rs
@@ -1,0 +1,94 @@
+use std::collections::HashMap;
+
+use repository::RequisitionRow;
+use serde::{Deserialize, Serialize};
+
+use crate::plugin;
+
+pub trait SuggestedQuantity: Send + Sync {
+    fn suggested_quantity(&self, input: SuggestedQuantityInput) -> SuggestedQuantityByItem;
+}
+
+pub struct SuggestedQuantityDefault;
+
+impl SuggestedQuantity for SuggestedQuantityDefault {
+    fn suggested_quantity(
+        &self,
+        SuggestedQuantityInput { requisition, items }: SuggestedQuantityInput,
+    ) -> SuggestedQuantityByItem {
+        let RequisitionRow {
+            min_months_of_stock,
+            max_months_of_stock,
+            ..
+        } = requisition;
+
+        items
+            .into_iter()
+            .map(|(item_id, suggest_quantity_stats)| {
+                (
+                    item_id,
+                    SuggestionQuantityItem {
+                        suggested_quantity: generate_single_suggested_quantity(
+                            min_months_of_stock,
+                            max_months_of_stock,
+                            suggest_quantity_stats,
+                        ),
+                    },
+                )
+            })
+            .collect()
+    }
+}
+
+pub fn generate_suggested_quantity(input: SuggestedQuantityInput) -> SuggestedQuantityByItem {
+    let default: Box<dyn SuggestedQuantity> = Box::new(SuggestedQuantityDefault);
+    plugin(|p| {
+        p.suggested_quantity
+            .as_ref()
+            .unwrap_or(&default)
+            .suggested_quantity(input)
+    })
+}
+#[derive(Clone, Deserialize, Serialize)]
+pub struct GenerateSuggestedQuantity {
+    pub average_monthly_consumption: f64,
+    pub available_stock_on_hand: f64,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct SuggestedQuantityInput {
+    pub requisition: RequisitionRow,
+    pub items: HashMap<String /* item id */, GenerateSuggestedQuantity>,
+}
+#[derive(Clone, Deserialize, Serialize)]
+pub struct SuggestionQuantityItem {
+    pub suggested_quantity: f64,
+}
+
+pub type SuggestedQuantityByItem = HashMap<String /* item id */, SuggestionQuantityItem>;
+
+fn generate_single_suggested_quantity(
+    min_months_of_stock: f64,
+    max_months_of_stock: f64,
+    GenerateSuggestedQuantity {
+        average_monthly_consumption,
+        available_stock_on_hand,
+    }: GenerateSuggestedQuantity,
+) -> f64 {
+    if average_monthly_consumption == 0.0 {
+        return 0.0;
+    }
+    let months_of_stock = available_stock_on_hand / average_monthly_consumption;
+
+    let default_min_months_of_stock = if min_months_of_stock == 0.0 {
+        max_months_of_stock
+    } else {
+        min_months_of_stock
+    };
+
+    if max_months_of_stock == 0.0 || (months_of_stock > default_min_months_of_stock) {
+        return 0.0;
+    }
+
+    (max_months_of_stock - months_of_stock) * average_monthly_consumption
+}

--- a/server/suggested_quantity/suggested_quantity.d.ts
+++ b/server/suggested_quantity/suggested_quantity.d.ts
@@ -1,0 +1,10 @@
+declare module 'main' {
+  // Extism exports take no params and return an I32
+  export function suggested_quantity(): I32;
+}
+
+declare module 'extism:host' {
+  interface user {
+    sql(ptr: I64): I64;
+  }
+}

--- a/server/suggested_quantity/suggested_quantity.js
+++ b/server/suggested_quantity/suggested_quantity.js
@@ -1,0 +1,42 @@
+// Would need to install extism-js: https://github.com/extism/js-pdk?tab=readme-ov-file#linux-macos
+// To build (from this dir): extism-js ./suggested_quantity.js -i suggested_quantity.d.ts -o suggested_quantity.wasm
+// To upload to server (from this dir): curl --form files='@suggested_quantity.wasm' --form "config={\"allowed_hosts\":[\"localhost\"], \"plugin_config\": { \"server_url\": \"http://localhost:3000\"}};type=application/json" 'http://localhost:8000/plugin?plugin-type=SUGGESTEDQUANTITY'
+
+// Run test json server with: npx json-server --watch test-db.json, edit test-db.json to include item ids in your datafile
+// Update above 'upload to server' query if your json server endpoint is not running on 3000
+
+// TODO type sharing
+// TODO build scripts to use typescript (as per extism js)
+
+function suggested_quantity() {
+  const { items, requisition } = JSON.parse(Host.inputString());
+
+  const config = JSON.parse(Config.get('config'));
+  const item_ids = Object.keys(items);
+
+  const item_ids_url_param = `id=${item_ids.join(',id=')}`;
+
+  // Can use requisition.store_id, but not bothering with mocking that in API atm
+  const request = {
+    url: `${config.server_url}/items?${item_ids_url_param}`,
+  };
+
+  try {
+    const http_response = Http.request(request);
+
+    const response_body = JSON.parse(http_response.body);
+
+    const response = {};
+    item_ids.forEach((item_id) => {
+      response[item_id] = {
+        suggested_quantity: response_body.find((r) => r.id === item_id)?.suggested || 0,
+      };
+    });
+
+    Host.outputString(JSON.stringify(response));
+  } catch (e) {
+    Host.outputString(JSON.stringify({}));
+  }
+}
+
+module.exports = { suggested_quantity };

--- a/server/suggested_quantity/test-db.json
+++ b/server/suggested_quantity/test-db.json
@@ -1,0 +1,12 @@
+{
+    "items": [
+        {
+            "id": "179D364578D343C8BC45930C16A1D61C",
+            "suggested": 55
+        },
+        {
+            "id": "B32AB019E5A64C2495A2FE43C3EDBE85",
+            "suggested": 72
+        }
+    ]
+}


### PR DESCRIPTION
Following up from [this PR:](https://github.com/msupply-foundation/open-msupply/pull/4806), another prototype of adding suggested quantity plugin, that uses API call to get quantities:

* Upload plugin endpoint now accepts json config and url parameter for plugin. name
* Json config from plugin includes common configurations (which hosts are allowed for http requests) and plugin specific configs (in this case url of the server)
* Expose suggested quantity calculation as a plugin (refactor slightly, to only be called once for all item ids being processed)
* Add suggested quantity plugin that queries API for suggested quantities for item (using mock json server)