### PR TITLE
#5247 Naive date fix

### DIFF
--- a/client/packages/common/src/intl/utils/DateUtils.test.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.test.ts
@@ -1,15 +1,12 @@
-import { renderHookWithProvider } from '../../utils/testing';
-import { useFormatDateTime } from './DateUtils';
+import { DateUtils } from './DateUtils';
 
 describe('useFormatDateTime', () => {
-  it('getLocalDateTime returns start of day for local timezone regardless of time zone', () => {
-    const { result } = renderHookWithProvider(useFormatDateTime);
+  it('getNaiveDate returns start of day for local timezone regardless of time zone', () => {
     const timeZone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
     const date = '2024-02-07';
 
     expect(
-      result.current
-        .getLocalDate(date, undefined, undefined, timeZone)
+      DateUtils.getNaiveDate(date, undefined, undefined, timeZone)
         ?.toString()
         .slice(0, 24)
     ).toBe('Wed Feb 07 2024 00:00:00');

--- a/client/packages/common/src/ui/components/inputs/Filters/DateFilter.tsx
+++ b/client/packages/common/src/ui/components/inputs/Filters/DateFilter.tsx
@@ -72,7 +72,7 @@ export const DateFilter: FC<{ filterDefinition: DateFilterDefinition }> = ({
 
 const getDateFromUrl = (query: string, range: RangeOption | undefined) => {
   const value = typeof query !== 'object' || !range ? query : query[range];
-  return DateUtils.getDateOrNull(value);
+  return DateUtils.getNaiveDate(value);
 };
 
 const getRangeBoundary = (
@@ -86,10 +86,11 @@ const getRangeBoundary = (
 
   if (range === 'from')
     return to
-      ? DateUtils.minDate(DateUtils.getDateOrNull(to), limitDate) ?? undefined
-      : limitDate ?? undefined;
+      ? (DateUtils.minDate(DateUtils.getDateOrNull(to), limitDate) ?? undefined)
+      : (limitDate ?? undefined);
   else
     return from
-      ? DateUtils.maxDate(DateUtils.getDateOrNull(from), limitDate) ?? undefined
-      : limitDate ?? undefined;
+      ? (DateUtils.maxDate(DateUtils.getDateOrNull(from), limitDate) ??
+          undefined)
+      : (limitDate ?? undefined);
 };

--- a/client/packages/common/src/ui/components/inputs/Filters/DateFilter.tsx
+++ b/client/packages/common/src/ui/components/inputs/Filters/DateFilter.tsx
@@ -80,17 +80,17 @@ const getRangeBoundary = (
   range: RangeOption | undefined,
   limit: Date | string | undefined
 ) => {
-  const limitDate = DateUtils.getDateOrNull(limit);
+  const limitDate = DateUtils.getNaiveDate(limit);
   if (typeof query !== 'object' || !range) return limitDate || undefined;
   const { from, to } = query as RangeObject<string>;
 
   if (range === 'from')
     return to
-      ? (DateUtils.minDate(DateUtils.getDateOrNull(to), limitDate) ?? undefined)
+      ? (DateUtils.minDate(DateUtils.getNaiveDate(to), limitDate) ?? undefined)
       : (limitDate ?? undefined);
   else
     return from
-      ? (DateUtils.maxDate(DateUtils.getDateOrNull(from), limitDate) ??
+      ? (DateUtils.maxDate(DateUtils.getNaiveDate(from), limitDate) ??
           undefined)
       : (limitDate ?? undefined);
 };

--- a/client/packages/programs/src/JsonForms/common/components/Date.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Date.tsx
@@ -5,6 +5,7 @@ import {
   DetailInputWithLabelRow,
   useFormatDateTime,
   BaseDatePickerInput,
+  DateUtils,
 } from '@openmsupply-client/common';
 import { DefaultFormRowSx, FORM_LABEL_WIDTH } from '../styleConstants';
 import { z } from 'zod';
@@ -52,7 +53,7 @@ const UIComponent = (props: ControlProps) => {
         <BaseDatePickerInput
           sx={{ width: '100%' }}
           // undefined is displayed as "now" and null as unset
-          value={formatDateTime.getLocalDate(data)}
+          value={DateUtils.getNaiveDate(data)}
           onChange={e => {
             handleChange(
               path,

--- a/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
+++ b/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
@@ -86,7 +86,7 @@ const UIComponent = (props: ControlProps) => {
         <Box display="flex" alignItems="center" gap={FORM_GAP} width="100%">
           <BaseDatePickerInput
             // undefined is displayed as "now" and null as unset
-            value={formatDateTime.getLocalDate(dob)}
+            value={DateUtils.getNaiveDate(dob)}
             onChange={onChangeDoB}
             format="P"
             width={135}

--- a/client/packages/system/src/Patient/PatientView/PatientSummary.tsx
+++ b/client/packages/system/src/Patient/PatientView/PatientSummary.tsx
@@ -36,7 +36,7 @@ export const PatientSummary: FC = () => {
   const { setCustomBreadcrumbs } = useBreadcrumbs();
   const t = useTranslation('dispensary');
   const formatDateOfBirth = (dateOfBirth: string | null) => {
-    const dob = DateUtils.getDateOrNull(dateOfBirth);
+    const dob = DateUtils.getNaiveDate(dateOfBirth);
 
     return !dob
       ? ''

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -152,7 +152,7 @@ export const StockLineForm: FC<StockLineFormProps> = ({
             label={t('label.expiry')}
             Input={
               <ExpiryDateInput
-                value={DateUtils.getDateOrNull(draft.expiryDate)}
+                value={DateUtils.getNaiveDate(draft.expiryDate)}
                 onChange={date =>
                   onUpdate({ expiryDate: Formatter.naiveDate(date) })
                 }

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -107,7 +107,7 @@ const StockListComponent: FC = () => {
     [
       'expiryDate',
       {
-        accessor: ({ rowData }) => DateUtils.getDateOrNull(rowData.expiryDate),
+        accessor: ({ rowData }) => DateUtils.getNaiveDate(rowData.expiryDate),
         width: 110,
       },
     ],


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5247

# 👩🏻‍💻 What does this PR do?

Note: in order to see the problem (and the solution), you'll probably need to set your computer's timezone to something that is still in "yesterday".

Okay, so the problem is that the values in question are "naive" dates (i.e. timezone is irrelevant), but the date filters and Patient summary were using the `getDateOrNull` method, which assumes a time stamp of "00:00:00" if not is specified, so dates get converted to the day before if local timezone is still in "yesterday" relative to UTC.

There was a method to return a "naive" version of the date, which I've used, but made a couple of small changes to it:

- changed the name from `getLocalTime` to `getNaiveDate` (it's kind of the opposite of "get local time", so I found the current name confusing/misleading)
- moved the method out of the `useFormatDateTime` hook into the main `DateUtils` object. This is so it can be used in functions that are not inside hooks. (There's actually several functions in that hook that don't need to be there -- they only need to be inside a hook if they use another hook, e.g. `useTranslation`, but that's a problem for another day)

## 💌 Any notes for the reviewer?

See inline comments in PR

# 🧪 Testing

- On original branch, change your computer timezone to something that reveals the problem as shown in the issue
- Switch to this branch
- Problem should be fixed:
  - Stock filters
  - Patient Summary
- Also, the Date pickers were auto-switching the displayed value to the day before after entry due to the same problem -- this should be fixed now too (See Stock expiry date modal and Patient DOB entry)