### PR TITLE
5619 indicators should show indicator line name 

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorEditPage.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorEditPage.tsx
@@ -55,7 +55,10 @@ export const IndicatorEditPage = () => {
     setCustomBreadcrumbs(
       {
         2: t('label.indicators'),
-        4: currentLine?.code || '',
+        4:
+          programIndicatorCode === 'HIV'
+            ? `${currentLine?.name}: ${currentLine?.code}`
+            : (currentLine?.code ?? ''),
       },
       [2, 3]
     );

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorEditPage.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorEditPage.tsx
@@ -55,10 +55,7 @@ export const IndicatorEditPage = () => {
     setCustomBreadcrumbs(
       {
         2: t('label.indicators'),
-        4:
-          programIndicatorCode === 'HIV'
-            ? `${currentLine?.name}: ${currentLine?.code}`
-            : (currentLine?.code ?? ''),
+        4: `${currentLine?.name}: ${currentLine?.code}`,
       },
       [2, 3]
     );

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
@@ -18,7 +18,6 @@ import { useDraftIndicatorValue } from './hooks';
 
 interface IndicatorLineEditProps {
   requisitionNumber: number;
-  indicatorCode?: string;
   hasNext: boolean;
   next: IndicatorLineRowFragment | null;
   hasPrevious: boolean;

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/ListIndicators.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/ListIndicators.tsx
@@ -3,6 +3,7 @@ import {
   ListOptions,
   RouteBuilder,
   useNavigate,
+  useParams,
 } from '@openmsupply-client/common';
 import { IndicatorLineRowFragment } from '../../api';
 
@@ -17,6 +18,7 @@ export const ListIndicatorLines = ({
   lines,
   route,
 }: ListIndicatorLineProps) => {
+  const { programIndicatorCode } = useParams();
   const navigate = useNavigate();
   const value = lines?.find(({ id }) => id === currentIndicatorLineId) ?? null;
 
@@ -29,9 +31,9 @@ export const ListIndicatorLines = ({
         });
       }}
       options={
-        lines?.map(({ id, code }) => ({
+        lines?.map(({ id, name, code }) => ({
           id,
-          value: code,
+          value: programIndicatorCode === 'HIV' ? `${name}: ${code}` : code,
         })) ?? []
       }
     />

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/ListIndicators.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/ListIndicators.tsx
@@ -3,7 +3,6 @@ import {
   ListOptions,
   RouteBuilder,
   useNavigate,
-  useParams,
 } from '@openmsupply-client/common';
 import { IndicatorLineRowFragment } from '../../api';
 
@@ -18,7 +17,6 @@ export const ListIndicatorLines = ({
   lines,
   route,
 }: ListIndicatorLineProps) => {
-  const { programIndicatorCode } = useParams();
   const navigate = useNavigate();
   const value = lines?.find(({ id }) => id === currentIndicatorLineId) ?? null;
 
@@ -33,7 +31,7 @@ export const ListIndicatorLines = ({
       options={
         lines?.map(({ id, name, code }) => ({
           id,
-          value: programIndicatorCode === 'HIV' ? `${name}: ${code}` : code,
+          value: `${name}: ${code}`,
         })) ?? []
       }
     />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5619

# 👩🏻‍💻 What does this PR do?
Show description + code for HIV indicators and code for regimen.

![Screenshot 2024-11-29 at 9 11 54 AM](https://github.com/user-attachments/assets/7a8cabc5-3cf3-44ce-b55f-2b3454311d42)
![Screenshot 2024-11-29 at 9 12 04 AM](https://github.com/user-attachments/assets/7e8ebbae-2be6-43ba-b3e2-754f862871ef)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have indicators set up for programs (both HIV and manual)
- [ ] Create program requisition
- [ ] Go to indicators tab
- [ ] Click on either of the buttons
- [ ] See that they are more descriptive

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
