### PR TITLE
5949 Integration problem when syncing mSupply master lists for programs when no "elmisCode" set

### DIFF
--- a/server/service/src/sync/translations/program_requisition_settings.rs
+++ b/server/service/src/sync/translations/program_requisition_settings.rs
@@ -34,6 +34,7 @@ pub struct LegacyListMasterRow {
 struct LegacyProgramSettings {
     #[serde(rename = "storeTags")]
     store_tags: Option<HashMap<String, LegacyProgramSettingsStoreTag>>,
+    #[serde(default)]
     #[serde(deserialize_with = "empty_str_as_option")]
     #[serde(rename = "elmisCode")]
     elmis_code: Option<String>,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5949

# 👩🏻‍💻 What does this PR do?
Defaults elmis_code in translation

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

In mSupply:
- Create master lists and enable "This master list is a program" for them
- In record browser change the programSettings field to be an object with no "elmisCode" field (Empty object is fine)
In OMS:
- Sync from mSupply
- Master list should sync and show up in master list page

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
