### PR TITLE
#5846 Fix Stock issue quantities for JSON Forms prescription

### DIFF
--- a/client/packages/programs/src/JsonForms/components/Prescription/StockLineTable.tsx
+++ b/client/packages/programs/src/JsonForms/components/Prescription/StockLineTable.tsx
@@ -71,6 +71,10 @@ export const StockLineTable = ({
             3
           ),
         setter: row => {
+          // Using `as` to allow for the `unitQuantity` field, which doesn't
+          // natively exist on DraftStockOutLine. This is preferable to using
+          // the `numberOfPacks` field, which would be misleading and need to be
+          // overwritten with the correct packs value here.
           const stockLine = { ...row } as Partial<DraftStockOutLine> & {
             id: string;
             unitQuantity: number;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5846

# 👩🏻‍💻 What does this PR do?

The actual labelling to "units" had already been done -- this just updates the functionality to properly handle units for the input and display.

## 💌 Any notes for the reviewer?

See inline comments

# 🧪 Testing

- Create prescription data for Family Planning encounter (as per previous PR, eg. https://github.com/msupply-foundation/open-msupply/pull/5581)
- Input some values to issue, ensuring you can't enter more than the available quantity
- Close the modal, and "Save"
- Should see "Prescription created" notification
- Go to the newly created prescription and ensure all values are consistent with what you entered previously (in terms of units/packs)