### PR TITLE
Add UTC to date columns in export file

### DIFF
--- a/client/packages/coldchain/src/Equipment/utils.ts
+++ b/client/packages/coldchain/src/Equipment/utils.ts
@@ -26,8 +26,8 @@ export const assetsToCsv = (
   const fields: string[] = ['id'].concat(baseAssetFields(t));
 
   fields.push(
-    `${t('label.created-datetime') + ' ' + '(UTC)'}`,
-    `${t('label.modified-datetime') + ' ' + '(UTC)'}`
+    `${t('label.created-datetime')} (UTC)`,
+    `${t('label.modified-datetime')} (UTC)`
   );
 
   fields.push(...properties);

--- a/client/packages/coldchain/src/Equipment/utils.ts
+++ b/client/packages/coldchain/src/Equipment/utils.ts
@@ -25,7 +25,10 @@ export const assetsToCsv = (
 ) => {
   const fields: string[] = ['id'].concat(baseAssetFields(t));
 
-  fields.push(t('label.created-datetime'), t('label.modified-datetime'));
+  fields.push(
+    `${t('label.created-datetime') + ' ' + '(UTC)'}`,
+    `${t('label.modified-datetime') + ' ' + '(UTC)'}`
+  );
 
   fields.push(...properties);
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5479 

# 👩🏻‍💻 What does this PR do?
Add UTC as a suffix to ```created date / time``` and ```modified date / time``` headers in the export csv 
<!-- Explain the changes you made -->
Add UTC as string inside a template literal so that it can work alongside existing translation

<!-- why are the changes needed -->
Changes needed as time displayed in the equipment log is different to what is displayed in the export file. Clearer label will explicitly state difference is because time is in UTC
<!-- Add a screenshot if there are UI changes  -->
<img width="526" alt="Screenshot 2024-11-25 at 2 40 07 PM" src="https://github.com/user-attachments/assets/eaafa352-1cd3-429a-b70d-741c9262d3fb">
## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to cold chain -> equipment
- [ ] Create a new asset - when clicking on it, note under Log created date and time
- [ ] Go back to the equipment list and export the equipment
- [ ] Find your newly created asset in the spreadsheet and note the created date/time
- [ ] It will  now indicate that the dates are in UTC

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
