### PR TITLE
autofocus first input in add variant modal

### DIFF
--- a/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantModal.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantModal.tsx
@@ -110,6 +110,7 @@ const ItemVariantForm = ({
           labelWidth="200"
           Input={
             <BasicTextInput
+              autoFocus
               value={variant.name}
               onChange={event => {
                 updateVariant({ name: event.target.value });


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes part 2 of #5554 

# 👩🏻‍💻 What does this PR do?

Autofocusses the first input of the add variant modal, to make it more keyboard friendly.
<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] log in to your _open_ mSupply central server
- [ ] navigate to catalogue>items
- [ ] select an item
- [ ] click on the variant tab
- [ ] click on the 'add variant' button in the top right corner
- [ ] see that when you start typing, input automatically goes in to the first input box on that screen, because it is autofocussed.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
