### PR TITLE
Fix out of stock calculation

### DIFF
--- a/server/reports/stock-status/2_3_0/src/template.html
+++ b/server/reports/stock-status/2_3_0/src/template.html
@@ -31,7 +31,7 @@
         <td>{{item.code}}</td>
         <td>{{item.name}}</td>
         <td class="status"> 
-          {% if SOH == 0 and AMC == 0 %}
+          {% if SOH == 0 and AMC > 0 %}
             <span class="out-of-stock">{{t(k="report.out-of-stock", f="Out of Stock")}}</span>
           {% elif AMC == 0 %}
             <span class="no-consumption">{{t(k="report.no-consumption", f="No consumption")}}</span>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes https://github.com/msupply-foundation/open-msupply-reports/issues/123

# 👩🏻‍💻 What does this PR do?
Out of stock calculation was wrong

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have stock with stock on hand = 0 and AMC greater than 0
- [ ] See that it's out of stock

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
