### PR TITLE
5102 cannot change servers tablet

### DIFF
--- a/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
+++ b/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
@@ -35,8 +35,6 @@ type NativeClientState = {
   discoveryTimedOut: boolean;
   isDiscovering: boolean;
   previousServer: FrontEndHost | null;
-  // User configuration mode for the app, client/server
-  mode: NativeMode;
   servers: FrontEndHost[];
 };
 
@@ -58,7 +56,6 @@ export const useNativeClient = ({
     discoveryTimedOut: false,
     isDiscovering: false,
     previousServer: null,
-    mode: NativeMode.None,
     servers: [],
   });
 

--- a/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
+++ b/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
@@ -35,6 +35,8 @@ type NativeClientState = {
   discoveryTimedOut: boolean;
   isDiscovering: boolean;
   previousServer: FrontEndHost | null;
+  // User configuration mode for the app, client/server
+  mode: NativeMode;
   servers: FrontEndHost[];
 };
 
@@ -56,6 +58,7 @@ export const useNativeClient = ({
     discoveryTimedOut: false,
     isDiscovering: false,
     previousServer: null,
+    mode: NativeMode.None,
     servers: [],
   });
 

--- a/client/packages/host/src/components/SiteInfo.tsx
+++ b/client/packages/host/src/components/SiteInfo.tsx
@@ -30,7 +30,6 @@ const RowWithLabel = ({
 export const SiteInfo: FC<{ siteName?: string | null }> = ({ siteName }) => {
   const { connectedServer, goBackToDiscovery, mode } = useNativeClient();
   const t = useTranslation();
-  console.log('connectedServer', connectedServer);
   if (!connectedServer) return null;
 
   return (

--- a/client/packages/host/src/components/SiteInfo.tsx
+++ b/client/packages/host/src/components/SiteInfo.tsx
@@ -3,6 +3,7 @@ import {
   frontEndHostUrl,
   Grid,
   IconButton,
+  NativeMode,
   Typography,
   useNativeClient,
 } from '@openmsupply-client/common';
@@ -27,7 +28,7 @@ const RowWithLabel = ({
 );
 
 export const SiteInfo: FC<{ siteName?: string | null }> = ({ siteName }) => {
-  const { connectedServer, goBackToDiscovery } = useNativeClient();
+  const { connectedServer, goBackToDiscovery, mode } = useNativeClient();
   const t = useTranslation();
   if (!connectedServer) return null;
 
@@ -39,21 +40,23 @@ export const SiteInfo: FC<{ siteName?: string | null }> = ({ siteName }) => {
           contents={<Typography whiteSpace="nowrap">{siteName}</Typography>}
         />
       )}
-      <RowWithLabel
-        label={`${t('label.server')}:`}
-        contents={
-          <>
-            <Typography whiteSpace="nowrap">
-              {frontEndHostUrl(connectedServer)}
-            </Typography>
-            <IconButton
-              label={t('messages.change-server')}
-              icon={<EditIcon style={{ height: 16, width: 16 }} />}
-              onClick={() => goBackToDiscovery()}
-            />
-          </>
-        }
-      />
+      {mode === NativeMode.Client && (
+        <RowWithLabel
+          label={`${t('label.server')}:`}
+          contents={
+            <>
+              <Typography whiteSpace="nowrap">
+                {frontEndHostUrl(connectedServer)}
+              </Typography>
+              <IconButton
+                label={t('messages.change-server')}
+                icon={<EditIcon style={{ height: 16, width: 16 }} />}
+                onClick={() => goBackToDiscovery()}
+              />
+            </>
+          }
+        />
+      )}
     </>
   );
 };

--- a/client/packages/host/src/components/SiteInfo.tsx
+++ b/client/packages/host/src/components/SiteInfo.tsx
@@ -1,6 +1,8 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import {
   frontEndHostUrl,
+  getNativeAPI,
+  getPreference,
   Grid,
   IconButton,
   NativeMode,
@@ -28,8 +30,17 @@ const RowWithLabel = ({
 );
 
 export const SiteInfo: FC<{ siteName?: string | null }> = ({ siteName }) => {
-  const { connectedServer, goBackToDiscovery, mode } = useNativeClient();
   const t = useTranslation();
+  const nativeApi = getNativeAPI();
+  const [localMode, setLocalMode] = useState(NativeMode.None);
+  const { connectedServer, goBackToDiscovery } = useNativeClient();
+
+  useEffect(() => {
+    getPreference('mode', '"none"').then(setLocalMode);
+  }, []);
+
+  const renderServerRow = !nativeApi || localMode !== NativeMode.Server;
+
   if (!connectedServer) return null;
 
   return (
@@ -40,7 +51,7 @@ export const SiteInfo: FC<{ siteName?: string | null }> = ({ siteName }) => {
           contents={<Typography whiteSpace="nowrap">{siteName}</Typography>}
         />
       )}
-      {mode === NativeMode.Client && (
+      {renderServerRow && (
         <RowWithLabel
           label={`${t('label.server')}:`}
           contents={

--- a/client/packages/host/src/components/SiteInfo.tsx
+++ b/client/packages/host/src/components/SiteInfo.tsx
@@ -36,7 +36,7 @@ export const SiteInfo: FC<{ siteName?: string | null }> = ({ siteName }) => {
   const { connectedServer, goBackToDiscovery } = useNativeClient();
 
   useEffect(() => {
-    getPreference('mode', '"none"').then(setLocalMode);
+    getPreference('mode', NativeMode.None).then(setLocalMode);
   }, []);
 
   const renderServerRow = !nativeApi || localMode !== NativeMode.Server;

--- a/client/packages/host/src/components/SiteInfo.tsx
+++ b/client/packages/host/src/components/SiteInfo.tsx
@@ -30,6 +30,7 @@ const RowWithLabel = ({
 export const SiteInfo: FC<{ siteName?: string | null }> = ({ siteName }) => {
   const { connectedServer, goBackToDiscovery, mode } = useNativeClient();
   const t = useTranslation();
+  console.log('connectedServer', connectedServer);
   if (!connectedServer) return null;
 
   return (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5102 

# 👩🏻‍💻 What does this PR do?

Tablet - Shouldn't be able to change servers if a user decides to initialise via the Server.

When initializing or going through the Client, users can change the server without any issues. However, initializing through the Server causes an authentication issue when a user tries to change servers.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

<img width="1341" alt="Screenshot 2025-01-17 at 11 57 43 AM" src="https://github.com/user-attachments/assets/53681ad0-28f4-406f-aaf0-6bca9e210594" />

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Run in tablet
- [ ] Initialise OMS through Server mode
- [ ] After initialise, login page shouldn't have the ability to change servers

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
