### PR TITLE
5147 fix on hold items counted towards available stock

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1532,7 +1532,7 @@
   "messages.stock-charges-description": "Total charges for stock lines. The calculated tax amount is an effective tax rate using the total tax paid over the subtotal of all stock lines.",
   "messages.stock-expired": "Some stock lines are expired and will not be auto-allocated.",
   "messages.stock-line-saved": "Stock line saved 🥳",
-  "messages.stock-on-hold": "Some stock lines are hold and cannot be allocated.",
+  "messages.stock-on-hold": "Some stock lines are on hold and cannot be allocated.",
   "messages.success-printing-asset-label": "Asset label printed successfully.",
   "messages.supply-to-approved": "Are you sure you want to set all lines supply quantity to the approved?",
   "messages.supply-to-requested": "Are you sure you want to set all lines supply quantity to the requested?",

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
@@ -95,7 +95,10 @@ export const useOutboundLineEditColumns = ({
       key: 'availableNumberOfPacks',
       align: ColumnAlign.Right,
       width: 90,
-      accessor: ({ rowData }) => rowData.stockLine?.availableNumberOfPacks,
+      accessor: ({ rowData }) =>
+        rowData.location?.onHold || rowData.stockLine?.onHold
+          ? 0
+          : rowData.stockLine?.availableNumberOfPacks,
     },
     [
       'numberOfPacks',
@@ -120,7 +123,8 @@ export const useOutboundLineEditColumns = ({
       label: 'label.on-hold',
       key: 'onHold',
       Cell: CheckCell,
-      accessor: ({ rowData }) => rowData.stockLine?.onHold,
+      accessor: ({ rowData }) =>
+        rowData.stockLine?.onHold || rowData.location?.onHold,
       align: ColumnAlign.Center,
       width: 70,
     }

--- a/client/packages/invoices/src/Prescriptions/LineEditView/hooks/useDraftPrescriptionLines.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/hooks/useDraftPrescriptionLines.tsx
@@ -54,7 +54,7 @@ export const useDraftPrescriptionLines = (
     const stockLines = uniqBy(
       [...data.nodes, ...invoiceLineStockLines],
       'id'
-   ).filter(stockLine => !stockLine.onHold ); // Filter out on hold stock lines
+    ).filter(stockLine => !stockLine.onHold); // Filter out on hold stock lines
 
     const noStockLines = stockLines.length == 0;
 
@@ -81,6 +81,7 @@ export const useDraftPrescriptionLines = (
           });
         }
       })
+      .filter(stockLine => !stockLine.location?.onHold)
       .sort(SortUtils.byExpiryAsc);
 
     if (status === InvoiceNodeStatus.New) {

--- a/client/packages/invoices/src/StockOut/utils.tsx
+++ b/client/packages/invoices/src/StockOut/utils.tsx
@@ -140,8 +140,10 @@ export const sumAvailableQuantity = (
   draftStockOutLines: DraftStockOutLine[]
 ) => {
   const sum = draftStockOutLines.reduce(
-    (acc, { stockLine, packSize }) =>
-      acc + (stockLine?.availableNumberOfPacks ?? 0) * packSize,
+    (acc, { stockLine, packSize, location }) =>
+      !location?.onHold && !stockLine?.onHold
+        ? acc + (stockLine?.availableNumberOfPacks ?? 0) * packSize
+        : acc,
     0
   );
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5147 

# 👩🏻‍💻 What does this PR do?
Update onhold stocklines to not be counted towards available stock when adding items to prescriptions or when adding items to outbound shipments

Thanks @lache-melvin  for unblocking!
<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
![Screenshot 2025-01-23 at 10 36 30 AM](https://github.com/user-attachments/assets/0163d77c-7f12-4e89-ad1f-6a4ce73cd854)
![Screenshot 2025-01-23 at 10 37 51 AM](https://github.com/user-attachments/assets/741897ad-eee4-4a10-814d-82d9a14a4107)
![Screenshot 2025-01-23 at 10 38 40 AM](https://github.com/user-attachments/assets/c8bc31b1-0fb1-4c72-9b18-0137fc8f36a3)
![Screenshot 2025-01-23 at 10 40 21 AM](https://github.com/user-attachments/assets/907b2455-fd74-4203-b493-262c2a9ab679)


## 💌 Any notes for the reviewer?
Please check different configurations of item or location on hold to ensure that the correct values are coming through.

Also does the value in the dropdown need to be updated?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

```Prescriptions```
- [ ] Select a Location and put it on Hold
- [ ] Select an item you are testing and assign the hold location to it
- [ ] Create a prescription with that item (ideally you'd have 2 batches, one in the hold location and one normal)
- [ ] See that on hold lines no longer display in prescriptions line edit table

```Outbound Shipments```
- [ ] Select a Location and put it on Hold
- [ ] Select an item you are testing and assign the hold location to it
- [ ] Create an outbound shipment with that item (ideally you'd have 2 batches, one in the hold location and one normal)
- [ ] See that on hold location now has checkmark applied in onhold column 
- [ ] See that available stock column for on hold line is 0
- [ ] See that available quantity is appropriately calculated to not include on hold stock



# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
