### PR TITLE
5868 requisition name filter not working

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
@@ -64,7 +64,6 @@ export const ResponseRequisitionListView: FC = () => {
   });
   const pagination = { page, first, offset };
   const queryParams = { ...filter, sortBy, page, first, offset };
-  console.log('params at list view', queryParams);
   const { data, isError, isLoading } = useResponse.document.list(queryParams);
   const { authoriseResponseRequisitions } = useResponse.utils.preferences();
   useDisableResponseRows(data?.nodes);

--- a/client/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
@@ -51,6 +51,7 @@ export const ResponseRequisitionListView: FC = () => {
     },
     filters: [
       { key: 'comment' },
+      { key: 'otherPartyName' },
       {
         key: 'status',
         condition: 'equalTo',
@@ -63,6 +64,7 @@ export const ResponseRequisitionListView: FC = () => {
   });
   const pagination = { page, first, offset };
   const queryParams = { ...filter, sortBy, page, first, offset };
+  console.log('params at list view', queryParams);
   const { data, isError, isLoading } = useResponse.document.list(queryParams);
   const { authoriseResponseRequisitions } = useResponse.utils.preferences();
   useDisableResponseRows(data?.nodes);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5868 

# 👩🏻‍💻 What does this PR do?

Currently, filtering the requisitions list by name is not working. The `filters` array passed to `useUrlQueryParams` is missing the `otherPartyName` key. Adding this key resolves the filtering issue.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

![Screenshot 2025-01-10 at 11 46 49 AM](https://github.com/user-attachments/assets/9ebc606a-5481-43c4-878f-36238334b0d5)

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to the Requisitions page
- [ ] Filter the list by name

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
