### PR TITLE
5025 hidden items showing on item usage and stock details reports

### DIFF
--- a/server/graphql/general/src/queries/item.rs
+++ b/server/graphql/general/src/queries/item.rs
@@ -47,9 +47,9 @@ pub struct ItemFilterInput {
     pub code: Option<StringFilterInput>,
     pub category_id: Option<String>,
     pub category_name: Option<String>,
-    /// Items that are visible in this store OR there is available stock of that item in this store
+    /// Items that are part of a masterlist which is visible in this store OR there is available stock of that item in this store
     pub is_visible_or_on_hand: Option<bool>,
-    /// Items that are visible in this store. This filter is void if `is_visible_or_on_hand` is true
+    /// Items that are part of a masterlist which is visible in this store. This filter is void if `is_visible_or_on_hand` is true
     pub is_visible: Option<bool>,
     pub code_or_name: Option<StringFilterInput>,
     pub is_active: Option<bool>,

--- a/server/graphql/stock_line/src/lib.rs
+++ b/server/graphql/stock_line/src/lib.rs
@@ -50,6 +50,7 @@ pub struct StockLineFilterInput {
     pub has_packs_in_store: Option<bool>,
     pub location: Option<LocationFilterInput>,
     pub master_list: Option<MasterListFilterInput>,
+    pub is_active: Option<bool>,
 }
 
 impl From<StockLineFilterInput> for StockLineFilter {
@@ -65,6 +66,7 @@ impl From<StockLineFilterInput> for StockLineFilter {
             has_packs_in_store: f.has_packs_in_store,
             location: f.location.map(LocationFilter::from),
             master_list: f.master_list.map(|f| f.to_domain()),
+            is_active: f.is_active,
         }
     }
 }

--- a/server/reports/expiring-items/2_3_0/convert_data_js/src/convert_data.js
+++ b/server/reports/expiring-items/2_3_0/convert_data_js/src/convert_data.js
@@ -5,8 +5,8 @@ function convert_data() {
   res.data.stockLines.nodes = processStockLines(
     res.data.stockLines.nodes,
     // assign default sort values
-    res?.arguments?.sort ?? "SOH",
-    res?.arguments?.dir ?? "desc"
+    res?.arguments?.sort ?? "item.name",
+    res?.arguments?.dir ?? "asc"
   );
   Host.outputString(JSON.stringify(res));
 }

--- a/server/reports/expiring-items/2_3_0/src/query.graphql
+++ b/server/reports/expiring-items/2_3_0/src/query.graphql
@@ -11,7 +11,6 @@ query ExpiringItems(
       hasPacksInStore: true
       isActive: true
     }
-    sort: { key: itemName, desc: false }
     page: { first: 5000 }
   ) {
     ... on StockLineConnector {

--- a/server/reports/expiring-items/2_3_0/src/query.graphql
+++ b/server/reports/expiring-items/2_3_0/src/query.graphql
@@ -9,6 +9,7 @@ query ExpiringItems(
       itemCodeOrName: { like: $itemCodeOrName }
       expiryDate: { beforeOrEqualTo: $expiryDate }
       hasPacksInStore: true
+      isActive: true
     }
     sort: { key: itemName, desc: false }
     page: { first: 5000 }

--- a/server/reports/item-usage/2_3_0/convert_data_js/src/convert_data.js
+++ b/server/reports/item-usage/2_3_0/convert_data_js/src/convert_data.js
@@ -5,8 +5,8 @@ function convert_data() {
   res.data.items.nodes = processItemLines(
     res.data,
     // assign default sort values
-    res?.arguments?.sort ?? "SOH",
-    res?.arguments?.dir ?? "desc"
+    res?.arguments?.sort ?? "name",
+    res?.arguments?.dir ?? "asc"
   );
   Host.outputString(JSON.stringify(res));
 }

--- a/server/reports/item-usage/2_3_0/src/query.graphql
+++ b/server/reports/item-usage/2_3_0/src/query.graphql
@@ -7,7 +7,6 @@ query ItemUsage($storeId: String, $itemCode: String, $itemName: String) {
       isVisibleOrOnHand: true
       isActive: true
     }
-    sort: { key: name, desc: false }
     page: { first: 5000 }
   ) {
     ... on ItemConnector {

--- a/server/reports/item-usage/2_3_0/src/query.graphql
+++ b/server/reports/item-usage/2_3_0/src/query.graphql
@@ -1,7 +1,12 @@
 query ItemUsage($storeId: String, $itemCode: String, $itemName: String) {
   items(
     storeId: $storeId
-    filter: { code: { like: $itemCode }, name: { like: $itemName } }
+    filter: {
+      code: { like: $itemCode }
+      name: { like: $itemName }
+      isVisibleOrOnHand: true
+      isActive: true
+    }
     sort: { key: name, desc: false }
     page: { first: 5000 }
   ) {

--- a/server/reports/stock-detail/2_3_0/argument_schemas/arguments.json
+++ b/server/reports/stock-detail/2_3_0/argument_schemas/arguments.json
@@ -7,18 +7,6 @@
           "description": "Item Code or Name",
           "type": "string"
         },
-        "monthlyConsumptionLookBackPeriod": {
-          "description": "Average Monthly Consumption Look Back Period",
-          "type": "number"
-        },
-        "monthsOverstock": {
-          "description": "Months Overstock",
-          "type": "number"
-        },
-        "monthsUnderstock": {
-          "description": "Months Understock",
-          "type": "number"
-        },
         "sort": {
           "description": "sort by",
           "type": "string",

--- a/server/reports/stock-detail/2_3_0/argument_schemas/arguments_ui.json
+++ b/server/reports/stock-detail/2_3_0/argument_schemas/arguments_ui.json
@@ -11,30 +11,6 @@
     },
     {
       "type": "Control",
-      "scope": "#/properties/monthlyConsumptionLookBackPeriod",
-      "label": "AMC Lookback Period",
-      "options": {
-        "readonly": true
-      }
-    },
-    {
-      "type": "Control",
-      "scope": "#/properties/monthsOverstock",
-      "label": "Target MOS",
-      "options": {
-        "readonly": true
-      }
-    },
-    {
-      "type": "Control",
-      "scope": "#/properties/monthsUnderstock",
-      "label": "Reorder threshold MOS",
-      "options": {
-        "readonly": true
-      }
-    },
-    {
-      "type": "Control",
       "scope": "#/properties/sort",
       "label": "Sort by:",
       "options": {

--- a/server/reports/stock-detail/2_3_0/convert_data_js/src/convert_data.js
+++ b/server/reports/stock-detail/2_3_0/convert_data_js/src/convert_data.js
@@ -6,7 +6,7 @@ function convert_data() {
     res.data.stockLines.nodes,
     // assign default sort values
     res?.arguments?.sort ?? "item.name",
-    res?.arguments?.dir ?? "desc"
+    res?.arguments?.dir ?? "asc"
   );
   Host.outputString(JSON.stringify(res));
 }

--- a/server/reports/stock-detail/2_3_0/src/query.graphql
+++ b/server/reports/stock-detail/2_3_0/src/query.graphql
@@ -2,7 +2,11 @@ query StockDetail($storeId: String, $itemCodeOrName: String) {
   stockLines(
     storeId: $storeId
     page: { first: 5000 }
-    filter: { itemCodeOrName: { like: $itemCodeOrName }, hasPacksInStore: true }
+    filter: {
+      itemCodeOrName: { like: $itemCodeOrName }
+      hasPacksInStore: true
+      isActive: true
+    }
     sort: { key: itemName, desc: false }
   ) {
     ... on StockLineConnector {

--- a/server/reports/stock-detail/2_3_0/src/query.graphql
+++ b/server/reports/stock-detail/2_3_0/src/query.graphql
@@ -7,7 +7,6 @@ query StockDetail($storeId: String, $itemCodeOrName: String) {
       hasPacksInStore: true
       isActive: true
     }
-    sort: { key: itemName, desc: false }
   ) {
     ... on StockLineConnector {
       nodes {

--- a/server/reports/stock-status/2_3_0/convert_data_js/src/convert_data.js
+++ b/server/reports/stock-status/2_3_0/convert_data_js/src/convert_data.js
@@ -6,7 +6,7 @@ function convert_data() {
     res.data.items.nodes,
     // assign default sort values
     res?.arguments?.sort ?? "name",
-    res?.arguments?.dir ?? "desc"
+    res?.arguments?.dir ?? "asc"
   );
   Host.outputString(JSON.stringify(res));
 }

--- a/server/reports/stock-status/2_3_0/src/query.graphql
+++ b/server/reports/stock-status/2_3_0/src/query.graphql
@@ -1,7 +1,12 @@
 query StockStatus($storeId: String, $itemCode: String, $itemName: String) {
   items(
     storeId: $storeId
-    filter: { code: { like: $itemCode }, name: { like: $itemName } }
+    filter: {
+      code: { like: $itemCode }
+      name: { like: $itemName }
+      isVisibleOrOnHand: true
+      isActive: true
+    }
     sort: { key: name, desc: false }
     page: { first: 5000 }
   ) {

--- a/server/reports/stock-status/2_3_0/src/query.graphql
+++ b/server/reports/stock-status/2_3_0/src/query.graphql
@@ -7,7 +7,6 @@ query StockStatus($storeId: String, $itemCode: String, $itemName: String) {
       isVisibleOrOnHand: true
       isActive: true
     }
-    sort: { key: name, desc: false }
     page: { first: 5000 }
   ) {
     ... on ItemConnector {

--- a/server/repository/src/db_diesel/stock_line.rs
+++ b/server/repository/src/db_diesel/stock_line.rs
@@ -57,6 +57,7 @@ pub struct StockLineFilter {
     pub has_packs_in_store: Option<bool>,
     pub location: Option<LocationFilter>,
     pub master_list: Option<MasterListFilter>,
+    pub is_active: Option<bool>,
 }
 
 pub type StockLineSort = Sort<StockLineSortField>;
@@ -191,6 +192,7 @@ fn create_filtered_query(filter: Option<StockLineFilter>) -> BoxedStockLineQuery
             has_packs_in_store,
             location,
             master_list,
+            is_active,
         } = f;
 
         apply_equal_filter!(query, id, stock_line_dsl::id);
@@ -198,6 +200,10 @@ fn create_filtered_query(filter: Option<StockLineFilter>) -> BoxedStockLineQuery
         apply_equal_filter!(query, location_id, stock_line_dsl::location_id);
         apply_date_filter!(query, expiry_date, stock_line_dsl::expiry_date);
         apply_equal_filter!(query, store_id, stock_line_dsl::store_id);
+
+        if let Some(is_active) = is_active {
+            query = query.filter(item_dsl::is_active.eq(is_active));
+        }
 
         query = match has_packs_in_store {
             Some(true) => query.filter(stock_line_dsl::total_number_of_packs.gt(0.0)),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5025

Removes hidden items from report rendering.

There might be some confusion about what visible means for items in oms. We don't sync the hidden boolean from OG. in OMS visible means being part of a masterlist which is visible on the store.

I've updated explanations in comments.

Also graphql report queries updated to only show items both active and with stock on hand.
I think this should be sufficient because items cannot be hidden on OG if there is stock available.

Also added default sorting ascending and by item name on all reports

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

For reviewers - the fastest way to get the new report is like so:

- [ ] Do not stop your server running instance.
- [ ] Manually delete the item-usage report from your database
- [ ] Open a new terminal and run:

```
cargo build &&  ./target/debug/remote_server_cli build-standard-reports && ./target/debug/remote_server_cli upsert-reports-json
```

Which will rebuild and upsert reports to the database name set up in your .yaml file.

# 🧪 Testing

- [ ] Run commands above to delete, rebuild, and upsert reports
- [ ] Go to reports
- [ ] Render reports and don't see empty items

# 📃 Documentation

- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour

