### PR TITLE
Disable breadcrumb link for indicators

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorEditPage.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorEditPage.tsx
@@ -64,7 +64,7 @@ export const IndicatorEditPage = () => {
   if (isLoading || isProgramIndicatorsLoading) {
     return <BasicSpinner />;
   }
-  if (!programIndicatorLineId || !response) {
+  if (!response) {
     return <NothingHere />;
   }
 

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorEditPage.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorEditPage.tsx
@@ -52,10 +52,13 @@ export const IndicatorEditPage = () => {
   );
 
   useEffect(() => {
-    setCustomBreadcrumbs({
-      2: t('label.indicators'),
-      4: currentLine?.code || '',
-    });
+    setCustomBreadcrumbs(
+      {
+        2: t('label.indicators'),
+        4: currentLine?.code || '',
+      },
+      [2, 3]
+    );
   }, [programIndicatorLineId]);
 
   if (isLoading || isProgramIndicatorsLoading) {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5610

# 👩🏻‍💻 What does this PR do?
Disables link in the indicators breadcrumbs as its only needed to load the correct indicators on the page and doesn't link to anything separately.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have indicators set up for your program
- [ ] Sync
- [ ] Create a new program Requisition
- [ ] Go to indicator tab and click on one of the buttons
- [ ] Only the Requisition and requisition number in the breadcrumb should be enabled

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
