### PR TITLE
4819 'Encounter missed' warning doesn't disappear until refresh

### DIFF
--- a/client/packages/system/src/Encounter/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Encounter/DetailView/DetailView.tsx
@@ -251,6 +251,8 @@ export const DetailView: FC = () => {
         const datetime = new Date(encounter.startDatetime);
         const status = getLogicalStatus(datetime, t);
         setLogicalStatus(status);
+      } else {
+        setLogicalStatus(undefined);
       }
     }
   }, [encounter]);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4819

# 👩🏻‍💻 What does this PR do?
Return undefined if status is not Pending since we aren't covering Visited or Cancelled Encounter statuses

https://github.com/user-attachments/assets/bd628c20-3886-4757-81b8-a27d44c1ce31

Logical statuses are derived from `Encounter Status: Pending` and are not saved in the database. 
If start datetime is greater than now then the logical status  = Scheduled
If less than now then logical status = Missed

P.S... Don't think the users should be able to change status to Visited if encounter is scheduled for the future...

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a pending encounter with either `Encounter Missed` or `Encounter Scheduled`
- [ ] Change status to visited or cancelled. 
- [ ] `Missed/Scheduled` text should disappear

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates 
stock quantity already in shipments -->
  1.
  2.
