### PR TITLE
5442 Include location type in selected location option

### DIFF
--- a/client/packages/system/src/Location/Components/LocationSearchInput.tsx
+++ b/client/packages/system/src/Location/Components/LocationSearchInput.tsx
@@ -82,6 +82,8 @@ export const LocationSearchInput: FC<LocationSearchInputProps> = ({
     options.push({ value: null, label: t('label.remove') });
   }
 
+  const selectedOption = options.find(o => o.value === selectedLocation?.id);
+
   return (
     <Autocomplete
       autoFocus={autoFocus}
@@ -89,13 +91,7 @@ export const LocationSearchInput: FC<LocationSearchInputProps> = ({
       width={`${width}px`}
       popperMinWidth={Number(width)}
       clearable={false}
-      value={
-        selectedLocation && {
-          value: selectedLocation.id,
-          label: formatLocationLabel(selectedLocation),
-          code: selectedLocation.code,
-        }
-      }
+      value={selectedOption || null}
       loading={isLoading}
       onChange={(_, option) => {
         onChange(locations.find(l => l.id === option?.value) || null);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5442

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
![Screenshot 2024-11-19 at 9 16 30 AM](https://github.com/user-attachments/assets/72ad0947-36d1-43c4-b2fc-64422f23168d)

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have storage types set for some locations
- [ ] For both a stocktake and an inbound shipment
- [ ] Open edit for a modal
- [ ] Go to locations tab
- [ ] Select a location for the line, one with a storage type
- [ ] Save
- [ ] Reopen the modal and navigate to locations tab
- [ ] TEST: you can still see the storage type of the selected location

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
