### PR TITLE
#5560 JSON Forms Prescription -- category filtering

### DIFF
--- a/client/packages/common/src/hooks/useQueryParams/types.ts
+++ b/client/packages/common/src/hooks/useQueryParams/types.ts
@@ -13,6 +13,10 @@ export type FilterRule = {
 
 export type FilterBy = Record<string, FilterRule | null>;
 export type FilterByWithBoolean = Record<string, FilterRule | null | boolean>;
+export type FilterByWithStringAndBool = Record<
+  string,
+  FilterRule | null | boolean | string
+>;
 
 export interface FilterController {
   filterBy: FilterByWithBoolean | null;

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -3554,6 +3554,7 @@ export type ItemCountsResponse = {
 
 export type ItemFilterInput = {
   categoryId?: InputMaybe<Scalars['String']['input']>;
+  categoryName?: InputMaybe<Scalars['String']['input']>;
   code?: InputMaybe<StringFilterInput>;
   codeOrName?: InputMaybe<StringFilterInput>;
   id?: InputMaybe<EqualFilterStringInput>;

--- a/client/packages/invoices/src/index.ts
+++ b/client/packages/invoices/src/index.ts
@@ -1,5 +1,4 @@
 import { ItemRowFragment } from '@openmsupply-client/system';
-
 export { default as InvoiceService } from './InvoiceService';
 export { useOutbound } from './OutboundShipment/api';
 export { useInbound, InboundFragment } from './InboundShipment/api';

--- a/client/packages/invoices/src/index.ts
+++ b/client/packages/invoices/src/index.ts
@@ -1,4 +1,5 @@
 import { ItemRowFragment } from '@openmsupply-client/system';
+
 export { default as InvoiceService } from './InvoiceService';
 export { useOutbound } from './OutboundShipment/api';
 export { useInbound, InboundFragment } from './InboundShipment/api';

--- a/client/packages/programs/src/JsonForms/components/Prescription/Prescription.tsx
+++ b/client/packages/programs/src/JsonForms/components/Prescription/Prescription.tsx
@@ -28,7 +28,22 @@ import { DraftStockOutLine } from 'packages/invoices/src/types';
 
 export const prescriptionTester = rankWith(10, uiTypeIs('Prescription'));
 
-const Options = z.object({ prescriptionIdPath: z.string() }).strict();
+const Options = z
+  .object({
+    /**
+     * There should only be one prescription for the whole encounter, so where
+     * it's stored in the schema won't be this component's path. Specify the
+     * path in the JSON schema where this value should kept (must be defined in
+     * JSON schema)
+     */
+    prescriptionIdPath: z.string(),
+    /**
+     * Path on the data object to look for an item category name. If not
+     * specified, will display all items, not a particular category
+     */
+    itemCategoryPath: z.string().optional(),
+  })
+  .strict();
 type Options = z.infer<typeof Options>;
 
 const UIComponent = (props: ControlProps) => {
@@ -55,6 +70,13 @@ const UIComponent = (props: ControlProps) => {
   const { mutateAsync: updateLines } = usePrescription.line.save();
 
   const { success } = useNotification();
+
+  const itemCategoryPath = options?.itemCategoryPath;
+  const categoryName: string | undefined = extractProperty(
+    core?.data,
+    itemCategoryPath ?? '',
+    undefined
+  );
 
   // Ensures that when this component is re-mounted (e.g. in a Modal), it will
   // populate the draft line data with previously acquired state
@@ -139,6 +161,7 @@ const UIComponent = (props: ControlProps) => {
           <StockItemSearchInput
             onChange={selected => handleItemSelect(selected)}
             currentItemId={selectedItem?.id}
+            itemCategoryName={categoryName}
           />
           {selectedItem && (
             <StockLineTable

--- a/client/packages/programs/src/JsonForms/components/Prescription/Prescription.tsx
+++ b/client/packages/programs/src/JsonForms/components/Prescription/Prescription.tsx
@@ -71,7 +71,8 @@ const UIComponent = (props: ControlProps) => {
 
   const { success } = useNotification();
 
-  const itemCategoryPath = options?.itemCategoryPath;
+  const itemCategoryPath = uischema.options?.['itemCategoryPath'];
+
   const categoryName: string | undefined = extractProperty(
     core?.data,
     itemCategoryPath ?? '',
@@ -87,6 +88,19 @@ const UIComponent = (props: ControlProps) => {
     if (existing && existing[0]?.item.id === selectedItem?.id)
       setDraftStockOutLines(existing);
   }, []);
+
+  useEffect(() => {
+    // We need the selected item to be reset when the category changes.
+    // Unfortunately, the effect runs on all re-mounts as well, so we need to
+    // capture and compare the category of the previous value to determine if
+    // it's *actually* changed or just remounted
+    const previous = formActions.getState(`${path}_category`);
+    if (previous !== categoryName) {
+      handleItemSelect(null);
+    }
+
+    formActions.setState(`${path}_category`, categoryName);
+  }, [categoryName]);
 
   const handleItemSelect = (selectedItem: ItemStockOnHandFragment | null) => {
     setSelectedItem(selectedItem);

--- a/client/packages/programs/src/JsonForms/components/Prescription/Prescription.tsx
+++ b/client/packages/programs/src/JsonForms/components/Prescription/Prescription.tsx
@@ -104,9 +104,9 @@ const UIComponent = (props: ControlProps) => {
 
   const handleItemSelect = (selectedItem: ItemStockOnHandFragment | null) => {
     setSelectedItem(selectedItem);
+    formActions.setState(`${path}_item`, selectedItem, false);
     if (prescriptionIdPath)
       handleChange(prescriptionIdPath, FnUtils.generateUUID());
-    formActions.setState(`${path}_item`, selectedItem);
   };
 
   const handleStockLineUpdate = (draftLines: DraftStockOutLine[]) => {

--- a/client/packages/programs/src/JsonForms/components/Prescription/Prescription.tsx
+++ b/client/packages/programs/src/JsonForms/components/Prescription/Prescription.tsx
@@ -32,9 +32,9 @@ const Options = z
   .object({
     /**
      * There should only be one prescription for the whole encounter, so where
-     * it's stored in the schema won't be this component's path. Specify the
-     * path in the JSON schema where this value should kept (must be defined in
-     * JSON schema)
+     * it's stored in the schema won't be this component's path. This property
+     * should reflect the path in the JSON schema where this value stored.
+     * (must be defined in JSON schema)
      */
     prescriptionIdPath: z.string(),
     /**

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
@@ -64,7 +64,7 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
   );
 
   const cachedSearchedItems = useMemo(() => {
-    const newItems = data?.nodes ?? [];
+    const newItems = [...items, ...(data?.nodes ?? [])];
     if (!!currentItem) newItems.unshift(currentItem);
 
     return ArrayUtils.uniqBy(newItems, 'id');

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
@@ -29,14 +29,19 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
   autoFocus = false,
   openOnFocus,
   includeNonVisibleWithStockOnHand = false,
+  itemCategoryName,
 }) => {
   const [items, setItems] = useState<ItemStockOnHandFragment[]>([]);
   const { pagination, onPageChange } = usePagination();
   const { filter, onFilter } = useStringFilter('name');
 
+  const fullFilter = itemCategoryName
+    ? { ...filter, categoryName: itemCategoryName }
+    : filter;
+
   const { data, isLoading } = useItemStockOnHand({
     pagination,
-    filter,
+    filter: fullFilter,
     includeNonVisibleWithStockOnHand,
   });
   // changed from useStockLines even though that is more appropriate
@@ -52,7 +57,7 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
   const options = useMemo(
     () =>
       defaultOptionMapper(
-        extraFilter ? items.filter(extraFilter) ?? [] : items ?? [],
+        extraFilter ? (items.filter(extraFilter) ?? []) : (items ?? []),
         'name'
       ).sort((a, b) => a.label.localeCompare(b.label)),
     [items]

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
@@ -64,7 +64,7 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
   );
 
   const cachedSearchedItems = useMemo(() => {
-    const newItems = [...items, ...(data?.nodes ?? [])];
+    const newItems = data?.nodes ?? [];
     if (!!currentItem) newItems.unshift(currentItem);
 
     return ArrayUtils.uniqBy(newItems, 'id');
@@ -83,8 +83,9 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
   );
 
   useEffect(() => {
-    // using the Autocomplete openOnFocus prop, the popper is incorrectly positioned
-    // when used within a Dialog. This is a workaround to fix the popper position.
+    // Using the Autocomplete openOnFocus prop, the popper is incorrectly
+    // positioned when used within a Dialog. This is a workaround to fix the
+    // popper position.
     if (openOnFocus) {
       setTimeout(() => selectControl.toggleOn(), DEBOUNCE_TIMEOUT);
     }

--- a/client/packages/system/src/Item/api/api.ts
+++ b/client/packages/system/src/Item/api/api.ts
@@ -2,7 +2,7 @@ import {
   ItemNodeType,
   SortBy,
   ItemSortFieldInput,
-  FilterByWithBoolean,
+  FilterByWithStringAndBool,
 } from '@openmsupply-client/common';
 import { Sdk, ItemRowFragment } from './operations.generated';
 
@@ -10,7 +10,7 @@ export type ListParams<T> = {
   first: number;
   offset: number;
   sortBy: SortBy<T>;
-  filterBy?: FilterByWithBoolean | null;
+  filterBy?: FilterByWithStringAndBool | null;
   isVisible?: boolean;
 };
 

--- a/client/packages/system/src/Item/api/hooks/useItemStockOnHand/useItemStockOnHand.tsx
+++ b/client/packages/system/src/Item/api/hooks/useItemStockOnHand/useItemStockOnHand.tsx
@@ -3,7 +3,7 @@ import { useItemApi } from '../useItemApi';
 
 type UseItemStockOnHandParams = {
   pagination: { first: number; offset: number };
-  filter: { [key: string]: { like: string } };
+  filter: Record<string, { like: string } | string>;
   preload?: boolean;
   includeNonVisibleWithStockOnHand?: boolean;
 };

--- a/client/packages/system/src/Item/utils.ts
+++ b/client/packages/system/src/Item/utils.ts
@@ -37,6 +37,7 @@ export interface StockItemSearchInputProps
   onChange: (item: ItemStockOnHandFragment | null) => void;
   extraFilter?: (item: ItemStockOnHandFragment) => boolean;
   includeNonVisibleWithStockOnHand?: boolean;
+  itemCategoryName?: string;
 }
 
 export interface StockItemSearchInputWithStatsProps

--- a/server/graphql/general/src/queries/item.rs
+++ b/server/graphql/general/src/queries/item.rs
@@ -46,6 +46,7 @@ pub struct ItemFilterInput {
     pub r#type: Option<EqualFilterItemTypeInput>,
     pub code: Option<StringFilterInput>,
     pub category_id: Option<String>,
+    pub category_name: Option<String>,
     /// Items that are visible in this store OR there is available stock of that item in this store
     pub is_visible_or_on_hand: Option<bool>,
     /// Items that are visible in this store. This filter is void if `is_visible_or_on_hand` is true
@@ -98,6 +99,7 @@ impl ItemFilterInput {
             r#type,
             code,
             category_id,
+            category_name,
             is_visible,
             code_or_name,
             is_active,
@@ -111,6 +113,7 @@ impl ItemFilterInput {
             code: code.map(StringFilter::from),
             r#type: r#type.map(|t| map_filter!(t, ItemNodeType::to_domain)),
             category_id,
+            category_name,
             is_visible,
             code_or_name: code_or_name.map(StringFilter::from),
             is_active,

--- a/server/repository/src/db_diesel/item.rs
+++ b/server/repository/src/db_diesel/item.rs
@@ -191,7 +191,7 @@ impl<'a> ItemRepository<'a> {
         // Debug diesel query
         //
         // println!(
-        //     "{}",
+        //    "{}",
         //     diesel::debug_query::<DBType, _>(&final_query).to_string()
         // );
 

--- a/server/repository/src/db_diesel/item.rs
+++ b/server/repository/src/db_diesel/item.rs
@@ -1,4 +1,5 @@
 use super::{
+    category_row::category::dsl as category_dsl,
     item_category_row::item_category_join,
     item_link_row::item_link::dsl as item_link_dsl,
     item_row::{item, item::dsl as item_dsl},
@@ -18,6 +19,7 @@ use diesel::{
 use util::inline_init;
 
 use crate::{
+    category_row::category,
     diesel_macros::{
         apply_equal_filter, apply_sort, apply_sort_no_case, apply_string_filter,
         apply_string_or_filter,
@@ -47,6 +49,7 @@ pub struct ItemFilter {
     pub code: Option<StringFilter>,
     pub r#type: Option<EqualFilter<ItemType>>,
     pub category_id: Option<String>,
+    pub category_name: Option<String>,
     /// If true it only returns ItemAndMasterList that have a name join row (void if is_visible_or_on_hand is true!)
     pub is_visible: Option<bool>,
     /// If true it returns ItemAndMasterList that have a name join row, or items with stock on hand
@@ -83,6 +86,11 @@ impl ItemFilter {
 
     pub fn category_id(mut self, filter: String) -> Self {
         self.category_id = Some(filter);
+        self
+    }
+
+    pub fn category_name(mut self, filter: String) -> Self {
+        self.category_name = Some(filter);
         self
     }
 
@@ -183,7 +191,7 @@ impl<'a> ItemRepository<'a> {
         // Debug diesel query
         //
         // println!(
-        //    "{}",
+        //     "{}",
         //     diesel::debug_query::<DBType, _>(&final_query).to_string()
         // );
 
@@ -209,6 +217,7 @@ fn create_filtered_query(store_id: String, filter: Option<ItemFilter>) -> BoxedI
             code,
             r#type,
             category_id,
+            category_name,
             is_visible,
             code_or_name,
             is_active,
@@ -245,6 +254,18 @@ fn create_filtered_query(store_id: String, filter: Option<ItemFilter>) -> BoxedI
                 .into_boxed();
 
             query = query.filter(item_dsl::id.eq_any(item_ids_for_category_id));
+        }
+
+        if let Some(category_name) = category_name {
+            let item_ids_for_category_name = item_category_join::table
+                .select(item_category_join::item_id)
+                .inner_join(
+                    category_dsl::category.on(category_dsl::id.eq(item_category_join::category_id)),
+                )
+                .filter(category::name.eq(category_name.clone()))
+                .into_boxed();
+
+            query = query.filter(item_dsl::id.eq_any(item_ids_for_category_name));
         }
 
         let visible_item_ids = item_link_dsl::item_link

--- a/server/repository/src/db_diesel/item_category_row.rs
+++ b/server/repository/src/db_diesel/item_category_row.rs
@@ -1,4 +1,4 @@
-use super::StorageConnection;
+use super::{category_row::category, StorageConnection};
 use crate::{repository_error::RepositoryError, Upsert};
 
 use chrono::NaiveDateTime;
@@ -12,6 +12,9 @@ table! {
         deleted_datetime -> Nullable<Timestamp>,
     }
 }
+
+joinable!(item_category_join -> category (category_id));
+allow_tables_to_appear_in_same_query!(item_category_join, category);
 
 #[derive(Clone, Insertable, Queryable, Debug, PartialEq, AsChangeset, Eq, Default)]
 #[diesel(table_name = item_category_join)]


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5560

@lache-melvin I've made a new branch `5264-json-forms-prescriptions-2.4.1` which is correctly branched off 2.4.1 and has the fixes for #5551 in it. So now basing this PR of that so it's just the new changes.

Adds support for filtering the Prescription items list by category (name). The category is defined elsewhere in the JSON schema, so this component requires an `itemCategoryPath` option to tell it where to look. If not defined, the item list will show all.

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Have updated the UI Schema in the Program schemas repo to reflect these changes, so you'll need to re-import that (I think just the UI schema has changed). (Branch still `djibouti_family_planning`)

You'll also need to add categories and assign some items to them. The category names are:

![Screenshot 2024-11-26 at 11 40 29 AM](https://github.com/user-attachments/assets/628d100f-d5ab-4784-b748-037d2072b3e2)

You can try excluding one of the categories, and see that it shows "No items" when it is selected.

You can see the Prescription component in "Contraceptive Method" requires the "Prescribed Method" to be selected before it becomes visible, and the item list reflects what is selected in that. The one in "Additional Prescription Item" has no category restriction (`itemCategoryPath` not set) and so shows the full item list.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Re-import/update the UI schema for "Reproductive Health Encounter" as outlined in #5551 
- [ ] Create prescriptions as before (#5551), but note the category restriction on Contraceptive Method -- the Prescription component won't show until a "Prescribed Method" is selected
- [ ] Switching the "Prescribed Method" selection resets the Prescription component (no item selected or lines displayed)
- [ ] Closing the modal and re-opening should persist all the selections
- [ ] Prescription creation works as before, and no other regressions from #5551 