### PR TITLE
fix internal order value after backspace

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -259,7 +259,11 @@ export const RequestLineEdit = ({
                   Input={
                     <NumericTextInput
                       width={INPUT_WIDTH}
-                      value={Math.ceil(draft?.requestedQuantity)}
+                      value={
+                        isNaN(Number(draft?.requestedQuantity))
+                          ? 0
+                          : Math.ceil(draft?.requestedQuantity)
+                      }
                       disabled={isPacks}
                       onChange={value => {
                         if (draft?.suggestedQuantity === value) {
@@ -320,7 +324,8 @@ export const RequestLineEdit = ({
                         decimalLimit={2}
                         width={100}
                         onChange={value => {
-                          const newValue = (value ?? 0) * (draft?.defaultPackSize ?? 0);
+                          const newValue =
+                            (value ?? 0) * (draft?.defaultPackSize ?? 0);
                           if (draft?.suggestedQuantity === newValue) {
                             update({
                               requestedQuantity: newValue,

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -259,20 +259,17 @@ export const RequestLineEdit = ({
                   Input={
                     <NumericTextInput
                       width={INPUT_WIDTH}
-                      value={
-                        isNaN(Number(draft?.requestedQuantity))
-                          ? 0
-                          : Math.ceil(draft?.requestedQuantity)
-                      }
+                      value={Math.ceil(draft?.requestedQuantity)}
                       disabled={isPacks}
                       onChange={value => {
-                        if (draft?.suggestedQuantity === value) {
+                        const newValue = isNaN(Number(value)) ? 0 : value;
+                        if (draft?.suggestedQuantity === newValue) {
                           update({
-                            requestedQuantity: value,
+                            requestedQuantity: newValue,
                             reason: null,
                           });
                         } else {
-                          update({ requestedQuantity: value });
+                          update({ requestedQuantity: newValue });
                         }
                       }}
                       onBlur={save}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6185 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

When backspacing a value in Internal Order -> New Item -> Requested Quantity, the empty value populates as 'NaN'
Added a NaN check, if the value is not a number it will show '0'. The user will then be able to type in the field with the new number

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go Replenishment -> Internal Orders
- [ ] Click on New Order
- [ ] Create new order and add an item
- [ ] add requested quantity and click on backspace
- [ ] See '0' and that you can type into the field with a new value

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
