### PR TITLE
5053-Store-hardware-id-in-memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "2.2.04",
+  "version": "2.2.05",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -136,7 +136,7 @@ pub async fn start_server(
     }
 
     // SET HARDWARE UUID
-    info!("Setting hardware uuid..");
+    info!("Getting hardware uuid..");
     #[cfg(not(target_os = "android"))]
     let machine_uid = machine_uid::get().expect("Failed to query OS for hardware id");
 
@@ -146,11 +146,13 @@ pub async fn start_server(
         .machine_uid
         .clone()
         .unwrap_or("".to_string());
+
+    info!("Setting hardware uuid [{}]", machine_uid.clone());
     service_provider
         .app_data_service
         .set_hardware_id(machine_uid.clone())
         .unwrap();
-    info!("Setting hardware uuid..done [{}]", machine_uid.clone());
+    info!("Setting hardware uuid.. done");
 
     // CHECK SYNC STATUS
     info!("Checking sync status..");

--- a/server/service/src/app_data.rs
+++ b/server/service/src/app_data.rs
@@ -1,23 +1,32 @@
 use serde::{Deserialize, Serialize};
-use std::{
-    fs::File,
-    io::{Error, Read, Write},
-    path::{Path, PathBuf},
-};
+use std::io::Error;
+
+use std::sync::RwLock;
+
+// TODO relocate from app data service and remove app_data server
+static HARDWARE_ID: RwLock<String> = RwLock::new(String::new());
+
+// Should be called once in run_server
+fn set_hardware_id(hardware_id: String) {
+    (*HARDWARE_ID.write().unwrap()) = hardware_id;
+}
+
+fn get_hardware_id() -> String {
+    HARDWARE_ID.read().unwrap().clone()
+}
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Default)]
 pub struct AppData {
     pub site_hardware_id: String,
 }
 
-const APP_DATA_FILE: &str = "settings_app_data.yaml";
-
 pub trait AppDataServiceTrait: Send + Sync {
-    fn get_app_data_directory(&self) -> Result<PathBuf, Error>;
-    fn get_app_data_file(&self) -> Result<PathBuf, Error>;
-    fn load_from_file(&self) -> Result<AppData, Error>;
-    fn get_hardware_id(&self) -> Result<String, Error>;
-    fn set_hardware_id(&self, hardware_id: String) -> Result<(), Error>;
+    fn get_hardware_id(&self) -> Result<String, Error> {
+        Ok(get_hardware_id())
+    }
+    fn set_hardware_id(&self, hardware_id: String) -> Result<(), Error> {
+        Ok(set_hardware_id(hardware_id))
+    }
 }
 
 pub struct AppDataService {
@@ -32,53 +41,4 @@ impl AppDataService {
     }
 }
 
-impl AppDataServiceTrait for AppDataService {
-    fn get_app_data_directory(&self) -> Result<PathBuf, Error> {
-        let root = Path::new("./");
-        let app_data_folder = root.join(self.app_data_folder.clone());
-        if !app_data_folder.exists() {
-            std::fs::create_dir_all(app_data_folder.clone())?;
-        }
-
-        Ok(app_data_folder)
-    }
-
-    fn get_app_data_file(&self) -> Result<PathBuf, Error> {
-        let app_data_directory = self.get_app_data_directory()?;
-
-        Ok(app_data_directory.join(APP_DATA_FILE))
-    }
-
-    fn load_from_file(&self) -> Result<AppData, Error> {
-        let file_path = self.get_app_data_file()?;
-
-        if !file_path.exists() {
-            let mut file = File::create(&file_path)?;
-            file.write_all(b"site_hardware_id: \"\"")?;
-        }
-
-        let mut file = File::open(file_path)?;
-        let mut contents = String::new();
-        file.read_to_string(&mut contents)?;
-        let app_data: AppData = serde_yaml::from_str(&contents).expect("Failed to parse app data");
-
-        Ok(app_data)
-    }
-
-    fn get_hardware_id(&self) -> Result<String, Error> {
-        let app_data = AppDataService::load_from_file(self)?;
-
-        Ok(app_data.site_hardware_id)
-    }
-
-    fn set_hardware_id(&self, hardware_id: String) -> Result<(), Error> {
-        let file_path = self.get_app_data_file()?;
-
-        let mut app_data = AppDataService::load_from_file(self)?;
-        app_data.site_hardware_id = hardware_id;
-        let mut file = File::create(file_path)?;
-        file.write_all(serde_yaml::to_string(&app_data).unwrap().as_bytes())?;
-
-        Ok(())
-    }
-}
+impl AppDataServiceTrait for AppDataService {}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5053

# 👩🏻‍💻 What does this PR do?

Uses global constant RwLock to get and set hardware id

## 💌 Any notes for the reviewer?

Would need to create a carry over refactor issue to:
* Remove app data service and set and get hardware id from the const
* Remove hardware id from settings and use set hardware id in android ?
* For non android, first time get_hardware_id is called get system hardware id ? 
* Above would allow integration test to work without too much extra (with this change I think integration tests will be broken)

# 🧪 Testing

Sync for existing sites does not break and existing hardware id is used

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
