### PR TITLE
Check for 01 ids before trying to create an asset...

### DIFF
--- a/client/packages/coldchain/src/Equipment/ListView/AddFromScannerButton.tsx
+++ b/client/packages/coldchain/src/Equipment/ListView/AddFromScannerButton.tsx
@@ -17,6 +17,7 @@ import {
   AssetLogStatusInput,
   UserPermission,
   useAuthContext,
+  RegexUtils,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { useAssets } from '../api';
@@ -70,8 +71,7 @@ export const AddFromScannerButtonComponent = () => {
   const handleScanResult = async (result: ScanResult) => {
     if (!!result.content) {
       const { gs1 } = result;
-
-      if (!gs1) {
+      if (!gs1 || RegexUtils.isLikelyId(result.content)) {
         // try to fetch the asset by id, as it could be an id from our own barcode
         const { content: id } = result;
         const asset = await fetchAsset(id).catch(() => {});

--- a/client/packages/common/src/utils/regex/RegexUtils.test.ts
+++ b/client/packages/common/src/utils/regex/RegexUtils.test.ts
@@ -149,3 +149,28 @@ describe('Check if email is valid', () => {
     expect(RegexUtils.checkEmailIsValid('test@email.domain.com')).toBeTruthy();
   });
 });
+
+describe('Check if isLikelyId', () => {
+  it('rejects empty space in id', () => {
+    expect(RegexUtils.isLikelyId('Some string')).toBeFalsy();
+  });
+  it('rejects something too small to be an id', () => {
+    expect(RegexUtils.isLikelyId('ABC')).toBeFalsy();
+  });
+  it('accepts UUID format', () => {
+    expect(
+      RegexUtils.isLikelyId('c8bc3bde-08c1-4b5e-b7f3-79163e61870e')
+    ).toBeTruthy();
+    expect(
+      RegexUtils.isLikelyId('01920ced-3e04-7ddf-95e2-683c8b880cd5')
+    ).toBeTruthy();
+  });
+  it('accepts mSupply format', () => {
+    expect(
+      RegexUtils.isLikelyId('8D967C2618BE4D78B3A6FAD6C1C8FF25')
+    ).toBeTruthy();
+    expect(
+      RegexUtils.isLikelyId('1E31B3575A284B7DB27EE755102446FE')
+    ).toBeTruthy();
+  });
+});

--- a/client/packages/common/src/utils/regex/RegexUtils.tsx
+++ b/client/packages/common/src/utils/regex/RegexUtils.tsx
@@ -76,4 +76,12 @@ export const RegexUtils = {
     const emailRegex = /^[^\s@]+@(?!\.)(?!.*\.{2})[^\s@]+\.[^\s@]+$/;
     return emailRegex.test(email);
   },
+
+  /* Checks a string to see if it's likely to be an ID */
+  isLikelyId: (input: string) => {
+    if (!input) return false;
+    if (input.length < 32) return false; // Too small for an mSupply ID
+    if (input.length > 36) return false; // Too large for a UUID
+    return /^([a-f\d]+-?)*$/i.test(input);
+  },
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5233

# 👩🏻‍💻 What does this PR do?

I found that scanning our own printed asset labels wasn't working for me due to IDs that started with `01` which is a kind of Valid GS1. The id was interpreted badly as GS1 and didn't navigate as expected.

## 💌 Any notes for the reviewer?

I've just created a check to see if an ID looks like an ID, but maybe we should look at changing our label QR code structure to have more information in it which would make it more identifiable. Would be nice to know which store it's for for example, so it could warn if you're scanning a barcode from a different store for example.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an ASSET with an id that starts with `01`
- [ ] Print asset label
- [ ] Try to scan asset label
- [ ] Check it navigates to the right place
- [ ] Try to see if we can create a valid GS1 that looks like our ID?

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
