### PR TITLE
Reduce apk size

### DIFF
--- a/client/packages/android/app/src/main/jniLibs/armeabi-v7a/.gitignore
+++ b/client/packages/android/app/src/main/jniLibs/armeabi-v7a/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/client/packages/android/build_remote_server_libs.sh
+++ b/client/packages/android/build_remote_server_libs.sh
@@ -7,7 +7,7 @@ set -e
 export AR=${NDK_BIN}/llvm-ar
 export CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi22-clang
 
-# Build arm64-v8a:aarch64-linux-android and armeabi-v7a:armv7-linux-androideabi
+# Build arm64-v8a:aarch64-linux-android (Defined in cargo.toml)
 PATH=PATH=$PATH:$NDK_BIN \
     cargo build \
         --release \
@@ -17,4 +17,3 @@ PATH=PATH=$PATH:$NDK_BIN \
 
 # Copy built .so files to jniLib
 cp "server-lib/aarch64-linux-android/release/libremote_server_android.so" "app/src/main/jniLibs/arm64-v8a/"
-cp "server-lib/armv7-linux-androideabi/release/libremote_server_android.so" "app/src/main/jniLibs/armeabi-v7a/"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "2.3.03",
+  "version": "2.3.04",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/android/.cargo/config.toml
+++ b/server/android/.cargo/config.toml
@@ -6,9 +6,10 @@
 # PATH=$PATH:$NDK_BIN cargo build --target aarch64-linux-android --release
 
 [build]
-target = ["aarch64-linux-android", "armv7-linux-androideabi"]
+target = ["aarch64-linux-android"]
 
 [target.aarch64-linux-android]
 linker = "aarch64-linux-android22-clang"
-[target.armv7-linux-androideabi]
-linker = "armv7a-linux-androideabi22-clang"
+
+[profile.release]
+opt-level = "s"


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #

# 👩🏻‍💻 What does this PR do?

Migrates the changes for building 64 bit only android from 2.4
Adds the `opt-level = "s"` flag to reduce the compiled build size...

## 💌 Any notes for the reviewer?

Here's an APK to try out
https://drive.google.com/file/d/14oAuLnzkPlEvUDEP8LGoIW5-goWcWNgD/view?usp=sharing

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Check that the apk installs, syncs and generally doesn't have any problems.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
