### PR TITLE
6088 dispensary directions popover shows batch but unclear this is batch

### DIFF
--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -73,18 +73,22 @@ export const usePrescriptionColumn = ({
         accessor: ({ rowData }) => {
           if ('lines' in rowData) {
             const { lines } = rowData;
-            const noteSections = lines
-              .map(({ batch, note }) => ({
-                header: batch ?? '',
-                body: note ?? '',
-              }))
-              .filter(({ body }) => !!body);
+            if (!lines) return null;
+
+            // All the lines should have the same note, so we just take the first one
+            const lineWithNote = lines.find(({ note }) => !!note);
+            if (!lineWithNote) return null;
+
+            const noteSections = [
+              {
+                header: null,
+                body: lineWithNote.note ?? '',
+              },
+            ];
+
             return noteSections.length ? noteSections : null;
-          } else {
-            return rowData.batch && rowData.note
-              ? { header: rowData.batch, body: rowData.note }
-              : null;
           }
+          return null;
         },
       },
     ],


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6088

# 👩🏻‍💻 What does this PR do?

<img width="653" alt="image" src="https://github.com/user-attachments/assets/bad73636-16d7-4581-886f-1076aad6bc63" />

Dispensing `directions` pop over not longer shows batch numbers, and only one directions section is shown

## 💌 Any notes for the reviewer?

UI looks a little bit untidy. could be Cleaned up at some point.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a prescription
- [ ] Add lines with directions
- [ ] Add multiple batches to a single line.
- [ ] Got to the main view for the prescriptoin and hoverover the notes button
- [ ] You should see the directions shown, but no batch numbers.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
