### PR TITLE
5409 fix location filter

### DIFF
--- a/server/repository/src/db_diesel/cold_storage_type.rs
+++ b/server/repository/src/db_diesel/cold_storage_type.rs
@@ -5,7 +5,7 @@ use super::{
     ColdStorageTypeRow, DBType, StorageConnection,
 };
 
-use diesel::prelude::*;
+use diesel::{dsl::not, prelude::*};
 
 use crate::{
     diesel_macros::{apply_equal_filter, apply_sort, apply_sort_no_case},
@@ -96,11 +96,9 @@ impl<'a> ColdStorageTypeRepository<'a> {
         let mut query = cold_storage_type_dsl::cold_storage_type.into_boxed();
         // Any cold storage types that don't have temperature set (OdegC to 0degC default value) are invalid => filter out
 
-        query = query.filter(
-            cold_storage_type_dsl::min_temperature
-                .ne(0.0)
-                .and(max_temperature.ne(0.0)),
-        );
+        query = query.filter(not(cold_storage_type_dsl::min_temperature
+            .eq(0.0)
+            .and(max_temperature.eq(0.0))));
 
         if let Some(f) = filter {
             let ColdStorageTypeFilter { id, name } = f;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5409

# 👩🏻‍💻 What does this PR do?

Correctly filters out only location_types with min and max temperature both 0.0.
E.g. you can now have a temperature range that goes from 0 to 15 for example.

![image](https://github.com/user-attachments/assets/c6552697-8024-4592-8f34-9c0c2a481033)


## 💌 Any notes for the reviewer?

Should have pick this up in code review.
Was actually worried about this and I thought I'd tested it... Here: https://github.com/msupply-foundation/open-msupply/pull/5518#pullrequestreview-2453186364

Not sure what happened!

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Test you can have a location_type with range 0 -> something and assign to a location in OMS

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
