### PR TITLE
#4884 Vax config age range improvement

### DIFF
--- a/client/packages/programs/src/VaccineCourseEditModal/VaccineCourseEditModal.tsx
+++ b/client/packages/programs/src/VaccineCourseEditModal/VaccineCourseEditModal.tsx
@@ -276,10 +276,9 @@ const VaccineCourseDoseTable = ({
   };
 
   const updateDose: ColumnDataSetter<VaccineCourseDoseFragment> = newData => {
-    const validData = constrainInput(newData, doses);
     updatePatch({
       vaccineCourseDoses: doses.map(dose =>
-        dose.id === newData.id ? { ...dose, ...validData } : dose
+        dose.id === newData.id ? { ...dose, ...newData } : dose
       ),
     });
   };
@@ -369,40 +368,4 @@ const AgeCell = (props: CellProps<VaccineCourseDoseFragment>) => {
       ]}
     />
   );
-};
-
-const constrainInput = (
-  rowData: Partial<VaccineCourseDoseFragment>,
-  doses: VaccineCourseDoseFragment[]
-) => {
-  const validRowData = { ...rowData };
-  const rowIndex = doses.findIndex(dose => dose.id === rowData.id);
-  console.log(rowIndex);
-  console.log(doses);
-
-  const prevDose = doses[rowIndex - 1];
-  const nextDose = doses[rowIndex + 1];
-
-  const { minAgeMonths = 0, maxAgeMonths = Infinity } = rowData;
-
-  // console.log('Min', minAgeMonths, 'Max', maxAgeMonths);
-  // console.log('Prev Max', prevDose?.maxAgeMonths);
-  // console.log('Next Min', nextDose?.minAgeMonths);
-
-  if (prevDose && minAgeMonths < prevDose.maxAgeMonths) {
-    console.log('Constraining');
-    validRowData.minAgeMonths = prevDose.maxAgeMonths;
-  }
-
-  if (nextDose && maxAgeMonths > nextDose.minAgeMonths) {
-    validRowData.maxAgeMonths = nextDose.minAgeMonths;
-  }
-
-  if (maxAgeMonths < minAgeMonths) {
-    validRowData.maxAgeMonths = minAgeMonths + 1;
-  }
-
-  console.log('validRowData', validRowData);
-
-  return validRowData;
 };

--- a/client/packages/programs/src/VaccineCourseEditModal/VaccineCourseEditModal.tsx
+++ b/client/packages/programs/src/VaccineCourseEditModal/VaccineCourseEditModal.tsx
@@ -253,6 +253,9 @@ const VaccineCourseDoseTable = ({
 
   const addDose = () => {
     const previousDose = doses[doses.length - 1];
+    const previousMin = previousDose?.minAgeMonths ?? 0;
+    const previousMax = previousDose?.maxAgeMonths ?? 0;
+    const previousRange = previousMax - previousMin;
 
     updatePatch({
       vaccineCourseDoses: [
@@ -261,8 +264,8 @@ const VaccineCourseDoseTable = ({
           __typename: 'VaccineCourseDoseNode',
           id: FnUtils.generateUUID(),
           label: `${courseName} ${doses.length + 1}`,
-          minAgeMonths: previousDose?.maxAgeMonths ?? 0,
-          maxAgeMonths: (previousDose?.maxAgeMonths ?? 0) + 1,
+          minAgeMonths: previousMax,
+          maxAgeMonths: previousMax + (previousRange || 1),
           minIntervalDays: previousDose?.minIntervalDays ?? 30,
         },
       ],


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4884 (sort of)

# 👩🏻‍💻 What does this PR do?

All it does currently is:
- remove the min/max constraints
- set the new min default to the previous dose maximum

I had started to add some additional constraints (max must be more than min, doses can't overlap), but have stopped that for now for two reasons:

- we're probably going to update this UI anyway, as per #4928, which would make this unnecessary for now
- I encountered a limitation of the `useBufferState` hook, where it doesn't update the local state value if the external data has been *reverted* to it's existing value after a user input change. So we'd need to either change this, or find a way to pass the *full* data set into the cell so we can compare rows within the cell.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Can change min age value without being constrained by the current max
- [ ] Ranges can overlap (obviously this is not what we want, but solution to that will be done elsewhere)