### PR TITLE
Asset Property for lifespan, Default existing assets to 10 years

### DIFF
--- a/server/repository/src/migrations/constants.rs
+++ b/server/repository/src/migrations/constants.rs
@@ -2,3 +2,5 @@ pub const COLD_CHAIN_EQUIPMENT_UUID: &str = "fad280b6-8384-41af-84cf-c7b6b4526ef
 pub const INSULATED_CONTAINERS_UUID: &str = "b7eea921-5a14-44cc-b5e0-ea59f2e9cb8d";
 pub const REFRIGERATORS_AND_FREEZERS_UUID: &str = "02cbea92-d5bf-4832-863b-c04e093a7760";
 pub const COLD_ROOMS_AND_FREEZER_ROOMS_UUID: &str = "7db32eb6-5929-4dd1-a5e9-01e36baa73ad";
+
+pub const DEFAULT_EXPECTED_LIFESPAN: i32 = 10;

--- a/server/repository/src/migrations/v2_04_00/add_expected_lifespan_to_assets.rs
+++ b/server/repository/src/migrations/v2_04_00/add_expected_lifespan_to_assets.rs
@@ -1,0 +1,44 @@
+use crate::migrations::constants::{COLD_CHAIN_EQUIPMENT_UUID, DEFAULT_EXPECTED_LIFESPAN};
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_expected_lifespan_to_assets"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        sql!(
+            connection,
+            r#"
+            INSERT INTO asset_property (id, key, name, value_type, allowed_values, asset_class_id) VALUES ('expected_lifespan', 'expected_lifespan', 'Expected Lifespan (in years)', 'FLOAT', NULL, '{COLD_CHAIN_EQUIPMENT_UUID}');
+            "#
+        )?;
+
+        // Add the expected lifespan at 10 years for all cold chain equipment assets
+        // properties are stored as JSON so we nee to update the JSON object
+
+        if cfg!(feature = "postgres") {
+            sql!(
+                connection,
+                r#"
+                UPDATE asset_catalogue_item
+                SET properties = jsonb_set(properties::jsonb, '{{expected_lifespan}}', '{DEFAULT_EXPECTED_LIFESPAN}')::text
+                WHERE asset_class_id = '{COLD_CHAIN_EQUIPMENT_UUID}';
+                "#
+            )?;
+        } else {
+            sql!(
+                connection,
+                r#"
+                UPDATE asset_catalogue_item
+                SET properties = json_set(properties, '$.expected_lifespan', {DEFAULT_EXPECTED_LIFESPAN})
+                WHERE asset_class_id = '{COLD_CHAIN_EQUIPMENT_UUID}';
+                "#
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_04_00/mod.rs
+++ b/server/repository/src/migrations/v2_04_00/mod.rs
@@ -1,5 +1,6 @@
 use super::{version::Version, Migration, MigrationFragment};
 
+mod add_expected_lifespan_to_assets;
 mod add_reason_option_table;
 
 use crate::StorageConnection;
@@ -16,7 +17,10 @@ impl Migration for V2_04_00 {
     }
 
     fn migrate_fragments(&self) -> Vec<Box<dyn MigrationFragment>> {
-        vec![Box::new(add_reason_option_table::Migrate)]
+        vec![
+            Box::new(add_reason_option_table::Migrate),
+            Box::new(add_expected_lifespan_to_assets::Migrate),
+        ]
     }
 }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3908

# 👩🏻‍💻 What does this PR do?

Adds migrations to add a new property for lifespan to the asset catalogue.
Existing asset catalogue items get a 10 year default, all new items need to have this entered to work.

<img width="1110" alt="image" src="https://github.com/user-attachments/assets/b1b3039b-4c5f-4daa-a75a-4b6d5e697e48">


## 💌 Any notes for the reviewer?

No frontend changes needed!

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Migrate an existing database with assets & asset catalogue
- [ ] Check that all existing assets get a 10 year lifespan property (in Details)
- [ ] Check that the example import shows the lifespan property
- [ ] Check that importing a record sets this lifespan correctly (You'll need to create this asset to see that.
- [ ] Not sure if updating is supported? If so be good to test that.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
