### PR TITLE
#4173 Prevent dose skipping

### DIFF
--- a/server/graphql/programs/src/mutations/vaccination/insert.rs
+++ b/server/graphql/programs/src/mutations/vaccination/insert.rs
@@ -101,6 +101,7 @@ fn map_error(error: ServiceError) -> Result<InsertVaccinationResponse> {
         | ServiceError::ReasonNotProvided
         | ServiceError::StockLineNotProvided
         | ServiceError::StockLineDoesNotExist
+        | ServiceError::VaccineIsNotNextDose
         | ServiceError::ItemDoesNotBelongToVaccineCourse => BadUserInput(formatted_error),
 
         ServiceError::CreatedRecordNotFound

--- a/server/repository/src/mock/vaccination.rs
+++ b/server/repository/src/mock/vaccination.rs
@@ -15,6 +15,7 @@ pub fn mock_vaccination_a() -> VaccinationRow {
         program_enrolment_id: mock_immunisation_program_enrolment_a().id,
         vaccine_course_dose_id: mock_vaccine_course_a_dose_a().id,
         encounter_id: mock_immunisation_encounter_a().id,
+        given: true,
         created_datetime: NaiveDate::from_ymd_opt(2024, 2, 1)
             .unwrap()
             .and_hms_opt(0, 0, 0)

--- a/server/service/src/vaccination/get_vaccination_card.rs
+++ b/server/service/src/vaccination/get_vaccination_card.rs
@@ -171,15 +171,17 @@ mod tests {
             first_item.row.vaccine_course_dose_id,
             mock_vaccine_course_a_dose_a().id
         );
-        // There is a vaccination, it was NOT given
-        assert_eq!(first_item.row.given, Some(false));
-        // Hence there is still a suggested date based on the DOB
+        // There is a vaccination, it was given
+        assert_eq!(first_item.row.given, Some(true));
+        // Hence there is no suggested date
+        assert_eq!(first_item.suggested_date, None);
+        // Second dose therefore has a suggested date, based min interval
         assert_eq!(
-            first_item.suggested_date,
-            NaiveDate::from_ymd_opt(2024, 1, 1)
+            result.items[1].suggested_date,
+            NaiveDate::from_ymd_opt(2024, 1, 31)
         );
-        // Second dose therefore has no suggested date
-        assert_eq!(result.items[1].suggested_date, None);
+        // Third dose has no suggested date
+        assert_eq!(result.items[2].suggested_date, None);
     }
 
     #[actix_rt::test]

--- a/server/service/src/vaccination/insert/mod.rs
+++ b/server/service/src/vaccination/insert/mod.rs
@@ -26,6 +26,7 @@ pub enum InsertVaccinationError {
     VaccineCourseDoseDoesNotExist,
     ProgramEnrolmentDoesNotMatchVaccineCourse,
     VaccinationAlreadyExistsForDose,
+    VaccineIsNotNextDose,
     ClinicianDoesNotExist,
     ReasonNotProvided,
     StockLineNotProvided,

--- a/server/service/src/vaccination/insert/mod.rs
+++ b/server/service/src/vaccination/insert/mod.rs
@@ -262,6 +262,22 @@ mod insert {
             Err(InsertVaccinationError::VaccinationAlreadyExistsForDose)
         );
 
+        // VaccineIsNotNextDose
+        assert_eq!(
+            service.insert_vaccination(
+                &context,
+                store_id,
+                InsertVaccination {
+                    id: "new_id".to_string(),
+                    encounter_id: mock_immunisation_encounter_a().id,
+                    // Only dose A has been administered
+                    vaccine_course_dose_id: mock_vaccine_course_a_dose_c().id,
+                    ..Default::default()
+                }
+            ),
+            Err(InsertVaccinationError::VaccineIsNotNextDose)
+        );
+
         // ClinicianDoesNotExist
         assert_eq!(
             service.insert_vaccination(
@@ -342,6 +358,38 @@ mod insert {
                 }
             ),
             Err(InsertVaccinationError::ItemDoesNotBelongToVaccineCourse)
+        );
+
+        // Insert dose B as NOT GIVEN
+        service
+            .insert_vaccination(
+                &context,
+                store_id,
+                InsertVaccination {
+                    id: "new_vaccination_given_id".to_string(),
+                    encounter_id: mock_immunisation_encounter_a().id,
+                    vaccine_course_dose_id: mock_vaccine_course_a_dose_b().id,
+                    given: false,
+                    not_given_reason: Some("reason".to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        // VaccineIsNotNextDose
+        assert_eq!(
+            service.insert_vaccination(
+                &context,
+                store_id,
+                InsertVaccination {
+                    id: "new_id".to_string(),
+                    encounter_id: mock_immunisation_encounter_a().id,
+                    // Dose B was not given, so can't give dose C
+                    vaccine_course_dose_id: mock_vaccine_course_a_dose_c().id,
+                    ..Default::default()
+                }
+            ),
+            Err(InsertVaccinationError::VaccineIsNotNextDose)
         );
     }
 

--- a/server/service/src/vaccination/insert/validate.rs
+++ b/server/service/src/vaccination/insert/validate.rs
@@ -47,14 +47,18 @@ pub fn validate(
         connection,
         &vaccine_course_dose.vaccine_course_row.id,
         &input.vaccine_course_dose_id,
-        &program_enrolment.program_row.id,
-    )?;
+        &program_enrolment.row.id,
+    )
+    .map_err(|err| match err {
+        RepositoryError::NotFound => InsertVaccinationError::VaccineIsNotNextDose,
+        _ => InsertVaccinationError::DatabaseError(err),
+    })?;
 
     if let Some(previous_vaccination) = previous_vaccination {
-        if !previous_vaccination.vaccination_row.given == true {
+        if !previous_vaccination.vaccination_row.given {
             return Err(InsertVaccinationError::VaccineIsNotNextDose);
         }
-    };
+    }
 
     if let Some(clinician_id) = &input.clinician_id {
         if !check_clinician_exists(clinician_id, connection)? {

--- a/server/service/src/vaccination/insert/validate.rs
+++ b/server/service/src/vaccination/insert/validate.rs
@@ -5,7 +5,7 @@ use crate::{
     vaccination::validate::{
         check_clinician_exists, check_encounter_exists, check_item_belongs_to_vaccine_course,
         check_program_enrolment_exists, check_vaccination_does_not_exist_for_dose,
-        check_vaccination_exists, check_vaccine_course_dose_exists,
+        check_vaccination_exists, check_vaccine_course_dose_exists, get_related_vaccinations,
     },
 };
 
@@ -42,7 +42,19 @@ pub fn validate(
         return Err(InsertVaccinationError::VaccinationAlreadyExistsForDose);
     }
 
-    // TODO: check is the next dose! (can't give a dose if the previous one hasn't been given)
+    // Check that the previous dose has been given
+    let (previous_vaccination, _) = get_related_vaccinations(
+        connection,
+        &vaccine_course_dose.vaccine_course_row.id,
+        &input.vaccine_course_dose_id,
+        &program_enrolment.program_row.id,
+    )?;
+
+    if let Some(previous_vaccination) = previous_vaccination {
+        if !previous_vaccination.vaccination_row.given == true {
+            return Err(InsertVaccinationError::VaccineIsNotNextDose);
+        }
+    };
 
     if let Some(clinician_id) = &input.clinician_id {
         if !check_clinician_exists(clinician_id, connection)? {

--- a/server/service/src/vaccination/update/validate.rs
+++ b/server/service/src/vaccination/update/validate.rs
@@ -1,13 +1,10 @@
-use repository::{
-    EqualFilter, RepositoryError, StockLine, StorageConnection, Vaccination, VaccinationFilter,
-    VaccinationRepository, VaccinationRow,
-};
+use repository::{RepositoryError, StockLine, StorageConnection, VaccinationRow};
 
 use crate::{
     common_stock::{check_stock_line_exists, CommonStockLineError},
     vaccination::validate::{
         check_clinician_exists, check_encounter_exists, check_item_belongs_to_vaccine_course,
-        check_vaccination_exists,
+        check_vaccination_exists, get_related_vaccinations,
     },
 };
 
@@ -94,8 +91,12 @@ pub fn validate(
     };
 
     // Check we can give/un-give this dose, based on previous and next doses
-    let (previous_vaccination, next_vaccination) =
-        get_related_vaccinations(connection, &vaccination)?;
+    let (previous_vaccination, next_vaccination) = get_related_vaccinations(
+        connection,
+        &vaccination.vaccine_course_dose_row.vaccine_course_id,
+        &vaccination.vaccine_course_dose_row.id,
+        &vaccination.vaccination_row.program_enrolment_id,
+    )?;
 
     if let Some(previous_vaccination) = previous_vaccination {
         if !previous_vaccination.vaccination_row.given && input.given == Some(true) {
@@ -126,39 +127,6 @@ fn check_doses_defined(stock_line: &StockLine) -> Result<(), UpdateVaccinationEr
     }
 
     Ok(())
-}
-
-fn get_related_vaccinations(
-    connection: &StorageConnection,
-    vaccination: &Vaccination,
-) -> Result<(Option<Vaccination>, Option<Vaccination>), RepositoryError> {
-    // Sorted by created date
-    let other_vaccinations_for_course = VaccinationRepository::new(connection).query_by_filter(
-        VaccinationFilter::new()
-            .program_enrolment_id(EqualFilter::equal_to(
-                &vaccination.vaccination_row.program_enrolment_id,
-            ))
-            .vaccine_course_id(EqualFilter::equal_to(
-                &vaccination.vaccine_course_dose_row.vaccine_course_id,
-            )),
-    )?;
-
-    let this_vaccination_index = other_vaccinations_for_course
-        .iter()
-        .position(|v| v.vaccination_row.id == vaccination.vaccination_row.id)
-        .unwrap_or(0);
-
-    let previous_vaccination = match this_vaccination_index {
-        // First in course
-        0 => None,
-        index => other_vaccinations_for_course.get(index - 1).cloned(),
-    };
-
-    let next_vaccination = other_vaccinations_for_course
-        .get(this_vaccination_index + 1)
-        .cloned();
-
-    return Ok((previous_vaccination, next_vaccination));
 }
 
 impl From<CommonStockLineError> for UpdateVaccinationError {

--- a/server/service/src/vaccination/update/validate.rs
+++ b/server/service/src/vaccination/update/validate.rs
@@ -96,7 +96,12 @@ pub fn validate(
         &vaccination.vaccine_course_dose_row.vaccine_course_id,
         &vaccination.vaccine_course_dose_row.id,
         &vaccination.vaccination_row.program_enrolment_id,
-    )?;
+    )
+    .map_err(|err| match err {
+        // If there was a previous dose, but a vaccination for it wasn't found
+        RepositoryError::NotFound => UpdateVaccinationError::NotNextDose,
+        _ => UpdateVaccinationError::DatabaseError(err),
+    })?;
 
     if let Some(previous_vaccination) = previous_vaccination {
         if !previous_vaccination.vaccination_row.given && input.given == Some(true) {

--- a/server/service/src/vaccination/validate.rs
+++ b/server/service/src/vaccination/validate.rs
@@ -93,7 +93,6 @@ pub fn get_related_vaccinations(
     vaccine_course_id: &String,
     vaccine_course_dose_id: &String,
     program_enrolment_id: &String,
-    // vaccination: &Vaccination,
 ) -> Result<(Option<Vaccination>, Option<Vaccination>), RepositoryError> {
     // Get all doses based on course id
     let all_course_doses = VaccineCourseDoseRepository::new(connection).query_by_filter(
@@ -114,13 +113,24 @@ pub fn get_related_vaccinations(
 
     let next_dose = all_course_doses.get(this_dose_index + 1).cloned();
 
-    let previous_vaccination = VaccinationRepository::new(connection).query_one(
-        VaccinationFilter::new()
-            .vaccine_course_dose_id(EqualFilter::equal_to(
-                &previous_dose.unwrap_or_default().vaccine_course_dose_row.id,
-            ))
-            .program_enrolment_id(EqualFilter::equal_to(&program_enrolment_id)),
-    )?;
+    let previous_vaccination = if let Some(previous_dose) = previous_dose {
+        let prev_vaccination = VaccinationRepository::new(connection).query_one(
+            VaccinationFilter::new()
+                .vaccine_course_dose_id(EqualFilter::equal_to(
+                    &previous_dose.vaccine_course_dose_row.id,
+                ))
+                .program_enrolment_id(EqualFilter::equal_to(&program_enrolment_id)),
+        )?;
+
+        // If there is a previous dose, it should have an associated vaccination
+        if prev_vaccination.is_none() {
+            return Err(RepositoryError::NotFound);
+        }
+
+        prev_vaccination
+    } else {
+        None
+    };
 
     let next_vaccination = VaccinationRepository::new(connection).query_one(
         VaccinationFilter::new()

--- a/server/service/src/vaccination/validate.rs
+++ b/server/service/src/vaccination/validate.rs
@@ -117,7 +117,7 @@ pub fn get_related_vaccinations(
     let previous_vaccination = VaccinationRepository::new(connection).query_one(
         VaccinationFilter::new()
             .vaccine_course_dose_id(EqualFilter::equal_to(
-                &previous_dose.unwrap_or_default().vaccine_course_row.id,
+                &previous_dose.unwrap_or_default().vaccine_course_dose_row.id,
             ))
             .program_enrolment_id(EqualFilter::equal_to(&program_enrolment_id)),
     )?;
@@ -125,7 +125,7 @@ pub fn get_related_vaccinations(
     let next_vaccination = VaccinationRepository::new(connection).query_one(
         VaccinationFilter::new()
             .vaccine_course_dose_id(EqualFilter::equal_to(
-                &next_dose.unwrap_or_default().vaccine_course_row.id,
+                &next_dose.unwrap_or_default().vaccine_course_dose_row.id,
             ))
             .program_enrolment_id(EqualFilter::equal_to(&program_enrolment_id)),
     )?;

--- a/server/service/src/vaccination/validate.rs
+++ b/server/service/src/vaccination/validate.rs
@@ -87,3 +87,48 @@ pub fn check_clinician_exists(
 
     Ok(result.is_some())
 }
+
+pub fn get_related_vaccinations(
+    connection: &StorageConnection,
+    vaccine_course_id: &String,
+    vaccine_course_dose_id: &String,
+    program_enrolment_id: &String,
+    // vaccination: &Vaccination,
+) -> Result<(Option<Vaccination>, Option<Vaccination>), RepositoryError> {
+    // Get all doses based on course id
+    let all_course_doses = VaccineCourseDoseRepository::new(connection).query_by_filter(
+        VaccineCourseDoseFilter::new().vaccine_course_id(EqualFilter::equal_to(vaccine_course_id)),
+    )?;
+
+    // Get previous and next dose based on dose_id
+    let this_dose_index = all_course_doses
+        .iter()
+        .position(|v| &v.vaccine_course_dose_row.id == vaccine_course_dose_id)
+        .unwrap_or(0);
+
+    let previous_dose = match this_dose_index {
+        // First in course
+        0 => None,
+        index => all_course_doses.get(index - 1).cloned(),
+    };
+
+    let next_dose = all_course_doses.get(this_dose_index + 1).cloned();
+
+    let previous_vaccination = VaccinationRepository::new(connection).query_one(
+        VaccinationFilter::new()
+            .vaccine_course_dose_id(EqualFilter::equal_to(
+                &previous_dose.unwrap_or_default().vaccine_course_row.id,
+            ))
+            .program_enrolment_id(EqualFilter::equal_to(&program_enrolment_id)),
+    )?;
+
+    let next_vaccination = VaccinationRepository::new(connection).query_one(
+        VaccinationFilter::new()
+            .vaccine_course_dose_id(EqualFilter::equal_to(
+                &next_dose.unwrap_or_default().vaccine_course_row.id,
+            ))
+            .program_enrolment_id(EqualFilter::equal_to(&program_enrolment_id)),
+    )?;
+
+    return Ok((previous_vaccination, next_vaccination));
+}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4713

# 👩🏻‍💻 What does this PR do?

Just adds logic to check that the previous dose has been when attempting to insert a vaccination.

I refactored the `get_related_vaccinations` method so that it takes a vaccination dose input rather than a vaccination, as the vaccination doesn't yet exist when inserting. The output of the method (previous dose, next dose) remains unchanged, we just get there a different way.

## 💌 Any notes for the reviewer?

Update tests confirmed still working. Not sure if I should add another case for the Insert?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Run tests. Try turning off the restriction in the front-end and confirm that an error is received?
