### PR TITLE
IO extra columns show with use consumption data pref

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -75,10 +75,8 @@ export const RequestLineEdit = ({
   const useConsumptionData =
     store?.preferences?.useConsumptionAndStockFromCustomersForInternalOrders;
   const isNew = !draft?.id;
-
-  const extraFields = store?.preferences?.extraFieldsInRequisition;
   const showItemInformation =
-    useConsumptionData && extraFields && !!draft?.itemInformation && isProgram;
+    useConsumptionData && !!draft?.itemInformation && isProgram;
   const itemInformationSorted = draft?.itemInformation
     ?.sort((a, b) => a.name.name.localeCompare(b.name.name))
     .sort((a, b) => b.amcInUnits - a.amcInUnits)
@@ -122,7 +120,7 @@ export const RequestLineEdit = ({
                 label={t('label.stock-on-hand')}
                 sx={{ marginBottom: 1 }}
               />
-              {isProgram && extraFields && (
+              {isProgram && useConsumptionData && (
                 <>
                   <InputWithLabelRow
                     Input={
@@ -214,7 +212,7 @@ export const RequestLineEdit = ({
                 label={t('label.amc')}
                 sx={{ marginBottom: 1 }}
               />
-              {isProgram && extraFields && (
+              {isProgram && useConsumptionData && (
                 <InputWithLabelRow
                   Input={
                     <NumericTextInput
@@ -360,7 +358,7 @@ export const RequestLineEdit = ({
                 label={t('label.suggested-quantity')}
                 sx={{ marginBottom: 1 }}
               />
-              {isProgram && extraFields && (
+              {isProgram && useConsumptionData && (
                 <InputWithLabelRow
                   Input={
                     <ReasonOptionsSearchInput


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6019

# 👩🏻‍💻 What does this PR do?
From specs

```
Note that the new columns have already been added to program based requisitions.
Implement the store permissions for
Keep requisition lines with zero requested quantity on finalise
Use consumption and clients stock data in internal orders
```

Showing extra columns only if the user has the `use consumption data` pref turned on.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have use consumption data pref off
- [ ] Create a program IO
- [ ] Don't see extra columns
- [ ] Turn pref on 
- [ ] Create program IO
- [ ] See extra columns

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
