### PR TITLE
4825 fix handling of 0 discount masterlists

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "2.2.02-RC3",
+  "version": "2.2.02-RC4",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/graphql/general/src/queries/master_list.rs
+++ b/server/graphql/general/src/queries/master_list.rs
@@ -19,6 +19,7 @@ pub enum MasterListSortFieldInput {
     Name,
     Code,
     Description,
+    DiscountPercentage,
 }
 
 #[derive(InputObject)]

--- a/server/repository/src/db_diesel/master_list.rs
+++ b/server/repository/src/db_diesel/master_list.rs
@@ -11,7 +11,7 @@ use super::{
 };
 
 use crate::{
-    diesel_macros::{apply_equal_filter, apply_sort_no_case, apply_string_filter},
+    diesel_macros::{apply_equal_filter, apply_sort, apply_sort_no_case, apply_string_filter},
     repository_error::RepositoryError,
 };
 
@@ -176,7 +176,7 @@ impl<'a> MasterListRepository<'a> {
                     apply_sort_no_case!(query, sort, master_list_dsl::description);
                 }
                 MasterListSortField::DiscountPercentage => {
-                    apply_sort_no_case!(query, sort, master_list_dsl::discount_percentage);
+                    apply_sort!(query, sort, master_list_dsl::discount_percentage);
                 }
             }
         } else {

--- a/server/repository/src/db_diesel/master_list.rs
+++ b/server/repository/src/db_diesel/master_list.rs
@@ -44,6 +44,7 @@ pub enum MasterListSortField {
     Name,
     Code,
     Description,
+    DiscountPercentage,
 }
 
 pub type MasterListSort = Sort<MasterListSortField>;
@@ -120,9 +121,13 @@ impl<'a> MasterListRepository<'a> {
 
             if let Some(is_discount_list) = f.is_discount_list {
                 if is_discount_list {
-                    query = query.filter(master_list_dsl::discount_percentage.is_not_null());
+                    query = query.filter(master_list_dsl::discount_percentage.gt(0.0));
                 } else {
-                    query = query.filter(master_list_dsl::discount_percentage.is_null());
+                    query = query.filter(
+                        master_list_dsl::discount_percentage
+                            .is_null()
+                            .or(master_list_dsl::discount_percentage.eq(0.0)),
+                    );
                 }
             }
 
@@ -169,6 +174,9 @@ impl<'a> MasterListRepository<'a> {
                 }
                 MasterListSortField::Description => {
                     apply_sort_no_case!(query, sort, master_list_dsl::description);
+                }
+                MasterListSortField::DiscountPercentage => {
+                    apply_sort_no_case!(query, sort, master_list_dsl::discount_percentage);
                 }
             }
         } else {

--- a/server/service/src/pricing/item_price.rs
+++ b/server/service/src/pricing/item_price.rs
@@ -66,11 +66,6 @@ pub fn get_pricing_for_item(
     let discount_percentage = if is_patient {
         None // Patients get no discount
     } else {
-        log::info!(
-            "Checking discounts: {:?}, {}",
-            input.customer_name_id,
-            input.item_id
-        );
         // 2.A Lookup the discount list
         // Always assign the biggest discount we can find
         let discount_master_list = MasterListRepository::new(&ctx.connection)

--- a/server/service/src/pricing/item_price.rs
+++ b/server/service/src/pricing/item_price.rs
@@ -1,6 +1,6 @@
 use repository::{
     EqualFilter, MasterListFilter, MasterListLineFilter, MasterListLineRepository,
-    MasterListRepository, PatientFilter,
+    MasterListRepository, MasterListSort, MasterListSortField, Pagination, PatientFilter,
 };
 use repository::{PatientRepository, RepositoryError};
 
@@ -66,13 +66,28 @@ pub fn get_pricing_for_item(
     let discount_percentage = if is_patient {
         None // Patients get no discount
     } else {
+        log::info!(
+            "Checking discounts: {:?}, {}",
+            input.customer_name_id,
+            input.item_id
+        );
         // 2.A Lookup the discount list
-        // Find the first discount list that has the item (not trying to be clever here, just using the first one found)
+        // Always assign the biggest discount we can find
         let discount_master_list = MasterListRepository::new(&ctx.connection)
-            .query_by_filter(
-                MasterListFilter::new()
-                    .is_discount_list(true)
-                    .item_id(EqualFilter::equal_to(&input.item_id)),
+            .query(
+                Pagination {
+                    limit: 1,
+                    offset: 0,
+                },
+                Some(
+                    MasterListFilter::new()
+                        .is_discount_list(true)
+                        .item_id(EqualFilter::equal_to(&input.item_id)),
+                ),
+                Some(MasterListSort {
+                    key: MasterListSortField::DiscountPercentage,
+                    desc: Some(true),
+                }),
             )?
             .pop();
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4825 

# 👩🏻‍💻 What does this PR do?

Finds the best available discount for an item's discount.

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Setup for discount lists in mSupply
- [ ] Edit at least one other masterlist to sync to open-mSupply
- [ ] Check that the discount is still applied even though there's masterlists with 0.0% discount now

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
