### PR TITLE
Add some safety to version from string conversion

### DIFF
--- a/server/repository/src/migrations/version.rs
+++ b/server/repository/src/migrations/version.rs
@@ -139,19 +139,25 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn parsing_version_panic1() {
-        Version::from_str("10.11");
+    fn parsing_version_poorly_formatted_1() {
+        let version = Version::from_str("10.11");
+        assert!(version.major == 10);
+        assert!(version.minor == 11);
+        assert!(version.patch == 0);
     }
     #[test]
-    #[should_panic]
-    fn parsing_version_panic2() {
-        Version::from_str("10.11.99RC1");
+    fn parsing_version_poorly_formatted_2() {
+        let version = Version::from_str("10.11.99RC1");
+        assert!(version.major == 10);
+        assert!(version.minor == 11);
+        assert!(version.patch == 0);
     }
     #[test]
-    #[should_panic]
-    fn parsing_version_panic3() {
-        Version::from_str("10.11b.99");
+    fn parsing_version_poorly_formatted_3() {
+        let version = Version::from_str("10.11b.99");
+        assert!(version.major == 10);
+        assert!(version.minor == 0);
+        assert!(version.patch == 99);
     }
 
     #[test]

--- a/server/repository/src/migrations/version.rs
+++ b/server/repository/src/migrations/version.rs
@@ -57,7 +57,6 @@ impl Display for Version {
         Ok(())
     }
 }
-// TODO no unwrap ?
 
 impl Version {
     pub fn from_package_json() -> Self {
@@ -66,18 +65,18 @@ impl Version {
 
     pub fn from_str(version: &str) -> Self {
         let mut version_split = version.split('.');
-        let major = version_split.next().unwrap();
-        let minor = version_split.next().unwrap();
-        let patch_and_extra = version_split.next().unwrap();
+        let major = version_split.next().unwrap_or("0");
+        let minor = version_split.next().unwrap_or("0");
+        let patch_and_extra = version_split.next().unwrap_or("0");
 
         let mut patch_and_extra_split = patch_and_extra.splitn(2, '-');
-        let patch = patch_and_extra_split.next().unwrap();
+        let patch = patch_and_extra_split.next().unwrap_or("");
         let extra = patch_and_extra_split.next();
 
         Version {
-            major: major.parse().unwrap(),
-            minor: minor.parse().unwrap(),
-            patch: patch.parse().unwrap(),
+            major: major.parse().unwrap_or(0),
+            minor: minor.parse().unwrap_or(0),
+            patch: patch.parse().unwrap_or(0),
             pre_release: extra.map(String::from),
         }
     }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5937

# 👩🏻‍💻 What does this PR do?
Adds some default values, so that the Version from_str won't fail if the version isn't perfect

<!-- Explain the changes you made -->
This was annoying when your database has old data, with a version of `1.0` for a report. The version conversion causes the report query to fail.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] update the version of a report to be invalid - try to view reports

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
