### PR TITLE
Add min/max to temperature dropdown

### DIFF
--- a/client/packages/system/src/Item/Components/ColdStorageTypeInput/ColdStorageTypeInput.tsx
+++ b/client/packages/system/src/Item/Components/ColdStorageTypeInput/ColdStorageTypeInput.tsx
@@ -17,6 +17,9 @@ export interface ColdStorageTypeInputProps {
   clearable?: boolean;
 }
 
+const getOptionLabel = (coldStorageType: ColdStorageTypeFragment) =>
+  `${coldStorageType.name} (${coldStorageType.minTemperature}°C - ${coldStorageType.maxTemperature}°C)`;
+
 export const ColdStorageTypeInput = ({
   onChange,
   width = 250,
@@ -37,7 +40,7 @@ export const ColdStorageTypeInput = ({
         onChange(name);
       }}
       options={data?.coldStorageTypes.nodes ?? []}
-      getOptionLabel={option => option.name}
+      getOptionLabel={getOptionLabel}
       width={`${width}px`}
       popperMinWidth={width}
       isOptionEqualToValue={(option, value) => option?.id === value?.id}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5410

## 👩🏻‍💻 What does this PR do?
Added option label to the Cold Storage component, to include min/max temperatures.
Aligned this to match the display in List View

Needed as when making a selection user could only see the name of the cold store, not the temperature range

Screenshot 2024-11-21 at 12 10 08 PM

## 💌 Any notes for the reviewer?
This component is also used in the Item Variant Modal. My current setup doesn't allow viewing this in localhost, so please view this too

I noticed the label 'Temperature' only appears when the dropdown is selected or has a value. Had a look at fixing it, found an easy fix but would change the design. New design would be in line with other modals

Options:

Update to bigger labels on this PR
Update to bigger labels on a new issue
Look for a way to fix the existing tiny label
New Temperature label example - would update for name and code as well:
Screenshot 2024-11-21 at 12 20 01 PM

## 🧪 Testing
- [ ] Go to Inventory -> Locations
- [ ] Choose an existing Location or create a new one
- [ ] Click on the temperature field dropdown and see names appear with the temperature ranges
- [ ] Repeat for Catalogue -> Items -> Detail -> Variants

## 📃 Documentation
- [ ] Part of an epic: documentation will be completed for the feature as a whole
- [ ] No documentation required: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] These areas should be updated or checked:
1.
5.


