### PR TITLE
Change OK button to Loading Button type

### DIFF
--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
@@ -18,6 +18,8 @@ import {
   useNotification,
   InvoiceNodeStatus,
   DateUtils,
+  LoadingButton,
+  CheckIcon,
 } from '@openmsupply-client/common';
 import { useDraftPrescriptionLines, useNextItem } from './hooks';
 import { usePrescription } from '../../api';
@@ -60,7 +62,7 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
     id: invoiceId,
     prescriptionDate,
   } = usePrescription.document.fields(['status', 'id', 'prescriptionDate']);
-  const { mutateAsync } = usePrescription.line.save();
+  const { mutateAsync, isLoading:isSaving } = usePrescription.line.save();
   const isDisabled = usePrescription.utils.isDisabled();
   const {
     draftStockOutLines: draftPrescriptionLines,
@@ -201,11 +203,18 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
         />
       }
       okButton={
-        <DialogButton
+        <LoadingButton
           disabled={!currentItem}
-          variant="ok"
+          isLoading={isSaving}
+          startIcon={<CheckIcon/>}
+          loadingStyle={{iconColor:'secondary.main' }}
+          variant="contained"
+          color='secondary'
+          aria-label={t('button.ok')}
           onClick={() => handleSave(onClose)}
-        />
+        >
+          {t('button.ok')}
+          </LoadingButton>
       }
       height={height}
       width={1000}

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
@@ -62,7 +62,7 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
     id: invoiceId,
     prescriptionDate,
   } = usePrescription.document.fields(['status', 'id', 'prescriptionDate']);
-  const { mutateAsync, isLoading:isSaving } = usePrescription.line.save();
+  const { mutateAsync, isLoading: isSaving } = usePrescription.line.save();
   const isDisabled = usePrescription.utils.isDisabled();
   const {
     draftStockOutLines: draftPrescriptionLines,
@@ -206,15 +206,15 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
         <LoadingButton
           disabled={!currentItem}
           isLoading={isSaving}
-          startIcon={<CheckIcon/>}
-          loadingStyle={{iconColor:'secondary.main' }}
+          startIcon={<CheckIcon />}
+          loadingStyle={{ iconColor: 'secondary.main' }}
           variant="contained"
-          color='secondary'
+          color="secondary"
           aria-label={t('button.ok')}
           onClick={() => handleSave(onClose)}
         >
           {t('button.ok')}
-          </LoadingButton>
+        </LoadingButton>
       }
       height={height}
       width={1000}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4915 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
Changed the OK button for creating/editing a prescription from a Dialog button to a Loading button. Uses loading state to prevent clicking OK multiple times, therefore preventing the action that leads to the error.

Updated to match the original button with color, aria label. New loading icon is blue to match buttons

<!-- why are the changes needed -->
If the OK button was clicked more than once whilst loading, the api was called more than once creating the 'Line already exists' error

<!-- Add a screenshot if there are UI changes  -->

![Screenshot 2024-11-15 at 11 29 37 AM](https://github.com/user-attachments/assets/de9214be-320c-4523-b8a5-17d5679ee0ec)


## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ]  Go to Dispensary -> Prescriptions
- [ ] Add a new prescription or edit an existing one
- [ ] Use dev tools to throttle network speed
- [ ] Add item
- [ ] Ensure the OK button cannot be clicked more than once

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour

