### PR TITLE
Add check for if extra fields in requisition showing

### DIFF
--- a/server/service/src/requisition/response_requisition/update.rs
+++ b/server/service/src/requisition/response_requisition/update.rs
@@ -5,6 +5,7 @@ use crate::{
         query::get_requisition,
     },
     service_provider::ServiceContext,
+    store_preference::get_store_preferences,
 };
 use chrono::Utc;
 use repository::{
@@ -103,7 +104,9 @@ pub fn validate(
         RequisitionLineFilter::new().requisition_id(EqualFilter::equal_to(&requisition_row.id)),
     )?;
 
-    if requisition_row.program_id.is_some() {
+    if requisition_row.program_id.is_some()
+        && get_store_preferences(connection, &store_id)?.extra_fields_in_requisition
+    {
         let mut lines_missing_reason = Vec::new();
 
         for line in response_lines {

--- a/server/service/src/requisition/response_requisition/update.rs
+++ b/server/service/src/requisition/response_requisition/update.rs
@@ -113,6 +113,7 @@ pub fn validate(
     )?;
 
     let prefs = get_store_preferences(connection, &store_id)?;
+
     if requisition_row.program_id.is_some()
         && prefs.extra_fields_in_requisition
         && reason_options.len() > 0

--- a/server/service/src/requisition/response_requisition/update.rs
+++ b/server/service/src/requisition/response_requisition/update.rs
@@ -9,9 +9,11 @@ use crate::{
 };
 use chrono::Utc;
 use repository::{
+    reason_option_row::ReasonOptionType,
     requisition_row::{RequisitionRow, RequisitionStatus, RequisitionType},
-    ActivityLogType, EqualFilter, RepositoryError, Requisition, RequisitionLine,
-    RequisitionLineFilter, RequisitionLineRepository, RequisitionRowRepository, StorageConnection,
+    ActivityLogType, EqualFilter, ReasonOptionFilter, ReasonOptionRepository, RepositoryError,
+    Requisition, RequisitionLine, RequisitionLineFilter, RequisitionLineRepository,
+    RequisitionRowRepository, StorageConnection,
 };
 use util::inline_edit;
 
@@ -104,8 +106,16 @@ pub fn validate(
         RequisitionLineFilter::new().requisition_id(EqualFilter::equal_to(&requisition_row.id)),
     )?;
 
+    let reason_options = ReasonOptionRepository::new(connection).query_by_filter(
+        ReasonOptionFilter::new().r#type(ReasonOptionType::equal_to(
+            &ReasonOptionType::RequisitionLineVariance,
+        )),
+    )?;
+
+    let prefs = get_store_preferences(connection, &store_id)?;
     if requisition_row.program_id.is_some()
-        && get_store_preferences(connection, &store_id)?.extra_fields_in_requisition
+        && prefs.extra_fields_in_requisition
+        && reason_options.len() > 0
     {
         let mut lines_missing_reason = Vec::new();
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5538

# 👩🏻‍💻 What does this PR do?

Adds not checking for requested == suggested when extra fields aren't set up in store preferences.


<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Set show extra response requisition fields to false
- [ ] create a response requisition
- [ ] set requested != suggested on a line
- [ ] confirm finalised
- [ ] See that status change works
- [ ] Set show extra response requisition fields to true
- [ ] Create a new response requisition
- [ ] Set requested != suggested
- [ ] Confirm finalised should fail


# 📃 Documentation

- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour

