### PR TITLE
4910 add support for kmf as a currency

### DIFF
--- a/client/packages/common/src/intl/currency/currency.ts
+++ b/client/packages/common/src/intl/currency/currency.ts
@@ -104,7 +104,8 @@ export type Currencies =
   | 'SSP'
   | 'PGK'
   | 'COP'
-  | 'SBD';
+  | 'SBD'
+  | 'KMF';
 
 export const currencyOptions = (locale: string, code?: Currencies) => {
   switch (code) {
@@ -182,6 +183,16 @@ export const currencyOptions = (locale: string, code?: Currencies) => {
         ...getSeparatorAndDecimal(locale),
         ...getPatterns(locale),
         symbol: 'SI$',
+        precision: 2,
+        format,
+      };
+    }
+    case 'KMF': {
+      return {
+        // separator: "," decimal = "."
+        ...getSeparatorAndDecimal(locale),
+        ...getPatterns(locale),
+        symbol: 'FC',
         precision: 2,
         format,
       };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4910

# 👩🏻‍💻 What does this PR do?

Possible fix for adding the KMF currency for Comoros

## 💌 Any notes for the reviewer?

Couldn't figure out how to test this...
I can't change the default currency in my mSupply, and I can't seem to change currency in Mac OS either.
I did try this incantaion...

`defaults write NSGlobalDomain AppleLocale -string "en_US@currency=KMF`

And set my language to `en_US` but it didn't apply. It's possible I need to restart?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour

