### PR TITLE
Update to use patientId instead of otherPartyId in dispensing

### DIFF
--- a/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
@@ -103,8 +103,8 @@ export const Toolbar: FC = () => {
                   <PatientSearchInput
                     disabled={isDisabled}
                     value={patient}
-                    onChange={async ({ id: otherPartyId }) => {
-                      await update({ id, otherPartyId });
+                    onChange={async ({ id: patientId }) => {
+                      await update({ id, patientId });
                     }}
                   />
                 }

--- a/client/packages/invoices/src/Prescriptions/api/operations.generated.ts
+++ b/client/packages/invoices/src/Prescriptions/api/operations.generated.ts
@@ -4,112 +4,7 @@ import { GraphQLClient, RequestOptions } from 'graphql-request';
 import gql from 'graphql-tag';
 import { StockOutLineFragmentDoc } from '../../StockOut/operations.generated';
 type GraphQLClientRequestHeaders = RequestOptions['requestHeaders'];
-export type PrescriptionRowFragment = {
-  __typename: 'InvoiceNode';
-  comment?: string | null;
-  createdDatetime: string;
-  pickedDatetime?: string | null;
-  verifiedDatetime?: string | null;
-  id: string;
-  invoiceNumber: number;
-  otherPartyName: string;
-  clinicianId?: string | null;
-  type: Types.InvoiceNodeType;
-  status: Types.InvoiceNodeStatus;
-  colour?: string | null;
-  currencyRate: number;
-  diagnosisId?: string | null;
-  prescriptionDate?: string | null;
-  patientId: string;
-  pricing: {
-    __typename: 'PricingNode';
-    totalAfterTax: number;
-    totalBeforeTax: number;
-    stockTotalBeforeTax: number;
-    stockTotalAfterTax: number;
-    serviceTotalAfterTax: number;
-    serviceTotalBeforeTax: number;
-    taxPercentage?: number | null;
-  };
-  user?: {
-    __typename: 'UserNode';
-    username: string;
-    email?: string | null;
-  } | null;
-  lines: {
-    __typename: 'InvoiceLineConnector';
-    totalCount: number;
-    nodes: Array<{
-      __typename: 'InvoiceLineNode';
-      id: string;
-      type: Types.InvoiceLineNodeType;
-      batch?: string | null;
-      expiryDate?: string | null;
-      numberOfPacks: number;
-      packSize: number;
-      invoiceId: string;
-      sellPricePerPack: number;
-      note?: string | null;
-      totalBeforeTax: number;
-      totalAfterTax: number;
-      taxPercentage?: number | null;
-      itemName: string;
-      item: {
-        __typename: 'ItemNode';
-        id: string;
-        name: string;
-        code: string;
-        unitName?: string | null;
-      };
-      location?: {
-        __typename: 'LocationNode';
-        id: string;
-        name: string;
-        code: string;
-        onHold: boolean;
-      } | null;
-      stockLine?: {
-        __typename: 'StockLineNode';
-        id: string;
-        itemId: string;
-        batch?: string | null;
-        availableNumberOfPacks: number;
-        totalNumberOfPacks: number;
-        onHold: boolean;
-        sellPricePerPack: number;
-        packSize: number;
-        expiryDate?: string | null;
-        item: { __typename: 'ItemNode'; name: string; code: string };
-      } | null;
-    }>;
-  };
-  patient?: {
-    __typename: 'PatientNode';
-    id: string;
-    name: string;
-    code: string;
-    isDeceased: boolean;
-  } | null;
-  clinician?: {
-    __typename: 'ClinicianNode';
-    id: string;
-    firstName?: string | null;
-    lastName: string;
-  } | null;
-  currency?: {
-    __typename: 'CurrencyNode';
-    id: string;
-    code: string;
-    rate: number;
-    isHomeCurrency: boolean;
-  } | null;
-  diagnosis?: {
-    __typename: 'DiagnosisNode';
-    id: string;
-    code: string;
-    description: string;
-  } | null;
-};
+export type PrescriptionRowFragment = { __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, pickedDatetime?: string | null, verifiedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyName: string, clinicianId?: string | null, type: Types.InvoiceNodeType, status: Types.InvoiceNodeStatus, colour?: string | null, currencyRate: number, diagnosisId?: string | null, prescriptionDate?: string | null, patientId: string, pricing: { __typename: 'PricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number, taxPercentage?: number | null }, user?: { __typename: 'UserNode', username: string, email?: string | null } | null, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', id: string, type: Types.InvoiceLineNodeType, batch?: string | null, expiryDate?: string | null, numberOfPacks: number, packSize: number, invoiceId: string, sellPricePerPack: number, note?: string | null, totalBeforeTax: number, totalAfterTax: number, taxPercentage?: number | null, itemName: string, item: { __typename: 'ItemNode', id: string, name: string, code: string, unitName?: string | null }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean } | null, stockLine?: { __typename: 'StockLineNode', id: string, itemId: string, batch?: string | null, availableNumberOfPacks: number, totalNumberOfPacks: number, onHold: boolean, sellPricePerPack: number, packSize: number, expiryDate?: string | null, item: { __typename: 'ItemNode', name: string, code: string } } | null }> }, patient?: { __typename: 'PatientNode', id: string, name: string, code: string, isDeceased: boolean } | null, clinician?: { __typename: 'ClinicianNode', id: string, firstName?: string | null, lastName: string } | null, currency?: { __typename: 'CurrencyNode', id: string, code: string, rate: number, isHomeCurrency: boolean } | null, diagnosis?: { __typename: 'DiagnosisNode', id: string, code: string, description: string } | null };
 
 export type PrescriptionsQueryVariables = Types.Exact<{
   first?: Types.InputMaybe<Types.Scalars['Int']['input']>;
@@ -120,371 +15,24 @@ export type PrescriptionsQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
 }>;
 
-export type PrescriptionsQuery = {
-  __typename: 'Queries';
-  invoices: {
-    __typename: 'InvoiceConnector';
-    totalCount: number;
-    nodes: Array<{
-      __typename: 'InvoiceNode';
-      comment?: string | null;
-      createdDatetime: string;
-      pickedDatetime?: string | null;
-      verifiedDatetime?: string | null;
-      id: string;
-      invoiceNumber: number;
-      otherPartyName: string;
-      clinicianId?: string | null;
-      type: Types.InvoiceNodeType;
-      status: Types.InvoiceNodeStatus;
-      colour?: string | null;
-      currencyRate: number;
-      diagnosisId?: string | null;
-      prescriptionDate?: string | null;
-      patientId: string;
-      pricing: {
-        __typename: 'PricingNode';
-        totalAfterTax: number;
-        totalBeforeTax: number;
-        stockTotalBeforeTax: number;
-        stockTotalAfterTax: number;
-        serviceTotalAfterTax: number;
-        serviceTotalBeforeTax: number;
-        taxPercentage?: number | null;
-      };
-      user?: {
-        __typename: 'UserNode';
-        username: string;
-        email?: string | null;
-      } | null;
-      lines: {
-        __typename: 'InvoiceLineConnector';
-        totalCount: number;
-        nodes: Array<{
-          __typename: 'InvoiceLineNode';
-          id: string;
-          type: Types.InvoiceLineNodeType;
-          batch?: string | null;
-          expiryDate?: string | null;
-          numberOfPacks: number;
-          packSize: number;
-          invoiceId: string;
-          sellPricePerPack: number;
-          note?: string | null;
-          totalBeforeTax: number;
-          totalAfterTax: number;
-          taxPercentage?: number | null;
-          itemName: string;
-          item: {
-            __typename: 'ItemNode';
-            id: string;
-            name: string;
-            code: string;
-            unitName?: string | null;
-          };
-          location?: {
-            __typename: 'LocationNode';
-            id: string;
-            name: string;
-            code: string;
-            onHold: boolean;
-          } | null;
-          stockLine?: {
-            __typename: 'StockLineNode';
-            id: string;
-            itemId: string;
-            batch?: string | null;
-            availableNumberOfPacks: number;
-            totalNumberOfPacks: number;
-            onHold: boolean;
-            sellPricePerPack: number;
-            packSize: number;
-            expiryDate?: string | null;
-            item: { __typename: 'ItemNode'; name: string; code: string };
-          } | null;
-        }>;
-      };
-      patient?: {
-        __typename: 'PatientNode';
-        id: string;
-        name: string;
-        code: string;
-        isDeceased: boolean;
-      } | null;
-      clinician?: {
-        __typename: 'ClinicianNode';
-        id: string;
-        firstName?: string | null;
-        lastName: string;
-      } | null;
-      currency?: {
-        __typename: 'CurrencyNode';
-        id: string;
-        code: string;
-        rate: number;
-        isHomeCurrency: boolean;
-      } | null;
-      diagnosis?: {
-        __typename: 'DiagnosisNode';
-        id: string;
-        code: string;
-        description: string;
-      } | null;
-    }>;
-  };
-};
+
+export type PrescriptionsQuery = { __typename: 'Queries', invoices: { __typename: 'InvoiceConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, pickedDatetime?: string | null, verifiedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyName: string, clinicianId?: string | null, type: Types.InvoiceNodeType, status: Types.InvoiceNodeStatus, colour?: string | null, currencyRate: number, diagnosisId?: string | null, prescriptionDate?: string | null, patientId: string, pricing: { __typename: 'PricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number, taxPercentage?: number | null }, user?: { __typename: 'UserNode', username: string, email?: string | null } | null, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', id: string, type: Types.InvoiceLineNodeType, batch?: string | null, expiryDate?: string | null, numberOfPacks: number, packSize: number, invoiceId: string, sellPricePerPack: number, note?: string | null, totalBeforeTax: number, totalAfterTax: number, taxPercentage?: number | null, itemName: string, item: { __typename: 'ItemNode', id: string, name: string, code: string, unitName?: string | null }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean } | null, stockLine?: { __typename: 'StockLineNode', id: string, itemId: string, batch?: string | null, availableNumberOfPacks: number, totalNumberOfPacks: number, onHold: boolean, sellPricePerPack: number, packSize: number, expiryDate?: string | null, item: { __typename: 'ItemNode', name: string, code: string } } | null }> }, patient?: { __typename: 'PatientNode', id: string, name: string, code: string, isDeceased: boolean } | null, clinician?: { __typename: 'ClinicianNode', id: string, firstName?: string | null, lastName: string } | null, currency?: { __typename: 'CurrencyNode', id: string, code: string, rate: number, isHomeCurrency: boolean } | null, diagnosis?: { __typename: 'DiagnosisNode', id: string, code: string, description: string } | null }> } };
 
 export type PrescriptionByNumberQueryVariables = Types.Exact<{
   invoiceNumber: Types.Scalars['Int']['input'];
   storeId: Types.Scalars['String']['input'];
 }>;
 
-export type PrescriptionByNumberQuery = {
-  __typename: 'Queries';
-  invoiceByNumber:
-    | {
-        __typename: 'InvoiceNode';
-        comment?: string | null;
-        createdDatetime: string;
-        pickedDatetime?: string | null;
-        verifiedDatetime?: string | null;
-        id: string;
-        invoiceNumber: number;
-        otherPartyName: string;
-        clinicianId?: string | null;
-        type: Types.InvoiceNodeType;
-        status: Types.InvoiceNodeStatus;
-        colour?: string | null;
-        currencyRate: number;
-        diagnosisId?: string | null;
-        prescriptionDate?: string | null;
-        patientId: string;
-        pricing: {
-          __typename: 'PricingNode';
-          totalAfterTax: number;
-          totalBeforeTax: number;
-          stockTotalBeforeTax: number;
-          stockTotalAfterTax: number;
-          serviceTotalAfterTax: number;
-          serviceTotalBeforeTax: number;
-          taxPercentage?: number | null;
-        };
-        user?: {
-          __typename: 'UserNode';
-          username: string;
-          email?: string | null;
-        } | null;
-        lines: {
-          __typename: 'InvoiceLineConnector';
-          totalCount: number;
-          nodes: Array<{
-            __typename: 'InvoiceLineNode';
-            id: string;
-            type: Types.InvoiceLineNodeType;
-            batch?: string | null;
-            expiryDate?: string | null;
-            numberOfPacks: number;
-            packSize: number;
-            invoiceId: string;
-            sellPricePerPack: number;
-            note?: string | null;
-            totalBeforeTax: number;
-            totalAfterTax: number;
-            taxPercentage?: number | null;
-            itemName: string;
-            item: {
-              __typename: 'ItemNode';
-              id: string;
-              name: string;
-              code: string;
-              unitName?: string | null;
-            };
-            location?: {
-              __typename: 'LocationNode';
-              id: string;
-              name: string;
-              code: string;
-              onHold: boolean;
-            } | null;
-            stockLine?: {
-              __typename: 'StockLineNode';
-              id: string;
-              itemId: string;
-              batch?: string | null;
-              availableNumberOfPacks: number;
-              totalNumberOfPacks: number;
-              onHold: boolean;
-              sellPricePerPack: number;
-              packSize: number;
-              expiryDate?: string | null;
-              item: { __typename: 'ItemNode'; name: string; code: string };
-            } | null;
-          }>;
-        };
-        patient?: {
-          __typename: 'PatientNode';
-          id: string;
-          name: string;
-          code: string;
-          isDeceased: boolean;
-        } | null;
-        clinician?: {
-          __typename: 'ClinicianNode';
-          id: string;
-          firstName?: string | null;
-          lastName: string;
-        } | null;
-        currency?: {
-          __typename: 'CurrencyNode';
-          id: string;
-          code: string;
-          rate: number;
-          isHomeCurrency: boolean;
-        } | null;
-        diagnosis?: {
-          __typename: 'DiagnosisNode';
-          id: string;
-          code: string;
-          description: string;
-        } | null;
-      }
-    | {
-        __typename: 'NodeError';
-        error:
-          | {
-              __typename: 'DatabaseError';
-              description: string;
-              fullError: string;
-            }
-          | { __typename: 'RecordNotFound'; description: string };
-      };
-};
+
+export type PrescriptionByNumberQuery = { __typename: 'Queries', invoiceByNumber: { __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, pickedDatetime?: string | null, verifiedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyName: string, clinicianId?: string | null, type: Types.InvoiceNodeType, status: Types.InvoiceNodeStatus, colour?: string | null, currencyRate: number, diagnosisId?: string | null, prescriptionDate?: string | null, patientId: string, pricing: { __typename: 'PricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number, taxPercentage?: number | null }, user?: { __typename: 'UserNode', username: string, email?: string | null } | null, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', id: string, type: Types.InvoiceLineNodeType, batch?: string | null, expiryDate?: string | null, numberOfPacks: number, packSize: number, invoiceId: string, sellPricePerPack: number, note?: string | null, totalBeforeTax: number, totalAfterTax: number, taxPercentage?: number | null, itemName: string, item: { __typename: 'ItemNode', id: string, name: string, code: string, unitName?: string | null }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean } | null, stockLine?: { __typename: 'StockLineNode', id: string, itemId: string, batch?: string | null, availableNumberOfPacks: number, totalNumberOfPacks: number, onHold: boolean, sellPricePerPack: number, packSize: number, expiryDate?: string | null, item: { __typename: 'ItemNode', name: string, code: string } } | null }> }, patient?: { __typename: 'PatientNode', id: string, name: string, code: string, isDeceased: boolean } | null, clinician?: { __typename: 'ClinicianNode', id: string, firstName?: string | null, lastName: string } | null, currency?: { __typename: 'CurrencyNode', id: string, code: string, rate: number, isHomeCurrency: boolean } | null, diagnosis?: { __typename: 'DiagnosisNode', id: string, code: string, description: string } | null } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } };
 
 export type PrescriptionByIdQueryVariables = Types.Exact<{
   invoiceId: Types.Scalars['String']['input'];
   storeId: Types.Scalars['String']['input'];
 }>;
 
-export type PrescriptionByIdQuery = {
-  __typename: 'Queries';
-  invoice:
-    | {
-        __typename: 'InvoiceNode';
-        comment?: string | null;
-        createdDatetime: string;
-        pickedDatetime?: string | null;
-        verifiedDatetime?: string | null;
-        id: string;
-        invoiceNumber: number;
-        otherPartyName: string;
-        clinicianId?: string | null;
-        type: Types.InvoiceNodeType;
-        status: Types.InvoiceNodeStatus;
-        colour?: string | null;
-        currencyRate: number;
-        diagnosisId?: string | null;
-        prescriptionDate?: string | null;
-        patientId: string;
-        pricing: {
-          __typename: 'PricingNode';
-          totalAfterTax: number;
-          totalBeforeTax: number;
-          stockTotalBeforeTax: number;
-          stockTotalAfterTax: number;
-          serviceTotalAfterTax: number;
-          serviceTotalBeforeTax: number;
-          taxPercentage?: number | null;
-        };
-        user?: {
-          __typename: 'UserNode';
-          username: string;
-          email?: string | null;
-        } | null;
-        lines: {
-          __typename: 'InvoiceLineConnector';
-          totalCount: number;
-          nodes: Array<{
-            __typename: 'InvoiceLineNode';
-            id: string;
-            type: Types.InvoiceLineNodeType;
-            batch?: string | null;
-            expiryDate?: string | null;
-            numberOfPacks: number;
-            packSize: number;
-            invoiceId: string;
-            sellPricePerPack: number;
-            note?: string | null;
-            totalBeforeTax: number;
-            totalAfterTax: number;
-            taxPercentage?: number | null;
-            itemName: string;
-            item: {
-              __typename: 'ItemNode';
-              id: string;
-              name: string;
-              code: string;
-              unitName?: string | null;
-            };
-            location?: {
-              __typename: 'LocationNode';
-              id: string;
-              name: string;
-              code: string;
-              onHold: boolean;
-            } | null;
-            stockLine?: {
-              __typename: 'StockLineNode';
-              id: string;
-              itemId: string;
-              batch?: string | null;
-              availableNumberOfPacks: number;
-              totalNumberOfPacks: number;
-              onHold: boolean;
-              sellPricePerPack: number;
-              packSize: number;
-              expiryDate?: string | null;
-              item: { __typename: 'ItemNode'; name: string; code: string };
-            } | null;
-          }>;
-        };
-        patient?: {
-          __typename: 'PatientNode';
-          id: string;
-          name: string;
-          code: string;
-          isDeceased: boolean;
-        } | null;
-        clinician?: {
-          __typename: 'ClinicianNode';
-          id: string;
-          firstName?: string | null;
-          lastName: string;
-        } | null;
-        currency?: {
-          __typename: 'CurrencyNode';
-          id: string;
-          code: string;
-          rate: number;
-          isHomeCurrency: boolean;
-        } | null;
-        diagnosis?: {
-          __typename: 'DiagnosisNode';
-          id: string;
-          code: string;
-          description: string;
-        } | null;
-      }
-    | {
-        __typename: 'NodeError';
-        error:
-          | {
-              __typename: 'DatabaseError';
-              description: string;
-              fullError: string;
-            }
-          | { __typename: 'RecordNotFound'; description: string };
-      };
-};
+
+export type PrescriptionByIdQuery = { __typename: 'Queries', invoice: { __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, pickedDatetime?: string | null, verifiedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyName: string, clinicianId?: string | null, type: Types.InvoiceNodeType, status: Types.InvoiceNodeStatus, colour?: string | null, currencyRate: number, diagnosisId?: string | null, prescriptionDate?: string | null, patientId: string, pricing: { __typename: 'PricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number, taxPercentage?: number | null }, user?: { __typename: 'UserNode', username: string, email?: string | null } | null, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', id: string, type: Types.InvoiceLineNodeType, batch?: string | null, expiryDate?: string | null, numberOfPacks: number, packSize: number, invoiceId: string, sellPricePerPack: number, note?: string | null, totalBeforeTax: number, totalAfterTax: number, taxPercentage?: number | null, itemName: string, item: { __typename: 'ItemNode', id: string, name: string, code: string, unitName?: string | null }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean } | null, stockLine?: { __typename: 'StockLineNode', id: string, itemId: string, batch?: string | null, availableNumberOfPacks: number, totalNumberOfPacks: number, onHold: boolean, sellPricePerPack: number, packSize: number, expiryDate?: string | null, item: { __typename: 'ItemNode', name: string, code: string } } | null }> }, patient?: { __typename: 'PatientNode', id: string, name: string, code: string, isDeceased: boolean } | null, clinician?: { __typename: 'ClinicianNode', id: string, firstName?: string | null, lastName: string } | null, currency?: { __typename: 'CurrencyNode', id: string, code: string, rate: number, isHomeCurrency: boolean } | null, diagnosis?: { __typename: 'DiagnosisNode', id: string, code: string, description: string } | null } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } };
 
 export type InsertPrescriptionMutationVariables = Types.Exact<{
   id: Types.Scalars['String']['input'];
@@ -492,815 +40,468 @@ export type InsertPrescriptionMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
 }>;
 
-export type InsertPrescriptionMutation = {
-  __typename: 'Mutations';
-  insertPrescription: {
-    __typename: 'InvoiceNode';
-    id: string;
-    invoiceNumber: number;
-  };
-};
+
+export type InsertPrescriptionMutation = { __typename: 'Mutations', insertPrescription: { __typename: 'InvoiceNode', id: string, invoiceNumber: number } };
 
 export type UpsertPrescriptionMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
   input: Types.BatchPrescriptionInput;
 }>;
 
-export type UpsertPrescriptionMutation = {
-  __typename: 'Mutations';
-  batchPrescription: {
-    __typename: 'BatchPrescriptionResponse';
-    deletePrescriptionLines?: Array<{
-      __typename: 'DeletePrescriptionLineResponseWithId';
-      id: string;
-      response:
-        | {
-            __typename: 'DeletePrescriptionLineError';
-            error:
-              | { __typename: 'CannotEditInvoice'; description: string }
-              | {
-                  __typename: 'ForeignKeyError';
-                  description: string;
-                  key: Types.ForeignKey;
-                }
-              | { __typename: 'RecordNotFound'; description: string };
-          }
-        | { __typename: 'DeleteResponse'; id: string };
-    }> | null;
-    deletePrescriptions?: Array<{
-      __typename: 'DeletePrescriptionResponseWithId';
-      id: string;
-      response:
-        | {
-            __typename: 'DeletePrescriptionError';
-            error:
-              | {
-                  __typename: 'CannotDeleteInvoiceWithLines';
-                  description: string;
-                }
-              | { __typename: 'CannotEditInvoice'; description: string }
-              | { __typename: 'RecordNotFound'; description: string };
-          }
-        | { __typename: 'DeleteResponse'; id: string };
-    }> | null;
-    insertPrescriptionLines?: Array<{
-      __typename: 'InsertPrescriptionLineResponseWithId';
-      id: string;
-      response:
-        | {
-            __typename: 'InsertPrescriptionLineError';
-            error:
-              | { __typename: 'CannotEditInvoice'; description: string }
-              | { __typename: 'ForeignKeyError'; description: string }
-              | { __typename: 'LocationIsOnHold'; description: string }
-              | { __typename: 'LocationNotFound'; description: string }
-              | {
-                  __typename: 'NotEnoughStockForReduction';
-                  description: string;
-                }
-              | {
-                  __typename: 'StockLineAlreadyExistsInInvoice';
-                  description: string;
-                }
-              | { __typename: 'StockLineIsOnHold'; description: string };
-          }
-        | { __typename: 'InvoiceLineNode' };
-    }> | null;
-    insertPrescriptions?: Array<{
-      __typename: 'InsertPrescriptionResponseWithId';
-      id: string;
-    }> | null;
-    updatePrescriptionLines?: Array<{
-      __typename: 'UpdatePrescriptionLineResponseWithId';
-      id: string;
-      response:
-        | { __typename: 'InvoiceLineNode' }
-        | {
-            __typename: 'UpdatePrescriptionLineError';
-            error:
-              | { __typename: 'CannotEditInvoice'; description: string }
-              | {
-                  __typename: 'ForeignKeyError';
-                  description: string;
-                  key: Types.ForeignKey;
-                }
-              | { __typename: 'LocationIsOnHold'; description: string }
-              | { __typename: 'LocationNotFound'; description: string }
-              | {
-                  __typename: 'NotEnoughStockForReduction';
-                  description: string;
-                  batch:
-                    | {
-                        __typename: 'NodeError';
-                        error:
-                          | {
-                              __typename: 'DatabaseError';
-                              description: string;
-                              fullError: string;
-                            }
-                          | {
-                              __typename: 'RecordNotFound';
-                              description: string;
-                            };
-                      }
-                    | { __typename: 'StockLineNode' };
-                }
-              | { __typename: 'RecordNotFound'; description: string }
-              | {
-                  __typename: 'StockLineAlreadyExistsInInvoice';
-                  description: string;
-                }
-              | { __typename: 'StockLineIsOnHold'; description: string };
-          };
-    }> | null;
-    updatePrescriptions?: Array<{
-      __typename: 'UpdatePrescriptionResponseWithId';
-      id: string;
-      response:
-        | { __typename: 'InvoiceNode' }
-        | {
-            __typename: 'NodeError';
-            error:
-              | { __typename: 'DatabaseError'; description: string }
-              | { __typename: 'RecordNotFound'; description: string };
-          }
-        | {
-            __typename: 'UpdatePrescriptionError';
-            error:
-              | {
-                  __typename: 'CanOnlyChangeToPickedWhenNoUnallocatedLines';
-                  description: string;
-                }
-              | {
-                  __typename: 'CannotReverseInvoiceStatus';
-                  description: string;
-                }
-              | { __typename: 'InvalidStockSelection'; description: string }
-              | { __typename: 'InvoiceIsNotEditable'; description: string }
-              | { __typename: 'RecordNotFound'; description: string };
-          };
-    }> | null;
-  };
-};
+
+export type UpsertPrescriptionMutation = { __typename: 'Mutations', batchPrescription: { __typename: 'BatchPrescriptionResponse', deletePrescriptionLines?: Array<{ __typename: 'DeletePrescriptionLineResponseWithId', id: string, response: { __typename: 'DeletePrescriptionLineError', error: { __typename: 'CannotEditInvoice', description: string } | { __typename: 'ForeignKeyError', description: string, key: Types.ForeignKey } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'DeleteResponse', id: string } }> | null, deletePrescriptions?: Array<{ __typename: 'DeletePrescriptionResponseWithId', id: string, response: { __typename: 'DeletePrescriptionError', error: { __typename: 'CannotDeleteInvoiceWithLines', description: string } | { __typename: 'CannotEditInvoice', description: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'DeleteResponse', id: string } }> | null, insertPrescriptionLines?: Array<{ __typename: 'InsertPrescriptionLineResponseWithId', id: string, response: { __typename: 'InsertPrescriptionLineError', error: { __typename: 'CannotEditInvoice', description: string } | { __typename: 'ForeignKeyError', description: string } | { __typename: 'LocationIsOnHold', description: string } | { __typename: 'LocationNotFound', description: string } | { __typename: 'NotEnoughStockForReduction', description: string } | { __typename: 'StockLineAlreadyExistsInInvoice', description: string } | { __typename: 'StockLineIsOnHold', description: string } } | { __typename: 'InvoiceLineNode' } }> | null, insertPrescriptions?: Array<{ __typename: 'InsertPrescriptionResponseWithId', id: string }> | null, updatePrescriptionLines?: Array<{ __typename: 'UpdatePrescriptionLineResponseWithId', id: string, response: { __typename: 'InvoiceLineNode' } | { __typename: 'UpdatePrescriptionLineError', error: { __typename: 'CannotEditInvoice', description: string } | { __typename: 'ForeignKeyError', description: string, key: Types.ForeignKey } | { __typename: 'LocationIsOnHold', description: string } | { __typename: 'LocationNotFound', description: string } | { __typename: 'NotEnoughStockForReduction', description: string, batch: { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'StockLineNode' } } | { __typename: 'RecordNotFound', description: string } | { __typename: 'StockLineAlreadyExistsInInvoice', description: string } | { __typename: 'StockLineIsOnHold', description: string } } }> | null, updatePrescriptions?: Array<{ __typename: 'UpdatePrescriptionResponseWithId', id: string, response: { __typename: 'InvoiceNode' } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'UpdatePrescriptionError', error: { __typename: 'CanOnlyChangeToPickedWhenNoUnallocatedLines', description: string } | { __typename: 'CannotReverseInvoiceStatus', description: string } | { __typename: 'InvalidStockSelection', description: string } | { __typename: 'InvoiceIsNotEditable', description: string } | { __typename: 'RecordNotFound', description: string } } }> | null } };
 
 export type DeletePrescriptionsMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
-  deletePrescriptions:
-    | Array<Types.Scalars['String']['input']>
-    | Types.Scalars['String']['input'];
+  deletePrescriptions: Array<Types.Scalars['String']['input']> | Types.Scalars['String']['input'];
 }>;
 
-export type DeletePrescriptionsMutation = {
-  __typename: 'Mutations';
-  batchPrescription: {
-    __typename: 'BatchPrescriptionResponse';
-    deletePrescriptions?: Array<{
-      __typename: 'DeletePrescriptionResponseWithId';
-      id: string;
-      response:
-        | {
-            __typename: 'DeletePrescriptionError';
-            error:
-              | {
-                  __typename: 'CannotDeleteInvoiceWithLines';
-                  description: string;
-                }
-              | { __typename: 'CannotEditInvoice'; description: string }
-              | { __typename: 'RecordNotFound'; description: string };
-          }
-        | { __typename: 'DeleteResponse'; id: string };
-    }> | null;
-  };
-};
+
+export type DeletePrescriptionsMutation = { __typename: 'Mutations', batchPrescription: { __typename: 'BatchPrescriptionResponse', deletePrescriptions?: Array<{ __typename: 'DeletePrescriptionResponseWithId', id: string, response: { __typename: 'DeletePrescriptionError', error: { __typename: 'CannotDeleteInvoiceWithLines', description: string } | { __typename: 'CannotEditInvoice', description: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'DeleteResponse', id: string } }> | null } };
 
 export type DeletePrescriptionLinesMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
-  deletePrescriptionLines:
-    | Array<Types.DeletePrescriptionLineInput>
-    | Types.DeletePrescriptionLineInput;
+  deletePrescriptionLines: Array<Types.DeletePrescriptionLineInput> | Types.DeletePrescriptionLineInput;
 }>;
 
-export type DeletePrescriptionLinesMutation = {
-  __typename: 'Mutations';
-  batchPrescription: {
-    __typename: 'BatchPrescriptionResponse';
-    deletePrescriptionLines?: Array<{
-      __typename: 'DeletePrescriptionLineResponseWithId';
-      id: string;
-      response:
-        | {
-            __typename: 'DeletePrescriptionLineError';
-            error:
-              | { __typename: 'CannotEditInvoice'; description: string }
-              | {
-                  __typename: 'ForeignKeyError';
-                  description: string;
-                  key: Types.ForeignKey;
-                }
-              | { __typename: 'RecordNotFound'; description: string };
-          }
-        | { __typename: 'DeleteResponse'; id: string };
-    }> | null;
-  };
-};
 
-export type HistoricalStockLineFragment = {
-  __typename: 'StockLineNode';
-  id: string;
-  availableNumberOfPacks: number;
-  packSize: number;
-};
+export type DeletePrescriptionLinesMutation = { __typename: 'Mutations', batchPrescription: { __typename: 'BatchPrescriptionResponse', deletePrescriptionLines?: Array<{ __typename: 'DeletePrescriptionLineResponseWithId', id: string, response: { __typename: 'DeletePrescriptionLineError', error: { __typename: 'CannotEditInvoice', description: string } | { __typename: 'ForeignKeyError', description: string, key: Types.ForeignKey } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'DeleteResponse', id: string } }> | null } };
 
-export type DiagnosisFragment = {
-  __typename: 'DiagnosisNode';
-  id: string;
-  code: string;
-  description: string;
-};
+export type HistoricalStockLineFragment = { __typename: 'StockLineNode', id: string, availableNumberOfPacks: number, packSize: number };
 
-export type DiagnosesActiveQueryVariables = Types.Exact<{
-  [key: string]: never;
-}>;
+export type DiagnosisFragment = { __typename: 'DiagnosisNode', id: string, code: string, description: string };
 
-export type DiagnosesActiveQuery = {
-  __typename: 'Queries';
-  diagnosesActive: Array<{
-    __typename: 'DiagnosisNode';
-    id: string;
-    code: string;
-    description: string;
-  }>;
-};
+export type DiagnosesActiveQueryVariables = Types.Exact<{ [key: string]: never; }>;
+
+
+export type DiagnosesActiveQuery = { __typename: 'Queries', diagnosesActive: Array<{ __typename: 'DiagnosisNode', id: string, code: string, description: string }> };
 
 export const PrescriptionRowFragmentDoc = gql`
-  fragment PrescriptionRow on InvoiceNode {
+    fragment PrescriptionRow on InvoiceNode {
+  __typename
+  comment
+  createdDatetime
+  prescriptionDate: backdatedDatetime
+  pickedDatetime
+  verifiedDatetime
+  id
+  invoiceNumber
+  patientId: otherPartyId
+  otherPartyName
+  clinicianId
+  type
+  status
+  colour
+  pricing {
     __typename
-    comment
-    createdDatetime
-    prescriptionDate: backdatedDatetime
-    pickedDatetime
-    verifiedDatetime
-    id
-    invoiceNumber
-    patientId: otherPartyId
-    otherPartyName
-    clinicianId
-    type
-    status
-    colour
-    pricing {
-      __typename
-      totalAfterTax
-      totalBeforeTax
-      stockTotalBeforeTax
-      stockTotalAfterTax
-      serviceTotalAfterTax
-      serviceTotalBeforeTax
-      taxPercentage
-    }
-    currencyRate
-    user {
-      __typename
-      username
-      email
-    }
-    lines {
-      __typename
-      nodes {
-        ...StockOutLine
-      }
-      totalCount
-    }
-    patient {
-      __typename
-      id
-      name
-      code
-      isDeceased
-    }
-    clinician {
-      id
-      firstName
-      lastName
-    }
-    currency {
-      id
-      code
-      rate
-      isHomeCurrency
-    }
-    currencyRate
-    diagnosisId
-    diagnosis {
-      id
-      code
-      description
-    }
+    totalAfterTax
+    totalBeforeTax
+    stockTotalBeforeTax
+    stockTotalAfterTax
+    serviceTotalAfterTax
+    serviceTotalBeforeTax
+    taxPercentage
   }
-  ${StockOutLineFragmentDoc}
-`;
-export const HistoricalStockLineFragmentDoc = gql`
-  fragment historicalStockLine on StockLineNode {
-    id
-    availableNumberOfPacks
-    packSize
+  currencyRate
+  user {
+    __typename
+    username
+    email
   }
-`;
-export const DiagnosisFragmentDoc = gql`
-  fragment diagnosis on DiagnosisNode {
+  lines {
+    __typename
+    nodes {
+      ...StockOutLine
+    }
+    totalCount
+  }
+  patient {
+    __typename
+    id
+    name
+    code
+    isDeceased
+  }
+  clinician {
+    id
+    firstName
+    lastName
+  }
+  currency {
+    id
+    code
+    rate
+    isHomeCurrency
+  }
+  currencyRate
+  diagnosisId
+  diagnosis {
     id
     code
     description
   }
-`;
+}
+    ${StockOutLineFragmentDoc}`;
+export const HistoricalStockLineFragmentDoc = gql`
+    fragment historicalStockLine on StockLineNode {
+  id
+  availableNumberOfPacks
+  packSize
+}
+    `;
+export const DiagnosisFragmentDoc = gql`
+    fragment diagnosis on DiagnosisNode {
+  id
+  code
+  description
+}
+    `;
 export const PrescriptionsDocument = gql`
-  query prescriptions(
-    $first: Int
-    $offset: Int
-    $key: InvoiceSortFieldInput!
-    $desc: Boolean
-    $filter: InvoiceFilterInput
-    $storeId: String!
+    query prescriptions($first: Int, $offset: Int, $key: InvoiceSortFieldInput!, $desc: Boolean, $filter: InvoiceFilterInput, $storeId: String!) {
+  invoices(
+    page: {first: $first, offset: $offset}
+    sort: {key: $key, desc: $desc}
+    filter: $filter
+    storeId: $storeId
   ) {
-    invoices(
-      page: { first: $first, offset: $offset }
-      sort: { key: $key, desc: $desc }
-      filter: $filter
-      storeId: $storeId
-    ) {
-      ... on InvoiceConnector {
-        __typename
-        nodes {
-          ...PrescriptionRow
-        }
-        totalCount
+    ... on InvoiceConnector {
+      __typename
+      nodes {
+        ...PrescriptionRow
       }
+      totalCount
     }
   }
-  ${PrescriptionRowFragmentDoc}
-`;
+}
+    ${PrescriptionRowFragmentDoc}`;
 export const PrescriptionByNumberDocument = gql`
-  query prescriptionByNumber($invoiceNumber: Int!, $storeId: String!) {
-    invoiceByNumber(
-      invoiceNumber: $invoiceNumber
-      storeId: $storeId
-      type: PRESCRIPTION
-    ) {
+    query prescriptionByNumber($invoiceNumber: Int!, $storeId: String!) {
+  invoiceByNumber(
+    invoiceNumber: $invoiceNumber
+    storeId: $storeId
+    type: PRESCRIPTION
+  ) {
+    __typename
+    ... on NodeError {
       __typename
-      ... on NodeError {
-        __typename
-        error {
+      error {
+        description
+        ... on DatabaseError {
+          __typename
           description
-          ... on DatabaseError {
-            __typename
-            description
-            fullError
-          }
-          ... on RecordNotFound {
-            __typename
-            description
-          }
+          fullError
+        }
+        ... on RecordNotFound {
+          __typename
+          description
         }
       }
-      ... on InvoiceNode {
-        ...PrescriptionRow
-      }
+    }
+    ... on InvoiceNode {
+      ...PrescriptionRow
     }
   }
-  ${PrescriptionRowFragmentDoc}
-`;
+}
+    ${PrescriptionRowFragmentDoc}`;
 export const PrescriptionByIdDocument = gql`
-  query prescriptionById($invoiceId: String!, $storeId: String!) {
-    invoice(id: $invoiceId, storeId: $storeId) {
+    query prescriptionById($invoiceId: String!, $storeId: String!) {
+  invoice(id: $invoiceId, storeId: $storeId) {
+    __typename
+    ... on NodeError {
       __typename
-      ... on NodeError {
-        __typename
-        error {
+      error {
+        description
+        ... on DatabaseError {
+          __typename
           description
-          ... on DatabaseError {
-            __typename
-            description
-            fullError
-          }
-          ... on RecordNotFound {
-            __typename
-            description
-          }
+          fullError
+        }
+        ... on RecordNotFound {
+          __typename
+          description
         }
       }
-      ... on InvoiceNode {
-        ...PrescriptionRow
-      }
+    }
+    ... on InvoiceNode {
+      ...PrescriptionRow
     }
   }
-  ${PrescriptionRowFragmentDoc}
-`;
+}
+    ${PrescriptionRowFragmentDoc}`;
 export const InsertPrescriptionDocument = gql`
-  mutation insertPrescription(
-    $id: String!
-    $patientId: String!
-    $storeId: String!
-  ) {
-    insertPrescription(
-      storeId: $storeId
-      input: { id: $id, patientId: $patientId }
-    ) {
-      __typename
-      ... on InvoiceNode {
-        id
-        invoiceNumber
-      }
+    mutation insertPrescription($id: String!, $patientId: String!, $storeId: String!) {
+  insertPrescription(storeId: $storeId, input: {id: $id, patientId: $patientId}) {
+    __typename
+    ... on InvoiceNode {
+      id
+      invoiceNumber
     }
   }
-`;
+}
+    `;
 export const UpsertPrescriptionDocument = gql`
-  mutation upsertPrescription(
-    $storeId: String!
-    $input: BatchPrescriptionInput!
-  ) {
-    batchPrescription(storeId: $storeId, input: $input) {
-      __typename
-      deletePrescriptionLines {
-        id
-        response {
-          ... on DeletePrescriptionLineError {
-            __typename
-            error {
+    mutation upsertPrescription($storeId: String!, $input: BatchPrescriptionInput!) {
+  batchPrescription(storeId: $storeId, input: $input) {
+    __typename
+    deletePrescriptionLines {
+      id
+      response {
+        ... on DeletePrescriptionLineError {
+          __typename
+          error {
+            description
+            ... on RecordNotFound {
+              __typename
               description
-              ... on RecordNotFound {
-                __typename
-                description
-              }
-              ... on CannotEditInvoice {
-                __typename
-                description
-              }
-              ... on ForeignKeyError {
-                __typename
-                description
-                key
-              }
             }
-          }
-          ... on DeleteResponse {
-            id
-          }
-        }
-      }
-      deletePrescriptions {
-        id
-        response {
-          ... on DeleteResponse {
-            id
-          }
-          ... on DeletePrescriptionError {
-            __typename
-            error {
+            ... on CannotEditInvoice {
+              __typename
               description
-              ... on RecordNotFound {
-                __typename
-                description
-              }
-              ... on CannotDeleteInvoiceWithLines {
-                __typename
-                description
-              }
-              ... on CannotEditInvoice {
-                __typename
-                description
-              }
+            }
+            ... on ForeignKeyError {
+              __typename
+              description
+              key
             }
           }
         }
-      }
-      insertPrescriptionLines {
-        id
-        response {
-          ... on InsertPrescriptionLineError {
-            __typename
-            error {
-              description
-            }
-          }
+        ... on DeleteResponse {
+          id
         }
       }
-      insertPrescriptions {
-        id
-      }
-      updatePrescriptionLines {
-        id
-        response {
-          ... on UpdatePrescriptionLineError {
-            __typename
-            error {
-              description
-              ... on RecordNotFound {
-                __typename
-                description
-              }
-              ... on CannotEditInvoice {
-                __typename
-                description
-              }
-              ... on ForeignKeyError {
-                __typename
-                description
-                key
-              }
-              ... on LocationIsOnHold {
-                __typename
-                description
-              }
-              ... on LocationNotFound {
-                __typename
-                description
-              }
-              ... on NotEnoughStockForReduction {
-                __typename
-                batch {
-                  ... on NodeError {
-                    __typename
-                    error {
-                      description
-                      ... on RecordNotFound {
-                        __typename
-                        description
-                      }
-                      ... on DatabaseError {
-                        __typename
-                        description
-                        fullError
-                      }
-                    }
-                  }
-                }
-              }
-              ... on StockLineAlreadyExistsInInvoice {
-                __typename
-                description
-              }
-              ... on StockLineIsOnHold {
-                __typename
-                description
-              }
-            }
-          }
+    }
+    deletePrescriptions {
+      id
+      response {
+        ... on DeleteResponse {
+          id
         }
-      }
-      updatePrescriptions {
-        id
-        response {
-          ... on UpdatePrescriptionError {
-            __typename
-            error {
+        ... on DeletePrescriptionError {
+          __typename
+          error {
+            description
+            ... on RecordNotFound {
+              __typename
+              description
+            }
+            ... on CannotDeleteInvoiceWithLines {
+              __typename
+              description
+            }
+            ... on CannotEditInvoice {
               __typename
               description
             }
           }
-          ... on NodeError {
-            __typename
-            error {
+        }
+      }
+    }
+    insertPrescriptionLines {
+      id
+      response {
+        ... on InsertPrescriptionLineError {
+          __typename
+          error {
+            description
+          }
+        }
+      }
+    }
+    insertPrescriptions {
+      id
+    }
+    updatePrescriptionLines {
+      id
+      response {
+        ... on UpdatePrescriptionLineError {
+          __typename
+          error {
+            description
+            ... on RecordNotFound {
+              __typename
+              description
+            }
+            ... on CannotEditInvoice {
+              __typename
+              description
+            }
+            ... on ForeignKeyError {
+              __typename
+              description
+              key
+            }
+            ... on LocationIsOnHold {
+              __typename
+              description
+            }
+            ... on LocationNotFound {
+              __typename
+              description
+            }
+            ... on NotEnoughStockForReduction {
+              __typename
+              batch {
+                ... on NodeError {
+                  __typename
+                  error {
+                    description
+                    ... on RecordNotFound {
+                      __typename
+                      description
+                    }
+                    ... on DatabaseError {
+                      __typename
+                      description
+                      fullError
+                    }
+                  }
+                }
+              }
+            }
+            ... on StockLineAlreadyExistsInInvoice {
+              __typename
+              description
+            }
+            ... on StockLineIsOnHold {
+              __typename
               description
             }
           }
         }
       }
     }
+    updatePrescriptions {
+      id
+      response {
+        ... on UpdatePrescriptionError {
+          __typename
+          error {
+            __typename
+            description
+          }
+        }
+        ... on NodeError {
+          __typename
+          error {
+            description
+          }
+        }
+      }
+    }
   }
-`;
+}
+    `;
 export const DeletePrescriptionsDocument = gql`
-  mutation deletePrescriptions(
-    $storeId: String!
-    $deletePrescriptions: [String!]!
+    mutation deletePrescriptions($storeId: String!, $deletePrescriptions: [String!]!) {
+  batchPrescription(
+    storeId: $storeId
+    input: {deletePrescriptions: $deletePrescriptions}
   ) {
-    batchPrescription(
-      storeId: $storeId
-      input: { deletePrescriptions: $deletePrescriptions }
-    ) {
-      __typename
-      deletePrescriptions {
-        id
-        response {
-          ... on DeletePrescriptionError {
-            __typename
-            error {
+    __typename
+    deletePrescriptions {
+      id
+      response {
+        ... on DeletePrescriptionError {
+          __typename
+          error {
+            description
+            ... on RecordNotFound {
+              __typename
               description
-              ... on RecordNotFound {
-                __typename
-                description
-              }
-              ... on CannotDeleteInvoiceWithLines {
-                __typename
-                description
-              }
-              ... on CannotEditInvoice {
-                __typename
-                description
-              }
+            }
+            ... on CannotDeleteInvoiceWithLines {
+              __typename
+              description
+            }
+            ... on CannotEditInvoice {
+              __typename
+              description
             }
           }
-          ... on DeleteResponse {
-            id
-          }
+        }
+        ... on DeleteResponse {
+          id
         }
       }
     }
   }
-`;
+}
+    `;
 export const DeletePrescriptionLinesDocument = gql`
-  mutation deletePrescriptionLines(
-    $storeId: String!
-    $deletePrescriptionLines: [DeletePrescriptionLineInput!]!
+    mutation deletePrescriptionLines($storeId: String!, $deletePrescriptionLines: [DeletePrescriptionLineInput!]!) {
+  batchPrescription(
+    storeId: $storeId
+    input: {deletePrescriptionLines: $deletePrescriptionLines}
   ) {
-    batchPrescription(
-      storeId: $storeId
-      input: { deletePrescriptionLines: $deletePrescriptionLines }
-    ) {
-      deletePrescriptionLines {
-        id
-        response {
-          ... on DeletePrescriptionLineError {
-            __typename
-            error {
+    deletePrescriptionLines {
+      id
+      response {
+        ... on DeletePrescriptionLineError {
+          __typename
+          error {
+            description
+            ... on RecordNotFound {
+              __typename
               description
-              ... on RecordNotFound {
-                __typename
-                description
-              }
-              ... on CannotEditInvoice {
-                __typename
-                description
-              }
-              ... on ForeignKeyError {
-                __typename
-                description
-                key
-              }
+            }
+            ... on CannotEditInvoice {
+              __typename
+              description
+            }
+            ... on ForeignKeyError {
+              __typename
+              description
+              key
             }
           }
-          ... on DeleteResponse {
-            id
-          }
+        }
+        ... on DeleteResponse {
+          id
         }
       }
     }
   }
-`;
+}
+    `;
 export const DiagnosesActiveDocument = gql`
-  query diagnosesActive {
-    diagnosesActive {
-      ...diagnosis
-    }
+    query diagnosesActive {
+  diagnosesActive {
+    ...diagnosis
   }
-  ${DiagnosisFragmentDoc}
-`;
+}
+    ${DiagnosisFragmentDoc}`;
 
-export type SdkFunctionWrapper = <T>(
-  action: (requestHeaders?: Record<string, string>) => Promise<T>,
-  operationName: string,
-  operationType?: string,
-  variables?: any
-) => Promise<T>;
+export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string, variables?: any) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (
-  action,
-  _operationName,
-  _operationType,
-  _variables
-) => action();
 
-export function getSdk(
-  client: GraphQLClient,
-  withWrapper: SdkFunctionWrapper = defaultWrapper
-) {
+const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType, _variables) => action();
+
+export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    prescriptions(
-      variables: PrescriptionsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders
-    ): Promise<PrescriptionsQuery> {
-      return withWrapper(
-        wrappedRequestHeaders =>
-          client.request<PrescriptionsQuery>(PrescriptionsDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'prescriptions',
-        'query',
-        variables
-      );
+    prescriptions(variables: PrescriptionsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<PrescriptionsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PrescriptionsQuery>(PrescriptionsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'prescriptions', 'query', variables);
     },
-    prescriptionByNumber(
-      variables: PrescriptionByNumberQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders
-    ): Promise<PrescriptionByNumberQuery> {
-      return withWrapper(
-        wrappedRequestHeaders =>
-          client.request<PrescriptionByNumberQuery>(
-            PrescriptionByNumberDocument,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders }
-          ),
-        'prescriptionByNumber',
-        'query',
-        variables
-      );
+    prescriptionByNumber(variables: PrescriptionByNumberQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<PrescriptionByNumberQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PrescriptionByNumberQuery>(PrescriptionByNumberDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'prescriptionByNumber', 'query', variables);
     },
-    prescriptionById(
-      variables: PrescriptionByIdQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders
-    ): Promise<PrescriptionByIdQuery> {
-      return withWrapper(
-        wrappedRequestHeaders =>
-          client.request<PrescriptionByIdQuery>(
-            PrescriptionByIdDocument,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders }
-          ),
-        'prescriptionById',
-        'query',
-        variables
-      );
+    prescriptionById(variables: PrescriptionByIdQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<PrescriptionByIdQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PrescriptionByIdQuery>(PrescriptionByIdDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'prescriptionById', 'query', variables);
     },
-    insertPrescription(
-      variables: InsertPrescriptionMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders
-    ): Promise<InsertPrescriptionMutation> {
-      return withWrapper(
-        wrappedRequestHeaders =>
-          client.request<InsertPrescriptionMutation>(
-            InsertPrescriptionDocument,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders }
-          ),
-        'insertPrescription',
-        'mutation',
-        variables
-      );
+    insertPrescription(variables: InsertPrescriptionMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<InsertPrescriptionMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<InsertPrescriptionMutation>(InsertPrescriptionDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'insertPrescription', 'mutation', variables);
     },
-    upsertPrescription(
-      variables: UpsertPrescriptionMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders
-    ): Promise<UpsertPrescriptionMutation> {
-      return withWrapper(
-        wrappedRequestHeaders =>
-          client.request<UpsertPrescriptionMutation>(
-            UpsertPrescriptionDocument,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders }
-          ),
-        'upsertPrescription',
-        'mutation',
-        variables
-      );
+    upsertPrescription(variables: UpsertPrescriptionMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<UpsertPrescriptionMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<UpsertPrescriptionMutation>(UpsertPrescriptionDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'upsertPrescription', 'mutation', variables);
     },
-    deletePrescriptions(
-      variables: DeletePrescriptionsMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders
-    ): Promise<DeletePrescriptionsMutation> {
-      return withWrapper(
-        wrappedRequestHeaders =>
-          client.request<DeletePrescriptionsMutation>(
-            DeletePrescriptionsDocument,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders }
-          ),
-        'deletePrescriptions',
-        'mutation',
-        variables
-      );
+    deletePrescriptions(variables: DeletePrescriptionsMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DeletePrescriptionsMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<DeletePrescriptionsMutation>(DeletePrescriptionsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'deletePrescriptions', 'mutation', variables);
     },
-    deletePrescriptionLines(
-      variables: DeletePrescriptionLinesMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders
-    ): Promise<DeletePrescriptionLinesMutation> {
-      return withWrapper(
-        wrappedRequestHeaders =>
-          client.request<DeletePrescriptionLinesMutation>(
-            DeletePrescriptionLinesDocument,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders }
-          ),
-        'deletePrescriptionLines',
-        'mutation',
-        variables
-      );
+    deletePrescriptionLines(variables: DeletePrescriptionLinesMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DeletePrescriptionLinesMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<DeletePrescriptionLinesMutation>(DeletePrescriptionLinesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'deletePrescriptionLines', 'mutation', variables);
     },
-    diagnosesActive(
-      variables?: DiagnosesActiveQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders
-    ): Promise<DiagnosesActiveQuery> {
-      return withWrapper(
-        wrappedRequestHeaders =>
-          client.request<DiagnosesActiveQuery>(
-            DiagnosesActiveDocument,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders }
-          ),
-        'diagnosesActive',
-        'query',
-        variables
-      );
-    },
+    diagnosesActive(variables?: DiagnosesActiveQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DiagnosesActiveQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<DiagnosesActiveQuery>(DiagnosesActiveDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'diagnosesActive', 'query', variables);
+    }
   };
 }
 export type Sdk = ReturnType<typeof getSdk>;

--- a/client/packages/invoices/src/Prescriptions/api/operations.generated.ts
+++ b/client/packages/invoices/src/Prescriptions/api/operations.generated.ts
@@ -4,7 +4,112 @@ import { GraphQLClient, RequestOptions } from 'graphql-request';
 import gql from 'graphql-tag';
 import { StockOutLineFragmentDoc } from '../../StockOut/operations.generated';
 type GraphQLClientRequestHeaders = RequestOptions['requestHeaders'];
-export type PrescriptionRowFragment = { __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, pickedDatetime?: string | null, verifiedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyId: string, otherPartyName: string, clinicianId?: string | null, type: Types.InvoiceNodeType, status: Types.InvoiceNodeStatus, colour?: string | null, currencyRate: number, diagnosisId?: string | null, prescriptionDate?: string | null, pricing: { __typename: 'PricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number, taxPercentage?: number | null }, user?: { __typename: 'UserNode', username: string, email?: string | null } | null, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', id: string, type: Types.InvoiceLineNodeType, batch?: string | null, expiryDate?: string | null, numberOfPacks: number, packSize: number, invoiceId: string, sellPricePerPack: number, note?: string | null, totalBeforeTax: number, totalAfterTax: number, taxPercentage?: number | null, itemName: string, item: { __typename: 'ItemNode', id: string, name: string, code: string, unitName?: string | null }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean } | null, stockLine?: { __typename: 'StockLineNode', id: string, itemId: string, batch?: string | null, availableNumberOfPacks: number, totalNumberOfPacks: number, onHold: boolean, sellPricePerPack: number, packSize: number, expiryDate?: string | null, item: { __typename: 'ItemNode', name: string, code: string } } | null }> }, patient?: { __typename: 'PatientNode', id: string, name: string, code: string, isDeceased: boolean } | null, clinician?: { __typename: 'ClinicianNode', id: string, firstName?: string | null, lastName: string } | null, currency?: { __typename: 'CurrencyNode', id: string, code: string, rate: number, isHomeCurrency: boolean } | null, diagnosis?: { __typename: 'DiagnosisNode', id: string, code: string, description: string } | null };
+export type PrescriptionRowFragment = {
+  __typename: 'InvoiceNode';
+  comment?: string | null;
+  createdDatetime: string;
+  pickedDatetime?: string | null;
+  verifiedDatetime?: string | null;
+  id: string;
+  invoiceNumber: number;
+  otherPartyName: string;
+  clinicianId?: string | null;
+  type: Types.InvoiceNodeType;
+  status: Types.InvoiceNodeStatus;
+  colour?: string | null;
+  currencyRate: number;
+  diagnosisId?: string | null;
+  prescriptionDate?: string | null;
+  patientId: string;
+  pricing: {
+    __typename: 'PricingNode';
+    totalAfterTax: number;
+    totalBeforeTax: number;
+    stockTotalBeforeTax: number;
+    stockTotalAfterTax: number;
+    serviceTotalAfterTax: number;
+    serviceTotalBeforeTax: number;
+    taxPercentage?: number | null;
+  };
+  user?: {
+    __typename: 'UserNode';
+    username: string;
+    email?: string | null;
+  } | null;
+  lines: {
+    __typename: 'InvoiceLineConnector';
+    totalCount: number;
+    nodes: Array<{
+      __typename: 'InvoiceLineNode';
+      id: string;
+      type: Types.InvoiceLineNodeType;
+      batch?: string | null;
+      expiryDate?: string | null;
+      numberOfPacks: number;
+      packSize: number;
+      invoiceId: string;
+      sellPricePerPack: number;
+      note?: string | null;
+      totalBeforeTax: number;
+      totalAfterTax: number;
+      taxPercentage?: number | null;
+      itemName: string;
+      item: {
+        __typename: 'ItemNode';
+        id: string;
+        name: string;
+        code: string;
+        unitName?: string | null;
+      };
+      location?: {
+        __typename: 'LocationNode';
+        id: string;
+        name: string;
+        code: string;
+        onHold: boolean;
+      } | null;
+      stockLine?: {
+        __typename: 'StockLineNode';
+        id: string;
+        itemId: string;
+        batch?: string | null;
+        availableNumberOfPacks: number;
+        totalNumberOfPacks: number;
+        onHold: boolean;
+        sellPricePerPack: number;
+        packSize: number;
+        expiryDate?: string | null;
+        item: { __typename: 'ItemNode'; name: string; code: string };
+      } | null;
+    }>;
+  };
+  patient?: {
+    __typename: 'PatientNode';
+    id: string;
+    name: string;
+    code: string;
+    isDeceased: boolean;
+  } | null;
+  clinician?: {
+    __typename: 'ClinicianNode';
+    id: string;
+    firstName?: string | null;
+    lastName: string;
+  } | null;
+  currency?: {
+    __typename: 'CurrencyNode';
+    id: string;
+    code: string;
+    rate: number;
+    isHomeCurrency: boolean;
+  } | null;
+  diagnosis?: {
+    __typename: 'DiagnosisNode';
+    id: string;
+    code: string;
+    description: string;
+  } | null;
+};
 
 export type PrescriptionsQueryVariables = Types.Exact<{
   first?: Types.InputMaybe<Types.Scalars['Int']['input']>;
@@ -15,24 +120,371 @@ export type PrescriptionsQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
 }>;
 
-
-export type PrescriptionsQuery = { __typename: 'Queries', invoices: { __typename: 'InvoiceConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, pickedDatetime?: string | null, verifiedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyId: string, otherPartyName: string, clinicianId?: string | null, type: Types.InvoiceNodeType, status: Types.InvoiceNodeStatus, colour?: string | null, currencyRate: number, diagnosisId?: string | null, prescriptionDate?: string | null, pricing: { __typename: 'PricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number, taxPercentage?: number | null }, user?: { __typename: 'UserNode', username: string, email?: string | null } | null, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', id: string, type: Types.InvoiceLineNodeType, batch?: string | null, expiryDate?: string | null, numberOfPacks: number, packSize: number, invoiceId: string, sellPricePerPack: number, note?: string | null, totalBeforeTax: number, totalAfterTax: number, taxPercentage?: number | null, itemName: string, item: { __typename: 'ItemNode', id: string, name: string, code: string, unitName?: string | null }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean } | null, stockLine?: { __typename: 'StockLineNode', id: string, itemId: string, batch?: string | null, availableNumberOfPacks: number, totalNumberOfPacks: number, onHold: boolean, sellPricePerPack: number, packSize: number, expiryDate?: string | null, item: { __typename: 'ItemNode', name: string, code: string } } | null }> }, patient?: { __typename: 'PatientNode', id: string, name: string, code: string, isDeceased: boolean } | null, clinician?: { __typename: 'ClinicianNode', id: string, firstName?: string | null, lastName: string } | null, currency?: { __typename: 'CurrencyNode', id: string, code: string, rate: number, isHomeCurrency: boolean } | null, diagnosis?: { __typename: 'DiagnosisNode', id: string, code: string, description: string } | null }> } };
+export type PrescriptionsQuery = {
+  __typename: 'Queries';
+  invoices: {
+    __typename: 'InvoiceConnector';
+    totalCount: number;
+    nodes: Array<{
+      __typename: 'InvoiceNode';
+      comment?: string | null;
+      createdDatetime: string;
+      pickedDatetime?: string | null;
+      verifiedDatetime?: string | null;
+      id: string;
+      invoiceNumber: number;
+      otherPartyName: string;
+      clinicianId?: string | null;
+      type: Types.InvoiceNodeType;
+      status: Types.InvoiceNodeStatus;
+      colour?: string | null;
+      currencyRate: number;
+      diagnosisId?: string | null;
+      prescriptionDate?: string | null;
+      patientId: string;
+      pricing: {
+        __typename: 'PricingNode';
+        totalAfterTax: number;
+        totalBeforeTax: number;
+        stockTotalBeforeTax: number;
+        stockTotalAfterTax: number;
+        serviceTotalAfterTax: number;
+        serviceTotalBeforeTax: number;
+        taxPercentage?: number | null;
+      };
+      user?: {
+        __typename: 'UserNode';
+        username: string;
+        email?: string | null;
+      } | null;
+      lines: {
+        __typename: 'InvoiceLineConnector';
+        totalCount: number;
+        nodes: Array<{
+          __typename: 'InvoiceLineNode';
+          id: string;
+          type: Types.InvoiceLineNodeType;
+          batch?: string | null;
+          expiryDate?: string | null;
+          numberOfPacks: number;
+          packSize: number;
+          invoiceId: string;
+          sellPricePerPack: number;
+          note?: string | null;
+          totalBeforeTax: number;
+          totalAfterTax: number;
+          taxPercentage?: number | null;
+          itemName: string;
+          item: {
+            __typename: 'ItemNode';
+            id: string;
+            name: string;
+            code: string;
+            unitName?: string | null;
+          };
+          location?: {
+            __typename: 'LocationNode';
+            id: string;
+            name: string;
+            code: string;
+            onHold: boolean;
+          } | null;
+          stockLine?: {
+            __typename: 'StockLineNode';
+            id: string;
+            itemId: string;
+            batch?: string | null;
+            availableNumberOfPacks: number;
+            totalNumberOfPacks: number;
+            onHold: boolean;
+            sellPricePerPack: number;
+            packSize: number;
+            expiryDate?: string | null;
+            item: { __typename: 'ItemNode'; name: string; code: string };
+          } | null;
+        }>;
+      };
+      patient?: {
+        __typename: 'PatientNode';
+        id: string;
+        name: string;
+        code: string;
+        isDeceased: boolean;
+      } | null;
+      clinician?: {
+        __typename: 'ClinicianNode';
+        id: string;
+        firstName?: string | null;
+        lastName: string;
+      } | null;
+      currency?: {
+        __typename: 'CurrencyNode';
+        id: string;
+        code: string;
+        rate: number;
+        isHomeCurrency: boolean;
+      } | null;
+      diagnosis?: {
+        __typename: 'DiagnosisNode';
+        id: string;
+        code: string;
+        description: string;
+      } | null;
+    }>;
+  };
+};
 
 export type PrescriptionByNumberQueryVariables = Types.Exact<{
   invoiceNumber: Types.Scalars['Int']['input'];
   storeId: Types.Scalars['String']['input'];
 }>;
 
-
-export type PrescriptionByNumberQuery = { __typename: 'Queries', invoiceByNumber: { __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, pickedDatetime?: string | null, verifiedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyId: string, otherPartyName: string, clinicianId?: string | null, type: Types.InvoiceNodeType, status: Types.InvoiceNodeStatus, colour?: string | null, currencyRate: number, diagnosisId?: string | null, prescriptionDate?: string | null, pricing: { __typename: 'PricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number, taxPercentage?: number | null }, user?: { __typename: 'UserNode', username: string, email?: string | null } | null, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', id: string, type: Types.InvoiceLineNodeType, batch?: string | null, expiryDate?: string | null, numberOfPacks: number, packSize: number, invoiceId: string, sellPricePerPack: number, note?: string | null, totalBeforeTax: number, totalAfterTax: number, taxPercentage?: number | null, itemName: string, item: { __typename: 'ItemNode', id: string, name: string, code: string, unitName?: string | null }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean } | null, stockLine?: { __typename: 'StockLineNode', id: string, itemId: string, batch?: string | null, availableNumberOfPacks: number, totalNumberOfPacks: number, onHold: boolean, sellPricePerPack: number, packSize: number, expiryDate?: string | null, item: { __typename: 'ItemNode', name: string, code: string } } | null }> }, patient?: { __typename: 'PatientNode', id: string, name: string, code: string, isDeceased: boolean } | null, clinician?: { __typename: 'ClinicianNode', id: string, firstName?: string | null, lastName: string } | null, currency?: { __typename: 'CurrencyNode', id: string, code: string, rate: number, isHomeCurrency: boolean } | null, diagnosis?: { __typename: 'DiagnosisNode', id: string, code: string, description: string } | null } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } };
+export type PrescriptionByNumberQuery = {
+  __typename: 'Queries';
+  invoiceByNumber:
+    | {
+        __typename: 'InvoiceNode';
+        comment?: string | null;
+        createdDatetime: string;
+        pickedDatetime?: string | null;
+        verifiedDatetime?: string | null;
+        id: string;
+        invoiceNumber: number;
+        otherPartyName: string;
+        clinicianId?: string | null;
+        type: Types.InvoiceNodeType;
+        status: Types.InvoiceNodeStatus;
+        colour?: string | null;
+        currencyRate: number;
+        diagnosisId?: string | null;
+        prescriptionDate?: string | null;
+        patientId: string;
+        pricing: {
+          __typename: 'PricingNode';
+          totalAfterTax: number;
+          totalBeforeTax: number;
+          stockTotalBeforeTax: number;
+          stockTotalAfterTax: number;
+          serviceTotalAfterTax: number;
+          serviceTotalBeforeTax: number;
+          taxPercentage?: number | null;
+        };
+        user?: {
+          __typename: 'UserNode';
+          username: string;
+          email?: string | null;
+        } | null;
+        lines: {
+          __typename: 'InvoiceLineConnector';
+          totalCount: number;
+          nodes: Array<{
+            __typename: 'InvoiceLineNode';
+            id: string;
+            type: Types.InvoiceLineNodeType;
+            batch?: string | null;
+            expiryDate?: string | null;
+            numberOfPacks: number;
+            packSize: number;
+            invoiceId: string;
+            sellPricePerPack: number;
+            note?: string | null;
+            totalBeforeTax: number;
+            totalAfterTax: number;
+            taxPercentage?: number | null;
+            itemName: string;
+            item: {
+              __typename: 'ItemNode';
+              id: string;
+              name: string;
+              code: string;
+              unitName?: string | null;
+            };
+            location?: {
+              __typename: 'LocationNode';
+              id: string;
+              name: string;
+              code: string;
+              onHold: boolean;
+            } | null;
+            stockLine?: {
+              __typename: 'StockLineNode';
+              id: string;
+              itemId: string;
+              batch?: string | null;
+              availableNumberOfPacks: number;
+              totalNumberOfPacks: number;
+              onHold: boolean;
+              sellPricePerPack: number;
+              packSize: number;
+              expiryDate?: string | null;
+              item: { __typename: 'ItemNode'; name: string; code: string };
+            } | null;
+          }>;
+        };
+        patient?: {
+          __typename: 'PatientNode';
+          id: string;
+          name: string;
+          code: string;
+          isDeceased: boolean;
+        } | null;
+        clinician?: {
+          __typename: 'ClinicianNode';
+          id: string;
+          firstName?: string | null;
+          lastName: string;
+        } | null;
+        currency?: {
+          __typename: 'CurrencyNode';
+          id: string;
+          code: string;
+          rate: number;
+          isHomeCurrency: boolean;
+        } | null;
+        diagnosis?: {
+          __typename: 'DiagnosisNode';
+          id: string;
+          code: string;
+          description: string;
+        } | null;
+      }
+    | {
+        __typename: 'NodeError';
+        error:
+          | {
+              __typename: 'DatabaseError';
+              description: string;
+              fullError: string;
+            }
+          | { __typename: 'RecordNotFound'; description: string };
+      };
+};
 
 export type PrescriptionByIdQueryVariables = Types.Exact<{
   invoiceId: Types.Scalars['String']['input'];
   storeId: Types.Scalars['String']['input'];
 }>;
 
-
-export type PrescriptionByIdQuery = { __typename: 'Queries', invoice: { __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, pickedDatetime?: string | null, verifiedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyId: string, otherPartyName: string, clinicianId?: string | null, type: Types.InvoiceNodeType, status: Types.InvoiceNodeStatus, colour?: string | null, currencyRate: number, diagnosisId?: string | null, prescriptionDate?: string | null, pricing: { __typename: 'PricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number, taxPercentage?: number | null }, user?: { __typename: 'UserNode', username: string, email?: string | null } | null, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', id: string, type: Types.InvoiceLineNodeType, batch?: string | null, expiryDate?: string | null, numberOfPacks: number, packSize: number, invoiceId: string, sellPricePerPack: number, note?: string | null, totalBeforeTax: number, totalAfterTax: number, taxPercentage?: number | null, itemName: string, item: { __typename: 'ItemNode', id: string, name: string, code: string, unitName?: string | null }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean } | null, stockLine?: { __typename: 'StockLineNode', id: string, itemId: string, batch?: string | null, availableNumberOfPacks: number, totalNumberOfPacks: number, onHold: boolean, sellPricePerPack: number, packSize: number, expiryDate?: string | null, item: { __typename: 'ItemNode', name: string, code: string } } | null }> }, patient?: { __typename: 'PatientNode', id: string, name: string, code: string, isDeceased: boolean } | null, clinician?: { __typename: 'ClinicianNode', id: string, firstName?: string | null, lastName: string } | null, currency?: { __typename: 'CurrencyNode', id: string, code: string, rate: number, isHomeCurrency: boolean } | null, diagnosis?: { __typename: 'DiagnosisNode', id: string, code: string, description: string } | null } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } };
+export type PrescriptionByIdQuery = {
+  __typename: 'Queries';
+  invoice:
+    | {
+        __typename: 'InvoiceNode';
+        comment?: string | null;
+        createdDatetime: string;
+        pickedDatetime?: string | null;
+        verifiedDatetime?: string | null;
+        id: string;
+        invoiceNumber: number;
+        otherPartyName: string;
+        clinicianId?: string | null;
+        type: Types.InvoiceNodeType;
+        status: Types.InvoiceNodeStatus;
+        colour?: string | null;
+        currencyRate: number;
+        diagnosisId?: string | null;
+        prescriptionDate?: string | null;
+        patientId: string;
+        pricing: {
+          __typename: 'PricingNode';
+          totalAfterTax: number;
+          totalBeforeTax: number;
+          stockTotalBeforeTax: number;
+          stockTotalAfterTax: number;
+          serviceTotalAfterTax: number;
+          serviceTotalBeforeTax: number;
+          taxPercentage?: number | null;
+        };
+        user?: {
+          __typename: 'UserNode';
+          username: string;
+          email?: string | null;
+        } | null;
+        lines: {
+          __typename: 'InvoiceLineConnector';
+          totalCount: number;
+          nodes: Array<{
+            __typename: 'InvoiceLineNode';
+            id: string;
+            type: Types.InvoiceLineNodeType;
+            batch?: string | null;
+            expiryDate?: string | null;
+            numberOfPacks: number;
+            packSize: number;
+            invoiceId: string;
+            sellPricePerPack: number;
+            note?: string | null;
+            totalBeforeTax: number;
+            totalAfterTax: number;
+            taxPercentage?: number | null;
+            itemName: string;
+            item: {
+              __typename: 'ItemNode';
+              id: string;
+              name: string;
+              code: string;
+              unitName?: string | null;
+            };
+            location?: {
+              __typename: 'LocationNode';
+              id: string;
+              name: string;
+              code: string;
+              onHold: boolean;
+            } | null;
+            stockLine?: {
+              __typename: 'StockLineNode';
+              id: string;
+              itemId: string;
+              batch?: string | null;
+              availableNumberOfPacks: number;
+              totalNumberOfPacks: number;
+              onHold: boolean;
+              sellPricePerPack: number;
+              packSize: number;
+              expiryDate?: string | null;
+              item: { __typename: 'ItemNode'; name: string; code: string };
+            } | null;
+          }>;
+        };
+        patient?: {
+          __typename: 'PatientNode';
+          id: string;
+          name: string;
+          code: string;
+          isDeceased: boolean;
+        } | null;
+        clinician?: {
+          __typename: 'ClinicianNode';
+          id: string;
+          firstName?: string | null;
+          lastName: string;
+        } | null;
+        currency?: {
+          __typename: 'CurrencyNode';
+          id: string;
+          code: string;
+          rate: number;
+          isHomeCurrency: boolean;
+        } | null;
+        diagnosis?: {
+          __typename: 'DiagnosisNode';
+          id: string;
+          code: string;
+          description: string;
+        } | null;
+      }
+    | {
+        __typename: 'NodeError';
+        error:
+          | {
+              __typename: 'DatabaseError';
+              description: string;
+              fullError: string;
+            }
+          | { __typename: 'RecordNotFound'; description: string };
+      };
+};
 
 export type InsertPrescriptionMutationVariables = Types.Exact<{
   id: Types.Scalars['String']['input'];
@@ -40,468 +492,815 @@ export type InsertPrescriptionMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
 }>;
 
-
-export type InsertPrescriptionMutation = { __typename: 'Mutations', insertPrescription: { __typename: 'InvoiceNode', id: string, invoiceNumber: number } };
+export type InsertPrescriptionMutation = {
+  __typename: 'Mutations';
+  insertPrescription: {
+    __typename: 'InvoiceNode';
+    id: string;
+    invoiceNumber: number;
+  };
+};
 
 export type UpsertPrescriptionMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
   input: Types.BatchPrescriptionInput;
 }>;
 
-
-export type UpsertPrescriptionMutation = { __typename: 'Mutations', batchPrescription: { __typename: 'BatchPrescriptionResponse', deletePrescriptionLines?: Array<{ __typename: 'DeletePrescriptionLineResponseWithId', id: string, response: { __typename: 'DeletePrescriptionLineError', error: { __typename: 'CannotEditInvoice', description: string } | { __typename: 'ForeignKeyError', description: string, key: Types.ForeignKey } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'DeleteResponse', id: string } }> | null, deletePrescriptions?: Array<{ __typename: 'DeletePrescriptionResponseWithId', id: string, response: { __typename: 'DeletePrescriptionError', error: { __typename: 'CannotDeleteInvoiceWithLines', description: string } | { __typename: 'CannotEditInvoice', description: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'DeleteResponse', id: string } }> | null, insertPrescriptionLines?: Array<{ __typename: 'InsertPrescriptionLineResponseWithId', id: string, response: { __typename: 'InsertPrescriptionLineError', error: { __typename: 'CannotEditInvoice', description: string } | { __typename: 'ForeignKeyError', description: string } | { __typename: 'LocationIsOnHold', description: string } | { __typename: 'LocationNotFound', description: string } | { __typename: 'NotEnoughStockForReduction', description: string } | { __typename: 'StockLineAlreadyExistsInInvoice', description: string } | { __typename: 'StockLineIsOnHold', description: string } } | { __typename: 'InvoiceLineNode' } }> | null, insertPrescriptions?: Array<{ __typename: 'InsertPrescriptionResponseWithId', id: string }> | null, updatePrescriptionLines?: Array<{ __typename: 'UpdatePrescriptionLineResponseWithId', id: string, response: { __typename: 'InvoiceLineNode' } | { __typename: 'UpdatePrescriptionLineError', error: { __typename: 'CannotEditInvoice', description: string } | { __typename: 'ForeignKeyError', description: string, key: Types.ForeignKey } | { __typename: 'LocationIsOnHold', description: string } | { __typename: 'LocationNotFound', description: string } | { __typename: 'NotEnoughStockForReduction', description: string, batch: { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'StockLineNode' } } | { __typename: 'RecordNotFound', description: string } | { __typename: 'StockLineAlreadyExistsInInvoice', description: string } | { __typename: 'StockLineIsOnHold', description: string } } }> | null, updatePrescriptions?: Array<{ __typename: 'UpdatePrescriptionResponseWithId', id: string, response: { __typename: 'InvoiceNode' } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'UpdatePrescriptionError', error: { __typename: 'CanOnlyChangeToPickedWhenNoUnallocatedLines', description: string } | { __typename: 'CannotReverseInvoiceStatus', description: string } | { __typename: 'InvalidStockSelection', description: string } | { __typename: 'InvoiceIsNotEditable', description: string } | { __typename: 'RecordNotFound', description: string } } }> | null } };
+export type UpsertPrescriptionMutation = {
+  __typename: 'Mutations';
+  batchPrescription: {
+    __typename: 'BatchPrescriptionResponse';
+    deletePrescriptionLines?: Array<{
+      __typename: 'DeletePrescriptionLineResponseWithId';
+      id: string;
+      response:
+        | {
+            __typename: 'DeletePrescriptionLineError';
+            error:
+              | { __typename: 'CannotEditInvoice'; description: string }
+              | {
+                  __typename: 'ForeignKeyError';
+                  description: string;
+                  key: Types.ForeignKey;
+                }
+              | { __typename: 'RecordNotFound'; description: string };
+          }
+        | { __typename: 'DeleteResponse'; id: string };
+    }> | null;
+    deletePrescriptions?: Array<{
+      __typename: 'DeletePrescriptionResponseWithId';
+      id: string;
+      response:
+        | {
+            __typename: 'DeletePrescriptionError';
+            error:
+              | {
+                  __typename: 'CannotDeleteInvoiceWithLines';
+                  description: string;
+                }
+              | { __typename: 'CannotEditInvoice'; description: string }
+              | { __typename: 'RecordNotFound'; description: string };
+          }
+        | { __typename: 'DeleteResponse'; id: string };
+    }> | null;
+    insertPrescriptionLines?: Array<{
+      __typename: 'InsertPrescriptionLineResponseWithId';
+      id: string;
+      response:
+        | {
+            __typename: 'InsertPrescriptionLineError';
+            error:
+              | { __typename: 'CannotEditInvoice'; description: string }
+              | { __typename: 'ForeignKeyError'; description: string }
+              | { __typename: 'LocationIsOnHold'; description: string }
+              | { __typename: 'LocationNotFound'; description: string }
+              | {
+                  __typename: 'NotEnoughStockForReduction';
+                  description: string;
+                }
+              | {
+                  __typename: 'StockLineAlreadyExistsInInvoice';
+                  description: string;
+                }
+              | { __typename: 'StockLineIsOnHold'; description: string };
+          }
+        | { __typename: 'InvoiceLineNode' };
+    }> | null;
+    insertPrescriptions?: Array<{
+      __typename: 'InsertPrescriptionResponseWithId';
+      id: string;
+    }> | null;
+    updatePrescriptionLines?: Array<{
+      __typename: 'UpdatePrescriptionLineResponseWithId';
+      id: string;
+      response:
+        | { __typename: 'InvoiceLineNode' }
+        | {
+            __typename: 'UpdatePrescriptionLineError';
+            error:
+              | { __typename: 'CannotEditInvoice'; description: string }
+              | {
+                  __typename: 'ForeignKeyError';
+                  description: string;
+                  key: Types.ForeignKey;
+                }
+              | { __typename: 'LocationIsOnHold'; description: string }
+              | { __typename: 'LocationNotFound'; description: string }
+              | {
+                  __typename: 'NotEnoughStockForReduction';
+                  description: string;
+                  batch:
+                    | {
+                        __typename: 'NodeError';
+                        error:
+                          | {
+                              __typename: 'DatabaseError';
+                              description: string;
+                              fullError: string;
+                            }
+                          | {
+                              __typename: 'RecordNotFound';
+                              description: string;
+                            };
+                      }
+                    | { __typename: 'StockLineNode' };
+                }
+              | { __typename: 'RecordNotFound'; description: string }
+              | {
+                  __typename: 'StockLineAlreadyExistsInInvoice';
+                  description: string;
+                }
+              | { __typename: 'StockLineIsOnHold'; description: string };
+          };
+    }> | null;
+    updatePrescriptions?: Array<{
+      __typename: 'UpdatePrescriptionResponseWithId';
+      id: string;
+      response:
+        | { __typename: 'InvoiceNode' }
+        | {
+            __typename: 'NodeError';
+            error:
+              | { __typename: 'DatabaseError'; description: string }
+              | { __typename: 'RecordNotFound'; description: string };
+          }
+        | {
+            __typename: 'UpdatePrescriptionError';
+            error:
+              | {
+                  __typename: 'CanOnlyChangeToPickedWhenNoUnallocatedLines';
+                  description: string;
+                }
+              | {
+                  __typename: 'CannotReverseInvoiceStatus';
+                  description: string;
+                }
+              | { __typename: 'InvalidStockSelection'; description: string }
+              | { __typename: 'InvoiceIsNotEditable'; description: string }
+              | { __typename: 'RecordNotFound'; description: string };
+          };
+    }> | null;
+  };
+};
 
 export type DeletePrescriptionsMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
-  deletePrescriptions: Array<Types.Scalars['String']['input']> | Types.Scalars['String']['input'];
+  deletePrescriptions:
+    | Array<Types.Scalars['String']['input']>
+    | Types.Scalars['String']['input'];
 }>;
 
-
-export type DeletePrescriptionsMutation = { __typename: 'Mutations', batchPrescription: { __typename: 'BatchPrescriptionResponse', deletePrescriptions?: Array<{ __typename: 'DeletePrescriptionResponseWithId', id: string, response: { __typename: 'DeletePrescriptionError', error: { __typename: 'CannotDeleteInvoiceWithLines', description: string } | { __typename: 'CannotEditInvoice', description: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'DeleteResponse', id: string } }> | null } };
+export type DeletePrescriptionsMutation = {
+  __typename: 'Mutations';
+  batchPrescription: {
+    __typename: 'BatchPrescriptionResponse';
+    deletePrescriptions?: Array<{
+      __typename: 'DeletePrescriptionResponseWithId';
+      id: string;
+      response:
+        | {
+            __typename: 'DeletePrescriptionError';
+            error:
+              | {
+                  __typename: 'CannotDeleteInvoiceWithLines';
+                  description: string;
+                }
+              | { __typename: 'CannotEditInvoice'; description: string }
+              | { __typename: 'RecordNotFound'; description: string };
+          }
+        | { __typename: 'DeleteResponse'; id: string };
+    }> | null;
+  };
+};
 
 export type DeletePrescriptionLinesMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
-  deletePrescriptionLines: Array<Types.DeletePrescriptionLineInput> | Types.DeletePrescriptionLineInput;
+  deletePrescriptionLines:
+    | Array<Types.DeletePrescriptionLineInput>
+    | Types.DeletePrescriptionLineInput;
 }>;
 
+export type DeletePrescriptionLinesMutation = {
+  __typename: 'Mutations';
+  batchPrescription: {
+    __typename: 'BatchPrescriptionResponse';
+    deletePrescriptionLines?: Array<{
+      __typename: 'DeletePrescriptionLineResponseWithId';
+      id: string;
+      response:
+        | {
+            __typename: 'DeletePrescriptionLineError';
+            error:
+              | { __typename: 'CannotEditInvoice'; description: string }
+              | {
+                  __typename: 'ForeignKeyError';
+                  description: string;
+                  key: Types.ForeignKey;
+                }
+              | { __typename: 'RecordNotFound'; description: string };
+          }
+        | { __typename: 'DeleteResponse'; id: string };
+    }> | null;
+  };
+};
 
-export type DeletePrescriptionLinesMutation = { __typename: 'Mutations', batchPrescription: { __typename: 'BatchPrescriptionResponse', deletePrescriptionLines?: Array<{ __typename: 'DeletePrescriptionLineResponseWithId', id: string, response: { __typename: 'DeletePrescriptionLineError', error: { __typename: 'CannotEditInvoice', description: string } | { __typename: 'ForeignKeyError', description: string, key: Types.ForeignKey } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'DeleteResponse', id: string } }> | null } };
+export type HistoricalStockLineFragment = {
+  __typename: 'StockLineNode';
+  id: string;
+  availableNumberOfPacks: number;
+  packSize: number;
+};
 
-export type HistoricalStockLineFragment = { __typename: 'StockLineNode', id: string, availableNumberOfPacks: number, packSize: number };
+export type DiagnosisFragment = {
+  __typename: 'DiagnosisNode';
+  id: string;
+  code: string;
+  description: string;
+};
 
-export type DiagnosisFragment = { __typename: 'DiagnosisNode', id: string, code: string, description: string };
+export type DiagnosesActiveQueryVariables = Types.Exact<{
+  [key: string]: never;
+}>;
 
-export type DiagnosesActiveQueryVariables = Types.Exact<{ [key: string]: never; }>;
-
-
-export type DiagnosesActiveQuery = { __typename: 'Queries', diagnosesActive: Array<{ __typename: 'DiagnosisNode', id: string, code: string, description: string }> };
+export type DiagnosesActiveQuery = {
+  __typename: 'Queries';
+  diagnosesActive: Array<{
+    __typename: 'DiagnosisNode';
+    id: string;
+    code: string;
+    description: string;
+  }>;
+};
 
 export const PrescriptionRowFragmentDoc = gql`
-    fragment PrescriptionRow on InvoiceNode {
-  __typename
-  comment
-  createdDatetime
-  prescriptionDate: backdatedDatetime
-  pickedDatetime
-  verifiedDatetime
-  id
-  invoiceNumber
-  otherPartyId
-  otherPartyName
-  clinicianId
-  type
-  status
-  colour
-  pricing {
+  fragment PrescriptionRow on InvoiceNode {
     __typename
-    totalAfterTax
-    totalBeforeTax
-    stockTotalBeforeTax
-    stockTotalAfterTax
-    serviceTotalAfterTax
-    serviceTotalBeforeTax
-    taxPercentage
-  }
-  currencyRate
-  user {
-    __typename
-    username
-    email
-  }
-  lines {
-    __typename
-    nodes {
-      ...StockOutLine
+    comment
+    createdDatetime
+    prescriptionDate: backdatedDatetime
+    pickedDatetime
+    verifiedDatetime
+    id
+    invoiceNumber
+    patientId: otherPartyId
+    otherPartyName
+    clinicianId
+    type
+    status
+    colour
+    pricing {
+      __typename
+      totalAfterTax
+      totalBeforeTax
+      stockTotalBeforeTax
+      stockTotalAfterTax
+      serviceTotalAfterTax
+      serviceTotalBeforeTax
+      taxPercentage
     }
-    totalCount
+    currencyRate
+    user {
+      __typename
+      username
+      email
+    }
+    lines {
+      __typename
+      nodes {
+        ...StockOutLine
+      }
+      totalCount
+    }
+    patient {
+      __typename
+      id
+      name
+      code
+      isDeceased
+    }
+    clinician {
+      id
+      firstName
+      lastName
+    }
+    currency {
+      id
+      code
+      rate
+      isHomeCurrency
+    }
+    currencyRate
+    diagnosisId
+    diagnosis {
+      id
+      code
+      description
+    }
   }
-  patient {
-    __typename
+  ${StockOutLineFragmentDoc}
+`;
+export const HistoricalStockLineFragmentDoc = gql`
+  fragment historicalStockLine on StockLineNode {
     id
-    name
-    code
-    isDeceased
+    availableNumberOfPacks
+    packSize
   }
-  clinician {
-    id
-    firstName
-    lastName
-  }
-  currency {
-    id
-    code
-    rate
-    isHomeCurrency
-  }
-  currencyRate
-  diagnosisId
-  diagnosis {
+`;
+export const DiagnosisFragmentDoc = gql`
+  fragment diagnosis on DiagnosisNode {
     id
     code
     description
   }
-}
-    ${StockOutLineFragmentDoc}`;
-export const HistoricalStockLineFragmentDoc = gql`
-    fragment historicalStockLine on StockLineNode {
-  id
-  availableNumberOfPacks
-  packSize
-}
-    `;
-export const DiagnosisFragmentDoc = gql`
-    fragment diagnosis on DiagnosisNode {
-  id
-  code
-  description
-}
-    `;
+`;
 export const PrescriptionsDocument = gql`
-    query prescriptions($first: Int, $offset: Int, $key: InvoiceSortFieldInput!, $desc: Boolean, $filter: InvoiceFilterInput, $storeId: String!) {
-  invoices(
-    page: {first: $first, offset: $offset}
-    sort: {key: $key, desc: $desc}
-    filter: $filter
-    storeId: $storeId
+  query prescriptions(
+    $first: Int
+    $offset: Int
+    $key: InvoiceSortFieldInput!
+    $desc: Boolean
+    $filter: InvoiceFilterInput
+    $storeId: String!
   ) {
-    ... on InvoiceConnector {
-      __typename
-      nodes {
-        ...PrescriptionRow
+    invoices(
+      page: { first: $first, offset: $offset }
+      sort: { key: $key, desc: $desc }
+      filter: $filter
+      storeId: $storeId
+    ) {
+      ... on InvoiceConnector {
+        __typename
+        nodes {
+          ...PrescriptionRow
+        }
+        totalCount
       }
-      totalCount
     }
   }
-}
-    ${PrescriptionRowFragmentDoc}`;
+  ${PrescriptionRowFragmentDoc}
+`;
 export const PrescriptionByNumberDocument = gql`
-    query prescriptionByNumber($invoiceNumber: Int!, $storeId: String!) {
-  invoiceByNumber(
-    invoiceNumber: $invoiceNumber
-    storeId: $storeId
-    type: PRESCRIPTION
-  ) {
-    __typename
-    ... on NodeError {
+  query prescriptionByNumber($invoiceNumber: Int!, $storeId: String!) {
+    invoiceByNumber(
+      invoiceNumber: $invoiceNumber
+      storeId: $storeId
+      type: PRESCRIPTION
+    ) {
       __typename
-      error {
-        description
-        ... on DatabaseError {
-          __typename
+      ... on NodeError {
+        __typename
+        error {
           description
-          fullError
-        }
-        ... on RecordNotFound {
-          __typename
-          description
-        }
-      }
-    }
-    ... on InvoiceNode {
-      ...PrescriptionRow
-    }
-  }
-}
-    ${PrescriptionRowFragmentDoc}`;
-export const PrescriptionByIdDocument = gql`
-    query prescriptionById($invoiceId: String!, $storeId: String!) {
-  invoice(id: $invoiceId, storeId: $storeId) {
-    __typename
-    ... on NodeError {
-      __typename
-      error {
-        description
-        ... on DatabaseError {
-          __typename
-          description
-          fullError
-        }
-        ... on RecordNotFound {
-          __typename
-          description
-        }
-      }
-    }
-    ... on InvoiceNode {
-      ...PrescriptionRow
-    }
-  }
-}
-    ${PrescriptionRowFragmentDoc}`;
-export const InsertPrescriptionDocument = gql`
-    mutation insertPrescription($id: String!, $patientId: String!, $storeId: String!) {
-  insertPrescription(storeId: $storeId, input: {id: $id, patientId: $patientId}) {
-    __typename
-    ... on InvoiceNode {
-      id
-      invoiceNumber
-    }
-  }
-}
-    `;
-export const UpsertPrescriptionDocument = gql`
-    mutation upsertPrescription($storeId: String!, $input: BatchPrescriptionInput!) {
-  batchPrescription(storeId: $storeId, input: $input) {
-    __typename
-    deletePrescriptionLines {
-      id
-      response {
-        ... on DeletePrescriptionLineError {
-          __typename
-          error {
+          ... on DatabaseError {
+            __typename
             description
-            ... on RecordNotFound {
-              __typename
-              description
-            }
-            ... on CannotEditInvoice {
-              __typename
-              description
-            }
-            ... on ForeignKeyError {
-              __typename
-              description
-              key
-            }
+            fullError
           }
-        }
-        ... on DeleteResponse {
-          id
-        }
-      }
-    }
-    deletePrescriptions {
-      id
-      response {
-        ... on DeleteResponse {
-          id
-        }
-        ... on DeletePrescriptionError {
-          __typename
-          error {
-            description
-            ... on RecordNotFound {
-              __typename
-              description
-            }
-            ... on CannotDeleteInvoiceWithLines {
-              __typename
-              description
-            }
-            ... on CannotEditInvoice {
-              __typename
-              description
-            }
-          }
-        }
-      }
-    }
-    insertPrescriptionLines {
-      id
-      response {
-        ... on InsertPrescriptionLineError {
-          __typename
-          error {
-            description
-          }
-        }
-      }
-    }
-    insertPrescriptions {
-      id
-    }
-    updatePrescriptionLines {
-      id
-      response {
-        ... on UpdatePrescriptionLineError {
-          __typename
-          error {
-            description
-            ... on RecordNotFound {
-              __typename
-              description
-            }
-            ... on CannotEditInvoice {
-              __typename
-              description
-            }
-            ... on ForeignKeyError {
-              __typename
-              description
-              key
-            }
-            ... on LocationIsOnHold {
-              __typename
-              description
-            }
-            ... on LocationNotFound {
-              __typename
-              description
-            }
-            ... on NotEnoughStockForReduction {
-              __typename
-              batch {
-                ... on NodeError {
-                  __typename
-                  error {
-                    description
-                    ... on RecordNotFound {
-                      __typename
-                      description
-                    }
-                    ... on DatabaseError {
-                      __typename
-                      description
-                      fullError
-                    }
-                  }
-                }
-              }
-            }
-            ... on StockLineAlreadyExistsInInvoice {
-              __typename
-              description
-            }
-            ... on StockLineIsOnHold {
-              __typename
-              description
-            }
-          }
-        }
-      }
-    }
-    updatePrescriptions {
-      id
-      response {
-        ... on UpdatePrescriptionError {
-          __typename
-          error {
+          ... on RecordNotFound {
             __typename
             description
           }
         }
-        ... on NodeError {
-          __typename
-          error {
+      }
+      ... on InvoiceNode {
+        ...PrescriptionRow
+      }
+    }
+  }
+  ${PrescriptionRowFragmentDoc}
+`;
+export const PrescriptionByIdDocument = gql`
+  query prescriptionById($invoiceId: String!, $storeId: String!) {
+    invoice(id: $invoiceId, storeId: $storeId) {
+      __typename
+      ... on NodeError {
+        __typename
+        error {
+          description
+          ... on DatabaseError {
+            __typename
             description
+            fullError
+          }
+          ... on RecordNotFound {
+            __typename
+            description
+          }
+        }
+      }
+      ... on InvoiceNode {
+        ...PrescriptionRow
+      }
+    }
+  }
+  ${PrescriptionRowFragmentDoc}
+`;
+export const InsertPrescriptionDocument = gql`
+  mutation insertPrescription(
+    $id: String!
+    $patientId: String!
+    $storeId: String!
+  ) {
+    insertPrescription(
+      storeId: $storeId
+      input: { id: $id, patientId: $patientId }
+    ) {
+      __typename
+      ... on InvoiceNode {
+        id
+        invoiceNumber
+      }
+    }
+  }
+`;
+export const UpsertPrescriptionDocument = gql`
+  mutation upsertPrescription(
+    $storeId: String!
+    $input: BatchPrescriptionInput!
+  ) {
+    batchPrescription(storeId: $storeId, input: $input) {
+      __typename
+      deletePrescriptionLines {
+        id
+        response {
+          ... on DeletePrescriptionLineError {
+            __typename
+            error {
+              description
+              ... on RecordNotFound {
+                __typename
+                description
+              }
+              ... on CannotEditInvoice {
+                __typename
+                description
+              }
+              ... on ForeignKeyError {
+                __typename
+                description
+                key
+              }
+            }
+          }
+          ... on DeleteResponse {
+            id
+          }
+        }
+      }
+      deletePrescriptions {
+        id
+        response {
+          ... on DeleteResponse {
+            id
+          }
+          ... on DeletePrescriptionError {
+            __typename
+            error {
+              description
+              ... on RecordNotFound {
+                __typename
+                description
+              }
+              ... on CannotDeleteInvoiceWithLines {
+                __typename
+                description
+              }
+              ... on CannotEditInvoice {
+                __typename
+                description
+              }
+            }
+          }
+        }
+      }
+      insertPrescriptionLines {
+        id
+        response {
+          ... on InsertPrescriptionLineError {
+            __typename
+            error {
+              description
+            }
+          }
+        }
+      }
+      insertPrescriptions {
+        id
+      }
+      updatePrescriptionLines {
+        id
+        response {
+          ... on UpdatePrescriptionLineError {
+            __typename
+            error {
+              description
+              ... on RecordNotFound {
+                __typename
+                description
+              }
+              ... on CannotEditInvoice {
+                __typename
+                description
+              }
+              ... on ForeignKeyError {
+                __typename
+                description
+                key
+              }
+              ... on LocationIsOnHold {
+                __typename
+                description
+              }
+              ... on LocationNotFound {
+                __typename
+                description
+              }
+              ... on NotEnoughStockForReduction {
+                __typename
+                batch {
+                  ... on NodeError {
+                    __typename
+                    error {
+                      description
+                      ... on RecordNotFound {
+                        __typename
+                        description
+                      }
+                      ... on DatabaseError {
+                        __typename
+                        description
+                        fullError
+                      }
+                    }
+                  }
+                }
+              }
+              ... on StockLineAlreadyExistsInInvoice {
+                __typename
+                description
+              }
+              ... on StockLineIsOnHold {
+                __typename
+                description
+              }
+            }
+          }
+        }
+      }
+      updatePrescriptions {
+        id
+        response {
+          ... on UpdatePrescriptionError {
+            __typename
+            error {
+              __typename
+              description
+            }
+          }
+          ... on NodeError {
+            __typename
+            error {
+              description
+            }
           }
         }
       }
     }
   }
-}
-    `;
+`;
 export const DeletePrescriptionsDocument = gql`
-    mutation deletePrescriptions($storeId: String!, $deletePrescriptions: [String!]!) {
-  batchPrescription(
-    storeId: $storeId
-    input: {deletePrescriptions: $deletePrescriptions}
+  mutation deletePrescriptions(
+    $storeId: String!
+    $deletePrescriptions: [String!]!
   ) {
-    __typename
-    deletePrescriptions {
-      id
-      response {
-        ... on DeletePrescriptionError {
-          __typename
-          error {
-            description
-            ... on RecordNotFound {
-              __typename
+    batchPrescription(
+      storeId: $storeId
+      input: { deletePrescriptions: $deletePrescriptions }
+    ) {
+      __typename
+      deletePrescriptions {
+        id
+        response {
+          ... on DeletePrescriptionError {
+            __typename
+            error {
               description
-            }
-            ... on CannotDeleteInvoiceWithLines {
-              __typename
-              description
-            }
-            ... on CannotEditInvoice {
-              __typename
-              description
+              ... on RecordNotFound {
+                __typename
+                description
+              }
+              ... on CannotDeleteInvoiceWithLines {
+                __typename
+                description
+              }
+              ... on CannotEditInvoice {
+                __typename
+                description
+              }
             }
           }
-        }
-        ... on DeleteResponse {
-          id
+          ... on DeleteResponse {
+            id
+          }
         }
       }
     }
   }
-}
-    `;
+`;
 export const DeletePrescriptionLinesDocument = gql`
-    mutation deletePrescriptionLines($storeId: String!, $deletePrescriptionLines: [DeletePrescriptionLineInput!]!) {
-  batchPrescription(
-    storeId: $storeId
-    input: {deletePrescriptionLines: $deletePrescriptionLines}
+  mutation deletePrescriptionLines(
+    $storeId: String!
+    $deletePrescriptionLines: [DeletePrescriptionLineInput!]!
   ) {
-    deletePrescriptionLines {
-      id
-      response {
-        ... on DeletePrescriptionLineError {
-          __typename
-          error {
-            description
-            ... on RecordNotFound {
-              __typename
+    batchPrescription(
+      storeId: $storeId
+      input: { deletePrescriptionLines: $deletePrescriptionLines }
+    ) {
+      deletePrescriptionLines {
+        id
+        response {
+          ... on DeletePrescriptionLineError {
+            __typename
+            error {
               description
-            }
-            ... on CannotEditInvoice {
-              __typename
-              description
-            }
-            ... on ForeignKeyError {
-              __typename
-              description
-              key
+              ... on RecordNotFound {
+                __typename
+                description
+              }
+              ... on CannotEditInvoice {
+                __typename
+                description
+              }
+              ... on ForeignKeyError {
+                __typename
+                description
+                key
+              }
             }
           }
-        }
-        ... on DeleteResponse {
-          id
+          ... on DeleteResponse {
+            id
+          }
         }
       }
     }
   }
-}
-    `;
+`;
 export const DiagnosesActiveDocument = gql`
-    query diagnosesActive {
-  diagnosesActive {
-    ...diagnosis
-  }
-}
-    ${DiagnosisFragmentDoc}`;
-
-export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string, variables?: any) => Promise<T>;
-
-
-const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType, _variables) => action();
-
-export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
-  return {
-    prescriptions(variables: PrescriptionsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<PrescriptionsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PrescriptionsQuery>(PrescriptionsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'prescriptions', 'query', variables);
-    },
-    prescriptionByNumber(variables: PrescriptionByNumberQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<PrescriptionByNumberQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PrescriptionByNumberQuery>(PrescriptionByNumberDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'prescriptionByNumber', 'query', variables);
-    },
-    prescriptionById(variables: PrescriptionByIdQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<PrescriptionByIdQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PrescriptionByIdQuery>(PrescriptionByIdDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'prescriptionById', 'query', variables);
-    },
-    insertPrescription(variables: InsertPrescriptionMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<InsertPrescriptionMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<InsertPrescriptionMutation>(InsertPrescriptionDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'insertPrescription', 'mutation', variables);
-    },
-    upsertPrescription(variables: UpsertPrescriptionMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<UpsertPrescriptionMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<UpsertPrescriptionMutation>(UpsertPrescriptionDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'upsertPrescription', 'mutation', variables);
-    },
-    deletePrescriptions(variables: DeletePrescriptionsMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DeletePrescriptionsMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<DeletePrescriptionsMutation>(DeletePrescriptionsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'deletePrescriptions', 'mutation', variables);
-    },
-    deletePrescriptionLines(variables: DeletePrescriptionLinesMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DeletePrescriptionLinesMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<DeletePrescriptionLinesMutation>(DeletePrescriptionLinesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'deletePrescriptionLines', 'mutation', variables);
-    },
-    diagnosesActive(variables?: DiagnosesActiveQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DiagnosesActiveQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<DiagnosesActiveQuery>(DiagnosesActiveDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'diagnosesActive', 'query', variables);
+  query diagnosesActive {
+    diagnosesActive {
+      ...diagnosis
     }
+  }
+  ${DiagnosisFragmentDoc}
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper
+) {
+  return {
+    prescriptions(
+      variables: PrescriptionsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders
+    ): Promise<PrescriptionsQuery> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<PrescriptionsQuery>(PrescriptionsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'prescriptions',
+        'query',
+        variables
+      );
+    },
+    prescriptionByNumber(
+      variables: PrescriptionByNumberQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders
+    ): Promise<PrescriptionByNumberQuery> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<PrescriptionByNumberQuery>(
+            PrescriptionByNumberDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'prescriptionByNumber',
+        'query',
+        variables
+      );
+    },
+    prescriptionById(
+      variables: PrescriptionByIdQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders
+    ): Promise<PrescriptionByIdQuery> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<PrescriptionByIdQuery>(
+            PrescriptionByIdDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'prescriptionById',
+        'query',
+        variables
+      );
+    },
+    insertPrescription(
+      variables: InsertPrescriptionMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders
+    ): Promise<InsertPrescriptionMutation> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<InsertPrescriptionMutation>(
+            InsertPrescriptionDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'insertPrescription',
+        'mutation',
+        variables
+      );
+    },
+    upsertPrescription(
+      variables: UpsertPrescriptionMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders
+    ): Promise<UpsertPrescriptionMutation> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<UpsertPrescriptionMutation>(
+            UpsertPrescriptionDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'upsertPrescription',
+        'mutation',
+        variables
+      );
+    },
+    deletePrescriptions(
+      variables: DeletePrescriptionsMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders
+    ): Promise<DeletePrescriptionsMutation> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<DeletePrescriptionsMutation>(
+            DeletePrescriptionsDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'deletePrescriptions',
+        'mutation',
+        variables
+      );
+    },
+    deletePrescriptionLines(
+      variables: DeletePrescriptionLinesMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders
+    ): Promise<DeletePrescriptionLinesMutation> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<DeletePrescriptionLinesMutation>(
+            DeletePrescriptionLinesDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'deletePrescriptionLines',
+        'mutation',
+        variables
+      );
+    },
+    diagnosesActive(
+      variables?: DiagnosesActiveQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders
+    ): Promise<DiagnosesActiveQuery> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<DiagnosesActiveQuery>(
+            DiagnosesActiveDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'diagnosesActive',
+        'query',
+        variables
+      );
+    },
   };
 }
 export type Sdk = ReturnType<typeof getSdk>;

--- a/client/packages/invoices/src/Prescriptions/api/operations.graphql
+++ b/client/packages/invoices/src/Prescriptions/api/operations.graphql
@@ -7,7 +7,7 @@ fragment PrescriptionRow on InvoiceNode {
   verifiedDatetime
   id
   invoiceNumber
-  otherPartyId
+  patientId: otherPartyId
   otherPartyName
   clinicianId
   type


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5969 
Fixes #5964

# 👩🏻‍💻 What does this PR do?

Changes the shape of the graphql query for Prescriptions to expicitly call `otherPartyId` `patientId`

## 💌 Any notes for the reviewer?

I think this is a nice solution than https://github.com/msupply-foundation/open-msupply/pull/5965
But open to feedback

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Try to change the patient on a prescriptoin

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
