### PR TITLE
5461 delete bundled items when item variant deleted

### DIFF
--- a/server/repository/src/db_diesel/item_variant/bundled_item.rs
+++ b/server/repository/src/db_diesel/item_variant/bundled_item.rs
@@ -1,8 +1,7 @@
 use super::bundled_item_row::{bundled_item, BundledItemRow};
 use crate::{
-    diesel_macros::{apply_equal_filter, apply_equal_or_filter},
-    repository_error::RepositoryError,
-    DBType, EqualFilter, Pagination, StorageConnection,
+    diesel_macros::apply_equal_filter, repository_error::RepositoryError, DBType, EqualFilter,
+    Pagination, StorageConnection,
 };
 use diesel::{dsl::IntoBoxed, prelude::*};
 

--- a/server/repository/src/diesel_macros.rs
+++ b/server/repository/src/diesel_macros.rs
@@ -1,3 +1,35 @@
+macro_rules! apply_equal_filter_method {
+    ($query:ident, $filter_method:ident, $filter_field:expr, $dsl_field:expr ) => {{
+        if let Some(equal_filter) = $filter_field {
+            if let Some(value) = equal_filter.equal_to {
+                $query = $query.$filter_method($dsl_field.eq(value));
+            }
+
+            if let Some(value) = equal_filter.not_equal_to {
+                $query = $query.$filter_method($dsl_field.ne(value));
+            }
+
+            if let Some(value) = equal_filter.equal_any {
+                $query = $query.$filter_method($dsl_field.eq_any(value));
+            }
+
+            if let Some(value) = equal_filter.equal_any_or_null {
+                $query = $query.$filter_method($dsl_field.eq_any(value).or($dsl_field.is_null()));
+            }
+
+            if let Some(value) = equal_filter.not_equal_all {
+                $query = $query.$filter_method($dsl_field.ne_all(value));
+            }
+
+            $query = match equal_filter.is_null {
+                Some(true) => $query.$filter_method($dsl_field.is_null()),
+                Some(false) => $query.$filter_method($dsl_field.is_not_null()),
+                None => $query,
+            }
+        }
+    }};
+}
+
 /// Example expand, when called with:
 ///
 /// ```
@@ -17,33 +49,18 @@
 /// ```
 macro_rules! apply_equal_filter {
     ($query:ident, $filter_field:expr, $dsl_field:expr ) => {{
-        if let Some(equal_filter) = $filter_field {
-            if let Some(value) = equal_filter.equal_to {
-                $query = $query.filter($dsl_field.eq(value));
-            }
+        crate::diesel_macros::apply_equal_filter_method!($query, filter, $filter_field, $dsl_field);
+    }};
+}
 
-            if let Some(value) = equal_filter.not_equal_to {
-                $query = $query.filter($dsl_field.ne(value));
-            }
-
-            if let Some(value) = equal_filter.equal_any {
-                $query = $query.filter($dsl_field.eq_any(value));
-            }
-
-            if let Some(value) = equal_filter.equal_any_or_null {
-                $query = $query.filter($dsl_field.eq_any(value).or($dsl_field.is_null()));
-            }
-
-            if let Some(value) = equal_filter.not_equal_all {
-                $query = $query.filter($dsl_field.ne_all(value));
-            }
-
-            $query = match equal_filter.is_null {
-                Some(true) => $query.filter($dsl_field.is_null()),
-                Some(false) => $query.filter($dsl_field.is_not_null()),
-                None => $query,
-            }
-        }
+macro_rules! apply_equal_or_filter {
+    ($query:ident, $filter_field:expr, $dsl_field:expr ) => {{
+        crate::diesel_macros::apply_equal_filter_method!(
+            $query,
+            or_filter,
+            $filter_field,
+            $dsl_field
+        );
     }};
 }
 
@@ -373,6 +390,8 @@ macro_rules! apply_sort_asc_nulls_first {
 pub(crate) use apply_date_filter;
 pub(crate) use apply_date_time_filter;
 pub(crate) use apply_equal_filter;
+pub(crate) use apply_equal_filter_method;
+pub(crate) use apply_equal_or_filter;
 pub(crate) use apply_number_filter;
 pub(crate) use apply_sort;
 pub(crate) use apply_sort_asc_nulls_first;

--- a/server/repository/src/diesel_macros.rs
+++ b/server/repository/src/diesel_macros.rs
@@ -1,35 +1,3 @@
-macro_rules! apply_equal_filter_method {
-    ($query:ident, $filter_method:ident, $filter_field:expr, $dsl_field:expr ) => {{
-        if let Some(equal_filter) = $filter_field {
-            if let Some(value) = equal_filter.equal_to {
-                $query = $query.$filter_method($dsl_field.eq(value));
-            }
-
-            if let Some(value) = equal_filter.not_equal_to {
-                $query = $query.$filter_method($dsl_field.ne(value));
-            }
-
-            if let Some(value) = equal_filter.equal_any {
-                $query = $query.$filter_method($dsl_field.eq_any(value));
-            }
-
-            if let Some(value) = equal_filter.equal_any_or_null {
-                $query = $query.$filter_method($dsl_field.eq_any(value).or($dsl_field.is_null()));
-            }
-
-            if let Some(value) = equal_filter.not_equal_all {
-                $query = $query.$filter_method($dsl_field.ne_all(value));
-            }
-
-            $query = match equal_filter.is_null {
-                Some(true) => $query.$filter_method($dsl_field.is_null()),
-                Some(false) => $query.$filter_method($dsl_field.is_not_null()),
-                None => $query,
-            }
-        }
-    }};
-}
-
 /// Example expand, when called with:
 ///
 /// ```
@@ -49,18 +17,33 @@ macro_rules! apply_equal_filter_method {
 /// ```
 macro_rules! apply_equal_filter {
     ($query:ident, $filter_field:expr, $dsl_field:expr ) => {{
-        crate::diesel_macros::apply_equal_filter_method!($query, filter, $filter_field, $dsl_field);
-    }};
-}
+        if let Some(equal_filter) = $filter_field {
+            if let Some(value) = equal_filter.equal_to {
+                $query = $query.filter($dsl_field.eq(value));
+            }
 
-macro_rules! apply_equal_or_filter {
-    ($query:ident, $filter_field:expr, $dsl_field:expr ) => {{
-        crate::diesel_macros::apply_equal_filter_method!(
-            $query,
-            or_filter,
-            $filter_field,
-            $dsl_field
-        );
+            if let Some(value) = equal_filter.not_equal_to {
+                $query = $query.filter($dsl_field.ne(value));
+            }
+
+            if let Some(value) = equal_filter.equal_any {
+                $query = $query.filter($dsl_field.eq_any(value));
+            }
+
+            if let Some(value) = equal_filter.equal_any_or_null {
+                $query = $query.filter($dsl_field.eq_any(value).or($dsl_field.is_null()));
+            }
+
+            if let Some(value) = equal_filter.not_equal_all {
+                $query = $query.filter($dsl_field.ne_all(value));
+            }
+
+            $query = match equal_filter.is_null {
+                Some(true) => $query.filter($dsl_field.is_null()),
+                Some(false) => $query.filter($dsl_field.is_not_null()),
+                None => $query,
+            }
+        }
     }};
 }
 
@@ -390,8 +373,6 @@ macro_rules! apply_sort_asc_nulls_first {
 pub(crate) use apply_date_filter;
 pub(crate) use apply_date_time_filter;
 pub(crate) use apply_equal_filter;
-pub(crate) use apply_equal_filter_method;
-pub(crate) use apply_equal_or_filter;
 pub(crate) use apply_number_filter;
 pub(crate) use apply_sort;
 pub(crate) use apply_sort_asc_nulls_first;

--- a/server/service/src/item/item_variant/delete.rs
+++ b/server/service/src/item/item_variant/delete.rs
@@ -33,8 +33,7 @@ pub fn delete_item_variant(
             let bundled_item_repo = BundledItemRepository::new(connection);
 
             let bundled_items = bundled_item_repo.query_by_filter(
-                BundledItemFilter::new()
-                    .principal_or_bundled_variant_id(EqualFilter::equal_to(&input.id)),
+                BundledItemFilter::new().principal_or_bundled_variant_id(input.id.clone()),
             )?;
 
             bundled_items

--- a/server/service/src/item/item_variant/delete.rs
+++ b/server/service/src/item/item_variant/delete.rs
@@ -4,7 +4,7 @@ use repository::{
         bundled_item_row::BundledItemRowRepository,
         item_variant_row::ItemVariantRowRepository,
     },
-    EqualFilter, RepositoryError,
+    RepositoryError,
 };
 
 use crate::service_provider::ServiceContext;

--- a/server/service/src/item/item_variant/test/mod.rs
+++ b/server/service/src/item/item_variant/test/mod.rs
@@ -1,11 +1,13 @@
 #[cfg(test)]
 mod query {
+    use repository::item_variant::bundled_item::BundledItemFilter;
     use repository::item_variant::item_variant::ItemVariantFilter;
     use repository::mock::{mock_item_a, mock_item_b, MockDataInserts};
     use repository::test_db::setup_all;
     use repository::{EqualFilter, StringFilter};
     use util::uuid::uuid;
 
+    use crate::item::bundled_item::UpsertBundledItem;
     use crate::item::item_variant::{
         DeleteItemVariant, UpsertItemVariantError, UpsertItemVariantWithPackaging,
     };
@@ -51,15 +53,30 @@ mod query {
             )
             .unwrap();
 
+        let test_item_b_variant_id = "test_item_b_variant_id";
+
         // Create a new item variant for item_b
         let _item_b_variant_a = service
             .upsert_item_variant(
                 &context,
                 UpsertItemVariantWithPackaging {
-                    id: uuid(),
+                    id: test_item_b_variant_id.to_string(),
                     item_id: mock_item_b().id,
                     name: "item_b_variant_a".to_string(),
                     ..Default::default()
+                },
+            )
+            .unwrap();
+
+        // Bundle item_a_variant_a with item_b_variant_a
+        let _bundled_item = service
+            .upsert_bundled_item(
+                &context,
+                UpsertBundledItem {
+                    id: uuid(),
+                    principal_item_variant_id: test_item_b_variant_id.to_string(),
+                    bundled_item_variant_id: test_item_a_variant_id.to_string(),
+                    ratio: 1.0,
                 },
             )
             .unwrap();
@@ -146,6 +163,20 @@ mod query {
             .unwrap();
 
         assert_eq!(item_variant.count, 0);
+
+        // Check that delete also soft deleted the bundled item record
+
+        let bundled_item = service
+            .get_bundled_items(
+                &context,
+                None,
+                Some(
+                    BundledItemFilter::new()
+                        .principal_item_variant_id(EqualFilter::equal_to(&test_item_b_variant_id)),
+                ),
+            )
+            .unwrap();
+        assert_eq!(bundled_item.count, 0);
     }
 
     #[actix_rt::test]


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5461 

# 👩🏻‍💻 What does this PR do?

Soft deleted bundled items when variants are deleted

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Define two items with item variants
- [ ] On item A variant 1 - bundle item B variant 1
- [ ] Go to item B and delete variant 1
- [ ] Go back to item A - no item B variant 1 in the bundled item table (and no blank row where it "should" be)
- [ ] Test this in both directions (no lingering deleted variants as the "base" or the "bundled" item!)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
