### PR TITLE
6075 'Invoice Number' column can be clearer

### DIFF
--- a/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
@@ -45,7 +45,7 @@ const ItemLedgerTable = ({
         key: 'type',
         label: 'label.type',
         accessor: ({ rowData }) =>
-          t(getInvoiceLocalisationKey(rowData.invoiceType)),
+          `${t(getInvoiceLocalisationKey(rowData.invoiceType))} #${rowData.invoiceNumber}`,
         sortable: false,
       },
       {
@@ -59,13 +59,6 @@ const ItemLedgerTable = ({
         label: 'label.time',
         accessor: ({ rowData }) => localisedTime(rowData.datetime),
         sortable: false,
-      },
-      {
-        key: 'number',
-        label: 'label.invoice-number',
-        accessor: ({ rowData }) => rowData.invoiceNumber,
-        sortable: false,
-        width: 90,
       },
       {
         key: 'name',

--- a/client/packages/system/src/Stock/Components/Ledger/useLedgerColumns.ts
+++ b/client/packages/system/src/Stock/Components/Ledger/useLedgerColumns.ts
@@ -55,16 +55,10 @@ export const useLedgerColumns = (
         description: 'description.unit-quantity',
       },
       {
-        key: ColumnKey.Number,
-        label: 'label.invoice-number',
-        accessor: ({ rowData }) => rowData.invoiceNumber,
-        sortable: false,
-      },
-      {
         key: ColumnKey.Type,
         label: 'label.type',
         accessor: ({ rowData }) =>
-          t(getInvoiceLocalisationKey(rowData.invoiceType)),
+          `${t(getInvoiceLocalisationKey(rowData.invoiceType))} #${rowData.invoiceNumber}`,
         sortable: false,
       },
       {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6075

# 👩🏻‍💻 What does this PR do?
Concat type + invoice num in ledgers... should change the header? I think it's fine... 🤷🏻 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to ledger either through item or stock
- [ ] See type now has invoice type + number

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. ledger ss updates
  2.
