### PR TITLE
6147 Indicators details show Nothing here where there is no customer to show. This text should be hidden

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
@@ -116,6 +116,9 @@ export const IndicatorLineEdit = ({
       .filter(c => c.value) // Columns may be added to a program after the requisition was made, we want to hide those
       .sort((a, b) => a.columnNumber - b.columnNumber) || [];
   const { store } = useAuthContext();
+  const showInfo =
+    store?.preferences.useConsumptionAndStockFromCustomersForInternalOrders &&
+    !!currentLine?.customerIndicatorInfo;
 
   return (
     <>
@@ -129,12 +132,11 @@ export const IndicatorLineEdit = ({
           />
         ))}
       </Box>
-      {store?.preferences
-        .useConsumptionAndStockFromCustomersForInternalOrders && (
+      {showInfo && (
         <Box paddingTop={1} maxHeight={200} width="100%" display="flex">
           <CustomerIndicatorInfoView
             columns={columns}
-            customerInfos={currentLine?.customerIndicatorInfo || []}
+            customerInfos={currentLine?.customerIndicatorInfo}
           />
         </Box>
       )}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6147 

# 👩🏻‍💻 What does this PR do?
Hide indicator information if there is none

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have the use consumption data preference on
- [ ] Have a requisition with indicators (create this in a store that isn't being used as a supplying store)
- [ ] Go to indicator edit page
- [ ] Shouldn't see anything under the edit inputs

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
