### PR TITLE
5492 unable to delete lines from a stocktake

### DIFF
--- a/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeDeleteSelectedLines.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeDeleteSelectedLines.ts
@@ -2,39 +2,23 @@ import {
   useTableStore,
   useDeleteConfirmation,
 } from '@openmsupply-client/common';
-import { StocktakeSummaryItem } from '../../../../types';
 import { StocktakeLineFragment } from '../../operations.generated';
 import { useTranslation } from '@common/intl';
 import { useStocktakeDeleteLines } from './useStocktakeDeleteLines';
 import { useStocktakeRows } from './useStocktakeRows';
 
 export const useStocktakeDeleteSelectedLines = (): (() => void) => {
-  const { isDisabled, items, lines } = useStocktakeRows();
+  const { isDisabled, lines } = useStocktakeRows();
   const { mutateAsync } = useStocktakeDeleteLines();
   const t = useTranslation();
 
   const { selectedRows } = useTableStore(state => {
-    const { isGrouped } = state;
-
-    if (isGrouped) {
-      return {
-        selectedRows: (
-          Object.keys(state.rowState)
-            .filter(id => state.rowState[id]?.isSelected)
-            .map(selectedId => items?.find(({ id }) => selectedId === id))
-            .filter(Boolean) as StocktakeSummaryItem[]
-        )
-          .map(({ lines }) => lines)
-          .flat(),
-      };
-    } else {
-      return {
-        selectedRows: Object.keys(state.rowState)
-          .filter(id => state.rowState[id]?.isSelected)
-          .map(selectedId => lines?.find(({ id }) => selectedId === id))
-          .filter(Boolean) as StocktakeLineFragment[],
-      };
-    }
+    return {
+      selectedRows: Object.keys(state.rowState)
+        .filter(id => state.rowState[id]?.isSelected)
+        .map(selectedId => lines?.find(({ id }) => selectedId === id))
+        .filter(Boolean) as StocktakeLineFragment[],
+    };
   });
 
   const onDelete = async () => {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5492

# 👩🏻‍💻 What does this PR do?
isGrouped logic has been removed in the frontend but wasn't removed from the delete selection >.>. This PR allows you to delete stocktake lines.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a new stocktake
- [ ] Add an item to the stocktake
- [ ] Try to delete the stocktake lines
- [ ] Note: Shouldn't refresh or navigate away from the stocktake when doing this

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
