### PR TITLE
add temperature range to item variants detail

### DIFF
--- a/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantsTab.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantsTab.tsx
@@ -76,6 +76,10 @@ const ItemVariant = ({
   const t = useTranslation();
   const confirmAndDelete = useDeleteItemVariant({ itemId });
 
+  const coldStorageValue = variant.coldStorageType
+    ? `${variant.coldStorageType.name} (${variant.coldStorageType.minTemperature}°C to ${variant.coldStorageType.maxTemperature}°C)`
+    : null;
+
   return (
     <Box maxWidth="1000px" margin="25px auto" paddingBottom={6}>
       <Box display="flex" justifyContent="space-between" alignItems="end">
@@ -116,11 +120,7 @@ const ItemVariant = ({
             label={t('label.cold-storage-type')}
             labelWidth="200"
             Input={
-              <BasicTextInput
-                value={variant.coldStorageType?.name ?? ''}
-                disabled
-                fullWidth
-              />
+              <BasicTextInput value={coldStorageValue} disabled fullWidth />
             }
           />
           <InputWithLabelRow


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5410

# 👩🏻‍💻 What does this PR do?

Allows the user to view the temperature range along with the cold storage type in an item variant in detail view

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

![Screenshot 2024-11-26 at 3 27 14 PM](https://github.com/user-attachments/assets/f71c7a4f-5b52-4d17-80eb-618f9bbc2bfb)

## 💌 Any notes for the reviewer?

Is it worth setting a centralised definition for the temperature range display value? (Option renderer?)
It's used in three places, so would need to find and update them all separately if they need changing



# 🧪 Testing

- [ ] Go to Catalogue -> Items -> Select an item -> Variants tab -> Add Variant
- [ ] Create a new variant with a cold storage type selection
- [ ] Click OK
- [ ] See temperature range visible in the detail view


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
