### PR TITLE
5583 error operator does not exist text asset log status on asset status page

### DIFF
--- a/server/repository/src/migrations/v2_04_00/fix_asset_log_reasons_postgres.rs
+++ b/server/repository/src/migrations/v2_04_00/fix_asset_log_reasons_postgres.rs
@@ -1,0 +1,26 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "fix_asset_log_reasons_postgres"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        // Previous migration wasn't correct for postgres, we need to re-create the column
+        if cfg!(feature = "postgres") {
+            sql!(
+                connection,
+                r#"
+                    ALTER TABLE asset_log_reason rename column asset_log_status to asset_log_status_old;
+                    ALTER TABLE asset_log_reason ADD COLUMN asset_log_status asset_log_status NOT NULL DEFAULT 'NOT_IN_USE';
+                    UPDATE asset_log_reason SET asset_log_status = asset_log_status_old::asset_log_status;
+                    ALTER TABLE asset_log_reason DROP COLUMN asset_log_status_old;
+                "#
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_04_00/mod.rs
+++ b/server/repository/src/migrations/v2_04_00/mod.rs
@@ -11,6 +11,7 @@ mod add_reason_option_table;
 mod add_store_pref_use_extra_fields;
 mod add_unserviceable_status_to_asset_status_enum;
 mod delete_pack_variant;
+mod fix_asset_log_reasons_postgres;
 mod indicator_indexes;
 mod indicator_line_column_create_tables;
 mod indicator_value_create_table;
@@ -50,6 +51,7 @@ impl Migration for V2_04_00 {
             Box::new(add_store_pref_use_extra_fields::Migrate),
             Box::new(add_item_variant_id_to_stocktake_line::Migrate),
             Box::new(item_changelog::Migrate),
+            Box::new(fix_asset_log_reasons_postgres::Migrate),
         ]
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5583

# 👩🏻‍💻 What does this PR do?

Fixes an error that only shows up when running a postgres server with open-mSupply.
The reason drop down when doing an asset status update, wasn't populating correctly and errors where thrown

## 💌 Any notes for the reviewer?

I haven't created a test but would have been good to have one to pick this up originally.
Not sure how much we need to test everything?

Surprised the sync test didn't have a problem, I guess it's not actually persisting it to the db...

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Run open-mSupply postgres edition
- [ ] Enable cold chain equipment in mSupply
- [ ] Create an asset (cold chain equipment) and try to set the status
- [ ] Check the reasons populate correctly for  `NOT_IN_USE` and `NOT_FUNCTIONING` status

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
