### PR TITLE
4967 new encounter window appearance

### DIFF
--- a/client/packages/system/src/Clinician/ClinicianSearchInput.tsx
+++ b/client/packages/system/src/Clinician/ClinicianSearchInput.tsx
@@ -9,6 +9,7 @@ interface ClinicianSearchInputProps {
   width?: number;
   clinicianValue: Clinician | null | undefined;
   disabled?: boolean;
+  fullWidth?: boolean;
 }
 
 export const ClinicianSearchInput: FC<ClinicianSearchInputProps> = ({
@@ -16,6 +17,7 @@ export const ClinicianSearchInput: FC<ClinicianSearchInputProps> = ({
   width = 250,
   clinicianValue,
   disabled,
+  fullWidth,
 }) => {
   const { data } = useClinicians.document.list({});
   const { getLocalisedFullName } = useIntlUtils();
@@ -53,6 +55,7 @@ export const ClinicianSearchInput: FC<ClinicianSearchInputProps> = ({
       )}
       sx={{ minWidth: width }}
       disabled={disabled}
+      fullWidth={fullWidth}
     />
   );
 };

--- a/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
@@ -257,7 +257,7 @@ export const CreateEncounterModal: FC = () => {
       <React.Suspense fallback={<div />}>
         <Stack gap={1} sx={{ padding: '20px' }}>
           <InputWithLabelRow
-            labelProps={{ sx: { flex: `${LABEL_FLEX}` } }}
+            labelProps={{ sx: { flex: LABEL_FLEX } }}
             label={t('label.encounter')}
             Input={
               <EncounterSearchInput
@@ -274,7 +274,7 @@ export const CreateEncounterModal: FC = () => {
             form={
               <>
                 <InputWithLabelRow
-                  labelProps={{ sx: { flex: `${LABEL_FLEX}` } }}
+                  labelProps={{ sx: { flex: LABEL_FLEX } }}
                   label={t('label.visit-date')}
                   Input={
                     <DateTimePickerInput
@@ -296,7 +296,7 @@ export const CreateEncounterModal: FC = () => {
                   }
                 />
                 <InputWithLabelRow
-                  labelProps={{ sx: { flex: `${LABEL_FLEX}` } }}
+                  labelProps={{ sx: { flex: LABEL_FLEX } }}
                   label={t('label.clinician')}
                   Input={
                     <ClinicianSearchInput
@@ -307,7 +307,7 @@ export const CreateEncounterModal: FC = () => {
                   }
                 />
                 <InputWithLabelRow
-                  labelProps={{ sx: { flex: `${LABEL_FLEX}` } }}
+                  labelProps={{ sx: { flex: LABEL_FLEX } }}
                   label={t('label.visit-notes')}
                   Input={
                     <TextArea

--- a/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
@@ -37,6 +37,8 @@ import { PatientTabValue } from '../PatientView/PatientView';
 import { PickersDay, PickersDayProps } from '@mui/x-date-pickers';
 import Badge from '@mui/material/Badge';
 
+const LABEL_FLEX = '0 0 100px';
+
 type HighlightedDay = { datetime: Date; label?: string | null };
 type BadgePickersDayProps = {
   highlightedDays: HighlightedDay[];
@@ -253,14 +255,15 @@ export const CreateEncounterModal: FC = () => {
       width={700}
     >
       <React.Suspense fallback={<div />}>
-        <Stack alignItems="flex-start" gap={1} sx={{ paddingLeft: '20px' }}>
+        <Stack gap={1} sx={{ padding: '20px' }}>
           <InputWithLabelRow
+            labelProps={{ sx: { flex: `${LABEL_FLEX}` } }}
             label={t('label.encounter')}
             Input={
               <EncounterSearchInput
+                fullWidth
                 onChange={onChangeEncounter}
                 lastEncounterType={latestEncounter?.type}
-                width={250}
               />
             }
           />
@@ -271,6 +274,7 @@ export const CreateEncounterModal: FC = () => {
             form={
               <>
                 <InputWithLabelRow
+                  labelProps={{ sx: { flex: `${LABEL_FLEX}` } }}
                   label={t('label.visit-date')}
                   Input={
                     <DateTimePickerInput
@@ -280,7 +284,6 @@ export const CreateEncounterModal: FC = () => {
                         setStartDateTimeError(validationError as string)
                       }
                       error={startDateTimeError}
-                      width={250}
                       slots={{
                         day: BadgePickersDay as React.FC<PickersDayProps<Date>>,
                       }}
@@ -293,16 +296,18 @@ export const CreateEncounterModal: FC = () => {
                   }
                 />
                 <InputWithLabelRow
+                  labelProps={{ sx: { flex: `${LABEL_FLEX}` } }}
                   label={t('label.clinician')}
                   Input={
                     <ClinicianSearchInput
+                      fullWidth
                       onChange={setClinician}
                       clinicianValue={draft?.clinician}
-                      width={250}
                     />
                   }
                 />
                 <InputWithLabelRow
+                  labelProps={{ sx: { flex: `${LABEL_FLEX}` } }}
                   label={t('label.visit-notes')}
                   Input={
                     <TextArea
@@ -311,6 +316,7 @@ export const CreateEncounterModal: FC = () => {
                           backgroundColor: 'background.drawer',
                         },
                       }}
+                      fullWidth
                       value={draft?.notes?.[0]?.text ?? ''}
                       onChange={e => {
                         setNote([

--- a/client/packages/system/src/Patient/Encounter/EncounterSearchInput.tsx
+++ b/client/packages/system/src/Patient/Encounter/EncounterSearchInput.tsx
@@ -18,6 +18,7 @@ interface EncounterSearchInputProps {
   width?: number;
   lastEncounterType: string | undefined;
   disabled?: boolean;
+  fullWidth?: boolean;
 }
 
 export const getEncounterOptionRenderer =
@@ -38,6 +39,7 @@ export const EncounterSearchInput: FC<EncounterSearchInputProps> = ({
   onChange,
   width = 250,
   disabled = false,
+  fullWidth,
   lastEncounterType: encounterType,
 }) => {
   const patientId = usePatient.utils.id();
@@ -82,6 +84,7 @@ export const EncounterSearchInput: FC<EncounterSearchInputProps> = ({
       options={encounterData ?? []}
       renderOption={EncounterOptionRenderer}
       width={`${width}px`}
+      fullWidth={fullWidth}
       popperMinWidth={width}
       isOptionEqualToValue={(option, value) =>
         option.encounter.id === value.encounter.id


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4967 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Improved the appearance of the new Encounter window
- Align the beginning of input fields
- Expand text input fields to take up the width of the space

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

![Screenshot 2024-11-20 at 5 04 02 PM](https://github.com/user-attachments/assets/4a4494c2-409c-4bfe-bc88-29472cd725c2)


![Screenshot 2024-11-20 at 5 01 29 PM](https://github.com/user-attachments/assets/7dcd64ef-f6f3-42b1-8c2b-8ad5f4f13d9e)

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

Visit Date is not an expandable field, it also can't go at the top (Encounter type needs to be the first entry). Open to suggestions on further improvements

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

I have not addressed validation appearance in this PR. To be done in  #4299 Standardise the appearance of required fields across omSupply


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Dispensary -> Patients
- [ ] Create a new patient or click on an existing one with a Programme Enrollment
- [ ] Click Encounters -> Add Encounter
- [ ] See the entry form

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
