### PR TITLE
5118 add service + endpoint to create a response requisition

### DIFF
--- a/server/graphql/requisition/src/lib.rs
+++ b/server/graphql/requisition/src/lib.rs
@@ -113,6 +113,15 @@ impl RequisitionMutations {
         request_requisition::add_from_master_list::add_from_master_list(ctx, &store_id, input)
     }
 
+    async fn insert_response_requisition(
+        &self,
+        ctx: &Context<'_>,
+        store_id: String,
+        input: response_requisition::insert::InsertInput,
+    ) -> Result<response_requisition::insert::InsertResponse> {
+        response_requisition::insert::insert(ctx, &store_id, input)
+    }
+
     async fn update_response_requisition(
         &self,
         ctx: &Context<'_>,

--- a/server/graphql/requisition/src/mutations/response_requisition/insert.rs
+++ b/server/graphql/requisition/src/mutations/response_requisition/insert.rs
@@ -111,8 +111,6 @@ pub fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
         // Standard Graphql Errors
         ServiceError::RequisitionAlreadyExists => BadUserInput(formatted_error),
         ServiceError::OtherPartyDoesNotExist => BadUserInput(formatted_error),
-
-        ServiceError::OtherPartyIsNotAStore => BadUserInput(formatted_error),
         ServiceError::NewlyCreatedRequisitionDoesNotExist => InternalError(formatted_error),
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
     };
@@ -237,18 +235,6 @@ mod test {
 
         // OtherPartyDoesNotExist
         let test_service = TestService(Box::new(|_| Err(ServiceError::OtherPartyDoesNotExist)));
-        let expected_message = "Bad user input";
-        assert_standard_graphql_error!(
-            &settings,
-            &mutation,
-            &Some(empty_variables()),
-            &expected_message,
-            None,
-            Some(service_provider(test_service, &connection_manager))
-        );
-
-        // OtherPartyIsNotAStore
-        let test_service = TestService(Box::new(|_| Err(ServiceError::OtherPartyIsNotAStore)));
         let expected_message = "Bad user input";
         assert_standard_graphql_error!(
             &settings,

--- a/server/graphql/requisition/src/mutations/response_requisition/insert.rs
+++ b/server/graphql/requisition/src/mutations/response_requisition/insert.rs
@@ -1,0 +1,355 @@
+use async_graphql::*;
+use graphql_core::{
+    simple_generic_errors::{OtherPartyNotACustomer, OtherPartyNotVisible},
+    standard_graphql_error::validate_auth,
+    standard_graphql_error::StandardGraphqlError,
+    ContextExt,
+};
+use graphql_types::types::RequisitionNode;
+use repository::Requisition;
+use service::{
+    auth::{Resource, ResourceAccessRequest},
+    requisition::response_requisition::{
+        InsertResponseRequisition as ServiceInput, InsertResponseRequisitionError as ServiceError,
+    },
+};
+
+#[derive(InputObject)]
+#[graphql(name = "InsertResponseRequisitionInput")]
+pub struct InsertInput {
+    pub id: String,
+    pub other_party_id: String,
+    pub max_months_of_stock: f64,
+    pub min_months_of_stock: f64,
+}
+
+#[derive(Interface)]
+#[graphql(name = "InsertResponseRequisitionErrorInterface")]
+#[graphql(field(name = "description", ty = "String"))]
+pub enum InsertErrorInterface {
+    OtherPartyNotVisible(OtherPartyNotVisible),
+    OtherPartyNotACustomer(OtherPartyNotACustomer),
+}
+
+#[derive(SimpleObject)]
+#[graphql(name = "InsertResponseRequisitionError")]
+pub struct InsertError {
+    pub error: InsertErrorInterface,
+}
+
+#[derive(Union)]
+#[graphql(name = "InsertResponseRequisitionResponse")]
+pub enum InsertResponse {
+    Error(InsertError),
+    Response(RequisitionNode),
+}
+
+pub fn insert(ctx: &Context<'_>, store_id: &str, input: InsertInput) -> Result<InsertResponse> {
+    let user = validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::MutateRequisition,
+            store_id: Some(store_id.to_string()),
+        },
+    )?;
+
+    let service_provider = ctx.service_provider();
+    let service_context = service_provider.context(store_id.to_string(), user.user_id)?;
+
+    map_response(
+        service_provider
+            .requisition_service
+            .insert_response_requisition(&service_context, input.to_domain()),
+    )
+}
+
+pub fn map_response(from: Result<Requisition, ServiceError>) -> Result<InsertResponse> {
+    let result = match from {
+        Ok(requisition) => InsertResponse::Response(RequisitionNode::from_domain(requisition)),
+        Err(error) => InsertResponse::Error(InsertError {
+            error: map_error(error)?,
+        }),
+    };
+
+    Ok(result)
+}
+
+impl InsertInput {
+    pub fn to_domain(self) -> ServiceInput {
+        let InsertInput {
+            id,
+            other_party_id,
+            max_months_of_stock,
+            min_months_of_stock,
+        } = self;
+
+        ServiceInput {
+            id,
+            other_party_id,
+            max_months_of_stock,
+            min_months_of_stock,
+        }
+    }
+}
+
+pub fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
+    use StandardGraphqlError::*;
+    let formatted_error = format!("{:#?}", error);
+
+    let graphql_error = match error {
+        // Structured Errors
+        ServiceError::OtherPartyNotACustomer => {
+            return Ok(InsertErrorInterface::OtherPartyNotACustomer(
+                OtherPartyNotACustomer,
+            ))
+        }
+        ServiceError::OtherPartyNotVisible => {
+            return Ok(InsertErrorInterface::OtherPartyNotVisible(
+                OtherPartyNotVisible,
+            ))
+        }
+        // Standard Graphql Errors
+        ServiceError::RequisitionAlreadyExists => BadUserInput(formatted_error),
+        ServiceError::OtherPartyDoesNotExist => BadUserInput(formatted_error),
+
+        ServiceError::OtherPartyIsNotAStore => BadUserInput(formatted_error),
+        ServiceError::NewlyCreatedRequisitionDoesNotExist => InternalError(formatted_error),
+        ServiceError::DatabaseError(_) => InternalError(formatted_error),
+    };
+
+    Err(graphql_error.extend())
+}
+
+#[cfg(test)]
+mod test {
+    use async_graphql::EmptyMutation;
+    use chrono::NaiveDate;
+    use graphql_core::{
+        assert_graphql_query, assert_standard_graphql_error, test_helpers::setup_graphql_test,
+    };
+    use repository::{
+        mock::MockDataInserts, Requisition, RequisitionRow, RequisitionStatus, RequisitionType,
+        StorageConnectionManager,
+    };
+    use serde_json::json;
+    use service::{
+        requisition::{
+            response_requisition::{
+                InsertResponseRequisition as ServiceInput,
+                InsertResponseRequisitionError as ServiceError,
+            },
+            RequisitionServiceTrait,
+        },
+        service_provider::{ServiceContext, ServiceProvider},
+    };
+    use util::inline_init;
+
+    use crate::RequisitionMutations;
+
+    type InsertLineMethod = dyn Fn(ServiceInput) -> Result<Requisition, ServiceError> + Sync + Send;
+
+    pub struct TestService(pub Box<InsertLineMethod>);
+
+    impl RequisitionServiceTrait for TestService {
+        fn insert_response_requisition(
+            &self,
+            _: &ServiceContext,
+            input: ServiceInput,
+        ) -> Result<Requisition, ServiceError> {
+            self.0(input)
+        }
+    }
+
+    fn service_provider(
+        test_service: TestService,
+        connection_manager: &StorageConnectionManager,
+    ) -> ServiceProvider {
+        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        service_provider.requisition_service = Box::new(test_service);
+        service_provider
+    }
+
+    fn empty_variables() -> serde_json::Value {
+        json!({
+          "input": {
+            "id": "n/a",
+            "otherPartyId": "n/a",
+            "maxMonthsOfStock": 0,
+            "minMonthsOfStock": 0
+          },
+          "storeId": "n/a"
+        })
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_insert_response_requisition_errors() {
+        let (_, _, connection_manager, settings) = setup_graphql_test(
+            EmptyMutation,
+            RequisitionMutations,
+            "test_graphql_insert_response_requisition_structured_errors",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($input: InsertResponseRequisitionInput!, $storeId: String) {
+            insertResponseRequisition(storeId: $storeId, input: $input) {
+              ... on InsertResponseRequisitionError {
+                error {
+                  __typename
+                }
+              }
+            }
+          }
+        "#;
+
+        // OtherPartyNotACustomer
+        let test_service = TestService(Box::new(|_| Err(ServiceError::OtherPartyNotACustomer)));
+
+        let expected = json!({
+            "insertResponseRequisition": {
+              "error": {
+                "__typename": "OtherPartyNotACustomer"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // RequisitionAlreadyExists
+        let test_service = TestService(Box::new(|_| Err(ServiceError::RequisitionAlreadyExists)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // OtherPartyDoesNotExist
+        let test_service = TestService(Box::new(|_| Err(ServiceError::OtherPartyDoesNotExist)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // OtherPartyIsNotAStore
+        let test_service = TestService(Box::new(|_| Err(ServiceError::OtherPartyIsNotAStore)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // NewlyCreatedRequisitionDoesNotExist
+        let test_service = TestService(Box::new(|_| {
+            Err(ServiceError::NewlyCreatedRequisitionDoesNotExist)
+        }));
+        let expected_message = "Internal error";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_insert_response_requisition_success() {
+        let (_, _, connection_manager, settings) = setup_graphql_test(
+            EmptyMutation,
+            RequisitionMutations,
+            "test_graphql_insert_response_requisition_success",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($storeId: String, $input: InsertResponseRequisitionInput!) {
+            insertResponseRequisition(storeId: $storeId, input: $input) {
+                ... on RequisitionNode {
+                    id
+                }
+            }
+          }
+        "#;
+
+        fn mock_response_draft_requisition() -> RequisitionRow {
+            inline_init(|r: &mut RequisitionRow| {
+                r.id = "mock_response_draft_requisition".to_string();
+                r.requisition_number = 1;
+                r.name_link_id = "name_b".to_string();
+                r.store_id = "store_a".to_string();
+                r.r#type = RequisitionType::Response;
+                r.status = RequisitionStatus::Draft;
+                r.created_datetime = NaiveDate::from_ymd_opt(2021, 1, 1)
+                    .unwrap()
+                    .and_hms_opt(0, 0, 0)
+                    .unwrap();
+                r.max_months_of_stock = 1.0;
+                r.min_months_of_stock = 0.9;
+            })
+        }
+
+        // Success
+        let test_service = TestService(Box::new(|input| {
+            assert_eq!(
+                input,
+                ServiceInput {
+                    id: "id input".to_string(),
+                    other_party_id: "other party input".to_string(),
+                    max_months_of_stock: 1.0,
+                    min_months_of_stock: 2.0,
+                }
+            );
+            Ok(inline_init(|r: &mut Requisition| {
+                r.requisition_row = mock_response_draft_requisition()
+            }))
+        }));
+
+        let variables = json!({
+          "input": {
+            "id": "id input",
+            "otherPartyId": "other party input",
+            "maxMonthsOfStock": 1,
+            "minMonthsOfStock": 2,
+          },
+          "storeId": "store_a"
+        });
+
+        let expected = json!({
+            "insertResponseRequisition": {
+                "id": mock_response_draft_requisition().id
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(variables),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+}

--- a/server/graphql/requisition/src/mutations/response_requisition/mod.rs
+++ b/server/graphql/requisition/src/mutations/response_requisition/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod create_requisition_shipment;
+pub(crate) mod insert;
 pub(crate) mod supply_requested_quantity;
 pub(crate) mod update;

--- a/server/service/src/requisition/mod.rs
+++ b/server/service/src/requisition/mod.rs
@@ -12,8 +12,9 @@ use self::{
     },
     requisition_supply_status::{get_requisitions_supply_statuses, RequisitionLineSupplyStatus},
     response_requisition::{
-        create_requisition_shipment, supply_requested_quantity, update_response_requisition,
-        CreateRequisitionShipment, CreateRequisitionShipmentError, SupplyRequestedQuantity,
+        create_requisition_shipment, insert_response_requisition, supply_requested_quantity,
+        update_response_requisition, CreateRequisitionShipment, CreateRequisitionShipmentError,
+        InsertResponseRequisition, InsertResponseRequisitionError, SupplyRequestedQuantity,
         SupplyRequestedQuantityError, UpdateResponseRequisition, UpdateResponseRequisitionError,
     },
 };
@@ -118,6 +119,14 @@ pub trait RequisitionServiceTrait: Sync + Send {
         input: AddFromMasterList,
     ) -> Result<Vec<RequisitionLine>, AddFromMasterListError> {
         add_from_master_list(ctx, input)
+    }
+
+    fn insert_response_requisition(
+        &self,
+        ctx: &ServiceContext,
+        input: InsertResponseRequisition,
+    ) -> Result<Requisition, InsertResponseRequisitionError> {
+        insert_response_requisition(ctx, input)
     }
 
     fn update_response_requisition(

--- a/server/service/src/requisition/response_requisition/insert.rs
+++ b/server/service/src/requisition/response_requisition/insert.rs
@@ -1,0 +1,299 @@
+use crate::{
+    activity_log::activity_log_entry,
+    number::next_number,
+    requisition::{common::check_requisition_row_exists, query::get_requisition},
+    service_provider::ServiceContext,
+    validate::{check_other_party, CheckOtherPartyType, OtherPartyErrors},
+};
+use chrono::Utc;
+use repository::{
+    requisition_row::{RequisitionRow, RequisitionStatus, RequisitionType},
+    ActivityLogType, NumberRowType, RepositoryError, Requisition, RequisitionRowRepository,
+    StorageConnection,
+};
+
+#[derive(Debug, PartialEq, Clone, Default)]
+pub struct InsertResponseRequisition {
+    pub id: String,
+    pub other_party_id: String,
+    pub max_months_of_stock: f64,
+    pub min_months_of_stock: f64,
+}
+
+#[derive(Debug, PartialEq)]
+
+pub enum InsertResponseRequisitionError {
+    RequisitionAlreadyExists,
+    // Name validation
+    OtherPartyNotACustomer,
+    OtherPartyDoesNotExist,
+    OtherPartyNotVisible,
+    OtherPartyIsNotAStore,
+    // Internal
+    NewlyCreatedRequisitionDoesNotExist,
+    DatabaseError(RepositoryError),
+}
+
+type OutError = InsertResponseRequisitionError;
+
+pub fn insert_response_requisition(
+    ctx: &ServiceContext,
+    input: InsertResponseRequisition,
+) -> Result<Requisition, OutError> {
+    let requisition = ctx
+        .connection
+        .transaction_sync(|connection| {
+            validate(connection, &ctx.store_id, &input)?;
+            let new_requisition = generate(connection, &ctx.store_id, &ctx.user_id, input)?;
+            RequisitionRowRepository::new(connection).upsert_one(&new_requisition)?;
+
+            activity_log_entry(
+                ctx,
+                ActivityLogType::RequisitionCreated,
+                Some(new_requisition.id.to_owned()),
+                None,
+                None,
+            )?;
+
+            get_requisition(ctx, None, &new_requisition.id)
+                .map_err(OutError::DatabaseError)?
+                .ok_or(OutError::NewlyCreatedRequisitionDoesNotExist)
+        })
+        .map_err(|error| error.to_inner_error())?;
+
+    Ok(requisition)
+}
+
+fn validate(
+    connection: &StorageConnection,
+    store_id: &str,
+    input: &InsertResponseRequisition,
+) -> Result<(), OutError> {
+    if (check_requisition_row_exists(connection, &input.id)?).is_some() {
+        return Err(OutError::RequisitionAlreadyExists);
+    }
+
+    let other_party = check_other_party(
+        connection,
+        store_id,
+        &input.other_party_id,
+        CheckOtherPartyType::Customer,
+    )
+    .map_err(|e| match e {
+        OtherPartyErrors::OtherPartyDoesNotExist => OutError::OtherPartyDoesNotExist {},
+        OtherPartyErrors::OtherPartyNotVisible => OutError::OtherPartyNotVisible,
+        OtherPartyErrors::TypeMismatched => OutError::OtherPartyNotACustomer,
+        OtherPartyErrors::DatabaseError(repository_error) => {
+            OutError::DatabaseError(repository_error)
+        }
+    })?;
+
+    other_party
+        .store_id()
+        .ok_or(OutError::OtherPartyIsNotAStore)?;
+
+    Ok(())
+}
+
+fn generate(
+    connection: &StorageConnection,
+    store_id: &str,
+    user_id: &str,
+    InsertResponseRequisition {
+        id,
+        other_party_id,
+        max_months_of_stock,
+        min_months_of_stock,
+    }: InsertResponseRequisition,
+) -> Result<RequisitionRow, RepositoryError> {
+    let result = RequisitionRow {
+        id,
+        user_id: Some(user_id.to_string()),
+        requisition_number: next_number(connection, &NumberRowType::ResponseRequisition, store_id)?,
+        name_link_id: other_party_id,
+        store_id: store_id.to_string(),
+        r#type: RequisitionType::Response,
+        status: RequisitionStatus::Draft,
+        created_datetime: Utc::now().naive_utc(),
+        max_months_of_stock,
+        min_months_of_stock,
+        // Default
+        colour: None,
+        comment: None,
+        expected_delivery_date: None,
+        their_reference: None,
+        sent_datetime: None,
+        approval_status: None,
+        finalised_datetime: None,
+        linked_requisition_id: None,
+        program_id: None,
+        period_id: None,
+        order_type: None,
+    };
+
+    Ok(result)
+}
+
+impl From<RepositoryError> for InsertResponseRequisitionError {
+    fn from(error: RepositoryError) -> Self {
+        InsertResponseRequisitionError::DatabaseError(error)
+    }
+}
+
+#[cfg(test)]
+mod test_insert {
+    use crate::{
+        requisition::response_requisition::{
+            InsertResponseRequisition, InsertResponseRequisitionError as ServiceError,
+        },
+        service_provider::ServiceProvider,
+    };
+    use repository::{
+        mock::{
+            mock_name_customer_a, mock_name_store_b, mock_name_store_c, mock_store_a,
+            mock_user_account_a, MockData, MockDataInserts,
+        },
+        test_db::{setup_all, setup_all_with_data},
+        NameRow, RequisitionRow, RequisitionRowRepository, RequisitionStatus, RequisitionType,
+    };
+    use util::{inline_edit, inline_init};
+
+    #[actix_rt::test]
+    async fn insert_response_requisition_errors() {
+        fn not_visible() -> NameRow {
+            inline_init(|r: &mut NameRow| {
+                r.id = "not_visible".to_string();
+            })
+        }
+
+        fn draft_response_requisition() -> RequisitionRow {
+            inline_init(|r: &mut RequisitionRow| {
+                r.id = "draft_response_requisition".to_string();
+                r.status = RequisitionStatus::Draft;
+                r.r#type = RequisitionType::Response;
+                r.name_link_id = mock_name_store_b().id;
+                r.store_id = mock_store_a().id.to_string();
+            })
+        }
+
+        let (_, _, connection_manager, _) = setup_all_with_data(
+            "insert_response_requisition_errors",
+            MockDataInserts::all(),
+            inline_init(|r: &mut MockData| {
+                r.names = vec![not_visible()];
+                r.requisitions = vec![draft_response_requisition()];
+            }),
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let context = service_provider
+            .context(mock_store_a().id, "".to_string())
+            .unwrap();
+        let service = service_provider.requisition_service;
+
+        // RequisitionAlreadyExists
+        assert_eq!(
+            service.insert_response_requisition(
+                &context,
+                inline_init(|r: &mut InsertResponseRequisition| {
+                    r.id = draft_response_requisition().id;
+                }),
+            ),
+            Err(ServiceError::RequisitionAlreadyExists)
+        );
+
+        let name_store_c = mock_name_store_c();
+        // OtherPartyNotACustomer
+        assert_eq!(
+            service.insert_response_requisition(
+                &context,
+                inline_init(|r: &mut InsertResponseRequisition| {
+                    r.id = "new_response_requisition".to_string();
+                    r.other_party_id.clone_from(&name_store_c.id);
+                }),
+            ),
+            Err(ServiceError::OtherPartyNotACustomer)
+        );
+
+        // OtherPartyNotVisible
+        assert_eq!(
+            service.insert_response_requisition(
+                &context,
+                inline_init(|r: &mut InsertResponseRequisition| {
+                    r.id = "new_id".to_string();
+                    r.other_party_id = not_visible().id;
+                })
+            ),
+            Err(ServiceError::OtherPartyNotVisible)
+        );
+
+        // OtherPartyDoesNotExist
+        assert_eq!(
+            service.insert_response_requisition(
+                &context,
+                inline_init(|r: &mut InsertResponseRequisition| {
+                    r.id = "new_response_requisition".to_string();
+                    r.other_party_id = "invalid".to_string();
+                }),
+            ),
+            Err(ServiceError::OtherPartyDoesNotExist)
+        );
+
+        // OtherPartyIsNotAStore
+        assert_eq!(
+            service.insert_response_requisition(
+                &context,
+                inline_init(|r: &mut InsertResponseRequisition| {
+                    r.id = "new_response_requisition".to_string();
+                    r.other_party_id = mock_name_customer_a().id;
+                }),
+            ),
+            Err(ServiceError::OtherPartyIsNotAStore)
+        );
+    }
+
+    #[actix_rt::test]
+    async fn insert_response_requisition_success() {
+        let (_, connection, connection_manager, _) = setup_all(
+            "insert_response_requisition_success",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let context = service_provider
+            .context(mock_store_a().id, mock_user_account_a().id)
+            .unwrap();
+        let service = service_provider.requisition_service;
+
+        let result = service
+            .insert_response_requisition(
+                &context,
+                InsertResponseRequisition {
+                    id: "new_response_requisition".to_string(),
+                    other_party_id: mock_name_store_b().id,
+                    max_months_of_stock: 1.0,
+                    min_months_of_stock: 0.5,
+                },
+            )
+            .unwrap();
+
+        let new_row = RequisitionRowRepository::new(&connection)
+            .find_one_by_id(&result.requisition_row.id)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            new_row,
+            inline_edit(&new_row, |mut u| {
+                u.id = "new_response_requisition".to_string();
+                u.user_id = Some(mock_user_account_a().id);
+                u.name_link_id = mock_name_store_b().id;
+                u.max_months_of_stock = 1.0;
+                u.min_months_of_stock = 0.5;
+                u
+            })
+        );
+    }
+}

--- a/server/service/src/requisition/response_requisition/mod.rs
+++ b/server/service/src/requisition/response_requisition/mod.rs
@@ -1,6 +1,9 @@
 mod update;
 pub use self::update::*;
 
+mod insert;
+pub use self::insert::*;
+
 mod supply_requested_quantity;
 pub use supply_requested_quantity::*;
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Part of #5118

# 👩🏻‍💻 What does this PR do?
Service and endpoint to create response requisitions (normal).

## PS ADDING LINES COMING IN NEXT PR

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Use GraphQL to call new endpoint

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
