### PR TITLE
Remove unique constraint on breach description

### DIFF
--- a/server/repository/src/migrations/mod.rs
+++ b/server/repository/src/migrations/mod.rs
@@ -24,6 +24,7 @@ mod v2_02_00;
 mod v2_02_01;
 mod v2_02_02;
 mod v2_03_00;
+mod v2_04_00;
 mod version;
 mod views;
 
@@ -119,6 +120,7 @@ pub fn migrate(
         Box::new(v2_02_01::V2_02_01),
         Box::new(v2_02_02::V2_02_02),
         Box::new(v2_03_00::V2_03_00),
+        Box::new(v2_04_00::V2_04_00),
     ];
 
     // Historic diesel migrations

--- a/server/repository/src/migrations/v2_04_00/mod.rs
+++ b/server/repository/src/migrations/v2_04_00/mod.rs
@@ -1,0 +1,43 @@
+use super::{version::Version, Migration, MigrationFragment};
+
+use crate::StorageConnection;
+mod remove_unique_description_on_tmp_breach;
+
+pub(crate) struct V2_04_00;
+
+impl Migration for V2_04_00 {
+    fn version(&self) -> Version {
+        Version::from_str("2.4.0")
+    }
+
+    fn migrate(&self, _connection: &StorageConnection) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn migrate_fragments(&self) -> Vec<Box<dyn MigrationFragment>> {
+        vec![Box::new(remove_unique_description_on_tmp_breach::Migrate)]
+    }
+}
+
+#[cfg(test)]
+#[actix_rt::test]
+async fn migration_2_04_00() {
+    use v2_03_00::V2_03_00;
+
+    use crate::migrations::*;
+    use crate::test_db::*;
+
+    let previous_version = V2_03_00.version();
+    let version = V2_03_00.version();
+
+    let SetupResult { connection, .. } = setup_test(SetupOption {
+        db_name: &format!("migration_{version}"),
+        version: Some(previous_version.clone()),
+        ..Default::default()
+    })
+    .await;
+
+    // Run this migration
+    migrate(&connection, Some(version.clone())).unwrap();
+    assert_eq!(get_database_version(&connection), version);
+}

--- a/server/repository/src/migrations/v2_04_00/remove_unique_description_on_tmp_breach.rs
+++ b/server/repository/src/migrations/v2_04_00/remove_unique_description_on_tmp_breach.rs
@@ -1,0 +1,44 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "remove_unique_description_on_tmp_breach"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        if cfg!(feature = "postgres") {
+            sql!(
+                connection,
+                r#"
+                    ALTER TABLE temperature_breach_config DROP CONSTRAINT temperature_breach_config_description_key;
+                "#
+            )?;
+        } else {
+            sql!(
+                connection,
+                r#"
+                CREATE TABLE tmp_temperature_breach_config (
+                    id TEXT NOT NULL PRIMARY KEY,
+                    duration_milliseconds INTEGER NOT NULL,
+                    type TEXT NOT NULL,
+                    description TEXT NOT NULL,
+                    is_active BOOLEAN,
+                    store_id TEXT NOT NULL REFERENCES store(id),
+                    minimum_temperature {DOUBLE} NOT NULL,
+                    maximum_temperature {DOUBLE} NOT NULL
+                );
+                INSERT INTO tmp_temperature_breach_config SELECT * FROM temperature_breach_config;
+
+                PRAGMA foreign_keys = OFF;
+                DROP TABLE temperature_breach_config;
+                ALTER TABLE tmp_temperature_breach_config RENAME TO temperature_breach_config;
+                PRAGMA foreign_keys = ON;
+                "#
+            )?;
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4755

# 👩🏻‍💻 What does this PR do?

It kind of fixes the issue above...

It's a dis-satisfying end though.

Removes the restriction on `temperature_breach_config`:`description`
This means if the same fridge tag is imported on different stores, the `config` will be duplicated for each store.
The fridge tag data is then imported in the other store.



## 💌 Any notes for the reviewer?

The way the endpoint works is that the sensor `last_connection_datetime` is checked and you get what looks like an error if you try to import the same data into a different store saying 

<img width="1137" alt="image" src="https://github.com/user-attachments/assets/1d5abe08-ea57-42e4-b073-5f96b9931d03">

The API needs to improve to clearly state that no `NEW` datapoints were found in the import.
Probably for a real use case when you're plugging in the device this won't be a problem as there should be new datapoints?

It feels like breach config should probably either be independent to the store it's loaded against, or perhaps linked to the `sensor_id`. However to change this we'll need to change mSupply as it's also using `store_id` it will also cause challenges for sync if there's no `store_id` so put it in the too hard bucket for now...

Maybe Adrian's suggestion of forcing the user to change store for a sensor is a good one? Although we might want to have Cold Chain devices that are deliberately imported into different stores though, e.g. if they're transported with product in future.

So I think that space needs some more design thinking rather than a hack now...

# 🧪 Testing

It would be best to test this with a real device, to avoid the issues with 

- [ ] Import data from a sensor into one store
- [ ] wait for new datapoint to be generated
- [ ] import data into another store
- [ ] Check new datapoints show up in the second store
- [ ] If you get an error than the one saying nothing to import then it's probably an issue

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
