### PR TITLE
6114 adding new asset crashes

### DIFF
--- a/client/packages/system/src/Store/components/StoreSearchInput/StoreSearchInput.tsx
+++ b/client/packages/system/src/Store/components/StoreSearchInput/StoreSearchInput.tsx
@@ -50,7 +50,9 @@ const StoreSearchComponent = ({
     filter,
   });
 
-  const pageNumber = data?.pages[data?.pages.length - 1]?.pageNumber ?? 0;
+  const pageNumber = data?.pages?.length
+    ? (data.pages[data.pages.length - 1]?.pageNumber ?? 0)
+    : 0;
 
   const debounceOnFilter = useDebounceCallback(
     (searchText: string) => {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6114 

# 👩🏻‍💻 What does this PR do?

Adding a new asset crashes when navigating away from the import modal. The issue occurs because the `usePaginatedStores` data briefly returns an empty page length. A length check has been added to handle this case

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

https://github.com/user-attachments/assets/3409ea0a-1e8e-4c6b-972a-cb8684bcd5dd

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Equipments page
- [ ] Click on Import
- [ ] Close modal
- [ ] Clicking on new asset shouldn't result in an error

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
