### PR TITLE
6092 Add icon and update shouldShrink

### DIFF
--- a/client/packages/common/src/ui/components/buttons/standard/DialogButton.tsx
+++ b/client/packages/common/src/ui/components/buttons/standard/DialogButton.tsx
@@ -37,6 +37,7 @@ interface DialogButtonProps {
   color?: 'primary';
   type?: 'button' | 'submit' | 'reset';
   customLabel?: string;
+  shouldShrink?: boolean;
 }
 
 const getButtonProps = (
@@ -124,6 +125,7 @@ export const DialogButton: React.FC<DialogButtonProps> = ({
   color,
   type,
   customLabel,
+  shouldShrink,
 }) => {
   const t = useTranslation();
   const { variant: buttonVariant, icon, labelKey } = getButtonProps(variant);
@@ -152,6 +154,7 @@ export const DialogButton: React.FC<DialogButtonProps> = ({
             }
           : {}
       }
+      shouldShrink={shouldShrink}
     />
   );
 };

--- a/client/packages/system/src/Stock/DetailView/Footer.tsx
+++ b/client/packages/system/src/Stock/DetailView/Footer.tsx
@@ -6,6 +6,7 @@ import {
   DialogButton,
   LoadingButton,
   useBreadcrumbs,
+  SaveIcon,
 } from '@openmsupply-client/common';
 import { FormInputData } from '@openmsupply-client/programs';
 
@@ -52,6 +53,7 @@ export const Footer: FC<FooterProps> = ({
               onClick={() =>
                 isDirty ? showCancelConfirmation() : navigateUpOne()
               }
+              shouldShrink={false}
             />
             <LoadingButton
               color="secondary"
@@ -61,6 +63,8 @@ export const Footer: FC<FooterProps> = ({
               label={
                 inputData?.isCreating ? t('button.create') : t('button.save')
               }
+              startIcon={<SaveIcon />}
+              shouldShrink={false}
             />
           </Box>
         </Box>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6092 

# 👩🏻‍💻 What does this PR do?
Add save icon and update ```shouldShrink``` to ```false```for buttons in View Stock detail view footer

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
<img width="1301" alt="Screenshot 2025-01-17 at 10 08 49 AM" src="https://github.com/user-attachments/assets/22422a6a-ac0b-494f-aac9-8a162dc16e43" />

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to Inventory -> View Stock
- [ ] Click on any item
- [ ] Observe that save button now has icon
- [ ] Shrink screen and observe that save and close buttons do not shrink

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
