### PR TITLE
delete doses on course delete

### DIFF
--- a/server/service/src/vaccine_course/delete.rs
+++ b/server/service/src/vaccine_course/delete.rs
@@ -28,13 +28,13 @@ pub fn delete_vaccine_course(
         .transaction_sync(|connection| {
             let doses = validate(connection, &id)?;
 
-            // Make the vaccine course doses as deleted
+            // Mark the vaccine course doses as deleted
             let dose_row_repo = VaccineCourseDoseRowRepository::new(connection);
             for dose in doses {
                 dose_row_repo.mark_deleted(&dose.vaccine_course_dose_row.id)?;
             }
 
-            // Make the vaccine course deleted
+            // Mark the vaccine course deleted
             let repo = VaccineCourseRowRepository::new(connection);
             repo.mark_deleted(&id)
                 .map(|_| id)

--- a/server/service/src/vaccine_course/delete.rs
+++ b/server/service/src/vaccine_course/delete.rs
@@ -1,6 +1,12 @@
 use repository::{
-    vaccine_course::vaccine_course_row::VaccineCourseRowRepository, RepositoryError,
-    StorageConnection,
+    vaccine_course::{
+        vaccine_course_dose::{
+            VaccineCourseDose, VaccineCourseDoseFilter, VaccineCourseDoseRepository,
+        },
+        vaccine_course_dose_row::VaccineCourseDoseRowRepository,
+        vaccine_course_row::VaccineCourseRowRepository,
+    },
+    EqualFilter, RepositoryError, StorageConnection,
 };
 
 use crate::service_provider::ServiceContext;
@@ -20,10 +26,16 @@ pub fn delete_vaccine_course(
     let vaccine_course_id = ctx
         .connection
         .transaction_sync(|connection| {
-            validate(connection, &id)?;
+            let doses = validate(connection, &id)?;
 
+            // Make the vaccine course doses as deleted
+            let dose_row_repo = VaccineCourseDoseRowRepository::new(connection);
+            for dose in doses {
+                dose_row_repo.mark_deleted(&dose.vaccine_course_dose_row.id)?;
+            }
+
+            // Make the vaccine course deleted
             let repo = VaccineCourseRowRepository::new(connection);
-
             repo.mark_deleted(&id)
                 .map(|_| id)
                 .map_err(DeleteVaccineCourseError::from)
@@ -38,9 +50,16 @@ impl From<RepositoryError> for DeleteVaccineCourseError {
     }
 }
 
-fn validate(connection: &StorageConnection, id: &str) -> Result<(), DeleteVaccineCourseError> {
+fn validate(
+    connection: &StorageConnection,
+    id: &str,
+) -> Result<Vec<VaccineCourseDose>, DeleteVaccineCourseError> {
     check_vaccine_course_exists(id, connection)?
         .ok_or(DeleteVaccineCourseError::VaccineCourseDoesNotExist)?;
 
-    Ok(())
+    let doses = VaccineCourseDoseRepository::new(connection).query_by_filter(
+        VaccineCourseDoseFilter::new().vaccine_course_id(EqualFilter::equal_to(id)),
+    )?;
+
+    Ok(doses)
 }

--- a/server/service/src/vaccine_course/test/delete.rs
+++ b/server/service/src/vaccine_course/test/delete.rs
@@ -3,11 +3,15 @@ mod delete {
     use repository::mock::{mock_immunisation_program_a, MockDataInserts};
     use repository::test_db::setup_all;
     use repository::vaccine_course::vaccine_course::VaccineCourseFilter;
+    use repository::vaccine_course::vaccine_course_dose::{
+        VaccineCourseDoseFilter, VaccineCourseDoseRepository,
+    };
     use repository::EqualFilter;
 
     use crate::service_provider::ServiceProvider;
     use crate::vaccine_course::delete::DeleteVaccineCourseError;
     use crate::vaccine_course::insert::InsertVaccineCourse;
+    use crate::vaccine_course::update::VaccineCourseDoseInput;
 
     #[actix_rt::test]
     async fn delete_vaccine_course_errors() {
@@ -39,7 +43,14 @@ mod delete {
             name: "vaccine_course_name".to_owned(),
             program_id: mock_immunisation_program_a().id.clone(),
             vaccine_items: vec![],
-            doses: vec![],
+            doses: vec![VaccineCourseDoseInput {
+                id: "dose_to_delete".to_string(),
+                label: "dose_label".to_string(),
+                min_age: 0.0,
+                max_age: 1.0,
+                min_interval_days: 0,
+                custom_age_label: None,
+            }],
             demographic_indicator_id: None,
             coverage_rate: 100.0,
             is_active: true,
@@ -50,19 +61,40 @@ mod delete {
             .insert_vaccine_course(&context, vaccine_course.clone())
             .unwrap();
 
-        // Soft delete it
+        // Check it is found
+        let course_filter =
+            VaccineCourseFilter::new().id(EqualFilter::equal_to(&vaccine_course.id));
+
+        let courses = service
+            .get_vaccine_courses(&context.connection, None, Some(course_filter.clone()), None)
+            .unwrap();
+
+        assert_eq!(courses.count, 1);
+
+        let dose_filter = VaccineCourseDoseFilter::new()
+            .vaccine_course_id(EqualFilter::equal_to(&vaccine_course.id));
+
+        let dose_repo = VaccineCourseDoseRepository::new(&context.connection);
+
+        // Dose is found
+        let doses = dose_repo.query_by_filter(dose_filter.clone()).unwrap();
+        assert_eq!(doses.len(), 1);
+
+        // Soft delete the vaccine course
         let result = service.delete_vaccine_course(&context, vaccine_course.id.clone());
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), vaccine_course.id);
 
         // Ensure it is not found in query
-        let filter = VaccineCourseFilter::new().id(EqualFilter::equal_to(&vaccine_course.id));
-
         let courses = service
-            .get_vaccine_courses(&context.connection, None, Some(filter), None)
+            .get_vaccine_courses(&context.connection, None, Some(course_filter), None)
             .unwrap();
 
         assert_eq!(courses.count, 0);
+
+        // Dose also not found
+        let doses = dose_repo.query_by_filter(dose_filter).unwrap();
+        assert_eq!(doses.len(), 0);
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4924

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Soft deletes vaccine course doses when vaccine course is soft deleted

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a vaccine course with doses
- [ ] See doses in vax card
- [ ] Delete the vaccine course
- [ ] Check vax card - doses should not be there
- [ ] (Note - doses where vaccination has already be recorded will continue to show in the card, just can't administer new ones!)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
