### PR TITLE
5635 when emptying an hiv indicator from it's default value, it is replaced by a strange text value and you can't change it easily to a valid value

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/DetailView.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/DetailView.tsx
@@ -101,7 +101,6 @@ export const DetailView: FC = () => {
       value: 'Log',
     },
   ];
-  console.log('programIndicators', programIndicators);
 
   if (
     data?.programName &&

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/DetailView.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/DetailView.tsx
@@ -101,8 +101,13 @@ export const DetailView: FC = () => {
       value: 'Log',
     },
   ];
+  console.log('programIndicators', programIndicators);
 
-  if (data?.programName && !!data?.otherParty.store) {
+  if (
+    data?.programName &&
+    !!data?.otherParty.store &&
+    programIndicators?.totalCount !== 0
+  ) {
     tabs.push({
       Component: (
         <IndicatorsTab

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
@@ -56,10 +56,8 @@ const InputWithLabel = ({ data }: { data: IndicatorColumnNode }) => {
         width={INPUT_WIDTH}
         value={isNaN(Number(draft?.value)) ? 0 : Number(draft?.value)}
         onChange={v => {
-          if (isNaN(Number(v))) {
-            update({ value: '0' }).then(errorHandler);
-          }
-          update({ value: String(v) }).then(errorHandler);
+          const newValue = isNaN(Number(v)) ? 0 : v;
+          update({ value: String(newValue) }).then(errorHandler);
         }}
         autoFocus
       />

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
@@ -54,7 +54,7 @@ const InputWithLabel = ({ data }: { data: IndicatorColumnNode }) => {
     data.valueType === IndicatorValueTypeNode.Number ? (
       <NumericTextInput
         width={INPUT_WIDTH}
-        value={Number(draft?.value)}
+        value={isNaN(Number(draft?.value)) ? 0 : Number(draft?.value)}
         onChange={v => {
           update({ value: String(v) }).then(errorHandler);
         }}

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
@@ -56,6 +56,9 @@ const InputWithLabel = ({ data }: { data: IndicatorColumnNode }) => {
         width={INPUT_WIDTH}
         value={isNaN(Number(draft?.value)) ? 0 : Number(draft?.value)}
         onChange={v => {
+          if (isNaN(Number(v))) {
+            update({ value: '0' }).then(errorHandler);
+          }
           update({ value: String(v) }).then(errorHandler);
         }}
         autoFocus


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5634 & #5635

# 👩🏻‍💻 What does this PR do?
Defaults to 0 if NaN input and hide indicators tab if no indicators

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have number input indicator
- [ ] Go to that indicator and backspace
- [ ] Should still be able to enter number and shouldn't say NaN

Next:
- [ ] Have program without indicators
- [ ] Create program requisition
- [ ] Shouldn't see indicators tab

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
