### PR TITLE
bump v6 sync version

### DIFF
--- a/server/service/src/sync/settings.rs
+++ b/server/service/src/sync/settings.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 
 // See README.md for description of when this API version needs to be updated
 pub(crate) static SYNC_V5_VERSION: u32 = 7;
-pub(crate) static SYNC_V6_VERSION: u32 = 2;
+pub(crate) static SYNC_V6_VERSION: u32 = 3;
 
 #[derive(Deserialize, Clone, Debug, PartialEq, Default)]
 pub struct SyncSettings {

--- a/server/service/src/sync/sync_on_central/mod.rs
+++ b/server/service/src/sync/sync_on_central/mod.rs
@@ -34,7 +34,7 @@ use super::{
 
 // See ../README.md for when to increment versions!
 static MIN_VERSION: u32 = 0;
-static MAX_VERSION: u32 = 2;
+static MAX_VERSION: u32 = 3;
 
 /// Send Records to a remote open-mSupply Server
 pub async fn pull(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5911 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
A new translation got added to our Sync function, specifically syncing Contact Form from Remote Server to Central Server. With this change we are also required to bump the V6 sync version in settings and `Max_version` in `sync_on_central` mod file by 1

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] 

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
