### PR TITLE
remove currentItem loading check

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditPage.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditPage.tsx
@@ -38,7 +38,7 @@ export const ResponseLineEditPage = () => {
     });
   }, [currentItem]);
 
-  if (isLoading || !currentItem) return <BasicSpinner />;
+  if (isLoading) return <BasicSpinner />;
   if (!data) return <NothingHere />;
 
   return (

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditPage.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditPage.tsx
@@ -7,7 +7,7 @@ import {
   useBreadcrumbs,
   useParams,
 } from '@openmsupply-client/common';
-import { useResponse } from '../../api';
+import { ResponseFragment, useResponse } from '../../api';
 import { ListItems } from '@openmsupply-client/system';
 import { ResponseLineEdit } from './ResponseLineEdit';
 import { AppRoute } from '@openmsupply-client/config';
@@ -15,14 +15,31 @@ import { useDraftRequisitionLine, usePreviousNextResponseLine } from './hooks';
 import { AppBarButtons } from './AppBarButtons';
 import { PageLayout } from '../PageLayout';
 
+interface ResponseLineEditPageInnerProps {
+  itemId: string;
+  requisition: ResponseFragment;
+}
+
 export const ResponseLineEditPage = () => {
   const { itemId } = useParams();
-  const { setCustomBreadcrumbs } = useBreadcrumbs();
   const { data, isLoading } = useResponse.document.get();
-  const lines =
-    data?.lines.nodes.sort((a, b) => a.item.name.localeCompare(b.item.name)) ??
-    [];
-  const currentItem = lines.find(l => l.item.id === itemId)?.item;
+
+  if (isLoading || !itemId) return <BasicSpinner />;
+  if (!data) return <NothingHere />;
+
+  return <ResponseLineEditPageInner requisition={data} itemId={itemId} />;
+};
+
+const ResponseLineEditPageInner = ({
+  itemId,
+  requisition,
+}: ResponseLineEditPageInnerProps) => {
+  const { setCustomBreadcrumbs } = useBreadcrumbs();
+
+  const lines = requisition.lines.nodes.sort((a, b) =>
+    a.item.name.localeCompare(b.item.name)
+  );
+  const currentItem = lines.find(line => line.item.id === itemId)?.item;
   const { draft, update, save } = useDraftRequisitionLine(currentItem);
   const { hasNext, next, hasPrevious, previous } = usePreviousNextResponseLine(
     lines,
@@ -38,22 +55,19 @@ export const ResponseLineEditPage = () => {
     });
   }, [currentItem]);
 
-  if (isLoading) return <BasicSpinner />;
-  if (!data) return <NothingHere />;
-
   return (
     <>
-      <AppBarButtons requisitionNumber={data?.requisitionNumber} />
+      <AppBarButtons requisitionNumber={requisition.requisitionNumber} />
       <DetailContainer>
         <PageLayout
           Left={
             <>
               <ListItems
                 currentItemId={itemId}
-                items={lines.map(l => l.item)}
+                items={lines.map(line => line.item)}
                 route={RouteBuilder.create(AppRoute.Distribution)
                   .addPart(AppRoute.CustomerRequisition)
-                  .addPart(String(data?.requisitionNumber))}
+                  .addPart(String(requisition.requisitionNumber))}
                 enteredLineIds={enteredLineIds}
               />
             </>
@@ -62,7 +76,7 @@ export const ResponseLineEditPage = () => {
             <>
               <ResponseLineEdit
                 item={currentItem}
-                hasLinkedRequisition={!!data?.linkedRequisition}
+                hasLinkedRequisition={!!requisition.linkedRequisition}
                 draft={draft}
                 update={update}
                 save={save}
@@ -70,7 +84,7 @@ export const ResponseLineEditPage = () => {
                 next={next}
                 hasPrevious={hasPrevious}
                 previous={previous}
-                isProgram={!!data?.programName}
+                isProgram={!!requisition.programName}
               />
             </>
           }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5857 

# 👩🏻‍💻 What does this PR do?

Adding an item to a requisition can sometimes cause the browser to enter an infinite loading state. This is due to race conditions in the code.

The loading check relies on `isLoading || !currentItem` to determine if data has been fetched and if `currentItem` is populated. However, `currentItem` is derived from the fetched data, and there’s a moment when `isLoading` becomes false (data fetched), but `currentItem` is still empty. This timing mismatch triggers the issue.

<img width="1444" alt="Screenshot 2024-12-20 at 10 02 09 AM" src="https://github.com/user-attachments/assets/f47abdca-d402-4121-9357-648794ee48b4" />

As seen as well with the length of the array return from data. Lines grows in size once data is retrieved.

<img width="1445" alt="Screenshot 2024-12-20 at 10 19 25 AM" src="https://github.com/user-attachments/assets/27e03107-4dfc-4569-a54f-c120722db008" />

Removing `currentItem` from the loading check fixes the infinite loading state issue.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Add a few items to a requisition
- [ ] Page shouldn't be stuck in a infinite loading state at any point

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
