### PR TITLE
5886 improve logout modal

### DIFF
--- a/client/packages/host/src/components/Footer/UserDetails.tsx
+++ b/client/packages/host/src/components/Footer/UserDetails.tsx
@@ -59,7 +59,6 @@ export const UserDetails: FC<PropsWithChildrenOnly> = ({ children }) => {
   return user ? (
     <PaperClickPopover
       placement="top"
-      width={300}
       Content={
         <PaperPopoverSection
           label={getLocalisedFullName(user.firstName, user.lastName)}

--- a/client/packages/host/src/components/Footer/UserDetails.tsx
+++ b/client/packages/host/src/components/Footer/UserDetails.tsx
@@ -26,7 +26,7 @@ export const UserDetails: FC<PropsWithChildrenOnly> = ({ children }) => {
   const { isLoading } = useUserDetails(token);
   const t = useTranslation();
   const { getLocalisedFullName } = useIntlUtils();
-  const LABEL_WIDTH = 80;
+  const LABEL_WIDTH = 150;
 
   const handleLogout = () => {
     navigate(RouteBuilder.create(AppRoute.Login).build());


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5886 

# 👩🏻‍💻 What does this PR do?
Remove width prop for paperclick modal so that long emails can be accommodated. Increase label width so that label and text no longer overlaps.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
![Screenshot 2025-01-13 at 12 23 41 PM](https://github.com/user-attachments/assets/e441ec03-f6a1-4d31-b6bf-7bbd7c9ab247)

## 💌 Any notes for the reviewer?
As label width is currently fixed we will need to keep an eye on whether any new translations will cause the label and text to overlap.
<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Open new user details modal from footer
- [ ] Check that labels and text do not overlap (check other languages as well)
- [ ] Check that long emails are fully shown

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
