### PR TITLE
Update to use getNaiveDate instead of getDateOrNull

### DIFF
--- a/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
+++ b/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
@@ -61,7 +61,7 @@ const UIComponent = (props: ControlProps) => {
 
   useEffect(() => {
     if (!data) return;
-    const dob = DateUtils.getDateOrNull(data.dateOfBirth);
+    const dob = DateUtils.getNaiveDate(data.dateOfBirth);
     setDoB(dob);
     if (dob === null) {
       setAge(undefined);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5438 

# 👩🏻‍💻 What does this PR do?
Fix issue where date picker age in days was off by 1 day before 1pm NZ time

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
![Screenshot 2024-12-09 at 8 08 11 PM](https://github.com/user-attachments/assets/2d4ab700-6976-4dda-a95c-51d73b729f4c)

Note the timezone (The issue "corrects" itself after 1pm NZ time so I have set my timezone to LA so that it is a day behind)
## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Make sure your system timezone is in a different day to GMT (in NZ, this will be until 1pm, otherwise you'll need to temporarily switch to a different timezone)
- [ ] Go to a Patient details page.
- [ ] Edit their date of birth to the current date.
- [ ] Age should show "0" 
- [ ] This should match what is shown in the toolbar

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
