### PR TITLE
4765 outbound shipment unit price incorrect, when multiple lines are grouped

### DIFF
--- a/client/packages/common/src/ui/layout/tables/components/Cells/CurrencyCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/CurrencyCell.tsx
@@ -28,12 +28,12 @@ export const CurrencyCell = <T extends RecordWithId>({
 > => {
   const { c } = useCurrency(currencyCode);
   const price = Number(column.accessor({ rowData }) ?? 0);
-  // format prices > 1 with default precision
-  const precision = price < 1 ? 10 : undefined;
-  const fullText = c(price, precision).format();
+  const fullText = c(price, 10).format();
   let text = fullText;
-  if (price !== 0 && price < 0.001) {
-    text = `< ${c(0.001, 3).format()}`;
+  if ((price * 100) % 1 !== 0) {
+    price < 0.01
+      ? (text = `< ${c(0.01, 2).format()}`)
+      : (text = `${c(price, 2).format()}...`);
   }
 
   return (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4765

# 👩🏻‍💻 What does this PR do?
- Corrects the calculation for unit price.
- Defaults all price to 10 dp to show in tooltip (displays @ 2dp with ellipsis)
- Pack qty now gets the correct total
- Pack size now shows multiple if the batches are different sizes.

![Screenshot 2024-10-01 at 2 25 13 PM](https://github.com/user-attachments/assets/28687ec6-0031-4f57-af77-5e924e35dbbc)
![Screenshot 2024-10-01 at 2 25 32 PM](https://github.com/user-attachments/assets/297a902f-9e22-4673-a557-6eff864f3fa9)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have stock lines with different prices maybe different pack sizes as well
- [ ] Add them to outbound shipment
- [ ] Calculate unit price to see that it matches with unit price (and that the logic is correct lul)
- [ ] Pack qty total should be sum of packs 
- [ ] Pack size should show multiple if multiple (and now same pack size)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Maybe screenshots? 
  2. Description of columns to avoid confusion? 
