### PR TITLE
#4759 Add new equipment status: "Unserviceable"

### DIFF
--- a/client/packages/coldchain/src/Equipment/Components/Status.tsx
+++ b/client/packages/coldchain/src/Equipment/Components/Status.tsx
@@ -31,6 +31,11 @@ const parseStatus = (
         key: 'status.not-in-use',
         colour: 'cceStatus.notInUse',
       };
+    case StatusType.Unserviceable:
+      return {
+        key: 'status.unserviceable',
+        colour: 'cceStatus.unserviceable',
+      };
     default:
       console.warn(`Unknown equipment status: ${status}`);
   }

--- a/client/packages/coldchain/src/Equipment/ListView/Toolbar.tsx
+++ b/client/packages/coldchain/src/Equipment/ListView/Toolbar.tsx
@@ -90,6 +90,10 @@ export const Toolbar = () => {
           label: t('status.not-in-use', { ns: 'coldchain' }),
           value: AssetLogStatusInput.NotInUse,
         },
+        {
+          label: t('status.unserviceable', { ns: 'coldchain' }),
+          value: AssetLogStatusInput.Unserviceable,
+        },
       ],
       isDefault: true,
     },

--- a/client/packages/coldchain/src/Equipment/utils.ts
+++ b/client/packages/coldchain/src/Equipment/utils.ts
@@ -81,6 +81,11 @@ export const parseLogStatus = (
         key: 'status.not-in-use',
         colour: 'cceStatus.notInUse',
       };
+    case StatusType.Unserviceable:
+      return {
+        key: 'status.unserviceable',
+        colour: 'cceStatus.unserviceable',
+      };
     default:
       console.warn(`Unknown equipment status: ${status}`);
   }

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1550,6 +1550,7 @@
   "status.new": "New",
   "status.not-functioning": "Not Functioning",
   "status.not-in-use": "Not in use",
+  "status.unserviceable": "Unserviceable",
   "stock": "View Stock",
   "stocktake-comment-items-have-stock-template": "Created using items that have stock",
   "stocktake.comment-list-template": "Created using master list '{{list}}'",

--- a/client/packages/common/src/styles/theme.ts
+++ b/client/packages/common/src/styles/theme.ts
@@ -88,6 +88,7 @@ declare module '@mui/material/styles/createPalette' {
       functioningButNeedsAttention: string;
       notFunctioning: string;
       notInUse: string;
+      unserviceable: string;
       text: string;
     };
     chart: {
@@ -218,6 +219,7 @@ export const themeOptions = {
       functioningButNeedsAttention: '#f2a001',
       notFunctioning: '#de0001',
       notInUse: '#b0b0b0',
+      unserviceable: '#555555',
       text: '#fff',
     },
     vaccinationStatus: {

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -502,7 +502,8 @@ export enum AssetLogStatusInput {
   Functioning = 'FUNCTIONING',
   FunctioningButNeedsAttention = 'FUNCTIONING_BUT_NEEDS_ATTENTION',
   NotFunctioning = 'NOT_FUNCTIONING',
-  NotInUse = 'NOT_IN_USE'
+  NotInUse = 'NOT_IN_USE',
+  Unserviceable = 'UNSERVICEABLE'
 }
 
 export type AssetLogsResponse = AssetLogConnector;
@@ -1987,6 +1988,12 @@ export type EqualFilterNumberInput = {
   equalAnyOrNull?: InputMaybe<Array<Scalars['Int']['input']>>;
   equalTo?: InputMaybe<Scalars['Int']['input']>;
   notEqualTo?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type EqualFilterReasonOptionTypeInput = {
+  equalAny?: InputMaybe<Array<ReasonOptionNodeType>>;
+  equalTo?: InputMaybe<ReasonOptionNodeType>;
+  notEqualTo?: InputMaybe<ReasonOptionNodeType>;
 };
 
 export type EqualFilterRelatedRecordTypeInput = {
@@ -5284,6 +5291,7 @@ export type Queries = {
   programs: ProgramsResponse;
   rAndRForm: RnRFormResponse;
   rAndRForms: RnRFormsResponse;
+  reasonOptions: ReasonOptionResponse;
   /**
    * Retrieves a new auth bearer and refresh token
    * The refresh token is returned as a cookie
@@ -5769,6 +5777,13 @@ export type QueriesRAndRFormsArgs = {
 };
 
 
+export type QueriesReasonOptionsArgs = {
+  filter?: InputMaybe<ReasonOptionFilterInput>;
+  page?: InputMaybe<PaginationInput>;
+  sort?: InputMaybe<Array<ReasonOptionSortInput>>;
+};
+
+
 export type QueriesRepackArgs = {
   invoiceId: Scalars['String']['input'];
   storeId: Scalars['String']['input'];
@@ -5966,6 +5981,50 @@ export type QueriesVaccineCoursesArgs = {
   filter?: InputMaybe<VaccineCourseFilterInput>;
   page?: InputMaybe<PaginationInput>;
   sort?: InputMaybe<Array<VaccineCourseSortInput>>;
+};
+
+export type ReasonOptionConnector = {
+  __typename: 'ReasonOptionConnector';
+  nodes: Array<ReasonOptionNode>;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type ReasonOptionFilterInput = {
+  id?: InputMaybe<EqualFilterStringInput>;
+  isActive?: InputMaybe<Scalars['Boolean']['input']>;
+  type?: InputMaybe<EqualFilterReasonOptionTypeInput>;
+};
+
+export type ReasonOptionNode = {
+  __typename: 'ReasonOptionNode';
+  id: Scalars['String']['output'];
+  isActive: Scalars['Boolean']['output'];
+  reason: Scalars['String']['output'];
+  type: ReasonOptionNodeType;
+};
+
+export enum ReasonOptionNodeType {
+  NegativeInventoryAdjustment = 'NEGATIVE_INVENTORY_ADJUSTMENT',
+  PositiveInventoryAdjustment = 'POSITIVE_INVENTORY_ADJUSTMENT',
+  RequisitionLineVariance = 'REQUISITION_LINE_VARIANCE',
+  ReturnReason = 'RETURN_REASON'
+}
+
+export type ReasonOptionResponse = ReasonOptionConnector;
+
+export enum ReasonOptionSortFieldInput {
+  Reason = 'reason',
+  ReasonOptionType = 'reasonOptionType'
+}
+
+export type ReasonOptionSortInput = {
+  /**
+   * Sort query result is sorted descending or ascending (if not provided the default is
+   * ascending)
+   */
+  desc?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Sort query result by `key` */
+  key: ReasonOptionSortFieldInput;
 };
 
 export type RecordAlreadyExist = InsertAssetCatalogueItemErrorInterface & InsertAssetErrorInterface & InsertAssetLogErrorInterface & InsertAssetLogReasonErrorInterface & InsertDemographicIndicatorErrorInterface & InsertDemographicProjectionErrorInterface & InsertLocationErrorInterface & InsertVaccineCourseErrorInterface & UpdateDemographicIndicatorErrorInterface & UpdateDemographicProjectionErrorInterface & {
@@ -6543,7 +6602,8 @@ export enum StatusType {
   Functioning = 'FUNCTIONING',
   FunctioningButNeedsAttention = 'FUNCTIONING_BUT_NEEDS_ATTENTION',
   NotFunctioning = 'NOT_FUNCTIONING',
-  NotInUse = 'NOT_IN_USE'
+  NotInUse = 'NOT_IN_USE',
+  Unserviceable = 'UNSERVICEABLE'
 }
 
 export type StockCounts = {

--- a/client/packages/system/src/Asset/utils.ts
+++ b/client/packages/system/src/Asset/utils.ts
@@ -53,6 +53,9 @@ export const parseStatus = (
     case StatusType.NotInUse: {
       return t('status.not-in-use', { ns: 'coldchain' });
     }
+    case StatusType.Unserviceable: {
+      return t('status.unserviceable', { ns: 'coldchain' });
+    }
   }
 };
 
@@ -75,6 +78,9 @@ const parseInputStatus = (
     }
     case AssetLogStatusInput.NotInUse: {
       return t('status.not-in-use', { ns: 'coldchain' });
+    }
+    case AssetLogStatusInput.Unserviceable: {
+      return t('status.unserviceable', { ns: 'coldchain' });
     }
   }
 };

--- a/server/graphql/asset/src/types/asset_log.rs
+++ b/server/graphql/asset/src/types/asset_log.rs
@@ -34,6 +34,7 @@ pub enum AssetLogStatusInput {
     FunctioningButNeedsAttention,
     NotFunctioning,
     Decommissioned,
+    Unserviceable,
 }
 
 impl AssetLogStatusInput {
@@ -46,6 +47,7 @@ impl AssetLogStatusInput {
             }
             AssetLogStatusInput::NotFunctioning => AssetLogStatus::NotFunctioning,
             AssetLogStatusInput::Decommissioned => AssetLogStatus::Decommissioned,
+            AssetLogStatusInput::Unserviceable => AssetLogStatus::Unserviceable,
         }
     }
 }
@@ -107,6 +109,7 @@ pub enum StatusType {
     FunctioningButNeedsAttention,
     NotFunctioning,
     Decommissioned,
+    Unserviceable,
 }
 impl StatusType {
     pub fn from_domain(status: &AssetLogStatus) -> Self {
@@ -118,6 +121,7 @@ impl StatusType {
             }
             AssetLogStatus::NotFunctioning => StatusType::NotFunctioning,
             AssetLogStatus::Decommissioned => StatusType::Decommissioned,
+            AssetLogStatus::Unserviceable => StatusType::Unserviceable,
         }
     }
 }

--- a/server/repository/src/db_diesel/assets/asset_log_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_log_row.rs
@@ -51,6 +51,7 @@ pub enum AssetLogStatus {
     FunctioningButNeedsAttention,
     NotFunctioning,
     Decommissioned,
+    Unserviceable,
 }
 
 #[derive(

--- a/server/repository/src/migrations/v2_04_00/add_unserviceable_status_to_asset_status_enum.rs
+++ b/server/repository/src/migrations/v2_04_00/add_unserviceable_status_to_asset_status_enum.rs
@@ -1,0 +1,23 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_unserviceable_status_to_asset_status_enum"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        if cfg!(feature = "postgres") {
+            sql!(
+                connection,
+                r#"
+                ALTER TYPE asset_log_status ADD VALUE IF NOT EXISTS
+                'UNSERVICEABLE' AFTER  'DECOMMISSIONED';
+            "#
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_04_00/add_unserviceable_status_to_asset_status_enum.rs
+++ b/server/repository/src/migrations/v2_04_00/add_unserviceable_status_to_asset_status_enum.rs
@@ -13,7 +13,7 @@ impl MigrationFragment for Migrate {
                 connection,
                 r#"
                 ALTER TYPE asset_log_status ADD VALUE IF NOT EXISTS
-                'UNSERVICEABLE' AFTER  'DECOMMISSIONED';
+                'UNSERVICEABLE' AFTER 'DECOMMISSIONED';
             "#
             )?;
         }

--- a/server/repository/src/migrations/v2_04_00/mod.rs
+++ b/server/repository/src/migrations/v2_04_00/mod.rs
@@ -1,6 +1,7 @@
 use super::{version::Version, Migration, MigrationFragment};
 
 mod add_reason_option_table;
+mod add_unserviceable_status_to_asset_status_enum;
 
 use crate::StorageConnection;
 
@@ -16,7 +17,10 @@ impl Migration for V2_04_00 {
     }
 
     fn migrate_fragments(&self) -> Vec<Box<dyn MigrationFragment>> {
-        vec![Box::new(add_reason_option_table::Migrate)]
+        vec![
+            Box::new(add_reason_option_table::Migrate),
+            Box::new(add_unserviceable_status_to_asset_status_enum::Migrate),
+        ]
     }
 }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4759 

# 👩🏻‍💻 What does this PR do?

Add "Unserviceable" status value to `StatusType` enum (and related) in back-end, and make available as a selectable option in front-end.

## 💌 Any notes for the reviewer?

I notice the asset list view at `/catalogue/assets` doesn't show the status column, nor a filter for it. Should it?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Can change the status of an existing piece of "Equipment" (`/cold-chain/equipment/<itemId>`)
- [ ] Can filter by "Unserviceable" status: `cold-chain/equipment`