### PR TITLE
4864 back date UI

### DIFF
--- a/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
@@ -39,7 +39,13 @@ export const Toolbar: FC = () => {
         alignItems="flex-end"
       >
         <Grid item display="flex" flex={1}>
-          <Box display="flex" flex={1} flexDirection="column" gap={1}>
+          <Box
+            display="flex"
+            flex={1}
+            flexDirection="column"
+            gap={1}
+            maxWidth={'fit-content'}
+          >
             {patient && (
               <InputWithLabelRow
                 label={t('label.patient')}
@@ -69,7 +75,12 @@ export const Toolbar: FC = () => {
               }
             />
           </Box>
-          <Box display="flex" flexDirection="column" flex={1}>
+          <Box
+            display="flex"
+            flexDirection="column"
+            flex={1}
+            marginLeft={'8px'}
+          >
             <InputWithLabelRow
               label={t('label.date')}
               Input={

--- a/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
@@ -85,6 +85,7 @@ export const Toolbar: FC = () => {
               label={t('label.date')}
               Input={
                 <DateTimePickerInput
+                  disabled={isDisabled}
                   value={DateUtils.getDateOrNull(prescriptionDate)}
                   format="P"
                   onChange={async prescriptionDate => {

--- a/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
@@ -75,12 +75,7 @@ export const Toolbar: FC = () => {
               }
             />
           </Box>
-          <Box
-            display="flex"
-            flexDirection="column"
-            flex={1}
-            marginLeft={'8px'}
-          >
+          <Box display="flex" flexDirection="column" flex={1} marginLeft={3}>
             <InputWithLabelRow
               label={t('label.date')}
               Input={

--- a/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
@@ -69,7 +69,7 @@ export const Toolbar: FC = () => {
               }
             />
           </Box>
-          <Box display="flex" flex={1}>
+          <Box display="flex" flexDirection="column" flex={1}>
             <InputWithLabelRow
               label={t('label.date')}
               Input={

--- a/server/service/src/invoice/prescription/insert/generate.rs
+++ b/server/service/src/invoice/prescription/insert/generate.rs
@@ -40,7 +40,7 @@ pub fn generate(
         comment: None,
         their_reference: None,
         transport_reference: None,
-        allocated_datetime: None,
+        allocated_datetime: Some(current_datetime),
         picked_datetime: None,
         shipped_datetime: None,
         delivered_datetime: None,

--- a/server/service/src/invoice/prescription/update/generate.rs
+++ b/server/service/src/invoice/prescription/update/generate.rs
@@ -121,6 +121,9 @@ fn set_new_status_datetime(
             invoice.picked_datetime = Some(status_datetime);
         }
         (InvoiceStatus::Picked, UpdatePrescriptionStatus::Verified) => {
+            if prescription_datetime.is_some() {
+                invoice.picked_datetime = Some(status_datetime);
+            }
             invoice.verified_datetime = Some(status_datetime)
         }
         _ => {}

--- a/server/service/src/invoice/prescription/update/generate.rs
+++ b/server/service/src/invoice/prescription/update/generate.rs
@@ -122,6 +122,7 @@ fn set_new_status_datetime(
         }
         (InvoiceStatus::Picked, UpdatePrescriptionStatus::Verified) => {
             if prescription_datetime.is_some() {
+                // Set picked date to prescription date if it was backdated
                 invoice.picked_datetime = Some(status_datetime);
             }
             invoice.verified_datetime = Some(status_datetime)

--- a/server/service/src/invoice/prescription/update/generate.rs
+++ b/server/service/src/invoice/prescription/update/generate.rs
@@ -5,8 +5,9 @@ use repository::{
     InvoiceStatus, RepositoryError, StockLineRow, StorageConnection,
 };
 
-use crate::invoice::common::{
-    generate_batches_total_number_of_packs_update, InvoiceLineHasNoStockLine,
+use crate::{
+    invoice::common::{generate_batches_total_number_of_packs_update, InvoiceLineHasNoStockLine},
+    invoice_line::stock_out_line::invoice_backdated_date,
 };
 
 use super::{UpdatePrescription, UpdatePrescriptionError, UpdatePrescriptionStatus};
@@ -34,9 +35,11 @@ pub(crate) fn generate(
         should_update_batches_total_number_of_packs(&existing_invoice, &input_status);
     let mut update_invoice = existing_invoice.clone();
 
+    // prescription_date is None if the invoice is not backdated, this means we get actual picked/verified date
+    // If we have a backdated invoice, we use the backdated date for picked/verified date
     let prescription_date = match prescription_date {
         Some(prescription_date) => Some(prescription_date),
-        None => existing_invoice.allocated_datetime, // prescription date is stored in allocated_datetime, if not provided in this request
+        None => invoice_backdated_date(&existing_invoice),
     };
 
     set_new_status_datetime(&mut update_invoice, &input_status, prescription_date);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4864

# 👩🏻‍💻 What does this PR do?

Aligns datepicker with rest of the inputs in dispensing.

![image](https://github.com/user-attachments/assets/ce49febf-9476-4998-9680-e8d74a341a94)

Defaults `prescription date` to created datetime

Sets picked_date to prescription date if we change the date time for a prescription (by setting it at verified time)

Disables date input after verified

## 💌 Any notes for the reviewer?

Do we still want the prescription date in the more tab?



# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Start dispensing, check date picker shows up correctly..

# 📃 Documentation


- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
