### PR TITLE
Add switch for item packs

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestEditPage.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestEditPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   BasicSpinner,
   DetailContainer,
@@ -27,6 +27,8 @@ export const RequestLineEditPage = () => {
     lines,
     currentItem
   );
+  const isPacksEnabled = !!draft?.defaultPackSize;
+  const [isPacks, setIsPacks] = useState(isPacksEnabled);
   const enteredLineIds = lines
     ? lines
         .filter(line => line.requestedQuantity !== 0)
@@ -71,6 +73,9 @@ export const RequestLineEditPage = () => {
                 hasPrevious={hasPrevious}
                 previous={previous}
                 isProgram={!!data?.programName}
+                isPacksEnabled={isPacksEnabled}
+                isPacks={isPacks}
+                setIsPacks={setIsPacks}
               />
             </>
           }

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -187,9 +187,15 @@ export const RequestLineEdit = ({
         </Box>
         <Box>
           {/* Right column content */}
-          <Box display="flex" flexDirection="row">
+          <Box
+            display="flex"
+            flexDirection="row"
+            justifyContent="flex-end"
+            paddingBottom={1}
+            paddingRight={2.5}
+          >
             {isPacksEnabled && (
-              <Box display="flex" justifyContent="flex-end" alignItems="center">
+              <Box display="flex">
                 <Switch
                   label={t('label.units')}
                   checked={isPacks}

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -36,7 +36,7 @@ interface RequestLineEditProps {
   isProgram: boolean;
   isPacksEnabled: boolean;
   isPacks: boolean;
-  setIsPacks: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsPacks: (isPacks: boolean) => void;
 }
 
 export const RequestLineEdit = ({

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -12,6 +12,7 @@ import {
   NumUtils,
   Popover,
   ReasonOptionNodeType,
+  Switch,
   TextArea,
   useAuthContext,
   useToggle,
@@ -33,6 +34,9 @@ interface RequestLineEditProps {
   hasPrevious: boolean;
   previous: ItemRowFragment | null;
   isProgram: boolean;
+  isPacksEnabled: boolean;
+  isPacks: boolean;
+  setIsPacks: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const RequestLineEdit = ({
@@ -44,6 +48,9 @@ export const RequestLineEdit = ({
   hasPrevious,
   previous,
   isProgram,
+  isPacksEnabled,
+  isPacks,
+  setIsPacks,
 }: RequestLineEditProps) => {
   const t = useTranslation();
   const { isOn, toggle } = useToggle();
@@ -181,11 +188,28 @@ export const RequestLineEdit = ({
         <Box>
           {/* Right column content */}
           <Box display="flex" flexDirection="row">
+            {isPacksEnabled && (
+              <Box display="flex" justifyContent="flex-end" alignItems="center">
+                <Switch
+                  label={t('label.units')}
+                  checked={isPacks}
+                  onChange={(_event, checked) => setIsPacks(checked)}
+                  size="small"
+                />
+                <Box paddingLeft={2} paddingRight={2}>
+                  {t('label.packs')}
+                </Box>
+              </Box>
+            )}
+          </Box>
+
+          <Box display="flex" flexDirection="row">
             <InputWithLabelRow
               Input={
                 <NumericTextInput
                   width={INPUT_WIDTH}
                   value={draft?.requestedQuantity}
+                  disabled={isPacks}
                   onChange={value => {
                     if (draft?.suggestedQuantity === value) {
                       update({
@@ -231,6 +255,49 @@ export const RequestLineEdit = ({
               )}
             </Box>
           </Box>
+          <Box display="flex" flexDirection="row">
+            {isPacksEnabled && (
+              <InputWithLabelRow
+                Input={
+                  <NumericTextInput
+                    autoFocus
+                    disabled={!isPacks}
+                    value={NumUtils.round(
+                      (draft?.requestedQuantity ?? 0) /
+                        (draft?.defaultPackSize ?? 1),
+                      2
+                    )}
+                    decimalLimit={2}
+                    width={100}
+                    onChange={quantity => {
+                      update({
+                        requestedQuantity:
+                          (quantity ?? 0) * (draft?.defaultPackSize ?? 0),
+                      });
+                    }}
+                  />
+                }
+                labelWidth={LABEL_WIDTH}
+                sx={{ marginBottom: 1 }}
+                label={t('label.requested-packs')}
+              />
+            )}
+          </Box>
+          {isPacksEnabled ? (
+            <InputWithLabelRow
+              Input={
+                <NumericTextInput
+                  width={INPUT_WIDTH}
+                  value={draft?.defaultPackSize}
+                  disabled
+                />
+              }
+              labelWidth={LABEL_WIDTH}
+              label={t('label.default-pack-size')}
+              sx={{ marginBottom: 1 }}
+            />
+          ) : null}
+
           <InputWithLabelRow
             Input={
               <NumericTextInput

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
@@ -13,6 +13,7 @@ export type DraftRequestLine = Omit<
 > & {
   isCreated: boolean;
   requisitionId: string;
+  defaultPackSize: number;
 };
 
 const createDraftFromItem = (
@@ -44,6 +45,7 @@ const createDraftFromItem = (
     additionInUnits: 0,
     daysOutOfStock: 0,
     expiringUnits: 0,
+    defaultPackSize: item.defaultPackSize,
   };
 };
 
@@ -58,6 +60,7 @@ const createDraftFromRequestLine = (
   suggestedQuantity: line.suggestedQuantity,
   isCreated: false,
   itemStats: line.itemStats,
+  defaultPackSize: line.item.defaultPackSize,
 });
 
 export const useDraftRequisitionLine = (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5852

# 👩🏻‍💻 What does this PR do?

Adds switch for item packs vs requested quantity in internal order line edit.

## 💌 Any notes for the reviewer?

Side note - RequestLineEditForm.tsx isn't used anywhere. I wonder can we get rid of this to reduce codebase size?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Internal orders
- [ ] Go to an internal order line
- [ ] See radio switch above requested quantity
- [ ] See default pack size below requested quantity
- [ ] Alternate between packs vs units, and try editing each field

# 📃 Documentation

- [ ] **Part of an epic**: I think this is part of an epic to be edited later? Might not require documentation changes.


