### PR TITLE
4684 Can change the other party (supplier) of automatic supplier returns

### DIFF
--- a/client/packages/invoices/src/Returns/SupplierDetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Returns/SupplierDetailView/Toolbar.tsx
@@ -21,7 +21,8 @@ export const Toolbar: FC = () => {
 
   const { bufferedState, setBufferedState } =
     useReturns.document.supplierReturn();
-  const { otherParty, theirReference, id } = bufferedState ?? { id: '' };
+  const { otherParty, theirReference, id, originalShipment } =
+    bufferedState ?? { id: '' };
   const { isGrouped, toggleIsGrouped } = useIsGrouped('supplierReturn');
   const { mutateAsync: updateOtherParty } =
     useReturns.document.updateOtherParty();
@@ -55,7 +56,7 @@ export const Toolbar: FC = () => {
                 sx={{ minWidth: 100 }}
                 Input={
                   <SupplierSearchInput
-                    disabled={isDisabled}
+                    disabled={isDisabled || !!originalShipment}
                     value={otherParty}
                     onChange={async ({ id: otherPartyId }) => {
                       await updateOtherParty({ id, otherPartyId });


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4684

# 👩🏻‍💻 What does this PR do?
Disable supplier selection if supplier return was created from inbound shipment.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have verified Inbound Shipment. 
- [ ] Return some stock
- [ ] Get redirected to supplier return
- [ ] See supplier selection disabled

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
