### PR TITLE
Fix queries on item usage report

### DIFF
--- a/server/graphql/types/src/types/item_stats.rs
+++ b/server/graphql/types/src/types/item_stats.rs
@@ -9,7 +9,7 @@ impl ItemStatsNode {
     pub async fn total_consumption(&self) -> f64 {
         self.item_stats.total_consumption
     }
-    
+
     pub async fn average_monthly_consumption(&self) -> f64 {
         self.item_stats.average_monthly_consumption
     }
@@ -22,6 +22,10 @@ impl ItemStatsNode {
         (self.item_stats.average_monthly_consumption != 0.0).then(|| {
             self.item_stats.available_stock_on_hand / self.item_stats.average_monthly_consumption
         })
+    }
+
+    pub async fn total_stock_on_hand(&self) -> f64 {
+        self.item_stats.total_stock_on_hand
     }
 }
 

--- a/server/reports/item-usage/2_3_0/convert_data_js/input.json
+++ b/server/reports/item-usage/2_3_0/convert_data_js/input.json
@@ -107,7 +107,7 @@
         "stats": {
           "totalConsumption": 1200,
           "availableMonthsOfStockOnHand": 4.5,
-          "availableStockOnHand": 300.902,
+          "totalStockOnHand": 300.902,
           "averageMonthlyConsumption": 266.7
         },
         "someOtherKey": ""
@@ -120,7 +120,7 @@
         "stats": {
           "totalConsumption": 100,
           "availableMonthsOfStockOnHand": 4.5,
-          "availableStockOnHand": 200,
+          "totalStockOnHand": 200,
           "someNestedEmptyStringKey": ""
         },
         "someOtherOtherKey": ""

--- a/server/reports/item-usage/2_3_0/convert_data_js/output.json
+++ b/server/reports/item-usage/2_3_0/convert_data_js/output.json
@@ -8,7 +8,7 @@
         "stats": {
           "totalConsumption": 1200,
           "availableMonthsOfStockOnHand": 4.5,
-          "availableStockOnHand": 300.902,
+          "totalStockOnHand": 300.902,
           "averageMonthlyConsumption": 266.7
         },
         "monthConsumption": 200,
@@ -27,7 +27,7 @@
         "code": "ITEM001",
         "name": "Item A",
         "stats": {
-          "availableStockOnHand": 200,
+          "totalStockOnHand": 200,
           "totalConsumption": 100,
           "availableMonthsOfStockOnHand": 4.5
         },

--- a/server/reports/item-usage/2_3_0/convert_data_js/src/utils.js
+++ b/server/reports/item-usage/2_3_0/convert_data_js/src/utils.js
@@ -29,7 +29,7 @@ const processItemLines = (data, sort, dir) => {
     item.stockOnOrder = calculateQuantity(data.stockOnOrder, item.id);
     item.AMC12 = calculateQuantity(data.AMCTwelve, item.id);
     item.AMC24 = calculateQuantity(data.AMCTwentyFour, item.id);
-    item.SOH = calculateStatValue(item?.stats?.availableStockOnHand);
+    item.SOH = calculateStatValue(item?.stats?.totalStockOnHand);
     item.MOS = calculateStatValue(item?.stats?.availableMonthsOfStockOnHand);
   });
   let cleanNodes = cleanUpNodes(data.items.nodes);

--- a/server/reports/item-usage/2_3_0/convert_data_js/src/utils.test.ts
+++ b/server/reports/item-usage/2_3_0/convert_data_js/src/utils.test.ts
@@ -132,7 +132,7 @@ describe("calculate SOH", () => {
   });
   it("returns rounded value if value exists", () => {
     expect(
-      calculateStatValue(inputData.items.nodes[0].stats.availableStockOnHand)
+      calculateStatValue(inputData.items.nodes[0].stats.totalStockOnHand)
     ).toBe(300.9);
   });
 });

--- a/server/reports/item-usage/2_3_0/src/expiringInSixMonths.postgres.sql
+++ b/server/reports/item-usage/2_3_0/src/expiringInSixMonths.postgres.sql
@@ -13,5 +13,5 @@ FROM stock_line s
 INNER JOIN item_link i ON i.id = s.item_link_id
 INNER JOIN this_month ON true
 INNER JOIN six_months ON true
-WHERE s.expiry_date >= this_month AND s.expiry_date < six_months AND s.store_id = $storeId
+WHERE s.expiry_date < six_months AND s.store_id = $storeId
 GROUP BY s.id, i.item_id

--- a/server/reports/item-usage/2_3_0/src/expiringInSixMonths.sqlite.sql
+++ b/server/reports/item-usage/2_3_0/src/expiringInSixMonths.sqlite.sql
@@ -11,5 +11,5 @@ SELECT
     SUM(stock_line.available_number_of_packs) AS quantity
 FROM stock_line, six_months, this_month
 INNER JOIN item_link i ON i.id = stock_line.item_link_id
-WHERE stock_line.expiry_date >= this_month AND stock_line.expiry_date < six_months AND stock_line.store_id = $storeId
+WHERE stock_line.expiry_date < six_months AND stock_line.store_id = $storeId
 GROUP BY i.item_id

--- a/server/reports/item-usage/2_3_0/src/expiringInTwelveMonths.postgres.sql
+++ b/server/reports/item-usage/2_3_0/src/expiringInTwelveMonths.postgres.sql
@@ -13,5 +13,5 @@ FROM stock_line s
 INNER JOIN item_link i ON i.id = s.item_link_id
 INNER JOIN this_month ON true
 INNER JOIN twelve_months ON true
-WHERE s.expiry_date >= this_month AND s.expiry_date < twelve_months AND s.store_id = $storeId
+WHERE s.expiry_date < twelve_months AND s.store_id = $storeId
 GROUP BY s.id, i.item_id

--- a/server/reports/item-usage/2_3_0/src/expiringInTwelveMonths.sqlite.sql
+++ b/server/reports/item-usage/2_3_0/src/expiringInTwelveMonths.sqlite.sql
@@ -11,5 +11,5 @@ SELECT
     SUM(stock_line.available_number_of_packs) AS quantity
 FROM stock_line, twelve_months, this_month
 INNER JOIN item_link i ON i.id = stock_line.item_link_id
-WHERE stock_line.expiry_date >= this_month AND stock_line.expiry_date < twelve_months AND stock_line.store_id = $storeId
+WHERE stock_line.expiry_date < twelve_months AND stock_line.store_id = $storeId
 GROUP BY item_id

--- a/server/reports/item-usage/2_3_0/src/query.graphql
+++ b/server/reports/item-usage/2_3_0/src/query.graphql
@@ -13,7 +13,7 @@ query ItemUsage($storeId: String, $itemCode: String, $itemName: String) {
         stats(storeId: $storeId) {
           totalConsumption
           availableMonthsOfStockOnHand
-          availableStockOnHand
+          totalStockOnHand
           averageMonthlyConsumption
         }
       }

--- a/server/reports/item-usage/2_3_0/src/stockOnOrder.sql
+++ b/server/reports/item-usage/2_3_0/src/stockOnOrder.sql
@@ -1,5 +1,5 @@
 SELECT 
-    item.id,
+    item.id as item_id,
     SUM(rl.requested_quantity) - COALESCE(SUM(il.pack_size * il.number_of_packs), 0) AS quantity
 FROM item
 INNER JOIN item_link i ON item.id = i.item_id
@@ -8,4 +8,4 @@ LEFT JOIN requisition r ON r.id = rl.requisition_id
 LEFT JOIN invoice ON invoice.requisition_id = r.id
 LEFT JOIN invoice_line il on invoice.id = il.invoice_id AND il.item_link_id = i.id
 WHERE r.store_id = $storeId AND r.type = 'REQUEST' AND r.status = 'SENT'
-GROUP BY item.id
+GROUP BY item_id

--- a/server/service/src/item_stats.rs
+++ b/server/service/src/item_stats.rs
@@ -22,6 +22,7 @@ pub struct ItemStats {
     pub total_consumption: f64,
     pub average_monthly_consumption: f64,
     pub available_stock_on_hand: f64,
+    pub total_stock_on_hand: f64,
     pub item_id: String,
     pub item_name: String,
 }
@@ -140,6 +141,7 @@ impl ItemStats {
                     .get(&stock_on_hand.item_id)
                     .copied()
                     .unwrap_or_default(),
+                total_stock_on_hand: stock_on_hand.total_stock_on_hand,
             })
             .collect()
     }
@@ -151,8 +153,9 @@ impl ItemStats {
             available_stock_on_hand: row.available_stock_on_hand,
             item_id: requisition_line.item_row.id.clone(),
             item_name: requisition_line.item_row.name.clone(),
-            // TODO: Implement total consumption
+            // TODO: Implement total consumption & total_stock_on_hand
             total_consumption: 0.0,
+            total_stock_on_hand: 0.0,
         }
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5579

# 👩🏻‍💻 What does this PR do?

Fixes queries to show data item usage report.

You can test this by removing the existing item-usage report in your database, rebuilding standard reports, and then upserting the updated report. Note starting the server will automatically upsert built report.

I write this here because documentation of these commands isn't comprehensive now.

Also added totalStockOnHand to item stats query. This is what is being used on stockLine list view and OG reports for 'in stock' column. Previously was using availableStockOnHand which caused discrepancy.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

For reviewers - the fastest way to get the new report is like so:

- [ ] Do not stop your server running instance.
- [ ] Manually delete the item-usage report from your database
- [ ] Open a new terminal and run:

```
cargo build &&  ./target/debug/remote_server_cli build-standard-reports && ./target/debug/remote_server_cli upsert-reports-json
```

Which will rebuild and upsert reports to the database name set up in your .yaml file.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Run commands above to delete, rebuild, and upsert reports
- [ ] Go to reports
- [ ] Open item usage report
- [ ] See expiring in 6/12 months matches expected from OG
- [ ] See stock on hand also populated


