### PR TITLE
6097 Stocktake with quantity and without quanity seem to be wrong way around?

### DIFF
--- a/server/reports/stock-take-with-quantity/2_3_0/src/template.html
+++ b/server/reports/stock-take-with-quantity/2_3_0/src/template.html
@@ -6,13 +6,14 @@
         <div class="main-table">
             <div class="table-header">
                 <div class="row">
-                <div class="bold col col-location">{{t(k="label.location", f="Location")}}</div>
-                <div class="bold col col-item-code">{{t(k="label.code", f="Code")}}</div>
-                <div class="bold col col-item-name">{{t(k="report.item-name", f="Item name")}}</div>
-                <div class="bold col col-batch">{{t(k="label.batch", f="batch")}}</div>
-                <div class="bold col col-expiry-date">{{t(k="label.expiry", f="Expiry")}}</div>
-                <div class="bold col col-packsize">{{t(k="label.pack",f="Pack")}}</div>
-                <div class="bold col col-actual-stock">{{t(k="report.actual-stock",f="Actual Stock")}}</div>
+                    <div class="bold col col-location">{{t(k="label.location",f="Location")}}</div>
+                    <div class="bold col col-item-code">{{t(k="label.code", f="Code")}}</div>
+                    <div class="bold col col-item-name">{{t(k="report.item-name",f="Item name")}}</div>
+                    <div class="bold col col-batch">{{t(k="label.batch", f="Batch")}}</div>
+                    <div class="bold col col-expiry-date">{{t(k="report.expiry-date",f="Expiry date")}}</div>
+                    <div class="bold col col-packsize">{{t(k="label.pack",f="Pack")}}</div>
+                    <div class="bold col col-packsize">{{t(k="report.quan",f="Quan")}}</div>
+                    <div class="bold col col-actual-stock">{{t(k="report.actual",f="Actual")}}</div>
                 </div>
             </div>
             <div class="table-body">
@@ -32,6 +33,7 @@
                         {% endif %}
                     </div>
                     <div class="col col-packsize">{{ line.packSize }}</div>
+                    <div class="col col-quantity">{{ line.countedNumberOfPacks }}</div>
                     <div class="col col-actual-stock">.....................</div>
                 </div>
                 {%- endfor %}

--- a/server/reports/stock-take-without-quantity/2_3_0/src/template.html
+++ b/server/reports/stock-take-without-quantity/2_3_0/src/template.html
@@ -6,14 +6,13 @@
         <div class="main-table">
             <div class="table-header">
                 <div class="row">
-                    <div class="bold col col-location">{{t(k="label.location",f="Location")}}</div>
-                    <div class="bold col col-item-code">{{t(k="label.code", f="Code")}}</div>
-                    <div class="bold col col-item-name">{{t(k="report.item-name",f="Item name")}}</div>
-                    <div class="bold col col-batch">{{t(k="label.batch", f="Batch")}}</div>
-                    <div class="bold col col-expiry-date">{{t(k="report.expiry-date",f="Expiry date")}}</div>
-                    <div class="bold col col-packsize">{{t(k="label.pack",f="Pack")}}</div>
-                    <div class="bold col col-packsize">{{t(k="report.quan",f="Quan")}}</div>
-                    <div class="bold col col-actual-stock">{{t(k="report.actual",f="Actual")}}</div>
+                <div class="bold col col-location">{{t(k="label.location", f="Location")}}</div>
+                <div class="bold col col-item-code">{{t(k="label.code", f="Code")}}</div>
+                <div class="bold col col-item-name">{{t(k="report.item-name", f="Item name")}}</div>
+                <div class="bold col col-batch">{{t(k="label.batch", f="batch")}}</div>
+                <div class="bold col col-expiry-date">{{t(k="label.expiry", f="Expiry")}}</div>
+                <div class="bold col col-packsize">{{t(k="label.pack",f="Pack")}}</div>
+                <div class="bold col col-actual-stock">{{t(k="report.actual-stock",f="Actual Stock")}}</div>
                 </div>
             </div>
             <div class="table-body">
@@ -33,7 +32,6 @@
                         {% endif %}
                     </div>
                     <div class="col col-packsize">{{ line.packSize }}</div>
-                    <div class="col col-quantity">{{ line.countedNumberOfPacks }}</div>
                     <div class="col col-actual-stock">.....................</div>
                 </div>
                 {%- endfor %}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6097

# 👩🏻‍💻 What does this PR do?
Rename stocktake reports to have correct name

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create stocktake 
- [ ] Go to detail view of stock take
- [ ] click print
- [ ] Confirm that the name of the report matches the info

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
