### PR TITLE
Add function to get name value and translate name value

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -515,6 +515,7 @@
   "internal-order": "Internal Orders",
   "inventory": "Inventory",
   "inventory-addition": "Inventory Addition",
+  "inventory-adjustment": "Inventory Adjustment",
   "inventory-management": "Inventory Management",
   "inventory-reduction": "Inventory Reduction",
   "items": "Items",

--- a/client/packages/system/src/Stock/Components/Ledger/useLedgerColumns.ts
+++ b/client/packages/system/src/Stock/Components/Ledger/useLedgerColumns.ts
@@ -3,6 +3,7 @@ import {
   InvoiceNodeType,
   LocaleKey,
   SortBy,
+  TypedTFunction,
   useColumns,
   useFormatDateTime,
   useTranslation,
@@ -43,6 +44,7 @@ export const useLedgerColumns = (
       {
         key: ColumnKey.Name,
         label: 'label.name',
+        accessor: ({ rowData }) => getNameValue(t, rowData.name),
         sortable: false,
       },
       {
@@ -107,4 +109,12 @@ const getLocalisationKey = (type: InvoiceNodeType): LocaleKey => {
     case InvoiceNodeType.Repack:
       return 'label.repack';
   }
+};
+
+const getNameValue = (t: TypedTFunction<LocaleKey>, name: String) => {
+  if (name == 'repack') {
+    return t('label.repack');
+  } else if (name == 'Inventory adjustments') {
+    return t('inventory-adjustment');
+  } else return name;
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5511

# 👩🏻‍💻 What does this PR do?
Fix initialise issue of updating ```repack``` to ```Repack```to be consistent with Type value. Additionally create util function to use translations for name values rather than hardcoded string values. 

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
![Screenshot 2024-12-11 at 1 18 44 PM](https://github.com/user-attachments/assets/9711f2de-ef6c-4ec0-8b57-ead564e36c86)
![Screenshot 2024-12-11 at 1 19 57 PM](https://github.com/user-attachments/assets/4ef2936f-d2de-474a-b308-4cc17ef889b1)

## 💌 Any notes for the reviewer?
Translation needed for "inventory-adjustment"

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to Inventory -> View Stock
- [ ] Click on an item to open detail view
- [ ] Click ledger
- [ ] Ensure there is a repack or inventory adjustment event
- [ ] See that repack is now Repack
- [ ] Change language and check that name values are translated 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
