### PR TITLE
5443 Fix expiring reports

### DIFF
--- a/server/graphql/reports/src/print.rs
+++ b/server/graphql/reports/src/print.rs
@@ -383,7 +383,9 @@ fn map_error(error: ReportError) -> Result<PrintReportErrorInterface> {
         ReportError::MultipleGraphqlQueriesNotAllowed => {
             StandardGraphqlError::BadUserInput(formatted_error)
         }
-        ReportError::TranslationError => StandardGraphqlError::InternalError(formatted_error),
+        ReportError::TranslationError | ReportError::ConvertDataError(_) => {
+            StandardGraphqlError::InternalError(formatted_error)
+        }
     };
 
     Err(graphql_error.extend())

--- a/server/reports/expiring-items/2_3_0/src/template.html
+++ b/server/reports/expiring-items/2_3_0/src/template.html
@@ -15,7 +15,7 @@
       </tr>
     </thead>
     <tbody>
-      {% for stockLine in data.data.stockLines.nodes %}
+      {% for stockLine in data.stockLines.nodes %}
       <tr>
         <td>{{stockLine.item.code}}</td>
         <td>{{stockLine.item.name}}</td>
@@ -32,7 +32,7 @@
             <span class="na">N/A</span>
           {% endif %}
         </td>
-        <td>{{stockLine.batch}}</td>
+        <td>{{stockLine.batch | default(value='')}}</td>
         <td>
           {% if stockLine.expiryDate %}
             {{ stockLine.expiryDate | date(format="%d/%m/%Y") }}

--- a/server/reports/item-usage/2_3_0/src/template.html
+++ b/server/reports/item-usage/2_3_0/src/template.html
@@ -28,7 +28,7 @@
       </tr>
     </thead>
     <tbody>
-      {% for item in data.data.items.nodes %}
+      {% for item in data.items.nodes %}
       <tr>
         <td>{{item.code}}</td>
         <td>{{item.name}}</td>

--- a/server/reports/stock-detail/2_3_0/manifest.json
+++ b/server/reports/stock-detail/2_3_0/manifest.json
@@ -11,6 +11,5 @@
   "arguments": {
     "schema": "argument_schemas/arguments.json",
     "ui": "argument_schemas/arguments_ui.json"
-  },
-  "convert_data": "convert_data_js"
+  }
 }

--- a/server/reports/stock-detail/2_3_0/src/template.html
+++ b/server/reports/stock-detail/2_3_0/src/template.html
@@ -19,7 +19,7 @@
       </tr>
     </thead>
     <tbody>
-      {% for stockLine in data.data.stockLines.nodes %}
+      {% for stockLine in data.stockLines.nodes %}
 
       <tr>
         <td>{{stockLine.item.code}}</td>

--- a/server/reports/stock-status/2_3_0/src/template.html
+++ b/server/reports/stock-status/2_3_0/src/template.html
@@ -20,7 +20,7 @@
       </tr>
     </thead>
     <tbody>
-      {% for item in data.data.items.nodes %}
+      {% for item in data.items.nodes %}
         {% set SOH = item.stats.availableStockOnHand | default(value=0) | round(
         precision=1) %}
         {% set AMC = item.stats.averageMonthlyConsumption | default(value=0) |


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5443

Also fixes other reports not loading due to standard reports not being re-run and generated, and report builder not working

# 👩🏻‍💻 What does this PR do?

* Fix expiry report (it was failing if any 'batch' names are null)
* Change access of 'data' in template to be from 'data' rather then nested 'data' @fergie-nz this was fixed in the wasm sorting PR, but not in template, can you please re-test in your PRs (maybe worth having a checklist before PR is merged, like, run your own test, check diff again, etc..)
* re-generate standard reports -> this file should not be in our repo, we should re-run report generation during build.

## 💌 Any notes for the reviewer?

Although this PR fixes report in dev env, there seems to be an error on android in built APK:
![Screenshot 2024-11-20 at 11 30 50 AM](https://github.com/user-attachments/assets/d6a3c01a-b373-4322-8e43-47252fc0c576)

Doing a quick investigate, hold of merge, i might fix it in this PR

The last commit: https://github.com/msupply-foundation/open-msupply/pull/5482/commits/3fa143bbf2e43a0bc4e65152b5d1929ef8841eec, fixes android

[Here is APK](https://www.dropbox.com/scl/fi/cz43zgqldatndfdztu2kx/open-msupply-2.4.00-RC1-release.apk?rlkey=xdcudylcn1igprsncgvdluiy8&st=dxgpe7bh&dl=1)

# 🧪 Testing

Initialise and check standard reports, they should all be working

# 📃 Documentation


