### PR TITLE
5383 Android - Load Plugins after they've be registered properly

### DIFF
--- a/client/packages/android/README.MD
+++ b/client/packages/android/README.MD
@@ -17,17 +17,17 @@ This requires a couple of steps.
 
 ![omSupply Android NDK](./doc/omSupply_android_ndk.png)
 
-Currently, we support two Android architectures;
+Currently, we support only 1 Android architecture (64bit);
 
 | rust target             | android ABI |
-| ----------------------- | ----------- |
 | aarch64-linux-android   | arm64-v8a   |
-| armv7-linux-androideabi | armeabi-v7a |
+| ----------------------- | ----------- |
+
 
 To add the required build targets to Rust run:
 
 ```bash
-rustup target add aarch64-linux-android && rustup target add armv7-linux-androideabi
+rustup target add aarch64-linux-android
 ```
 
 Next we have to tell Rust where to find the Android NDK binaries required to link the server library.

--- a/client/packages/android/README.MD
+++ b/client/packages/android/README.MD
@@ -12,7 +12,7 @@ The UI is not bundled within Capacitor, it is served by the server the client co
 Before building the Android app, the Rust server library that allows us to run the mSupply server on the mobile device needs to be built.
 This requires a couple of steps.
 
-- Install Android Studio
+- Install Android Studio (Ladybug at time of writing 15/11/24)
 - Install NDK (26.1.10909125 at the time of writing on the 8/4/24)
 
 ![omSupply Android NDK](./doc/omSupply_android_ndk.png)

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/ExtendedWebViewClient.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/ExtendedWebViewClient.java
@@ -21,8 +21,13 @@ public class ExtendedWebViewClient extends BridgeWebViewClient {
 
     public ExtendedWebViewClient(Bridge bridge) {
         super(bridge);
-
         this.bridge = bridge;
+    }
+
+    public void loadJsInject() {
+        if(this.jsInject == null) {
+            this.jsInject = this.generatePluginScript();
+        }
     }
 
     // Have to manually inject Capacitor JS, this typically happens in
@@ -34,23 +39,13 @@ public class ExtendedWebViewClient extends BridgeWebViewClient {
         Logger.debug("onPageStarted" + url   );
         if (url.startsWith("data:text")) return;
 
-        if (this.jsInject == null){
-            this.jsInject = this.generatePluginScript();
-        }
+        // Just incase the js hasn't been generated yet, generate it here.
+        this.loadJsInject()
 
         if(this.jsInject != null) {
             Logger.debug("injecting JS");
             // .post to run on UI thread
             webView.post(() -> webView.evaluateJavascript(this.jsInject, null));
-        }
-    }
-
-
-    private void sleep(int delay) {
-        try {
-            Thread.sleep(delay);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
         }
     }
 
@@ -66,7 +61,7 @@ public class ExtendedWebViewClient extends BridgeWebViewClient {
             PluginHandle plugin = bridge.getPlugin(pluginName);
             if (plugin == null) {
                 Logger.error("Couldn't find plugin : " + pluginName);
-                continue;
+                return null;
             }
             pluginList.add(plugin);
         }

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/ExtendedWebViewClient.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/ExtendedWebViewClient.java
@@ -71,7 +71,7 @@ public class ExtendedWebViewClient extends BridgeWebViewClient {
             String globalJS = JSExport.getGlobalJS(bridge.getContext(), bridge.getConfig().isLoggingEnabled(),
                     bridge.isDevMode());
             String bridgeJS = JSExport.getBridgeJS(bridge.getContext());
-            String pluginJS = JSExport.getPluginJS(pluginList);    
+            String pluginJS = JSExport.getPluginJS(pluginList);
             String cordovaJS = JSExport.getCordovaJS(bridge.getContext());
             String cordovaPluginsJS = JSExport.getCordovaPluginJS(bridge.getContext());
             String cordovaPluginsFileJS = JSExport.getCordovaPluginsFileJS(bridge.getContext());

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/ExtendedWebViewClient.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/ExtendedWebViewClient.java
@@ -26,6 +26,7 @@ public class ExtendedWebViewClient extends BridgeWebViewClient {
 
     public void loadJsInject() {
         if(this.jsInject == null) {
+            Logger.debug("Generating JS");
             this.jsInject = this.generatePluginScript();
         }
     }
@@ -36,11 +37,10 @@ public class ExtendedWebViewClient extends BridgeWebViewClient {
     // fails for self signed certificates and plugin definitions etc is not injected
     @Override
     public void onPageStarted(WebView webView, String url, Bitmap favicon) {
-        Logger.debug("onPageStarted" + url   );
         if (url.startsWith("data:text")) return;
 
         // Just incase the js hasn't been generated yet, generate it here.
-        this.loadJsInject()
+        this.loadJsInject();
 
         if(this.jsInject != null) {
             Logger.debug("injecting JS");

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/ExtendedWebViewClient.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/ExtendedWebViewClient.java
@@ -46,6 +46,9 @@ public class ExtendedWebViewClient extends BridgeWebViewClient {
             Logger.debug("injecting JS");
             // .post to run on UI thread
             webView.post(() -> webView.evaluateJavascript(this.jsInject, null));
+        } else {
+            Logger.error("JS not generated, not injecting");
+            webView.post(() -> webView.evaluateJavascript("alert('Error unable to load javascript to inject. Please contact mSupply Support for assistance.')", null));
         }
     }
 

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
@@ -113,9 +113,10 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
 
     @Override
     protected void handleOnStart() {
+        Logger.debug("NativeAPI.handleOnStart()");
         WebView webView = this.getBridge().getWebView();
 
-        // Normally javascript would be loaded by Capcitor by loading the generated javascript from WEBVIEW_SERVER_URL
+        // Normally javascript would be loaded by Capacitor by loading the generated javascript from WEBVIEW_SERVER_URL
         // However we'd get an SSL issue with this approach, so we need to generate it ourselves and inject it later.
 
         // NOTE: There have been various timing issues with this javascript injection loading, including onPageStarted in ExtendedWebViewClient

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
@@ -64,11 +64,13 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
     boolean isResolvingServer;
     boolean shouldRestartDiscovery;
 
+    CertWebViewClient client;
+
     @Override
     public void load() {
         super.load();
 
-        CertWebViewClient client = new CertWebViewClient(this.getBridge(), this.getContext().getFilesDir(), this);
+        client = new CertWebViewClient(this.getBridge(), this.getContext().getFilesDir(), this);
         bridge.setWebViewClient(client);
 
         serversToResolve = new ArrayDeque<NsdServiceInfo>();
@@ -112,6 +114,17 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
     @Override
     protected void handleOnStart() {
         WebView webView = this.getBridge().getWebView();
+
+        // Normally javascript would be loaded by Capcitor by loading the generated javascript from WEBVIEW_SERVER_URL
+        // However we'd get an SSL issue with this approach, so we need to generate it ourselves and inject it later.
+
+        // NOTE: There have been various timing issues with this javascript injection loading, including onPageStarted in ExtendedWebViewClient
+        // We call it here as well as in ExtendedWebViewClient as this gives more time for it to be generated before the webview loads
+        // and onPageStarted happens in the ExtendedWebViewClient
+        // Avoiding issues with it taking too long to generate.
+        client.loadJsInject();
+
+
         // this method (handleOnStart) is called when resuming and switching to the app
         // the webView url will be DEFAULT_URL only on the initial load
         // so this test is a quick check to see if we should be redirecting to the

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
@@ -119,10 +119,10 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
         // Normally javascript would be loaded by Capacitor by loading the generated javascript from WEBVIEW_SERVER_URL
         // However we'd get an SSL issue with this approach, so we need to generate it ourselves and inject it later.
 
-        // NOTE: There have been various timing issues with this javascript injection loading, including onPageStarted in ExtendedWebViewClient
+        // NOTE: There have been various timing issues with this javascript injection loading
+        // We do the actual injection during onPageStarted in ExtendedWebViewClient
         // We call it here as well as in ExtendedWebViewClient as this gives more time for it to be generated before the webview loads
-        // and onPageStarted happens in the ExtendedWebViewClient
-        // Avoiding issues with it taking too long to generate.
+        // Potentially avoiding issues if it takes too long to generate.
         client.loadJsInject();
 
 

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/RemoteServer.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/RemoteServer.java
@@ -1,5 +1,7 @@
 package org.openmsupply.client;
 
+import com.getcapacitor.Logger;
+
 public class RemoteServer {
     static {
         // This will load libremote_server_android, from app/src/main/jniLib/ directory
@@ -12,6 +14,7 @@ public class RemoteServer {
     }
 
     public void start(int port, String filesDir, String cacheDir, String androidId) {
+        Logger.info("Starting OMS Rust Server");
         startServer(port, filesDir, cacheDir, androidId);
     }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5383 

This behaviour with Android 11/12 isn't entirely consistent, this appears to be an improvement over the old method at least.

# 👩🏻‍💻 What does this PR do?

After much re-discovery of how things work and various attempts to fix similar issues.
E.g. https://github.com/msupply-foundation/open-msupply/pull/4390

I've changed the logic for the `ExtendedWebViewClient` to generate the javascript to inject on App Start and at page_load (as a backup method).

It seemed like in my emulators that the code that registers the plugins, and the web view constractor run concurrently so ordering of operations can't be guarenteed.

Here's what the `logcat` output looks like now.
```
2024-11-15 17:15:53.901  7282-7282  Capacitor               org.openmsupply.client               D  Starting BridgeActivity
2024-11-15 17:15:53.918  7282-7282  Capacitor               org.openmsupply.client               D  Registering plugin instance: CapacitorCookies
2024-11-15 17:15:53.919  7282-7282  Capacitor               org.openmsupply.client               D  Registering plugin instance: WebView
2024-11-15 17:15:53.920  7282-7282  Capacitor               org.openmsupply.client               D  Registering plugin instance: CapacitorHttp
2024-11-15 17:15:53.920  7282-7282  Capacitor               org.openmsupply.client               D  Registering plugin instance: NativeApi
```

Before it seemed to switch halfway through to the `generatePluginScript` code, and even putting in a thread sleep didn't work, I guess it's on the same thread, not familiar enough with how this works in Java?

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Build APK and try it on an android 10, 11, and/or 12 tablet, check you can initialize and then start the app again after

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
