### PR TITLE
modify the tooltips of table column headers

### DIFF
--- a/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -72,10 +72,10 @@ export const HeaderCell = <T extends RecordWithId>({
         {sortable ? (
           <div>
             {t('label.click-to-sort')}
-            {` ${columnLabel}`}
+            {` ${columnLabel.toLocaleLowerCase()}`}
           </div>
         ) : (
-          columnLabel
+          !description && columnLabel
         )}
       </>
     );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5235

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
I modified the tooltips for header cells, so that now, if a description of the column has been shown, the label is not shown - if the description has already been shown, showing the label will not add anything. 
That prevents things being repetitive

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
![image](https://github.com/user-attachments/assets/0567c309-5b2b-417a-a5d1-30f47c861f5e)

## 💌 Any notes for the reviewer?

I changed the tooltips so that now it says 'sort by [column label in lower case]' - before it did not transform it to lower case. Is this ok?

Is it worth creating an issue for this - at the moment, you get tooltips for every single entry in a table, which add no information, and stop you interacting with what's covered by them. Here are some examples:

This one stops you clicking on two lines:

![Screenshot 2024-12-19 at 16 40 32](https://github.com/user-attachments/assets/ac0b2263-2bd8-423e-a642-f6a3cd0748a9)

These tooltips don't add information, and might lead to confusion due to their position:

![Screenshot 2024-12-19 at 16 40 02](https://github.com/user-attachments/assets/be5965a7-4b81-4de5-adc3-8b3fa1ff4997)
![Screenshot 2024-12-19 at 16 39 51](https://github.com/user-attachments/assets/7ff4a258-dffd-4797-84c8-6671577f8a7f)

This one gives you no new information but stops you from sorting the table by name. This tooltip comes up if the cursor is even slightly below the header cell, meaning it might be frustrating for users trying to sort a column quickly:

![Screenshot 2024-12-19 at 16 40 18](https://github.com/user-attachments/assets/ddcb0392-9ad7-442a-9b89-f2918b0bb1ac)

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

- [ ] Go to catalogue>items and hover on the columns' headers
- [ ] Go to other tables around the app and hover on the columns' headers
- [ ] See if the tooltips avoid repeating themselves

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
