### PR TITLE
4977 Spanish currency crash

### DIFF
--- a/client/packages/common/src/intl/currency/currency.ts
+++ b/client/packages/common/src/intl/currency/currency.ts
@@ -77,7 +77,8 @@ export const format: currency.Format = (
 // even though it looks like a regular space (CharCode 32)), so for consistency
 // this should be the source of truth.
 const getSeparatorAndDecimal = (locale: string) => {
-  const parts = new Intl.NumberFormat(locale).formatToParts(1000.1);
+  // Some locales (at least `es`) don't include a group separator for 4 digits (1000), only for 5 (10000)
+  const parts = new Intl.NumberFormat(locale).formatToParts(10000.1);
   const separator = parts.find(({ type }) => type === 'group')?.value ?? ',';
   const decimal = parts.find(({ type }) => type === 'decimal')?.value ?? '.';
   return { separator, decimal };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4977

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Fixes app crashing if spanish language is selected.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

This fixes the urgent issue (the app crashing) but when we deploy to different spanish speaking regions, we make need to refine - some countries use `,` as the decimal separator, others use `.` 👀 

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Set language to spanish
- [ ] Go to view stock page for a stock line
- [ ] App does not crash

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
