### PR TITLE
Handle optional gs1 warranty dates

### DIFF
--- a/server/service/src/asset/parse.rs
+++ b/server/service/src/asset/parse.rs
@@ -81,11 +81,12 @@ fn create_draft_asset_from_gs1(ctx: &ServiceContext, gs1: GS1) -> Result<Asset, 
         gs1.serial_number().unwrap_or_default()
     ));
 
-    let (warranty_start, warranty_end) =
-        gs1.warranty_dates().ok_or(AssetFromGs1Error::ParseError)?;
+    let warranty_option = gs1.warranty_dates();
 
-    asset.warranty_start = Some(warranty_start);
-    asset.warranty_end = Some(warranty_end);
+    if let Some((warranty_start, warranty_end)) = warranty_option {
+        asset.warranty_start = Some(warranty_start);
+        asset.warranty_end = Some(warranty_end);
+    }
 
     if let Some(part_number) = gs1.part_number() {
         asset.catalogue_item_id = lookup_asset_catalogue_id_by_pqs_code(ctx, &part_number)?;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes potential issue of missing waranty dates in GS1 codes
Especially since this standard isn't verified yet, we need to allow this to be empty when scanning a GS1 Matrix Barcode for assets

# 👩🏻‍💻 What does this PR do?

Makes waranty dates optional

## 💌 Any notes for the reviewer?

Haven't create a test GS1 for this but I think the code change is safe.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] This would require creating a new GS1 barcode without a `91` field.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
