### PR TITLE
3175 Stocktake: something's wrong with the pagination

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/ContentArea.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/ContentArea.tsx
@@ -94,12 +94,12 @@ export const ContentArea: FC<ContentAreaProps> = ({
     updatePaginationQuery,
     queryParams: { page, first, offset, sortBy },
   } = useUrlQueryParams({ initialSort: { key: 'itemName', dir: 'asc' } });
-  const { isDisabled, isLoading, rows, totalLineCount } =
+  const { isDisabled, isLoading, lines, totalLineCount } =
     useStocktake.line.rows();
   const columns = useStocktakeColumns({ onChangeSortBy, sortBy });
   const pagination = { page, first, offset };
 
-  useHighlightUncountedRows(rows);
+  useHighlightUncountedRows(lines);
 
   return isLoading ? (
     <BasicSpinner />
@@ -109,7 +109,7 @@ export const ContentArea: FC<ContentAreaProps> = ({
       ExpandContent={Expando}
       isRowAnimated={true}
       columns={columns}
-      data={rows}
+      data={lines}
       id="stocktake-detail"
       noDataElement={
         <NothingHere

--- a/client/packages/inventory/src/Stocktake/DetailView/Toolbar.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/Toolbar.tsx
@@ -12,11 +12,8 @@ import {
   DateTimePickerInput,
   Formatter,
   SearchBar,
-  Box,
-  Switch,
   DateUtils,
   Alert,
-  useIsGrouped,
   useUrlQuery,
   RewindIcon,
   useEditModal,
@@ -29,8 +26,6 @@ import { ChangeLocationConfirmationModal } from './ChangeLocationModal';
 
 export const Toolbar = () => {
   const { info } = useNotification();
-  const { isGrouped, toggleIsGrouped } = useIsGrouped('stocktake');
-  const [localIsGrouped, setLocalIsGrouped] = React.useState(isGrouped);
   const isDisabled = useStocktake.utils.isDisabled();
   const t = useTranslation('inventory');
   const { isLocked, stocktakeDate, description, update } =
@@ -41,13 +36,7 @@ export const Toolbar = () => {
   const infoMessage = isLocked
     ? t('messages.on-hold-stock-take')
     : t('messages.finalised-stock-take');
-  const onChangeIsGrouped = () => {
-    setLocalIsGrouped(!localIsGrouped);
-    // when the render of the dependent component is slow
-    // separate the render of the switch change from the wider state change
-    // otherwise the switch doesn't render until the slow component completes
-    setTimeout(toggleIsGrouped, 100);
-  };
+
   const { urlQuery, updateQuery } = useUrlQuery({
     skipParse: ['itemCodeOrName'],
   });
@@ -148,15 +137,6 @@ export const Toolbar = () => {
               setItemFilter(newValue);
             }}
           />
-          <Box sx={{ marginRight: 2 }}>
-            <Switch
-              label={t('label.group-by-item')}
-              onChange={onChangeIsGrouped}
-              checked={localIsGrouped}
-              size="small"
-              color="secondary"
-            />
-          </Box>
           <DropdownMenu disabled={isDisabled} label={t('label.actions')}>
             <>
               <DropdownMenuItem

--- a/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
@@ -1,4 +1,4 @@
-import { ArrayUtils, useIsGrouped } from '@openmsupply-client/common';
+import { ArrayUtils } from '@openmsupply-client/common';
 import { StocktakeLineFragment } from '../../operations.generated';
 import { StocktakeSummaryItem } from '../../../../types';
 import { useStocktake } from '..';
@@ -21,8 +21,6 @@ export const useStocktakeRows = () => {
   const lines = lineData?.nodes;
   const items = useMemo(() => getStocktakeItems(lines ?? []), [lines]);
   const totalLineCount = lineData?.totalCount ?? 0;
-  const { isGrouped } = useIsGrouped('stocktake');
-  const rows = isGrouped ? items : lines;
   const isDisabled = !stocktake || isStocktakeDisabled(stocktake);
 
   return {
@@ -30,7 +28,6 @@ export const useStocktakeRows = () => {
     isLoading,
     items,
     lines,
-    rows,
     totalLineCount,
   };
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3175

# 👩🏻‍💻 What does this PR do?
Remove the `group by item` toggle in stocktake. Another issue has been created for group by to be refactored in backend

![Screenshot 2024-09-25 at 9 33 56 AM](https://github.com/user-attachments/assets/1eda3de9-0ab1-4a21-9d59-5374223f06cd)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to stocktake
- [ ] Shouldn't see the group by item toggle anymore

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Any mention of group by in stocktake docs
  2. Screenshots showing the group by item toggle
