### PR TITLE
Update inbound shipment generate.rs to use default item packsize

### DIFF
--- a/server/service/src/invoice/inbound_shipment/add_from_master_list.rs
+++ b/server/service/src/invoice/inbound_shipment/add_from_master_list.rs
@@ -38,7 +38,7 @@ pub fn add_from_master_list(
         .connection
         .transaction_sync(|connection| {
             let invoice_row = validate(connection, &ctx.store_id, &input)?;
-            let new_invoice_line_rows = generate(ctx, invoice_row, &input)?;
+            let new_invoice_line_rows = generate(connection, ctx, invoice_row, &input)?;
 
             let invoice_line_row_repository = InvoiceLineRowRepository::new(connection);
 
@@ -83,6 +83,7 @@ fn validate(
 }
 
 fn generate(
+    connection: &StorageConnection,
     ctx: &ServiceContext,
     invoice_row: InvoiceRow,
     input: &ServiceInput,
@@ -107,7 +108,7 @@ fn generate(
         .map(|master_list_line| master_list_line.item_id)
         .collect();
 
-    generate_empty_invoice_lines(ctx, &invoice_row, items_ids_not_in_invoice)
+    generate_empty_invoice_lines(connection, ctx, &invoice_row, items_ids_not_in_invoice)
 }
 
 #[cfg(test)]

--- a/server/service/src/invoice/inbound_shipment/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/generate.rs
@@ -24,7 +24,7 @@ pub fn generate_empty_invoice_lines(
                     location_id: None,
                     batch: None,
                     expiry_date: None,
-                    pack_size: 1.0,
+                    pack_size: item.default_pack_size,
                     cost_price_per_pack: 0.0,
                     sell_price_per_pack: 0.0,
                     total_before_tax: 0.0,

--- a/server/service/src/invoice/inbound_shipment/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/generate.rs
@@ -1,19 +1,28 @@
 use repository::db_diesel::InvoiceLineType;
-use repository::{InvoiceLineRow, InvoiceRow, ItemRowRepository, RepositoryError};
+use repository::{
+    InvoiceLineRow, InvoiceRow, ItemRowRepository, RepositoryError, StorageConnection,
+};
 use util::uuid::uuid;
 
 use crate::service_provider::ServiceContext;
+use crate::store_preference::get_store_preferences;
 
 pub fn generate_empty_invoice_lines(
+    connection: &StorageConnection,
     ctx: &ServiceContext,
     invoice_row: &InvoiceRow,
     item_ids: Vec<String>,
 ) -> Result<Vec<InvoiceLineRow>, RepositoryError> {
     let mut result: Vec<InvoiceLineRow> = Vec::new();
+    let store_preferences = get_store_preferences(connection, &invoice_row.store_id)?;
 
     item_ids.into_iter().for_each(|item_id| {
         match ItemRowRepository::new(&ctx.connection).find_active_by_id(&item_id) {
             Ok(Some(item)) => {
+                let default_pack_size = match store_preferences.pack_to_one {
+                    true => 1.0,
+                    false => item.default_pack_size,
+                };
                 result.push(InvoiceLineRow {
                     id: uuid(),
                     invoice_id: invoice_row.id.clone(),
@@ -24,7 +33,7 @@ pub fn generate_empty_invoice_lines(
                     location_id: None,
                     batch: None,
                     expiry_date: None,
-                    pack_size: item.default_pack_size,
+                    pack_size: default_pack_size,
                     cost_price_per_pack: 0.0,
                     sell_price_per_pack: 0.0,
                     total_before_tax: 0.0,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5561

# 👩🏻‍💻 What does this PR do?
Fix issue where items added to inbound shipment from masterlist had a default pack size of 1 instead of item default pack size

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
![Screenshot 2024-12-12 at 10 55 41 AM](https://github.com/user-attachments/assets/ab542404-a1c4-4911-a96e-46b46796ad2b)
![Screenshot 2024-12-12 at 10 56 07 AM](https://github.com/user-attachments/assets/dd6d6f6f-b59e-4f4b-aeeb-5854f868ec99)

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Replenishments -> Inbound Shipments
- [ ] Click on existing shipment or create a new one
- [ ] Click add from masterlist button
- [ ] Select a list and add items
- [ ] Check to see that pack size is using item default rather than settting to 1 (Note some packs have a default size of 1)
- [ ] Click on item to see that pack size displayed matches that from list view

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
