### PR TITLE
change portuguese translation of log

### DIFF
--- a/client/packages/common/src/intl/locales/pt/common.json
+++ b/client/packages/common/src/intl/locales/pt/common.json
@@ -548,7 +548,7 @@
   "label.line-total": "Total da Linha",
   "label.location": "Localização",
   "label.locked": "Bloqueado",
-  "label.log": "Registro",
+  "label.log": "Histórico",
   "label.low-stock": "Baixo stock",
   "label.low-stock-items_few": "Artigos com menos de 3 meses de stock",
   "label.low-stock-items_many": "Artigos com menos de 3 meses de stock",


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5748 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
Fixes the display issue caused by log and ledger being the same word in portuguese.
Before:

![IMAGE 2024-12-18 15:32:07](https://github.com/user-attachments/assets/70eb9238-1f2f-4fcf-b7ea-587d4a8f7d87)

After:

![image](https://github.com/user-attachments/assets/7b6390e2-c182-4cb2-902d-97edb15c87aa)

![image](https://github.com/user-attachments/assets/f1f5d9dd-3c08-4d58-8f76-7ba1c93ce59e)


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Complete love ends all fears.

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] view inventory stock in portuguese
- [ ] relax
- [ ] because
- [ ] that's
- [ ] it
- [ ] done
- [ ] :)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: if there are any, screenshots showing the inventory>view stock page in portuguese might be worth updating. But I'm guessing if we had any then this issue would have come up before now.