### PR TITLE
Hack: Always use base year 2024 for demographic projections

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1116,6 +1116,7 @@
   "label.wastage-rate": "Wastage rate",
   "label.website": "Website",
   "label.weight": "Weight",
+  "label.year": "Year",
   "label.years-abbreviation": "Y",
   "label.your-email-address": "Your email address",
   "link.copy-to-clipboard": "Copy to Clipboard",

--- a/client/packages/system/src/IndicatorsDemographics/DetailView/IndicatorsDemographics.tsx
+++ b/client/packages/system/src/IndicatorsDemographics/DetailView/IndicatorsDemographics.tsx
@@ -253,8 +253,7 @@ const yearColumn = (year: number, format: (n: number) => string) => ({
   key: String(year),
   width: 150,
   align: ColumnAlign.Right,
-  label: undefined,
-  labelProps: { defaultValue: currentYear + year },
+  label: `${currentYear + year}`,
   sortable: false,
   accessor: ({ rowData }: { rowData: Row }) => {
     // using a switch to appease typescript

--- a/client/packages/system/src/IndicatorsDemographics/DetailView/IndicatorsDemographics.tsx
+++ b/client/packages/system/src/IndicatorsDemographics/DetailView/IndicatorsDemographics.tsx
@@ -4,7 +4,6 @@ import {
   Box,
   ColumnAlign,
   DataTable,
-  DateUtils,
   Formatter,
   RecordPatch,
   TableProvider,
@@ -49,7 +48,7 @@ const IndicatorsDemographicsComponent = () => {
   const t = useTranslation();
 
   const { draft, setDraft } = useDemographicData.indicator.list(headerDraft);
-  const baseYear = headerDraft?.baseYear ?? DateUtils.getCurrentYear();
+  const baseYear = headerDraft?.baseYear ?? 2024; // TODO: Allow the user to select the base year for their projections
   const { data: projection, isLoading: isLoadingProjection } =
     useDemographicData.projection.get(baseYear);
 

--- a/client/packages/system/src/IndicatorsDemographics/DetailView/IndicatorsDemographics.tsx
+++ b/client/packages/system/src/IndicatorsDemographics/DetailView/IndicatorsDemographics.tsx
@@ -30,8 +30,6 @@ import {
 } from './utils';
 import { HeaderData, Row } from '../types';
 
-const currentYear = new Date().getFullYear();
-
 const IndicatorsDemographicsComponent = () => {
   const {
     updateSortQuery,
@@ -195,11 +193,11 @@ const IndicatorsDemographicsComponent = () => {
       [nameColumn(), { setter }],
       [percentageColumn(), { setter }],
       [populationColumn(), { setter: handlePopulationChange }],
-      yearColumn(1, formatNumber.format),
-      yearColumn(2, formatNumber.format),
-      yearColumn(3, formatNumber.format),
-      yearColumn(4, formatNumber.format),
-      yearColumn(5, formatNumber.format),
+      yearColumn(1, formatNumber.format, t('label.year')),
+      yearColumn(2, formatNumber.format, t('label.year')),
+      yearColumn(3, formatNumber.format, t('label.year')),
+      yearColumn(4, formatNumber.format, t('label.year')),
+      yearColumn(5, formatNumber.format, t('label.year')),
     ],
     { sortBy, onChangeSortBy: updateSortQuery },
     [draft, indexPopulation, sortBy]
@@ -249,11 +247,15 @@ export const IndicatorsDemographics = () => (
   </TableProvider>
 );
 
-const yearColumn = (year: number, format: (n: number) => string) => ({
+const yearColumn = (
+  year: number,
+  format: (n: number) => string,
+  yearTranslation: string
+) => ({
   key: String(year),
   width: 150,
   align: ColumnAlign.Right,
-  label: `${currentYear + year}`,
+  label: `${yearTranslation} ${year}`,
   sortable: false,
   accessor: ({ rowData }: { rowData: Row }) => {
     // using a switch to appease typescript

--- a/client/packages/system/src/IndicatorsDemographics/DetailView/utils.tsx
+++ b/client/packages/system/src/IndicatorsDemographics/DetailView/utils.tsx
@@ -114,7 +114,7 @@ export const mapProjection = (
   headerData: HeaderData,
   generalPopulationRow?: Row
 ) => ({
-  baseYear: generalPopulationRow?.baseYear ?? 2024,
+  baseYear: generalPopulationRow?.baseYear ?? 2024, // TODO: Allow the user to select the base year for their projections
   id: headerData.id,
   year1: headerData[1].value,
   year2: headerData[2].value,
@@ -142,7 +142,7 @@ export const toDemographicIndicatorRow = (row: {
   name: row.name,
   baseYear: row.baseYear ?? 0,
   basePopulation: row.basePopulation ?? 0,
-  0: (row.basePopulation ?? 0) * (row.populationPercentage ?? 0)/100,
+  0: ((row.basePopulation ?? 0) * (row.populationPercentage ?? 0)) / 100,
   1: row.year1Projection ?? 0,
   2: row.year2Projection ?? 0,
   3: row.year3Projection ?? 0,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6181

# 👩🏻‍💻 What does this PR do?

I've changed from looking at the current year as the base for projections to assume we always base it off 2024.
Not an ideal solution but good enough for the 2.5 hotfix I think.

Also fixes the missing headers for the years, which might have been broken by MUI6 upgrade???
Anyway, it's now Year 1, 2, 3, 4, 5 instead of the actual years as it doesn't make sense when hard coded...

## 💌 Any notes for the reviewer?

The intention was to allow the system to capture different scenarios for different years, so for example you could do your planning for 2020, then come back in to 2025 an start a new round of planning without loosing what you'd saved in 2020.
However, this haven't been fully implemented, and part of the system were assuming the 2024 base year and other parts were just looking at the calendar date. Now everything assumes 2024, but eventually we'll want to implement the base year feature properly

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] On your open mSupply Central Server
- [ ] Try to edit demographics and demographic projections

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
