### PR TITLE
5691 Encounter delete fix

### DIFF
--- a/client/packages/system/src/Encounter/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Encounter/DetailView/DetailView.tsx
@@ -192,12 +192,14 @@ export const DetailView: FC = () => {
     updateEncounter({ status: EncounterNodeStatus.Deleted });
     setDeleteRequest(true);
   };
+
   useEffect(() => {
     if (!deleteRequest) return;
     if (
       (data as Record<string, JsonData>)['status'] ===
       EncounterNodeStatus.Deleted
     ) {
+      setDeleteRequest(false);
       (async () => {
         const result = await saveData(true);
         if (!result) return;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5691

# 👩🏻‍💻 What does this PR do?

Resets the `deleteRequest` value to avoid the infinite loop over the `useEffect` function.

## 💌 Any notes for the reviewer?

I think the `useEffect` chaining using the `deleteRequest` intermediate value is not great React usage, but changing that is a bit of a bigger job so won't do that now. The problem is we can't easily update the data using JSON Forms' `setData` method and then immediately save that changed data in a single render. Something to figure out another time...

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Try to delete an encounter
- [ ] Make sure it works and you are navigated back to the Encounter list without any unnecessary loops
- [ ] Try changing something in the Encounter first before deleting and also confirm no probs
