### PR TITLE
Fix item_variant selection on customer return

### DIFF
--- a/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnQuantitiesTable.tsx
@@ -14,7 +14,7 @@ import {
   ItemVariantInputCell,
   useIsItemVariantsEnabled,
 } from '@openmsupply-client/system';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { GenerateCustomerReturnLineFragment } from '../../api';
 import { PackSizeEntryCell } from '@openmsupply-client/system';
 
@@ -31,82 +31,85 @@ export const QuantityReturnedTableComponent = ({
 }) => {
   const showItemVariantsColumn = useIsItemVariantsEnabled();
 
-  const columnDefinitions: ColumnDescription<GenerateCustomerReturnLineFragment>[] =
-    ['itemCode', 'itemName'];
-
-  columnDefinitions.push([
-    'batch',
-    {
-      width: 125,
-      accessor: ({ rowData }) => rowData.batch ?? '',
-      setter: updateLine,
-      Cell: props => (
-        <TextInputCell {...props} isRequired autocompleteName="batch" />
-      ),
-      getIsDisabled: () => isDisabled,
-    },
-  ]);
-
-  if (showItemVariantsColumn)
-    columnDefinitions.push({
-      key: 'itemVariantId',
-      label: 'label.item-variant',
-      width: 170,
-      setter: updateLine,
-      Cell: props => (
-        <ItemVariantInputCell {...props} itemId={props.rowData.item.id} />
-      ),
-      getIsDisabled: () => isDisabled,
-    });
-
-  columnDefinitions.push(
-    [
-      expiryInputColumn,
-      {
-        width: 150,
-        getIsDisabled: () => isDisabled,
-        setter: l =>
-          updateLine({
-            ...l,
-            expiryDate: l.expiryDate
-              ? Formatter.naiveDate(new Date(l.expiryDate))
-              : null,
-          }),
-      },
-    ],
-    getColumnLookupWithOverrides('packSize', {
-      Cell: PackUnitEntryCell,
-      setter: updateLine,
-      getIsDisabled: () => isDisabled,
-      label: 'label.pack-size',
-    })
-  );
-
-  if (lines.some(l => l.numberOfPacksIssued !== null)) {
-    // if any line has a value, show the column
+  const columnDefinitions = useMemo(() => {
+    const columnDefinitions: ColumnDescription<GenerateCustomerReturnLineFragment>[] =
+      ['itemCode', 'itemName'];
 
     columnDefinitions.push([
-      'numberOfPacks',
+      'batch',
       {
-        label: 'label.pack-quantity-issued',
-        width: 110,
-        accessor: ({ rowData }) => rowData.numberOfPacksIssued ?? '--',
-        Cell: BasicCell,
+        width: 125,
+        accessor: ({ rowData }) => rowData.batch ?? '',
+        setter: updateLine,
+        Cell: props => (
+          <TextInputCell {...props} isRequired autocompleteName="batch" />
+        ),
         getIsDisabled: () => isDisabled,
       },
     ]);
-  }
 
-  columnDefinitions.push([
-    'numberOfPacksReturned',
-    {
-      description: 'description.pack-quantity',
-      width: 100,
-      setter: updateLine,
-      getIsDisabled: () => isDisabled,
-      Cell: NumberOfPacksReturnedInputCell,
-    },
-  ]);
+    if (showItemVariantsColumn)
+      columnDefinitions.push({
+        key: 'itemVariantId',
+        label: 'label.item-variant',
+        width: 170,
+        setter: updateLine,
+        Cell: props => (
+          <ItemVariantInputCell {...props} itemId={props.rowData.item.id} />
+        ),
+        getIsDisabled: () => isDisabled,
+      });
+
+    columnDefinitions.push(
+      [
+        expiryInputColumn,
+        {
+          width: 150,
+          getIsDisabled: () => isDisabled,
+          setter: l =>
+            updateLine({
+              ...l,
+              expiryDate: l.expiryDate
+                ? Formatter.naiveDate(new Date(l.expiryDate))
+                : null,
+            }),
+        },
+      ],
+      getColumnLookupWithOverrides('packSize', {
+        Cell: PackUnitEntryCell,
+        setter: updateLine,
+        getIsDisabled: () => isDisabled,
+        label: 'label.pack-size',
+      })
+    );
+
+    if (lines.some(l => l.numberOfPacksIssued !== null)) {
+      // if any line has a value, show the column
+
+      columnDefinitions.push([
+        'numberOfPacks',
+        {
+          label: 'label.pack-quantity-issued',
+          width: 110,
+          accessor: ({ rowData }) => rowData.numberOfPacksIssued ?? '--',
+          Cell: BasicCell,
+          getIsDisabled: () => isDisabled,
+        },
+      ]);
+    }
+
+    columnDefinitions.push([
+      'numberOfPacksReturned',
+      {
+        description: 'description.pack-quantity',
+        width: 100,
+        setter: updateLine,
+        getIsDisabled: () => isDisabled,
+        Cell: NumberOfPacksReturnedInputCell,
+      },
+    ]);
+    return columnDefinitions;
+  }, [showItemVariantsColumn]);
 
   const columns = useColumns(columnDefinitions, {}, [
     updateLine,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5513

# 👩🏻‍💻 What does this PR do?

Move's batch to be beginning of the modal, this seems to help and is more consistent with other screens, although there's still some issues with tabing when changing item_variants

## 💌 Any notes for the reviewer?
This is a deeply unsatisfying fix, someone better at React should probably help fix the underlying issue.
It seems like the reason this didn't happen on other screens is just luck that there's a default text component first in the modal so the keyboard height doesn't go haywire. Changing the order is good to do anyway, but we could run into this again I think unless we fix the underlying issue.

If you change the item_variant and hit tab, you don't tab to the next field in the table correctly.
I assume the component is being re-created for some reason?
I think it's worth getting this in 2.4 though even if it just changes the order to be consistent

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have item variants setup
- [ ] On android, create a customer return
- [ ] Add an item and try to set the item_variant on that item
- [ ] If you can, success!

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
