### PR TITLE
5463 manual requisitions some UI improvements to consider

### DIFF
--- a/client/packages/common/src/ui/components/buttons/standard/DialogButton.tsx
+++ b/client/packages/common/src/ui/components/buttons/standard/DialogButton.tsx
@@ -111,7 +111,7 @@ const getButtonProps = (
       return {
         icon: <ArrowLeftIcon />,
         labelKey: 'button.previous',
-        variant: 'outlined',
+        variant: 'contained',
       };
   }
 };

--- a/client/packages/common/src/ui/components/navigation/ListOptions/ListOptions.tsx
+++ b/client/packages/common/src/ui/components/navigation/ListOptions/ListOptions.tsx
@@ -50,7 +50,13 @@ export const ListOptions = ({
   );
 
   return (
-    <List sx={{ padding: 0, maxHeight: height * 0.8, overflow: 'auto' }}>
+    <List
+      sx={{
+        padding: 0,
+        maxHeight: height * 0.6,
+        overflow: 'auto',
+      }}
+    >
       {options?.map((option, _) => (
         <React.Fragment key={option.id}>
           <ListItem

--- a/client/packages/common/src/ui/components/navigation/ListOptions/ListOptions.tsx
+++ b/client/packages/common/src/ui/components/navigation/ListOptions/ListOptions.tsx
@@ -55,6 +55,7 @@ export const ListOptions = ({
         padding: 0,
         maxHeight: height * 0.6,
         overflow: 'auto',
+        scrollBehavior: 'smooth',
       }}
     >
       {options?.map((option, _) => (
@@ -62,6 +63,12 @@ export const ListOptions = ({
           <ListItem
             sx={{ padding: '5px 0px' }}
             onClick={() => onClick(option.id)}
+            ref={
+              option.id === currentId
+                ? l =>
+                    l?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                : null
+            }
           >
             <ListItemIcon sx={{ padding: 0, minWidth: 25 }}>
               <Box


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5463

# 👩🏻‍💻 What does this PR do?
- Make list smaller to fit better on screens
- Make variant for previous button same as next button
- Keep current selected item in view when navigating between items

https://github.com/user-attachments/assets/4c1b7238-145e-4f1a-aa37-61e7c49906de

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a manual requisition (can be program too) with lots of item lines
- [ ] Use previous/next to scroll through items
- [ ] Current item in list view should stay in view

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
