### PR TITLE
Restore row expansion in prescription detail view

### DIFF
--- a/client/packages/invoices/src/Prescriptions/DetailView/ContentArea.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/ContentArea.tsx
@@ -5,16 +5,30 @@ import {
   useUrlQueryParams,
   Box,
   DataTable,
+  MiniTable,
 } from '@openmsupply-client/common';
 import { usePrescription } from '../api';
 import { usePrescriptionColumn } from './columns';
 import { StockOutItem } from '../../types';
 import { StockOutLineFragment } from '../../StockOut';
+import { useExpansionColumns } from './columns';
 
 interface ContentAreaProps {
   onAddItem: () => void;
   onRowClick?: null | ((rowData: StockOutLineFragment | StockOutItem) => void);
 }
+
+const Expand: FC<{
+  rowData: StockOutLineFragment | StockOutItem;
+}> = ({ rowData }) => {
+  const expandoColumns = useExpansionColumns();
+
+  if ('lines' in rowData && rowData.lines.length > 1) {
+    return <MiniTable rows={rowData.lines} columns={expandoColumns} />;
+  } else {
+    return null;
+  }
+};
 
 export const ContentAreaComponent: FC<ContentAreaProps> = ({
   onAddItem,
@@ -41,6 +55,7 @@ export const ContentAreaComponent: FC<ContentAreaProps> = ({
         columns={columns}
         data={rows}
         enableColumnSelection
+        ExpandContent={Expand}
         noDataElement={
           <NothingHere
             body={t('error.no-prescriptions')}

--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -25,6 +25,32 @@ const expansionColumn = getRowExpandColumn<
   StockOutLineFragment | StockOutItem
 >();
 
+export const useExpansionColumns = (): Column<StockOutLineFragment>[] =>
+  useColumns([
+    'batch',
+    'expiryDate',
+    [
+      'location',
+      {
+        accessor: ({ rowData }) => rowData.location?.code,
+      },
+    ],
+    [
+      'itemUnit',
+      {
+        accessor: ({ rowData }) => rowData.item?.unitName,
+      },
+    ],
+    'numberOfPacks',
+    'packSize',
+    [
+      'unitQuantity',
+      {
+        accessor: ({ rowData }) => rowData.numberOfPacks,
+      },
+    ],
+  ]);
+
 export const usePrescriptionColumn = ({
   sortBy,
   onChangeSortBy,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5967

# 👩🏻‍💻 What does this PR do?
Adds back the expanding rows. Not sure why it was deleted but I need screenshots for the docs and found that the expansion column was there but the underlying functionality was not.

Given that the rows are grouped by item I think it important to retain the expansion.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
<img width="1510" alt="Screenshot 2025-01-09 at 6 14 58 PM" src="https://github.com/user-attachments/assets/4cf1bcbe-0398-41f9-b922-d4f1851de75c" />

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Add multiple batches of an item to a prescription. In the detail view, click the expand button

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. The documentation already says that this should work
