### PR TITLE
105-report-translations

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -582,5 +582,6 @@
   "table.select-unselect-all-columns": "Select / unselect all columns",
   "table.show-columns": "Show / hide columns",
   "title.confirm-delete-encounter": "Delete encounter",
-  "warning.caps-lock": "Warning: Caps lock is on"
+  "warning.caps-lock": "Warning: Caps lock is on",
+  "label.report-filters": "Report Filters"
 }

--- a/client/packages/common/src/intl/locales/fr/common.json
+++ b/client/packages/common/src/intl/locales/fr/common.json
@@ -583,5 +583,7 @@
   "label.dose-number": "Dose #",
   "label.label": "Etiquette",
   "error.field-must-be-specified": "{{field}} doit être spécifié",
-  "button.add-new-vaccine-course": "Ajouter un calendrier de vaccination"
+  "button.add-new-vaccine-course": "Ajouter un calendrier de vaccination",
+  "message.arguments": "Vous pouvez personnaliser l'affichage du rapport en spécifiant certains des détails facultatifs ci-dessous. Cliquez sur OK pour afficher le rapport.",
+  "label.report-filters": "Filtres du rapport"
 }

--- a/client/packages/common/src/intl/locales/fr/common.json
+++ b/client/packages/common/src/intl/locales/fr/common.json
@@ -584,6 +584,5 @@
   "label.label": "Etiquette",
   "error.field-must-be-specified": "{{field}} doit être spécifié",
   "button.add-new-vaccine-course": "Ajouter un calendrier de vaccination",
-  "message.arguments": "Vous pouvez personnaliser l'affichage du rapport en spécifiant certains des détails facultatifs ci-dessous. Cliquez sur OK pour afficher le rapport.",
   "label.report-filters": "Filtres du rapport"
 }

--- a/client/packages/common/src/intl/locales/fr/reports.json
+++ b/client/packages/common/src/intl/locales/fr/reports.json
@@ -1,4 +1,5 @@
 {
-    "heading.stock-and-items": "Stock et articles",
-    "heading.expiring": "En cours d'expiration"
+  "heading.stock-and-items": "Stock et articles",
+  "heading.expiring": "En cours d'expiration",
+  "message.arguments": "Vous pouvez personnaliser l'affichage du rapport en spécifiant certains des détails facultatifs ci-dessous. Cliquez sur OK pour afficher le rapport."
 }

--- a/client/packages/common/src/intl/locales/fr/reports.json
+++ b/client/packages/common/src/intl/locales/fr/reports.json
@@ -1,0 +1,4 @@
+{
+    "heading.stock-and-items": "Stock et articles",
+    "heading.expiring": "En cours d'expiration"
+}

--- a/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
+++ b/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
@@ -54,7 +54,7 @@ export const ReportArgumentsModal: FC<ReportArgumentsModalProps> = ({
 
   return (
     <Modal
-      title="Report arguments"
+      title={t('label.report-filters')}
       cancelButton={<DialogButton variant="cancel" onClick={cleanUp} />}
       slideAnimation={false}
       width={560}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Partially fixes: https://github.com/msupply-foundation/open-msupply-reports/issues/105

# 👩🏻‍💻 What does this PR do?

Adds french translations that relate to general reports. For report filter modal and for report category headers

## 💌 Any notes for the reviewer?

These translations are in develop, but I had to manually insert them here, location of json file was change and argument/filter modal title was not translated yet in 2.2.3 

# 🧪 Testing

Check translation of report categories in french language and report filter modal (note the filters themselves are not translated here, but the modal title and the dscirption should be)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
