### PR TITLE
5362 hide item variants if none configured

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -5533,6 +5533,7 @@ export type Queries = {
   isCentralServer: Scalars['Boolean']['output'];
   itemCounts: ItemCounts;
   itemPrice: ItemPriceResponse;
+  itemVariantsConfigured: Scalars['Boolean']['output'];
   /** Query omSupply "item" entries */
   items: ItemsResponse;
   labelPrinterSettings?: Maybe<LabelPrinterSettingNode>;
@@ -5939,6 +5940,11 @@ export type QueriesItemCountsArgs = {
 
 export type QueriesItemPriceArgs = {
   input: ItemPriceInput;
+  storeId: Scalars['String']['input'];
+};
+
+
+export type QueriesItemVariantsConfiguredArgs = {
   storeId: Scalars['String']['input'];
 };
 

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -26,7 +26,7 @@ import {
   ItemVariantInputCell,
   LocationRowFragment,
   PackSizeEntryCell,
-  useItemVariantsConfigured,
+  useIsItemVariantsEnabled,
 } from '@openmsupply-client/system';
 
 interface TableProps {
@@ -90,7 +90,7 @@ export const QuantityTableComponent: FC<TableProps> = ({
   isDisabled = false,
 }) => {
   const theme = useTheme();
-  const showItemVariantsColumn = useItemVariantsConfigured();
+  const showItemVariantsColumn = useIsItemVariantsEnabled();
 
   const columns = useColumns<DraftInboundLine>(
     [

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -137,7 +137,6 @@ export const QuantityTableComponent: FC<TableProps> = ({
     columnDefinitions,
   ]);
 
-  console.log('render');
   return (
     <DataTable
       id="inbound-line-quantity"

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -26,6 +26,7 @@ import {
   ItemVariantInputCell,
   LocationRowFragment,
   PackSizeEntryCell,
+  useItemVariantsConfigured,
 } from '@openmsupply-client/system';
 
 interface TableProps {
@@ -89,21 +90,28 @@ export const QuantityTableComponent: FC<TableProps> = ({
   isDisabled = false,
 }) => {
   const theme = useTheme();
+  const showItemVariantsColumn = useItemVariantsConfigured();
 
   const columns = useColumns<DraftInboundLine>(
     [
       getBatchColumn(updateDraftLine, theme),
       getExpiryColumn(updateDraftLine, theme),
-
-      {
-        key: 'itemVariantId',
-        label: 'label.item-variant',
-        width: 170,
-        Cell: props => (
-          <ItemVariantInputCell {...props} itemId={props.rowData.item.id} />
-        ),
-        setter: updateDraftLine,
-      },
+      ...((showItemVariantsColumn
+        ? [
+            {
+              key: 'itemVariantId',
+              label: 'label.item-variant',
+              width: 170,
+              Cell: props => (
+                <ItemVariantInputCell
+                  {...props}
+                  itemId={props.rowData.item.id}
+                />
+              ),
+              setter: updateDraftLine,
+            },
+          ]
+        : []) as ColumnDescription<DraftInboundLine>[]),
       [
         'numberOfPacks',
         {

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -90,53 +90,54 @@ export const QuantityTableComponent: FC<TableProps> = ({
   isDisabled = false,
 }) => {
   const theme = useTheme();
-  const showItemVariantsColumn = useIsItemVariantsEnabled();
+  const itemVariantsEnabled = useIsItemVariantsEnabled();
 
-  const columns = useColumns<DraftInboundLine>(
+  const columnDefinitions: ColumnDescription<DraftInboundLine>[] = [
+    getBatchColumn(updateDraftLine, theme),
+    getExpiryColumn(updateDraftLine, theme),
+  ];
+
+  if (itemVariantsEnabled) {
+    columnDefinitions.push({
+      key: 'itemVariantId',
+      label: 'label.item-variant',
+      width: 170,
+      Cell: props => (
+        <ItemVariantInputCell {...props} itemId={props.rowData.item.id} />
+      ),
+      setter: updateDraftLine,
+    });
+  }
+  columnDefinitions.push(
     [
-      getBatchColumn(updateDraftLine, theme),
-      getExpiryColumn(updateDraftLine, theme),
-      ...((showItemVariantsColumn
-        ? [
-            {
-              key: 'itemVariantId',
-              label: 'label.item-variant',
-              width: 170,
-              Cell: props => (
-                <ItemVariantInputCell
-                  {...props}
-                  itemId={props.rowData.item.id}
-                />
-              ),
-              setter: updateDraftLine,
-            },
-          ]
-        : []) as ColumnDescription<DraftInboundLine>[]),
-      [
-        'numberOfPacks',
-        {
-          Cell: NumberOfPacksCell,
-          width: 100,
-          label: 'label.num-packs',
-          setter: updateDraftLine,
-        },
-      ],
-      getColumnLookupWithOverrides('packSize', {
-        Cell: PackUnitEntryCell,
+      'numberOfPacks',
+      {
+        Cell: NumberOfPacksCell,
+        width: 100,
+        label: 'label.num-packs',
         setter: updateDraftLine,
-        label: 'label.pack-size',
-      }),
-      [
-        'unitQuantity',
-        {
-          accessor: ({ rowData }) => rowData.packSize * rowData.numberOfPacks,
-        },
-      ],
+      },
     ],
-    {},
-    [updateDraftLine, lines]
+    getColumnLookupWithOverrides('packSize', {
+      Cell: PackUnitEntryCell,
+      setter: updateDraftLine,
+      label: 'label.pack-size',
+    }),
+    [
+      'unitQuantity',
+      {
+        accessor: ({ rowData }) => rowData.packSize * rowData.numberOfPacks,
+      },
+    ]
   );
 
+  const columns = useColumns<DraftInboundLine>(columnDefinitions, {}, [
+    updateDraftLine,
+    lines,
+    columnDefinitions,
+  ]);
+
+  console.log('render');
   return (
     <DataTable
       id="inbound-line-quantity"

--- a/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnQuantitiesTable.tsx
@@ -12,7 +12,7 @@ import {
 } from '@openmsupply-client/common';
 import {
   ItemVariantInputCell,
-  useItemVariantsConfigured,
+  useIsItemVariantsEnabled,
 } from '@openmsupply-client/system';
 import React from 'react';
 import { GenerateCustomerReturnLineFragment } from '../../api';
@@ -29,7 +29,7 @@ export const QuantityReturnedTableComponent = ({
   ) => void;
   isDisabled: boolean;
 }) => {
-  const showItemVariantsColumn = useItemVariantsConfigured();
+  const showItemVariantsColumn = useIsItemVariantsEnabled();
 
   const columns = useColumns<GenerateCustomerReturnLineFragment>(
     [

--- a/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnQuantitiesTable.tsx
@@ -10,7 +10,10 @@ import {
   getExpiryDateInputColumn,
   useColumns,
 } from '@openmsupply-client/common';
-import { ItemVariantInputCell } from '@openmsupply-client/system';
+import {
+  ItemVariantInputCell,
+  useItemVariantsConfigured,
+} from '@openmsupply-client/system';
 import React from 'react';
 import { GenerateCustomerReturnLineFragment } from '../../api';
 import { PackSizeEntryCell } from '@openmsupply-client/system';
@@ -26,20 +29,29 @@ export const QuantityReturnedTableComponent = ({
   ) => void;
   isDisabled: boolean;
 }) => {
+  const showItemVariantsColumn = useItemVariantsConfigured();
+
   const columns = useColumns<GenerateCustomerReturnLineFragment>(
     [
       'itemCode',
       'itemName',
-      {
-        key: 'itemVariantId',
-        label: 'label.item-variant',
-        width: 170,
-        setter: updateLine,
-        Cell: props => (
-          <ItemVariantInputCell {...props} itemId={props.rowData.item.id} />
-        ),
-        getIsDisabled: () => isDisabled,
-      },
+      ...((showItemVariantsColumn
+        ? [
+            {
+              key: 'itemVariantId',
+              label: 'label.item-variant',
+              width: 170,
+              setter: updateLine,
+              Cell: props => (
+                <ItemVariantInputCell
+                  {...props}
+                  itemId={props.rowData.item.id}
+                />
+              ),
+              getIsDisabled: () => isDisabled,
+            },
+          ]
+        : []) as ColumnDescription<GenerateCustomerReturnLineFragment>[]),
       [
         'batch',
         {

--- a/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnQuantitiesTable.tsx
@@ -31,85 +31,84 @@ export const QuantityReturnedTableComponent = ({
 }) => {
   const showItemVariantsColumn = useIsItemVariantsEnabled();
 
-  const columns = useColumns<GenerateCustomerReturnLineFragment>(
+  const columnDefinitions: ColumnDescription<GenerateCustomerReturnLineFragment>[] =
+    ['itemCode', 'itemName'];
+  if (showItemVariantsColumn)
+    columnDefinitions.push({
+      key: 'itemVariantId',
+      label: 'label.item-variant',
+      width: 170,
+      setter: updateLine,
+      Cell: props => (
+        <ItemVariantInputCell {...props} itemId={props.rowData.item.id} />
+      ),
+      getIsDisabled: () => isDisabled,
+    });
+
+  columnDefinitions.push(
     [
-      'itemCode',
-      'itemName',
-      ...((showItemVariantsColumn
-        ? [
-            {
-              key: 'itemVariantId',
-              label: 'label.item-variant',
-              width: 170,
-              setter: updateLine,
-              Cell: props => (
-                <ItemVariantInputCell
-                  {...props}
-                  itemId={props.rowData.item.id}
-                />
-              ),
-              getIsDisabled: () => isDisabled,
-            },
-          ]
-        : []) as ColumnDescription<GenerateCustomerReturnLineFragment>[]),
-      [
-        'batch',
-        {
-          width: 125,
-          accessor: ({ rowData }) => rowData.batch ?? '',
-          setter: updateLine,
-          Cell: TextInputCell,
-          getIsDisabled: () => isDisabled,
-        },
-      ],
-      [
-        expiryInputColumn,
-        {
-          width: 150,
-          getIsDisabled: () => isDisabled,
-          setter: l =>
-            updateLine({
-              ...l,
-              expiryDate: l.expiryDate
-                ? Formatter.naiveDate(new Date(l.expiryDate))
-                : null,
-            }),
-        },
-      ],
-      getColumnLookupWithOverrides('packSize', {
-        Cell: PackUnitEntryCell,
+      'batch',
+      {
+        width: 125,
+        accessor: ({ rowData }) => rowData.batch ?? '',
         setter: updateLine,
+        Cell: TextInputCell,
         getIsDisabled: () => isDisabled,
-        label: 'label.pack-size',
-      }),
-      ...(lines.some(l => l.numberOfPacksIssued !== null) // if any line has a value, show the column
-        ? ([
-            [
-              'numberOfPacks',
-              {
-                label: 'label.pack-quantity-issued',
-                width: 110,
-                accessor: ({ rowData }) => rowData.numberOfPacksIssued ?? '--',
-                Cell: BasicCell,
-                getIsDisabled: () => isDisabled,
-              },
-            ],
-          ] as ColumnDescription<GenerateCustomerReturnLineFragment>[])
-        : []),
-      [
-        'numberOfPacksReturned',
-        {
-          description: 'description.pack-quantity',
-          width: 100,
-          setter: updateLine,
-          getIsDisabled: () => isDisabled,
-          Cell: NumberOfPacksReturnedInputCell,
-        },
-      ],
+      },
     ],
-    {},
-    [updateLine, lines]
+    [
+      expiryInputColumn,
+      {
+        width: 150,
+        getIsDisabled: () => isDisabled,
+        setter: l =>
+          updateLine({
+            ...l,
+            expiryDate: l.expiryDate
+              ? Formatter.naiveDate(new Date(l.expiryDate))
+              : null,
+          }),
+      },
+    ],
+    getColumnLookupWithOverrides('packSize', {
+      Cell: PackUnitEntryCell,
+      setter: updateLine,
+      getIsDisabled: () => isDisabled,
+      label: 'label.pack-size',
+    })
   );
+
+  if (lines.some(l => l.numberOfPacksIssued !== null)) {
+    // if any line has a value, show the column
+
+    columnDefinitions.push([
+      'numberOfPacks',
+      {
+        label: 'label.pack-quantity-issued',
+        width: 110,
+        accessor: ({ rowData }) => rowData.numberOfPacksIssued ?? '--',
+        Cell: BasicCell,
+        getIsDisabled: () => isDisabled,
+      },
+    ]);
+  }
+
+  columnDefinitions.push([
+    'numberOfPacksReturned',
+    {
+      description: 'description.pack-quantity',
+      width: 100,
+      setter: updateLine,
+      getIsDisabled: () => isDisabled,
+      Cell: NumberOfPacksReturnedInputCell,
+    },
+  ]);
+
+  const columns = useColumns(columnDefinitions, {}, [
+    updateLine,
+    lines,
+    columnDefinitions,
+  ]);
 
   return (
     <DataTable

--- a/client/packages/requisitions/src/ResponseRequisition/api/operations.generated.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/api/operations.generated.ts
@@ -2,9 +2,9 @@ import * as Types from '@openmsupply-client/common';
 
 import { GraphQLClient, RequestOptions } from 'graphql-request';
 import gql from 'graphql-tag';
-import { ItemRowFragmentDoc } from 'packages/system/src/Item/api/operations.generated';
-import { NameRowFragmentDoc } from 'packages/system/src/Name/api/operations.generated';
-import { ReasonOptionRowFragmentDoc } from 'packages/system/src/ReasonOption/api/operations.generated';
+import { ItemRowFragmentDoc } from '../../../../system/src/Item/api/operations.generated';
+import { ReasonOptionRowFragmentDoc } from '../../../../system/src/ReasonOption/api/operations.generated';
+import { NameRowFragmentDoc } from '../../../../system/src/Name/api/operations.generated';
 type GraphQLClientRequestHeaders = RequestOptions['requestHeaders'];
 export type UpdateResponseMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];

--- a/client/packages/system/src/Item/api/hooks/useItemVariant/index.ts
+++ b/client/packages/system/src/Item/api/hooks/useItemVariant/index.ts
@@ -1,4 +1,4 @@
 export * from './useItemVariant';
 export * from './useItemVariants';
 export * from './useDeleteItemVariant';
-export * from './useItemVariantsConfigured';
+export * from './useIsItemVariantsEnabled';

--- a/client/packages/system/src/Item/api/hooks/useItemVariant/index.ts
+++ b/client/packages/system/src/Item/api/hooks/useItemVariant/index.ts
@@ -1,3 +1,4 @@
 export * from './useItemVariant';
 export * from './useItemVariants';
 export * from './useDeleteItemVariant';
+export * from './useItemVariantsConfigured';

--- a/client/packages/system/src/Item/api/hooks/useItemVariant/useIsItemVariantsEnabled.ts
+++ b/client/packages/system/src/Item/api/hooks/useItemVariant/useIsItemVariantsEnabled.ts
@@ -1,7 +1,7 @@
 import { useQuery } from 'react-query';
 import { useItemGraphQL } from '../useItemApi';
 
-// Item variant inputs (i.e. in Inbound Shipment) should not be available if no item variants are configured
+// Item variant inputs (e.g. in Inbound Shipment) should not be available if no item variants are configured
 export const useIsItemVariantsEnabled = () => {
   const { api, storeId } = useItemGraphQL();
   const { data } = useQuery({

--- a/client/packages/system/src/Item/api/hooks/useItemVariant/useIsItemVariantsEnabled.ts
+++ b/client/packages/system/src/Item/api/hooks/useItemVariant/useIsItemVariantsEnabled.ts
@@ -1,12 +1,10 @@
 import { useQuery } from 'react-query';
 import { useItemGraphQL } from '../useItemApi';
-import { ITEM_VARIANTS } from '../../keys';
 
 // Item variant inputs (i.e. in Inbound Shipment) should not be available if no item variants are configured
 export const useIsItemVariantsEnabled = () => {
   const { api, storeId } = useItemGraphQL();
   const { data } = useQuery({
-    queryKey: [ITEM_VARIANTS],
     queryFn: async () => {
       const result = await api.itemVariantsConfigured({
         storeId,

--- a/client/packages/system/src/Item/api/hooks/useItemVariant/useIsItemVariantsEnabled.ts
+++ b/client/packages/system/src/Item/api/hooks/useItemVariant/useIsItemVariantsEnabled.ts
@@ -2,7 +2,8 @@ import { useQuery } from 'react-query';
 import { useItemGraphQL } from '../useItemApi';
 import { ITEM_VARIANTS } from '../../keys';
 
-export const useItemVariantsConfigured = () => {
+// Item variant inputs (i.e. in Inbound Shipment) should not be available if no item variants are configured
+export const useIsItemVariantsEnabled = () => {
   const { api, storeId } = useItemGraphQL();
   const { data } = useQuery({
     queryKey: [ITEM_VARIANTS],

--- a/client/packages/system/src/Item/api/hooks/useItemVariant/useItemVariant.ts
+++ b/client/packages/system/src/Item/api/hooks/useItemVariant/useItemVariant.ts
@@ -10,6 +10,7 @@ import {
   PackagingVariantFragment,
 } from '../../operations.generated';
 import { useItemApi, useItemGraphQL } from '../useItemApi';
+import { ITEM_VARIANTS } from '../../keys';
 
 export function useItemVariant({
   itemId,
@@ -117,6 +118,7 @@ const useUpsert = ({ itemId }: { itemId: string }) => {
     mutationFn,
     onSuccess: () => {
       queryClient.invalidateQueries(keys.detail(itemId));
+      queryClient.invalidateQueries(ITEM_VARIANTS);
     },
   });
 };

--- a/client/packages/system/src/Item/api/hooks/useItemVariant/useItemVariantsConfigured.ts
+++ b/client/packages/system/src/Item/api/hooks/useItemVariant/useItemVariantsConfigured.ts
@@ -1,0 +1,41 @@
+import { useQuery } from 'react-query';
+import { useNotification } from '@common/hooks';
+import { useTranslation } from '@common/intl';
+import { useItemGraphQL } from '../useItemApi';
+import { ITEM_VARIANTS } from '../../keys';
+
+export const useIsCentralServerApi = () => {
+  const { api, storeId } = useItemGraphQL();
+  const { data } = useQuery({
+    queryKey: [ITEM_VARIANTS],
+    queryFn: async () => {
+      const result = await api.itemVariantsConfigured({
+        storeId,
+      });
+
+      return result.itemVariantsConfigured;
+    },
+    // Only call on page load
+    refetchOnMount: false,
+  });
+
+  return !!data;
+};
+
+const returnOrFallback =
+  (isCentralServer: boolean, fallback: () => void) =>
+  <T>(f: T | (() => void)) =>
+    isCentralServer ? f : fallback;
+
+export const useCentralServerCallback = () => {
+  const { warning } = useNotification();
+  const isCentralServer = useIsCentralServerApi();
+  const t = useTranslation();
+
+  return {
+    executeIfCentralOrShowWarning: returnOrFallback(
+      isCentralServer,
+      warning(t('auth.not-a-central-server'))
+    ),
+  };
+};

--- a/client/packages/system/src/Item/api/hooks/useItemVariant/useItemVariantsConfigured.ts
+++ b/client/packages/system/src/Item/api/hooks/useItemVariant/useItemVariantsConfigured.ts
@@ -1,10 +1,8 @@
 import { useQuery } from 'react-query';
-import { useNotification } from '@common/hooks';
-import { useTranslation } from '@common/intl';
 import { useItemGraphQL } from '../useItemApi';
 import { ITEM_VARIANTS } from '../../keys';
 
-export const useIsCentralServerApi = () => {
+export const useItemVariantsConfigured = () => {
   const { api, storeId } = useItemGraphQL();
   const { data } = useQuery({
     queryKey: [ITEM_VARIANTS],
@@ -20,22 +18,4 @@ export const useIsCentralServerApi = () => {
   });
 
   return !!data;
-};
-
-const returnOrFallback =
-  (isCentralServer: boolean, fallback: () => void) =>
-  <T>(f: T | (() => void)) =>
-    isCentralServer ? f : fallback;
-
-export const useCentralServerCallback = () => {
-  const { warning } = useNotification();
-  const isCentralServer = useIsCentralServerApi();
-  const t = useTranslation();
-
-  return {
-    executeIfCentralOrShowWarning: returnOrFallback(
-      isCentralServer,
-      warning(t('auth.not-a-central-server'))
-    ),
-  };
 };

--- a/client/packages/system/src/Item/api/operations.generated.ts
+++ b/client/packages/system/src/Item/api/operations.generated.ts
@@ -88,6 +88,13 @@ export type ItemByIdQuery = { __typename: 'Queries', items: { __typename: 'ItemC
 
 export type ItemVariantOptionFragment = { __typename: 'ItemVariantNode', id: string, label: string, bundledItemVariants: Array<{ __typename: 'BundledItemNode', id: string }> };
 
+export type ItemVariantsConfiguredQueryVariables = Types.Exact<{
+  storeId: Types.Scalars['String']['input'];
+}>;
+
+
+export type ItemVariantsConfiguredQuery = { __typename: 'Queries', itemVariantsConfigured: boolean };
+
 export type ItemVariantsQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
   itemId: Types.Scalars['String']['input'];
@@ -453,6 +460,11 @@ export const ItemByIdDocument = gql`
 }
     ${ItemFragmentDoc}
 ${StockLineFragmentDoc}`;
+export const ItemVariantsConfiguredDocument = gql`
+    query itemVariantsConfigured($storeId: String!) {
+  itemVariantsConfigured(storeId: $storeId)
+}
+    `;
 export const ItemVariantsDocument = gql`
     query itemVariants($storeId: String!, $itemId: String!) {
   items(storeId: $storeId, filter: {id: {equalTo: $itemId}, isActive: true}) {
@@ -581,6 +593,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     itemById(variables: ItemByIdQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ItemByIdQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<ItemByIdQuery>(ItemByIdDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'itemById', 'query', variables);
+    },
+    itemVariantsConfigured(variables: ItemVariantsConfiguredQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ItemVariantsConfiguredQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ItemVariantsConfiguredQuery>(ItemVariantsConfiguredDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'itemVariantsConfigured', 'query', variables);
     },
     itemVariants(variables: ItemVariantsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ItemVariantsQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<ItemVariantsQuery>(ItemVariantsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'itemVariants', 'query', variables);

--- a/client/packages/system/src/Item/api/operations.graphql
+++ b/client/packages/system/src/Item/api/operations.graphql
@@ -313,6 +313,10 @@ fragment ItemVariantOption on ItemVariantNode {
   }
 }
 
+query itemVariantsConfigured($storeId: String!) {
+  itemVariantsConfigured(storeId: $storeId)
+}
+
 query itemVariants($storeId: String!, $itemId: String!) {
   items(
     storeId: $storeId

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -23,7 +23,7 @@ import { StockLineRowFragment } from '../api';
 import { LocationSearchInput } from '../../Location/Components/LocationSearchInput';
 import { ItemVariantSearchInput } from '../..';
 import { StyledInputRow } from './StyledInputRow';
-import { PackSizeNumberInput } from '../../Item';
+import { PackSizeNumberInput, useItemVariantsConfigured } from '../../Item';
 
 interface StockLineFormProps {
   draft: StockLineRowFragment;
@@ -45,6 +45,8 @@ export const StockLineForm: FC<StockLineFormProps> = ({
   const { error } = useNotification();
   const { isConnected, isEnabled, isScanning, startScan } =
     useBarcodeScannerContext();
+  const showItemVariantsInput = useItemVariantsConfigured();
+
   const supplierName = draft.supplierName
     ? draft.supplierName
     : t('message.no-supplier');
@@ -159,17 +161,19 @@ export const StockLineForm: FC<StockLineFormProps> = ({
               />
             }
           />
-          <StyledInputRow
-            label={t('label.item-variant')}
-            Input={
-              <ItemVariantSearchInput
-                itemId={draft.itemId}
-                selectedId={draft.itemVariantId ?? null}
-                width={160}
-                onChange={id => onUpdate({ itemVariantId: id })}
-              />
-            }
-          />
+          {showItemVariantsInput && (
+            <StyledInputRow
+              label={t('label.item-variant')}
+              Input={
+                <ItemVariantSearchInput
+                  itemId={draft.itemId}
+                  selectedId={draft.itemVariantId ?? null}
+                  width={160}
+                  onChange={id => onUpdate({ itemVariantId: id })}
+                />
+              }
+            />
+          )}
           {plugins}
         </Grid>
         <Grid

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -23,7 +23,7 @@ import { StockLineRowFragment } from '../api';
 import { LocationSearchInput } from '../../Location/Components/LocationSearchInput';
 import { ItemVariantSearchInput } from '../..';
 import { StyledInputRow } from './StyledInputRow';
-import { PackSizeNumberInput, useItemVariantsConfigured } from '../../Item';
+import { PackSizeNumberInput, useIsItemVariantsEnabled } from '../../Item';
 
 interface StockLineFormProps {
   draft: StockLineRowFragment;
@@ -45,7 +45,7 @@ export const StockLineForm: FC<StockLineFormProps> = ({
   const { error } = useNotification();
   const { isConnected, isEnabled, isScanning, startScan } =
     useBarcodeScannerContext();
-  const showItemVariantsInput = useItemVariantsConfigured();
+  const showItemVariantsInput = useIsItemVariantsEnabled();
 
   const supplierName = draft.supplierName
     ? draft.supplierName

--- a/server/graphql/item_variant/src/lib.rs
+++ b/server/graphql/item_variant/src/lib.rs
@@ -1,7 +1,42 @@
 use async_graphql::*;
+use graphql_core::{
+    standard_graphql_error::{validate_auth, StandardGraphqlError},
+    ContextExt,
+};
+use service::auth::{Resource, ResourceAccessRequest};
 
 mod mutations;
 use self::mutations::*;
+
+#[derive(Default, Clone)]
+pub struct ItemVariantQueries;
+
+#[Object]
+impl ItemVariantQueries {
+    pub async fn item_variants_configured(
+        &self,
+        ctx: &Context<'_>,
+        store_id: String,
+    ) -> Result<bool> {
+        let user = validate_auth(
+            ctx,
+            &ResourceAccessRequest {
+                resource: Resource::QueryItems,
+                store_id: Some(store_id.clone()),
+            },
+        )?;
+
+        let service_provider = ctx.service_provider();
+        let service_context = service_provider.context(store_id.clone(), user.user_id)?;
+
+        let item_variants = service_provider
+            .item_service
+            .get_item_variants(&service_context, None, None, None)
+            .map_err(StandardGraphqlError::from_list_error)?;
+
+        Ok(item_variants.count > 0)
+    }
+}
 
 #[derive(Default, Clone)]
 pub struct ItemVariantMutations;

--- a/server/graphql/lib.rs
+++ b/server/graphql/lib.rs
@@ -34,7 +34,7 @@ use graphql_inventory_adjustment::InventoryAdjustmentMutations;
 use graphql_invoice::{InvoiceMutations, InvoiceQueries};
 use graphql_invoice_line::{InvoiceLineMutations, InvoiceLineQueries};
 use graphql_item_bundle::BundledItemMutations;
-use graphql_item_variant::ItemVariantMutations;
+use graphql_item_variant::{ItemVariantMutations, ItemVariantQueries};
 use graphql_location::{LocationMutations, LocationQueries};
 use graphql_plugin::{PluginMutations, PluginQueries};
 use graphql_programs::{ProgramsMutations, ProgramsQueries};
@@ -127,6 +127,7 @@ pub struct Queries(
     pub AssetPropertiesQueries,
     pub DemographicIndicatorQueries,
     pub VaccineCourseQueries,
+    pub ItemVariantQueries,
 );
 
 impl Queries {
@@ -154,6 +155,7 @@ impl Queries {
             AssetPropertiesQueries,
             DemographicIndicatorQueries,
             VaccineCourseQueries,
+            ItemVariantQueries,
         )
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5362

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Hides the item variant column on inbound modals/the stock detail page, if no item variants have been configured.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Make sure it feels okay to be hiding/showing base on there being _any_ variants set up, rather than for the item in question?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have no item variants configured (for any items)
  - [ ] There is no item variant column in:
    - [ ] Inbound shipment
    - [ ] Customer return
    - [ ] Stock detail view
- [ ] Configure an item variant
  - [ ] There is now an item variant column in:
    - [ ] Inbound shipment
    - [ ] Customer return
    - [ ] Stock detail view

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
