### PR TITLE
5367 add category id to item filter

### DIFF
--- a/server/graphql/general/src/queries/item.rs
+++ b/server/graphql/general/src/queries/item.rs
@@ -45,6 +45,7 @@ pub struct ItemFilterInput {
     pub name: Option<StringFilterInput>,
     pub r#type: Option<EqualFilterItemTypeInput>,
     pub code: Option<StringFilterInput>,
+    pub category_id: Option<String>,
     /// Items that are visible in this store OR there is available stock of that item in this store
     pub is_visible_or_on_hand: Option<bool>,
     /// Items that are visible in this store. This filter is void if `is_visible_or_on_hand` is true
@@ -96,6 +97,7 @@ impl ItemFilterInput {
             name,
             r#type,
             code,
+            category_id,
             is_visible,
             code_or_name,
             is_active,
@@ -108,6 +110,7 @@ impl ItemFilterInput {
             name: name.map(StringFilter::from),
             code: code.map(StringFilter::from),
             r#type: r#type.map(|t| map_filter!(t, ItemNodeType::to_domain)),
+            category_id,
             is_visible,
             code_or_name: code_or_name.map(StringFilter::from),
             is_active,

--- a/server/repository/src/db_diesel/item.rs
+++ b/server/repository/src/db_diesel/item.rs
@@ -236,6 +236,9 @@ fn create_filtered_query(store_id: String, filter: Option<ItemFilter>) -> BoxedI
         }
 
         if let Some(category_id) = category_id {
+            // Don't need to consider merged items (item_link) here - if item
+            // has been merged, we only need to find by the category of the
+            // kept item, not the one that was "deleted"
             let item_ids_for_category_id = item_category_join::table
                 .select(item_category_join::item_id)
                 .filter(item_category_join::category_id.eq(category_id.clone()))


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5367


# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Adds category ID to item filter, to use from custom JSON form component

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?


Note: we currently only join at, and therefore support search by, lowest level category - this is all we need for RH module... but where should I capture this? Don't want someone confused trying to filter by higher level category and it not working?

<!-- Do you have any specific questions for the reviewer? -->


<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->


You can test with this query - compare results with item search in 4D:
```gql
query itemByCategoryId($storeId: String!, $categoryId: String!) {
  items(
    storeId: $storeId
    filter: { categoryId: $categoryId }
  ) {
    ... on ItemConnector {
      nodes {
        id
        name
      }
    }
  }
}

```

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
