### PR TITLE
Navigate to new encounter after exiting create encounter modal

### DIFF
--- a/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
@@ -33,7 +33,6 @@ import {
   ClinicianAutocompleteOption,
   ClinicianSearchInput,
 } from '../../Clinician';
-import { PatientTabValue } from '../PatientView/PatientView';
 import { PickersDay, PickersDayProps } from '@mui/x-date-pickers';
 import Badge from '@mui/material/Badge';
 
@@ -230,23 +229,13 @@ export const CreateEncounterModal: FC = () => {
                 error(t('error.encounter-not-created'))();
                 return;
               }
-              const startDatetime = new Date(draft?.startDatetime ?? 0);
-              if (DateUtils.addHours(startDatetime, 1).getTime() > Date.now()) {
-                navigate(
-                  RouteBuilder.create(AppRoute.Dispensary)
-                    .addPart(AppRoute.Patients)
-                    .addPart(patientId)
-                    .addQuery({ tab: PatientTabValue.Encounters })
-                    .build()
-                );
-              } else {
-                navigate(
-                  RouteBuilder.create(AppRoute.Dispensary)
-                    .addPart(AppRoute.Encounter)
-                    .addPart(id)
-                    .build()
-                );
-              }
+
+              navigate(
+                RouteBuilder.create(AppRoute.Dispensary)
+                  .addPart(AppRoute.Encounter)
+                  .addPart(id)
+                  .build()
+              );
             }
             reset();
           }}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5818

# 👩🏻‍💻 What does this PR do?

This PR ensures that after creating a new encounter you are taken to the detail view of that encounter.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

My understanding of the issue is that we want to make creating a new encounter _always_ navigate to that new encounter's detail view. As a result, I removed the condition that would have navigated to the patient's encounter list view _if_ the start time of the appointment was later than the current date. Is this what was desired? I couldn't understand why that conditiona would be in there and was hesitant to delete it in case it is in fact needed.

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

- [ ] Set up mSupply and open mSupply to use programmes (instructions are just after these testing steps).
- [ ] In open mSupply, go to Dispensary>Patients and select a patient.
- [ ] Click 'add programme' and add the programme you created while setting up mSupply to use programmes.
- [ ] After that you should be back on the Dispensary>Patients>your selected patient screen. Next, all you have to do is go to the encounter tab, and create a new encounter with a start date LATER than today and a unique note. Save that, and then check it takes you to that new encounter's detail view. To make sure it's the same encounter, check the start date, patient name and the encounter note (which is in the encounter's details tab).
- [ ] Then go back to the Dispensary>Patients>your selected patient screen, select the encounter tab, and create another encounter with a start date BEFORE today, and a unique note. Save that, and then check mSupply takes you to your new encounter's detail page like before.

### Setting up mSupply to use Programmes

These instructions are copied from here: https://github.com/msupply-foundation/open-msupply/issues/4642

- [ ] Configure some vaccine items in mSupply
- [ ] Configure an immunisation program in mSupply
    - Create a master list for the program (Items > Master Lists) (it will need at least one item - add your vaccine items!)
    - Under Program Settings
      - Check `This master list is a program`
      - Check `Immunisation program` 
      - Create a Program tag
    - Then under Special > Stores > your store > Master Lists, make the new master list visible
      - Add the `Open mSupply: Uses program module` & `Open mSupply: Uses vaccine module` store preferences, and ensure store is a dispensary
    - Add JSON schemas to document registry (Toolbar Special tab > Show document registry...)
      - You'll need to download files (those specified in the following sub-steps) from [programschemas](https://github.com/msupply-foundation/programschemas) repo (for now you'll need to check out the `immunisation-programs` branch)
      - Create new document for program enrolment
        - e.g. Document type: `SomeImmunisationProgramEnrolment`, category: `PROGRAM_ENROLMENT`, context: `your_new_master_list`, name: `Some Immunisation Program`
        - Data schema: from programschemas repo - `immunisation_program/generated/immunisation_program.json`
        - UI schema: from programschemas repo - `immunisation_program/ui_schemas/immunisation_program_ui_schema.json`
      - Create new document for encounter
        - e.g. Document type: `SomeImmunisationProgramEncounter`, category: `ENCOUNTER`, context: `your_new_master_list`, name: `Some Immunisation Program Encounter`
        - Data schema: from programschemas repo - `immunisation_program/generated/encounter_creation.json`
        - UI schema: from programschemas repo - `immunisation_program/ui_schemas/immunisation_program_encounter_ui_schema.json`
  - Under Admin > Edit Users > Your user > Open mSupply Permissions, 
    - Add view and edit permissions for your program (ensure you are setting perms for the correct store 😁)
    - Allow `Can modify central data`

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: Creating new encounter modal documentation for programmes.
