### PR TITLE
6070 Localise ledger date + fix adjustment calculation

### DIFF
--- a/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
@@ -37,7 +37,7 @@ const ItemLedgerTable = ({
   const pagination = { page, first, offset };
 
   const { data, isLoading } = useItemLedger(itemId);
-  const { localisedTime } = useFormatDateTime();
+  const { localisedTime, localisedDate } = useFormatDateTime();
 
   const columns = useColumns<ItemLedgerFragment>(
     [
@@ -53,6 +53,7 @@ const ItemLedgerTable = ({
         label: 'label.date',
         format: ColumnFormat.Date,
         sortable: false,
+        accessor: ({ rowData }) => localisedDate(rowData.datetime),
       },
       {
         key: 'time',

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
@@ -37,7 +37,7 @@ const ItemLedgerTable = ({
   const pagination = { page, first, offset };
 
   const { data, isLoading } = useItemLedger(itemId);
-  const { localisedTime, localisedDate } = useFormatDateTime();
+  const { localisedTime } = useFormatDateTime();
 
   const columns = useColumns<ItemLedgerFragment>(
     [
@@ -53,7 +53,6 @@ const ItemLedgerTable = ({
         label: 'label.date',
         format: ColumnFormat.Date,
         sortable: false,
-        accessor: ({ rowData }) => localisedDate(rowData.datetime),
       },
       {
         key: 'time',

--- a/server/service/src/requisition/request_requisition/requisition_item_info.rs
+++ b/server/service/src/requisition/request_requisition/requisition_item_info.rs
@@ -346,7 +346,7 @@ fn get_store_information(
         id: store_name.id.clone(),
         amc_in_units: area_amc,
         stock_in_units: ledger.map_or(0.0, |l| l.balance),
-        adjustments_in_units: additions_in_units + losses_in_units + adjustments_in_units,
+        adjustments_in_units: additions_in_units - losses_in_units + adjustments_in_units,
         outgoing_units: losses_in_units,
         date_range: end_date.and_hms_opt(0, 0, 0),
     })


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6070

# 👩🏻‍💻 What does this PR do?
Fix calculation for ledger adjustment + localise date

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have `use consumption data from customers` pref on
- [ ] Create an IO at a store that is a supplying store for another customer
- [ ] Add an item line that has previous requisitions made for it in the same period (note should have other data such as IA + Inbound/Outbound Shipments for this item in the same period)
- [ ] Check the adjustment column for this item for the store (table at the bottom of the input). The calculation should be for period: Delivered Inbound - Verified Outbound + IA (any reductions/additions)

Second:
- [ ] Change timezone and make sure the date is correct with OG

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
