### PR TITLE
#5289 Clear inbound item selection

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
@@ -17,7 +17,7 @@ type InboundLineItem = InboundLineFragment['item'];
 interface InboundLineEditProps {
   item: InboundLineItem | null;
   disabled: boolean;
-  onChangeItem: (item: ItemStockOnHandFragment) => void;
+  onChangeItem: (item: ItemStockOnHandFragment | null) => void;
 }
 
 export const InboundLineEditForm: FC<InboundLineEditProps> = ({
@@ -41,7 +41,7 @@ export const InboundLineEditForm: FC<InboundLineEditProps> = ({
             openOnFocus={!item}
             disabled={disabled}
             currentItemId={item?.id}
-            onChange={newItem => newItem && onChangeItem(newItem)}
+            onChange={newItem => onChangeItem(newItem)}
             extraFilter={
               disabled
                 ? undefined


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5289

# 👩🏻‍💻 What does this PR do?

Very small fix required to make item clearable. It was only running the `onChangeItem` function if the input had a truthy value, so when clearing, the `null` input wasn't being handled.

## 💌 Any notes for the reviewer?

There's still some outstanding weirdness involving the debouncing when searching the item input, but that's on all item searches, so we can look at that later if we think it's a problem

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to an Inbound Shipment, add a new item (loads modal)
- [ ] Select an item
- [ ] Click the "X" at the end of the dropdown (only appears when hovering)
- [ ] Item selection should be cleared
