### PR TITLE
4883 create return when not this facility

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -8043,7 +8043,7 @@ export type UpdateVaccinationInput = {
   given?: InputMaybe<Scalars['Boolean']['input']>;
   id: Scalars['String']['input'];
   notGivenReason?: InputMaybe<Scalars['String']['input']>;
-  stockLineId?: InputMaybe<Scalars['String']['input']>;
+  stockLineId?: InputMaybe<NullableStringUpdate>;
   updateTransactions?: InputMaybe<Scalars['Boolean']['input']>;
   vaccinationDate?: InputMaybe<Scalars['NaiveDate']['input']>;
 };

--- a/client/packages/system/src/Vaccination/Components/VaccinationModal.tsx
+++ b/client/packages/system/src/Vaccination/Components/VaccinationModal.tsx
@@ -186,6 +186,8 @@ const VaccinationForm = ({
     />
   );
 
+  const isOtherFacility = draft.facilityId === OTHER_FACILITY;
+
   return (
     <Container
       maxWidth="xs"
@@ -205,7 +207,7 @@ const VaccinationForm = ({
               facilityId={draft.facilityId}
             />
 
-            {draft.facilityId === OTHER_FACILITY && (
+            {isOtherFacility && (
               <BasicTextInput
                 fullWidth
                 autoFocus
@@ -220,21 +222,23 @@ const VaccinationForm = ({
           </Grid>
         }
       />
-      <InputWithLabelRow
-        label={t('label.clinician')}
-        Input={
-          <Grid item flex={1}>
-            <ClinicianSearchInput
-              onChange={clinician => {
-                updateDraft({
-                  clinician: clinician?.value,
-                });
-              }}
-              clinicianValue={draft.clinician}
-            />
-          </Grid>
-        }
-      />
+      {!isOtherFacility && (
+        <InputWithLabelRow
+          label={t('label.clinician')}
+          Input={
+            <Grid item flex={1}>
+              <ClinicianSearchInput
+                onChange={clinician => {
+                  updateDraft({
+                    clinician: clinician?.value,
+                  });
+                }}
+                clinicianValue={draft.clinician}
+              />
+            </Grid>
+          }
+        />
+      )}
       <InputWithLabelRow
         label={t('label.date')}
         Input={

--- a/client/packages/system/src/Vaccination/Components/getSwitchReason.test.ts
+++ b/client/packages/system/src/Vaccination/Components/getSwitchReason.test.ts
@@ -17,13 +17,26 @@ describe('getSwitchReason', () => {
     });
 
     it('should return null if no doses configured', () => {
-      const draft = { date: new Date('2021-01-01') } as VaccinationDraft;
+      const draft = {
+        date: new Date('2021-01-01'),
+        given: true,
+      } as VaccinationDraft;
       const hasDosesConfigured = false;
       expect(getSwitchReason(draft, hasDosesConfigured)).toBeNull();
     });
 
     it('should return null if the date is not historical', () => {
-      const draft = { date: new Date() } as VaccinationDraft;
+      const draft = { date: new Date(), given: true } as VaccinationDraft;
+      const hasDosesConfigured = true;
+      expect(getSwitchReason(draft, hasDosesConfigured)).toBeNull();
+    });
+
+    it('should return null if the facility is other', () => {
+      const draft = {
+        date: new Date('2021-01-01'),
+        facilityId: OTHER_FACILITY,
+        given: true,
+      } as VaccinationDraft;
       const hasDosesConfigured = true;
       expect(getSwitchReason(draft, hasDosesConfigured)).toBeNull();
     });

--- a/client/packages/system/src/Vaccination/Components/getSwitchReason.ts
+++ b/client/packages/system/src/Vaccination/Components/getSwitchReason.ts
@@ -16,6 +16,7 @@ export function getSwitchReason(
     isHistorical &&
     noExistingSelectedBatch &&
     draft.given &&
+    draft.facilityId !== OTHER_FACILITY &&
     hasDosesConfigured
   ) {
     return 'label.record-stock-transaction';

--- a/client/packages/system/src/Vaccination/api/useVaccination.ts
+++ b/client/packages/system/src/Vaccination/api/useVaccination.ts
@@ -209,6 +209,8 @@ const useUpdate = (vaccinationId: string | undefined) => {
       throw new Error(t('error.failed-to-save-vaccination'));
     }
 
+    const isOtherFacility = input.facilityId === OTHER_FACILITY;
+
     const apiResult = await api.updateVaccination({
       storeId,
       input: {
@@ -218,17 +220,15 @@ const useUpdate = (vaccinationId: string | undefined) => {
         clinicianId: setNullableInput('id', input.clinician),
         comment: input.comment,
         notGivenReason: !input.given ? input.notGivenReason : null,
-        stockLineId: input.given ? input.stockLine?.id : null,
+        stockLineId: {
+          value: input.given && !isOtherFacility ? input.stockLine?.id : null,
+        },
 
         facilityNameId: {
-          value:
-            input.facilityId === OTHER_FACILITY ? undefined : input?.facilityId,
+          value: isOtherFacility ? undefined : input?.facilityId,
         },
         facilityFreeText: {
-          value:
-            input.facilityId === OTHER_FACILITY
-              ? input.facilityFreeText
-              : undefined,
+          value: isOtherFacility ? input.facilityFreeText : undefined,
         },
 
         updateTransactions: input.createTransactions,

--- a/client/packages/system/src/Vaccination/api/useVaccination.ts
+++ b/client/packages/system/src/Vaccination/api/useVaccination.ts
@@ -156,6 +156,8 @@ const useInsert = ({
   const mutationFn = async (input: VaccinationDraft) => {
     if (!encounterId) return;
 
+    const isOtherFacility = input.facilityId === OTHER_FACILITY;
+
     const apiResult = await api.insertVaccination({
       storeId,
       input: {
@@ -163,16 +165,13 @@ const useInsert = ({
         encounterId,
         vaccineCourseDoseId,
 
-        facilityNameId:
-          input.facilityId === OTHER_FACILITY ? undefined : input?.facilityId,
-        facilityFreeText:
-          input.facilityId === OTHER_FACILITY
-            ? input.facilityFreeText
-            : undefined,
+        facilityNameId: isOtherFacility ? undefined : input?.facilityId,
+        facilityFreeText: isOtherFacility ? input.facilityFreeText : undefined,
+
+        clinicianId: isOtherFacility ? undefined : input?.clinician?.id,
 
         given: input.given ?? false,
         vaccinationDate: Formatter.naiveDate(input.date ?? new Date()),
-        clinicianId: input.clinician?.id,
         comment: input.comment,
         notGivenReason: input.notGivenReason,
         stockLineId: input.stockLine?.id,
@@ -217,19 +216,25 @@ const useUpdate = (vaccinationId: string | undefined) => {
         id: vaccinationId,
         given: input.given ?? false,
         vaccinationDate: Formatter.naiveDate(input.date ?? new Date()),
-        clinicianId: setNullableInput('id', input.clinician),
         comment: input.comment,
         notGivenReason: !input.given ? input.notGivenReason : null,
-        stockLineId: {
-          value: input.given && !isOtherFacility ? input.stockLine?.id : null,
-        },
 
-        facilityNameId: {
-          value: isOtherFacility ? undefined : input?.facilityId,
-        },
-        facilityFreeText: {
-          value: isOtherFacility ? input.facilityFreeText : undefined,
-        },
+        clinicianId: setNullableInput(
+          'id',
+          isOtherFacility ? null : input.clinician
+        ),
+        stockLineId: setNullableInput(
+          'id',
+          input.given && !isOtherFacility ? input.stockLine : null
+        ),
+        facilityNameId: setNullableInput(
+          'facilityId',
+          isOtherFacility ? null : input
+        ),
+        facilityFreeText: setNullableInput(
+          'facilityFreeText',
+          isOtherFacility ? input : null
+        ),
 
         updateTransactions: input.createTransactions,
       },

--- a/server/graphql/programs/src/mutations/vaccination/update.rs
+++ b/server/graphql/programs/src/mutations/vaccination/update.rs
@@ -22,7 +22,7 @@ pub struct UpdateVaccinationInput {
     pub clinician_id: Option<NullableUpdateInput<String>>,
     pub comment: Option<String>,
     pub given: Option<bool>,
-    pub stock_line_id: Option<String>,
+    pub stock_line_id: Option<NullableUpdateInput<String>>,
     pub not_given_reason: Option<String>,
     pub update_transactions: Option<bool>,
 }
@@ -50,7 +50,9 @@ impl From<UpdateVaccinationInput> for UpdateVaccination {
             }),
             comment,
             given,
-            stock_line_id,
+            stock_line_id: stock_line_id.map(|stock_line_id| NullableUpdate {
+                value: stock_line_id.value,
+            }),
             not_given_reason,
             facility_name_id: facility_name_id.map(|facility_name_id| NullableUpdate {
                 value: facility_name_id.value,

--- a/server/service/src/vaccination/generate.rs
+++ b/server/service/src/vaccination/generate.rs
@@ -1,4 +1,4 @@
-use repository::StockLine;
+use repository::{ItemRow, StockLine, StockLineRow};
 use util::uuid::uuid;
 
 use crate::{
@@ -25,7 +25,8 @@ pub fn generate_create_prescription(
         patient_id,
     };
 
-    let number_of_packs = get_dose_as_number_of_packs(&stock_line);
+    let number_of_packs =
+        get_dose_as_number_of_packs(&stock_line.item_row, &stock_line.stock_line_row);
 
     let insert_stock_out_line = InsertStockOutLine {
         id: uuid(),
@@ -66,6 +67,6 @@ pub fn generate_create_prescription(
     }
 }
 
-pub fn get_dose_as_number_of_packs(stock_line: &StockLine) -> f64 {
-    1.0 / stock_line.item_row.vaccine_doses as f64 / stock_line.stock_line_row.pack_size
+pub fn get_dose_as_number_of_packs(item_row: &ItemRow, stock_line_row: &StockLineRow) -> f64 {
+    1.0 / item_row.vaccine_doses as f64 / stock_line_row.pack_size
 }

--- a/server/service/src/vaccination/update/generate.rs
+++ b/server/service/src/vaccination/update/generate.rs
@@ -1,4 +1,4 @@
-use repository::{StockLine, VaccinationRow};
+use repository::{InvoiceLine, StockLine, VaccinationRow};
 use util::uuid::uuid;
 
 use crate::{
@@ -20,6 +20,7 @@ pub struct GenerateInput {
     pub update_input: UpdateVaccination,
     pub existing_stock_line: Option<StockLine>,
     pub new_stock_line: Option<StockLine>,
+    pub existing_prescription_line: Option<InvoiceLine>,
 }
 
 #[derive(Debug)]
@@ -41,6 +42,7 @@ pub fn generate(
         update_input,
         existing_stock_line,
         new_stock_line,
+        existing_prescription_line,
     }: GenerateInput,
 ) -> GenerateResult {
     // Update from input, or keep existing
@@ -62,44 +64,53 @@ pub fn generate(
 
     let update_transactions = update_input.update_transactions.unwrap_or(false);
 
+    let should_revert = new_stock_line.is_none() && existing_prescription_line.is_some();
+
     // Reverse prescription if it existed, and the stock line is changing
-    let create_customer_return = if stock_line_has_changed && update_transactions {
-        existing_stock_line.map(|stock_line| {
-            let amount = get_dose_as_number_of_packs(&stock_line);
-            let stock_line_row = stock_line.stock_line_row;
+    let create_customer_return = if (stock_line_has_changed || should_revert) && update_transactions
+    {
+        existing_prescription_line
+            .map(|invoice_line| {
+                let stock_line_row = match invoice_line.stock_line_option {
+                    Some(stock_line) => stock_line,
+                    None => return None,
+                };
 
-            let create_return = InsertCustomerReturn {
-                id: uuid(),
-                other_party_id: patient_id.clone(),
-                is_patient_return: true,
-                outbound_shipment_id: None,
-                customer_return_lines: vec![CustomerReturnLineInput {
+                let amount = get_dose_as_number_of_packs(&invoice_line.item_row, &stock_line_row);
+
+                let create_return = InsertCustomerReturn {
                     id: uuid(),
-                    stock_line_id: Some(stock_line_row.id),
-                    item_id: stock_line_row.item_link_id,
-                    expiry_date: stock_line_row.expiry_date,
-                    batch: stock_line_row.batch,
-                    pack_size: stock_line_row.pack_size,
-                    number_of_packs: amount,
-                    reason_id: None,
-                    note: None,
-                }],
-            };
-            let finalise_return = UpdateCustomerReturn {
-                id: create_return.id.clone(),
-                status: Some(UpdateCustomerReturnStatus::Verified),
-                comment: Some("Reversed vaccination prescription".to_string()),
-                on_hold: None,
-                colour: None,
-                their_reference: None,
-                other_party_id: None,
-            };
+                    other_party_id: patient_id.clone(),
+                    is_patient_return: true,
+                    outbound_shipment_id: None,
+                    customer_return_lines: vec![CustomerReturnLineInput {
+                        id: uuid(),
+                        stock_line_id: Some(stock_line_row.id),
+                        item_id: stock_line_row.item_link_id,
+                        expiry_date: stock_line_row.expiry_date,
+                        batch: stock_line_row.batch,
+                        pack_size: stock_line_row.pack_size,
+                        number_of_packs: amount,
+                        reason_id: None,
+                        note: None,
+                    }],
+                };
+                let finalise_return = UpdateCustomerReturn {
+                    id: create_return.id.clone(),
+                    status: Some(UpdateCustomerReturnStatus::Verified),
+                    comment: Some("Reversed vaccination prescription".to_string()),
+                    on_hold: None,
+                    colour: None,
+                    their_reference: None,
+                    other_party_id: None,
+                };
 
-            CreateCustomerReturn {
-                create_return,
-                finalise_return,
-            }
-        })
+                Some(CreateCustomerReturn {
+                    create_return,
+                    finalise_return,
+                })
+            })
+            .flatten()
     } else {
         None
     };
@@ -168,13 +179,14 @@ pub fn generate(
             _ => update_input.not_given_reason.or(not_given_reason),
         },
 
-        invoice_id: match update_input.given {
-            // If we updated to not given, and are reversing prescription with a return, clear the invoice
-            Some(false) if create_customer_return.is_some() => None,
-            _ => create_prescription
-                .as_ref()
-                .map(|p| p.create_prescription.id.clone())
-                .or(invoice_id),
+        invoice_id: match create_prescription
+            .as_ref()
+            .map(|p| p.create_prescription.id.clone())
+        {
+            Some(id) => Some(id),
+            // If we create a return (reverse the prescription) and didn't create a new prescription, clear the invoice
+            None if create_customer_return.is_some() => None,
+            None => invoice_id,
         },
     };
 

--- a/server/service/src/vaccination/update/mod.rs
+++ b/server/service/src/vaccination/update/mod.rs
@@ -65,6 +65,7 @@ pub fn update_vaccination(
                 patient_id,
                 existing_stock_line,
                 new_stock_line,
+                existing_prescription_line,
             } = validate(&input, connection, store_id)?;
 
             let GenerateResult {
@@ -77,6 +78,7 @@ pub fn update_vaccination(
                 patient_id,
                 existing_stock_line,
                 new_stock_line,
+                existing_prescription_line,
             });
 
             // Update the vaccination
@@ -558,6 +560,46 @@ mod update {
         assert_eq!(stock_line.available_number_of_packs, 9.975);
 
         // ----------------------------
+        // Update: Remove stock_line (e.g. changing to `other` facility)
+        // ----------------------------
+        let result = service_provider
+            .vaccination_service
+            .update_vaccination(
+                &context,
+                &mock_store_a().id,
+                UpdateVaccination {
+                    id: mock_vaccination_a().id,
+                    stock_line_id: Some(NullableUpdate { value: None }),
+                    update_transactions: Some(true),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        // Still given
+        assert_eq!(result.vaccination_row.given, true);
+
+        // New invoice has been created, inventory addition to reverse the original prescription
+        let created_invoices = InvoiceRepository::new(&context.connection)
+            .query_by_filter(
+                InvoiceFilter::new().stock_line_id(mock_stock_line_b_vaccine_item_a().id),
+            )
+            .unwrap();
+
+        assert_eq!(created_invoices.len(), 2);
+        assert!(created_invoices
+            .iter()
+            .any(|inv| inv.invoice_row.r#type == InvoiceType::CustomerReturn));
+
+        // Check stock was re-introduced
+        let stock_line = StockLineRowRepository::new(&context.connection)
+            .find_one_by_id(&mock_stock_line_b_vaccine_item_a().id)
+            .unwrap()
+            .unwrap();
+        // 1 dose was reversed, was 9.975, so 10.0 now
+        assert_eq!(stock_line.available_number_of_packs, 10.0);
+
+        // ----------------------------
         // Update: Given -> not given
         // ----------------------------
         let result = service_provider
@@ -588,17 +630,7 @@ mod update {
             )
             .unwrap();
 
+        // Already had the return, another one was not created
         assert_eq!(created_invoices.len(), 2);
-        assert!(created_invoices
-            .iter()
-            .any(|inv| inv.invoice_row.r#type == InvoiceType::CustomerReturn));
-
-        // Check stock was adjusted back up
-        let stock_line = StockLineRowRepository::new(&context.connection)
-            .find_one_by_id(&mock_stock_line_b_vaccine_item_a().id)
-            .unwrap()
-            .unwrap();
-        // 1 dose was reversed, was 9.975, so now 10
-        assert_eq!(stock_line.available_number_of_packs, 10.0);
     }
 }

--- a/server/service/src/vaccination/update/mod.rs
+++ b/server/service/src/vaccination/update/mod.rs
@@ -45,7 +45,7 @@ pub struct UpdateVaccination {
     pub clinician_id: Option<NullableUpdate<String>>,
     pub comment: Option<String>,
     pub given: Option<bool>,
-    pub stock_line_id: Option<String>,
+    pub stock_line_id: Option<NullableUpdate<String>>,
     pub not_given_reason: Option<String>,
     pub facility_name_id: Option<NullableUpdate<String>>,
     pub facility_free_text: Option<NullableUpdate<String>>,
@@ -288,7 +288,9 @@ mod update {
                 UpdateVaccination {
                     id: mock_vaccination_a().id,
                     given: Some(true),
-                    stock_line_id: Some("non_existent_stock_line_id".to_string()),
+                    stock_line_id: Some(NullableUpdate {
+                        value: Some("non_existent_stock_line_id".to_string())
+                    }),
                     ..Default::default()
                 }
             ),
@@ -303,7 +305,9 @@ mod update {
                 UpdateVaccination {
                     id: mock_vaccination_a().id,
                     given: Some(true),
-                    stock_line_id: Some(mock_stock_line_a().id), // FOR ITEM A (not linked to vaccine course)
+                    stock_line_id: Some(NullableUpdate {
+                        value: Some(mock_stock_line_a().id)
+                    }),
                     ..Default::default()
                 }
             ),
@@ -350,7 +354,9 @@ mod update {
                 UpdateVaccination {
                     id: mock_vaccination_b_given().id, // vaccination (dose) A was also not given, cant give B before A
                     given: Some(true),
-                    stock_line_id: Some(mock_stock_line_vaccine_item_a().id),
+                    stock_line_id: Some(NullableUpdate {
+                        value: Some(mock_stock_line_vaccine_item_a().id)
+                    }),
                     ..Default::default()
                 }
             ),
@@ -405,7 +411,9 @@ mod update {
                 UpdateVaccination {
                     id: mock_vaccination_a().id,
                     given: Some(true),
-                    stock_line_id: Some(mock_stock_line_vaccine_item_a().id),
+                    stock_line_id: Some(NullableUpdate {
+                        value: Some(mock_stock_line_vaccine_item_a().id),
+                    }),
                     update_transactions: Some(false),
                     ..Default::default()
                 },
@@ -456,7 +464,9 @@ mod update {
                 UpdateVaccination {
                     id: mock_vaccination_a().id,
                     given: Some(true),
-                    stock_line_id: Some(mock_stock_line_vaccine_item_a().id), // Vaccine item A is linked to vaccine course A
+                    stock_line_id: Some(NullableUpdate {
+                        value: Some(mock_stock_line_vaccine_item_a().id),
+                    }),
                     update_transactions: Some(true),
                     ..Default::default()
                 },
@@ -495,7 +505,9 @@ mod update {
                 &mock_store_a().id,
                 UpdateVaccination {
                     id: mock_vaccination_a().id,
-                    stock_line_id: Some(mock_stock_line_b_vaccine_item_a().id),
+                    stock_line_id: Some(NullableUpdate {
+                        value: Some(mock_stock_line_b_vaccine_item_a().id),
+                    }),
                     update_transactions: Some(true),
                     ..Default::default()
                 },

--- a/server/service/src/vaccination/update/validate.rs
+++ b/server/service/src/vaccination/update/validate.rs
@@ -37,13 +37,13 @@ pub fn validate(
             UpdateVaccinationError::InternalError("Encounter does not exist".to_string()),
         )?;
 
-    if let Some(clinician_id) = input.clinician_id.clone().map(|u| u.value).flatten() {
+    if let Some(clinician_id) = input.clinician_id.clone().and_then(|u| u.value) {
         if !check_clinician_exists(&clinician_id, connection)? {
             return Err(UpdateVaccinationError::ClinicianDoesNotExist);
         }
     }
 
-    if let Some(facility_name_id) = input.facility_name_id.clone().map(|u| u.value).flatten() {
+    if let Some(facility_name_id) = input.facility_name_id.clone().and_then(|u| u.value) {
         if !check_name_exists(connection, &facility_name_id)?.is_some() {
             return Err(UpdateVaccinationError::FacilityNameDoesNotExist);
         }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4883

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Ensures invoices are updated when facility is changed from this facility to other.

Also fixes the `record historic transaction` toggle showing up when it shouldn't


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to a vaccination that was given at this facility (that has a prescription created)
- [ ] Change facility to Other
- [ ] Toggle the Revert existing stock transaction ON
- [ ] Save
- [ ] prescription no longer shows at the top of the vaccination, customer return was created

ALSO
- [ ] Create vaccination at Other facility
- [ ] Enter for date in the past
- [ ] Set to given
- [ ] Ensure no toggle shows up to `record historic stock transaction`

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
