### PR TITLE
4766 When migrating a finalised stocktake there's no finalised date

### DIFF
--- a/server/service/src/sync/translations/stocktake.rs
+++ b/server/service/src/sync/translations/stocktake.rs
@@ -108,7 +108,7 @@ impl SyncTranslation for StocktakeTranslation {
             }
             None => (
                 data.stock_take_created_date.and_time(data.stock_take_time),
-                None,
+                Some(data.stock_take_created_date.and_time(data.stock_take_time)),
             ),
         };
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4766

# 👩🏻‍💻 What does this PR do?
Populates stocktake finalised datetime in translators

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have store in OG site
- [ ] Do stocktake finalised
- [ ] Migrate store to OMS site
- [ ] Initialise/sync whichever 
- [ ] Go to just created stocktake and see finalised datetime

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
