### PR TITLE
Add generating with customer_name_id

### DIFF
--- a/server/service/src/requisition/request_requisition/insert_program.rs
+++ b/server/service/src/requisition/request_requisition/insert_program.rs
@@ -19,7 +19,7 @@ use repository::{
     IndicatorValueType, MasterListLineFilter, MasterListLineRepository, NameFilter, NameRepository,
     NumberRowType, Pagination, ProgramIndicatorFilter, ProgramRequisitionOrderTypeRow, ProgramRow,
     RepositoryError, Requisition, RequisitionLineRowRepository, RequisitionRowRepository,
-    StorageConnection, StoreRowRepository,
+    StorageConnection, StoreFilter, StoreRepository,
 };
 use util::uuid::uuid;
 

--- a/server/service/src/requisition/request_requisition/insert_program.rs
+++ b/server/service/src/requisition/request_requisition/insert_program.rs
@@ -19,7 +19,7 @@ use repository::{
     IndicatorValueType, MasterListLineFilter, MasterListLineRepository, NameFilter, NameRepository,
     NumberRowType, Pagination, ProgramIndicatorFilter, ProgramRequisitionOrderTypeRow, ProgramRow,
     RepositoryError, Requisition, RequisitionLineRowRepository, RequisitionRowRepository,
-    StorageConnection,
+    StorageConnection, StoreRowRepository,
 };
 use util::uuid::uuid;
 
@@ -204,12 +204,17 @@ fn generate(
         Some(ProgramIndicatorFilter::new().program_id(EqualFilter::equal_to(&program.id))),
     )?;
 
+    let customer_name_id = StoreRowRepository::new(connection)
+        .find_one_by_id(&ctx.user_id.clone())?
+        .ok_or(RepositoryError::NotFound)?
+        .name_link_id;
+
     let indicator_values = generate_program_indicator_values(
         connection,
         &ctx.store_id,
         &period_id,
         program_indicators,
-        &other_party_id,
+        &customer_name_id,
     )?;
 
     Ok(GenerateResult {

--- a/server/service/src/requisition/request_requisition/insert_program.rs
+++ b/server/service/src/requisition/request_requisition/insert_program.rs
@@ -204,10 +204,12 @@ fn generate(
         Some(ProgramIndicatorFilter::new().program_id(EqualFilter::equal_to(&program.id))),
     )?;
 
-    let customer_name_id = StoreRowRepository::new(connection)
-        .find_one_by_id(&ctx.user_id.clone())?
+    let customer_name_id = StoreRepository::new(connection)
+        .query_by_filter(StoreFilter::new().id(EqualFilter::equal_to(&ctx.store_id)))?
+        .pop()
         .ok_or(RepositoryError::NotFound)?
-        .name_link_id;
+        .name_row
+        .id;
 
     let indicator_values = generate_program_indicator_values(
         connection,

--- a/server/service/src/requisition/response_requisition/insert_program.rs
+++ b/server/service/src/requisition/response_requisition/insert_program.rs
@@ -218,10 +218,10 @@ fn generate(
         .query_one(StoreFilter::new().name_id(EqualFilter::equal_to(&other_party_id)))?;
 
     let indicator_values = match customer_store {
-        Some(customer_store) => generate_program_indicator_values(
+        Some(_) => generate_program_indicator_values(
             &ctx.store_id,
             &period_id,
-            &customer_store.name_row.id,
+            &other_party_id,
             program_indicators,
         ),
         None => vec![],

--- a/server/service/src/requisition/response_requisition/insert_program.rs
+++ b/server/service/src/requisition/response_requisition/insert_program.rs
@@ -218,10 +218,10 @@ fn generate(
         .query_one(StoreFilter::new().name_id(EqualFilter::equal_to(&other_party_id)))?;
 
     let indicator_values = match customer_store {
-        Some(_) => generate_program_indicator_values(
+        Some(customer_store) => generate_program_indicator_values(
             &ctx.store_id,
             &period_id,
-            &other_party_id,
+            &customer_store.name_row.id,
             program_indicators,
         ),
         None => vec![],


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5951

# 👩🏻‍💻 What does this PR do?

Fixes to use customer store name id rather than other party (which could be the supplier) store name id for indicator values.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

I was struggling to get tests working with time available and removed them [here](https://github.com/msupply-foundation/open-msupply/pull/5718/commits/bdaace5b41b05d57c474f3dbd851618e961a6c55). I wonder if worthwhile adding these in and including tests to cover correct assignment of store_id, name_id, etc.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Generate a request requisition which is part of a program with program indicators
- [ ] Add regimen data to the requisition
- [ ] Check indicator values (probably easiest with database viewer) to see that they customer id refers to the same store as the store id

