### PR TITLE
Bug fix for backdated prescriptions

### DIFF
--- a/server/service/src/invoice/prescription/update/mod.rs
+++ b/server/service/src/invoice/prescription/update/mod.rs
@@ -62,7 +62,8 @@ pub fn update_prescription(
         .transaction_sync(|connection| {
             // if the backdated_datetime is in the future, we assume we actually mean now
             // This is a fix for where backdated_date is set to the end of the day even though the invoice is created in the morning
-            // TODO: backdated datetime Should be a nullable update, and should be unset if it's in the future
+            // TODO: backdated datetime Should possibly be a nullable update, and should be unset if it's in the future?
+            // https://github.com/msupply-foundation/open-msupply/issues/4979
             let patch = match patch.backdated_datetime {
                 Some(backdated_datetime) => {
                     match backdated_datetime > chrono::Utc::now().naive_utc() {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5146 

# 👩🏻‍💻 What does this PR do?

When we changed to setting the backdated invoice time to the end of the day, we broke the historical stock levels calculation.

This is because we're querying for all stock movements from `Now()` back until the backdated time.
However, the code was assuming the current invoice would be included in calculations to see how much stock was available at that time. If the current invoice is in the future as far as the database is concerned it will not be seen as a stock movement.

This changes the behaviour so that if the backdated time is in the future, we set it to the current time.
This slightly breaks the behaviour in that stock introduced after the backdated time is not available to be used in a prescription, but I think this is a rare scenario and arguably wrong to allow an invoice to issue stock introduced after it's picked date anyway.

Created an issue to clean this up. https://github.com/msupply-foundation/open-msupply/issues/5149
Although we already have this, which is kind of a duplicate... https://github.com/msupply-foundation/open-msupply/issues/4979

## 💌 Any notes for the reviewer?

What else might have gone wrong...

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Backdate a prescription to say, yesterday
- [ ] Allocate all available stock to it (including todays)
- [ ] Change the prescription date to today
- [ ] Check there's no error
- [ ] Check you can't change the prescription date to before the stock was introduced
- [ ] Check other things you can think of :)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
