### PR TITLE
5100 sync items to legacy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "2.4.00-test1",
+  "version": "2.4.01-test1",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "2.4.01-test1",
+  "version": "2.4.00-test1",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -111,6 +111,7 @@ pub enum ChangelogTableName {
     PackagingVariant,
     IndicatorValue,
     BundledItem,
+    Item,
 }
 
 pub(crate) enum ChangeLogSyncStyle {
@@ -149,6 +150,7 @@ impl ChangelogTableName {
             ChangelogTableName::TemperatureBreachConfig => ChangeLogSyncStyle::Legacy,
             ChangelogTableName::TemperatureLog => ChangeLogSyncStyle::Legacy,
             ChangelogTableName::Currency => ChangeLogSyncStyle::Legacy,
+            ChangelogTableName::Item => ChangeLogSyncStyle::Legacy,
             ChangelogTableName::PackVariant => ChangeLogSyncStyle::Central,
             ChangelogTableName::AssetClass => ChangeLogSyncStyle::Central,
             ChangelogTableName::AssetCategory => ChangeLogSyncStyle::Central,

--- a/server/repository/src/db_diesel/item_row.rs
+++ b/server/repository/src/db_diesel/item_row.rs
@@ -148,7 +148,7 @@ impl<'a> ItemRowRepository<'a> {
         Ok(result)
     }
 
-    fn find_one_by_id(&self, item_id: &str) -> Result<Option<ItemRow>, RepositoryError> {
+    pub fn find_one_by_id(&self, item_id: &str) -> Result<Option<ItemRow>, RepositoryError> {
         let result = item
             .filter(id.eq(item_id))
             .first(self.connection.lock().connection())

--- a/server/service/src/sync/translations/item.rs
+++ b/server/service/src/sync/translations/item.rs
@@ -1,6 +1,6 @@
 use repository::{
-    ChangelogRow, ItemRow, ItemRowDelete, ItemRowRepository, ItemType, StorageConnection,
-    SyncBufferRow, VENCategory,
+    ChangelogRow, ChangelogTableName, ItemRow, ItemRowDelete, ItemRowRepository, ItemType,
+    StorageConnection, SyncBufferRow, VENCategory,
 };
 use serde::{Deserialize, Serialize};
 
@@ -119,6 +119,10 @@ impl SyncTranslation for ItemTranslation {
         Ok(PullTranslateResult::delete(ItemRowDelete(
             sync_record.record_id.clone(),
         )))
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::Item)
     }
 
     fn try_translate_to_upsert_sync_record(

--- a/server/service/src/sync/translations/item.rs
+++ b/server/service/src/sync/translations/item.rs
@@ -4,7 +4,10 @@ use repository::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::sync::{sync_serde::empty_str_as_option_string, translations::unit::UnitTranslation};
+use crate::sync::{
+    sync_serde::empty_str_as_option_string, translations::unit::UnitTranslation,
+    CentralServerConfig,
+};
 
 use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
@@ -130,6 +133,12 @@ impl SyncTranslation for ItemTranslation {
         connection: &StorageConnection,
         changelog: &ChangelogRow,
     ) -> Result<PushTranslateResult, anyhow::Error> {
+        if !CentralServerConfig::is_central_server() {
+            return Err(anyhow::anyhow!(
+                "Item push is only supported from the central server"
+            ));
+        }
+
         let Some(item) = ItemRowRepository::new(connection).find_one_by_id(&changelog.record_id)?
         else {
             return Err(anyhow::anyhow!(

--- a/server/service/src/sync/translations/item.rs
+++ b/server/service/src/sync/translations/item.rs
@@ -1,12 +1,15 @@
-use repository::{ItemRow, ItemRowDelete, ItemType, StorageConnection, SyncBufferRow, VENCategory};
-use serde::Deserialize;
+use repository::{
+    ChangelogRow, ItemRow, ItemRowDelete, ItemRowRepository, ItemType, StorageConnection,
+    SyncBufferRow, VENCategory,
+};
+use serde::{Deserialize, Serialize};
 
 use crate::sync::{sync_serde::empty_str_as_option_string, translations::unit::UnitTranslation};
 
-use super::{PullTranslateResult, SyncTranslation};
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[allow(non_camel_case_types)]
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 pub enum LegacyItemType {
     non_stock,
     service,
@@ -14,7 +17,7 @@ pub enum LegacyItemType {
 }
 
 #[allow(non_snake_case)]
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 pub struct LegacyItemRow {
     ID: String,
     item_name: String,
@@ -37,12 +40,28 @@ fn to_item_type(type_of: LegacyItemType) -> ItemType {
         LegacyItemType::general => ItemType::Stock,
     }
 }
+fn to_legacy_item_type(r#type: ItemType) -> LegacyItemType {
+    match r#type {
+        ItemType::NonStock => LegacyItemType::non_stock,
+        ItemType::Service => LegacyItemType::service,
+        ItemType::Stock => LegacyItemType::general,
+    }
+}
+
 fn to_ven_category(ven_category: String) -> VENCategory {
     match ven_category.as_str() {
         "V" => VENCategory::V,
         "E" => VENCategory::E,
         "N" => VENCategory::N,
         _ => VENCategory::NotAssigned,
+    }
+}
+fn to_legacy_ven_category(ven_category: VENCategory) -> String {
+    match ven_category {
+        VENCategory::V => "V".to_string(),
+        VENCategory::E => "E".to_string(),
+        VENCategory::N => "N".to_string(),
+        VENCategory::NotAssigned => "".to_string(),
     }
 }
 
@@ -100,6 +119,56 @@ impl SyncTranslation for ItemTranslation {
         Ok(PullTranslateResult::delete(ItemRowDelete(
             sync_record.record_id.clone(),
         )))
+    }
+
+    fn try_translate_to_upsert_sync_record(
+        &self,
+        connection: &StorageConnection,
+        changelog: &ChangelogRow,
+    ) -> Result<PushTranslateResult, anyhow::Error> {
+        let Some(item) = ItemRowRepository::new(connection).find_one_by_id(&changelog.record_id)?
+        else {
+            return Err(anyhow::anyhow!(
+                "Item with ID {} could not be found",
+                changelog.record_id
+            ));
+        };
+
+        let ItemRow {
+            id,
+            name,
+            code,
+            unit_id,
+            r#type,
+            legacy_record: _,
+            default_pack_size,
+            is_active: _,
+            is_vaccine,
+            strength,
+            ven_category,
+            vaccine_doses,
+        } = item;
+
+        let legacy_row = LegacyItemRow {
+            ID: id,
+            item_name: name,
+            code,
+            default_pack_size,
+            is_vaccine,
+            doses: vaccine_doses,
+            unit_ID: unit_id,
+            strength,
+            type_of: to_legacy_item_type(r#type),
+            VEN_category: to_legacy_ven_category(ven_category),
+        };
+
+        let json_record = serde_json::to_value(legacy_row)?;
+
+        Ok(PushTranslateResult::upsert(
+            changelog,
+            self.table_name(),
+            json_record,
+        ))
     }
 }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5100

# 👩🏻‍💻 What does this PR do?

For adding all the GAPS data, it's much simpler if we can do that all from one script from OMS central. So adds the `to_sync_record` implementation for items, so new items can be created and synced to legacy from OMS central. 

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Will leave with you @jmbrunskill, whether you think best to add data via DB script or if we want more code changes for this issues to try and add through the service layer + get the changelogs etc. for free?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an item (in DB)
- [ ] Add changelog for that item
- [ ] Sync
- [ ] See item in Legacy mSupply

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
