### PR TITLE
5582 Add rounding to internal order request edit

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -259,7 +259,8 @@ export const RequestLineEdit = ({
                   Input={
                     <NumericTextInput
                       width={INPUT_WIDTH}
-                      value={draft?.requestedQuantity}
+                      // value={draft?.requestedQuantity}
+                      value={Math.ceil(draft?.requestedQuantity)}
                       disabled={isPacks}
                       onChange={value => {
                         if (draft?.suggestedQuantity === value) {
@@ -352,7 +353,8 @@ export const RequestLineEdit = ({
                 Input={
                   <NumericTextInput
                     width={INPUT_WIDTH}
-                    value={draft?.suggestedQuantity}
+                    value={Math.round(draft?.suggestedQuantity * 100) / 100}
+                    // value={draft?.suggestedQuantity}
                     disabled
                   />
                 }

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -352,7 +352,7 @@ export const RequestLineEdit = ({
                 Input={
                   <NumericTextInput
                     width={INPUT_WIDTH}
-                    value={Math.round(draft?.suggestedQuantity * 100) / 100}
+                    value={NumUtils.round(draft?.suggestedQuantity, 2)}
                     disabled
                   />
                 }

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -259,7 +259,6 @@ export const RequestLineEdit = ({
                   Input={
                     <NumericTextInput
                       width={INPUT_WIDTH}
-                      // value={draft?.requestedQuantity}
                       value={Math.ceil(draft?.requestedQuantity)}
                       disabled={isPacks}
                       onChange={value => {
@@ -354,7 +353,6 @@ export const RequestLineEdit = ({
                   <NumericTextInput
                     width={INPUT_WIDTH}
                     value={Math.round(draft?.suggestedQuantity * 100) / 100}
-                    // value={draft?.suggestedQuantity}
                     disabled
                   />
                 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5582 

# 👩🏻‍💻 What does this PR do?
Update ```Requested quantity``` to round up to next integer and update ```Suggested quantity``` to round to 2 decimal places.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
Before
![Screenshot 2025-01-14 at 11 12 59 AM](https://github.com/user-attachments/assets/054a86ce-39b2-42c4-93d6-0341fab518ec)

After
![Screenshot 2025-01-14 at 11 14 15 AM](https://github.com/user-attachments/assets/baf76c11-60ce-47f9-a6e6-0dbcc0095ae6)

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create internal order
- [ ] Add item (ensure SOH is lower than AMC)
- [ ] Observe that suggested quantity now rounds to 2 decimal places if number has decimals
- [ ] Toggle from ```units``` to ```packs``` and enter any number with decimals
- [ ] Observe that ```Requested quantity``` only displays a whole integer (not a number with decimals)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
