### PR TITLE
6119/6212 Disable next button when adding new item (internal order + manual requisition)

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
@@ -100,7 +100,7 @@ export const usePreviousNextRequestLine = (
   lines?: RequestLineFragment[],
   currentItem?: ItemWithStatsFragment | null
 ) => {
-  if (!lines) {
+  if (!lines || !currentItem) {
     return { hasNext: false, next: null, hasPrevious: false, previous: null };
   }
 

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/hooks.tsx
@@ -71,7 +71,7 @@ export const usePreviousNextResponseLine = (
   lines?: ResponseLineFragment[],
   currentItem?: ItemRowFragment | null
 ) => {
-  if (!lines) {
+  if (!lines || !currentItem) {
     return { hasNext: false, next: null, hasPrevious: false, previous: null };
   }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6119 #6212 

# 👩🏻‍💻 What does this PR do?
Disable next button when adding a new item in line edit view so that it doesn't go to undefined page/infinite spinner.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
![Screenshot 2025-01-22 at 1 16 16 PM](https://github.com/user-attachments/assets/4791d720-7238-48d7-af92-bbd129af1cfe)
![Screenshot 2025-01-22 at 1 17 28 PM](https://github.com/user-attachments/assets/1356b998-4794-4269-8cbd-f605abfd3ecb)

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create new internal order or manual requisition
- [ ] Click button to Add items 
- [ ] In the line edit view click on new item
- [ ] When on new item observe that the next button in footer is disabled

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
