### PR TITLE
5014 can give wrong vaccinations on new site

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -531,7 +531,7 @@
   "message.nothing-to-save": "Nothing to save",
   "messages.ago": "{{time}} ago",
   "messages.cannot-delete-multiple-lines": "One or more lines cannot be deleted",
-  "messages.cannot-view-vaccine-card": "This patient was enrolled in the {{ programName }} by another store and cannot be viewed in this store",
+  "messages.cannot-view-vaccine-card": "You cannot view this patient's Vaccination Card from this store, because they were enrolled in the {{ programName }} by another store",
   "messages.cant-delete-generic": "You cannot delete one or more of the selected items",
   "messages.click-to-expand": "Click to expand",
   "messages.confirm-add-from-master-list": "Do you want to add all of the items from this master list?",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -531,6 +531,7 @@
   "message.nothing-to-save": "Nothing to save",
   "messages.ago": "{{time}} ago",
   "messages.cannot-delete-multiple-lines": "One or more lines cannot be deleted",
+  "messages.cannot-view-vaccine-card": "Patient is enrolled in this immunisation program in another store. You cannot view the vaccination card.",
   "messages.cant-delete-generic": "You cannot delete one or more of the selected items",
   "messages.click-to-expand": "Click to expand",
   "messages.confirm-add-from-master-list": "Do you want to add all of the items from this master list?",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -531,7 +531,7 @@
   "message.nothing-to-save": "Nothing to save",
   "messages.ago": "{{time}} ago",
   "messages.cannot-delete-multiple-lines": "One or more lines cannot be deleted",
-  "messages.cannot-view-vaccine-card": "Patient is enrolled in this immunisation program in another store. You cannot view the vaccination card.",
+  "messages.cannot-view-vaccine-card": "This patient was enrolled in the {{ programName }} by another store and cannot be viewed in this store",
   "messages.cant-delete-generic": "You cannot delete one or more of the selected items",
   "messages.click-to-expand": "Click to expand",
   "messages.confirm-add-from-master-list": "Do you want to add all of the items from this master list?",

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -8234,6 +8234,7 @@ export enum VaccinationCardItemNodeStatus {
 
 export type VaccinationCardNode = {
   __typename: 'VaccinationCardNode';
+  enrolmentStoreId?: Maybe<Scalars['String']['output']>;
   id: Scalars['String']['output'];
   items: Array<VaccinationCardItemNode>;
   patientFirstName?: Maybe<Scalars['String']['output']>;

--- a/client/packages/system/src/Patient/PatientView/PatientView.tsx
+++ b/client/packages/system/src/Patient/PatientView/PatientView.tsx
@@ -282,7 +282,7 @@ export const PatientView = () => {
   const { setCurrentPatient, createNewPatient } = usePatientStore();
   const { data: currentPatient } = usePatient.document.get(patientId);
   const [isDirtyPatient, setIsDirtyPatient] = useState(false);
-  const { store } = useAuthContext();
+  const { store, storeId } = useAuthContext();
 
   const requiresConfirmation = (tab: string) => {
     return tab === PatientTabValue.Details && isDirtyPatient;
@@ -349,6 +349,7 @@ export const PatientView = () => {
               data: {
                 enrolmentDatetime: new Date().toISOString(),
                 status: 'ACTIVE',
+                storeId,
               },
               schema: documentRegistry,
               isCreating: true,

--- a/client/packages/system/src/Vaccination/Components/VaccineCardTable.tsx
+++ b/client/packages/system/src/Vaccination/Components/VaccineCardTable.tsx
@@ -13,9 +13,13 @@ import {
   useTheme,
   StatusCell,
   VaccinationCardItemNodeStatus,
+  useAuthContext,
 } from '@openmsupply-client/common';
 import { usePatientVaccineCard } from '../api/usePatientVaccineCard';
-import { VaccinationCardItemFragment } from '../api/operations.generated';
+import {
+  VaccinationCardFragment,
+  VaccinationCardItemFragment,
+} from '../api/operations.generated';
 
 interface VaccinationCardProps {
   programEnrolmentId: string;
@@ -110,18 +114,16 @@ const useStyleRowsByStatus = (
   }, [rows]);
 };
 
-export const VaccinationCardComponent: FC<VaccinationCardProps> = ({
-  programEnrolmentId,
-  openModal,
+const VaccinationCardComponent = ({
+  data,
   encounterId,
+  openModal,
+}: VaccinationCardProps & {
+  data: VaccinationCardFragment;
 }) => {
   const t = useTranslation('dispensary');
   const { localisedDate } = useFormatDateTime();
   const theme = useTheme();
-
-  const {
-    query: { data, isLoading },
-  } = usePatientVaccineCard(programEnrolmentId);
 
   const isEncounter = !!encounterId;
 
@@ -222,15 +224,12 @@ export const VaccinationCardComponent: FC<VaccinationCardProps> = ({
     [data]
   );
 
-  return isLoading ? (
-    <InlineSpinner />
-  ) : (
+  return (
     <>
       <DataTable
         id={'Vaccine Course List'}
         columns={columns}
         data={data?.items ?? []}
-        isLoading={isLoading}
         onRowClick={row => {
           if (includeRow(isEncounter, row, data?.items))
             openModal(row.vaccinationId, row.vaccineCourseDoseId);
@@ -241,13 +240,26 @@ export const VaccinationCardComponent: FC<VaccinationCardProps> = ({
   );
 };
 
-export const VaccineCardTable: FC<VaccinationCardProps> = props => (
-  <TableProvider
-    createStore={createTableStore}
-    queryParamsStore={createQueryParamsStore({
-      initialSortBy: { key: 'name' },
-    })}
-  >
-    <VaccinationCardComponent {...props} />
-  </TableProvider>
-);
+export const VaccineCardTable: FC<VaccinationCardProps> = props => {
+  const { storeId } = useAuthContext();
+  const t = useTranslation();
+  const {
+    query: { data, isLoading },
+  } = usePatientVaccineCard(props.programEnrolmentId);
+
+  if (data?.enrolmentStoreId !== storeId)
+    return <NothingHere body={t('messages.cannot-view-vaccine-card')} />;
+
+  if (isLoading) return <InlineSpinner />;
+
+  return (
+    <TableProvider
+      createStore={createTableStore}
+      queryParamsStore={createQueryParamsStore({
+        initialSortBy: { key: 'name' },
+      })}
+    >
+      <VaccinationCardComponent data={data} {...props} />
+    </TableProvider>
+  );
+};

--- a/client/packages/system/src/Vaccination/Components/VaccineCardTable.tsx
+++ b/client/packages/system/src/Vaccination/Components/VaccineCardTable.tsx
@@ -14,6 +14,9 @@ import {
   StatusCell,
   VaccinationCardItemNodeStatus,
   useAuthContext,
+  Alert,
+  Box,
+  UnhappyMan,
 } from '@openmsupply-client/common';
 import { usePatientVaccineCard } from '../api/usePatientVaccineCard';
 import {
@@ -247,10 +250,25 @@ export const VaccineCardTable: FC<VaccinationCardProps> = props => {
     query: { data, isLoading },
   } = usePatientVaccineCard(props.programEnrolmentId);
 
-  if (data?.enrolmentStoreId !== storeId)
-    return <NothingHere body={t('messages.cannot-view-vaccine-card')} />;
-
   if (isLoading) return <InlineSpinner />;
+
+  if (data?.enrolmentStoreId !== storeId)
+    return (
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        width="100%"
+        flexDirection="column"
+      >
+        <UnhappyMan />
+        <Alert severity="info">
+          {t('messages.cannot-view-vaccine-card', {
+            programName: data?.programName,
+          })}
+        </Alert>
+      </Box>
+    );
 
   return (
     <TableProvider

--- a/client/packages/system/src/Vaccination/api/operations.generated.ts
+++ b/client/packages/system/src/Vaccination/api/operations.generated.ts
@@ -10,7 +10,7 @@ export type VaccinationDetailFragment = { __typename: 'VaccinationNode', id: str
 
 export type VaccinationCardItemFragment = { __typename: 'VaccinationCardItemNode', id: string, vaccineCourseId: string, vaccineCourseDoseId: string, vaccinationId?: string | null, label: string, minAgeMonths: number, customAgeLabel?: string | null, vaccinationDate?: string | null, suggestedDate?: string | null, given?: boolean | null, batch?: string | null, facilityName?: string | null, status?: Types.VaccinationCardItemNodeStatus | null };
 
-export type VaccinationCardFragment = { __typename: 'VaccinationCardNode', id: string, patientFirstName?: string | null, patientLastName?: string | null, programName: string, items: Array<{ __typename: 'VaccinationCardItemNode', id: string, vaccineCourseId: string, vaccineCourseDoseId: string, vaccinationId?: string | null, label: string, minAgeMonths: number, customAgeLabel?: string | null, vaccinationDate?: string | null, suggestedDate?: string | null, given?: boolean | null, batch?: string | null, facilityName?: string | null, status?: Types.VaccinationCardItemNodeStatus | null }> };
+export type VaccinationCardFragment = { __typename: 'VaccinationCardNode', id: string, patientFirstName?: string | null, patientLastName?: string | null, programName: string, enrolmentStoreId?: string | null, items: Array<{ __typename: 'VaccinationCardItemNode', id: string, vaccineCourseId: string, vaccineCourseDoseId: string, vaccinationId?: string | null, label: string, minAgeMonths: number, customAgeLabel?: string | null, vaccinationDate?: string | null, suggestedDate?: string | null, given?: boolean | null, batch?: string | null, facilityName?: string | null, status?: Types.VaccinationCardItemNodeStatus | null }> };
 
 export type VaccinationCardQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -18,7 +18,7 @@ export type VaccinationCardQueryVariables = Types.Exact<{
 }>;
 
 
-export type VaccinationCardQuery = { __typename: 'Queries', vaccinationCard: { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'VaccinationCardNode', id: string, patientFirstName?: string | null, patientLastName?: string | null, programName: string, items: Array<{ __typename: 'VaccinationCardItemNode', id: string, vaccineCourseId: string, vaccineCourseDoseId: string, vaccinationId?: string | null, label: string, minAgeMonths: number, customAgeLabel?: string | null, vaccinationDate?: string | null, suggestedDate?: string | null, given?: boolean | null, batch?: string | null, facilityName?: string | null, status?: Types.VaccinationCardItemNodeStatus | null }> } };
+export type VaccinationCardQuery = { __typename: 'Queries', vaccinationCard: { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'VaccinationCardNode', id: string, patientFirstName?: string | null, patientLastName?: string | null, programName: string, enrolmentStoreId?: string | null, items: Array<{ __typename: 'VaccinationCardItemNode', id: string, vaccineCourseId: string, vaccineCourseDoseId: string, vaccinationId?: string | null, label: string, minAgeMonths: number, customAgeLabel?: string | null, vaccinationDate?: string | null, suggestedDate?: string | null, given?: boolean | null, batch?: string | null, facilityName?: string | null, status?: Types.VaccinationCardItemNodeStatus | null }> } };
 
 export type VaccinationQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -116,6 +116,7 @@ export const VaccinationCardFragmentDoc = gql`
   patientFirstName
   patientLastName
   programName
+  enrolmentStoreId
   items {
     ... on VaccinationCardItemNode {
       ...VaccinationCardItem

--- a/client/packages/system/src/Vaccination/api/operations.graphql
+++ b/client/packages/system/src/Vaccination/api/operations.graphql
@@ -59,6 +59,7 @@ fragment VaccinationCard on VaccinationCardNode {
   patientFirstName
   patientLastName
   programName
+  enrolmentStoreId
   items {
     ... on VaccinationCardItemNode {
       ...VaccinationCardItem

--- a/server/graphql/types/src/types/program/vaccination_card.rs
+++ b/server/graphql/types/src/types/program/vaccination_card.rs
@@ -45,6 +45,10 @@ impl VaccinationCardNode {
         &self.vaccination_card.enrolment.patient_row.last_name
     }
 
+    pub async fn enrolment_store_id(&self) -> &Option<String> {
+        &self.vaccination_card.enrolment.row.store_id
+    }
+
     pub async fn items(&self) -> Vec<VaccinationCardItemNode> {
         self.vaccination_card
             .items

--- a/server/repository/src/db_diesel/program_enrolment_row.rs
+++ b/server/repository/src/db_diesel/program_enrolment_row.rs
@@ -16,6 +16,7 @@ table! {
         enrolment_datetime -> Timestamp,
         program_enrolment_id -> Nullable<Text>,
         status -> Nullable<Text>,
+        store_id -> Nullable<Text>,
     }
 }
 
@@ -45,6 +46,8 @@ pub struct ProgramEnrolmentRow {
     /// Program specific patient id
     pub program_enrolment_id: Option<String>,
     pub status: Option<String>,
+    /// Store where patient was originally enrolled
+    pub store_id: Option<String>,
 }
 
 pub struct ProgramEnrolmentRowRepository<'a> {

--- a/server/repository/src/migrations/v2_03_00/add_store_id_to_program_enrolment.rs
+++ b/server/repository/src/migrations/v2_03_00/add_store_id_to_program_enrolment.rs
@@ -1,0 +1,20 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_store_id_to_program_enrolment"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        sql!(
+            connection,
+            r#"
+                ALTER TABLE program_enrolment ADD COLUMN store_id TEXT REFERENCES store(id);
+            "#
+        )?;
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_03_00/mod.rs
+++ b/server/repository/src/migrations/v2_03_00/mod.rs
@@ -5,6 +5,7 @@ mod add_backdated_datetime;
 mod add_facility_to_vaccination;
 mod add_max_age_to_vaccine_dose;
 mod add_report_versioning;
+mod add_store_id_to_program_enrolment;
 mod add_vaccination_activity_log_types;
 mod add_vaccinations_table;
 mod add_vaccine_course_changelog_table_names;
@@ -47,6 +48,7 @@ impl Migration for V2_03_00 {
             Box::new(add_vaccine_course_dose_custom_age_label::Migrate),
             Box::new(add_backdated_datetime::Migrate),
             Box::new(add_vaccine_course_item_deleted_datetime::Migrate),
+            Box::new(add_store_id_to_program_enrolment::Migrate),
         ]
     }
 }

--- a/server/repository/src/mock/form_schema.rs
+++ b/server/repository/src/mock/form_schema.rs
@@ -143,6 +143,10 @@ pub fn mock_form_schema_simplified_enrolment() -> FormSchema {
                 "programEnrolmentId": {
                   "description": "Patient's program id",
                   "type": "string"
+                },
+                "storeId": {
+                  "description": "Store ID of facility where patient was originally enrolled",
+                  "type": "string"
                 }
               },
               "required": [

--- a/server/service/src/programs/program_enrolment/program_enrolment_updated.rs
+++ b/server/service/src/programs/program_enrolment/program_enrolment_updated.rs
@@ -49,6 +49,7 @@ pub(crate) fn update_program_enrolment_row(
         enrolment_datetime,
         program_enrolment_id: program.program_enrolment_id,
         status,
+        store_id: program.store_id,
     };
     ProgramEnrolmentRowRepository::new(con).upsert_one(&program_row)?;
 

--- a/server/service/src/programs/program_enrolment/program_schema.rs
+++ b/server/service/src/programs/program_enrolment/program_schema.rs
@@ -18,6 +18,7 @@ impl Default for SchemaProgramEnrolment {
             notes: Default::default(),
             contacts: Default::default(),
             extension: Default::default(),
+            store_id: None,
         }
     }
 }

--- a/server/service/src/programs/schemas/program_enrolment.json
+++ b/server/service/src/programs/schemas/program_enrolment.json
@@ -152,6 +152,10 @@
             "$ref": "#/definitions/ProgramStatus"
           },
           "type": "array"
+        },
+        "storeId": {
+          "description": "Store ID of the facility where the patient was originally enrolled",
+          "type": "string"
         }
       },
       "required": ["enrolmentDatetime"],

--- a/server/service/src/sync/integrate_document.rs
+++ b/server/service/src/sync/integrate_document.rs
@@ -197,6 +197,7 @@ mod integrate_document_test {
                   "enrolmentDatetime": "2023-11-28T18:24:57.184Z",
                   "status": "ACTIVE",
                   "programEnrolmentId": "name1",
+                  "storeId": "store_a"
                 }),
                 form_schema_id: None,
                 status: DocumentStatus::Active,
@@ -221,6 +222,7 @@ mod integrate_document_test {
             .unwrap()
             .row;
         assert_eq!(&found.program_enrolment_id.unwrap(), "name1");
+        assert_eq!(&found.store_id.unwrap(), "store_a");
 
         // adding older document shouldn't update the patient entry
         sync_upsert_document(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5014

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Hides the vaccination card for patients that have been fetched from another facility, where they were already enrolled in the immunisation program.

This prevents the patient being inadvertently enrolled/vaccinated twice!

![Screenshot 2024-10-08 at 9 33 52 AM](https://github.com/user-attachments/assets/5385441a-9ee6-436e-b883-67e6cdf04480)



<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] You'll need the [latest enrolment JSON schema](https://github.com/msupply-foundation/programschemas/blob/immunisation-programs/immunisation_program/generated/immunisation_program.json)
- [ ] Enrol a patient in the immunisation program
- [ ] Fetch that patient from another site
- [ ] Ensure that in the first store, you can see the vax card
- [ ] In the second store, vax card is hidden

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Probably should be mentioned that this is the behaviour if patients are fetched. We don't support vaccinations across multiple facilities at this time
  2.
