### PR TITLE
change tooltip placement to top

### DIFF
--- a/client/packages/common/src/ui/layout/tables/components/tooltipPlacement.ts
+++ b/client/packages/common/src/ui/layout/tables/components/tooltipPlacement.ts
@@ -7,14 +7,14 @@ import { ColumnAlign } from '../columns';
  */
 export const tooltipPlacement = (
   align: ColumnAlign
-): 'bottom-end' | 'bottom-start' | 'bottom' => {
+): 'top-end' | 'top-start' | 'top' => {
   switch (align) {
     case ColumnAlign.Left:
-      return 'bottom-start';
+      return 'top-start';
     case ColumnAlign.Right:
-      return 'bottom-end';
+      return 'top-end';
     case ColumnAlign.Center:
-      return 'bottom';
+      return 'top';
     default:
       return noOtherVariants(align);
   }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4892 

# 👩🏻‍💻 What does this PR do?

The current placement of the tooltip obscures or hides data entry fields. To fix this issue we are to move up the placement of the tooltip from bottom to the top. 

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

<img width="326" alt="Screenshot 2024-12-16 at 6 00 15 PM" src="https://github.com/user-attachments/assets/1d82bcff-c63f-45e3-b700-d7e952778ca7" />

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Visit any page that renders a data table
- [ ] Hover over the column title
- [ ] Tooltip should be rendering at the top of the text

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
