### PR TITLE
Item variants: Packaging tables ordering

### DIFF
--- a/server/repository/src/db_diesel/item_variant/packaging_variant.rs
+++ b/server/repository/src/db_diesel/item_variant/packaging_variant.rs
@@ -80,7 +80,7 @@ impl<'a> PackagingVariantRepository<'a> {
                 }
             }
         } else {
-            query = query.order(packaging_variant::id.asc())
+            query = query.order(packaging_variant::packaging_level.asc())
         }
 
         let final_query = query


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5808 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
Change the ordering in the packaging variant from 'id' to 'packaging_level' so that the tables are in order: 1, 2, 3

This appeared in this imported data set as the packaging variant id is a UUID. Variants created in the front end are created in order due to the modal layout - I could not reproduce this bug without the imported data.

This would have the potential to be recreated any time a user has imported item variant data

![Screenshot 2025-01-22 at 10 12 35 AM](https://github.com/user-attachments/assets/d357e14f-613c-4e9b-8062-f056585067d7)

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Run James' PQS item variant SQL script to populate item variants
- [ ] Go to Catalogue -> Items
- [ ] Look at Polio vaccine, on the variants tab. Ensure that all tables are ordered by packaging levels 1, 2, 3 
- [ ] Check a few others as well

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
