### PR TITLE
4912 Can't create/edit patients with a Date of Birth

### DIFF
--- a/client/packages/system/src/Patient/PatientView/PatientView.tsx
+++ b/client/packages/system/src/Patient/PatientView/PatientView.tsx
@@ -189,7 +189,12 @@ const PatientDetailView = ({
         isCreating: isCreatingPatient,
         schema: DEFAULT_SCHEMA,
         save: async (data: unknown) => {
-          await handlePatientSave(data);
+          const newData = Object.fromEntries(
+            Object.entries(data ?? {}).filter(
+              ([key]) => key !== 'dateOfBirthIsEstimated'
+            )
+          );
+          await handlePatientSave(newData);
         },
       };
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4912

# 👩🏻‍💻 What does this PR do?
Parse of estimated date of birth in the json data since the insert and update patient input doesn't contain this field.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a patient
- [ ] Add date of birth
- [ ] Click create (Should create)
- [ ] Update patient's date of birth
- [ ] Click save (should update)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
