### PR TITLE
#5957 Remove duplicate "New item" link

### DIFF
--- a/client/packages/system/src/Item/Components/ListItems/ListItems.tsx
+++ b/client/packages/system/src/Item/Components/ListItems/ListItems.tsx
@@ -7,8 +7,6 @@ import {
   useTranslation,
   useConfirmationModal,
   Box,
-  FlatButton,
-  PlusCircleIcon,
 } from '@openmsupply-client/common';
 import { ItemRowFragment } from '../../api';
 
@@ -65,19 +63,6 @@ export const ListItems = ({
             enteredLineIds={enteredLineIds}
           />
         </Box>
-        {showNew && (
-          <FlatButton
-            label={t('label.new-item')}
-            onClick={() => navigate(route.addPart('new').build())}
-            startIcon={<PlusCircleIcon />}
-            sx={{
-              position: 'sticky',
-              bottom: 0,
-              padding: '1em',
-              justifyContent: 'flex-start',
-            }}
-          />
-        )}
       </Box>
     </Tooltip>
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5957

# 👩🏻‍💻 What does this PR do?

I don't think this is a complete solution, more a quick fix to get rid of the duplicate for 2.5 release.

I've made it match the designs (for Prescriptions at least), but there's still an inconsistency in how the "New" link works between Prescriptions and Internal orders. For internal orders, it seems to work more like a "button" in that it just provides a temporary stock selector which is then immediately added to the order (and re-directed), whereas in Prescriptions it remains in local state until explicitly "Saved", so the user stays on the "New" page until the entire item is filled it.

So I think we need to make this behaviour consistent and agree on a standard pattern for this component, but that will require a bit of discussion. We also need to consider how to easily access the "New" link when it's at the bottom of a really long list, as mentioned by @lache-melvin [here](https://github.com/msupply-foundation/open-msupply/issues/5957#issuecomment-2578579614). (Making it sticky doesn't quite look right to me at the moment -- perhaps it could jump to the top of the list once the list gets beyond a certain length? Thoughts, @mariyamsupply ?)

Shall we make a new issue for it?

# 🧪 Testing

Make sure there is only one "New Item" link in the list, and confirm behaviour is as expected for both Prescriptions and Internal Orders (anywhere else @roxy-dao ?)