### PR TITLE
5282 Allow initialisation from export

### DIFF
--- a/server/service/src/sync/translations/activity_log.rs
+++ b/server/service/src/sync/translations/activity_log.rs
@@ -24,8 +24,10 @@ pub struct LegacyActivityLogRow {
     pub record_id: String,
     pub datetime: NaiveDateTime,
     #[serde(deserialize_with = "empty_str_as_option_string")]
+    #[serde(default)]
     pub changed_to: Option<String>,
     #[serde(deserialize_with = "empty_str_as_option_string")]
+    #[serde(default)]
     pub changed_from: Option<String>,
 }
 

--- a/server/service/src/sync/translations/name.rs
+++ b/server/service/src/sync/translations/name.rs
@@ -122,6 +122,7 @@ pub struct LegacyNameRow {
     #[serde(deserialize_with = "empty_str_as_option")]
     pub gender: Option<GenderType>,
     #[serde(rename = "om_date_of_death")]
+    #[serde(default)]
     #[serde(deserialize_with = "zero_date_as_option")]
     #[serde(serialize_with = "date_option_to_isostring")]
     pub date_of_death: Option<NaiveDate>,

--- a/server/service/src/sync/translations/stocktake_line.rs
+++ b/server/service/src/sync/translations/stocktake_line.rs
@@ -34,7 +34,6 @@ pub struct LegacyStocktakeLineRow {
     #[serde(deserialize_with = "empty_str_as_option_string")]
     pub item_line_ID: Option<String>,
     pub item_ID: String,
-    #[serde(default)]
     pub item_name: String,
     #[serde(deserialize_with = "empty_str_as_option_string")]
     pub Batch: Option<String>,

--- a/server/service/src/sync/translations/stocktake_line.rs
+++ b/server/service/src/sync/translations/stocktake_line.rs
@@ -34,6 +34,7 @@ pub struct LegacyStocktakeLineRow {
     #[serde(deserialize_with = "empty_str_as_option_string")]
     pub item_line_ID: Option<String>,
     pub item_ID: String,
+    #[serde(default)]
     pub item_name: String,
     #[serde(deserialize_with = "empty_str_as_option_string")]
     pub Batch: Option<String>,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5282

# 👩🏻‍💻 What does this PR do?

Initialising from reference data was failing due to a missing `om_date_of_death`.
I've fixed a couple of other errors too such as missing fields on `activity_log` and `stock_take_line`

There's still a few other sync errors but don't seem to critical...

## 💌 Any notes for the reviewer?

Are we ok with defaults for these fields?
At some point we might need to update the reference data file, but this seemed like a nice quick fix...

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ]  APP__DATABASE__DATABASE_NAME=reference1 cargo run --bin remote_server_cli -- initialise-from-export -n reference1
- [ ]  APP__DATABASE__DATABASE_NAME=reference1 cargo run 
- [ ] Check you can login!

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
