### PR TITLE
Improve handing of backdated date

### DIFF
--- a/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
@@ -19,22 +19,14 @@ import { ClinicianSearchInput } from '../../../../system/src/Clinician';
 import { usePrescriptionRows } from '../api/hooks/line/usePrescriptionRows';
 
 export const Toolbar: FC = () => {
-  const {
-    id,
-    patient,
-    clinician,
-    prescriptionDate,
-    createdDatetime,
-    pickedDatetime,
-    update,
-  } = usePrescription.document.fields([
-    'id',
-    'patient',
-    'clinician',
-    'prescriptionDate',
-    'createdDatetime',
-    'pickedDatetime',
-  ]);
+  const { id, patient, clinician, prescriptionDate, createdDatetime, update } =
+    usePrescription.document.fields([
+      'id',
+      'patient',
+      'clinician',
+      'prescriptionDate',
+      'createdDatetime',
+    ]);
   const onDelete = usePrescription.line.deleteSelected();
   const onDeleteAll = usePrescription.line.deleteAll();
   const { items } = usePrescriptionRows();
@@ -81,7 +73,6 @@ export const Toolbar: FC = () => {
 
   const defaultPrescriptionDate =
     DateUtils.getDateOrNull(prescriptionDate) ??
-    DateUtils.getDateOrNull(pickedDatetime) ??
     DateUtils.getDateOrNull(createdDatetime) ??
     new Date();
 

--- a/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
@@ -19,13 +19,22 @@ import { ClinicianSearchInput } from '../../../../system/src/Clinician';
 import { usePrescriptionRows } from '../api/hooks/line/usePrescriptionRows';
 
 export const Toolbar: FC = () => {
-  const { id, patient, clinician, prescriptionDate, update } =
-    usePrescription.document.fields([
-      'id',
-      'patient',
-      'clinician',
-      'prescriptionDate',
-    ]);
+  const {
+    id,
+    patient,
+    clinician,
+    prescriptionDate,
+    createdDatetime,
+    pickedDatetime,
+    update,
+  } = usePrescription.document.fields([
+    'id',
+    'patient',
+    'clinician',
+    'prescriptionDate',
+    'createdDatetime',
+    'pickedDatetime',
+  ]);
   const onDelete = usePrescription.line.deleteSelected();
   const onDeleteAll = usePrescription.line.deleteAll();
   const { items } = usePrescriptionRows();
@@ -69,6 +78,12 @@ export const Toolbar: FC = () => {
       },
     });
   };
+
+  const defaultPrescriptionDate =
+    DateUtils.getDateOrNull(prescriptionDate) ??
+    DateUtils.getDateOrNull(pickedDatetime) ??
+    DateUtils.getDateOrNull(createdDatetime) ??
+    new Date();
 
   return (
     <AppBarContentPortal sx={{ display: 'flex', flex: 1, marginBottom: 1 }}>
@@ -122,7 +137,7 @@ export const Toolbar: FC = () => {
               Input={
                 <DateTimePickerInput
                   disabled={isDisabled}
-                  defaultValue={new Date()}
+                  defaultValue={defaultPrescriptionDate}
                   value={DateUtils.getDateOrNull(prescriptionDate)}
                   format="P"
                   onChange={handleDateChange}

--- a/server/service/src/invoice/prescription/update/generate.rs
+++ b/server/service/src/invoice/prescription/update/generate.rs
@@ -34,13 +34,16 @@ pub(crate) fn generate(
         should_update_batches_total_number_of_packs(&existing_invoice, &input_status);
     let mut update_invoice = existing_invoice.clone();
 
-
     if let Some(backdated_datetime) = backdated_datetime_input {
         // This will update the backdated_datetime in the mut update_invoice
         // So status code can assume it's already been set on the update_invoice
-        handle_new_backdated_datetime(&mut update_invoice, backdated_datetime);
+        handle_new_backdated_datetime(
+            &mut update_invoice,
+            backdated_datetime,
+            Utc::now().naive_utc(),
+        );
     }
-   
+
     set_new_status_datetime(&mut update_invoice, &input_status);
 
     update_invoice.name_link_id = input_patient_id.unwrap_or(update_invoice.name_link_id);
@@ -100,20 +103,20 @@ fn replace_status_datetimes(invoice: &mut InvoiceRow, new_status_datetime: Naive
 }
 
 // Handle a change to backdated_time
-fn handle_new_backdated_datetime(invoice: &mut InvoiceRow, backdated_datetime: NaiveDateTime){
-    
-    // We need to check if we are actually needing to back_date here, if the backdated_datetime is in the future, we unset the backdated_datetime as it isn't possible to future date.
-    if invoice.created_datetime < backdated_datetime {
-        // Not actually backdated!
-        let now = Utc::now().naive_utc();
+fn handle_new_backdated_datetime(
+    invoice: &mut InvoiceRow,
+    backdated_datetime: NaiveDateTime,
+    now: NaiveDateTime,
+) {
+    if backdated_datetime > now {
+        // If the backdated_datetime is in the future, we unset the backdated_datetime as it isn't possible to future date.
         invoice.backdated_datetime = None;
         replace_status_datetimes(invoice, now);
-     } else{
+    } else {
         // Otherwise, we need to update the backdated_datetime to the new one, and replace existing status times
         invoice.backdated_datetime = Some(backdated_datetime);
         replace_status_datetimes(invoice, backdated_datetime);
     }
-
 }
 
 fn set_new_status_datetime(invoice: &mut InvoiceRow, status: &Option<UpdatePrescriptionStatus>) {
@@ -182,4 +185,77 @@ fn lines_to_trim(
         .map(|l| l.invoice_line_row)
         .collect();
     Ok(Some(invoice_line_rows))
+}
+
+#[cfg(test)]
+mod test {
+    use chrono::Utc;
+    use repository::InvoiceRow;
+    use repository::InvoiceStatus;
+    use repository::InvoiceType;
+
+    #[actix_rt::test]
+    async fn handle_new_backdated_datetime_test() {
+        let now = Utc::now().naive_utc();
+        // Create a new invoice 2 days ago
+        let invoice_time = Utc::now().naive_utc() - chrono::Duration::days(2);
+
+        let mut invoice = InvoiceRow {
+            id: "test_invoice_id".to_string(),
+            status: InvoiceStatus::Picked,
+            created_datetime: invoice_time,
+            allocated_datetime: Some(invoice_time),
+            picked_datetime: Some(invoice_time),
+            verified_datetime: None,
+            backdated_datetime: None,
+            name_link_id: "test_patient_id".to_string(),
+            clinician_link_id: None,
+            comment: None,
+            colour: None,
+            name_store_id: None,
+            store_id: String::new(),
+            user_id: None,
+            invoice_number: 0,
+            r#type: InvoiceType::Prescription,
+            on_hold: false,
+            their_reference: None,
+            transport_reference: None,
+            shipped_datetime: None,
+            delivered_datetime: None,
+            requisition_id: None,
+            linked_invoice_id: None,
+            tax_percentage: None,
+            currency_id: None,
+            currency_rate: 0.0,
+            original_shipment_id: None,
+        };
+
+        // Check that we can backdate to 3 days ago
+        let backdated_datetime = Utc::now().naive_utc() - chrono::Duration::days(3);
+        super::handle_new_backdated_datetime(&mut invoice, backdated_datetime, now);
+
+        assert_eq!(invoice.backdated_datetime, Some(backdated_datetime));
+        assert_eq!(invoice.allocated_datetime, Some(backdated_datetime));
+        assert_eq!(invoice.picked_datetime, Some(backdated_datetime));
+        assert_eq!(invoice.verified_datetime, None);
+
+        // Check that we can't backdate to tomorrow, this should unset the backdated_datetime
+        // and set the status times to now
+        let backdated_datetime = Utc::now().naive_utc() + chrono::Duration::days(1);
+        super::handle_new_backdated_datetime(&mut invoice, backdated_datetime, now);
+
+        assert_eq!(invoice.backdated_datetime, None);
+        assert_eq!(invoice.allocated_datetime, Some(now));
+        assert_eq!(invoice.picked_datetime, Some(now));
+        assert_eq!(invoice.verified_datetime, None);
+
+        // Check that we can backdate to 2 days ago
+        let backdated_datetime = Utc::now().naive_utc() - chrono::Duration::days(2);
+        super::handle_new_backdated_datetime(&mut invoice, backdated_datetime, now);
+
+        assert_eq!(invoice.backdated_datetime, Some(backdated_datetime));
+        assert_eq!(invoice.allocated_datetime, Some(backdated_datetime));
+        assert_eq!(invoice.picked_datetime, Some(backdated_datetime));
+        assert_eq!(invoice.verified_datetime, None);
+    }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5325

# 👩🏻‍💻 What does this PR do?

We're now comparing if a `backdated date` is in the future, rather than if just greater than created date.

We're displaying the following dates in the frontend (in order)

`backdated_datetime`
`picked_datetime`
`created_datetime`


## 💌 Any notes for the reviewer?

We could handle the situation where we're backdating to a date after created_date differently, but simply setting the other fields such as `picked_date`, as it's kind of not backdated. 
This ways simpler though, which I like...

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a prescription in the past without setting a prescription date/backdating (more than 2 days is needed to test properly)
- [ ] This could either by an old record or, by waiting till a few days to continue testing, or editing the database
- [ ] Try to set the Backdated date, to something in the past, but after created date
- [ ] Try other combinations of date times to select
- [ ] Check that the date displays properly after updating/changing these dates.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
