### PR TITLE
#6078 Prevent unnecessary scrolling

### DIFF
--- a/client/packages/common/src/ui/components/navigation/ListOptions/ListOptions.tsx
+++ b/client/packages/common/src/ui/components/navigation/ListOptions/ListOptions.tsx
@@ -21,7 +21,7 @@ interface ListProps {
   options: ListOptionValues[];
   currentId?: string;
   enteredLineIds?: string[];
-  scrollRef?: React.MutableRefObject<HTMLLIElement | null>;
+  scrollRef: React.MutableRefObject<HTMLLIElement | null>;
 }
 
 export const ListOptions = ({

--- a/client/packages/common/src/ui/components/navigation/ListOptions/ListOptions.tsx
+++ b/client/packages/common/src/ui/components/navigation/ListOptions/ListOptions.tsx
@@ -21,6 +21,7 @@ interface ListProps {
   options: ListOptionValues[];
   currentId?: string;
   enteredLineIds?: string[];
+  scrollRef?: React.MutableRefObject<HTMLLIElement | null>;
 }
 
 export const ListOptions = ({
@@ -28,6 +29,7 @@ export const ListOptions = ({
   options,
   currentId,
   enteredLineIds,
+  scrollRef,
 }: ListProps) => {
   const { height } = useWindowDimensions();
 
@@ -64,12 +66,7 @@ export const ListOptions = ({
           <ListItem
             sx={{ padding: '5px 0px', cursor: 'pointer' }}
             onClick={() => onClick(option.id)}
-            ref={
-              option.id === currentId
-                ? l =>
-                    l?.scrollIntoView({ behavior: 'smooth', block: 'center' })
-                : null
-            }
+            ref={option.id === currentId ? scrollRef : null}
           >
             <ListItemIcon sx={{ padding: 0, minWidth: 25 }}>
               <Box

--- a/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
@@ -38,6 +38,14 @@ export const PrescriptionLineEditView = () => {
 
   const newItemId = useRef<string>();
 
+  // This ref is attached to the currently selected list item, and is used to
+  // "scroll into view" when the Previous/Next buttons are clicked in the NavBar
+  const scrollRef = useRef<null | HTMLLIElement>(null);
+  const scrollSelectedItemIntoView = () =>
+    // Small time delay to allow the ref to change to the previous/next item in
+    // the list before scrolling to it
+    setTimeout(() => scrollRef.current?.scrollIntoView(), 100);
+
   const { isDirty, setIsDirty } = useDirtyCheck();
 
   const lines =
@@ -162,6 +170,7 @@ export const PrescriptionLineEditView = () => {
             showNew={status !== InvoiceNodeStatus.Verified}
             isDirty={isDirty}
             handleSaveNew={onSave}
+            scrollRef={scrollRef}
           />
         }
         Right={
@@ -184,6 +193,7 @@ export const PrescriptionLineEditView = () => {
                     .build()
                 )
               }
+              scrollIntoView={scrollSelectedItemIntoView}
             />
           </>
         }

--- a/client/packages/invoices/src/Prescriptions/LineEditView/NavBar.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/NavBar.tsx
@@ -17,12 +17,14 @@ interface NavBarProps {
   items: string[];
   currentItem: string;
   setItem: (itemId: string) => void;
+  scrollIntoView: () => void;
 }
 
 export const NavBar: React.FC<NavBarProps> = ({
   items,
   currentItem,
   setItem,
+  scrollIntoView,
 }) => {
   const t = useTranslation();
   const currentIndex = items.findIndex(item => item === currentItem);
@@ -48,6 +50,7 @@ export const NavBar: React.FC<NavBarProps> = ({
         disabled={!hasPrevious}
         onClick={() => {
           setItem(items[currentIndex - 1] ?? '');
+          scrollIntoView();
         }}
       />
       <Typography>
@@ -60,6 +63,7 @@ export const NavBar: React.FC<NavBarProps> = ({
         disabled={!hasNext}
         onClick={() => {
           setItem(items[currentIndex + 1] ?? '');
+          scrollIntoView();
         }}
       />
     </Box>

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/Footer.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/Footer.tsx
@@ -9,6 +9,7 @@ interface FooterProps {
   hasPrevious: boolean;
   previous: IndicatorLineRowFragment | null;
   requisitionNumber?: number;
+  scrollIntoView: () => void;
 }
 
 export const Footer = ({
@@ -17,10 +18,17 @@ export const Footer = ({
   hasPrevious,
   previous,
   requisitionNumber,
+  scrollIntoView,
 }: FooterProps) => {
   const navigateTo = useIndicatorNavigation(requisitionNumber);
-  const navigateToNext = () => navigateTo(next?.id);
-  const navigateToPrevious = () => navigateTo(previous?.id);
+  const navigateToNext = () => {
+    navigateTo(next?.id);
+    scrollIntoView();
+  };
+  const navigateToPrevious = () => {
+    navigateTo(previous?.id);
+    scrollIntoView();
+  };
 
   return (
     <AppFooterPortal

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/IndicatorEditPage.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/IndicatorEditPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import {
   BasicSpinner,
   DetailContainer,
@@ -65,6 +65,14 @@ export const IndicatorEditPage = () => {
     );
   }, [programIndicatorLineId, programIndicators]);
 
+  // This ref is attached to the currently selected list item, and is used to
+  // "scroll into view" when the Previous/Next buttons are clicked in the NavBar
+  const scrollRef = useRef<null | HTMLLIElement>(null);
+  const scrollSelectedItemIntoView = () =>
+    // Small time delay to allow the ref to change to the previous/next item in
+    // the list before scrolling to it
+    setTimeout(() => scrollRef.current?.scrollIntoView(), 100);
+
   if (isLoading || isProgramIndicatorsLoading) {
     return <BasicSpinner />;
   }
@@ -87,6 +95,7 @@ export const IndicatorEditPage = () => {
                   .addPart(String(request?.requisitionNumber))
                   .addPart(AppRoute.Indicators)
                   .addPart(String(programIndicatorCode))}
+                scrollRef={scrollRef}
               />
             </>
           }
@@ -100,6 +109,7 @@ export const IndicatorEditPage = () => {
                 previous={previous}
                 requisitionNumber={request?.requisitionNumber}
                 disabled={isDisabled}
+                scrollIntoView={scrollSelectedItemIntoView}
               />
             </>
           }

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
@@ -27,6 +27,7 @@ interface IndicatorLineEditProps {
   previous: IndicatorLineRowFragment | null;
   currentLine?: IndicatorLineWithColumnsFragment | null;
   disabled: boolean;
+  scrollIntoView: () => void;
 }
 
 const INPUT_WIDTH = 185;
@@ -108,6 +109,7 @@ export const IndicatorLineEdit = ({
   previous,
   currentLine,
   disabled,
+  scrollIntoView,
 }: IndicatorLineEditProps) => {
   const columns =
     currentLine?.columns
@@ -143,6 +145,7 @@ export const IndicatorLineEdit = ({
           hasPrevious={hasPrevious}
           previous={previous}
           requisitionNumber={requisitionNumber}
+          scrollIntoView={scrollIntoView}
         />
       </Box>
     </>

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/Footer.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/Footer.tsx
@@ -14,6 +14,7 @@ interface FooterProps {
   hasPrevious: boolean;
   previous: ItemRowFragment | null;
   requisitionNumber?: number;
+  scrollIntoView: () => void;
 }
 
 export const Footer = ({
@@ -22,6 +23,7 @@ export const Footer = ({
   hasPrevious,
   previous,
   requisitionNumber,
+  scrollIntoView,
 }: FooterProps) => {
   const navigate = useNavigate();
 
@@ -45,16 +47,18 @@ export const Footer = ({
             <DialogButton
               variant="previous"
               disabled={!hasPrevious}
-              onClick={() =>
-                navigate(buildItemEditRoute(requisitionNumber, previous?.id))
-              }
+              onClick={() => {
+                navigate(buildItemEditRoute(requisitionNumber, previous?.id));
+                scrollIntoView();
+              }}
             />
             <DialogButton
               variant="next"
               disabled={!hasNext}
-              onClick={() =>
-                navigate(buildItemEditRoute(requisitionNumber, next?.id))
-              }
+              onClick={() => {
+                navigate(buildItemEditRoute(requisitionNumber, next?.id));
+                scrollIntoView();
+              }}
             />
           </Box>
         </Box>

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestEditPage.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestEditPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   BasicSpinner,
   DetailContainer,
@@ -38,6 +38,14 @@ export const RequestLineEditPage = () => {
     : [];
   const isProgram = !!data?.programName;
 
+  // This ref is attached to the currently selected list item, and is used to
+  // "scroll into view" when the Previous/Next buttons are clicked in the NavBar
+  const scrollRef = useRef<null | HTMLLIElement>(null);
+  const scrollSelectedItemIntoView = () =>
+    // Small time delay to allow the ref to change to the previous/next item in
+    // the list before scrolling to it
+    setTimeout(() => scrollRef.current?.scrollIntoView(), 100);
+
   useEffect(() => {
     setCustomBreadcrumbs({
       2: currentItem?.name || '',
@@ -63,6 +71,7 @@ export const RequestLineEditPage = () => {
               showNew={
                 data?.status !== RequisitionNodeStatus.Sent && !isProgram
               }
+              scrollRef={scrollRef}
             />
           }
           Right={
@@ -83,6 +92,7 @@ export const RequestLineEditPage = () => {
               requisitionId={data?.id ?? ''}
               requisitionNumber={data?.requisitionNumber}
               lines={lines}
+              scrollIntoView={scrollSelectedItemIntoView}
             />
           }
         />

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -48,6 +48,7 @@ interface RequestLineEditProps {
   requisitionNumber?: number;
   requisitionId: string;
   insert: (patch: InsertRequestRequisitionLineInput) => void;
+  scrollIntoView: () => void;
 }
 
 export const RequestLineEdit = ({
@@ -66,6 +67,7 @@ export const RequestLineEdit = ({
   requisitionNumber,
   requisitionId,
   insert,
+  scrollIntoView,
 }: RequestLineEditProps) => {
   const t = useTranslation();
   const navigate = useNavigate();
@@ -417,6 +419,7 @@ export const RequestLineEdit = ({
           hasPrevious={hasPrevious}
           previous={previous}
           requisitionNumber={draft?.requisitionNumber}
+          scrollIntoView={scrollIntoView}
         />
       </Box>
     </Box>

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/Footer.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/Footer.tsx
@@ -16,6 +16,7 @@ interface FooterProps {
   hasPrevious: boolean;
   previous: IndicatorLineRowFragment | null;
   requisitionNumber?: number;
+  scrollIntoView: () => void;
 }
 
 export const Footer = ({
@@ -24,6 +25,7 @@ export const Footer = ({
   hasPrevious,
   previous,
   requisitionNumber,
+  scrollIntoView,
 }: FooterProps) => {
   const navigate = useNavigate();
   const { programIndicatorCode } = useParams();
@@ -48,7 +50,7 @@ export const Footer = ({
             <DialogButton
               variant="previous"
               disabled={!hasPrevious}
-              onClick={() =>
+              onClick={() => {
                 navigate(
                   RouteBuilder.create(AppRoute.Distribution)
                     .addPart(AppRoute.CustomerRequisition)
@@ -57,13 +59,14 @@ export const Footer = ({
                     .addPart(String(programIndicatorCode))
                     .addPart(String(previous?.id))
                     .build()
-                )
-              }
+                );
+                scrollIntoView();
+              }}
             />
             <DialogButton
               variant="next"
               disabled={!hasNext}
-              onClick={() =>
+              onClick={() => {
                 navigate(
                   RouteBuilder.create(AppRoute.Distribution)
                     .addPart(AppRoute.CustomerRequisition)
@@ -72,8 +75,9 @@ export const Footer = ({
                     .addPart(String(programIndicatorCode))
                     .addPart(String(next?.id))
                     .build()
-                )
-              }
+                );
+                scrollIntoView();
+              }}
             />
           </Box>
         </Box>

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorEditPage.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorEditPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import {
   BasicSpinner,
   DetailContainer,
@@ -63,6 +63,14 @@ export const IndicatorEditPage = () => {
     );
   }, [programIndicatorLineId, programIndicators]);
 
+  // This ref is attached to the currently selected list item, and is used to
+  // "scroll into view" when the Previous/Next buttons are clicked in the NavBar
+  const scrollRef = useRef<null | HTMLLIElement>(null);
+  const scrollSelectedItemIntoView = () =>
+    // Small time delay to allow the ref to change to the previous/next item in
+    // the list before scrolling to it
+    setTimeout(() => scrollRef.current?.scrollIntoView(), 100);
+
   if (isLoading || isProgramIndicatorsLoading) {
     return <BasicSpinner />;
   }
@@ -85,6 +93,7 @@ export const IndicatorEditPage = () => {
                   .addPart(String(response?.requisitionNumber))
                   .addPart(AppRoute.Indicators)
                   .addPart(String(programIndicatorCode))}
+                scrollRef={scrollRef}
               />
             </>
           }
@@ -98,6 +107,7 @@ export const IndicatorEditPage = () => {
                 previous={previous}
                 requisitionNumber={response?.requisitionNumber}
                 disabled={isDisabled}
+                scrollIntoView={scrollSelectedItemIntoView}
               />
             </>
           }

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
@@ -25,6 +25,7 @@ interface IndicatorLineEditProps {
   previous: IndicatorLineRowFragment | null;
   currentLine?: IndicatorLineWithColumnsFragment | null;
   disabled: boolean;
+  scrollIntoView: () => void;
 }
 
 const INPUT_WIDTH = 185;
@@ -105,6 +106,7 @@ export const IndicatorLineEdit = ({
   previous,
   currentLine,
   disabled,
+  scrollIntoView,
 }: IndicatorLineEditProps) => {
   const columns = currentLine?.columns
     .filter(c => c.value) // Columns may be added to a program after the requisition was made, we want to hide those
@@ -131,6 +133,7 @@ export const IndicatorLineEdit = ({
           hasPrevious={hasPrevious}
           previous={previous}
           requisitionNumber={requisitionNumber}
+          scrollIntoView={scrollIntoView}
         />
       </Box>
     </>

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/Footer.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/Footer.tsx
@@ -14,6 +14,7 @@ interface FooterProps {
   hasPrevious: boolean;
   previous: ItemRowFragment | null;
   requisitionNumber?: number;
+  scrollIntoView: () => void;
 }
 
 export const Footer = ({
@@ -22,6 +23,7 @@ export const Footer = ({
   hasPrevious,
   previous,
   requisitionNumber,
+  scrollIntoView,
 }: FooterProps) => {
   const navigate = useNavigate();
 
@@ -45,16 +47,18 @@ export const Footer = ({
             <DialogButton
               variant="previous"
               disabled={!hasPrevious}
-              onClick={() =>
-                navigate(buildItemEditRoute(requisitionNumber, previous?.id))
-              }
+              onClick={() => {
+                navigate(buildItemEditRoute(requisitionNumber, previous?.id));
+                scrollIntoView();
+              }}
             />
             <DialogButton
               variant="next"
               disabled={!hasNext}
-              onClick={() =>
-                navigate(buildItemEditRoute(requisitionNumber, next?.id))
-              }
+              onClick={() => {
+                navigate(buildItemEditRoute(requisitionNumber, next?.id));
+                scrollIntoView();
+              }}
             />
           </Box>
         </Box>

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditPage.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import {
   BasicSpinner,
   DetailContainer,
@@ -58,6 +58,14 @@ const ResponseLineEditPageInner = ({
     });
   }, [currentItem]);
 
+  // This ref is attached to the currently selected list item, and is used to
+  // "scroll into view" when the Previous/Next buttons are clicked in the NavBar
+  const scrollRef = useRef<null | HTMLLIElement>(null);
+  const scrollSelectedItemIntoView = () =>
+    // Small time delay to allow the ref to change to the previous/next item in
+    // the list before scrolling to it
+    setTimeout(() => scrollRef.current?.scrollIntoView(), 100);
+
   return (
     <>
       <AppBarButtons requisitionNumber={requisition.requisitionNumber} />
@@ -75,6 +83,7 @@ const ResponseLineEditPageInner = ({
                 requisition.status !== RequisitionNodeStatus.Finalised &&
                 !isProgram
               }
+              scrollRef={scrollRef}
             />
           }
           Right={
@@ -92,6 +101,7 @@ const ResponseLineEditPageInner = ({
               requisitionNumber={requisition.requisitionNumber}
               requisitionId={requisition.id}
               insert={mutateAsync}
+              scrollIntoView={scrollSelectedItemIntoView}
             />
           }
         />

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -45,6 +45,7 @@ interface ResponseLineEditProps {
   requisitionNumber?: number;
   requisitionId: string;
   insert: (patch: InsertResponseRequisitionLineInput) => void;
+  scrollIntoView: () => void;
 }
 
 export const ResponseLineEdit = ({
@@ -61,6 +62,7 @@ export const ResponseLineEdit = ({
   requisitionNumber,
   requisitionId,
   insert,
+  scrollIntoView,
 }: ResponseLineEditProps) => {
   const t = useTranslation();
   const navigate = useNavigate();
@@ -500,6 +502,7 @@ export const ResponseLineEdit = ({
           hasPrevious={hasPrevious}
           previous={previous}
           requisitionNumber={draft?.requisitionNumber}
+          scrollIntoView={scrollIntoView}
         />
       </Box>
     </Box>

--- a/client/packages/requisitions/src/common/ListIndicators.tsx
+++ b/client/packages/requisitions/src/common/ListIndicators.tsx
@@ -10,12 +10,14 @@ interface ListIndicatorLineProps {
   currentIndicatorLineId?: string | null;
   lines: IndicatorLineRowFragment[];
   route: RouteBuilder;
+  scrollRef: React.MutableRefObject<HTMLLIElement | null>;
 }
 
 export const ListIndicatorLines = ({
   currentIndicatorLineId,
   lines,
   route,
+  scrollRef,
 }: ListIndicatorLineProps) => {
   const navigate = useNavigate();
   const value = lines?.find(({ id }) => id === currentIndicatorLineId) ?? null;
@@ -34,6 +36,7 @@ export const ListIndicatorLines = ({
           value: `${name}: ${code}`,
         })) ?? []
       }
+      scrollRef={scrollRef}
     />
   );
 };

--- a/client/packages/system/src/Item/Components/ListItems/ListItems.tsx
+++ b/client/packages/system/src/Item/Components/ListItems/ListItems.tsx
@@ -18,7 +18,7 @@ interface ListItemProps {
   isDirty?: boolean;
   showNew?: boolean;
   handleSaveNew?: () => void;
-  scrollRef?: React.MutableRefObject<HTMLLIElement | null>;
+  scrollRef: React.MutableRefObject<HTMLLIElement | null>;
 }
 
 export const ListItems = ({

--- a/client/packages/system/src/Item/Components/ListItems/ListItems.tsx
+++ b/client/packages/system/src/Item/Components/ListItems/ListItems.tsx
@@ -18,6 +18,7 @@ interface ListItemProps {
   isDirty?: boolean;
   showNew?: boolean;
   handleSaveNew?: () => void;
+  scrollRef?: React.MutableRefObject<HTMLLIElement | null>;
 }
 
 export const ListItems = ({
@@ -28,6 +29,7 @@ export const ListItems = ({
   showNew = false,
   isDirty = false,
   handleSaveNew = () => {},
+  scrollRef,
 }: ListItemProps) => {
   const t = useTranslation();
   const navigate = useNavigate();
@@ -60,6 +62,7 @@ export const ListItems = ({
           }}
           options={options}
           enteredLineIds={enteredLineIds}
+          scrollRef={scrollRef}
         />
       </Box>
     </Tooltip>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6078

# 👩🏻‍💻 What does this PR do?

Turns out the `ref` definition in `<ListOptions>` was calling `scrollIntoView` on every re-render, which was pulling the whole page up.

I've changed it to define the ref in a parent component, and passed it down to the ListOptions, and also defined a `scrollIntoView` method which calls `scrollIntoView()` on that ref from the Nav Bars (Prev/Next buttons).

Also, this problem was affecting *all* `<ListOptions>` implementations, so have made the same fix (in addition to Prescriptions) for:
- Requisitions
- Internal Orders
- Indicators for both of the above

## 💌 Any notes for the reviewer?

There's a lot of duplicate code, plus the different implementations of the Navigation bars are inconsistent, so hopefully can consolidate this a bit better with #5973 .

# 🧪 Testing

Go to a prescription "Line Edit View" with a decent number of items, and make your browser window small enough to require a scroll bar on the list of items, like this:
![Screenshot 2025-01-17 at 12 40 52 PM](https://github.com/user-attachments/assets/af5943ae-9d68-4015-beec-3333145f9293)

Then, scroll down so the selected item is no longer visible:
![Screenshot 2025-01-17 at 12 41 01 PM](https://github.com/user-attachments/assets/9b38ef3a-b17e-40d0-aa4b-aea8e19970ef)

- [ ] Then, click the "Next" button and the next item should smoothly scroll back into view :)
- [ ] Try out different variations with the "Previous" button, etc.
- [ ] Do similar for the Requisition line edit views
- [ ] Please also test the "How to reproduce" from the original issue (#6078) to confirm the unwanted scrolling is no longer a problem,