### PR TITLE
5986 Add migration to drop user_account fk constraint

### DIFF
--- a/server/repository/src/migrations/v2_05_00/mod.rs
+++ b/server/repository/src/migrations/v2_05_00/mod.rs
@@ -14,6 +14,7 @@ mod new_store_preferences;
 mod remove_contact_form_site_id;
 mod remove_contact_form_user_account_fk;
 mod remove_unique_description_on_tmp_breach;
+mod remove_vaccination_user_account_fk;
 
 use crate::StorageConnection;
 
@@ -44,6 +45,7 @@ impl Migration for V2_05_00 {
             Box::new(add_email_retry_at::Migrate),
             Box::new(remove_contact_form_user_account_fk::Migrate),
             Box::new(add_contact_form_processor_pg_enum_type::Migrate),
+            Box::new(remove_vaccination_user_account_fk::Migrate),
         ]
     }
 }

--- a/server/repository/src/migrations/v2_05_00/remove_vaccination_user_account_fk.rs
+++ b/server/repository/src/migrations/v2_05_00/remove_vaccination_user_account_fk.rs
@@ -1,0 +1,57 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "remove_vaccination_user_account_fk"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        // Temp fix - user_account record not always available on central server!
+
+        if cfg!(feature = "postgres") {
+            let result = sql!(
+                connection,
+                r#"
+                    ALTER TABLE vaccination DROP CONSTRAINT vaccination_user_id_fkey;
+                "#
+            );
+            if result.is_err() {
+                log::warn!("Failed to drop FK constraint on user_id column of vaccination table, please check name of constraint");
+            }
+        } else {
+            sql!(
+                connection,
+                r#"
+                CREATE TABLE tmp_vaccination (
+                    id TEXT NOT NULL PRIMARY KEY,
+                    program_enrolment_id TEXT NOT NULL,
+                    encounter_id TEXT NOT NULL,
+                    created_datetime TIMESTAMP NOT NULL,
+                    user_id TEXT NOT NULL,
+                    vaccine_course_dose_id TEXT NOT NULL REFERENCES vaccine_course_dose(id),
+                    store_id TEXT NOT NULL,
+                    clinician_link_id TEXT,
+                    invoice_id TEXT,
+                    stock_line_id TEXT,
+                    vaccination_date {DATE} NOT NULL,
+                    given BOOLEAN NOT NULL,
+                    not_given_reason TEXT,
+                    comment TEXT,
+                    facility_name_link_id TEXT,
+                    facility_free_text TEXT
+                );
+                INSERT INTO tmp_vaccination SELECT * FROM vaccination;
+
+                PRAGMA foreign_keys = OFF;              
+                DROP TABLE vaccination;
+                ALTER TABLE tmp_vaccination RENAME TO vaccination;              
+                PRAGMA foreign_keys = ON;
+                "#
+            )?;
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5986 

# 👩🏻‍💻 What does this PR do?
Add migratoin to drop user_account fk constraint from vaccination table. Vaccinations given by new users on remote sites now show up in the vaccination table.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
<img width="1256" alt="Screenshot 2025-01-17 at 2 42 55 PM" src="https://github.com/user-attachments/assets/608f1beb-59b0-46c3-9259-e098b9a8b744" />

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] On OG, create a new user
- [ ] On OMS remote site, log in as this new user
- [ ] Within a vaccination program encounter, give a new vaccination
- [ ] Sync to OMS central
- [ ] Open vaccination table in dbeaver and see given vaccination in the vaccination table

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
