### PR TITLE
5409 hide temperature ranges if unspecified

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -976,6 +976,7 @@
   "label.stocktake-date": "Stocktake Date",
   "label.stocktake-frequency": "Stocktake frequency",
   "label.storage-type": "Storage type",
+  "label.cold-storage-type": "Cold storage type",
   "label.store": "Store",
   "label.strength": "Strength",
   "label.sub-catalogue": "Sub catalogue",

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantModal.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantModal.tsx
@@ -121,7 +121,7 @@ const ItemVariantForm = ({
         />
 
         <InputWithLabelRow
-          label={t('label.temperature')}
+          label={t('label.cold-storage-type')}
           labelWidth="200"
           Input={
             <Box width="100%">

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantsTab.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantsTab.tsx
@@ -114,7 +114,7 @@ const ItemVariant = ({
           />
 
           <InputWithLabelRow
-            label={t('label.temperature')}
+            label={t('label.cold-storage-type')}
             labelWidth="200"
             Input={
               <BasicTextInput

--- a/client/packages/system/src/Location/ListView/ListView.tsx
+++ b/client/packages/system/src/Location/ListView/ListView.tsx
@@ -42,7 +42,7 @@ const LocationListComponent: FC = () => {
       'name',
       {
         key: 'coldStorageType',
-        label: 'label.storage-type',
+        label: 'label.cold-storage-type',
         accessor: ({ rowData: { coldStorageType } }) =>
           coldStorageType
             ? `${coldStorageType.name} (${coldStorageType.minTemperature}°C to ${coldStorageType.maxTemperature}°C)`

--- a/client/packages/system/src/Location/ListView/LocationEditModal/LocationEditModal.tsx
+++ b/client/packages/system/src/Location/ListView/LocationEditModal/LocationEditModal.tsx
@@ -142,7 +142,7 @@ export const LocationEditModal: FC<LocationEditModalProps> = ({
           />
           <ColdStorageTypeInput
             value={draft.coldStorageType ?? null}
-            label={t('label.temperature')}
+            label={t('label.cold-storage-type')}
             onChange={coldStorageType => onUpdate({ coldStorageType })}
           />
           <Grid alignSelf="center">

--- a/server/repository/src/db_diesel/cold_storage_type.rs
+++ b/server/repository/src/db_diesel/cold_storage_type.rs
@@ -1,5 +1,7 @@
 use super::{
-    cold_storage_type_row::{cold_storage_type, cold_storage_type::dsl as cold_storage_type_dsl},
+    cold_storage_type_row::cold_storage_type::{
+        self, dsl as cold_storage_type_dsl, max_temperature,
+    },
     ColdStorageTypeRow, DBType, StorageConnection,
 };
 
@@ -74,6 +76,12 @@ impl<'a> ColdStorageTypeRepository<'a> {
             query = query.order(cold_storage_type_dsl::name.desc())
         }
 
+        // Debug diesel query
+        // println!(
+        //     "{}",
+        //     diesel::debug_query::<crate::DBType, _>(&query).to_string()
+        // );
+
         let result = query
             .offset(pagination.offset as i64)
             .limit(pagination.limit as i64)
@@ -86,6 +94,13 @@ impl<'a> ColdStorageTypeRepository<'a> {
         filter: Option<ColdStorageTypeFilter>,
     ) -> BoxedColdStorageTypeQuery {
         let mut query = cold_storage_type_dsl::cold_storage_type.into_boxed();
+        // Any cold storage types that don't have temperature set (OdegC to 0degC default value) are invalid => filter out
+
+        query = query.filter(
+            cold_storage_type_dsl::min_temperature
+                .ne(0.0)
+                .and(max_temperature.ne(0.0)),
+        );
 
         if let Some(f) = filter {
             let ColdStorageTypeFilter { id, name } = f;


### PR DESCRIPTION
Fixes #5409

# 👩🏻‍💻 What does this PR do?

Changes the rust query to filter out all cold storage types with a min tempereature = 0 and a max temperature = 0, so that they are not displayed on the front end.
Changes the label of...
- the 'storage type' column in inventory>locations,

<img width="676" alt="image" src="https://github.com/user-attachments/assets/d9f2b013-6bc7-45d8-8416-00d531b38139">

- the 'temperature' selector dropdown in the inventory>locations>add location menu

<img width="501" alt="image" src="https://github.com/user-attachments/assets/4544e6a4-a468-4de6-a057-80795b84b10b">

- the 'temperature' in catalogue>detail view>item variants

<img width="791" alt="image" src="https://github.com/user-attachments/assets/6e0b539d-6e8e-46e5-b742-51062b136c64">

- the 'temperature in catalogue>detail view> item variant>add variant menu

<img width="501" alt="image" src="https://github.com/user-attachments/assets/96d0a039-5430-44f4-b1dd-c2a8b715e1d9">

...to 'cold storage type' to avoid confusion.

This required a new 'label.cold-storage-type', which requires translation.

## 💌 Any notes for the reviewer?

Have a nice day :)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->
 

- [ ] In OG mSupply, create a Location Type with both 0 as values.
- [ ] Sync omSupply.
- [ ] Go to Inventory -> Locations -> click on an existing location or create a new one.
- [ ] Once done, click on it and set the test temperature range.
- [ ] See that ranges that are 0degC to 0degC don't appear.
- [ ] Navigate to the locations mentioned above and see that the labels make sense and fit well.

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour