### PR TITLE
5656 cdi 2.5 store preferences

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1167,7 +1167,7 @@
   "messages.cant-download-android": "File cannot be downloaded on this device",
   "messages.cant-return-shipment": "Cannot process return of lines until the status is 'Shipped'",
   "messages.cant-return-shipment-replenishment": "Cannot return lines until the status is 'Delivered'",
-  "messages.cant-send-order": "Cannot send Internal Order because there are no lines or because there are only placeholder lines",
+  "messages.cant-send-order": "Cannot send Internal Order because there are no lines",
   "messages.catalogue-property": "This property is defined in the catalogue",
   "messages.cce-created": "CCE created successfully",
   "messages.change-server": "Change server",

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
@@ -143,9 +143,7 @@ export const StatusChangeButton = () => {
   const isDisabled = useRequest.utils.isDisabled();
   const { userHasPermission } = useAuthContext();
   const t = useTranslation();
-  const cantSend =
-    lines?.totalCount === 0 ||
-    lines?.nodes.every(line => line.requestedQuantity === 0);
+  const cantSend = lines?.totalCount === 0;
 
   const showPermissionDenied = useDisabledNotificationToast(
     t('auth.permission-denied')

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "2.4.00",
+  "version": "2.5.00",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/graphql/types/src/types/store_preference.rs
+++ b/server/graphql/types/src/types/store_preference.rs
@@ -66,6 +66,12 @@ impl StorePreferenceNode {
     pub async fn extra_fields_in_requisition(&self) -> &bool {
         &self.store_preference.extra_fields_in_requisition
     }
+
+    pub async fn manually_link_internal_order_to_inbound_shipment(&self) -> &bool {
+        &self
+            .store_preference
+            .manually_link_internal_order_to_inbound_shipment
+    }
 }
 
 impl StorePreferenceNode {

--- a/server/repository/src/db_diesel/store_preference_row.rs
+++ b/server/repository/src/db_diesel/store_preference_row.rs
@@ -27,6 +27,9 @@ table! {
         months_items_expire -> Double,
         stocktake_frequency -> Double,
         extra_fields_in_requisition -> Bool,
+        keep_requisition_lines_with_zero_requested_quantity_on_finalised -> Bool,
+        use_consumption_and_stock_from_customers_for_internal_orders -> Bool,
+        manually_link_internal_order_to_inbound_shipment -> Bool,
     }
 }
 
@@ -62,6 +65,9 @@ pub struct StorePreferenceRow {
     pub months_items_expire: f64,
     pub stocktake_frequency: f64,
     pub extra_fields_in_requisition: bool,
+    pub keep_requisition_lines_with_zero_requested_quantity_on_finalised: bool,
+    pub use_consumption_and_stock_from_customers_for_internal_orders: bool,
+    pub manually_link_internal_order_to_inbound_shipment: bool,
 }
 
 pub struct StorePreferenceRowRepository<'a> {

--- a/server/repository/src/migrations/mod.rs
+++ b/server/repository/src/migrations/mod.rs
@@ -26,6 +26,7 @@ mod v2_02_02;
 mod v2_03_00;
 mod v2_03_01;
 mod v2_04_00;
+mod v2_05_00;
 mod version;
 mod views;
 
@@ -123,6 +124,7 @@ pub fn migrate(
         Box::new(v2_03_00::V2_03_00),
         Box::new(v2_03_01::V2_03_01),
         Box::new(v2_04_00::V2_04_00),
+        Box::new(v2_05_00::V2_05_00),
     ];
 
     // Historic diesel migrations

--- a/server/repository/src/migrations/v2_05_00/mod.rs
+++ b/server/repository/src/migrations/v2_05_00/mod.rs
@@ -1,0 +1,44 @@
+use super::{version::Version, Migration, MigrationFragment};
+
+mod new_store_preferences;
+
+use crate::StorageConnection;
+
+pub(crate) struct V2_05_00;
+
+impl Migration for V2_05_00 {
+    fn version(&self) -> Version {
+        Version::from_str("2.5.0")
+    }
+
+    fn migrate(&self, _connection: &StorageConnection) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn migrate_fragments(&self) -> Vec<Box<dyn MigrationFragment>> {
+        vec![Box::new(new_store_preferences::Migrate)]
+    }
+}
+
+#[cfg(test)]
+#[actix_rt::test]
+async fn migration_2_05_00() {
+    use v2_04_00::V2_04_00;
+
+    use crate::migrations::*;
+    use crate::test_db::*;
+
+    let previous_version = V2_04_00.version();
+    let version = V2_05_00.version();
+
+    let SetupResult { connection, .. } = setup_test(SetupOption {
+        db_name: &format!("migration_{version}"),
+        version: Some(previous_version.clone()),
+        ..Default::default()
+    })
+    .await;
+
+    // Run this migration
+    migrate(&connection, Some(version.clone())).unwrap();
+    assert_eq!(get_database_version(&connection), version);
+}

--- a/server/repository/src/migrations/v2_05_00/new_store_preferences.rs
+++ b/server/repository/src/migrations/v2_05_00/new_store_preferences.rs
@@ -1,0 +1,22 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "new_store_preferences"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        sql!(
+            connection,
+            r#"
+                ALTER TABLE store_preference ADD keep_requisition_lines_with_zero_requested_quantity_on_finalised BOOLEAN NOT NULL DEFAULT FALSE;
+                ALTER TABLE store_preference ADD use_consumption_and_stock_from_customers_for_internal_orders BOOLEAN NOT NULL DEFAULT FALSE;
+                ALTER TABLE store_preference ADD manually_link_internal_order_to_inbound_shipment BOOLEAN NOT NULL DEFAULT FALSE;
+            "#
+        )?;
+
+        Ok(())
+    }
+}

--- a/server/service/src/sync/test/test_data/store_preference.rs
+++ b/server/service/src/sync/test/test_data/store_preference.rs
@@ -43,7 +43,7 @@ const STORE_PREFERENCE_1: (&str, &str) = (
         "consolidateBatches": false,
         "editPrescribedQuantityOnPrescription": false,
         "chooseDiagnosisOnPrescription": false,
-        "useConsumptionAndStockFromCustomersForInternalOrders": false,
+        "useConsumptionAndStockFromCustomersForInternalOrders": true,
         "alertIfDispensingSameVaccine": false,
         "monthlyConsumptionEnforceLookBackPeriod": false,
         "usesVaccineModule": false,
@@ -65,7 +65,9 @@ const STORE_PREFERENCE_1: (&str, &str) = (
         "boxPrefix": "",
         "boxPercentageSpace": 0,
         "omSupplyUsesProgramModule": true,
-        "stocktakeFrequency": 1.34
+        "stocktakeFrequency": 1.34,
+        "keepRequisitionLinesWithZeroQuantity": true,
+        "canLinkRequistionToSupplierInvoice": false
     }
 }"#,
 );
@@ -131,7 +133,9 @@ const STORE_PREFERENCE_2: (&str, &str) = (
         "monthsItemsExpire": 3,
         "boxPrefix": "",
         "boxPercentageSpace": 0,
-        "stocktakeFrequency": 1
+        "stocktakeFrequency": 1,
+        "keepRequisitionLinesWithZeroQuantity": false,
+        "canLinkRequistionToSupplierInvoice": true
     }
 }"#,
 );
@@ -157,6 +161,9 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
                 months_items_expire: 2.12,
                 stocktake_frequency: 1.34,
                 extra_fields_in_requisition: false,
+                keep_requisition_lines_with_zero_requested_quantity_on_finalised: true,
+                use_consumption_and_stock_from_customers_for_internal_orders: true,
+                manually_link_internal_order_to_inbound_shipment: false,
             },
         ),
         TestSyncIncomingRecord::new_pull_upsert(
@@ -179,6 +186,9 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
                 months_items_expire: 3.0,
                 stocktake_frequency: 1.0,
                 extra_fields_in_requisition: true,
+                keep_requisition_lines_with_zero_requested_quantity_on_finalised: false,
+                use_consumption_and_stock_from_customers_for_internal_orders: false,
+                manually_link_internal_order_to_inbound_shipment: true,
             },
         ),
     ]

--- a/server/service/src/sync/translations/store_preference.rs
+++ b/server/service/src/sync/translations/store_preference.rs
@@ -64,6 +64,15 @@ pub struct LegacyPrefData {
     #[serde(default)]
     #[serde(rename = "useExtraFieldsForRequisitions")]
     pub extra_fields_in_requisition: bool,
+    #[serde(default)]
+    #[serde(rename = "keepRequisitionLinesWithZeroQuantity")]
+    pub keep_requisition_lines_with_zero_requested_quantity_on_finalised: bool,
+    #[serde(default)]
+    #[serde(rename = "useConsumptionAndStockFromCustomersForInternalOrders")]
+    pub use_consumption_and_stock_from_customers_for_internal_orders: bool,
+    #[serde(default)]
+    #[serde(rename = "canLinkRequistionToSupplierInvoice")]
+    pub manually_link_internal_order_to_inbound_shipment: bool,
 }
 
 // Needs to be added to all_translators()
@@ -114,6 +123,9 @@ impl SyncTranslation for StorePreferenceTranslation {
             months_items_expire,
             stocktake_frequency,
             extra_fields_in_requisition,
+            keep_requisition_lines_with_zero_requested_quantity_on_finalised,
+            use_consumption_and_stock_from_customers_for_internal_orders,
+            manually_link_internal_order_to_inbound_shipment,
         } = data;
 
         let result = StorePreferenceRow {
@@ -132,6 +144,9 @@ impl SyncTranslation for StorePreferenceTranslation {
             months_items_expire,
             stocktake_frequency,
             extra_fields_in_requisition,
+            keep_requisition_lines_with_zero_requested_quantity_on_finalised,
+            use_consumption_and_stock_from_customers_for_internal_orders,
+            manually_link_internal_order_to_inbound_shipment,
         };
 
         Ok(PullTranslateResult::upsert(result))


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5656

# 👩🏻‍💻 What does this PR do?
- New store prefs:
   - Keep requisition lines with zero requested quantity on finalised
   - Use consumption and stock from customers for internal orders
   - Manually link Internal Order to Inbound Shipment
- Sync store prefs
- Expose `Manually link Internal Order to Inbound Shipment` pref in API
- Don't prune 0 requested quantity lines in Internal Orders if the the `Keep requisition lines with zero requested quantity on finalised` pref is on

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Run tests (dev)
- [ ] Have the store pref `Keep requisition lines with zero requested quantity on finalised` on
- [ ] Create an Internal Order with lines that have 0 requested quantity
- [ ] `Send` Requisition
- [ ] 0 requested lines shouldn't be prune
- [ ] Similarly turn the pref off and go through steps again. This time the lines should be pruned

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
