### PR TITLE
4963 demographic permissions

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -5465,6 +5465,7 @@ export type QueriesDemographicIndicatorsArgs = {
   filter?: InputMaybe<DemographicIndicatorFilterInput>;
   page?: InputMaybe<PaginationInput>;
   sort?: InputMaybe<Array<DemographicIndicatorSortInput>>;
+  storeId: Scalars['String']['input'];
 };
 
 

--- a/client/packages/system/src/IndicatorsDemographics/api/api.ts
+++ b/client/packages/system/src/IndicatorsDemographics/api/api.ts
@@ -38,11 +38,12 @@ const Parsers = {
   },
 };
 
-export const getDemographicIndicatorQueries = (sdk: Sdk) => ({
+export const getDemographicIndicatorQueries = (sdk: Sdk, storeId: string) => ({
   getIndicators: {
     byId: async (demographicIndicatorId: string) => {
       const result = await sdk.demographicIndicatorById({
         demographicIndicatorId,
+        storeId,
       });
       const { demographicIndicators } = result;
       if (
@@ -66,6 +67,7 @@ export const getDemographicIndicatorQueries = (sdk: Sdk) => ({
         key: Parsers.toIndicatorSortField(sortBy),
         desc: sortBy.isDesc,
         filter: filterBy,
+        storeId: storeId,
       });
 
       return result?.demographicIndicators;
@@ -74,6 +76,7 @@ export const getDemographicIndicatorQueries = (sdk: Sdk) => ({
       const result = await sdk.demographicIndicators({
         key: Parsers.toIndicatorSortField(sortBy),
         desc: sortBy.isDesc,
+        storeId: storeId,
       });
 
       const demographicIndicators = result?.demographicIndicators;

--- a/client/packages/system/src/IndicatorsDemographics/api/hooks/utils/useDemographicApi.ts
+++ b/client/packages/system/src/IndicatorsDemographics/api/hooks/utils/useDemographicApi.ts
@@ -1,4 +1,4 @@
-import { SortBy, useGql } from '@openmsupply-client/common';
+import { SortBy, useAuthContext, useGql } from '@openmsupply-client/common';
 import { ListParams, getDemographicIndicatorQueries } from '../../api';
 import {
   DemographicIndicatorFragment,
@@ -7,6 +7,7 @@ import {
 } from '../../operations.generated';
 export const useDemographicsApi = () => {
   const { client } = useGql();
+  const { storeId } = useAuthContext();
 
   const keys = {
     baseIndicator: () => ['demographic indicator'] as const,
@@ -27,6 +28,6 @@ export const useDemographicsApi = () => {
       [...keys.projectionList(), sortBy] as const,
   };
 
-  const queries = getDemographicIndicatorQueries(getSdk(client));
+  const queries = getDemographicIndicatorQueries(getSdk(client), storeId);
   return { ...queries, keys };
 };

--- a/client/packages/system/src/IndicatorsDemographics/api/operations.generated.ts
+++ b/client/packages/system/src/IndicatorsDemographics/api/operations.generated.ts
@@ -10,6 +10,7 @@ export type DemographicProjectionFragment = { __typename: 'DemographicProjection
 export type DemographicIndicatorsQueryVariables = Types.Exact<{
   first?: Types.InputMaybe<Types.Scalars['Int']['input']>;
   offset?: Types.InputMaybe<Types.Scalars['Int']['input']>;
+  storeId: Types.Scalars['String']['input'];
   key: Types.DemographicIndicatorSortFieldInput;
   desc?: Types.InputMaybe<Types.Scalars['Boolean']['input']>;
   filter?: Types.InputMaybe<Types.DemographicIndicatorFilterInput>;
@@ -38,6 +39,7 @@ export type DemographicProjectionsByBaseYearQuery = { __typename: 'Queries', dem
 
 export type DemographicIndicatorByIdQueryVariables = Types.Exact<{
   demographicIndicatorId: Types.Scalars['String']['input'];
+  storeId: Types.Scalars['String']['input'];
 }>;
 
 
@@ -97,13 +99,15 @@ export const DemographicProjectionFragmentDoc = gql`
 }
     `;
 export const DemographicIndicatorsDocument = gql`
-    query demographicIndicators($first: Int, $offset: Int, $key: DemographicIndicatorSortFieldInput!, $desc: Boolean, $filter: DemographicIndicatorFilterInput) {
+    query demographicIndicators($first: Int, $offset: Int, $storeId: String!, $key: DemographicIndicatorSortFieldInput!, $desc: Boolean, $filter: DemographicIndicatorFilterInput) {
   demographicIndicators(
     page: {first: $first, offset: $offset}
     sort: {key: $key, desc: $desc}
     filter: $filter
+    storeId: $storeId
   ) {
     ... on DemographicIndicatorConnector {
+      __typename
       nodes {
         ...DemographicIndicator
       }
@@ -145,8 +149,11 @@ export const DemographicProjectionsByBaseYearDocument = gql`
 }
     ${DemographicProjectionFragmentDoc}`;
 export const DemographicIndicatorByIdDocument = gql`
-    query demographicIndicatorById($demographicIndicatorId: String!) {
-  demographicIndicators(filter: {id: {equalTo: $demographicIndicatorId}}) {
+    query demographicIndicatorById($demographicIndicatorId: String!, $storeId: String!) {
+  demographicIndicators(
+    filter: {id: {equalTo: $demographicIndicatorId}}
+    storeId: $storeId
+  ) {
     ... on DemographicIndicatorConnector {
       nodes {
         ...DemographicIndicator

--- a/client/packages/system/src/IndicatorsDemographics/api/operations.graphql
+++ b/client/packages/system/src/IndicatorsDemographics/api/operations.graphql
@@ -24,6 +24,7 @@ fragment DemographicProjection on DemographicProjectionNode {
 query demographicIndicators(
   $first: Int
   $offset: Int
+  $storeId: String!
   $key: DemographicIndicatorSortFieldInput!
   $desc: Boolean
   $filter: DemographicIndicatorFilterInput
@@ -32,8 +33,10 @@ query demographicIndicators(
     page: { first: $first, offset: $offset }
     sort: { key: $key, desc: $desc }
     filter: $filter
+    storeId: $storeId
   ) {
     ... on DemographicIndicatorConnector {
+      __typename
       nodes {
         ...DemographicIndicator
       }
@@ -78,8 +81,14 @@ query demographicProjectionsByBaseYear($baseYear: Int!) {
   }
 }
 
-query demographicIndicatorById($demographicIndicatorId: String!) {
-  demographicIndicators(filter: { id: { equalTo: $demographicIndicatorId } }) {
+query demographicIndicatorById(
+  $demographicIndicatorId: String!
+  $storeId: String!
+) {
+  demographicIndicators(
+    filter: { id: { equalTo: $demographicIndicatorId } }
+    storeId: $storeId
+  ) {
     ... on DemographicIndicatorConnector {
       nodes {
         ...DemographicIndicator

--- a/server/graphql/demographic/src/lib.rs
+++ b/server/graphql/demographic/src/lib.rs
@@ -36,6 +36,7 @@ impl DemographicIndicatorQueries {
     pub async fn demographic_indicators(
         &self,
         ctx: &Context<'_>,
+        store_id: String,
         page: Option<PaginationInput>,
         filter: Option<DemographicIndicatorFilterInput>,
         sort: Option<Vec<DemographicIndicatorSortInput>>,
@@ -44,11 +45,11 @@ impl DemographicIndicatorQueries {
             ctx,
             &ResourceAccessRequest {
                 resource: Resource::QueryDemographic,
-                store_id: None,
+                store_id: Some(store_id.clone()),
             },
         )?;
         let service_provider = ctx.service_provider();
-        let service_context = service_provider.context("".to_string(), user.user_id)?;
+        let service_context = service_provider.context(store_id, user.user_id)?;
 
         let demographic_indicators = service_provider
             .demographic_service

--- a/server/graphql/demographic/src/lib.rs
+++ b/server/graphql/demographic/src/lib.rs
@@ -43,7 +43,7 @@ impl DemographicIndicatorQueries {
         let user = validate_auth(
             ctx,
             &ResourceAccessRequest {
-                resource: Resource::QueryAsset,
+                resource: Resource::QueryDemographic,
                 store_id: None,
             },
         )?;
@@ -77,7 +77,7 @@ impl DemographicIndicatorQueries {
         let user = validate_auth(
             ctx,
             &ResourceAccessRequest {
-                resource: Resource::QueryAsset,
+                resource: Resource::QueryDemographic,
                 store_id: None,
             },
         )?;
@@ -108,7 +108,7 @@ impl DemographicIndicatorQueries {
         let user = validate_auth(
             ctx,
             &ResourceAccessRequest {
-                resource: Resource::QueryAsset,
+                resource: Resource::QueryDemographic,
                 store_id: None,
             },
         )?;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4963

# 👩🏻‍💻 What does this PR do?
- Use the QueryDemographics permission for all demographic query endpoints (this requires no permission to view)
- Fixes the `__typename` error
- Passes in store_id to check user has correct permission for store

QueryDemographics no longer requires permission, so should never get the permission denied pop up in vaccination... but will need to refactor this bit of code if permission does change in the future.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Be an OMS central 
- [ ] Go to demographics
- [ ] Should be able to view demographics without permission

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
