### PR TITLE
6128 Internal order editing requested packs does not save changes

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -309,7 +309,6 @@ export const RequestLineEdit = ({
                   <InputWithLabelRow
                     Input={
                       <NumericTextInput
-                        autoFocus
                         disabled={!isPacks}
                         value={NumUtils.round(
                           (draft?.requestedQuantity ?? 0) /
@@ -318,12 +317,18 @@ export const RequestLineEdit = ({
                         )}
                         decimalLimit={2}
                         width={100}
-                        onChange={quantity => {
-                          update({
-                            requestedQuantity:
-                              (quantity ?? 0) * (draft?.defaultPackSize ?? 0),
-                          });
+                        onChange={value => {
+                          const newValue = (value ?? 0) * (draft?.defaultPackSize ?? 0);
+                          if (draft?.suggestedQuantity === newValue) {
+                            update({
+                              requestedQuantity: newValue,
+                              reason: null,
+                            });
+                          } else {
+                            update({ requestedQuantity: newValue });
+                          }
                         }}
+                        onBlur={save}
                       />
                     }
                     labelWidth={LABEL_WIDTH}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6128

# 👩🏻‍💻 What does this PR do?
Save requested quantity on blur if user is requesting in packs 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Change toggle to packs
- [ ] Enter a quantity in requested packs
- [ ] Navigate away
- [ ] navigate back
- [ ] Should be same number

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
