### PR TITLE
5579 fix remaining report bugs

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1568,6 +1568,7 @@
   "report.extension": "Extension",
   "report.global-total": "Global total",
   "report.in-stock": "In stock",
+  "report.available-stock-on-hand": "Available stock on hand",
   "report.invoice": "Invoice",
   "report.invoice-type": "Invoice type",
   "report.issued": "Issued",

--- a/server/graphql/types/src/types/item_stats.rs
+++ b/server/graphql/types/src/types/item_stats.rs
@@ -23,10 +23,6 @@ impl ItemStatsNode {
             self.item_stats.available_stock_on_hand / self.item_stats.average_monthly_consumption
         })
     }
-
-    pub async fn total_stock_on_hand(&self) -> f64 {
-        self.item_stats.total_stock_on_hand
-    }
 }
 
 impl ItemStatsNode {

--- a/server/reports/expiring-items/2_3_0/convert_data_js/input.json
+++ b/server/reports/expiring-items/2_3_0/convert_data_js/input.json
@@ -37,7 +37,7 @@
           "name": "Ibuprofen",
           "unitName": "box",
           "stats": {
-            "averageMonthlyConsumption": 20
+            "averageMonthlyConsumption": 20.16
           }
         }
       },

--- a/server/reports/expiring-items/2_3_0/convert_data_js/output.json
+++ b/server/reports/expiring-items/2_3_0/convert_data_js/output.json
@@ -2,6 +2,7 @@
   "stockLines": {
     "nodes": [
       {
+        "averageMonthlyConsumption": 50,
         "batch": "ABC123",
         "expiryDate": "2024-12-01",
         "id": "1",
@@ -25,6 +26,7 @@
         "stockAtRisk": 593
       },
       {
+        "averageMonthlyConsumption": 0,
         "batch": "DEF123",
         "expiryDate": "2024-01-10",
         "id": "3",
@@ -44,6 +46,7 @@
         "stockAtRisk": 500
       },
       {
+        "averageMonthlyConsumption": 20.2,
         "batch": "XYZ456",
         "expiryDate": "2024-01-01",
         "id": "2",
@@ -59,7 +62,7 @@
           "name": "Ibuprofen",
           "unitName": "box",
           "stats": {
-            "averageMonthlyConsumption": 20
+            "averageMonthlyConsumption": 20.16
           }
         },
         "daysUntilExpired": -91,

--- a/server/reports/expiring-items/2_3_0/convert_data_js/src/utils.js
+++ b/server/reports/expiring-items/2_3_0/convert_data_js/src/utils.js
@@ -11,7 +11,10 @@ const processStockLines = (nodes, sort, dir) => {
       line?.item?.stats?.averageMonthlyConsumption
     );
     if (!!expectedUsage) {
-      line.expectedUsage = expectedUsage;
+      line.expectedUsage = Math.min(
+        expectedUsage,
+        totalNumberOfPacks ?? expectedUsage
+      );
     }
     const stockAtRisk = calculateStockAtRisk(
       line?.packSize,

--- a/server/reports/expiring-items/2_3_0/convert_data_js/src/utils.js
+++ b/server/reports/expiring-items/2_3_0/convert_data_js/src/utils.js
@@ -23,7 +23,10 @@ const processStockLines = (nodes, sort, dir) => {
       line.stockAtRisk = stockAtRisk;
     }
     line.daysUntilExpired = roundDaysToInteger(daysUntilExpiredFloat);
+    line.averageMonthlyConsumption =
+      Math.round((line?.item?.stats?.averageMonthlyConsumption ?? 0) * 10) / 10;
   });
+
   let cleanNodes = cleanUpNodes(nodes);
   let sortedNodes = sortNodes(cleanNodes, sort, dir);
   return sortedNodes;

--- a/server/reports/expiring-items/2_3_0/convert_data_js/src/utils.js
+++ b/server/reports/expiring-items/2_3_0/convert_data_js/src/utils.js
@@ -77,6 +77,9 @@ const calculateStockAtRisk = (
       }
     }
   }
+  if (stockAtRisk < 0) {
+    return 0;
+  }
   return stockAtRisk;
 };
 

--- a/server/reports/expiring-items/2_3_0/convert_data_js/src/utils.test.ts
+++ b/server/reports/expiring-items/2_3_0/convert_data_js/src/utils.test.ts
@@ -79,18 +79,22 @@ describe("calculate stock at risk ", () => {
   it("returns stock at risk as all stock minus what we will consume before expiry date", () => {
     expect(calculateStockAtRisk(2, 100, 10, 60)).toBe(180);
   });
-});
 
-describe("test round days to integer", () => {
-  it("returns undefined if undefined", () => {
-    expect(roundDaysToInteger(undefined)).toBe(undefined);
+  it("returns 0 if will consume more than total stock within expiry date", () => {
+    expect(calculateStockAtRisk(1, 1, 3, 30)).toBe(0);
   });
 
-  it("returns rounded value if defined", () => {
-    expect(roundDaysToInteger(2.1)).toBe(2);
-    expect(roundDaysToInteger(2.11)).toBe(2);
-    expect(roundDaysToInteger(0.123)).toBe(0);
-    expect(roundDaysToInteger(2)).toBe(2);
+  describe("test round days to integer", () => {
+    it("returns undefined if undefined", () => {
+      expect(roundDaysToInteger(undefined)).toBe(undefined);
+    });
+
+    it("returns rounded value if defined", () => {
+      expect(roundDaysToInteger(2.1)).toBe(2);
+      expect(roundDaysToInteger(2.11)).toBe(2);
+      expect(roundDaysToInteger(0.123)).toBe(0);
+      expect(roundDaysToInteger(2)).toBe(2);
+    });
   });
 });
 

--- a/server/reports/expiring-items/2_3_0/src/template.html
+++ b/server/reports/expiring-items/2_3_0/src/template.html
@@ -10,6 +10,7 @@
         <td>{{t(k="label.batch", f="Batch")}}</td>
         <td>{{t(k="report.expiry-date", f="Expiry date")}}</td>
         <td>{{t(k="report.stock-on-hand", f="Stock on hand")}}</td>
+        <td>{{t(k="report.average-monthly-consumption", f="Average monthly consumption")}}</td>
         <td>{{t(k="report.expected-usage", f="Expected usage")}}</td>
         <td>{{t(k="report.stock-at-risk", f="Stock at risk")}}</td>
       </tr>
@@ -42,6 +43,7 @@
         </td>
         <td>{{stockLine.totalNumberOfPacks * stockLine.packSize | round( precision=1)
           }}</td>
+        <td>{{stockLine.averageMonthlyConsumption }}</td>
         <td>
           {% if stockLine.expectedUsage %}
               {{ stockLine.expectedUsage | round( precision=1) }}

--- a/server/reports/item-usage/2_3_0/convert_data_js/input.json
+++ b/server/reports/item-usage/2_3_0/convert_data_js/input.json
@@ -107,7 +107,7 @@
         "stats": {
           "totalConsumption": 1200,
           "availableMonthsOfStockOnHand": 4.5,
-          "totalStockOnHand": 300.902,
+          "availableStockOnHand": 300.902,
           "averageMonthlyConsumption": 266.7
         },
         "someOtherKey": ""
@@ -120,7 +120,7 @@
         "stats": {
           "totalConsumption": 100,
           "availableMonthsOfStockOnHand": 4.5,
-          "totalStockOnHand": 200,
+          "availableStockOnHand": 200,
           "someNestedEmptyStringKey": ""
         },
         "someOtherOtherKey": ""

--- a/server/reports/item-usage/2_3_0/convert_data_js/input.json
+++ b/server/reports/item-usage/2_3_0/convert_data_js/input.json
@@ -98,6 +98,20 @@
       "item_id": "103"
     }
   ],
+  "stockOnOrder": [
+    {
+      "quantity": 5,
+      "item_id": "101"
+    },
+    {
+      "quantity": -2,
+      "item_id": "102"
+    },
+    {
+      "quantity": 1,
+      "item_id": "103"
+    }
+  ],
   "items": {
     "nodes": [
       {

--- a/server/reports/item-usage/2_3_0/convert_data_js/output.json
+++ b/server/reports/item-usage/2_3_0/convert_data_js/output.json
@@ -16,7 +16,7 @@
         "twoMonthsAgoConsumption": 123,
         "expiringInSixMonths": 150,
         "expiringInTwelveMonths": 170,
-        "stockOnOrder": 0,
+        "stockOnOrder": 5,
         "AMC12": 150.8,
         "AMC24": 250.8,
         "SOH": 300.9,
@@ -31,7 +31,7 @@
           "totalConsumption": 100,
           "availableMonthsOfStockOnHand": 4.5
         },
-        "stockOnOrder": 0,
+        "stockOnOrder": 5,
         "AMC12": 150.8,
         "AMC24": 250.8,
         "SOH": 200,

--- a/server/reports/item-usage/2_3_0/convert_data_js/output.json
+++ b/server/reports/item-usage/2_3_0/convert_data_js/output.json
@@ -8,7 +8,7 @@
         "stats": {
           "totalConsumption": 1200,
           "availableMonthsOfStockOnHand": 4.5,
-          "totalStockOnHand": 300.902,
+          "availableStockOnHand": 300.902,
           "averageMonthlyConsumption": 266.7
         },
         "monthConsumption": 200,
@@ -27,7 +27,7 @@
         "code": "ITEM001",
         "name": "Item A",
         "stats": {
-          "totalStockOnHand": 200,
+          "availableStockOnHand": 200,
           "totalConsumption": 100,
           "availableMonthsOfStockOnHand": 4.5
         },

--- a/server/reports/item-usage/2_3_0/convert_data_js/src/utils.js
+++ b/server/reports/item-usage/2_3_0/convert_data_js/src/utils.js
@@ -29,7 +29,7 @@ const processItemLines = (data, sort, dir) => {
     item.stockOnOrder = calculateQuantity(data.stockOnOrder, item.id);
     item.AMC12 = calculateQuantity(data.AMCTwelve, item.id);
     item.AMC24 = calculateQuantity(data.AMCTwentyFour, item.id);
-    item.SOH = calculateStatValue(item?.stats?.totalStockOnHand);
+    item.SOH = calculateStatValue(item?.stats?.availableStockOnHand);
     item.MOS = calculateStatValue(item?.stats?.availableMonthsOfStockOnHand);
   });
   let cleanNodes = cleanUpNodes(data.items.nodes);

--- a/server/reports/item-usage/2_3_0/convert_data_js/src/utils.js
+++ b/server/reports/item-usage/2_3_0/convert_data_js/src/utils.js
@@ -44,6 +44,10 @@ const calculateQuantity = (queryResult, id) => {
     const node = queryResult.find((element) => element.item_id == id);
     quantity = node?.quantity ? node.quantity : 0;
   }
+  // return 0 if quantity is less than 0. This covers use cases such as stock on order which can be negative if invoice line stock is greater than requested stock.
+  if (quantity < 0) {
+    return 0;
+  }
   return quantity;
 };
 

--- a/server/reports/item-usage/2_3_0/convert_data_js/src/utils.test.ts
+++ b/server/reports/item-usage/2_3_0/convert_data_js/src/utils.test.ts
@@ -132,7 +132,7 @@ describe("calculate SOH", () => {
   });
   it("returns rounded value if value exists", () => {
     expect(
-      calculateStatValue(inputData.items.nodes[0].stats.totalStockOnHand)
+      calculateStatValue(inputData.items.nodes[0].stats.availableStockOnHand)
     ).toBe(300.9);
   });
 });

--- a/server/reports/item-usage/2_3_0/convert_data_js/src/utils.test.ts
+++ b/server/reports/item-usage/2_3_0/convert_data_js/src/utils.test.ts
@@ -149,3 +149,10 @@ describe("calculate MOS", () => {
     ).toBe(4.5);
   });
 });
+
+describe("calculate stockOnOrder", () => {
+  it("return  0 when calculate quantity input is negative", () => {
+    // covers possible negative cases such as where invoice line stock is greater than requisition line stock
+    expect(calculateQuantity(inputData.stockOnOrder, "102")).toBe(0);
+  });
+});

--- a/server/reports/item-usage/2_3_0/src/query.graphql
+++ b/server/reports/item-usage/2_3_0/src/query.graphql
@@ -17,7 +17,7 @@ query ItemUsage($storeId: String, $itemCode: String, $itemName: String) {
         stats(storeId: $storeId) {
           totalConsumption
           availableMonthsOfStockOnHand
-          totalStockOnHand
+          availableStockOnHand
           averageMonthlyConsumption
         }
       }

--- a/server/reports/item-usage/2_3_0/src/template.html
+++ b/server/reports/item-usage/2_3_0/src/template.html
@@ -8,7 +8,7 @@
       <tr class="heading">
         <td>{{t(k="label.code", f="Code")}}</td>
         <td>{{t(k="label.name", f="Name")}}</td>
-        <td>{{t(k="report.in-stock", f="In stock")}}</td>
+        <td>{{t(k="report.available-stock-on-hand", f="Available stock on hand")}}</td>
         <td>{{t(k="report.stock-on-order", f="Stock on order")}}</td>
         <td>{{t(k="report.amc-12-months", f="AMC (12 months)")}}</td>
         <td>{{t(k="report.amc-24-months", f="AMC (24 months)")}}</td>

--- a/server/service/src/item_stats.rs
+++ b/server/service/src/item_stats.rs
@@ -22,7 +22,6 @@ pub struct ItemStats {
     pub total_consumption: f64,
     pub average_monthly_consumption: f64,
     pub available_stock_on_hand: f64,
-    pub total_stock_on_hand: f64,
     pub item_id: String,
     pub item_name: String,
 }
@@ -141,7 +140,6 @@ impl ItemStats {
                     .get(&stock_on_hand.item_id)
                     .copied()
                     .unwrap_or_default(),
-                total_stock_on_hand: stock_on_hand.total_stock_on_hand,
             })
             .collect()
     }
@@ -155,7 +153,6 @@ impl ItemStats {
             item_name: requisition_line.item_row.name.clone(),
             // TODO: Implement total consumption & total_stock_on_hand
             total_consumption: 0.0,
-            total_stock_on_hand: 0.0,
         }
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5579 

# 👩🏻‍💻 What does this PR do?

- Adds AMC column to expiring items report
- Prevents negative numbers for stock at risk on expiring items report
- Prevents negative numbers for stock on order in item usage report
- Update item usage in stock to be available stock, not total stock. Also update column header
- Update test suite

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

You can test this by deleting old reports in database, then running:

```
cargo build &&  ./target/debug/remote_server_cli build-standard-reports && ./target/debug/remote_server_cli upsert-reports-json
```

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Rebuild and upsert reports with above command (first delete old reports from database)
- [ ] open item usage report - see changed field header and data for available stock
- [ ] See stock on order shows 0 where previously showed negative numbers
- [ ] open expiring items report - see added AMC column
- [ ] See stock at risk shows 0 where previously showed negative numbers

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
Later will need to update documentation to explain how fields are calculated in OMS reports.

