### PR TITLE
#5977(2) Fix prescription update tests

### DIFF
--- a/server/graphql/invoice/src/mutations/prescription/update.rs
+++ b/server/graphql/invoice/src/mutations/prescription/update.rs
@@ -233,7 +233,7 @@ mod test {
           "input": {
             "id": "n/a",
             "patientId": "n/a",
-            "clinicianId": "n/a",
+            "clinicianId": {"value": "n/a"},
             "comment": "n/a",
             "colour": "n/a"
           }
@@ -390,7 +390,7 @@ mod test {
           "input": {
             "id": "id input",
             "patientId": "patient_a",
-            "clinicianId": "some_clinician",
+            "clinicianId": {"value": "some_clinician"},
             "status": "PICKED",
             "comment": "comment input",
             "colour": "colour input"

--- a/server/graphql/invoice/src/mutations/prescription/update.rs
+++ b/server/graphql/invoice/src/mutations/prescription/update.rs
@@ -200,6 +200,7 @@ mod test {
             InvoiceServiceTrait,
         },
         service_provider::{ServiceContext, ServiceProvider},
+        NullableUpdate,
     };
 
     use crate::InvoiceMutations;
@@ -367,7 +368,9 @@ mod test {
                 ServiceInput {
                     id: "id input".to_string(),
                     patient_id: Some("patient_a".to_string()),
-                    clinician_id: Some("some_clinician".to_string()),
+                    clinician_id: Some(NullableUpdate {
+                        value: Some("some_clinician".to_string())
+                    }),
                     status: Some(UpdatePrescriptionStatus::Picked),
                     comment: Some("comment input".to_string()),
                     colour: Some("colour input".to_string()),

--- a/server/service/src/invoice/prescription/update/mod.rs
+++ b/server/service/src/invoice/prescription/update/mod.rs
@@ -147,6 +147,7 @@ mod test {
     use crate::{
         invoice::prescription::{UpdatePrescription, UpdatePrescriptionStatus},
         service_provider::ServiceProvider,
+        NullableUpdate,
     };
 
     use super::UpdatePrescriptionError;
@@ -251,7 +252,9 @@ mod test {
                 &context,
                 inline_init(|r: &mut UpdatePrescription| {
                     r.id = prescription_no_stock().id;
-                    r.clinician_id = Some("invalid".to_string());
+                    r.clinician_id = Some(NullableUpdate {
+                        value: Some("invalid".to_string()),
+                    })
                 })
             ),
             Err(ServiceError::ClinicianDoesNotExist)
@@ -321,7 +324,9 @@ mod test {
                 id: prescription().id,
                 status: None,
                 patient_id: Some(mock_patient_b().id),
-                clinician_id: Some(clinician().id),
+                clinician_id: Some(NullableUpdate {
+                    value: Some(clinician().id),
+                }),
                 comment: Some("test_comment".to_string()),
                 colour: Some("test_colour".to_string()),
                 backdated_datetime: None,
@@ -352,7 +357,7 @@ mod test {
                     diagnosis_id: _,
                 } = get_update();
                 u.name_link_id = patient_id.unwrap();
-                u.clinician_link_id = clinician_id;
+                u.clinician_link_id = clinician_id.unwrap().value;
                 u.comment = comment;
                 u.colour = colour;
                 u


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Follow-up to #5977 to fix tests broken by clinician_id field to NullableUpdate.

## 💌 Any notes for the reviewer?

I think @jmbrunskill wanted to have a quick look at the `unwrap()` to try and improve it.

# 🧪 Testing

- Run `cargo test` -- should all pass