### PR TITLE
Bugfixes for asset locations

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/DetailView.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/DetailView.tsx
@@ -106,6 +106,8 @@ export const EquipmentDetailView = () => {
       value: location.id,
     })) || [];
 
+  // Any locations that are already assigned to the asset won't be returned by the query above
+  // So we add them in manually here...
   if (data && data?.locations.nodes.length) {
     const assignedLocations = data.locations.nodes.map(location => ({
       label: formatLocationLabel(location),

--- a/client/packages/coldchain/src/Equipment/DetailView/DetailView.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/DetailView.tsx
@@ -100,11 +100,19 @@ export const EquipmentDetailView = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data, setDraft]);
 
-  const locations =
+  let locations =
     locationData?.nodes.map(location => ({
       label: formatLocationLabel(location),
       value: location.id,
     })) || [];
+
+  if (data && data?.locations.nodes.length) {
+    const assignedLocations = data.locations.nodes.map(location => ({
+      label: formatLocationLabel(location),
+      value: location.id,
+    }));
+    locations.push(...assignedLocations);
+  }
 
   if (isLoading || isLoadingLocations) return <DetailFormSkeleton />;
 

--- a/client/packages/coldchain/src/Equipment/api/hooks/document/useAssetUpdate.ts
+++ b/client/packages/coldchain/src/Equipment/api/hooks/document/useAssetUpdate.ts
@@ -1,13 +1,18 @@
 import { useMutation, useQueryClient } from '@openmsupply-client/common';
 import { useAssetApi } from '../utils/useAssetApi';
 import { DraftAsset } from '../../../types';
+import { useLocationApi } from '@openmsupply-client/system/src/Location/api/hooks/utils/useLocationApi';
 
 export const useAssetUpdate = () => {
   const queryClient = useQueryClient();
   const api = useAssetApi();
+  const locationApi = useLocationApi();
 
   return useMutation(async (asset: Partial<DraftAsset>) => api.update(asset), {
-    onSuccess: id => queryClient.invalidateQueries(api.keys.detail(id)),
+    onSuccess: id => {
+      queryClient.invalidateQueries(locationApi.keys.list());
+      queryClient.invalidateQueries(api.keys.detail(id));
+    },
     onError: e => {
       console.error(e);
     },


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5415

# 👩🏻‍💻 What does this PR do?

Fixes issue with locations not being available to select when deleting and re-adding locations from assets.

2 problems
First, that after saving an asset, we didn't invalidate the location query and there for didn't see the locations as unassigned.
Second, if deleting a location, if before saving you wanted to add that back in you couldn't.

## 💌 Any notes for the reviewer?

Pre-exising locations show up at the end of the list.
It might be nice if they were at the top, or we sorted them or something.
Doesn't feel important enough to spend time on to me...

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

See video in the issue to see how to re-create the issues.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
