### PR TITLE
5920 prescriptions filter out on hold stock

### DIFF
--- a/client/packages/invoices/src/Prescriptions/LineEditView/hooks/useDraftPrescriptionLines.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/hooks/useDraftPrescriptionLines.tsx
@@ -58,7 +58,10 @@ export const useDraftPrescriptionLines = (
     const invoiceLineStockLines = (lines ?? []).flatMap(l =>
       l.stockLine ? [l.stockLine] : []
     );
-    const stockLines = uniqBy([...data.nodes, ...invoiceLineStockLines], 'id');
+    const stockLines = uniqBy(
+      [...data.nodes, ...invoiceLineStockLines],
+      'id'
+    ).filter(stockLine => stockLine.onHold === false); // Filter out on hold stock lines
 
     const noStockLines = stockLines.length == 0;
 

--- a/client/packages/invoices/src/Prescriptions/LineEditView/hooks/useDraftPrescriptionLines.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/hooks/useDraftPrescriptionLines.tsx
@@ -61,7 +61,7 @@ export const useDraftPrescriptionLines = (
     const stockLines = uniqBy(
       [...data.nodes, ...invoiceLineStockLines],
       'id'
-    ).filter(stockLine => stockLine.onHold === false); // Filter out on hold stock lines
+   ).filter(stockLine => !stockLine.onHold ); // Filter out on hold stock lines
 
     const noStockLines = stockLines.length == 0;
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5920

# 👩🏻‍💻 What does this PR do?

The new Prescriptions UI doesn't show the On Hold Column, instead we just won't show any on hold batches at all.

## 💌 Any notes for the reviewer?

Did this as a front end change, I think it should be fine to do here rather than making backend changes and filters on the historical stock. Also makes it possible to show on hold easily again. There isn't usually a lot of stock on hold so a backend filter shouldn't be a big deal IMHO.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Try creating a prescription with an item that has some stock on hold
- [ ] You shouldn't see the old hold stock.

# 📃 Documentation

- [X] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
