### PR TITLE
5599 adjust settings page permissions

### DIFF
--- a/client/packages/host/src/Admin/DisplaySettings.tsx
+++ b/client/packages/host/src/Admin/DisplaySettings.tsx
@@ -7,6 +7,8 @@ import {
   useTranslation,
   useNotification,
   LocalStorage,
+  useAuthContext,
+  UserPermission,
 } from '@openmsupply-client/common';
 import { themeOptions } from '@common/styles';
 
@@ -23,6 +25,7 @@ export const DisplaySettings: React.FC = () => {
   const [customTheme, setCustomTheme] = useLocalStorage('/theme/custom');
   const [customLogo, setCustomLogo] = useLocalStorage('/theme/logo');
   const { mutate: updateSettings } = useHost.settings.updateDisplaySettings();
+  const { userHasPermission } = useAuthContext();
   const customThemeEnabled =
     !!customTheme && Object.keys(customTheme).length > 0;
 
@@ -118,6 +121,7 @@ export const DisplaySettings: React.FC = () => {
         onSave={saveTheme}
         onToggle={onToggleCustomTheme}
         title={t('heading.custom-theme')}
+        visible={userHasPermission(UserPermission.ServerAdmin)}
       />
       <SettingTextArea
         defaultValue={customLogoValue}
@@ -125,6 +129,7 @@ export const DisplaySettings: React.FC = () => {
         onToggle={onToggleCustomLogo}
         infoText={t('heading.custom-logo-info')}
         title={t('heading.custom-logo')}
+        visible={userHasPermission(UserPermission.ServerAdmin)}
       />
     </>
   );

--- a/client/packages/host/src/Admin/DisplaySettings.tsx
+++ b/client/packages/host/src/Admin/DisplaySettings.tsx
@@ -6,8 +6,6 @@ import {
   useNavigate,
   useTranslation,
   useNotification,
-  UserPermission,
-  usePermissionCheck,
   LocalStorage,
 } from '@openmsupply-client/common';
 import { themeOptions } from '@common/styles';
@@ -25,7 +23,6 @@ export const DisplaySettings: React.FC = () => {
   const [customTheme, setCustomTheme] = useLocalStorage('/theme/custom');
   const [customLogo, setCustomLogo] = useLocalStorage('/theme/logo');
   const { mutate: updateSettings } = useHost.settings.updateDisplaySettings();
-  usePermissionCheck(UserPermission.ServerAdmin);
   const customThemeEnabled =
     !!customTheme && Object.keys(customTheme).length > 0;
 

--- a/client/packages/host/src/Admin/SettingTextArea.tsx
+++ b/client/packages/host/src/Admin/SettingTextArea.tsx
@@ -22,6 +22,7 @@ interface SettingTextAreaProps {
   /** Info text displayed next to the settings label */
   infoText?: string;
   title: string;
+  visible: boolean;
 }
 
 export const SettingTextArea: React.FC<SettingTextAreaProps> = ({
@@ -31,6 +32,7 @@ export const SettingTextArea: React.FC<SettingTextAreaProps> = ({
   onToggle,
   infoText,
   title,
+  visible,
 }) => {
   const t = useTranslation();
   const [value, setValue] = React.useState(defaultValue);
@@ -46,7 +48,7 @@ export const SettingTextArea: React.FC<SettingTextAreaProps> = ({
     onToggle?.(checked);
   };
 
-  return (
+  return visible ? (
     <>
       <Setting
         infoText={infoText}
@@ -96,5 +98,5 @@ export const SettingTextArea: React.FC<SettingTextAreaProps> = ({
         </Grid>
       )}
     </>
-  );
+  ) : null;
 };

--- a/client/packages/host/src/Admin/Settings.tsx
+++ b/client/packages/host/src/Admin/Settings.tsx
@@ -5,6 +5,8 @@ import {
   Box,
   AppBarButtonsPortal,
   useIsCentralServerApi,
+  UserPermission,
+  useAuthContext,
 } from '@openmsupply-client/common';
 import {
   RadioIcon,
@@ -28,6 +30,7 @@ export const Settings: React.FC = () => {
   const [activeSection, setActiveSection] = React.useState<number | null>(null);
 
   const isCentralServer = useIsCentralServerApi();
+  const { userHasPermission } = useAuthContext();
 
   const toggleSection = (index: number) => () =>
     setActiveSection(activeSection === index ? null : index);
@@ -39,6 +42,7 @@ export const Settings: React.FC = () => {
         titleKey="heading.settings-display"
         expanded={activeSection === 0}
         onChange={toggleSection(0)}
+        visible={true}
       >
         <DisplaySettings />
       </SettingsSection>
@@ -47,6 +51,7 @@ export const Settings: React.FC = () => {
         titleKey="heading.settings-sync"
         expanded={activeSection === 1}
         onChange={toggleSection(1)}
+        visible={userHasPermission(UserPermission.ServerAdmin)}
       >
         <SyncSettings />
       </SettingsSection>
@@ -55,6 +60,7 @@ export const Settings: React.FC = () => {
         titleKey="heading.support"
         expanded={activeSection === 2}
         onChange={toggleSection(2)}
+        visible={userHasPermission(UserPermission.ServerAdmin)}
       >
         <ServerSettings />
       </SettingsSection>
@@ -63,6 +69,7 @@ export const Settings: React.FC = () => {
         titleKey="heading.devices"
         expanded={activeSection === 3}
         onChange={toggleSection(3)}
+        visible={userHasPermission(UserPermission.ServerAdmin)}
       >
         <LabelPrinterSettings />
         <ElectronSettings />
@@ -73,6 +80,7 @@ export const Settings: React.FC = () => {
           titleKey="heading.configuration"
           expanded={activeSection === 4}
           onChange={toggleSection(4)}
+          visible={userHasPermission(UserPermission.ServerAdmin)}
         >
           <ConfigurationSettings />
         </SettingsSection>

--- a/client/packages/host/src/Admin/SettingsSection.tsx
+++ b/client/packages/host/src/Admin/SettingsSection.tsx
@@ -15,6 +15,7 @@ interface SettingsSectionProps {
   Icon: (props: SvgIconProps & { stroke?: string }) => JSX.Element;
   onChange: () => void;
   titleKey: LocaleKey;
+  visible: boolean;
 }
 export const SettingsSubHeading = ({ title }: { title: string }) => (
   <Typography
@@ -36,10 +37,11 @@ export const SettingsSection: FC<PropsWithChildren<SettingsSectionProps>> = ({
   Icon,
   onChange,
   titleKey,
+  visible,
 }) => {
   const t = useTranslation();
 
-  return (
+  return visible ? (
     <Accordion expanded={expanded} onChange={onChange}>
       <AccordionSummary
         expandIcon={<ChevronDownIcon />}
@@ -61,5 +63,5 @@ export const SettingsSection: FC<PropsWithChildren<SettingsSectionProps>> = ({
       </AccordionSummary>
       <AccordionDetails>{children}</AccordionDetails>
     </Accordion>
-  );
+  ) : null;
 };

--- a/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -18,7 +18,6 @@ import {
   useAuthContext,
   useLocation,
   EnvUtils,
-  UserPermission,
   RouteBuilder,
   useConfirmationModal,
   ReportsIcon,
@@ -152,7 +151,7 @@ export const AppDrawer: React.FC = () => {
   const t = useTranslation();
   const isMediumScreen = useIsMediumScreen();
   const drawer = useDrawer();
-  const { logout, userHasPermission, store } = useAuthContext();
+  const { logout, store } = useAuthContext();
   const { fullScreen } = useHostContext();
   const location = useLocation();
   const navigate = useNavigate();
@@ -250,7 +249,6 @@ export const AppDrawer: React.FC = () => {
             to={AppRoute.Settings}
             icon={<SettingsIcon fontSize="small" color="primary" />}
             text={t('settings')}
-            visible={userHasPermission(UserPermission.ServerAdmin)}
           />
           <AppNavLink
             to={AppRoute.Help}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5599

# 👩🏻‍💻 What does this PR do?

- Makes the Settings icon in the app drawer available to every user.
- Hides all of the Settings sections except Display settings from every non-admin.
- Hides all the Display settings except the Language settings from every non-admin.

<!-- Add a screenshot if there are UI changes  -->

![image](https://github.com/user-attachments/assets/bb556a1e-4d4c-4f47-bd70-cecfcf799a8d)

## 💌 Any notes for the reviewer?

Is it secure: could a malicious party force the custom theme or logo sections, or other settings sections, to be visible somehow?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

[ ] log in as an admin and check that all settings sections are visible

[ ] log in as a user with minimum permissions and check that the setting icon is available, but ONLY display settings are visible, and within those settings only language is visible.

# 📃 Documentation

[x] **Part of an epic**: documentation will be completed for the feature as a whole