### PR TITLE
Show Average unit price in prescriptions

### DIFF
--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -268,11 +268,17 @@ export const usePrescriptionColumn = ({
       Cell: CurrencyCell,
       accessor: ({ rowData }) => {
         if ('lines' in rowData) {
-          return Object.values(rowData.lines).reduce(
-            (sum, batch) =>
-              sum + (batch.sellPricePerPack ?? 0) / batch.packSize,
-            0
-          );
+          // Multiple lines, so we need to calculate the average price per unit
+
+          let totalSellPrice = 0;
+          let totalUnits = 0;
+
+          for (const line of rowData.lines) {
+            totalSellPrice += line.sellPricePerPack * line.numberOfPacks;
+            totalUnits += line.numberOfPacks * line.packSize;
+          }
+
+          return totalSellPrice / totalUnits;
         } else {
           return (rowData.sellPricePerPack ?? 0) / rowData.packSize;
         }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4764

# 👩🏻‍💻 What does this PR do?

Previously the unit price was shown as the sum of all the pack price per line.

Now it shows the average...

![image](https://github.com/user-attachments/assets/cd46fa46-9ff7-4ff5-b2e7-f7276c5b23cc)

## 💌 Any notes for the reviewer?

We maybe should just show [Multiple] if there are different prices?
Should the title be updated to show average?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Make sure you have an item in stock with different packsizes available and prices
- [ ] Create a prescription for a patient and select stock from two different packsizes
- [ ] Check the prices are calculated correctly.
- [ ] Test with default prices lists and discount price lists in case this affects things

# 📃 Documentation

- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
