### PR TITLE
#6014 Handle date change properly

### DIFF
--- a/client/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.tsx
+++ b/client/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.tsx
@@ -90,7 +90,6 @@ export const ConfirmationModal = ({
                   await result;
                   setLoading(false);
                 }
-                onCancel();
               }}
               label={buttonLabel ? buttonLabel : t('button.ok')}
             />

--- a/client/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModalProvider.tsx
+++ b/client/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModalProvider.tsx
@@ -62,7 +62,10 @@ export const ConfirmationModalProvider: FC<PropsWithChildrenOnly> = ({
         message={message}
         info={info}
         title={title}
-        onConfirm={onConfirm}
+        onConfirm={async () => {
+          onConfirm && (await onConfirm());
+          setState(state => ({ ...state, open: false }));
+        }}
         onCancel={() => {
           setState(state => ({ ...state, open: false }));
           onCancel && onCancel();

--- a/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
@@ -59,7 +59,7 @@ export const Toolbar: FC = () => {
     if (!newPrescriptionDate) return;
     setDateValue(newPrescriptionDate);
 
-    const oldPrescriptionDate = DateUtils.getDateOrNull(prescriptionDate);
+    const oldPrescriptionDate = DateUtils.getDateOrNull(dateValue);
 
     if (
       newPrescriptionDate.toLocaleDateString() ===

--- a/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
@@ -30,6 +30,11 @@ export const Toolbar: FC = () => {
   const [clinicianValue, setClinicianValue] = useState<Clinician | null>(
     clinician ?? null
   );
+  const [dateValue, setDateValue] = useState(
+    DateUtils.getDateOrNull(prescriptionDate) ??
+      DateUtils.getDateOrNull(createdDatetime) ??
+      null
+  );
 
   const {
     delete: { deleteLines },
@@ -49,11 +54,18 @@ export const Toolbar: FC = () => {
   });
 
   const handleDateChange = async (newPrescriptionDate: Date | null) => {
+    const currentDateValue = dateValue; // Revert to this value if user cancels
+
     if (!newPrescriptionDate) return;
+    setDateValue(newPrescriptionDate);
 
     const oldPrescriptionDate = DateUtils.getDateOrNull(prescriptionDate);
 
-    if (newPrescriptionDate === oldPrescriptionDate) return;
+    if (
+      newPrescriptionDate.toLocaleDateString() ===
+      oldPrescriptionDate?.toLocaleDateString()
+    )
+      return;
 
     if (!items || items.length === 0) {
       // If there are no lines, we can just update the prescription date
@@ -77,13 +89,9 @@ export const Toolbar: FC = () => {
           ),
         });
       },
+      onCancel: () => setDateValue(currentDateValue),
     });
   };
-
-  const defaultPrescriptionDate =
-    DateUtils.getDateOrNull(prescriptionDate) ??
-    DateUtils.getDateOrNull(createdDatetime) ??
-    new Date();
 
   return (
     <AppBarContentPortal sx={{ display: 'flex', flex: 1, marginBottom: 1 }}>
@@ -139,14 +147,9 @@ export const Toolbar: FC = () => {
               Input={
                 <DateTimePickerInput
                   disabled={isDisabled}
-                  defaultValue={defaultPrescriptionDate}
-                  value={DateUtils.getDateOrNull(prescriptionDate)}
+                  value={DateUtils.getDateOrNull(dateValue) ?? new Date()}
                   format="P"
-                  // Using onAccept rather than onChange -- on mobile, onChange
-                  // is triggered when first opening the picker, which causes UI
-                  // conflict with the confirmation modal
-                  onAccept={handleDateChange}
-                  onChange={() => {}}
+                  onChange={handleDateChange}
                   maxDate={new Date()}
                 />
               }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6014

# 👩🏻‍💻 What does this PR do?

The date wasn't being saved if it was input via the text input (as opposed to the Date picker). This was due to the input only having an `onAccept` handler rather than `onChange`. This was done to fix an earlier change where the `onChange` method would run as soon as the Date picker opened on Mobile, and then cause a conflict with the confirmation modal.

There was a mistake in the `onChange` method when comparing dates -- we can't just use `===` to compare Date objects's values, so the early return from `onChange` when the date hasn't changed wasn't working. We should have just fixed that originally, rather than changing to `onAccept`, so have done that here, which solves the main issue.

Have also added another state value `"dateValue"` for the current prescription date, which means the Date input can show changes immediately rather than wait for the next round trip. Have also added an `onCancel` method for the confirmation to revert this date value when cancelling.

In the process of the above, I discovered a rather nasty bug in the existing ConfirmationModal -- it was running `onCancel` as well as `onConfirm` when confirming. I think we've not noticed this before as we haven't really had explicit `onCancel` events defined. But anyway, have also fixed that.

## 💌 Any notes for the reviewer?

See review comments for further detail

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

(Would probably be a good idea to do these tests on both Android and in browser as the behaviours of the Date picker can be slightly different)

- [ ] Can change the date by editing the text input (not DatePicker) for a prescription and ensure the results are saved (refresh, or go out and back in)
- [ ] When changing the date for a prescription with items already added, confirm that the "Are you sure?" confirmation pops up:
  - [ ] When confirming, the items should be removed and the date should be changed
  - [ ] When cancelling, the items should be unchanged and the date should be reset back to its previous value (i.e. not changed)
- [ ] Edit the date, but revert it to its original value before exiting the input -- you should NOT get the confirmation
- [ ] Do the above with the normal DatePicker and confirm behaviour is correct