### PR TITLE
add link to create new variant if none

### DIFF
--- a/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantModal.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantModal.tsx
@@ -110,6 +110,7 @@ const ItemVariantForm = ({
           labelWidth="200"
           Input={
             <BasicTextInput
+              autoFocus
               value={variant.name}
               onChange={event => {
                 updateVariant({ name: event.target.value });

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantsTab.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantsTab.tsx
@@ -48,7 +48,12 @@ export const ItemVariantsTab = ({
       </AppBarButtonsPortal>
       <Box flex={1} marginX={2}>
         {itemVariants.length === 0 ? (
-          <NothingHere body={t('messages.no-item-variants')} />
+          <>
+            <NothingHere
+              body={t('messages.no-item-variants')}
+              onCreate={() => onOpen()}
+            />
+          </>
         ) : (
           itemVariants.map(v => (
             <ItemVariant


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes Part 1 of #5554

# 👩🏻‍💻 What does this PR do?

Adds a create new variant link on the catalogue>item>variants tab, if there are no variants present.

![Screenshot 2024-12-30 at 09 02 38](https://github.com/user-attachments/assets/f3e4866c-039b-4aa2-a628-4c87b4c024ba)

## 💌 Any notes for the reviewer?

The capitalisation seems a bit dodgy. It seems all the 'create a new one' links will be similar. Using a function called toLocaleLowerCase() in the NothingHere.tsx file can solve this - should I create an issue to do that?

# 🧪 Testing

- [ ] log in to your _open_ mSupply central server
- [ ] go to cataogue>item page and then click on an item that has no variants to see its detail view
- [ ] go to the variants tab
- [ ] see if the link that says 'create a new one' functions the same as the 'add variant' button on the top right of the variants tab page.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
