### PR TITLE
Catch panic in discovery

### DIFF
--- a/server/server/src/discovery.rs
+++ b/server/server/src/discovery.rs
@@ -29,7 +29,6 @@ pub(crate) fn start_discovery(protocol: Protocol, port: u16, hardware_id: String
             // This code is to test the panic handling. Uncomment the following lines to test.
             // let x: Option<String> = None;
             // let _y = x.unwrap();
-            // log::info!("Discovery registration result: {:?}", registration_result);
             registration_result
         });
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5018 (hopefully?)

# 👩🏻‍💻 What does this PR do?

Catches the panic on discovery, and just logs an error.

We still probably want to get a proper fix, and possibly re-try adding discovery

Not 100% sure if this solved the issue as it's not happening for me here at home at the moment.
Would be good for someone to test it who's having the problem regularly...


## 💌 Any notes for the reviewer?

Branched off V2.5.0 RC branch as that is where I was seeing the problem more regularly.

@andreievg  also suggested we could do add a configuration file to disable discovery.
Thought I'd try this first to see if it helps...

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] start your remote server in the office a number of times, see if it randomly crashes sometimes or not...

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
