### PR TITLE
Add log on panic to 2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "2.2.03",
+  "version": "2.2.04",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -5818,6 +5818,7 @@ dependencies = [
  "graphql_core",
  "httpmock",
  "log",
+ "log-panics",
  "machine-uid",
  "mime_guess",
  "rcgen",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -4335,6 +4335,7 @@ dependencies = [
  "eventlog",
  "futures",
  "log",
+ "log-panics",
  "server",
  "service",
  "tokio",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -45,6 +45,7 @@ anyhow = "1.0.56"
 actix-files = "0.6.0"
 # TODO: Remove. async_graphql is using 1.0 but SET_COOKIE was being imported from wrong version.
 http2 = { package = "http", version = "1.0.0" }
+log-panics = { version = "2.1.0", features = ["with-backtrace"] }
 
 [workspace.lints.clippy]
 wrong_self_convention = "allow"

--- a/server/android/Cargo.toml
+++ b/server/android/Cargo.toml
@@ -13,7 +13,7 @@ actix-web = { workspace = true }
 futures = "0.3.30"
 jni = { version = "0.21.1" }
 log = { workspace = true }
-log-panics = { version = "2.1.0", features = ["with-backtrace"] }
+log-panics = { workspace = true }
 once_cell = "1.19.0"
 rcgen = { workspace = true }
 repository = { path = "../repository" }

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -46,6 +46,7 @@ regex = { workspace = true }
 actix-multipart = { workspace = true }
 futures-util = { workspace = true }
 serde_json = { workspace = true }
+log-panics = { workspace = true }
 
 [dev-dependencies]
 actix-rt = { workspace = true }

--- a/server/server/src/main.rs
+++ b/server/server/src/main.rs
@@ -8,6 +8,7 @@ async fn main() -> std::io::Result<()> {
         configuration::get_configuration().expect("Failed to parse configuration settings");
 
     logging_init(settings.logging.clone(), None);
+    log_panics::init();
 
     let off_switch = tokio::sync::mpsc::channel(1).1;
     start_server(settings, off_switch).await

--- a/server/windows/Cargo.toml
+++ b/server/windows/Cargo.toml
@@ -15,11 +15,17 @@ bench = false
 default-target = "x86_64-pc-windows-msvc"
 
 [target.'cfg(windows)'.dependencies]
+windows-service = "0.5.0"
+eventlog = "0.2.2"
+
+[dependencies]
 actix-web = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
 server = { path = "../server", default-features = false }
 service = { path = "../service" }
 tokio = { workspace = true }
-windows-service = "0.5.0"
-eventlog = "0.2.2"
+log-panics = { workspace = true }
+
+
+

--- a/server/windows/src/windows.rs
+++ b/server/windows/src/windows.rs
@@ -66,6 +66,7 @@ mod omsupply_service {
             }
         };
         logging_init(settings.logging.clone(), None);
+        log_panics::init();
 
         panic::set_hook(Box::new(|panic_info| {
             error!("panic occurred {:?}", panic_info);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5046

# 👩🏻‍💻 What does this PR do?

Add panic log to 2.2, similar to #4666, this would allow windows service to log panic.

Also increment version to 2.2

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

Testing would require a way to panic while service is running, and do it withing the main thread (not just graphql endpoint), this is a bit hard to do but we do have a service that is crashing, build can be validated there
