### PR TITLE
5003 months years input fix

### DIFF
--- a/client/packages/common/src/intl/locales/en/programs.json
+++ b/client/packages/common/src/intl/locales/en/programs.json
@@ -15,5 +15,5 @@
   "label.document-edit-history": "Document Edit History",
   "label.dose": "Dose",
   "label.systolic": "Systolic",
-  "message.add-a-dose": "Add a dose"
+  "message.add-a-dose": "No doses configured yet. Click the '+ Dose' button to add a dose."
 }

--- a/client/packages/common/src/ui/layout/tables/components/Cells/MultiNumberInputCell/MultiNumberInputCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/MultiNumberInputCell/MultiNumberInputCell.tsx
@@ -57,6 +57,7 @@ interface Unit {
   key: string;
   ratio: number;
   label: string;
+  max?: number;
 }
 
 export const MultipleNumberInputCell = <T extends RecordWithId>({
@@ -127,6 +128,7 @@ export const MultipleNumberInputCell = <T extends RecordWithId>({
           value={cellValues[index]}
           width={width}
           endAdornment={unit.label}
+          max={unit.max}
         />
       ))}
     </Box>

--- a/client/packages/programs/src/VaccineCourseEditModal/VaccineCourseEditModal.tsx
+++ b/client/packages/programs/src/VaccineCourseEditModal/VaccineCourseEditModal.tsx
@@ -379,7 +379,12 @@ const AgeCell = (props: CellProps<VaccineCourseDoseFragment>) => {
       width={25}
       {...props}
       units={[
-        { key: 'year', ratio: 12, label: t('label.years-abbreviation') },
+        {
+          key: 'year',
+          ratio: 12,
+          label: t('label.years-abbreviation'),
+          max: 150,
+        },
         {
           key: 'month',
           ratio: 1,

--- a/client/packages/programs/src/VaccineCourseEditModal/VaccineCourseEditModal.tsx
+++ b/client/packages/programs/src/VaccineCourseEditModal/VaccineCourseEditModal.tsx
@@ -380,7 +380,12 @@ const AgeCell = (props: CellProps<VaccineCourseDoseFragment>) => {
       {...props}
       units={[
         { key: 'year', ratio: 12, label: t('label.years-abbreviation') },
-        { key: 'month', ratio: 1, label: t('label.months-abbreviation') },
+        {
+          key: 'month',
+          ratio: 1,
+          label: t('label.months-abbreviation'),
+          max: 11,
+        },
       ]}
     />
   );

--- a/client/packages/system/src/Vaccination/Components/VaccineCardTable.tsx
+++ b/client/packages/system/src/Vaccination/Components/VaccineCardTable.tsx
@@ -122,7 +122,7 @@ const VaccinationCardComponent = ({
   encounterId,
   openModal,
 }: VaccinationCardProps & {
-  data: VaccinationCardFragment;
+  data?: VaccinationCardFragment;
 }) => {
   const t = useTranslation('dispensary');
   const { localisedDate } = useFormatDateTime();
@@ -252,7 +252,7 @@ export const VaccineCardTable: FC<VaccinationCardProps> = props => {
 
   if (isLoading) return <InlineSpinner />;
 
-  if (data?.enrolmentStoreId !== storeId)
+  if (!!data?.enrolmentStoreId && data?.enrolmentStoreId !== storeId)
     return (
       <Box
         display="flex"


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5003 
Fixes #5016

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Adds a max value of 11 to the months input on dose modal, so it doesn't start updating the years field if months >= 12.

Left the code that would update the years if months max was not set, possibly useful behaviour somewhere? 🤷‍♀️ 

and wording fix for #5016

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] On central
- [ ]  Add/edit dose
- [ ] type number >11 in the age months cells
- [ ] It maxes out at 11, years cell is not affected

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
