### PR TITLE
4721 Program enrolment date not populated in edit modal

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/DateTime.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/DateTime.tsx
@@ -100,7 +100,7 @@ const UIComponent = (props: ControlProps) => {
   };
 
   const sharedComponentProps = {
-    value: DateUtils.getDateOrNull(data, inputFormat),
+    value: DateUtils.getDateOrNull(data),
     onChange: (e: Date | null) => onChange(e),
     inputFormat,
     readOnly: !!props.uischema.options?.['readonly'],


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4721

# 👩🏻‍💻 What does this PR do?
Date is already being formatted in component so don't need to format twice.

![Screenshot 2024-09-23 at 9 41 28 AM](https://github.com/user-attachments/assets/9f33554f-d20d-4fc8-9343-82fb4d67ed59)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have patient programs set up 
- [ ] Enrol a patient into a program (add an enrolment date)
- [ ] Go to `Programs` tab in Patient detail view
- [ ] Click on the enrolment
- [ ] Should see enrolment date populated

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
