### PR TITLE
Move selection to be first column in list view tables

### DIFF
--- a/client/packages/coldchain/src/Equipment/ListView/ListView.tsx
+++ b/client/packages/coldchain/src/Equipment/ListView/ListView.tsx
@@ -16,6 +16,7 @@ import {
   DotCell,
   RouteBuilder,
   ColumnFormat,
+  GenericColumnKey,
 } from '@openmsupply-client/common';
 import { useAssets } from '../api';
 import { Toolbar } from './Toolbar';
@@ -52,7 +53,7 @@ const AssetListComponent: FC = () => {
 
   const columnsToCreate: ColumnDescription<AssetRowFragment>[] = [];
   if (isCentralServer)
-    columnsToCreate.push({
+    columnsToCreate.push(GenericColumnKey.Selection, {
       key: 'store',
       label: 'label.store',
       accessor: ({ rowData }) => rowData.store?.code,
@@ -121,8 +122,7 @@ const AssetListComponent: FC = () => {
       key: 'notes',
       label: 'label.notes',
       sortable: false,
-    },
-    'selection'
+    }
   );
 
   const columns = useColumns(

--- a/client/packages/common/src/ui/layout/tables/columns/CheckboxSelectionColumn.tsx
+++ b/client/packages/common/src/ui/layout/tables/columns/CheckboxSelectionColumn.tsx
@@ -36,7 +36,7 @@ export const getCheckboxSelectionColumn = <
 >(): ColumnDefinition<T> => ({
   key: GenericColumnKey.Selection,
   sortable: false,
-  align: ColumnAlign.Right,
+  align: ColumnAlign.Left,
   width: 60,
   label: 'table.select-unselect-all-columns',
   Header: () => {

--- a/client/packages/inventory/src/Stocktake/ListView/ListView.tsx
+++ b/client/packages/inventory/src/Stocktake/ListView/ListView.tsx
@@ -12,6 +12,7 @@ import {
   NothingHere,
   useUrlQueryParams,
   ColumnFormat,
+  GenericColumnKey,
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
@@ -46,6 +47,7 @@ export const StocktakeListView: FC = () => {
 
   const columns = useColumns<StocktakeRowFragment>(
     [
+      GenericColumnKey.Selection, // Adds padding to the left
       ['stocktakeNumber', { maxWidth: 75, sortable: false }],
       [
         'status',
@@ -57,7 +59,6 @@ export const StocktakeListView: FC = () => {
       ['createdDatetime', { format: ColumnFormat.Date }],
       ['stocktakeDate', { sortable: false }],
       ['comment', { sortable: false }],
-      'selection',
     ],
     { onChangeSortBy: updateSortQuery, sortBy },
     [sortBy]

--- a/client/packages/inventory/src/Stocktake/ListView/ListView.tsx
+++ b/client/packages/inventory/src/Stocktake/ListView/ListView.tsx
@@ -47,7 +47,7 @@ export const StocktakeListView: FC = () => {
 
   const columns = useColumns<StocktakeRowFragment>(
     [
-      GenericColumnKey.Selection, // Adds padding to the left
+      GenericColumnKey.Selection,
       ['stocktakeNumber', { maxWidth: 75, sortable: false }],
       [
         'status',

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -29,6 +29,7 @@ export const useInboundShipmentColumns = () => {
 
   const columns = useColumns<InboundLineFragment | InboundItem>(
     [
+      GenericColumnKey.Selection,
       [
         getNotePopoverColumn(),
         {
@@ -224,7 +225,6 @@ export const useInboundShipmentColumns = () => {
         sortable: false,
       },
       getRowExpandColumn(),
-      GenericColumnKey.Selection,
     ],
     { sortBy, onChangeSortBy: updateSortQuery },
     [sortBy, updateSortQuery]

--- a/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
@@ -13,6 +13,7 @@ import {
   useToggle,
   useUrlQueryParams,
   TooltipTextCell,
+  GenericColumnKey,
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
@@ -60,6 +61,7 @@ export const InboundListView: FC = () => {
 
   const columns = useColumns<InboundRowFragment>(
     [
+      GenericColumnKey.Selection,
       [getNameAndColorColumn(), { setter: onUpdate }],
       [
         'status',
@@ -85,7 +87,6 @@ export const InboundListView: FC = () => {
           accessor: ({ rowData }) => rowData.pricing.totalAfterTax,
         },
       ],
-      'selection',
     ],
     { onChangeSortBy: updateSortQuery, sortBy },
     [sortBy]

--- a/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -45,6 +45,7 @@ export const useOutboundColumns = ({
   const { getColumnProperty, getColumnPropertyAsString } = useColumnUtils();
 
   const columns: ColumnDescription<StockOutLineFragment | StockOutItem>[] = [
+    GenericColumnKey.Selection,
     [
       notePopoverColumn,
       {
@@ -281,7 +282,6 @@ export const useOutboundColumns = ({
       },
     },
     expansionColumn,
-    GenericColumnKey.Selection,
   ];
 
   return useColumns(columns, { onChangeSortBy, sortBy }, [sortBy]);

--- a/client/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/client/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -13,6 +13,7 @@ import {
   useToggle,
   useUrlQueryParams,
   TooltipTextCell,
+  GenericColumnKey,
 } from '@openmsupply-client/common';
 import { getStatusTranslator, isOutboundDisabled } from '../../utils';
 import { Toolbar } from './Toolbar';
@@ -53,6 +54,7 @@ const OutboundShipmentListViewComponent: FC = () => {
 
   const columns = useColumns<OutboundRowFragment>(
     [
+      GenericColumnKey.Selection,
       [getNameAndColorColumn(), { setter: onUpdate }],
       [
         'status',
@@ -86,7 +88,6 @@ const OutboundShipmentListViewComponent: FC = () => {
           width: 125,
         },
       ],
-      'selection',
     ],
     { onChangeSortBy: updateSortQuery, sortBy },
     [sortBy]

--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -35,6 +35,7 @@ export const usePrescriptionColumn = ({
   const { getColumnPropertyAsString, getColumnProperty } = useColumnUtils();
 
   const columns: ColumnDescription<StockOutLineFragment | StockOutItem>[] = [
+    GenericColumnKey.Selection,
     [
       getNotePopoverColumn(t('label.directions')),
       {
@@ -288,7 +289,6 @@ export const usePrescriptionColumn = ({
       },
     },
     expansionColumn,
-    GenericColumnKey.Selection,
   ];
 
   return useColumns(columns, { onChangeSortBy, sortBy }, [sortBy]);

--- a/client/packages/invoices/src/Prescriptions/ListView/ListView.tsx
+++ b/client/packages/invoices/src/Prescriptions/ListView/ListView.tsx
@@ -13,6 +13,7 @@ import {
   useToggle,
   useUrlQueryParams,
   ColumnFormat,
+  GenericColumnKey,
 } from '@openmsupply-client/common';
 import { getStatusTranslator, isPrescriptionDisabled } from '../../utils';
 import { usePrescriptionList, usePrescription } from '../api';
@@ -62,6 +63,7 @@ const PrescriptionListViewComponent: FC = () => {
 
   const columns = useColumns<PrescriptionRowFragment>(
     [
+      GenericColumnKey.Selection,
       [getNameAndColorColumn(), { setter: update }],
       [
         'status',
@@ -85,7 +87,6 @@ const PrescriptionListViewComponent: FC = () => {
         sortable: true,
       },
       ['comment'],
-      'selection',
     ],
     { onChangeSortBy: updateSortQuery, sortBy },
     [sortBy]

--- a/client/packages/invoices/src/Returns/CustomerDetailView/columns.ts
+++ b/client/packages/invoices/src/Returns/CustomerDetailView/columns.ts
@@ -36,6 +36,7 @@ export const useCustomerReturnColumns = ({
   const columns: ColumnDescription<
     CustomerReturnLineFragment | CustomerReturnItem
   >[] = [
+    GenericColumnKey.Selection,
     [
       'itemCode',
       {
@@ -177,7 +178,6 @@ export const useCustomerReturnColumns = ({
       },
     ],
     expansionColumn,
-    GenericColumnKey.Selection,
   ];
 
   return useColumns(columns, { onChangeSortBy, sortBy }, [sortBy]);

--- a/client/packages/invoices/src/Returns/CustomerListView/ListView.tsx
+++ b/client/packages/invoices/src/Returns/CustomerListView/ListView.tsx
@@ -14,6 +14,7 @@ import {
   ColumnDataSetter,
   useTableStore,
   TooltipTextCell,
+  GenericColumnKey,
 } from '@openmsupply-client/common';
 import { getStatusTranslator, isInboundListItemDisabled } from '../../utils';
 import { Toolbar } from './Toolbar';
@@ -61,6 +62,7 @@ const CustomerReturnListViewComponent: FC = () => {
 
   const columns = useColumns<CustomerReturnRowFragment>(
     [
+      GenericColumnKey.Selection,
       [getNameAndColorColumn(), { setter: onUpdateColour }],
       [
         'status',
@@ -82,7 +84,6 @@ const CustomerReturnListViewComponent: FC = () => {
           width: 125,
         },
       ],
-      'selection',
     ],
     { onChangeSortBy: updateSortQuery, sortBy },
     [sortBy]

--- a/client/packages/invoices/src/Returns/SupplierDetailView/columns.ts
+++ b/client/packages/invoices/src/Returns/SupplierDetailView/columns.ts
@@ -39,6 +39,7 @@ export const useSupplierReturnColumns = ({
   const columns: ColumnDescription<
     SupplierReturnLineFragment | SupplierReturnItem
   >[] = [
+    GenericColumnKey.Selection,
     [
       'itemCode',
       {
@@ -234,7 +235,6 @@ export const useSupplierReturnColumns = ({
       },
     },
     expansionColumn,
-    GenericColumnKey.Selection,
   ];
 
   return useColumns(columns, { onChangeSortBy, sortBy }, [sortBy]);

--- a/client/packages/invoices/src/Returns/SupplierListView/ListView.tsx
+++ b/client/packages/invoices/src/Returns/SupplierListView/ListView.tsx
@@ -14,6 +14,7 @@ import {
   ColumnDataSetter,
   useTableStore,
   TooltipTextCell,
+  GenericColumnKey,
 } from '@openmsupply-client/common';
 import { getStatusTranslator, isOutboundDisabled } from '../../utils';
 import { Toolbar } from './Toolbar';
@@ -61,6 +62,7 @@ const SupplierReturnListViewComponent: FC = () => {
 
   const columns = useColumns<SupplierReturnRowFragment>(
     [
+      GenericColumnKey.Selection,
       [getNameAndColorColumn(), { setter: onUpdateColour }],
       [
         'status',
@@ -82,7 +84,6 @@ const SupplierReturnListViewComponent: FC = () => {
           width: 150,
         },
       ],
-      'selection',
     ],
     { onChangeSortBy: updateSortQuery, sortBy },
     [sortBy]

--- a/client/packages/programs/src/ImmunisationProgramDetailView/ImmunisationProgramDetailView.tsx
+++ b/client/packages/programs/src/ImmunisationProgramDetailView/ImmunisationProgramDetailView.tsx
@@ -17,6 +17,7 @@ import {
   NothingHere,
   useEditModal,
   UNDEFINED_STRING_VALUE,
+  GenericColumnKey,
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
@@ -56,6 +57,7 @@ export const ProgramComponent: FC = () => {
 
   const columns = useColumns<VaccineCourseFragment>(
     [
+      GenericColumnKey.Selection,
       { key: 'name', label: 'label.name' },
       {
         key: 'demographicIndicator',
@@ -72,7 +74,6 @@ export const ProgramComponent: FC = () => {
         label: 'label.doses',
         accessor: ({ rowData }) => rowData?.vaccineCourseDoses?.length ?? 0,
       },
-      'selection',
     ],
     {
       onChangeSortBy: updateSortQuery,

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
@@ -250,7 +250,7 @@ export const useRequestColumns = () => {
       accessor: ({ rowData }) => rowData.linkedRequisitionLine?.approvalComment,
     });
   }
-  columnDefinitions.push(GenericColumnKey.Selection);
+  columnDefinitions.unshift(GenericColumnKey.Selection);
 
   const columns = useColumns<RequestLineFragment>(
     columnDefinitions,

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
@@ -50,6 +50,7 @@ export const useRequestColumns = () => {
   const { getError } = useRequestRequisitionLineErrorContext();
 
   const columnDefinitions: ColumnDescription<RequestLineFragment>[] = [
+    GenericColumnKey.Selection,
     getCommentPopoverColumn(),
     [
       'itemCode',
@@ -250,7 +251,6 @@ export const useRequestColumns = () => {
       accessor: ({ rowData }) => rowData.linkedRequisitionLine?.approvalComment,
     });
   }
-  columnDefinitions.unshift(GenericColumnKey.Selection);
 
   const columns = useColumns<RequestLineFragment>(
     columnDefinitions,

--- a/client/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
@@ -14,6 +14,7 @@ import {
   useUrlQueryParams,
   ColumnDescription,
   TooltipTextCell,
+  GenericColumnKey,
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
@@ -59,6 +60,7 @@ export const RequestRequisitionListView: FC = () => {
   const { requireSupplierAuthorisation } = useRequest.utils.preferences();
 
   const columnDefinitions: ColumnDescription<RequestRowFragment>[] = [
+    GenericColumnKey.Selection,
     [getNameAndColorColumn(), { setter: onUpdate }],
     {
       key: 'requisitionNumber',
@@ -115,8 +117,6 @@ export const RequestRequisitionListView: FC = () => {
         t(getApprovalStatusKey(rowData.linkedRequisition?.approvalStatus)),
     });
   }
-
-  columnDefinitions.push('selection');
 
   const columns = useColumns<RequestRowFragment>(
     columnDefinitions,

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
@@ -273,7 +273,7 @@ export const useResponseColumns = () => {
     Cell: PackQuantityCell,
     accessor: ({ rowData }) => rowData.remainingQuantityToSupply,
   });
-  columnDefinitions.push(GenericColumnKey.Selection);
+  columnDefinitions.unshift(GenericColumnKey.Selection);
 
   const columns = useColumns<ResponseLineFragment>(
     columnDefinitions,

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
@@ -26,6 +26,7 @@ export const useResponseColumns = () => {
   const { programName } = useResponse.document.fields(['programName']);
 
   const columnDefinitions: ColumnDescription<ResponseLineFragment>[] = [
+    GenericColumnKey.Selection,
     getCommentPopoverColumn(),
     [
       'itemCode',
@@ -273,7 +274,6 @@ export const useResponseColumns = () => {
     Cell: PackQuantityCell,
     accessor: ({ rowData }) => rowData.remainingQuantityToSupply,
   });
-  columnDefinitions.unshift(GenericColumnKey.Selection);
 
   const columns = useColumns<ResponseLineFragment>(
     columnDefinitions,

--- a/client/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
@@ -14,6 +14,7 @@ import {
   ColumnDescription,
   TooltipTextCell,
   useToggle,
+  GenericColumnKey,
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
@@ -70,6 +71,7 @@ export const ResponseRequisitionListView: FC = () => {
     data?.nodes.some(row => row.period);
 
   const columnDefinitions: ColumnDescription<ResponseRowFragment>[] = [
+    GenericColumnKey.Selection,
     [
       getNameAndColorColumn(),
       { setter: ({ id, colour }) => onUpdate({ id, colour }) },
@@ -133,7 +135,7 @@ export const ResponseRequisitionListView: FC = () => {
   }
   columnDefinitions.push(
     ['comment', { minWidth: 350, Cell: TooltipTextCell }],
-    ['selection']
+    
   );
 
   const columns = useColumns<ResponseRowFragment>(

--- a/client/packages/system/src/Asset/AssetLogReasons/ListView.tsx
+++ b/client/packages/system/src/Asset/AssetLogReasons/ListView.tsx
@@ -10,6 +10,7 @@ import {
   useUrlQueryParams,
   useEditModal,
   InsertAssetLogReasonInput,
+  GenericColumnKey,
 } from '@openmsupply-client/common';
 import { AssetLogReasonFragment, useAssetData } from '../api';
 import { Toolbar } from './Toolbar';
@@ -34,6 +35,7 @@ const AssetListComponent: FC = () => {
 
   const columns = useColumns<AssetLogReasonFragment>(
     [
+      GenericColumnKey.Selection,
       {
         key: 'status',
         label: 'label.status',
@@ -45,7 +47,6 @@ const AssetListComponent: FC = () => {
         label: 'label.reason',
         sortable: false,
       },
-      'selection',
     ],
     {
       sortBy,

--- a/client/packages/system/src/Asset/ListView/ListView.tsx
+++ b/client/packages/system/src/Asset/ListView/ListView.tsx
@@ -11,6 +11,7 @@ import {
   useToggle,
   useIsCentralServerApi,
   ColumnDescription,
+  GenericColumnKey,
 } from '@openmsupply-client/common';
 import { AssetCatalogueItemFragment, useAssetData } from '../api';
 import { Toolbar } from './Toolbar';
@@ -79,7 +80,7 @@ const AssetListComponent: FC = () => {
     },
   ];
 
-  if (isCentralServer) columnDescriptions.push('selection');
+  if (isCentralServer) columnDescriptions.unshift(GenericColumnKey.Selection);
   const columns = useColumns<AssetCatalogueItemFragment>(
     columnDescriptions,
     {

--- a/client/packages/system/src/Asset/ListView/ListView.tsx
+++ b/client/packages/system/src/Asset/ListView/ListView.tsx
@@ -41,6 +41,7 @@ const AssetListComponent: FC = () => {
   const importModalController = useToggle();
 
   const columnDescriptions: ColumnDescription<AssetCatalogueItemFragment>[] = [
+    ...(isCentralServer ? [GenericColumnKey.Selection] : []),
     {
       key: 'subCatalogue',
       label: 'label.sub-catalogue',
@@ -80,7 +81,6 @@ const AssetListComponent: FC = () => {
     },
   ];
 
-  if (isCentralServer) columnDescriptions.unshift(GenericColumnKey.Selection);
   const columns = useColumns<AssetCatalogueItemFragment>(
     columnDescriptions,
     {

--- a/client/packages/system/src/Location/ListView/ListView.tsx
+++ b/client/packages/system/src/Location/ListView/ListView.tsx
@@ -39,7 +39,7 @@ const LocationListComponent: FC = () => {
   const t = useTranslation();
   const columns = useColumns<LocationRowFragment>(
     [
-      GenericColumnKey.Selection, // adds padding to the left not sure why
+      GenericColumnKey.Selection,
       'code',
       'name',
       {

--- a/client/packages/system/src/Location/ListView/ListView.tsx
+++ b/client/packages/system/src/Location/ListView/ListView.tsx
@@ -8,6 +8,7 @@ import {
   NothingHere,
   useTranslation,
   useUrlQueryParams,
+  GenericColumnKey,
 } from '@openmsupply-client/common';
 import { useLocation, LocationRowFragment } from '../api';
 import { AppBarButtons } from './AppBarButtons';
@@ -38,6 +39,7 @@ const LocationListComponent: FC = () => {
   const t = useTranslation();
   const columns = useColumns<LocationRowFragment>(
     [
+      GenericColumnKey.Selection, // adds padding to the left not sure why
       'code',
       'name',
       {
@@ -50,7 +52,6 @@ const LocationListComponent: FC = () => {
         width: 200,
         sortable: false,
       },
-      'selection',
     ],
     {
       onChangeSortBy: updateSortQuery,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5655

# 👩🏻‍💻 What does this PR do?
Move selection to be first column and also rename ```'selection'``` to ```genericColumnKey.Selection```

<!-- Explain the changes you made -->

<!-- why are the changes needed -->
Changes needed to make it easier for user to select rows in list view

<!-- Add a screenshot if there are UI changes  -->
![Screenshot 2024-12-13 at 12 59 39 PM](https://github.com/user-attachments/assets/d6ff9235-4485-469b-b1e6-5222d385cb6f)
![Screenshot 2024-12-13 at 1 05 40 PM](https://github.com/user-attachments/assets/ec8ef6be-2b01-4088-bd9c-bf77148eef04)
![Screenshot 2024-12-13 at 1 05 57 PM](https://github.com/user-attachments/assets/aece1fdd-5619-4d66-81ce-3ecb40410441)
![Screenshot 2024-12-13 at 1 06 15 PM](https://github.com/user-attachments/assets/f15db9b4-e317-41df-9f4a-0c8cd71cc4c7)
![Screenshot 2024-12-13 at 1 06 31 PM](https://github.com/user-attachments/assets/1fdc9797-c687-4231-92d2-84b4e961ab03)
![Screenshot 2024-12-13 at 1 06 54 PM](https://github.com/user-attachments/assets/01f2a3aa-f3b1-462c-95b7-9744aa499f15)
![Screenshot 2024-12-13 at 1 07 10 PM](https://github.com/user-attachments/assets/7d12277d-3e97-4ea4-8a70-b67cc9ec91ea)
No screenshot for programs
![Screenshot 2024-12-13 at 1 09 11 PM](https://github.com/user-attachments/assets/dc35fadc-fde0-4a08-b320-692a919ea85b)
![Screenshot 2024-12-13 at 1 09 29 PM](https://github.com/user-attachments/assets/2bf040ca-c1d7-465a-9116-303de2cae5f9)
![Screenshot 2024-12-13 at 1 09 48 PM](https://github.com/user-attachments/assets/be81aa91-ead2-4832-a493-c0fcfb6638ee)
![Screenshot 2024-12-13 at 1 10 09 PM](https://github.com/user-attachments/assets/bf22ef0d-adca-4a3a-9934-351189345be5)
![Screenshot 2024-12-13 at 1 10 23 PM](https://github.com/user-attachments/assets/2c1d1d9c-2956-498d-b5c7-b40352861547)

## 💌 Any notes for the reviewer?
Note sure why padding is being added to the left of the column in Inventory -> Locations and Stocktakes
<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Check the areas in the screenshots 
- [ ] See that selection column is now the first column in the tables
- [ ] Test that selection is working correctly

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
