### PR TITLE
Allow editing of asset number

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/Tabs/Summary.tsx
@@ -180,6 +180,13 @@ export const Summary = ({ draft, onChange, locations }: SummaryProps) => {
               onChange={e => onChange({ serialNumber: e.target.value })}
             />
           </Row>
+          <Row label={t('label.asset-number')}>
+            <BasicTextInput
+              value={draft.assetNumber ?? ''}
+              fullWidth
+              onChange={e => onChange({ assetNumber: e.target.value })}
+            />
+          </Row>
           <Row label={t('label.installation-date')}>
             <DateTimePickerInput
               value={DateUtils.getDateOrNull(draft.installationDate)}

--- a/server/graphql/asset/src/mutations/update.rs
+++ b/server/graphql/asset/src/mutations/update.rs
@@ -151,6 +151,7 @@ fn map_error(error: ServiceError) -> Result<UpdateAssetErrorInterface> {
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
         ServiceError::SerialNumberAlreadyExists => BadUserInput(formatted_error),
         ServiceError::LocationsAlreadyAssigned => BadUserInput(formatted_error),
+        ServiceError::AssetNumberAlreadyExists => BadUserInput(formatted_error),
     };
 
     Err(graphql_error.extend())

--- a/server/service/src/asset/insert.rs
+++ b/server/service/src/asset/insert.rs
@@ -95,6 +95,7 @@ pub fn validate(
         return Err(InsertAssetError::AssetAlreadyExists);
     }
 
+    // Check asset number is unique (on this site)
     if let Some(asset_number) = &input.asset_number {
         if check_asset_number_exists(asset_number, connection)?.len() >= 1 {
             return Err(InsertAssetError::AssetNumberAlreadyExists);

--- a/server/service/src/asset/insert.rs
+++ b/server/service/src/asset/insert.rs
@@ -97,7 +97,7 @@ pub fn validate(
 
     // Check asset number is unique (on this site)
     if let Some(asset_number) = &input.asset_number {
-        if check_asset_number_exists(asset_number, connection)?.len() >= 1 {
+        if check_asset_number_exists(connection, asset_number, None)?.len() >= 1 {
             return Err(InsertAssetError::AssetNumberAlreadyExists);
         }
     }

--- a/server/service/src/asset/update.rs
+++ b/server/service/src/asset/update.rs
@@ -1,7 +1,10 @@
 use super::{
     location::set_asset_location,
     query::get_asset,
-    validate::{check_asset_exists, check_locations_are_assigned, check_locations_belong_to_store},
+    validate::{
+        check_asset_exists, check_asset_number_exists, check_locations_are_assigned,
+        check_locations_belong_to_store,
+    },
 };
 use crate::{
     activity_log::activity_log_entry, service_provider::ServiceContext, NullableUpdate,
@@ -25,6 +28,7 @@ pub enum UpdateAssetError {
     DatabaseError(RepositoryError),
     LocationsAlreadyAssigned,
     LocationDoesNotBelongToStore,
+    AssetNumberAlreadyExists,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -97,6 +101,13 @@ pub fn validate(
             {
                 return Err(UpdateAssetError::SerialNumberAlreadyExists);
             }
+        }
+    }
+
+    // Check asset number is unique (on this site)
+    if let Some(asset_number) = &input.asset_number {
+        if check_asset_number_exists(asset_number, connection)?.len() >= 1 {
+            return Err(UpdateAssetError::AssetNumberAlreadyExists);
         }
     }
 

--- a/server/service/src/asset/update.rs
+++ b/server/service/src/asset/update.rs
@@ -106,7 +106,8 @@ pub fn validate(
 
     // Check asset number is unique (on this site)
     if let Some(asset_number) = &input.asset_number {
-        if check_asset_number_exists(asset_number, connection)?.len() >= 1 {
+        if check_asset_number_exists(connection, &asset_number, Some(input.id.clone()))?.len() >= 1
+        {
             return Err(UpdateAssetError::AssetNumberAlreadyExists);
         }
     }

--- a/server/service/src/asset/validate.rs
+++ b/server/service/src/asset/validate.rs
@@ -30,11 +30,15 @@ pub fn check_asset_property_exists(
 }
 
 pub fn check_asset_number_exists(
-    asset_number: &str,
     connection: &StorageConnection,
+    asset_number: &str,
+    updated_asset_id: Option<String>,
 ) -> Result<Vec<Asset>, RepositoryError> {
-    AssetRepository::new(connection)
-        .query_by_filter(AssetFilter::new().asset_number(StringFilter::equal_to(asset_number)))
+    let mut filter = AssetFilter::new().asset_number(StringFilter::equal_to(asset_number));
+    if let Some(updated_asset_id) = updated_asset_id {
+        filter = filter.id(EqualFilter::not_equal_to(&updated_asset_id));
+    }
+    AssetRepository::new(connection).query_by_filter(filter)
 }
 
 pub fn check_asset_log_exists(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5392

# 👩🏻‍💻 What does this PR do?

This is the simplest version of this -- it just makes the Asset number editable after the asset is created. I'll make a follow-up issue to get user input on scanning, as that's a bit more involved and could do with some further planning to make it work nicely.

## 💌 Any notes for the reviewer?

I notice we're not enforcing unique-ness for Asset number. Should it be?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to an Asset detail page
- [ ] Can edit the Asset Number
- [ ] Can save, and Asset number is updated in the Breadcrumb title at the top of the page

