### PR TITLE
Invalidate Graphql Queries After Sync

### DIFF
--- a/client/packages/host/src/components/Sync/SyncModal.tsx
+++ b/client/packages/host/src/components/Sync/SyncModal.tsx
@@ -12,6 +12,7 @@ import {
   useAuthContext,
   useFormatDateTime,
   useNativeClient,
+  useQueryClient,
   useTranslation,
 } from '@openmsupply-client/common';
 import { useSync } from '@openmsupply-client/system';
@@ -38,6 +39,7 @@ const useHostSync = (enabled: boolean) => {
 
   // true by default to wait for first syncStatus api result
   const [isLoading, setIsLoading] = useState(true);
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     if (!syncStatus) {
@@ -52,6 +54,7 @@ const useHostSync = (enabled: boolean) => {
       keepAwake();
     } else {
       allowSleep();
+      queryClient.invalidateQueries(); //refresh the page user is on after sync finishes
     }
   }, [syncStatus?.isSyncing]);
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5956 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
All query keys are invalidated after a manual sync has finished

The result of this is when the sync modal is closed, whichever page the user is on will refresh and show any updated records immediately. This is what a user might expect to happen after intentionally syncing

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Set up with a store on a tablet (Store A) that can ship stock to a store running locally on your computer (Store B)
- [ ] On the computer, got to Inbound Shipments
- [ ] On the tablet go to Outbound Shipments -> New Shipment -> Select Store B. 
- [ ] Add an item with a quantity -> OK
- [ ] Confirm Allocated, then sync on tablet
- [ ] When finished, sync on computer
- [ ] When you close the sync modal, see the new shipment appear

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
