### PR TITLE
5471 Requisition's supply quantity is incorrect

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
@@ -231,7 +231,7 @@ export const useResponseColumns = () => {
     {
       getSortValue: rowData => rowData.supplyQuantity,
       Cell: PackQuantityCell,
-      accessor: ({ rowData }) => rowData.requestedQuantity,
+      accessor: ({ rowData }) => rowData.supplyQuantity,
     },
   ]);
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5471

# 👩🏻‍💻 What does this PR do?
Get correct supply quantity

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Edit supply quantity in a requisition
- [ ] Go back to detail view
- [ ] See that supply quantity in table matches supply quantity in page

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
