### PR TITLE
Windows panic

### DIFF
--- a/server/windows/src/windows.rs
+++ b/server/windows/src/windows.rs
@@ -65,7 +65,10 @@ mod omsupply_service {
             }
         };
         logging_init(settings.logging.clone(), None);
-        log_panics::init();
+
+        log_panics::Config::new()
+            .backtrace_mode(log_panics::BacktraceMode::Off)
+            .install_panic_hook();
 
         if let Err(_e) = run_service(settings) {
             error!("Unable to start service");

--- a/server/windows/src/windows.rs
+++ b/server/windows/src/windows.rs
@@ -68,10 +68,6 @@ mod omsupply_service {
         logging_init(settings.logging.clone(), None);
         log_panics::init();
 
-        panic::set_hook(Box::new(|panic_info| {
-            error!("panic occurred {:?}", panic_info);
-        }));
-
         if let Err(_e) = run_service(settings) {
             error!("Unable to start service");
         }

--- a/server/windows/src/windows.rs
+++ b/server/windows/src/windows.rs
@@ -20,7 +20,6 @@ mod omsupply_service {
     use std::{
         env::{current_exe, set_current_dir},
         ffi::OsString,
-        panic,
         time::Duration,
     };
     use tokio::sync::mpsc;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5069
A manual rebase from #5490 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
Removed the extraneous hook and tested on the mac mini.

before:
```
2024-11-20 15:54:40.721921100 [ERROR] <windows\src/windows.rs:72>:panic occurred PanicHookInfo { payload: Any { .. }, location: Location { file: "C:\\Users\\Administrator\\AppData\\Local\\Jenkins\\.jenkins\\workspace\\omSupplyMain\\server\\server\\src/lib.rs", line: 89, col: 10 }, can_unwind: true, force_no_backtrace: false }
2024-11-20 15:54:40.723844500 [ERROR] <windows\src/windows.rs:72>:panic occurred PanicHookInfo { payload: Any { .. }, location: Location { file: "library\\core\\src\\panicking.rs", line: 221, col: 5 }, can_unwind: false, force_no_backtrace: false }
```

after:
```
2024-11-20 22:12:24.065151100 [ERROR] <log_panics:130>:thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Failed to run DB migrations

Caused by:
    Problem dropping or re-creating views': C:\Users\Administrator\AppData\Local\Jenkins\.jenkins\workspace\omSupplyMain\server\server\src/lib.rs:90
2024-11-20 22:12:24.067516000 [ERROR] <log_panics:130>:thread '<unnamed>' panicked at 'panic in a function that cannot unwind': library\core\src\panicking.rs:221
```

as an alternative - if `log_panics::init();` is called then the default of `BacktraceMode::Unresolved` is used which gives an unhelpful backtrace. I didn't test with resolved, I think the `Off` version works nicely enough.

```
2024-11-20 17:18:28.721192800 [ERROR] <log_panics:130>:thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Failed to run DB migrations

Caused by:
    Problem dropping or re-creating views': C:\Users\Administrator\AppData\Local\Jenkins\.jenkins\workspace\omSupplyMain\server\server\src/lib.rs:90
   0: <unknown>
   1: <unknown>
   2: <unknown>
   3: <unknown>
   4: <unknown>
   5: <unknown>
   6: <unknown>
   7: <unknown>
   8: _jit_debug_register_code
   9: _jit_debug_register_code
  10: <unknown>
  11: <unknown>
  12: <unknown>
  13: <unknown>
  14: <unknown>
  15: <unknown>
  16: QueryServiceConfig2W
  17: BaseThreadInitThunk
  18: RtlUserThreadStart

2024-11-20 17:18:28.723253600 [ERROR] <log_panics:130>:thread '<unnamed>' panicked at 'panic in a function that cannot unwind': library\core\src\panicking.rs:221
   0: <unknown>
   1: <unknown>
   2: <unknown>
   3: <unknown>
   4: <unknown>
   5: <unknown>
   6: <unknown>
   7: <unknown>
   8: _jit_debug_register_code
   9: _jit_debug_register_code
  10: _jit_debug_register_code
  11: <unknown>
  12: <unknown>
  13: is_exception_typeof
  14: RtlCaptureContext2
  15: <unknown>
  16: QueryServiceConfig2W
  17: BaseThreadInitThunk
  18: RtlUserThreadStart
```


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->
This is what I've done:
- [ ] Installed an earlier version 
- [ ] manually run a database migration for a later version
- [ ] upgraded and waited for the panic

I used the mac mini - and so have a SQLite database on that machine which will fail to migrate.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
