### PR TITLE
4941 inbound shipment crashes when status changed to delivered

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
@@ -199,9 +199,6 @@ export const StatusChangeButton = () => {
     lines?.totalCount === 0 || lines?.nodes?.every(l => l.numberOfPacks === 0);
   const t = useTranslation();
 
-  if (!selectedOption) return null;
-  if (isStatusChangeDisabled) return null;
-
   const noLinesNotification = useDisabledNotificationToast(
     t('messages.no-lines')
   );
@@ -209,6 +206,9 @@ export const StatusChangeButton = () => {
   const onHoldNotification = useDisabledNotificationToast(
     t('messages.on-hold')
   );
+
+  if (!selectedOption) return null;
+  if (isStatusChangeDisabled) return null;
 
   const onStatusClick = () => {
     if (noLines) return noLinesNotification();


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4941

# 👩🏻‍💻 What does this PR do?

Moves the early returns to below the hook calls, so we don't get the "rendered fewer hooks than the previous render" crash

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] create Inbound shipment
- [ ] change the status to verified
- [ ] no crash

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
