### PR TITLE
4015 Allow filtering "View Stock Page" by master list

### DIFF
--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -21,6 +21,7 @@ import { AppBarButtons } from './AppBarButtons';
 import { Toolbar } from './Toolbar';
 import { AppRoute } from '@openmsupply-client/config';
 import { useStockList } from '../api/hooks/useStockList';
+import { ChipTableCell } from '../../Patient';
 
 const StockListComponent: FC = () => {
   const {
@@ -39,11 +40,14 @@ const StockListComponent: FC = () => {
         key: 'expiryDate',
         condition: 'between',
       },
+      {
+        key: 'masterList.name',
+      },
     ],
   });
   const navigate = useNavigate();
   const queryParams = {
-    filterBy,
+    filterBy: filterBy ?? undefined,
     offset,
     sortBy,
     first,
@@ -71,7 +75,13 @@ const StockListComponent: FC = () => {
       Cell: TooltipTextCell,
       width: 350,
     },
-    // TODO:: Add a column for the master list name
+    {
+      key: 'masterList',
+      label: 'label.master-list',
+      Cell: ChipTableCell,
+      width: 150,
+      accessor: ({ rowData }) => rowData.masterList.map(m => m.name),
+    },
     { key: 'batch', label: 'label.batch', Cell: TooltipTextCell, width: 100 },
     {
       key: 'expiryDate',

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -21,7 +21,6 @@ import { AppBarButtons } from './AppBarButtons';
 import { Toolbar } from './Toolbar';
 import { AppRoute } from '@openmsupply-client/config';
 import { useStockList } from '../api/hooks/useStockList';
-import { ChipTableCell } from '../../Patient';
 
 const StockListComponent: FC = () => {
   const {
@@ -75,13 +74,14 @@ const StockListComponent: FC = () => {
       Cell: TooltipTextCell,
       width: 350,
     },
-    {
-      key: 'masterList',
-      label: 'label.master-list',
-      Cell: ChipTableCell,
-      width: 150,
-      accessor: ({ rowData }) => rowData.masterList.map(m => m.name),
-    },
+    // TODO: Add back when design has been decided
+    // {
+    //   key: 'masterList',
+    //   label: 'label.master-list',
+    //   Cell: ChipTableCell,
+    //   width: 150,
+    //   accessor: ({ rowData }) => rowData.masterList.map(m => m.name),
+    // },
     { key: 'batch', label: 'label.batch', Cell: TooltipTextCell, width: 100 },
     {
       key: 'expiryDate',

--- a/client/packages/system/src/Stock/api/hooks/useStockList.ts
+++ b/client/packages/system/src/Stock/api/hooks/useStockList.ts
@@ -1,6 +1,6 @@
 import {
-  FilterByWithBoolean,
   SortBy,
+  StockLineFilterInput,
   StockLineNode,
   StockLineSortFieldInput,
   useQuery,
@@ -13,7 +13,7 @@ export type ListParams = {
   first?: number;
   offset?: number;
   sortBy?: SortBy<StockLineRowFragment>;
-  filterBy?: FilterByWithBoolean | null;
+  filterBy?: StockLineFilterInput;
 };
 
 export const useStockList = (queryParams: ListParams) => {
@@ -39,6 +39,7 @@ export const useStockList = (queryParams: ListParams) => {
       hasPacksInStore: true,
       masterList: {
         existsForStoreId: { equalTo: storeId },
+        ...filterBy?.masterList,
       },
     };
     const query = await stockApi.stockLines({


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4015

# 👩🏻‍💻 What does this PR do?
Display master list names in stock view and allow the user to filter by master list

![nn](https://github.com/user-attachments/assets/38f87eb9-d342-4236-817c-c85ae8df59a0)

![Screenshot 2025-01-15 at 8 16 41 AM](https://github.com/user-attachments/assets/75543944-5d0c-4a36-bdcc-1a55bc3aa0eb)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to stock view
- [ ] See master list name listed
- [ ] Click filter -> filter by master list name
- [ ] Start filtering

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Stock screenshots
  2.
