### PR TITLE
5423 cant download CCE template on android

### DIFF
--- a/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
@@ -17,6 +17,8 @@ import {
   FileUtils,
   Formatter,
   useIsCentralServerApi,
+  EnvUtils,
+  Platform,
 } from '@openmsupply-client/common';
 import * as EquipmentImportModal from './EquipmentImportModal';
 import { ImportRow } from './EquipmentImportModal';
@@ -195,12 +197,17 @@ export const EquipmentUploadTab: FC<ImportPanel & EquipmentUploadTabProps> = ({
   const t = useTranslation();
   const isCentralServer = useIsCentralServerApi();
   const { data: stores } = useStore.document.list();
-  const { error } = useNotification();
+  const { error, info } = useNotification();
   const [isLoading, setIsLoading] = useState(false);
   const EquipmentBuffer: EquipmentImportModal.ImportRow[] = [];
   const { data: properties } = useAssetData.utils.properties();
 
   const csvExample = async () => {
+    if (EnvUtils.platform === Platform.Android) {
+      info(t('messages.cant-download-android'))();
+      return;
+    }
+
     const exampleRows: Partial<ImportRow>[] = [
       {
         assetNumber: 'ASSET NUMBER',

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1152,6 +1152,7 @@
   "messages.cannot-view-vaccine-card": "You cannot view this patient's Vaccination Card from this store, because they were enrolled in the {{ programName }} by another store",
   "messages.cant-delete-generic": "You cannot delete one or more of the selected items",
   "messages.cant-delete-requisitions": "Can only delete requisitions with a status of 'Draft'",
+  "messages.cant-download-android": "File cannot be download on this device",
   "messages.cant-return-shipment": "Cannot process return of lines until the status is 'Shipped'",
   "messages.cant-return-shipment-replenishment": "Cannot return lines until the status is 'Delivered'",
   "messages.cant-send-order": "Cannot send Internal Order because there are no lines or because there are only placeholder lines",


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5423

# 👩🏻‍💻 What does this PR do?

Show info popup when trying to download CCE template on android:

![Screenshot 2024-11-19 at 9 01 25 AM](https://github.com/user-attachments/assets/2999cdb4-af3c-4274-80fd-5ca4aa6d6aef)

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] On ANDROID
- [ ] Coldchain > Equipment
- [ ] Click `Import`
- [ ] Click the `Download template` link
- [ ] See popup

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Could mention that download is not available on android. Also fine to leave I think 😁 
  2.
