### PR TITLE
5121 Floor decimal quantity to return

### DIFF
--- a/client/packages/invoices/src/Returns/modals/SupplierReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/SupplierReturn/ReturnQuantitiesTable.tsx
@@ -74,7 +74,7 @@ const NumberOfPacksToReturnReturnInputCell: React.FC<
   <NumberInputCell
     {...props}
     isRequired
-    max={props.rowData.availableNumberOfPacks}
+    max={Math.floor(props.rowData.availableNumberOfPacks)}
   />
 );
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5121 

# 👩🏻‍💻 What does this PR do?
Rounds decimal ```Quantity to return``` input value down to nearest integer.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

https://github.com/user-attachments/assets/da7ae1e2-96f3-444e-ae89-9613e91dd561


## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Replenishment -> Supplier Returns
- [ ] Create a Return -> make sure it's for an item that has decimal values in stock. It might be easier to select an item, set quantity available to something decimal and then intentionally choose it for the return you are testing.
- [ ] Try entering different values in the ```Quantity to return``` input field (e.g same number, whole number, number higher, decimal number) 
- [ ] You should not be allowed to enter decimal numbers and numbers higher than available quantity to should round down to nearest integer

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
