### PR TITLE
#4834 Group vaccines by age

### DIFF
--- a/client/packages/common/src/ui/layout/tables/context/TableContext.tsx
+++ b/client/packages/common/src/ui/layout/tables/context/TableContext.tsx
@@ -142,7 +142,10 @@ export const createTableStore = () =>
 
         // Set new styles for the ids passed.
         ids.forEach(id => {
-          rowState[id] = getRowState(state, id, { style });
+          const currentRowStyle = rowState?.[id]?.style ?? {};
+          rowState[id] = getRowState(state, id, {
+            style: { ...currentRowStyle, ...style } as AppSxProp,
+          });
         });
 
         return { ...state, rowState: { ...rowState } };

--- a/client/packages/system/src/Vaccination/Components/VaccineCardTable.tsx
+++ b/client/packages/system/src/Vaccination/Components/VaccineCardTable.tsx
@@ -149,6 +149,7 @@ export const VaccinationCardComponent: FC<VaccinationCardProps> = ({
         label: 'label.age',
         sortable: false,
         accessor: ({ rowData }) => {
+          // Only show age label for first of each "block", when repeated
           const index =
             data?.items.findIndex(item => item.id === rowData.id) ?? 0;
           const sameAsPrev =


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4834

# 👩🏻‍💻 What does this PR do?

Quite a bit of CSS hackery here to get this all to work! The current "box-shadow" property, which is used to add the row dividers doesn't work for over-riding per cell. So I've turned off the box-shadow and replaced it with a "border", matching as best I can by eye (could probably be tweaked further, but I think it's pretty close).

Then set up a bunch of rules per-cell, and by status to make Vax table match the designs as much as possible.

<img width="1155" alt="Screenshot 2024-09-30 at 1 02 35 PM" src="https://github.com/user-attachments/assets/29d796b9-10cb-4c9f-b10e-3029b94b9321">

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

At some stage, we probably want to provide a more general mechanism to do some of this table styling (ie. merged cells)