### PR TITLE
5107 clean up app data folder reference for hardware id

### DIFF
--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -168,15 +168,7 @@ async fn initialise_from_central(
     info!("Finished database reset");
 
     let connection_manager = get_storage_connection_manager(&settings.database);
-    let app_data_folder = settings
-        .clone()
-        .server
-        .base_dir
-        .ok_or(anyhow!("based dir not set in yaml configurations"))?;
-    let service_provider = Arc::new(ServiceProvider::new(
-        connection_manager.clone(),
-        &app_data_folder,
-    ));
+    let service_provider = Arc::new(ServiceProvider::new(connection_manager.clone()));
 
     let sync_settings = settings
         .clone()
@@ -312,14 +304,7 @@ async fn main() -> anyhow::Result<()> {
             test_db::setup(&settings.database).await;
 
             let connection_manager = get_storage_connection_manager(&settings.database);
-            let hardware_id = settings
-                .server
-                .base_dir
-                .ok_or(anyhow!("based dir not set in yaml configurations"))?;
-            let service_provider = Arc::new(ServiceProvider::new(
-                connection_manager.clone(),
-                &hardware_id,
-            ));
+            let service_provider = Arc::new(ServiceProvider::new(connection_manager.clone()));
             let ctx = service_provider.basic_context()?;
 
             let (_, import_file, users_file) = export_paths(&name);
@@ -383,19 +368,12 @@ async fn main() -> anyhow::Result<()> {
         Action::RefreshDates { enable_sync } => {
             let connection_manager = get_storage_connection_manager(&settings.database);
             let connection = connection_manager.connection()?;
-            let app_data_folder = settings
-                .server
-                .base_dir
-                .ok_or(anyhow!("based dir not set in yaml configurations"))?;
 
             info!("Refreshing dates");
             let result =
                 RefreshDatesRepository::new(&connection).refresh_dates(Utc::now().naive_utc())?;
 
-            let service_provider = Arc::new(ServiceProvider::new(
-                connection_manager.clone(),
-                &app_data_folder,
-            ));
+            let service_provider = Arc::new(ServiceProvider::new(connection_manager.clone()));
             let ctx = service_provider.basic_context()?;
             let service = &service_provider.settings;
 

--- a/server/cli/src/test_connection.rs
+++ b/server/cli/src/test_connection.rs
@@ -247,13 +247,9 @@ impl Test for SyncTest {
 
         let v5_settings = get_sync_settings(config)?;
 
-        let server_folder = config
-            .server
-            .base_dir
-            .clone()
-            .ok_or(anyhow!("No server base dir in config"))?;
+        let app_data_service = AppDataService {};
 
-        let hardware_id = AppDataService::new(server_folder.as_str())
+        let hardware_id = app_data_service
             .get_hardware_id()
             .map_err(|err| anyhow!("Failed to get hardware ID from app data service: {:?}", err))?;
 
@@ -506,10 +502,7 @@ fn get_url(config: &service::settings::Settings) -> Result<Url> {
 fn get_sync_settings(config: &service::settings::Settings) -> Result<SyncSettings> {
     let machine_uid = machine_uid::get().expect("Failed to query OS for hardware id");
     let connection_manager = get_storage_connection_manager(&config.database);
-    let service_provider = ServiceProvider::new(
-        connection_manager.clone(),
-        &config.server.base_dir.clone().unwrap(),
-    );
+    let service_provider = ServiceProvider::new(connection_manager.clone());
 
     service_provider
         .app_data_service

--- a/server/graphql/asset/src/lib.rs
+++ b/server/graphql/asset/src/lib.rs
@@ -171,7 +171,7 @@ mod test {
         asset_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.asset_service = Box::new(asset_service);
         service_provider
     }

--- a/server/graphql/asset/src/logs/insert.rs
+++ b/server/graphql/asset/src/logs/insert.rs
@@ -153,7 +153,7 @@ mod test {
         asset_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.asset_service = Box::new(asset_service);
         service_provider
     }

--- a/server/graphql/asset/src/logs/insert_reason.rs
+++ b/server/graphql/asset/src/logs/insert_reason.rs
@@ -141,7 +141,7 @@ mod test {
         asset_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.asset_service = Box::new(asset_service);
         service_provider
     }

--- a/server/graphql/asset/src/mutations/insert.rs
+++ b/server/graphql/asset/src/mutations/insert.rs
@@ -202,7 +202,7 @@ mod test {
         asset_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.asset_service = Box::new(asset_service);
         service_provider
     }

--- a/server/graphql/batch_mutations/src/batch_inbound_shipment.rs
+++ b/server/graphql/batch_mutations/src/batch_inbound_shipment.rs
@@ -417,7 +417,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/batch_mutations/src/batch_outbound_shipment.rs
+++ b/server/graphql/batch_mutations/src/batch_outbound_shipment.rs
@@ -571,7 +571,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/batch_mutations/src/batch_prescription.rs
+++ b/server/graphql/batch_mutations/src/batch_prescription.rs
@@ -301,7 +301,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/batch_mutations/src/batch_request_requisition.rs
+++ b/server/graphql/batch_mutations/src/batch_request_requisition.rs
@@ -324,7 +324,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/batch_mutations/src/batch_response_requisition.rs
+++ b/server/graphql/batch_mutations/src/batch_response_requisition.rs
@@ -185,7 +185,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/batch_mutations/src/batch_stocktake.rs
+++ b/server/graphql/batch_mutations/src/batch_stocktake.rs
@@ -297,7 +297,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.stocktake_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/cold_chain/src/lib.rs
+++ b/server/graphql/cold_chain/src/lib.rs
@@ -289,7 +289,7 @@ mod test_logs {
         cold_chain_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.cold_chain_service = Box::new(cold_chain_service);
         service_provider
     }
@@ -546,7 +546,7 @@ mod test_breaches {
         cold_chain_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.cold_chain_service = Box::new(cold_chain_service);
         service_provider
     }
@@ -721,7 +721,7 @@ mod test_notifications {
         temperature_excursion_service: TestExcursionService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.cold_chain_service = Box::new(cold_chain_service);
         service_provider.temperature_excursion_service = Box::new(temperature_excursion_service);
         service_provider
@@ -930,7 +930,7 @@ mod test_sensor {
         sensor_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.sensor_service = Box::new(sensor_service);
         service_provider
     }

--- a/server/graphql/cold_chain/src/mutations/temperature_breach.rs
+++ b/server/graphql/cold_chain/src/mutations/temperature_breach.rs
@@ -135,7 +135,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.cold_chain_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/core/src/test_helpers.rs
+++ b/server/graphql/core/src/test_helpers.rs
@@ -40,7 +40,7 @@ pub async fn run_test_gql_query<
 
     let service_provider_data = Data::new(match service_provider_override {
         Some(service_provider) => service_provider,
-        None => ServiceProvider::new(connection_manager.clone(), "app_data"),
+        None => ServiceProvider::new(connection_manager.clone()),
     });
 
     let loaders = get_loaders(&connection_manager, service_provider_data.clone()).await;

--- a/server/graphql/general/src/queries/requisition_line_chart.rs
+++ b/server/graphql/general/src/queries/requisition_line_chart.rs
@@ -191,7 +191,7 @@ mod graphql {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/general/src/queries/store.rs
+++ b/server/graphql/general/src/queries/store.rs
@@ -191,7 +191,7 @@ mod graphql {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.general_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/general/src/queries/tests/master_lists.rs
+++ b/server/graphql/general/src/queries/tests/master_lists.rs
@@ -43,7 +43,7 @@ mod graphql {
         masterlist_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.master_list_service = Box::new(masterlist_service);
         service_provider
     }

--- a/server/graphql/general/src/queries/tests/names.rs
+++ b/server/graphql/general/src/queries/tests/names.rs
@@ -49,7 +49,7 @@ mod graphql {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.name_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice/src/mutations/inbound_shipment/add_from_master_list.rs
+++ b/server/graphql/invoice/src/mutations/inbound_shipment/add_from_master_list.rs
@@ -135,7 +135,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice/src/mutations/inbound_shipment/delete.rs
+++ b/server/graphql/invoice/src/mutations/inbound_shipment/delete.rs
@@ -142,7 +142,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice/src/mutations/inbound_shipment/insert.rs
+++ b/server/graphql/invoice/src/mutations/inbound_shipment/insert.rs
@@ -161,7 +161,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice/src/mutations/inbound_shipment/update.rs
+++ b/server/graphql/invoice/src/mutations/inbound_shipment/update.rs
@@ -234,7 +234,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice/src/mutations/outbound_shipment/add_from_master_list.rs
+++ b/server/graphql/invoice/src/mutations/outbound_shipment/add_from_master_list.rs
@@ -144,7 +144,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice/src/mutations/outbound_shipment/update_name.rs
+++ b/server/graphql/invoice/src/mutations/outbound_shipment/update_name.rs
@@ -162,7 +162,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice/src/mutations/prescription/insert.rs
+++ b/server/graphql/invoice/src/mutations/prescription/insert.rs
@@ -115,7 +115,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice/src/mutations/prescription/update.rs
+++ b/server/graphql/invoice/src/mutations/prescription/update.rs
@@ -213,7 +213,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice/src/mutations/supplier_return/update_other_party.rs
+++ b/server/graphql/invoice/src/mutations/supplier_return/update_other_party.rs
@@ -168,7 +168,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice/src/query_tests/invoice_by_number.rs
+++ b/server/graphql/invoice/src/query_tests/invoice_by_number.rs
@@ -34,7 +34,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/delete.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/delete.rs
@@ -154,7 +154,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
@@ -209,7 +209,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
@@ -223,7 +223,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/service_line/delete.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/service_line/delete.rs
@@ -148,7 +148,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/service_line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/service_line/insert.rs
@@ -173,7 +173,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/service_line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/service_line/update.rs
@@ -177,7 +177,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/delete.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/delete.rs
@@ -151,7 +151,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/insert.rs
@@ -218,7 +218,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/update.rs
@@ -223,7 +223,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/service_line/delete.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/service_line/delete.rs
@@ -147,7 +147,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/service_line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/service_line/insert.rs
@@ -173,7 +173,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/service_line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/service_line/update.rs
@@ -177,7 +177,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/unallocated_line/allocate.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/unallocated_line/allocate.rs
@@ -159,7 +159,7 @@ mod graphql {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/unallocated_line/delete.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/unallocated_line/delete.rs
@@ -140,7 +140,7 @@ mod graphql {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/unallocated_line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/unallocated_line/insert.rs
@@ -188,7 +188,7 @@ mod graphql {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/unallocated_line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/unallocated_line/update.rs
@@ -152,7 +152,7 @@ mod graphql {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice_line/src/mutations/prescription_line/delete.rs
+++ b/server/graphql/invoice_line/src/mutations/prescription_line/delete.rs
@@ -148,7 +148,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice_line/src/mutations/prescription_line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/prescription_line/insert.rs
@@ -217,7 +217,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/invoice_line/src/mutations/prescription_line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/prescription_line/update.rs
@@ -219,7 +219,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/location/src/lib.rs
+++ b/server/graphql/location/src/lib.rs
@@ -143,7 +143,7 @@ mod test {
         location_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.location_service = Box::new(location_service);
         service_provider
     }

--- a/server/graphql/location/src/mutations/delete.rs
+++ b/server/graphql/location/src/mutations/delete.rs
@@ -157,7 +157,7 @@ mod test {
         location_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.location_service = Box::new(location_service);
         service_provider
     }

--- a/server/graphql/location/src/mutations/insert.rs
+++ b/server/graphql/location/src/mutations/insert.rs
@@ -145,7 +145,7 @@ mod test {
         location_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.location_service = Box::new(location_service);
         service_provider
     }

--- a/server/graphql/requisition/src/mutations/request_requisition/add_from_master_list.rs
+++ b/server/graphql/requisition/src/mutations/request_requisition/add_from_master_list.rs
@@ -160,7 +160,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/requisition/src/mutations/request_requisition/delete.rs
+++ b/server/graphql/requisition/src/mutations/request_requisition/delete.rs
@@ -148,7 +148,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/requisition/src/mutations/request_requisition/insert.rs
+++ b/server/graphql/requisition/src/mutations/request_requisition/insert.rs
@@ -180,7 +180,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/requisition/src/mutations/request_requisition/insert_program.rs
+++ b/server/graphql/requisition/src/mutations/request_requisition/insert_program.rs
@@ -177,7 +177,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/requisition/src/mutations/request_requisition/update.rs
+++ b/server/graphql/requisition/src/mutations/request_requisition/update.rs
@@ -218,7 +218,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/requisition/src/mutations/request_requisition/use_suggested_quantity.rs
+++ b/server/graphql/requisition/src/mutations/request_requisition/use_suggested_quantity.rs
@@ -150,7 +150,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/requisition/src/mutations/response_requisition/create_requisition_shipment.rs
+++ b/server/graphql/requisition/src/mutations/response_requisition/create_requisition_shipment.rs
@@ -163,7 +163,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/requisition/src/mutations/response_requisition/delete.rs
+++ b/server/graphql/requisition/src/mutations/response_requisition/delete.rs
@@ -158,7 +158,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/requisition/src/mutations/response_requisition/insert.rs
+++ b/server/graphql/requisition/src/mutations/response_requisition/insert.rs
@@ -162,7 +162,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/requisition/src/mutations/response_requisition/supply_requested_quantity.rs
+++ b/server/graphql/requisition/src/mutations/response_requisition/supply_requested_quantity.rs
@@ -149,7 +149,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/requisition/src/mutations/response_requisition/update.rs
+++ b/server/graphql/requisition/src/mutations/response_requisition/update.rs
@@ -172,7 +172,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/requisition/src/query_tests/requisition.rs
+++ b/server/graphql/requisition/src/query_tests/requisition.rs
@@ -49,7 +49,7 @@ mod graphql {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/requisition/src/query_tests/requisition_by_number.rs
+++ b/server/graphql/requisition/src/query_tests/requisition_by_number.rs
@@ -37,7 +37,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/requisition/src/query_tests/requisitions.rs
+++ b/server/graphql/requisition/src/query_tests/requisitions.rs
@@ -48,7 +48,7 @@ mod graphql {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/requisition_line/src/mutations/request_requisition_line/delete.rs
+++ b/server/graphql/requisition_line/src/mutations/request_requisition_line/delete.rs
@@ -140,7 +140,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/requisition_line/src/mutations/request_requisition_line/insert.rs
+++ b/server/graphql/requisition_line/src/mutations/request_requisition_line/insert.rs
@@ -179,7 +179,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/requisition_line/src/mutations/request_requisition_line/update.rs
+++ b/server/graphql/requisition_line/src/mutations/request_requisition_line/update.rs
@@ -165,7 +165,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/requisition_line/src/mutations/response_requisition_line/delete.rs
+++ b/server/graphql/requisition_line/src/mutations/response_requisition_line/delete.rs
@@ -152,7 +152,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/requisition_line/src/mutations/response_requisition_line/update.rs
+++ b/server/graphql/requisition_line/src/mutations/response_requisition_line/update.rs
@@ -194,7 +194,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.requisition_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/stock_line/src/mutations/insert.rs
+++ b/server/graphql/stock_line/src/mutations/insert.rs
@@ -163,7 +163,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.invoice_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/stock_line/src/mutations/update.rs
+++ b/server/graphql/stock_line/src/mutations/update.rs
@@ -176,7 +176,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.stock_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/stocktake/src/mutations/delete.rs
+++ b/server/graphql/stocktake/src/mutations/delete.rs
@@ -130,7 +130,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.stocktake_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/stocktake/src/mutations/insert.rs
+++ b/server/graphql/stocktake/src/mutations/insert.rs
@@ -155,7 +155,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.stocktake_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/stocktake/src/mutations/update.rs
+++ b/server/graphql/stocktake/src/mutations/update.rs
@@ -218,7 +218,7 @@ mod graphql {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.stocktake_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/stocktake/src/stocktake_queries.rs
+++ b/server/graphql/stocktake/src/stocktake_queries.rs
@@ -278,7 +278,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.stocktake_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/stocktake_line/src/mutations/delete.rs
+++ b/server/graphql/stocktake_line/src/mutations/delete.rs
@@ -129,7 +129,7 @@ mod graphql {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.stocktake_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/stocktake_line/src/mutations/insert.rs
+++ b/server/graphql/stocktake_line/src/mutations/insert.rs
@@ -215,7 +215,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.stocktake_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/stocktake_line/src/mutations/update.rs
+++ b/server/graphql/stocktake_line/src/mutations/update.rs
@@ -211,7 +211,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.stocktake_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/stocktake_line/src/stocktake_line_queries.rs
+++ b/server/graphql/stocktake_line/src/stocktake_line_queries.rs
@@ -194,7 +194,7 @@ mod test {
         test_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.stocktake_line_service = Box::new(test_service);
         service_provider
     }

--- a/server/graphql/tests/pagination.rs
+++ b/server/graphql/tests/pagination.rs
@@ -44,7 +44,7 @@ mod pagination_test {
         location_service: TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.location_service = Box::new(location_service);
         service_provider
     }

--- a/server/graphql/tests/permissions.rs
+++ b/server/graphql/tests/permissions.rs
@@ -1175,7 +1175,7 @@ mod permission_tests {
         test_service: &TestService,
         connection_manager: &StorageConnectionManager,
     ) -> ServiceProvider {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         service_provider.validation_service = Box::new(test_service.clone());
         service_provider
     }

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -103,7 +103,6 @@ pub async fn start_server(
 
     let service_provider = Data::new(ServiceProvider::new_with_triggers(
         connection_manager.clone(),
-        &settings.server.base_dir.clone().unwrap(),
         processors_trigger,
         sync_trigger,
         site_is_initialise_trigger,

--- a/server/service/src/app_data.rs
+++ b/server/service/src/app_data.rs
@@ -29,16 +29,6 @@ pub trait AppDataServiceTrait: Send + Sync {
     }
 }
 
-pub struct AppDataService {
-    pub app_data_folder: String,
-}
-
-impl AppDataService {
-    pub fn new(app_data_folder: &str) -> Self {
-        AppDataService {
-            app_data_folder: app_data_folder.to_string(),
-        }
-    }
-}
+pub struct AppDataService {}
 
 impl AppDataServiceTrait for AppDataService {}

--- a/server/service/src/asset/parse.rs
+++ b/server/service/src/asset/parse.rs
@@ -128,7 +128,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -166,7 +166,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/asset/tests/insert.rs
+++ b/server/service/src/asset/tests/insert.rs
@@ -15,7 +15,7 @@ mod query {
         let (_, _connection, connection_manager, _) =
             setup_all("asset_service_insert", MockDataInserts::none().stores()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/asset/tests/insert_log.rs
+++ b/server/service/src/asset/tests/insert_log.rs
@@ -22,7 +22,7 @@ mod query {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/asset/tests/query.rs
+++ b/server/service/src/asset/tests/query.rs
@@ -20,7 +20,7 @@ mod query {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let service = service_provider.asset_service;
 
         assert_eq!(
@@ -55,7 +55,7 @@ mod query {
         let (_, _, connection_manager, _) =
             setup_all("test_asset_single_record", MockDataInserts::none().assets()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.asset_service;
 
@@ -74,7 +74,7 @@ mod query {
         let (_, connection, connection_manager, _) =
             setup_all("test_asset_filter", MockDataInserts::none().assets()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let service = service_provider.asset_service;
 
         // In mock data we have

--- a/server/service/src/asset/tests/query_log.rs
+++ b/server/service/src/asset/tests/query_log.rs
@@ -18,7 +18,7 @@ mod query {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let service = service_provider.asset_service;
 
         assert_eq!(
@@ -56,7 +56,7 @@ mod query {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.asset_service;
 

--- a/server/service/src/asset/tests/update.rs
+++ b/server/service/src/asset/tests/update.rs
@@ -23,7 +23,7 @@ mod query {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/auth.rs
+++ b/server/service/src/auth.rs
@@ -1200,7 +1200,7 @@ mod permission_validation_test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let service_provider = ServiceProvider::new(connection_manager.clone());
         let context = service_provider
             .context("".to_string(), user_id.to_string())
             .unwrap();
@@ -1362,7 +1362,7 @@ mod permission_validation_test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let password = "pass";
 

--- a/server/service/src/catalogue/tests/insert.rs
+++ b/server/service/src/catalogue/tests/insert.rs
@@ -21,7 +21,7 @@ mod query {
 
         const REFRIGERATORS_UUID: &str = "fd79171f-5da8-4801-b299-9426f34310a8";
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/catalogue/tests/query_catalogue_item.rs
+++ b/server/service/src/catalogue/tests/query_catalogue_item.rs
@@ -17,7 +17,7 @@ mod query_catalogue_item {
     async fn catalogue_service_pagination() {
         let (_, _, connection_manager, _) =
             setup_all("test_catalogue_service_pagination", MockDataInserts::none()).await;
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.catalogue_service;
 
@@ -52,7 +52,7 @@ mod query_catalogue_item {
     async fn catalogue_service_filter() {
         let (_, _, connection_manager, _) =
             setup_all("test_catalogue_service_filter", MockDataInserts::none()).await;
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.catalogue_service;
 
@@ -299,7 +299,7 @@ mod query_catalogue_item {
     async fn catalogue_service_sort() {
         let (_, _, connection_manager, _) =
             setup_all("test_catalogue_service_sort", MockDataInserts::none()).await;
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.catalogue_service;
         // Test Name sort with default sort order

--- a/server/service/src/cold_chain/tests/query_temperature_breach.rs
+++ b/server/service/src/cold_chain/tests/query_temperature_breach.rs
@@ -15,7 +15,7 @@ mod query {
         let (_, connection, connection_manager, _) =
             setup_all("test_cold_chain_service_pagination", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let service = service_provider.cold_chain_service;
 
         assert_eq!(
@@ -53,7 +53,7 @@ mod query {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.cold_chain_service;
 
@@ -78,7 +78,7 @@ mod query {
         let (_, connection, connection_manager, _) =
             setup_all("test_temperature_breach_filter", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let service = service_provider.cold_chain_service;
 
         let result = service
@@ -129,7 +129,7 @@ mod query {
         let (mock_data, connection, connection_manager, _) =
             setup_all("test_temperature_breach_sort", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let service = service_provider.cold_chain_service;
         // Test StartDatetime sort with default sort order
         let result = service

--- a/server/service/src/cold_chain/tests/query_temperature_log.rs
+++ b/server/service/src/cold_chain/tests/query_temperature_log.rs
@@ -15,7 +15,7 @@ mod query {
         let (_, connection, connection_manager, _) =
             setup_all("test_cold_chain_service_pagination", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let service = service_provider.cold_chain_service;
 
         assert_eq!(
@@ -50,7 +50,7 @@ mod query {
         let (_, _, connection_manager, _) =
             setup_all("test_temperature_log_single_record", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.cold_chain_service;
 
@@ -72,7 +72,7 @@ mod query {
         let (_, connection, connection_manager, _) =
             setup_all("test_temperature_log_filter", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let service = service_provider.cold_chain_service;
 
         let result = service
@@ -109,7 +109,7 @@ mod query {
         let (mock_data, connection, connection_manager, _) =
             setup_all("test_temperature_log_sort", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let service = service_provider.cold_chain_service;
         // Test Datetime sort with default sort order
         let result = service

--- a/server/service/src/dashboard/stock_expiry_count.rs
+++ b/server/service/src/dashboard/stock_expiry_count.rs
@@ -94,7 +94,7 @@ mod stock_count_test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/demographic/tests/insert_indicator.rs
+++ b/server/service/src/demographic/tests/insert_indicator.rs
@@ -18,7 +18,7 @@ mod query {
         let (_, _connection, connection_manager, _) =
             setup_all("indicator_insert", MockDataInserts::none().stores()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/demographic/tests/insert_projection.rs
+++ b/server/service/src/demographic/tests/insert_projection.rs
@@ -18,7 +18,7 @@ mod query {
         let (_, _connection, connection_manager, _) =
             setup_all("projection_insert", MockDataInserts::none().stores()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/demographic/tests/update_indicator.rs
+++ b/server/service/src/demographic/tests/update_indicator.rs
@@ -21,7 +21,7 @@ mod query {
         let (_, _connection, connection_manager, _) =
             setup_all("indicator_update", MockDataInserts::none().stores()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/demographic/tests/update_projection.rs
+++ b/server/service/src/demographic/tests/update_projection.rs
@@ -24,7 +24,7 @@ mod query {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/document/document_registry/tests/insert.rs
+++ b/server/service/src/document/document_registry/tests/insert.rs
@@ -21,7 +21,7 @@ mod tests {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.document_registry_service;
         let context_id = context_program_a().id;

--- a/server/service/src/document/document_service.rs
+++ b/server/service/src/document/document_service.rs
@@ -251,7 +251,7 @@ mod document_service_test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.document_service;
 
@@ -402,7 +402,7 @@ mod document_service_test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
 
         let service = service_provider.document_service;

--- a/server/service/src/invoice/customer_return/delete/mod.rs
+++ b/server/service/src/invoice/customer_return/delete/mod.rs
@@ -125,7 +125,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_b().id, "".to_string())
             .unwrap();
@@ -201,7 +201,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_b().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice/customer_return/generate_lines.rs
+++ b/server/service/src/invoice/customer_return/generate_lines.rs
@@ -160,7 +160,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.invoice_service;
 
@@ -188,7 +188,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.invoice_service;
 
@@ -227,7 +227,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.invoice_service;
 

--- a/server/service/src/invoice/customer_return/insert/mod.rs
+++ b/server/service/src/invoice/customer_return/insert/mod.rs
@@ -189,7 +189,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();
@@ -365,7 +365,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/invoice/customer_return/update/mod.rs
+++ b/server/service/src/invoice/customer_return/update/mod.rs
@@ -220,7 +220,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -288,7 +288,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("update_customer_return_success", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_b().id, mock_user_account_a().id)
             .unwrap();
@@ -409,7 +409,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_b().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/invoice/customer_return/update_lines/mod.rs
+++ b/server/service/src/invoice/customer_return/update_lines/mod.rs
@@ -193,7 +193,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_b().id, mock_user_account_a().id)
             .unwrap();
@@ -353,7 +353,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_b().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/invoice/inbound_shipment/add_from_master_list.rs
+++ b/server/service/src/invoice/inbound_shipment/add_from_master_list.rs
@@ -132,7 +132,7 @@ mod test {
         let (_, _, connection_manager, _) =
             setup_all("is_add_from_master_list_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -262,7 +262,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice/inbound_shipment/batch.rs
+++ b/server/service/src/invoice/inbound_shipment/batch.rs
@@ -207,7 +207,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("batch_inbound_shipment_service", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_c().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice/inbound_shipment/delete/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/delete/mod.rs
@@ -119,7 +119,7 @@ mod test {
         let (_, _, connection_manager, _) =
             setup_all("delete_inbound_shipment_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();
@@ -190,7 +190,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("delete_inbound_shipment_success", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/invoice/inbound_shipment/insert/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/insert/mod.rs
@@ -136,7 +136,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -217,7 +217,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/invoice/inbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/update/mod.rs
@@ -240,7 +240,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -392,7 +392,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();
@@ -583,7 +583,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/invoice/inventory_adjustment/add_new_stock_line/insert.rs
+++ b/server/service/src/invoice/inventory_adjustment/add_new_stock_line/insert.rs
@@ -156,7 +156,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -238,7 +238,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();
@@ -321,7 +321,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/invoice/inventory_adjustment/adjust_existing_stock/insert.rs
+++ b/server/service/src/invoice/inventory_adjustment/adjust_existing_stock/insert.rs
@@ -164,7 +164,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -283,7 +283,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();
@@ -310,7 +310,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/invoice/outbound_shipment/add_from_master_list.rs
+++ b/server/service/src/invoice/outbound_shipment/add_from_master_list.rs
@@ -143,7 +143,7 @@ mod test {
         let (_, _, connection_manager, _) =
             setup_all("os_add_from_master_list_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -273,7 +273,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_c().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice/outbound_shipment/batch.rs
+++ b/server/service/src/invoice/outbound_shipment/batch.rs
@@ -284,7 +284,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("batch_outbound_shipment_service", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice/outbound_shipment/delete/mod.rs
+++ b/server/service/src/invoice/outbound_shipment/delete/mod.rs
@@ -128,7 +128,7 @@ mod test {
         let (_, _, connection_manager, _) =
             setup_all("delete_outbound_shipment_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -165,7 +165,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("delete_outbound_shipment_success", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_c().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice/outbound_shipment/insert/mod.rs
+++ b/server/service/src/invoice/outbound_shipment/insert/mod.rs
@@ -141,7 +141,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -221,7 +221,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/invoice/outbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/outbound_shipment/update/mod.rs
@@ -235,7 +235,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_c().id, "".to_string())
             .unwrap();
@@ -359,7 +359,7 @@ mod test {
             Ok(Some(invoice_line()))
         );
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -416,7 +416,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -588,7 +588,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -681,7 +681,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice/outbound_shipment/update_name/mod.rs
+++ b/server/service/src/invoice/outbound_shipment/update_name/mod.rs
@@ -139,7 +139,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_c().id, "".to_string())
             .unwrap();
@@ -281,7 +281,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_c().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice/prescription/batch.rs
+++ b/server/service/src/invoice/prescription/batch.rs
@@ -140,7 +140,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("batch_prescription_service", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice/prescription/delete/mod.rs
+++ b/server/service/src/invoice/prescription/delete/mod.rs
@@ -98,7 +98,7 @@ mod test {
         let (_, _, connection_manager, _) =
             setup_all("delete_prescription_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -135,7 +135,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("delete_prescription_success", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice/prescription/insert/mod.rs
+++ b/server/service/src/invoice/prescription/insert/mod.rs
@@ -125,7 +125,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -183,7 +183,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/invoice/prescription/update/mod.rs
+++ b/server/service/src/invoice/prescription/update/mod.rs
@@ -195,7 +195,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -307,7 +307,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice/query.rs
+++ b/server/service/src/invoice/query.rs
@@ -72,7 +72,7 @@ mod test_query {
         let (_, _, connection_manager, _) =
             setup_all("get_invoice_by_number", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.invoice_service;
 

--- a/server/service/src/invoice/supplier_return/delete/mod.rs
+++ b/server/service/src/invoice/supplier_return/delete/mod.rs
@@ -130,7 +130,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_b().id, "".to_string())
             .unwrap();
@@ -166,7 +166,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("delete_supplier_return_success", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice/supplier_return/generate_supplier_return_lines.rs
+++ b/server/service/src/invoice/supplier_return/generate_supplier_return_lines.rs
@@ -225,7 +225,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.invoice_service;
 
@@ -260,7 +260,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.invoice_service;
 
@@ -292,7 +292,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.invoice_service;
 
@@ -324,7 +324,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.invoice_service;
 
@@ -366,7 +366,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.invoice_service;
 
@@ -435,7 +435,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.invoice_service;
 
@@ -498,7 +498,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.invoice_service;
 
@@ -561,7 +561,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.invoice_service;
 
@@ -612,7 +612,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.invoice_service;
 

--- a/server/service/src/invoice/supplier_return/insert/mod.rs
+++ b/server/service/src/invoice/supplier_return/insert/mod.rs
@@ -183,7 +183,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();
@@ -367,7 +367,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/invoice/supplier_return/update/mod.rs
+++ b/server/service/src/invoice/supplier_return/update/mod.rs
@@ -197,7 +197,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_b().id, mock_user_account_a().id)
             .unwrap();
@@ -274,7 +274,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_b().id, mock_user_account_a().id)
             .unwrap();
@@ -324,7 +324,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/invoice/supplier_return/update_lines/mod.rs
+++ b/server/service/src/invoice/supplier_return/update_lines/mod.rs
@@ -195,7 +195,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();
@@ -344,7 +344,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/invoice/supplier_return/update_other_party/mod.rs
+++ b/server/service/src/invoice/supplier_return/update_other_party/mod.rs
@@ -146,7 +146,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -290,7 +290,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_c().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice_line/inbound_shipment_service_line/delete/mod.rs
+++ b/server/service/src/invoice_line/inbound_shipment_service_line/delete/mod.rs
@@ -83,7 +83,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -143,7 +143,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice_line/inbound_shipment_service_line/insert/mod.rs
+++ b/server/service/src/invoice_line/inbound_shipment_service_line/insert/mod.rs
@@ -108,7 +108,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -205,7 +205,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice_line/inbound_shipment_service_line/update/mod.rs
+++ b/server/service/src/invoice_line/inbound_shipment_service_line/update/mod.rs
@@ -111,7 +111,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -196,7 +196,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice_line/outbound_shipment_service_line/delete/mod.rs
+++ b/server/service/src/invoice_line/outbound_shipment_service_line/delete/mod.rs
@@ -81,7 +81,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -141,7 +141,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice_line/outbound_shipment_service_line/insert/mod.rs
+++ b/server/service/src/invoice_line/outbound_shipment_service_line/insert/mod.rs
@@ -108,7 +108,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -194,7 +194,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_c().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice_line/outbound_shipment_service_line/update/mod.rs
+++ b/server/service/src/invoice_line/outbound_shipment_service_line/update/mod.rs
@@ -115,7 +115,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -200,7 +200,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice_line/outbound_shipment_unallocated_line/allocate/test.rs
+++ b/server/service/src/invoice_line/outbound_shipment_unallocated_line/allocate/test.rs
@@ -26,7 +26,7 @@ mod test {
         let (_, _, connection_manager, _) =
             setup_all("allocate_unallocated_line_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -118,7 +118,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let service_provider = ServiceProvider::new(connection_manager.clone());
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -223,7 +223,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let service_provider = ServiceProvider::new(connection_manager.clone());
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -390,7 +390,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let service_provider = ServiceProvider::new(connection_manager.clone());
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -541,7 +541,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let service_provider = ServiceProvider::new(connection_manager.clone());
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -633,7 +633,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let service_provider = ServiceProvider::new(connection_manager.clone());
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice_line/outbound_shipment_unallocated_line/delete.rs
+++ b/server/service/src/invoice_line/outbound_shipment_unallocated_line/delete.rs
@@ -92,7 +92,7 @@ mod test_delete {
         let (_, _, connection_manager, _) =
             setup_all("delete_unallocated_line_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -138,7 +138,7 @@ mod test_delete {
             setup_all("delete_unallocated_line_success", MockDataInserts::all()).await;
 
         let connection = connection_manager.connection().unwrap();
-        let service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let service_provider = ServiceProvider::new(connection_manager.clone());
         let context = service_provider
             .context(mock_store_c().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice_line/outbound_shipment_unallocated_line/insert.rs
+++ b/server/service/src/invoice_line/outbound_shipment_unallocated_line/insert.rs
@@ -176,7 +176,7 @@ mod test_insert {
         let (_, _, connection_manager, _) =
             setup_all("insert_unallocated_line_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -304,7 +304,7 @@ mod test_insert {
             setup_all("insert_unallocated_line_success", MockDataInserts::all()).await;
 
         let connection = connection_manager.connection().unwrap();
-        let service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let service_provider = ServiceProvider::new(connection_manager.clone());
         let context = service_provider
             .context(mock_store_c().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice_line/outbound_shipment_unallocated_line/update.rs
+++ b/server/service/src/invoice_line/outbound_shipment_unallocated_line/update.rs
@@ -107,7 +107,7 @@ mod test_update {
         let (_, _, connection_manager, _) =
             setup_all("update_unallocated_line_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -156,7 +156,7 @@ mod test_update {
             setup_all("update_unallocated_line_success", MockDataInserts::all()).await;
 
         let connection = connection_manager.connection().unwrap();
-        let service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let service_provider = ServiceProvider::new(connection_manager.clone());
         let context = service_provider
             .context(mock_store_c().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice_line/stock_in_line/delete/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/delete/mod.rs
@@ -131,7 +131,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_b().id, mock_user_account_a().id)
             .unwrap();
@@ -229,7 +229,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_b().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/invoice_line/stock_in_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/mod.rs
@@ -165,7 +165,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();
@@ -318,7 +318,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("insert_stock_in_line_success", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_b().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/invoice_line/stock_in_line/update/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/mod.rs
@@ -169,7 +169,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_b().id, mock_user_account_a().id)
             .unwrap();
@@ -314,7 +314,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("update_stock_in_line_success", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_b().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/invoice_line/stock_out_line/delete/mod.rs
+++ b/server/service/src/invoice_line/stock_out_line/delete/mod.rs
@@ -101,7 +101,7 @@ mod test {
         let (_, _, connection_manager, _) =
             setup_all("delete_stock_out_line_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_b().id, "".to_string())
             .unwrap();
@@ -208,7 +208,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_b().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice_line/stock_out_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_out_line/insert/mod.rs
@@ -117,7 +117,7 @@ mod test {
         let (_, _, connection_manager, _) =
             setup_all("insert_stock_out_line_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_b().id, "".to_string())
             .unwrap();
@@ -284,7 +284,7 @@ mod test {
                 .unwrap()
         };
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_c().id, "".to_string())
             .unwrap();
@@ -472,7 +472,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("insert_stock_out_line_back_dated", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_b().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice_line/stock_out_line/update/mod.rs
+++ b/server/service/src/invoice_line/stock_out_line/update/mod.rs
@@ -155,7 +155,7 @@ mod test {
         let (_, _, connection_manager, _) =
             setup_all("update_stock_out_line_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -327,7 +327,7 @@ mod test {
                 .unwrap()
         };
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_c().id, "".to_string())
             .unwrap();
@@ -524,7 +524,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("update_stock_out_line_back_dated", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_b().id, "".to_string())
             .unwrap();

--- a/server/service/src/invoice_line/update_return_reason_id/mod.rs
+++ b/server/service/src/invoice_line/update_return_reason_id/mod.rs
@@ -95,7 +95,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_b().id, "".to_string())
             .unwrap();
@@ -164,7 +164,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_b().id, "".to_string())
             .unwrap();

--- a/server/service/src/item/bundled_item/test/mod.rs
+++ b/server/service/src/item/bundled_item/test/mod.rs
@@ -20,7 +20,7 @@ mod query {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.item_service;
 
@@ -116,7 +116,7 @@ mod query {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.item_service;
 

--- a/server/service/src/item/item_variant/test/mod.rs
+++ b/server/service/src/item/item_variant/test/mod.rs
@@ -21,7 +21,7 @@ mod query {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.item_service;
 
@@ -184,7 +184,7 @@ mod query {
         let (_, _, connection_manager, _) =
             setup_all("validate_item_variant", MockDataInserts::none().items()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.item_service;
 

--- a/server/service/src/item/packaging_variant/test/mod.rs
+++ b/server/service/src/item/packaging_variant/test/mod.rs
@@ -20,7 +20,7 @@ mod query {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.item_service;
 
@@ -142,7 +142,7 @@ mod query {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.item_service;
 

--- a/server/service/src/item_stats.rs
+++ b/server/service/src/item_stats.rs
@@ -185,7 +185,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.item_stats_service;
 

--- a/server/service/src/location/tests/delete.rs
+++ b/server/service/src/location/tests/delete.rs
@@ -24,7 +24,7 @@ mod query {
         let stock_line_repository = StockLineRepository::new(&connection);
         let invoice_line_repository = InvoiceLineRepository::new(&connection);
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -107,7 +107,7 @@ mod query {
 
         let connection = connection_manager.connection().unwrap();
         let location_repository = LocationRepository::new(&connection);
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/location/tests/insert.rs
+++ b/server/service/src/location/tests/insert.rs
@@ -21,7 +21,7 @@ mod query {
 
         let connection = connection_manager.connection().unwrap();
         let location_repository = LocationRepository::new(&connection);
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -67,7 +67,7 @@ mod query {
 
         let connection = connection_manager.connection().unwrap();
         let location_repository = LocationRepository::new(&connection);
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/location/tests/query.rs
+++ b/server/service/src/location/tests/query.rs
@@ -16,7 +16,7 @@ mod query {
         let (_, _, connection_manager, _) =
             setup_all("test_location_service_pagination", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.location_service;
 
@@ -52,7 +52,7 @@ mod query {
         let (_, _, connection_manager, _) =
             setup_all("test_location_single_record", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.location_service;
 
@@ -74,7 +74,7 @@ mod query {
         let (_, _, connection_manager, _) =
             setup_all("test_location_filter", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.location_service;
 
@@ -112,7 +112,7 @@ mod query {
         let (mock_data, _, connection_manager, _) =
             setup_all("test_location_sort", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.location_service;
         // Test Name sort with default sort order
@@ -177,7 +177,7 @@ mod query {
         let (_mock_data, _, connection_manager, _) =
             setup_all("test_location_asset_assigned", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.location_service;
 

--- a/server/service/src/location/tests/update.rs
+++ b/server/service/src/location/tests/update.rs
@@ -20,7 +20,7 @@ mod query {
 
         let connection = connection_manager.connection().unwrap();
         let location_repository = LocationRepository::new(&connection);
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -78,7 +78,7 @@ mod query {
 
         let connection = connection_manager.connection().unwrap();
         let location_repository = LocationRepository::new(&connection);
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/login.rs
+++ b/server/service/src/login.rs
@@ -530,7 +530,7 @@ mod test {
             MockDataInserts::none().names().stores().user_accounts(),
         )
         .await;
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context("".to_string(), "".to_string())
             .unwrap();

--- a/server/service/src/master_list/tests/query.rs
+++ b/server/service/src/master_list/tests/query.rs
@@ -10,7 +10,7 @@ mod query {
         let (_, _, connection_manager, _) =
             setup_all("test_master_list_filter", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.master_list_service;
 

--- a/server/service/src/plugin_data/insert.rs
+++ b/server/service/src/plugin_data/insert.rs
@@ -108,7 +108,7 @@ mod test {
         let (_, _, connection_manager, _) =
             setup_all("insert_plugin_data_success", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/plugin_data/update.rs
+++ b/server/service/src/plugin_data/update.rs
@@ -148,7 +148,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/pricing/tests/item_price.rs
+++ b/server/service/src/pricing/tests/item_price.rs
@@ -14,7 +14,7 @@ mod query {
         let (_, _, connection_manager, _) =
             setup_all("discount_from_master_list", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.pricing_service;
 
@@ -81,7 +81,7 @@ mod query {
         let (_, _, connection_manager, _) =
             setup_all("default_price_list", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.pricing_service;
 
@@ -152,7 +152,7 @@ mod query {
         let (_, _, connection_manager, _) =
             setup_all("default_price_plus_discount", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.pricing_service;
 

--- a/server/service/src/program/test/query.rs
+++ b/server/service/src/program/test/query.rs
@@ -15,7 +15,7 @@ mod query {
         let (_, _, connection_manager, _) =
             setup_all("test_program_single_record", MockDataInserts::none()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.program_service;
 
@@ -49,7 +49,7 @@ mod query {
         let (_, connection, connection_manager, _) =
             setup_all("test_program_filter", MockDataInserts::none()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.program_service;
 

--- a/server/service/src/programs/contact_trace/upsert.rs
+++ b/server/service/src/programs/contact_trace/upsert.rs
@@ -291,7 +291,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider.basic_context().unwrap();
 
         // dummy schema

--- a/server/service/src/programs/encounter/encounter_updated.rs
+++ b/server/service/src/programs/encounter/encounter_updated.rs
@@ -143,7 +143,7 @@ mod encounter_document_updated_test {
         let (_, _, connection_manager, _) =
             setup_all("test_encounter_deletion", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
 
         let patient = mock_patient();

--- a/server/service/src/programs/encounter/insert.rs
+++ b/server/service/src/programs/encounter/insert.rs
@@ -270,7 +270,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider.basic_context().unwrap();
 
         // dummy schema

--- a/server/service/src/programs/encounter/update.rs
+++ b/server/service/src/programs/encounter/update.rs
@@ -233,7 +233,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider.basic_context().unwrap();
 
         // dummy schema

--- a/server/service/src/programs/patient/patient_updated.rs
+++ b/server/service/src/programs/patient/patient_updated.rs
@@ -1,8 +1,7 @@
 use chrono::{DateTime, NaiveDate, Utc};
 use repository::{
-    EqualFilter, GenderType, NameRow, NameRowRepository, NameStoreJoinFilter,
-    NameStoreJoinRepository, NameStoreJoinRow, NameRowType, Patient, RepositoryError,
-    StorageConnection,
+    EqualFilter, GenderType, NameRow, NameRowRepository, NameRowType, NameStoreJoinFilter,
+    NameStoreJoinRepository, NameStoreJoinRow, Patient, RepositoryError, StorageConnection,
 };
 use std::str::FromStr;
 use util::uuid::uuid;
@@ -287,7 +286,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider.basic_context().unwrap();
 
         let service = &service_provider.patient_service;

--- a/server/service/src/programs/patient/upsert_program_patient.rs
+++ b/server/service/src/programs/patient/upsert_program_patient.rs
@@ -266,7 +266,7 @@ pub mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider.basic_context().unwrap();
 
         // dummy schema

--- a/server/service/src/programs/program_enrolment/upsert.rs
+++ b/server/service/src/programs/program_enrolment/upsert.rs
@@ -252,7 +252,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider.basic_context().unwrap();
 
         // dummy schema

--- a/server/service/src/programs/program_event.rs
+++ b/server/service/src/programs/program_event.rs
@@ -387,7 +387,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider.basic_context().unwrap();
 
         let service = service_provider.program_event_service;
@@ -475,7 +475,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider.basic_context().unwrap();
 
         let service = service_provider.program_event_service;
@@ -527,7 +527,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider.basic_context().unwrap();
 
         let service = service_provider.program_event_service;
@@ -605,7 +605,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider.basic_context().unwrap();
 
         let service = service_provider.program_event_service;
@@ -656,7 +656,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider.basic_context().unwrap();
 
         let service = service_provider.program_event_service;
@@ -724,7 +724,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider.basic_context().unwrap();
 
         let service = service_provider.program_event_service;
@@ -884,7 +884,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider.basic_context().unwrap();
 
         let service = service_provider.program_event_service;
@@ -948,7 +948,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "");
+        let service_provider = ServiceProvider::new(connection_manager);
         let ctx = service_provider.basic_context().unwrap();
 
         let service = service_provider.program_event_service;

--- a/server/service/src/repack/insert.rs
+++ b/server/service/src/repack/insert.rs
@@ -112,7 +112,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("insert_repack_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id.to_string())
             .unwrap();
@@ -235,7 +235,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id.to_string())
             .unwrap();

--- a/server/service/src/repack/query.rs
+++ b/server/service/src/repack/query.rs
@@ -233,7 +233,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id.to_string())
             .unwrap();

--- a/server/service/src/report/report_service.rs
+++ b/server/service/src/report/report_service.rs
@@ -837,7 +837,7 @@ mod report_service_test {
         })
         .unwrap();
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context("store_id".to_string(), "".to_string())
             .unwrap();
@@ -997,7 +997,7 @@ mod report_generation_test {
             setup_all("test_report_translations", MockDataInserts::none()).await;
 
         let translation_service =
-            ServiceProvider::new(connection_manager, "app_data").translations_service;
+            ServiceProvider::new(connection_manager).translations_service;
 
         let mut templates = HashMap::new();
         templates.insert("test.html".to_string(), tera_template);

--- a/server/service/src/requisition/indicator_value/update.rs
+++ b/server/service/src/requisition/indicator_value/update.rs
@@ -181,7 +181,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -237,7 +237,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/requisition/program_indicator/query.rs
+++ b/server/service/src/requisition/program_indicator/query.rs
@@ -74,7 +74,7 @@ mod query {
         let (_, connection, connection_manager, _) =
             setup_all("test_program_indicator_query", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let service = service_provider.program_indicator_service;
 
         let result = service

--- a/server/service/src/requisition/query.rs
+++ b/server/service/src/requisition/query.rs
@@ -78,7 +78,7 @@ mod test {
         let (_, _, connection_manager, _) =
             setup_all("test_requisition_filter", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.requisition_service;
 

--- a/server/service/src/requisition/request_requisition/add_from_master_list.rs
+++ b/server/service/src/requisition/request_requisition/add_from_master_list.rs
@@ -171,7 +171,7 @@ mod test {
         let (_, _, connection_manager, _) =
             setup_all("add_from_master_list_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -296,7 +296,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/requisition/request_requisition/batch.rs
+++ b/server/service/src/requisition/request_requisition/batch.rs
@@ -153,7 +153,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("batch_request_requisition_service", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/requisition/request_requisition/delete.rs
+++ b/server/service/src/requisition/request_requisition/delete.rs
@@ -141,7 +141,7 @@ mod test_delete {
         let (_, _, connection_manager, _) =
             setup_all("delete_request_requisition_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -215,7 +215,7 @@ mod test_delete {
         let (_, connection, connection_manager, _) =
             setup_all("delete_request_requisition_success", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/requisition/request_requisition/insert.rs
+++ b/server/service/src/requisition/request_requisition/insert.rs
@@ -186,7 +186,7 @@ mod test_insert {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -258,7 +258,7 @@ mod test_insert {
         let (_, connection, connection_manager, _) =
             setup_all("insert_request_requisition_success", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/requisition/request_requisition/insert_program.rs
+++ b/server/service/src/requisition/request_requisition/insert_program.rs
@@ -226,7 +226,7 @@ mod test_insert {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(program_master_list_store().id, mock_user_account_a().id)
             .unwrap();
@@ -281,7 +281,7 @@ mod test_insert {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(program_master_list_store().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/requisition/request_requisition/update/test.rs
+++ b/server/service/src/requisition/request_requisition/update/test.rs
@@ -56,7 +56,7 @@ mod test_update {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -162,7 +162,7 @@ mod test_update {
         let (_, connection, connection_manager, _) =
             setup_all("update_request_requisition_success", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/requisition/request_requisition/use_suggested_quantity.rs
+++ b/server/service/src/requisition/request_requisition/use_suggested_quantity.rs
@@ -132,7 +132,7 @@ mod test {
         let (_, _, connection_manager, _) =
             setup_all("use_suggested_quantity_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -191,7 +191,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("use_suggested_quantity_success", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/requisition/response_requisition/batch.rs
+++ b/server/service/src/requisition/response_requisition/batch.rs
@@ -93,7 +93,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("batch_response_requisition_service", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/requisition/response_requisition/create_requisition_shipment/test.rs
+++ b/server/service/src/requisition/response_requisition/create_requisition_shipment/test.rs
@@ -25,7 +25,7 @@ mod test_update {
         let (_, _, connection_manager, _) =
             setup_all("create_requisition_shipment_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -85,7 +85,7 @@ mod test_update {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/requisition/response_requisition/delete.rs
+++ b/server/service/src/requisition/response_requisition/delete.rs
@@ -142,7 +142,7 @@ mod test_delete {
         let (_, connection, connection_manager, _) =
             setup_all("delete_response_requisition_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -255,7 +255,7 @@ mod test_delete {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/requisition/response_requisition/insert.rs
+++ b/server/service/src/requisition/response_requisition/insert.rs
@@ -181,7 +181,7 @@ mod test_insert {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -244,7 +244,7 @@ mod test_insert {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/requisition/response_requisition/supply_requested_quantity.rs
+++ b/server/service/src/requisition/response_requisition/supply_requested_quantity.rs
@@ -140,9 +140,9 @@ mod test {
     use repository::{
         mock::{
             mock_finalised_response_requisition,
-            mock_full_new_response_requisition_for_update_test,
-            mock_new_response_requisition_test, mock_sent_request_requisition, mock_store_a,
-            mock_store_b, mock_user_account_b, MockDataInserts,
+            mock_full_new_response_requisition_for_update_test, mock_new_response_requisition_test,
+            mock_sent_request_requisition, mock_store_a, mock_store_b, mock_user_account_b,
+            MockDataInserts,
         },
         test_db::setup_all,
         ApprovalStatusType, RequisitionLineRow, RequisitionLineRowRepository, RequisitionRow,
@@ -165,7 +165,7 @@ mod test {
         let (_, _, connection_manager, _) =
             setup_all("supply_requested_quantity_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -224,7 +224,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("supply_requested_quantity_success", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_b().id)
             .unwrap();

--- a/server/service/src/requisition/response_requisition/update.rs
+++ b/server/service/src/requisition/response_requisition/update.rs
@@ -168,7 +168,7 @@ mod test_update {
         let (_, _, connection_manager, _) =
             setup_all("update_response_requisition_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -256,7 +256,7 @@ mod test_update {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_b().id)
             .unwrap();

--- a/server/service/src/requisition_line/chart/mod.rs
+++ b/server/service/src/requisition_line/chart/mod.rs
@@ -189,7 +189,7 @@ mod test {
         let (_, _, connection_manager, _) =
             setup_all("get_requisition_line_chart_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -411,7 +411,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(store().id, "".to_string())
             .unwrap();
@@ -646,7 +646,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(store().id, "".to_string())
             .unwrap();

--- a/server/service/src/requisition_line/query.rs
+++ b/server/service/src/requisition_line/query.rs
@@ -42,7 +42,7 @@ mod test {
         let (_, _, connection_manager, _) =
             setup_all("test_requisition_line_filter", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.requisition_line_service;
 

--- a/server/service/src/requisition_line/request_requisition_line/delete.rs
+++ b/server/service/src/requisition_line/request_requisition_line/delete.rs
@@ -102,7 +102,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -166,7 +166,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/requisition_line/request_requisition_line/insert.rs
+++ b/server/service/src/requisition_line/request_requisition_line/insert.rs
@@ -166,7 +166,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -284,7 +284,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/requisition_line/request_requisition_line/update.rs
+++ b/server/service/src/requisition_line/request_requisition_line/update.rs
@@ -130,7 +130,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -192,7 +192,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/requisition_line/response_line_stats/mod.rs
+++ b/server/service/src/requisition_line/response_line_stats/mod.rs
@@ -88,7 +88,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -243,7 +243,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/requisition_line/response_requisition_line/delete.rs
+++ b/server/service/src/requisition_line/response_requisition_line/delete.rs
@@ -108,7 +108,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -161,7 +161,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/requisition_line/response_requisition_line/insert/mod.rs
+++ b/server/service/src/requisition_line/response_requisition_line/insert/mod.rs
@@ -123,7 +123,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -233,7 +233,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/requisition_line/response_requisition_line/update.rs
+++ b/server/service/src/requisition_line/response_requisition_line/update.rs
@@ -189,7 +189,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -261,7 +261,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_b().id)
             .unwrap();

--- a/server/service/src/rnr_form/tests/finalise.rs
+++ b/server/service/src/rnr_form/tests/finalise.rs
@@ -17,7 +17,7 @@ mod finalise {
         let (_, _, connection_manager, _) =
             setup_all("finalise_rnr_form_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -66,7 +66,7 @@ mod finalise {
         let (_, _, connection_manager, _) =
             setup_all("finalise_rnr_form_success", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/rnr_form/tests/generate_rnr_form_lines.rs
+++ b/server/service/src/rnr_form/tests/generate_rnr_form_lines.rs
@@ -59,7 +59,7 @@ mod generate_rnr_form_lines {
         .await;
         let rnr_form_id = mock_rnr_form_a().id;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/rnr_form/tests/insert.rs
+++ b/server/service/src/rnr_form/tests/insert.rs
@@ -45,7 +45,7 @@ mod insert {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -253,7 +253,7 @@ mod insert {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/rnr_form/tests/schedules_with_periods.rs
+++ b/server/service/src/rnr_form/tests/schedules_with_periods.rs
@@ -36,7 +36,7 @@ mod query {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.rnr_form_service;
 

--- a/server/service/src/rnr_form/tests/update.rs
+++ b/server/service/src/rnr_form/tests/update.rs
@@ -21,7 +21,7 @@ mod update {
         let (_, _, connection_manager, _) =
             setup_all("update_rnr_form_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -210,7 +210,7 @@ mod update {
         let (_, _, connection_manager, _) =
             setup_all("update_rnr_form_success", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/sensor/tests/insert.rs
+++ b/server/service/src/sensor/tests/insert.rs
@@ -19,7 +19,7 @@ mod query {
 
         let connection = connection_manager.connection().unwrap();
         let sensor_repository = SensorRepository::new(&connection);
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -69,7 +69,7 @@ mod query {
 
         let connection = connection_manager.connection().unwrap();
         let sensor_repository = SensorRepository::new(&connection);
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/sensor/tests/query.rs
+++ b/server/service/src/sensor/tests/query.rs
@@ -10,7 +10,7 @@ mod query {
         let (_, _, connection_manager, _) =
             setup_all("test_sensor_service_pagination", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.sensor_service;
 
@@ -46,7 +46,7 @@ mod query {
         let (_, _, connection_manager, _) =
             setup_all("test_sensor_single_record", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.sensor_service;
 
@@ -68,7 +68,7 @@ mod query {
         let (_, _, connection_manager, _) =
             setup_all("test_sensor_filter", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.sensor_service;
 
@@ -106,7 +106,7 @@ mod query {
         let (mock_data, _, connection_manager, _) =
             setup_all("test_sensor_sort", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.sensor_service;
         // Test Name sort with default sort order

--- a/server/service/src/sensor/tests/update.rs
+++ b/server/service/src/sensor/tests/update.rs
@@ -17,7 +17,7 @@ mod query {
 
         let connection = connection_manager.connection().unwrap();
         let sensor_repository = SensorRepository::new(&connection);
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -67,7 +67,7 @@ mod query {
 
         let connection = connection_manager.connection().unwrap();
         let sensor_repository = SensorRepository::new(&connection);
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/service_provider.rs
+++ b/server/service/src/service_provider.rs
@@ -171,10 +171,9 @@ impl ServiceProvider {
     // TODO we should really use `new` with processors_trigger, we constructs ServiceProvider manually in tests though
     // and it would be a bit of refactor, ideally setup_all and setup_all_with_data will return an instance of ServiceProvider
     // {make an issue}
-    pub fn new(connection_manager: StorageConnectionManager, app_data_folder: &str) -> Self {
+    pub fn new(connection_manager: StorageConnectionManager) -> Self {
         ServiceProvider::new_with_triggers(
             connection_manager,
-            app_data_folder,
             ProcessorsTrigger::new_void(),
             SyncTrigger::new_void(),
             SiteIsInitialisedTrigger::new_void(),
@@ -183,7 +182,6 @@ impl ServiceProvider {
 
     pub fn new_with_triggers(
         connection_manager: StorageConnectionManager,
-        app_data_folder: &str,
         processors_trigger: ProcessorsTrigger,
         sync_trigger: SyncTrigger,
         site_is_initialised_trigger: SiteIsInitialisedTrigger,
@@ -220,7 +218,7 @@ impl ServiceProvider {
             program_event_service: Box::new(ProgramEventService {}),
             encounter_service: Box::new(EncounterService {}),
             contact_trace_service: Box::new(ContactTraceService {}),
-            app_data_service: Box::new(AppDataService::new(app_data_folder)),
+            app_data_service: Box::new(AppDataService {}),
             site_info_service: Box::new(SiteInfoService),
             sync_status_service: Box::new(SyncStatusService),
             processors_trigger,

--- a/server/service/src/stock_line/tests/query.rs
+++ b/server/service/src/stock_line/tests/query.rs
@@ -14,7 +14,7 @@ mod query {
         let (_, _, connection_manager, _) =
             setup_all("test_stock_line_service_pagination", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.stock_line_service;
 
@@ -52,7 +52,7 @@ mod query {
         let (_, _, connection_manager, _) =
             setup_all("test_stock_line_single_record", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let service_provider = ServiceProvider::new(connection_manager.clone());
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.stock_line_service;
 
@@ -74,7 +74,7 @@ mod query {
         let (_, _, connection_manager, _) =
             setup_all("test_stock_line_filter", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.stock_line_service;
 
@@ -131,7 +131,7 @@ mod query {
         let (mock_data, _, connection_manager, _) =
             setup_all("test_stock_line_sort", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.stock_line_service;
         let mut stock_lines = mock_data["base"].stock_lines.clone();

--- a/server/service/src/stock_line/tests/update.rs
+++ b/server/service/src/stock_line/tests/update.rs
@@ -16,7 +16,7 @@ mod test {
         let (_, _, connection_manager, _) =
             setup_all("update_stock_line_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();
@@ -82,7 +82,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("update_stock_line_success", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/stocktake/batch.rs
+++ b/server/service/src/stocktake/batch.rs
@@ -127,7 +127,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("batch_stocktake_service", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/stocktake/delete/mod.rs
+++ b/server/service/src/stocktake/delete/mod.rs
@@ -79,7 +79,7 @@ mod stocktake_test {
         let (_, _, connection_manager, _) =
             setup_all("delete_stocktake", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/stocktake/insert/mod.rs
+++ b/server/service/src/stocktake/insert/mod.rs
@@ -103,7 +103,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("insert_stocktake", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();
@@ -185,7 +185,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("insert_stocktake_with_master_list", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();
@@ -311,7 +311,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("insert_stocktake_with_location", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();
@@ -444,7 +444,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();
@@ -508,7 +508,7 @@ mod test {
         let (_, connection, connection_manager, _) =
             setup_all("insert_stocktake_with_expiry", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/stocktake/update/mod.rs
+++ b/server/service/src/stocktake/update/mod.rs
@@ -298,7 +298,7 @@ mod test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context("invalid".to_string(), "".to_string())
             .unwrap();

--- a/server/service/src/stocktake_line/delete/mod.rs
+++ b/server/service/src/stocktake_line/delete/mod.rs
@@ -55,7 +55,7 @@ mod stocktake_line_test {
         let (_, _, connection_manager, _) =
             setup_all("delete_stocktake_line", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/stocktake_line/insert/mod.rs
+++ b/server/service/src/stocktake_line/insert/mod.rs
@@ -185,7 +185,7 @@ mod stocktake_line_test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/stocktake_line/query.rs
+++ b/server/service/src/stocktake_line/query.rs
@@ -87,7 +87,7 @@ mod stocktake_line_test {
         let (_, _, connection_manager, _) =
             setup_all("query_stocktake_line", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.stocktake_line_service;
 

--- a/server/service/src/stocktake_line/update/mod.rs
+++ b/server/service/src/stocktake_line/update/mod.rs
@@ -160,7 +160,7 @@ mod stocktake_line_test {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
             .context(mock_store_a().id, "".to_string())
             .unwrap();

--- a/server/service/src/sync/integrate_document.rs
+++ b/server/service/src/sync/integrate_document.rs
@@ -174,7 +174,7 @@ mod integrate_document_test {
         let (_, _, connection_manager, _) =
             setup_all("test_integrate_latest_document", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.program_enrolment_service;
 

--- a/server/service/src/sync/test/integration/errors.rs
+++ b/server/service/src/sync/test/integration/errors.rs
@@ -27,7 +27,7 @@ mod tests {
         settings: &SyncSettings,
         hardware_id: &str,
     ) -> Synchroniser {
-        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
         struct TestService1(String);
         impl AppDataServiceTrait for TestService1 {
             fn get_hardware_id(&self) -> Result<String, Error> {

--- a/server/service/src/test_helpers.rs
+++ b/server/service/src/test_helpers.rs
@@ -57,7 +57,6 @@ pub(crate) async fn setup_all_with_data_and_service_provider(
 
     let service_provider = Arc::new(ServiceProvider::new_with_triggers(
         connection_manager.clone(),
-        "../app_data",
         processors_trigger,
         sync_trigger,
         site_is_initialise_trigger,

--- a/server/service/src/user_account.rs
+++ b/server/service/src/user_account.rs
@@ -195,7 +195,7 @@ impl<'a> UserAccountService<'a> {
             return Err(VerifyPasswordError::EmptyHashedPassword);
         }
 
-        // verify password  
+        // verify password
         let valid = verify(password, &user.hashed_password).map_err(|err| {
             error!("verify_password: {}", err);
             VerifyPasswordError::InvalidCredentialsBackend(err)
@@ -211,7 +211,10 @@ impl<'a> UserAccountService<'a> {
 #[cfg(test)]
 mod user_account_test {
     use repository::{
-        mock::{mock_user_account_a, mock_user_account_b, mock_user_empty_hashed_password, MockDataInserts},
+        mock::{
+            mock_user_account_a, mock_user_account_b, mock_user_empty_hashed_password,
+            MockDataInserts,
+        },
         test_db::{self, setup_all},
         PermissionType,
     };
@@ -270,7 +273,7 @@ mod user_account_test {
                 .user_permissions(),
         )
         .await;
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
 
         let user_repo = UserRepository::new(&context.connection);
@@ -350,17 +353,19 @@ mod user_account_test {
     async fn test_missing_hashed_password() {
         let (_, _, connection_manager, _) = setup_all(
             "test_missing_hashed_password",
-            MockDataInserts::none()
-                .user_accounts()
+            MockDataInserts::none().user_accounts(),
         )
         .await;
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
 
         let user_service = UserAccountService::new(&context.connection);
 
-        let result = user_service.verify_password(&mock_user_empty_hashed_password().username, "password");
-        assert!(matches!(result, Err(VerifyPasswordError::EmptyHashedPassword)));
+        let result =
+            user_service.verify_password(&mock_user_empty_hashed_password().username, "password");
+        assert!(matches!(
+            result,
+            Err(VerifyPasswordError::EmptyHashedPassword)
+        ));
     }
-
 }

--- a/server/service/src/vaccination/insert/mod.rs
+++ b/server/service/src/vaccination/insert/mod.rs
@@ -170,7 +170,7 @@ mod insert {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();
@@ -402,7 +402,7 @@ mod insert {
         let (_, _, connection_manager, _) =
             setup_all("insert_vaccination_success", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();
@@ -479,7 +479,7 @@ mod insert {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/vaccination/update/mod.rs
+++ b/server/service/src/vaccination/update/mod.rs
@@ -216,7 +216,7 @@ mod update {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();
@@ -371,7 +371,7 @@ mod update {
         let (_, _, connection_manager, _) =
             setup_all("update_vaccination_success", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();
@@ -450,7 +450,7 @@ mod update {
         )
         .await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
             .context(mock_store_a().id, mock_user_account_a().id)
             .unwrap();

--- a/server/service/src/vaccine_course/test/delete.rs
+++ b/server/service/src/vaccine_course/test/delete.rs
@@ -18,7 +18,7 @@ mod delete {
         let (_, _, connection_manager, _) =
             setup_all("delete_vaccine_course_errors", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.vaccine_course_service;
 
@@ -33,7 +33,7 @@ mod delete {
         let (_, _, connection_manager, _) =
             setup_all("delete_vaccine_course_success", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.vaccine_course_service;
 

--- a/server/service/src/vaccine_course/test/insert.rs
+++ b/server/service/src/vaccine_course/test/insert.rs
@@ -22,7 +22,7 @@ mod query {
         let (_, _connection, connection_manager, _) =
             setup_all("test_insert_vaccine_course", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.vaccine_course_service;
 

--- a/server/service/src/vaccine_course/test/query.rs
+++ b/server/service/src/vaccine_course/test/query.rs
@@ -17,7 +17,7 @@ mod query {
         let (_, _, connection_manager, _) =
             setup_all("test_vaccine_course_single_record", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.vaccine_course_service;
 
@@ -55,7 +55,7 @@ mod query {
         let (_, connection, connection_manager, _) =
             setup_all("test_vaccine_course_filter", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.vaccine_course_service;
 

--- a/server/service/src/vaccine_course/test/update.rs
+++ b/server/service/src/vaccine_course/test/update.rs
@@ -24,7 +24,7 @@ mod query {
         let (_, _connection, connection_manager, _) =
             setup_all("test_update_vaccine_course", MockDataInserts::all()).await;
 
-        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider.basic_context().unwrap();
         let service = service_provider.vaccine_course_service;
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5107

# 👩🏻‍💻 What does this PR do?
Now that hardware ID is being stored in memory, no longer need the references to store the hardware id in the app data folder

<!-- Explain the changes you made -->

<!-- why are the changes needed -->
Changes needed to clean up the codebase

<!-- Add a screenshot if there are UI changes  -->
Cheers to the Korimako hive mind who worked on this @lache-melvin @aimee-mcneil-melville @zachariah-at-msupply 

Also shoutout to @jmbrunskill for clarifying a whole bunch of stuff for me (e.g. note below). 
## 💌 Any notes for the reviewer?
Even though app data folder is no longer being used for hardware id, it is still used to store sync files and report files.
Please test syncing when adding files and also printing.

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to cold chain equipments and create new asset
- [ ] Update asset status and add an image
- [ ] Sync and check that the image appears in central server

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [-] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
