### PR TITLE
Improve confirm on leaving modal

### DIFF
--- a/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.ts
+++ b/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.ts
@@ -1,32 +1,42 @@
-import { useCallback } from 'react';
+import { useCallback, useContext, useEffect } from 'react';
 import { BlockerFunction, useBeforeUnload, useBlocker } from 'react-router-dom';
 import { useTranslation } from '@common/intl';
+import { ConfirmationModalContext } from '@openmsupply-client/common'; // '@common/components';
 
 /** useConfirmOnLeaving is a hook that will prompt the user if they try to navigate away from,
  *  or refresh the page, when there are unsaved changes.
  * */
 export const useConfirmOnLeaving = (isUnsaved?: boolean) => {
   const t = useTranslation();
-  const confirmMessage = `${t('heading.are-you-sure')}\n${t('messages.confirm-cancel-generic')}`;
-
   const customConfirm = (onOk: () => void) => {
-    if (confirm(confirmMessage)) {
-      onOk();
-    }
+    setOnConfirm(onOk);
+    showConfirmation();
   };
 
-  useBlocker(
-    useCallback<BlockerFunction>(
-      ({ currentLocation, nextLocation }) => {
-        if (!!isUnsaved && currentLocation.pathname !== nextLocation.pathname) {
-          return !confirm(confirmMessage);
-        }
-        return false;
-      },
-      [isUnsaved]
-    )
+  const { setOpen, setMessage, setOnConfirm, setTitle } = useContext(
+    ConfirmationModalContext
   );
 
+  const showConfirmation = useCallback(() => {
+    setMessage(t('heading.are-you-sure'));
+    setTitle(t('messages.confirm-cancel-generic'));
+    setOpen(true);
+  }, [setMessage, setTitle, setOpen]);
+
+  const shouldBlock = useCallback<BlockerFunction>(
+    ({ currentLocation, nextLocation }) => {
+      if (!!isUnsaved && currentLocation.pathname !== nextLocation.pathname) {
+        showConfirmation();
+        return true;
+      }
+      return false;
+    },
+    [isUnsaved, showConfirmation]
+  );
+
+  const blocker = useBlocker(shouldBlock);
+
+  // handle page refresh events
   useBeforeUnload(
     useCallback(
       event => {
@@ -37,6 +47,20 @@ export const useConfirmOnLeaving = (isUnsaved?: boolean) => {
     ),
     { capture: true }
   );
+
+  // Reset the blocker if the dirty state changes
+  useEffect(() => {
+    if (blocker.state === 'blocked' && !isUnsaved) {
+      blocker.reset();
+    }
+  }, [blocker, isUnsaved]);
+
+  // update the onConfirm function when the blocker changes
+  useEffect(() => {
+    setOnConfirm(() => {
+      blocker?.proceed?.();
+    });
+  }, [blocker]);
 
   return { showConfirmation: customConfirm };
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5285

# 👩🏻‍💻 What does this PR do?
Uses the confirmation modal rather than the `confirm` method, giving:

Patients, when changing tabs:
<img width="701" alt="image" src="https://github.com/user-attachments/assets/29c3ffb4-84d7-4816-a0e8-f1fe72ea8386">

R&R form, when navigating away from page:
<img width="645" alt="image" src="https://github.com/user-attachments/assets/129a8d87-5377-41f9-8c1b-378301fb71b5">


<!-- Explain the changes you made -->
Have used the confirmation modal.

<!-- why are the changes needed -->
It looks a little nicer
<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?
I think this should be targeted for develop, there's no urgency to get it into the patch release. Have just targeted the patch branch to make the PR cleaner to read, ahead of it being merged back into develop.

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Test the R&R form, making a change and navigating away or refreshing the page
- [ ] OK and Cancel should work as expected

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
