### PR TITLE
4996 inventory adjustment modal height fix

### DIFF
--- a/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
+++ b/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
@@ -8,6 +8,7 @@ import {
   useNotification,
   AdjustmentTypeInput,
   useDialog,
+  useKeyboardHeightAdjustment,
 } from '@openmsupply-client/common';
 import { StockLineRowFragment, useInventoryAdjustment } from '../../api';
 import { InventoryAdjustmentReasonSearchInput, usePackVariant } from '../../..';
@@ -27,6 +28,7 @@ export const InventoryAdjustmentModal: FC<InventoryAdjustmentModalProps> = ({
   const t = useTranslation('inventory');
   const { success, error } = useNotification();
   const { Modal } = useDialog({ isOpen, onClose });
+  const height = useKeyboardHeightAdjustment(575);
 
   const { draft, setDraft, create } = useInventoryAdjustment(stockLine);
 
@@ -58,7 +60,8 @@ export const InventoryAdjustmentModal: FC<InventoryAdjustmentModalProps> = ({
 
   return (
     <Modal
-      sx={{ maxWidth: 'unset', minWidth: 700, minHeight: 575 }}
+      sx={{ maxWidth: 'unset', minWidth: 700 }}
+      height={height}
       slideAnimation={false}
       title={t('title.adjustment-details')}
       okButton={


### PR DESCRIPTION

<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4996 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Adds the keyboard height adjustment to inventory adjustment modal for android

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

Refactor issue created: #5009

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] ON APK
- [ ] Go to View stock > some stock line
- [ ] Click `Adjust`
- [ ] Tap one of the inputs to open the keyboard
- [ ] The modal adjusts it's height, and its scrollable

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
