### PR TITLE
Use invoice status to adjustStockLines

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
@@ -73,11 +73,12 @@ export const useDraftOutboundLines = (
           const invoiceLine = lines?.find(
             ({ stockLine }) => stockLine?.id === batch.id
           );
-
           if (invoiceLine) {
             return createDraftStockOutLine({
               invoiceLine,
+              stockLine: batch,
               invoiceId,
+              invoiceStatus: status,
             });
           } else {
             return createDraftStockOutLineFromStockLine({
@@ -98,7 +99,11 @@ export const useDraftOutboundLines = (
           const placeHolderItem = lines?.find(l => l.item.id === item.id)?.item;
           if (!!placeHolderItem) placeholder.item = placeHolderItem;
           rows.push(
-            createDraftStockOutLine({ invoiceId, invoiceLine: placeholder })
+            createDraftStockOutLine({
+              invoiceId,
+              invoiceLine: placeholder,
+              invoiceStatus: status,
+            })
           );
         } else {
           rows.push(createStockOutPlaceholderRow(invoiceId, item.id));

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/hooks/useDraftPrescriptionLines.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/hooks/useDraftPrescriptionLines.tsx
@@ -78,7 +78,7 @@ export const useDraftPrescriptionLines = (
               invoiceLine,
               invoiceId,
               stockLine: batch,
-              adjustTotalNumberOfPacks: true,
+              invoiceStatus: status,
             });
           } else {
             return createDraftStockOutLineFromStockLine({
@@ -102,7 +102,11 @@ export const useDraftPrescriptionLines = (
           const placeholderItem = lines?.find(l => l.item.id === item.id)?.item;
           if (!!placeholderItem) placeholder.item = placeholderItem;
           rows.push(
-            createDraftStockOutLine({ invoiceId, invoiceLine: placeholder })
+            createDraftStockOutLine({
+              invoiceId,
+              invoiceLine: placeholder,
+              invoiceStatus: status,
+            })
           );
         } else {
           // Commented out for now until placeholders are implemented for prescriptions

--- a/client/packages/invoices/src/StockOut/hooks/usePackSizeController.test.tsx
+++ b/client/packages/invoices/src/StockOut/hooks/usePackSizeController.test.tsx
@@ -2,6 +2,7 @@ import { usePackSizeController } from './usePackSizeController';
 import { act } from '@testing-library/react';
 import {
   InvoiceLineNodeType,
+  InvoiceNodeStatus,
   renderHookWithProvider,
 } from '@openmsupply-client/common';
 import {
@@ -37,6 +38,7 @@ const testLine = ({
 }: TestLineParams): DraftStockOutLine =>
   createDraftStockOutLine({
     invoiceId: '',
+    invoiceStatus: InvoiceNodeStatus.New,
     invoiceLine: {
       id,
       expiryDate,

--- a/client/packages/invoices/src/StockOut/utils.test.ts
+++ b/client/packages/invoices/src/StockOut/utils.test.ts
@@ -33,6 +33,7 @@ const createTestLine = ({
 }: TestLineParams): DraftStockOutLine =>
   createDraftStockOutLine({
     invoiceId: '',
+    invoiceStatus: InvoiceNodeStatus.New,
     invoiceLine: {
       id,
       totalAfterTax: 0,

--- a/client/packages/invoices/src/StockOut/utils.tsx
+++ b/client/packages/invoices/src/StockOut/utils.tsx
@@ -101,9 +101,7 @@ export const createDraftStockOutLine = ({
   // Other statuses such as Shipped shouldn't show the stock line as available, so we don't need to adjust the available number of packs
   // If the invoice is New, no adjustments are needed, as the stockLines shouldn't be updated yet
 
-  const adjustAvailableNumberOfPacks =
-    invoiceStatus === InvoiceNodeStatus.Picked ||
-    invoiceStatus === InvoiceNodeStatus.Allocated;
+  const adjustAvailableNumberOfPacks = invoiceStatus !== InvoiceNodeStatus.New;
   const adjustTotalNumberOfPacks = invoiceStatus === InvoiceNodeStatus.Picked;
 
   let adjustedStockLine = stockLine ? stockLine : invoiceLine?.stockLine;

--- a/client/packages/invoices/src/StockOut/utils.tsx
+++ b/client/packages/invoices/src/StockOut/utils.tsx
@@ -96,19 +96,17 @@ export const createDraftStockOutLine = ({
   invoiceStatus,
 }: DraftStockOutLineSeeds): DraftStockOutLine => {
   // When creating a draft stock out line from an invoice line we may need to adjust the available and total number of packs
-  // This is because, once an invoice line is created and it is in the allocated state, the available number of packs is reduced by the number of packs in the invoice line
+  // This is because, once an invoice line is created (even in New Status), the available number of packs is reduced by the number of packs in the invoice line
   // After it is in picked status, the total number of packs is also reduced by the number of packs in the invoice line
   // Other statuses such as Shipped shouldn't show the stock line as available, so we don't need to adjust the available number of packs
   // If the invoice is New, no adjustments are needed, as the stockLines shouldn't be updated yet
 
-  const adjustAvailableNumberOfPacks = invoiceStatus !== InvoiceNodeStatus.New;
   const adjustTotalNumberOfPacks = invoiceStatus === InvoiceNodeStatus.Picked;
 
   let adjustedStockLine = stockLine ? stockLine : invoiceLine?.stockLine;
   if (!!adjustedStockLine) {
-    adjustedStockLine.availableNumberOfPacks = adjustAvailableNumberOfPacks
-      ? adjustedStockLine.availableNumberOfPacks + invoiceLine.numberOfPacks
-      : adjustedStockLine.availableNumberOfPacks;
+    adjustedStockLine.availableNumberOfPacks =
+      adjustedStockLine.availableNumberOfPacks + invoiceLine.numberOfPacks;
     adjustedStockLine.totalNumberOfPacks = adjustTotalNumberOfPacks
       ? adjustedStockLine.totalNumberOfPacks + invoiceLine.numberOfPacks
       : adjustedStockLine.totalNumberOfPacks;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4936 

# 👩🏻‍💻 What does this PR do?

Changes the code for creating draftStockOutLines to decide when to adjust stock levels based on 

Logic should be

Available Stock show is the total of the available stock in store (e.g total stock - allocated to other invoices) plus the amount  you have allocated or picked on this invoice line.
Total stock (in store) is also adjusted to include what you have allocated to this line too, once the invoice is in the picked state.

This is because by updating that line you can adjust the total stock and or available stock levels, so we need to show the adjusted stock levels to avoid confusion about how much you can or can't allocate to the invoice.

## 💌 Any notes for the reviewer?

Any status things I'm missing?
Is there some kind of magic logic from before that I've missed?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an outbound shipment
- [ ] Try editing lines, saving, re-opening, etc, check that the available stock is always less than total stock (in store)
- [ ] Update status e.g allocated, repeat earlier tests
- [ ] Update status to Picked, repeat earlier tests
- [ ] Do the same but with prescriptions (these are affected by this change too)

# 📃 Documentation
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
Is there some documentation on this that needs to be updated?
