### PR TITLE
5674 Disable indicator buttons if requisition is finalised

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/DetailView.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/DetailView.tsx
@@ -114,6 +114,7 @@ export const DetailView: FC = () => {
           isLoading={isLoading || isProgramIndicatorsLoading}
           response={data}
           indicators={programIndicators?.nodes}
+          disabled={isDisabled}
         />
       ),
       value: t('label.indicators'),

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorsTab.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorsTab.tsx
@@ -19,6 +19,7 @@ interface IndicatorTabProps {
   isLoading: boolean;
   response?: ResponseFragment;
   indicators?: ProgramIndicatorFragment[];
+  disabled: boolean;
 }
 
 export const IndicatorsTab = ({
@@ -26,6 +27,7 @@ export const IndicatorsTab = ({
   isLoading,
   response,
   indicators,
+  disabled,
 }: IndicatorTabProps) => {
   const t = useTranslation();
   if (isLoading) {
@@ -60,7 +62,7 @@ export const IndicatorsTab = ({
     <Box display="flex" flexDirection="column" padding={2} gap={2}>
       {regimenIndicators.length > 0 && (
         <ButtonWithIcon
-          // disabled={disableAddButton}
+          disabled={disabled}
           label={t('button.regimen')}
           Icon={<PlusCircleIcon />}
           onClick={() =>
@@ -70,7 +72,7 @@ export const IndicatorsTab = ({
       )}
       {hivIndicators.length > 0 && (
         <ButtonWithIcon
-          // disabled={disableAddButton}
+          disabled={disabled}
           label={t('button.hiv')}
           Icon={<PlusCircleIcon />}
           onClick={() => onClick(hivIndicators[0], firstHivLine, response)}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5674

# 👩🏻‍💻 What does this PR do?
Disable the edit indicator buttons in the indicator tab if the Requisition has been finalised. 

## 💌 Any notes for the reviewer?
Will need to implement #5677 so that the user can actually view the indicators after its been finalised, but also useful for the user to see all the indicators at once instead of having to go through the indicators one by one

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a program requisition for a store name
- [ ] Finalise Requisition
- [ ] The buttons should be disabled

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
