### PR TITLE
4685 Requisitions: number of shipments sort actually sorts by requisition num 

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
@@ -91,6 +91,7 @@ export const ResponseRequisitionListView: FC = () => {
       label: 'label.shipments',
       description: 'description.number-of-shipments',
       accessor: ({ rowData }) => rowData?.shipments?.totalCount ?? 0,
+      sortable: false,
     },
   ];
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4685

# 👩🏻‍💻 What does this PR do?
Disables sort by number of shipments created from requisitions. 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to requisitions
- [ ] Try sort by `Shipments`
- [ ] Shouldn't be able to sort

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
