### PR TITLE
6199 Able to add items to a non-manual requisition 

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditPage.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditPage.tsx
@@ -65,6 +65,10 @@ const ResponseLineEditPageInner = ({
     // Small time delay to allow the ref to change to the previous/next item in
     // the list before scrolling to it
     setTimeout(() => scrollRef.current?.scrollIntoView(), 100);
+  const showNew =
+    requisition.status !== RequisitionNodeStatus.Finalised &&
+    !isProgram &&
+    !requisition.linkedRequisition;
 
   return (
     <>
@@ -79,10 +83,7 @@ const ResponseLineEditPageInner = ({
                 .addPart(AppRoute.CustomerRequisition)
                 .addPart(String(requisition.requisitionNumber))}
               enteredLineIds={enteredLineIds}
-              showNew={
-                requisition.status !== RequisitionNodeStatus.Finalised &&
-                !isProgram
-              }
+              showNew={showNew}
               scrollRef={scrollRef}
             />
           }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6199

# 👩🏻‍💻 What does this PR do?
Don't show add item option if requisition is created from an internal order

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create IO to store, finalise
- [ ] Go to supplying store, click on the just sent IO
- [ ] Click on line to edit
- [ ] Don't see the `New item` option

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
