### PR TITLE
5448 Navigating back from editing requisition line goes back to requisition list rather than to the requisition being modified

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/DetailView.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/DetailView.tsx
@@ -41,8 +41,7 @@ export const DetailView: FC = () => {
         .addPart(AppRoute.CustomerRequisition)
         .addPart(String(line.requisitionNumber))
         .addPart(String(line.item.id))
-        .build(),
-      { replace: true }
+        .build()
     );
   }, []);
 
@@ -101,8 +100,7 @@ export const DetailView: FC = () => {
                       .addPart(AppRoute.CustomerRequisition)
                       .addPart(String(data.requisitionNumber))
                       .addPart(String(newItem.id))
-                      .build(),
-                    { replace: true }
+                      .build()
                   );
                 }
               }}

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/AppBarButtons.tsx
@@ -27,8 +27,7 @@ export const AppBarButtonsComponent = ({
               RouteBuilder.create(AppRoute.Distribution)
                 .addPart(AppRoute.CustomerRequisition)
                 .addPart(String(requisitionNumber))
-                .build(),
-              { replace: true }
+                .build()
             )
           }
         />

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/Footer.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/Footer.tsx
@@ -52,8 +52,7 @@ export const Footer: FC<FooterProps> = ({
                     .addPart(AppRoute.CustomerRequisition)
                     .addPart(String(requisitionNumber))
                     .addPart(String(previous?.id))
-                    .build(),
-                  { replace: true }
+                    .build()
                 )
               }
             />
@@ -66,8 +65,7 @@ export const Footer: FC<FooterProps> = ({
                     .addPart(AppRoute.CustomerRequisition)
                     .addPart(String(requisitionNumber))
                     .addPart(String(next?.id))
-                    .build(),
-                  { replace: true }
+                    .build()
                 )
               }
             />

--- a/client/packages/requisitions/src/ResponseRequisition/ListView/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/ListView/AppBarButtons.tsx
@@ -84,8 +84,7 @@ export const AppBarButtons = ({
                   RouteBuilder.create(AppRoute.Distribution)
                     .addPart(AppRoute.CustomerRequisition)
                     .addPart(String(requisitionNumber))
-                    .build(),
-                  { replace: true }
+                    .build()
                 );
               });
             case NewRequisitionType.Program:
@@ -99,8 +98,7 @@ export const AppBarButtons = ({
                   RouteBuilder.create(AppRoute.Distribution)
                     .addPart(AppRoute.CustomerRequisition)
                     .addPart(String(requisitionNumber))
-                    .build(),
-                  { replace: true }
+                    .build()
                 );
               });
           }

--- a/client/packages/system/src/Item/Components/ListItems/ListItems.tsx
+++ b/client/packages/system/src/Item/Components/ListItems/ListItems.tsx
@@ -28,7 +28,7 @@ export const ListItems = ({
       <ListOptions
         currentId={value?.id}
         onClick={id => {
-          navigate(route.addPart(id).build(), { replace: true });
+          navigate(route.addPart(id).build());
         }}
         options={
           items?.map(({ id, name }) => ({


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5448

# 👩🏻‍💻 What does this PR do?
Don't replace history in Response Requisition navigation 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create new requisition -> Click back. Should be previous page
- [ ] Go to a requisition line
- [ ] Navigate to a different line -> Click back. Should be previous item

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
