### PR TITLE
Update new stock item pack size to use item default

### DIFF
--- a/client/packages/system/src/Stock/Components/NewStockLineModal.tsx
+++ b/client/packages/system/src/Stock/Components/NewStockLineModal.tsx
@@ -94,7 +94,12 @@ export const NewStockLineModal: FC<NewStockLineModalProps> = ({
               disabled={!!draft.itemId}
               currentItemId={draft.itemId}
               onChange={newItem =>
-                newItem && updatePatch({ itemId: newItem.id, item: newItem })
+                newItem &&
+                updatePatch({
+                  itemId: newItem.id,
+                  item: newItem,
+                  packSize: newItem.defaultPackSize,
+                })
               }
             />
           </Grid>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5253

# 👩🏻‍💻 What does this PR do?
When creating a new stock line, update new item pack size to use item's pre-defined default pack size number

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
![image](https://github.com/user-attachments/assets/9b9b3613-7780-406c-91a9-9ea310956666)


## 💌 Any notes for the reviewer?
Thanks Laché!

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to Inventory --> View Stock
- [ ] Create new stock item
- [ ] Select item 
- [ ] Pack size is now item default pack size

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
