### PR TITLE
fixed show/hide all

### DIFF
--- a/client/packages/common/src/ui/layout/tables/hooks/useColumnDisplayState.ts
+++ b/client/packages/common/src/ui/layout/tables/hooks/useColumnDisplayState.ts
@@ -25,6 +25,10 @@ export const useColumnDisplayState = <T extends RecordWithId>(
     ])
   );
 
+  const [allIsSelected, setAllIsSelected] = useState(false)
+
+
+
   const toggleColumn = (colKey: string) => {
     const newState = {
       ...columnDisplayState,
@@ -36,6 +40,16 @@ export const useColumnDisplayState = <T extends RecordWithId>(
           ? false
           : !columnDisplayState[colKey],
     };
+    if(colKey === 'selection'){
+      if(!allIsSelected){
+        Object.keys(newState).forEach((key)=>newState[key] = true)
+        setAllIsSelected(true)
+      }else{
+        Object.keys(newState).forEach((key)=>newState[key] = false)
+        setAllIsSelected(false)
+      }
+      
+    }
     setColumnDisplayState(newState);
     setHiddenColsStorage({
       ...hiddenColsStorage,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5396

# 👩🏻‍💻 What does this PR do?
This adds the show or hide all logic to the data table custom column picker, reported in the detailed view of any outbound shipment. Previously, the hide/show all checkbox existed but the logic was unavailable.
<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
