### PR TITLE
5733 remove numeric input mode for number inputs

### DIFF
--- a/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
@@ -195,6 +195,7 @@ export const NumericTextInput = React.forwardRef<
       noFormatting = false,
       fullWidth,
       endAdornment,
+      inputMode,
       ...props
     },
     ref
@@ -265,8 +266,6 @@ export const NumericTextInput = React.forwardRef<
 
     return (
       <BasicTextInput
-        // NOTE: not setting input mode as numeric here, because on Samsung tablets,
-        // the numeric keyboard doesn't allow entering negative numbers!
         ref={ref}
         sx={{
           '& .MuiInput-input': {
@@ -275,6 +274,7 @@ export const NumericTextInput = React.forwardRef<
           },
           ...sx,
         }}
+        inputMode={inputMode ?? 'numeric'}
         InputProps={{
           endAdornment: endAdornment ? (
             <InputAdornment position="end" sx={{ paddingBottom: '2px' }}>

--- a/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
@@ -265,6 +265,8 @@ export const NumericTextInput = React.forwardRef<
 
     return (
       <BasicTextInput
+        // NOTE: not setting input mode as numeric here, because on Samsung tablets,
+        // the numeric keyboard doesn't allow entering negative numbers!
         ref={ref}
         sx={{
           '& .MuiInput-input': {
@@ -273,7 +275,6 @@ export const NumericTextInput = React.forwardRef<
           },
           ...sx,
         }}
-        inputMode="numeric"
         InputProps={{
           endAdornment: endAdornment ? (
             <InputAdornment position="end" sx={{ paddingBottom: '2px' }}>

--- a/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
@@ -360,6 +360,11 @@ const RnRNumberCell = ({
           max={max}
           allowNegative={allowNegative}
           defaultValue={0}
+          // NOTE: not setting input mode to text, because on Samsung tablets,
+          // the numeric keyboard doesn't allow entering negative numbers!
+          // Only needed for the negative columns, but better feel to have a consistent
+          // keyboard as you click through the whole R&R form
+          inputMode="text"
         />
       </Tooltip>
     </td>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5733

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Couldn't enter negative values in R&R forms on samsung tablet!

This PR switches back to alphanumeric keyboard, so users have access to the `-` key as needed.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

R&R form and demographic growth rates are the only two places where we allow entering negative values... it feels a shame to remove the simplicity of the numeric keyboard everywhere for these two cases?

Considered something like `inputMode = allowNegative ? "text" : "numeric"` - but this was quite ick as you clicked through negative and non-negative fields in the R&R form. Probably best just to be consistent, but curious for thoughts! 😢 

Other interim solution for demo has been to install Gboard app, and set this as default keyboard. This keyboard has `-` key and allows us to keep the numeric keyboard. But I don't think this is a feasible option long term...

May we keep an eye out for the inevitable update where the `-` comes back!

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] On Samsung tablet
- [ ] Have R&R form
- [ ] Edit a row 
  - [ ] Non-negative fields, like quantity received, you still can't make negative
  - [ ] Adjustments field, you can type a negative number

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
