### PR TITLE
5422 indicator api not retrieving an indicator value

### DIFF
--- a/server/repository/src/db_diesel/filter_sort_pagination.rs
+++ b/server/repository/src/db_diesel/filter_sort_pagination.rs
@@ -356,7 +356,7 @@ impl Pagination {
     pub fn all() -> Pagination {
         Pagination {
             offset: 0,
-            limit: std::u32::MAX,
+            limit: u32::MAX,
         }
     }
 

--- a/server/repository/src/db_diesel/indicator_value.rs
+++ b/server/repository/src/db_diesel/indicator_value.rs
@@ -76,7 +76,7 @@ impl<'a> IndicatorValueRepository<'a> {
         &self,
         filter: IndicatorValueFilter,
     ) -> Result<Vec<IndicatorValueRow>, RepositoryError> {
-        self.query(Pagination::new(), Some(filter))
+        self.query(Pagination::all(), Some(filter))
     }
 
     pub fn create_filtered_query(filter: Option<IndicatorValueFilter>) -> BoxedIndicatorQuery {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5422

# 👩🏻‍💻 What does this PR do?
- Return all indicator values

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have 100 + indicator values
- [ ] Call endpoint
- [ ] They should all be there.

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
