### PR TITLE
Update cost per unit when items not grouped

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -38,7 +38,7 @@ export const useInboundShipmentColumns = () => {
     queryParams: { sortBy },
   } = useUrlQueryParams({ initialSort: { key: 'itemName', dir: 'asc' } });
   const getCostPrice = (row: InboundLineFragment) =>
-    isInboundPlaceholderRow(row) ? 0 : row.costPricePerPack;
+    isInboundPlaceholderRow(row) ? 0 : row.costPricePerPack / row.packSize;
   const { getColumnPropertyAsString, getColumnProperty } = useColumnUtils();
 
   const columns = useColumns<InboundLineFragment | InboundItem>(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4591 

# 👩🏻‍💻 What does this PR do?
Fix issue where cost per unit was not being calculated correctly when items were not grouped. 

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
![Screenshot 2025-01-13 at 4 35 09 PM](https://github.com/user-attachments/assets/c720989c-9b20-4166-8390-d8c840384d3e)
![Screenshot 2025-01-13 at 4 36 02 PM](https://github.com/user-attachments/assets/bcacb191-b7a7-487f-adaa-347ea202f950)
![Screenshot 2025-01-13 at 4 44 08 PM](https://github.com/user-attachments/assets/064e0061-b871-41ee-bdce-131d780c5309)
![Screenshot 2025-01-13 at 4 37 04 PM](https://github.com/user-attachments/assets/d2278f5d-5e5b-4cbc-bd5d-3ad021e071c4)

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Open inbound shipment
- [ ] Add item 
- [ ] Add a batch and update  pack size (e.g. 3, pack quantity (e.g. 1), and pack cost price (e.g $6).
- [ ] Go back to detail view and toggle Group by OFF
- [ ] Cost per unit should display $2.00 (e.g total cost (6 * 1) divided by pack size (3) = $2 cost per unit)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
