### PR TITLE
#4805 Vaccination card statuses

### DIFF
--- a/client/packages/common/src/intl/locales/en/dispensary.json
+++ b/client/packages/common/src/intl/locales/en/dispensary.json
@@ -59,7 +59,7 @@
   "label.status-given": "Given",
   "label.status-not-given": "Not given",
   "label.status-pending": "Pending",
-  "label.status-late": "Late",
+  "label.status-late": "Overdue",
   "label.update-transactions": "Update stock transactions",
   "label.vaccination": "Vaccination",
   "label.vaccinations": "Vaccinations",

--- a/client/packages/common/src/intl/locales/en/dispensary.json
+++ b/client/packages/common/src/intl/locales/en/dispensary.json
@@ -58,6 +58,7 @@
   "label.select-batch": "Select batch",
   "label.status-given": "Given",
   "label.status-not-given": "Not given",
+  "label.status-pending": "Pending",
   "label.status-late": "Late",
   "label.update-transactions": "Update stock transactions",
   "label.vaccination": "Vaccination",

--- a/client/packages/common/src/styles/theme.ts
+++ b/client/packages/common/src/styles/theme.ts
@@ -95,6 +95,12 @@ declare module '@mui/material/styles/createPalette' {
       hot: PaletteColor;
       lines: string[];
     };
+    vaccinationStatus: {
+      given: string;
+      notGiven: string;
+      pending: string;
+      late: string;
+    };
     drawerDivider: string;
     gray: PaletteColor & { pale: string };
     outline: Palette['primary'];
@@ -196,7 +202,6 @@ export const themeOptions = {
       white: '#fff',
       success: 'rgb(237, 247, 237)',
     },
-
     form: {
       field: '#555770',
       label: '#28293d',
@@ -214,6 +219,12 @@ export const themeOptions = {
       notFunctioning: '#de0001',
       notInUse: '#b0b0b0',
       text: '#fff',
+    },
+    vaccinationStatus: {
+      given: 'success.light',
+      notGiven: 'error.main',
+      pending: 'cceStatus.notInUse',
+      late: 'cceStatus.functioningButNeedsAttention',
     },
   },
   zIndex: {

--- a/client/packages/common/src/styles/theme.ts
+++ b/client/packages/common/src/styles/theme.ts
@@ -223,8 +223,8 @@ export const themeOptions = {
     vaccinationStatus: {
       given: 'success.light',
       notGiven: 'error.main',
-      pending: 'cceStatus.notInUse',
-      late: 'cceStatus.functioningButNeedsAttention',
+      pending: 'info.light',
+      late: 'error.main',
     },
   },
   zIndex: {

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -8220,6 +8220,7 @@ export type VaccinationCardItemNode = {
   maxAgeMonths: Scalars['Float']['output'];
   minAgeMonths: Scalars['Float']['output'];
   minIntervalDays: Scalars['Int']['output'];
+  status?: Maybe<VaccinationCardItemNodeStatus>;
   stockLine?: Maybe<StockLineNode>;
   suggestedDate?: Maybe<Scalars['NaiveDate']['output']>;
   vaccinationDate?: Maybe<Scalars['NaiveDate']['output']>;
@@ -8232,6 +8233,13 @@ export type VaccinationCardItemNode = {
 export type VaccinationCardItemNodeFacilityNameArgs = {
   storeId: Scalars['String']['input'];
 };
+
+export enum VaccinationCardItemNodeStatus {
+  Given = 'GIVEN',
+  Late = 'LATE',
+  NotGiven = 'NOT_GIVEN',
+  Pending = 'PENDING'
+}
 
 export type VaccinationCardNode = {
   __typename: 'VaccinationCardNode';

--- a/client/packages/system/src/Vaccination/Components/VaccineCardTable.tsx
+++ b/client/packages/system/src/Vaccination/Components/VaccineCardTable.tsx
@@ -126,6 +126,7 @@ export const VaccinationCardComponent: FC<VaccinationCardProps> = ({
         key: 'status',
         label: 'label.status',
         accessor: ({ rowData }) =>
+          // Only show label for the next editable row
           isRowClickable(isEncounter, rowData, data?.items)
             ? rowData.status
             : null,
@@ -173,8 +174,8 @@ export const VaccinationCardComponent: FC<VaccinationCardProps> = ({
       },
     ],
     {},
-    // Putting items into deps array so that status labels get recalculated on
-    // changes
+    // Putting data/items into deps array so that status labels get recalculated
+    // on changes
     [data]
   );
 

--- a/client/packages/system/src/Vaccination/Components/VaccineCardTable.tsx
+++ b/client/packages/system/src/Vaccination/Components/VaccineCardTable.tsx
@@ -12,6 +12,7 @@ import {
   useRowStyle,
   useTheme,
   StatusCell,
+  VaccinationCardItemNodeStatus,
 } from '@openmsupply-client/common';
 import { usePatientVaccineCard } from '../api/usePatientVaccineCard';
 import { VaccinationCardItemFragment } from '../api/operations.generated';
@@ -55,8 +56,12 @@ const useStyleRowsByStatus = (
   useEffect(() => {
     if (!rows) return;
 
-    const doneRows = rows.filter(row => row.given).map(row => row.id);
-    const notDoneRows = rows.filter(row => !row.given).map(row => row.id);
+    const doneRows = rows
+      .filter(row => row.status === VaccinationCardItemNodeStatus.Given)
+      .map(row => row.id);
+    const notDoneRows = rows
+      .filter(row => row.status !== VaccinationCardItemNodeStatus.Given)
+      .map(row => row.id);
     const nonClickableRows = rows
       .filter(row => !isRowClickable(isEncounter, row, rows))
       .map(row => row.id);
@@ -119,18 +124,26 @@ export const VaccinationCardComponent: FC<VaccinationCardProps> = ({
     {
       key: 'status',
       label: 'label.status',
-      accessor: ({ rowData }) => rowData.given,
+      accessor: ({ rowData }) => rowData.status,
       Cell: ({ ...props }) => (
         <StatusCell
           {...props}
           statusMap={{
-            true: {
-              color: theme.palette.success.light,
+            [VaccinationCardItemNodeStatus.Given]: {
+              color: theme.palette.vaccinationStatus.given,
               label: t('label.status-given'),
             },
-            false: {
-              color: theme.palette.error.main,
+            [VaccinationCardItemNodeStatus.NotGiven]: {
+              color: theme.palette.vaccinationStatus.notGiven,
               label: t('label.status-not-given'),
+            },
+            [VaccinationCardItemNodeStatus.Pending]: {
+              color: theme.palette.vaccinationStatus.pending,
+              label: t('label.status-pending'),
+            },
+            [VaccinationCardItemNodeStatus.Late]: {
+              color: theme.palette.vaccinationStatus.late,
+              label: t('label.status-late'),
             },
           }}
         />

--- a/client/packages/system/src/Vaccination/Components/VaccineCardTable.tsx
+++ b/client/packages/system/src/Vaccination/Components/VaccineCardTable.tsx
@@ -108,66 +108,75 @@ export const VaccinationCardComponent: FC<VaccinationCardProps> = ({
 
   useStyleRowsByStatus(data?.items, isEncounter);
 
-  const columns = useColumns<VaccinationCardItemFragment>([
-    {
-      key: 'age',
-      label: 'label.age',
-      sortable: false,
-      accessor: ({ rowData }) =>
-        t('label.age-months-count', { count: rowData.minAgeMonths }),
-    },
-    {
-      key: 'label',
-      label: 'label.dose',
-      accessor: ({ rowData }) => rowData.label,
-    },
-    {
-      key: 'status',
-      label: 'label.status',
-      accessor: ({ rowData }) => rowData.status,
-      Cell: ({ ...props }) => (
-        <StatusCell
-          {...props}
-          statusMap={{
-            [VaccinationCardItemNodeStatus.Given]: {
-              color: theme.palette.vaccinationStatus.given,
-              label: t('label.status-given'),
-            },
-            [VaccinationCardItemNodeStatus.NotGiven]: {
-              color: theme.palette.vaccinationStatus.notGiven,
-              label: t('label.status-not-given'),
-            },
-            [VaccinationCardItemNodeStatus.Pending]: {
-              color: theme.palette.vaccinationStatus.pending,
-              label: t('label.status-pending'),
-            },
-            [VaccinationCardItemNodeStatus.Late]: {
-              color: theme.palette.vaccinationStatus.late,
-              label: t('label.status-late'),
-            },
-          }}
-        />
-      ),
-    },
-    {
-      key: 'suggestedDate',
-      label: 'label.suggested-date',
-      accessor: ({ rowData }) => localisedDate(rowData.suggestedDate ?? ''),
-    },
-    {
-      key: 'dateGiven',
-      label: 'label.date-given',
-      accessor: ({ rowData }) => localisedDate(rowData.vaccinationDate ?? ''),
-    },
-    {
-      key: 'batch',
-      label: 'label.batch',
-    },
-    {
-      key: 'facilityName',
-      label: 'label.facility',
-    },
-  ]);
+  const columns = useColumns<VaccinationCardItemFragment>(
+    [
+      {
+        key: 'age',
+        label: 'label.age',
+        sortable: false,
+        accessor: ({ rowData }) =>
+          t('label.age-months-count', { count: rowData.minAgeMonths }),
+      },
+      {
+        key: 'label',
+        label: 'label.dose',
+        accessor: ({ rowData }) => rowData.label,
+      },
+      {
+        key: 'status',
+        label: 'label.status',
+        accessor: ({ rowData }) =>
+          isRowClickable(isEncounter, rowData, data?.items)
+            ? rowData.status
+            : null,
+        Cell: ({ ...props }) => (
+          <StatusCell
+            {...props}
+            statusMap={{
+              [VaccinationCardItemNodeStatus.Given]: {
+                color: theme.palette.vaccinationStatus.given,
+                label: t('label.status-given'),
+              },
+              [VaccinationCardItemNodeStatus.NotGiven]: {
+                color: theme.palette.vaccinationStatus.notGiven,
+                label: t('label.status-not-given'),
+              },
+              [VaccinationCardItemNodeStatus.Pending]: {
+                color: theme.palette.vaccinationStatus.pending,
+                label: t('label.status-pending'),
+              },
+              [VaccinationCardItemNodeStatus.Late]: {
+                color: theme.palette.vaccinationStatus.late,
+                label: t('label.status-late'),
+              },
+            }}
+          />
+        ),
+      },
+      {
+        key: 'suggestedDate',
+        label: 'label.suggested-date',
+        accessor: ({ rowData }) => localisedDate(rowData.suggestedDate ?? ''),
+      },
+      {
+        key: 'dateGiven',
+        label: 'label.date-given',
+        accessor: ({ rowData }) => localisedDate(rowData.vaccinationDate ?? ''),
+      },
+      {
+        key: 'batch',
+        label: 'label.batch',
+      },
+      {
+        key: 'facilityName',
+        label: 'label.facility',
+      },
+    ],
+    {},
+    // Putting items into deps array so that status labels get recalculated on
+    // changes
+    [data]
+  );
 
   return isLoading ? (
     <InlineSpinner />

--- a/client/packages/system/src/Vaccination/api/operations.generated.ts
+++ b/client/packages/system/src/Vaccination/api/operations.generated.ts
@@ -8,9 +8,9 @@ export type VaccinationCourseDoseFragment = { __typename: 'VaccineCourseDoseNode
 
 export type VaccinationDetailFragment = { __typename: 'VaccinationNode', id: string, facilityNameId?: string | null, facilityFreeText?: string | null, vaccinationDate: string, given: boolean, notGivenReason?: string | null, comment?: string | null, clinician?: { __typename: 'ClinicianNode', id: string, firstName?: string | null, lastName: string } | null, stockLine?: { __typename: 'StockLineNode', id: string, itemId: string, batch?: string | null } | null, invoice?: { __typename: 'InvoiceNode', id: string, invoiceNumber: number } | null };
 
-export type VaccinationCardItemFragment = { __typename: 'VaccinationCardItemNode', id: string, vaccineCourseId: string, vaccineCourseDoseId: string, vaccinationId?: string | null, label: string, minAgeMonths: number, vaccinationDate?: string | null, suggestedDate?: string | null, given?: boolean | null, batch?: string | null, facilityName?: string | null };
+export type VaccinationCardItemFragment = { __typename: 'VaccinationCardItemNode', id: string, vaccineCourseId: string, vaccineCourseDoseId: string, vaccinationId?: string | null, label: string, minAgeMonths: number, vaccinationDate?: string | null, suggestedDate?: string | null, given?: boolean | null, batch?: string | null, facilityName?: string | null, status?: Types.VaccinationCardItemNodeStatus | null };
 
-export type VaccinationCardFragment = { __typename: 'VaccinationCardNode', id: string, patientFirstName?: string | null, patientLastName?: string | null, programName: string, items: Array<{ __typename: 'VaccinationCardItemNode', id: string, vaccineCourseId: string, vaccineCourseDoseId: string, vaccinationId?: string | null, label: string, minAgeMonths: number, vaccinationDate?: string | null, suggestedDate?: string | null, given?: boolean | null, batch?: string | null, facilityName?: string | null }> };
+export type VaccinationCardFragment = { __typename: 'VaccinationCardNode', id: string, patientFirstName?: string | null, patientLastName?: string | null, programName: string, items: Array<{ __typename: 'VaccinationCardItemNode', id: string, vaccineCourseId: string, vaccineCourseDoseId: string, vaccinationId?: string | null, label: string, minAgeMonths: number, vaccinationDate?: string | null, suggestedDate?: string | null, given?: boolean | null, batch?: string | null, facilityName?: string | null, status?: Types.VaccinationCardItemNodeStatus | null }> };
 
 export type VaccinationCardQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -18,7 +18,7 @@ export type VaccinationCardQueryVariables = Types.Exact<{
 }>;
 
 
-export type VaccinationCardQuery = { __typename: 'Queries', vaccinationCard: { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'VaccinationCardNode', id: string, patientFirstName?: string | null, patientLastName?: string | null, programName: string, items: Array<{ __typename: 'VaccinationCardItemNode', id: string, vaccineCourseId: string, vaccineCourseDoseId: string, vaccinationId?: string | null, label: string, minAgeMonths: number, vaccinationDate?: string | null, suggestedDate?: string | null, given?: boolean | null, batch?: string | null, facilityName?: string | null }> } };
+export type VaccinationCardQuery = { __typename: 'Queries', vaccinationCard: { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'VaccinationCardNode', id: string, patientFirstName?: string | null, patientLastName?: string | null, programName: string, items: Array<{ __typename: 'VaccinationCardItemNode', id: string, vaccineCourseId: string, vaccineCourseDoseId: string, vaccinationId?: string | null, label: string, minAgeMonths: number, vaccinationDate?: string | null, suggestedDate?: string | null, given?: boolean | null, batch?: string | null, facilityName?: string | null, status?: Types.VaccinationCardItemNodeStatus | null }> } };
 
 export type VaccinationQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -104,6 +104,7 @@ export const VaccinationCardItemFragmentDoc = gql`
   given
   batch
   facilityName(storeId: $storeId)
+  status
 }
     `;
 export const VaccinationCardFragmentDoc = gql`

--- a/client/packages/system/src/Vaccination/api/operations.graphql
+++ b/client/packages/system/src/Vaccination/api/operations.graphql
@@ -48,6 +48,7 @@ fragment VaccinationCardItem on VaccinationCardItemNode {
   given
   batch
   facilityName(storeId: $storeId)
+  status
 }
 
 fragment VaccinationCard on VaccinationCardNode {

--- a/server/graphql/types/src/types/program/vaccination_card.rs
+++ b/server/graphql/types/src/types/program/vaccination_card.rs
@@ -7,9 +7,21 @@ use graphql_core::{
     loader::{NameByIdLoader, NameByIdLoaderInput, StockLineByIdLoader},
     ContextExt,
 };
-use service::vaccination::get_vaccination_card::{VaccinationCard, VaccinationCardItem};
+use serde::Serialize;
+use service::vaccination::get_vaccination_card::{
+    VaccinationCard, VaccinationCardItem, VaccinationCardItemStatus,
+};
 
 use crate::types::StockLineNode;
+
+#[derive(Enum, Copy, Clone, PartialEq, Eq, Debug, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum VaccinationCardItemNodeStatus {
+    Given,
+    NotGiven,
+    Pending,
+    Late,
+}
 
 pub struct VaccinationCardNode {
     pub vaccination_card: VaccinationCard,
@@ -87,6 +99,13 @@ impl VaccinationCardItemNode {
     pub async fn suggested_date(&self) -> &Option<NaiveDate> {
         &self.item.suggested_date
     }
+    pub async fn status(&self) -> &Option<VaccinationCardItemNodeStatus> {
+        &Some(VaccinationCardItemNodeStatus::Given)
+        // &self
+        //     .item
+        //     .status
+        //     .map(|status| VaccinationCardItemNodeStatus::from_domain(&status))
+    }
 
     pub async fn stock_line(&self, ctx: &Context<'_>) -> Result<Option<StockLineNode>> {
         let loader = ctx.get_loader::<DataLoader<StockLineByIdLoader>>();
@@ -134,6 +153,28 @@ impl VaccinationCardItemNode {
     pub fn from_domain(vaccination_card_item: VaccinationCardItem) -> VaccinationCardItemNode {
         VaccinationCardItemNode {
             item: vaccination_card_item,
+        }
+    }
+}
+
+impl VaccinationCardItemNodeStatus {
+    pub fn to_domain(self) -> VaccinationCardItemStatus {
+        use VaccinationCardItemNodeStatus::*;
+        match self {
+            Given => VaccinationCardItemStatus::Given,
+            NotGiven => VaccinationCardItemStatus::NotGiven,
+            Pending => VaccinationCardItemStatus::Pending,
+            Late => VaccinationCardItemStatus::Late,
+        }
+    }
+
+    pub fn from_domain(status: &VaccinationCardItemStatus) -> VaccinationCardItemNodeStatus {
+        use VaccinationCardItemStatus::*;
+        match status {
+            Given => VaccinationCardItemNodeStatus::Given,
+            NotGiven => VaccinationCardItemNodeStatus::NotGiven,
+            Pending => VaccinationCardItemNodeStatus::Pending,
+            Late => VaccinationCardItemNodeStatus::Late,
         }
     }
 }

--- a/server/graphql/types/src/types/program/vaccination_card.rs
+++ b/server/graphql/types/src/types/program/vaccination_card.rs
@@ -99,12 +99,11 @@ impl VaccinationCardItemNode {
     pub async fn suggested_date(&self) -> &Option<NaiveDate> {
         &self.item.suggested_date
     }
-    pub async fn status(&self) -> &Option<VaccinationCardItemNodeStatus> {
-        &Some(VaccinationCardItemNodeStatus::Given)
-        // &self
-        //     .item
-        //     .status
-        //     .map(|status| VaccinationCardItemNodeStatus::from_domain(&status))
+    pub async fn status(&self) -> Option<VaccinationCardItemNodeStatus> {
+        self.item
+            .status
+            .as_ref()
+            .map(|status| VaccinationCardItemNodeStatus::from_domain(status))
     }
 
     pub async fn stock_line(&self, ctx: &Context<'_>) -> Result<Option<StockLineNode>> {

--- a/server/service/src/vaccination/get_vaccination_card.rs
+++ b/server/service/src/vaccination/get_vaccination_card.rs
@@ -5,6 +5,7 @@ use repository::{
     EqualFilter, ProgramEnrolment, ProgramEnrolmentFilter, ProgramEnrolmentRepository,
     RepositoryError, VaccinationCardRepository, VaccinationCardRow,
 };
+use util::constants::DAYS_PER_MONTH;
 
 use crate::service_provider::ServiceContext;
 
@@ -28,8 +29,6 @@ pub enum VaccinationCardItemStatus {
     Pending,
     Late,
 }
-
-const MONTHS_PER_YEAR: f64 = 365.25 / 12.0;
 
 pub fn get_vaccination_card(
     ctx: &ServiceContext,
@@ -85,7 +84,7 @@ pub fn get_suggested_date(
     course_rows: Vec<VaccinationCardRow>,
 ) -> Option<NaiveDate> {
     let suggested_date_by_age = patient_dob
-        .map(|dob| dob.checked_add_signed(Duration::days((row.min_age * MONTHS_PER_YEAR) as i64)))
+        .map(|dob| dob.checked_add_signed(Duration::days((row.min_age * DAYS_PER_MONTH) as i64)))
         .flatten();
 
     // If the dose was already given, no need to suggest date
@@ -153,7 +152,7 @@ pub fn get_vaccination_status(
     }
 
     let patient_age_in_months =
-        ((Local::now().date_naive() - patient_dob.unwrap()).num_days() as f64) / MONTHS_PER_YEAR;
+        ((Local::now().date_naive() - patient_dob.unwrap()).num_days() as f64) / DAYS_PER_MONTH;
 
     if row.given == None {
         if patient_age_in_months < row.max_age {

--- a/server/service/src/vaccination/get_vaccination_card.rs
+++ b/server/service/src/vaccination/get_vaccination_card.rs
@@ -140,27 +140,23 @@ pub fn get_vaccination_status(
     row: &VaccinationCardRow,
     patient_dob: Option<NaiveDate>,
 ) -> Option<VaccinationCardItemStatus> {
-    if row.given == Some(true) {
-        Some(VaccinationCardItemStatus::Given);
-    }
-    if row.given == Some(false) {
-        Some(VaccinationCardItemStatus::NotGiven);
-    }
-
-    if patient_dob == None {
-        return None;
+    match row.given {
+        Some(true) => return Some(VaccinationCardItemStatus::Given),
+        Some(false) => return Some(VaccinationCardItemStatus::NotGiven),
+        None => {}
     }
 
-    let patient_age_in_months =
-        ((Local::now().date_naive() - patient_dob.unwrap()).num_days() as f64) / DAYS_PER_MONTH;
+    if let Some(dob) = patient_dob {
+        let patient_age_in_months =
+            ((Local::now().date_naive() - dob).num_days() as f64) / DAYS_PER_MONTH;
 
-    if row.given == None {
-        if patient_age_in_months < row.max_age {
-            Some(VaccinationCardItemStatus::Pending);
-        };
         if patient_age_in_months > row.max_age {
-            Some(VaccinationCardItemStatus::Pending);
-        };
+            return Some(VaccinationCardItemStatus::Late);
+        }
+
+        if patient_age_in_months > row.min_age {
+            return Some(VaccinationCardItemStatus::Pending);
+        }
     }
 
     None

--- a/server/util/src/constants.rs
+++ b/server/util/src/constants.rs
@@ -31,3 +31,7 @@ pub const PATIENT_TYPE: &str = "Patient";
 pub const PATIENT_CONTEXT_ID: &str = "Patient";
 // Default context for immunisation
 pub const IMMUNISATION_CONTEXT_ID: &str = "Immunisation";
+
+/// Use this value for accurate average month length (i.e. when considered over
+/// a long time period)
+pub const DAYS_PER_MONTH: f64 = 365.25 / 12.0;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4805

(In Draft cos there's one Rust compilation error in the GraphQL layer that I can't quite resolve)

# 👩🏻‍💻 What does this PR do?

- Returns "status" from server as an enum value "Given", "NotGiven", "Pending", "Late" or `null`, based on patient age/vax status etc.
- Front-end maps this enum value to appropriate display chip instead of just the boolean `given` field

## 💌 Any notes for the reviewer?

See inline comments

# 🧪 Testing

- [ ] Vax card table displays the correct "Status" chip based on the rules in the [original issue](#4805)
- [ ] Colours for each status are appropriate and correct