### PR TITLE
4691 Wrapped AppBarButtons have no margin

### DIFF
--- a/client/packages/common/src/ui/components/portals/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/common/src/ui/components/portals/AppBarButtons/AppBarButtons.tsx
@@ -27,7 +27,12 @@ export const AppBarButtonsPortal: FC<BoxProps> = props => {
 
   return (
     <Portal container={appBarButtonsRef.current}>
-      <Box {...props} />
+      <Box
+        sx={{
+          padding: 1.5,
+        }}
+        {...props}
+      />
     </Portal>
   );
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4691

# 👩🏻‍💻 What does this PR do?
Was trying to find where the padding/margin was... but looks like it was a min-height set on some element... so have added padding to account for wrapping in App Bar Button

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to internal order
- [ ] Inspector
- [ ] Change sizing of screen

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
