### PR TITLE
Ensure consistent gap in toolbar

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
@@ -69,6 +69,7 @@ export const Toolbar: FC<{
         display="flex"
         flex={1}
         alignItems="flex-end"
+        gap={1}
       >
         <Grid item display="flex" flex={1}>
           <Box display="flex" flex={1} flexDirection="column" gap={1}>


### PR DESCRIPTION
Fixes part 1 of #5371

# 👩🏻‍💻 What does this PR do?

Adds a gap between the reference field and the group by item slider and actions dropdown in the detail view of inbound shipments.

<img width="459" alt="image" src="https://github.com/user-attachments/assets/5d7870be-c248-46fd-81e6-60d36c2b64ca">

Before there was inconsistent spacing:

![image](https://github.com/user-attachments/assets/b6607677-6da1-4bcc-bccf-0169e063edfd)

## 💌 Any notes for the reviewer?

The issue highlights six UI issues, this PR fixes one of them, the first.

# 🧪 Testing

- [ ] Navigate to replenishment>inbound shipments.
- [ ] Select an item in order to see the detail view.
- [ ] Make the window narrow until the group by item slider and 'actions' dropdown are on the left hand side of the portal.
- [ ] Check that there is consistent spacing as in the screenshot above.

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
