### PR TITLE
Build for 64bit android only

### DIFF
--- a/client/packages/android/build_remote_server_libs.sh
+++ b/client/packages/android/build_remote_server_libs.sh
@@ -7,7 +7,7 @@ set -e
 export AR=${NDK_BIN}/llvm-ar
 export CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi22-clang
 
-# Build arm64-v8a:aarch64-linux-android and armeabi-v7a:armv7-linux-androideabi
+# Build arm64-v8a:aarch64-linux-android (Defined in cargo.toml)
 PATH=PATH=$PATH:$NDK_BIN \
     cargo build \
         --release \
@@ -17,4 +17,3 @@ PATH=PATH=$PATH:$NDK_BIN \
 
 # Copy built .so files to jniLib
 cp "server-lib/aarch64-linux-android/release/libremote_server_android.so" "app/src/main/jniLibs/arm64-v8a/"
-cp "server-lib/armv7-linux-androideabi/release/libremote_server_android.so" "app/src/main/jniLibs/armeabi-v7a/"

--- a/client/packages/android/package.json
+++ b/client/packages/android/package.json
@@ -15,6 +15,7 @@
     "build:server": "./build_remote_server_libs.sh",
     "build:debug": "yarn build:server && ./gradlew assembleDebug",
     "build:release": "yarn build:server && ./gradlew assembleRelease",
+    "clean": "./gradlew clean",
     "apply-config": "npx cap copy"
   },
   "dependencies": {

--- a/server/android/.cargo/config.toml
+++ b/server/android/.cargo/config.toml
@@ -6,9 +6,7 @@
 # PATH=$PATH:$NDK_BIN cargo build --target aarch64-linux-android --release
 
 [build]
-target = ["aarch64-linux-android", "armv7-linux-androideabi"]
+target = ["aarch64-linux-android"]
 
 [target.aarch64-linux-android]
 linker = "aarch64-linux-android22-clang"
-[target.armv7-linux-androideabi]
-linker = "armv7a-linux-androideabi22-clang"


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes Android build (I think)

# 👩🏻‍💻 What does this PR do?

This build only targets `armv8`/`aarch-line-android` e.g. 64bit tablets

I think this is probably ok due to our docs already stating you need a 64bit android version???

## 💌 Any notes for the reviewer?

Arm 32 was failing to build `cranelift` due to this error.
`cranelift-codegen v0.110.3`
```
error when identifying target: "no supported isa found for arch `armv7`”
```

Which we think was introduced with WASM for the reports...

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] See if you can build android
- [ ] See if it works when installed

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
