### PR TITLE
Don't calculated suggested quantity

### DIFF
--- a/server/service/src/requisition/response_requisition/insert_program.rs
+++ b/server/service/src/requisition/response_requisition/insert_program.rs
@@ -1,12 +1,12 @@
 use crate::{
     activity_log::activity_log_entry,
+    item_stats::{get_item_stats, ItemStatsFilter},
     number::next_number,
     requisition::{
         common::check_requisition_row_exists,
         program_indicator::query::{program_indicators, ProgramIndicator},
         program_settings::get_customer_program_requisition_settings,
         query::get_requisition,
-        request_requisition::generate_requisition_lines,
     },
     service_provider::ServiceContext,
 };
@@ -206,8 +206,7 @@ fn generate(
         .map(|line| line.item_id)
         .collect();
 
-    let requisition_lines =
-        generate_requisition_lines(ctx, &ctx.store_id, &requisition, program_item_ids)?;
+    let requisition_lines = generate_lines(ctx, &ctx.store_id, &requisition, program_item_ids)?;
 
     let program_indicators = program_indicators(
         connection,
@@ -234,6 +233,52 @@ fn generate(
         requisition_lines,
         indicator_values,
     })
+}
+
+fn generate_lines(
+    ctx: &ServiceContext,
+    store_id: &str,
+    requisition_row: &RequisitionRow,
+    item_ids: Vec<String>,
+) -> Result<Vec<RequisitionLineRow>, RepositoryError> {
+    let item_stats_rows = get_item_stats(
+        ctx,
+        store_id,
+        None,
+        Some(ItemStatsFilter::new().item_id(EqualFilter::equal_any(item_ids))),
+    )?;
+
+    let result = item_stats_rows
+        .into_iter()
+        .map(|item_stats| {
+            RequisitionLineRow {
+                id: uuid(),
+                requisition_id: requisition_row.id.clone(),
+                item_link_id: item_stats.item_id,
+                item_name: item_stats.item_name,
+                snapshot_datetime: Some(Utc::now().naive_utc()),
+                // Default
+                suggested_quantity: 0.0,
+                available_stock_on_hand: 0.0,
+                average_monthly_consumption: 0.0,
+                comment: None,
+                supply_quantity: 0.0,
+                requested_quantity: 0.0,
+                approved_quantity: 0.0,
+                approval_comment: None,
+                initial_stock_on_hand_units: 0.0,
+                incoming_units: 0.0,
+                outgoing_units: 0.0,
+                loss_in_units: 0.0,
+                addition_in_units: 0.0,
+                expiring_units: 0.0,
+                days_out_of_stock: 0.0,
+                option_id: None,
+            }
+        })
+        .collect();
+
+    Ok(result)
 }
 
 fn generate_program_indicator_values(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Part of #5458

# 👩🏻‍💻 What does this PR do?
Suggested, available and AMC was being calculated incorrectly for response requisitions as they are supposed to be the customer's values not the supplier's, so have removed them for now until discussion in 5458 is concluded.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create program requisition that has an item that would have a suggested quantity
- [ ] See that it isn't being calculated

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
