### PR TITLE
Basic spinner if current item isn't populated yet

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditPage.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditPage.tsx
@@ -60,7 +60,7 @@ export const ResponseLineEditPage = () => {
   }, [currentItem]);
 
   if (isLoading || !currentItem) return <BasicSpinner />;
-  if (!data || !itemId) return <NothingHere />;
+  if (!data) return <NothingHere />;
 
   return (
     <>

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditPage.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditPage.tsx
@@ -37,19 +37,18 @@ const ResponseLineEditFormLayout = ({
 };
 
 export const ResponseLineEditPage = () => {
+  const { itemId } = useParams();
+  const { setCustomBreadcrumbs } = useBreadcrumbs();
   const { data, isLoading } = useResponse.document.get();
   const lines =
     data?.lines.nodes.sort((a, b) => a.item.name.localeCompare(b.item.name)) ??
     [];
-  const { itemId } = useParams();
   const currentItem = lines.find(l => l.item.id === itemId)?.item;
-  const { setCustomBreadcrumbs } = useBreadcrumbs();
   const { draft, update, save } = useDraftRequisitionLine(currentItem);
   const { hasNext, next, hasPrevious, previous } = usePreviousNextResponseLine(
     lines,
     currentItem
   );
-
   const enteredLineIds = lines
     .filter(line => line.supplyQuantity !== 0)
     .map(line => line.item.id);
@@ -60,8 +59,8 @@ export const ResponseLineEditPage = () => {
     });
   }, [currentItem]);
 
-  if (isLoading) return <BasicSpinner />;
-  if (!data || !currentItem) return <NothingHere />;
+  if (isLoading || !currentItem) return <BasicSpinner />;
+  if (!data || !itemId) return <NothingHere />;
 
   return (
     <>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5562

# 👩🏻‍💻 What does this PR do?
Show spinner if current item isn't populated and NothingHere if the itemId isn't in the URL

https://github.com/user-attachments/assets/c2d338ed-39df-4a02-955f-3bbd5c5a59e9

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Throttle network
- [ ] Have an existing manual Requisition
- [ ] Go to that Requisition and add an item
- [ ] Edit page should load instead of showing nothing here

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
