### PR TITLE
4900 improve stock numbers backdated

### DIFF
--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -145,6 +145,12 @@ export const DateUtils = {
   },
   startOfDay,
   startOfToday,
+  endOfDayOrNull: (date?: Date | string | number | null): Date | null => {
+    if (!date) return null;
+
+    const d = dateInputHandler(date);
+    return isValid(d) ? endOfDay(d) : null;
+  },
   endOfDay,
   startOfYear,
   previousMonday,

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/hooks/useDraftPrescriptionLines.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/hooks/useDraftPrescriptionLines.tsx
@@ -78,6 +78,7 @@ export const useDraftPrescriptionLines = (
               invoiceLine,
               invoiceId,
               stockLine: batch,
+              adjustTotalNumberOfPacks: true,
             });
           } else {
             return createDraftStockOutLineFromStockLine({

--- a/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
@@ -81,12 +81,15 @@ export const Toolbar: FC = () => {
               Input={
                 <DateTimePickerInput
                   disabled={isDisabled}
+                  defaultValue={new Date()}
                   value={DateUtils.getDateOrNull(prescriptionDate)}
                   format="P"
                   onChange={async prescriptionDate => {
                     await update({
                       id,
-                      prescriptionDate: Formatter.toIsoString(prescriptionDate),
+                      prescriptionDate: Formatter.toIsoString(
+                        DateUtils.endOfDayOrNull(prescriptionDate)
+                      ),
                     });
                   }}
                   maxDate={new Date()}

--- a/client/packages/invoices/src/StockOut/utils.tsx
+++ b/client/packages/invoices/src/StockOut/utils.tsx
@@ -38,6 +38,7 @@ export interface DraftStockOutLineSeeds {
   invoiceId: string;
   invoiceLine: StockOutLineFragment;
   stockLine?: PartialStockLineFragment;
+  adjustTotalNumberOfPacks?: boolean;
 }
 
 export const createDraftStockOutLineFromStockLine = ({
@@ -92,6 +93,7 @@ export const createDraftStockOutLineFromStockLine = ({
 export const createDraftStockOutLine = ({
   invoiceLine,
   stockLine,
+  adjustTotalNumberOfPacks = false,
 }: DraftStockOutLineSeeds): DraftStockOutLine => ({
   isCreated: !invoiceLine,
   isUpdated: false,
@@ -99,12 +101,16 @@ export const createDraftStockOutLine = ({
   // When creating a draft outbound from an existing outbound line, add the available quantity
   // to the number of packs. This is because the available quantity has been adjusted for outbound
   // lines that have been saved.
+  // It's a similar story for totalNumber of packs if the invoice is in a picked state.
   ...(stockLine
     ? {
         stockLine: {
           ...stockLine,
           availableNumberOfPacks:
             stockLine.availableNumberOfPacks + invoiceLine.numberOfPacks,
+          totalNumberOfPacks: adjustTotalNumberOfPacks
+            ? stockLine.totalNumberOfPacks + invoiceLine.numberOfPacks
+            : stockLine.totalNumberOfPacks,
         },
       }
     : {}),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4900

# 👩🏻‍💻 What does this PR do?

Removes default of `allocated_date` to `created_date`
Shows today's date in the Date Picker (even though no date is specified in backend)
Defaults the time of a backdating to midnight local time (from the frontend)
Adjusts the Total Stock in store to show as the total stock in store plus what allocated in this line.
This mi required because prescription lines automatically go to `picked` but this means they are removed from the stock line, it's not then clear how the stock line can be adjusted.

## 💌 Any notes for the reviewer?

Doing a separate PR for adding a `backdated_datetime` into the backend and some logic cleanup

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Test prescriptions with backdated prescription time and without.
- [ ] Check the total available, always shows the current level of stock in the store plus the amount on the line
- [ ] Check the available total is correct (should always be less than the total stock in store) 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [X] **These areas should be updated or checked**: Prescriptions
