### PR TITLE
5818 Creating a new encounter does not take you to a newly created encounter, instead keeps you on a landing page

### DIFF
--- a/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
@@ -296,6 +296,7 @@ export const CreateEncounterModal: FC = () => {
                           highlightedDays: getHighlightedDays(),
                         } as any,
                       }}
+                      showTime
                     />
                   }
                 />

--- a/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
@@ -173,9 +173,7 @@ export const CreateEncounterModal: FC = () => {
   ]);
 
   const setStartDatetime = (date: Date | null): void => {
-    const startDatetime = DateUtils.formatRFC3339(
-      DateUtils.addCurrentTime(date)
-    );
+    const startDatetime = date?.toISOString();
     setDraft({
       ...currentOrNewDraft(),
       startDatetime,

--- a/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
@@ -231,19 +231,23 @@ export const CreateEncounterModal: FC = () => {
                 return;
               }
               const startDatetime = new Date(draft?.startDatetime ?? 0);
-              if (DateUtils.addHours(startDatetime, 1).getTime() > Date.now()) {
+              const dateNow = Date.now();
+              if (
+                startDatetime.getTime() <=
+                DateUtils.addMinutes(dateNow, 5).getTime()
+              ) {
                 navigate(
                   RouteBuilder.create(AppRoute.Dispensary)
-                    .addPart(AppRoute.Patients)
-                    .addPart(patientId)
-                    .addQuery({ tab: PatientTabValue.Encounters })
+                    .addPart(AppRoute.Encounter)
+                    .addPart(id)
                     .build()
                 );
               } else {
                 navigate(
                   RouteBuilder.create(AppRoute.Dispensary)
-                    .addPart(AppRoute.Encounter)
-                    .addPart(id)
+                    .addPart(AppRoute.Patients)
+                    .addPart(patientId)
+                    .addQuery({ tab: PatientTabValue.Encounters })
                     .build()
                 );
               }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5818

# 👩🏻‍💻 What does this PR do?
Redirecting to Encounter if the datetime is less than right now (with 5 minute buffer). Have also allowed users to select a time to save in the start datetime so they don't have to go into future encounters to configure this

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an encounter for tomorrow
- [ ] Don't get redirected
- [ ] Create an encounter for today or in the past
- [ ] Get redirected to Encounter edit page

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
