### PR TITLE
#5164 Fix Prescriptions DatePicker/Confirmation conflict

### DIFF
--- a/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
@@ -125,7 +125,11 @@ export const Toolbar: FC = () => {
                   defaultValue={new Date()}
                   value={DateUtils.getDateOrNull(prescriptionDate)}
                   format="P"
-                  onChange={handleDateChange}
+                  // Using onAccept rather than onChange -- on mobile, onChange
+                  // is triggered when first opening the picker, which causes UI
+                  // conflict with the confirmation modal
+                  onAccept={handleDateChange}
+                  onChange={() => {}}
                   maxDate={new Date()}
                 />
               }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5164

# 👩🏻‍💻 What does this PR do?

This seems too simple, but it appears to fix the problem! 🤷‍♂️

I just changed the `onChange` prop the DatePicker to `onAccept`, so the `handleDateChange` function doesn't get called when the picker opens (which it does on Mobile)

## 💌 Any notes for the reviewer?

Haven't tested on Tablet specifically. However, can replicate the problem by changing to a mobile layout with browser DevTools, and this fix works for that.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] If using Desktop browser, open DevTools and switch to a mobile layout (the DatePicker will be different)
- [ ] Open a Prescription and click on date
- [ ] Should *not* get any item deletion confirmation modal
- [ ] Change the date and submit
- [ ] Should get the confirmation modal
- [ ] Also test in normal browser to confirm existing behaviour is unchanged

