### PR TITLE
update temperature spacer from '-' to 'to'

### DIFF
--- a/client/packages/system/src/Item/Components/ColdStorageTypeInput/ColdStorageTypeInput.tsx
+++ b/client/packages/system/src/Item/Components/ColdStorageTypeInput/ColdStorageTypeInput.tsx
@@ -18,7 +18,7 @@ export interface ColdStorageTypeInputProps {
 }
 
 const getOptionLabel = (coldStorageType: ColdStorageTypeFragment) =>
-  `${coldStorageType.name} (${coldStorageType.minTemperature}°C - ${coldStorageType.maxTemperature}°C)`;
+  `${coldStorageType.name} (${coldStorageType.minTemperature}°C to ${coldStorageType.maxTemperature}°C)`;
 
 export const ColdStorageTypeInput = ({
   onChange,

--- a/client/packages/system/src/Location/ListView/ListView.tsx
+++ b/client/packages/system/src/Location/ListView/ListView.tsx
@@ -45,7 +45,7 @@ const LocationListComponent: FC = () => {
         label: 'label.storage-type',
         accessor: ({ rowData: { coldStorageType } }) =>
           coldStorageType
-            ? `${coldStorageType.name} (${coldStorageType.minTemperature}°C - ${coldStorageType.maxTemperature}°C)`
+            ? `${coldStorageType.name} (${coldStorageType.minTemperature}°C to ${coldStorageType.maxTemperature}°C)`
             : null,
         width: 200,
         sortable: false,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5408 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
Change the separator between Min and Max temperature to the word 'to' instead of '-'
'-' is the same symbol used for negative values, so using 'to' as the separator increases readability

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

Change in locations list view:
![Screenshot 2024-11-21 at 5 27 17 PM](https://github.com/user-attachments/assets/539ab65a-ef99-488f-b6eb-c8b5dd7fd418)

Change in locations edit/add view:
![Screenshot 2024-11-21 at 5 27 32 PM](https://github.com/user-attachments/assets/0f43ecde-5541-416d-96f8-bd17b5c8d59e)

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Inventory -> Locations
- [ ] Ensure you have the needed setup for GAPS testing from V2.4.0 Features Demo
- [ ] Ensure you have a temperate range with both negative values for testing
- [ ] Assign a temperature to a location
- [ ] If negative temperature is chosen, it is clear that it is a range of negative temperatures

# 📃 Documentation

- [] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Screenshots updated for UI
  2.
