### PR TITLE
6272 move status change to footer

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -825,6 +825,7 @@
   "label.low-stock-items_other": "Items with less than 3 months of stock",
   "label.manufacturer": "Manufacturer",
   "label.margin": "Margin",
+  "label.mark-as-status": "Mark as {{status}}",
   "label.master-list": "Master List",
   "label.master-lists": "Master Lists",
   "label.max": "Max",

--- a/client/packages/common/src/ui/components/buttons/standard/SplitButton.tsx
+++ b/client/packages/common/src/ui/components/buttons/standard/SplitButton.tsx
@@ -46,7 +46,7 @@ export const SplitButton = <T,>({
       <ButtonGroup color={color} variant="outlined" aria-label={ariaLabel}>
         <ButtonWithIcon
           color={color}
-          disabled={isDisabled}
+          disabled={isDisabled || selectedOption.isDisabled}
           sx={{
             borderRadius: 0,
             borderStartStartRadius: '24px',

--- a/client/packages/system/src/Encounter/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Encounter/DetailView/DetailView.tsx
@@ -305,13 +305,13 @@ export const DetailView: FC = () => {
         />
       ) : (
         <>
-          <Toolbar
-            onChange={updateEncounter}
+          <Toolbar onChange={updateEncounter} encounter={encounter} />
+          {tabs.length > 0 ? <DetailTabs tabs={tabs} /> : JsonForm}
+          <SidePanel
             encounter={encounter}
+            onChange={updateEncounter}
             onDelete={onDelete}
           />
-          {tabs.length > 0 ? <DetailTabs tabs={tabs} /> : JsonForm}
-          <SidePanel encounter={encounter} onChange={updateEncounter} />
         </>
       )}
       <SaveAsVisitedModal />

--- a/client/packages/system/src/Encounter/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Encounter/DetailView/DetailView.tsx
@@ -81,11 +81,15 @@ const useSaveWithStatus = (
   };
 };
 
-const useSaveWithStatusChangeModal = (
+const useSaveWithStatusChange = (
   onSave: () => void,
   encounterData: EncounterSchema | undefined,
   updateEncounter: (patch: Partial<EncounterFragment>) => Promise<void>
-): { showDialog: () => void; SaveAsVisitedModal: React.FC } => {
+): {
+  showDialog: () => void;
+  SaveAsVisitedModal: React.FC;
+  saveWithStatusChange: (status: EncounterNodeStatus) => void;
+} => {
   const { Modal, hideDialog, showDialog } = useDialog({
     disableBackdrop: true,
   });
@@ -131,6 +135,7 @@ const useSaveWithStatusChangeModal = (
   return {
     showDialog,
     SaveAsVisitedModal,
+    saveWithStatusChange,
   };
 };
 
@@ -211,12 +216,15 @@ export const DetailView: FC = () => {
     }
   }, [deleteRequest, data]);
 
-  const { showDialog: showSaveAsVisitedDialog, SaveAsVisitedModal } =
-    useSaveWithStatusChangeModal(
-      saveData,
-      data as unknown as EncounterSchema,
-      updateEncounter
-    );
+  const {
+    showDialog: showSaveAsVisitedDialog,
+    SaveAsVisitedModal,
+    saveWithStatusChange,
+  } = useSaveWithStatusChange(
+    saveData,
+    data as unknown as EncounterSchema,
+    updateEncounter
+  );
   const dataStatus = data
     ? (data as Record<string, JsonData>)['status']
     : undefined;
@@ -316,6 +324,7 @@ export const DetailView: FC = () => {
             saveData();
           }
         }}
+        onChangeStatus={saveWithStatusChange}
         onCancel={revert}
         isSaving={isSaving}
         isDisabled={!isDirty || !!validationError}

--- a/client/packages/system/src/Encounter/DetailView/Footer.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Footer.tsx
@@ -21,6 +21,7 @@ import {
   EncounterFragment,
 } from '@openmsupply-client/programs';
 import { encounterStatusTranslation } from '../utils';
+import { StatusChangeButton } from './StatusChangeButton';
 
 interface FooterProps {
   documentName?: string;
@@ -117,6 +118,7 @@ export const Footer: FC<FooterProps> = ({
               startIcon={<SaveIcon />}
               label={t('button.save')}
             />
+            <StatusChangeButton />
           </Box>
 
           <Modal
@@ -133,6 +135,7 @@ export const Footer: FC<FooterProps> = ({
                 gap={2}
               >
                 <Typography sx={{ fontSize: 18, fontWeight: 700 }}>
+                  {/* // todo fix this */}
                   Document Edit History
                 </Typography>
                 {documentName ? (

--- a/client/packages/system/src/Encounter/DetailView/Footer.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Footer.tsx
@@ -135,8 +135,7 @@ export const Footer: FC<FooterProps> = ({
                 gap={2}
               >
                 <Typography sx={{ fontSize: 18, fontWeight: 700 }}>
-                  {/* // todo fix this */}
-                  Document Edit History
+                  {t('label.document-edit-history')}
                 </Typography>
                 {documentName ? (
                   <DocumentHistory documentName={documentName} />

--- a/client/packages/system/src/Encounter/DetailView/Footer.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Footer.tsx
@@ -28,6 +28,7 @@ interface FooterProps {
   isDisabled: boolean;
   isSaving: boolean;
   onCancel: () => void;
+  onChangeStatus: (status: EncounterNodeStatus) => void;
   onSave: () => void;
   encounter?: EncounterFragment;
 }
@@ -67,6 +68,7 @@ export const Footer: FC<FooterProps> = ({
   isDisabled,
   isSaving,
   onCancel,
+  onChangeStatus,
   onSave,
   encounter,
 }) => {
@@ -118,7 +120,12 @@ export const Footer: FC<FooterProps> = ({
               startIcon={<SaveIcon />}
               label={t('button.save')}
             />
-            <StatusChangeButton />
+            {encounter?.status && (
+              <StatusChangeButton
+                currentStatus={encounter.status}
+                onSave={onChangeStatus}
+              />
+            )}
           </Box>
 
           <Modal

--- a/client/packages/system/src/Encounter/DetailView/SidePanel.tsx
+++ b/client/packages/system/src/Encounter/DetailView/SidePanel.tsx
@@ -15,6 +15,10 @@ import {
   useAuthContext,
   BasicTextInput,
   UNDEFINED_STRING_VALUE,
+  DetailPanelAction,
+  DeleteIcon,
+  EncounterNodeStatus,
+  useConfirmationModal,
 } from '@openmsupply-client/common';
 import {
   EncounterFragment,
@@ -33,9 +37,14 @@ interface SidePanelProps {
       createdBy?: { username: string; id?: string };
     }
   ) => void;
+  onDelete: () => void;
 }
 
-export const SidePanel: FC<SidePanelProps> = ({ encounter, onChange }) => {
+export const SidePanel: FC<SidePanelProps> = ({
+  encounter,
+  onChange,
+  onDelete,
+}) => {
   const [encounterNote, setEncounterNote] = useState(
     encounter.document.data?.notes?.[0]?.text ?? ''
   );
@@ -63,8 +72,30 @@ export const SidePanel: FC<SidePanelProps> = ({ encounter, onChange }) => {
     pagination: { first: NUM_RECENT_ENCOUNTERS },
   });
 
+  const getDeleteConfirmation = useConfirmationModal({
+    message: t('message.confirm-delete-encounter'),
+    title: t('title.confirm-delete-encounter'),
+  });
+
+  const onDeleteClick = () => {
+    getDeleteConfirmation({
+      onConfirm: () => {
+        onDelete();
+      },
+    });
+  };
+
   return (
-    <DetailPanelPortal>
+    <DetailPanelPortal
+      Actions={
+        <DetailPanelAction
+          onClick={onDeleteClick}
+          icon={<DeleteIcon />}
+          title={t('label.delete')}
+          disabled={encounter.status === EncounterNodeStatus.Deleted}
+        />
+      }
+    >
       <DetailPanelSection title={t('label.additional-info')}>
         <Grid container gap={0.5} key="additional-info">
           <PanelRow>
@@ -112,7 +143,7 @@ export const SidePanel: FC<SidePanelProps> = ({ encounter, onChange }) => {
                         created: encounter.startDatetime,
                         authorId: user?.id,
                         authorName: user?.name,
-                      } ?? null,
+                      },
                     ],
                   });
                 }}

--- a/client/packages/system/src/Encounter/DetailView/StatusChangeButton.tsx
+++ b/client/packages/system/src/Encounter/DetailView/StatusChangeButton.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { SplitButton, SplitButtonOption } from '@common/components';
+import { LocaleKey, TypedTFunction, useTranslation } from '@common/intl';
+import { EncounterNodeStatus } from '@common/types';
+import { encounterStatusTranslation } from '../utils';
+import { ArrowRightIcon } from '@common/icons';
+
+export const StatusChangeButton = () => {
+  const t = useTranslation();
+
+  const [selectedOption, setSelectedOption] = useState<
+    SplitButtonOption<EncounterNodeStatus>
+  >(encounterStatusOption(EncounterNodeStatus.Visited, t));
+
+  const onStatusClick = () => {
+    // return getConfirmation();
+  };
+
+  const statusOptions = [
+    encounterStatusOption(EncounterNodeStatus.Pending, t),
+    encounterStatusOption(EncounterNodeStatus.Visited, t),
+    encounterStatusOption(EncounterNodeStatus.Cancelled, t),
+  ];
+
+  return (
+    <SplitButton
+      // deleted?
+      // label={noLines ? t('messages.no-lines') : ''}
+      options={statusOptions}
+      selectedOption={selectedOption}
+      onSelectOption={setSelectedOption}
+      Icon={<ArrowRightIcon />}
+      onClick={onStatusClick}
+    />
+  );
+};
+
+function encounterStatusOption(
+  status: EncounterNodeStatus,
+  t: TypedTFunction<LocaleKey>
+): SplitButtonOption<EncounterNodeStatus> {
+  return {
+    label: encounterStatusTranslation(status, t),
+    value: status,
+  };
+}

--- a/client/packages/system/src/Encounter/DetailView/StatusChangeButton.tsx
+++ b/client/packages/system/src/Encounter/DetailView/StatusChangeButton.tsx
@@ -5,27 +5,33 @@ import { EncounterNodeStatus } from '@common/types';
 import { encounterStatusTranslation } from '../utils';
 import { ArrowRightIcon } from '@common/icons';
 
-export const StatusChangeButton = () => {
+export const StatusChangeButton = ({
+  currentStatus,
+  onSave,
+}: {
+  currentStatus: EncounterNodeStatus;
+  onSave: (status: EncounterNodeStatus) => void;
+}) => {
   const t = useTranslation();
 
   const [selectedOption, setSelectedOption] = useState<
     SplitButtonOption<EncounterNodeStatus>
-  >(encounterStatusOption(EncounterNodeStatus.Visited, t));
+  >(encounterStatusOption(EncounterNodeStatus.Visited, t, currentStatus));
 
   const onStatusClick = () => {
-    // return getConfirmation();
+    if (!selectedOption.value || selectedOption.value === currentStatus) return;
+    onSave(selectedOption.value);
+    setSelectedOption(selected => ({ ...selected, isDisabled: true }));
   };
 
   const statusOptions = [
-    encounterStatusOption(EncounterNodeStatus.Pending, t),
-    encounterStatusOption(EncounterNodeStatus.Visited, t),
-    encounterStatusOption(EncounterNodeStatus.Cancelled, t),
+    encounterStatusOption(EncounterNodeStatus.Pending, t, currentStatus),
+    encounterStatusOption(EncounterNodeStatus.Visited, t, currentStatus),
+    encounterStatusOption(EncounterNodeStatus.Cancelled, t, currentStatus),
   ];
 
   return (
     <SplitButton
-      // deleted?
-      // label={noLines ? t('messages.no-lines') : ''}
       options={statusOptions}
       selectedOption={selectedOption}
       onSelectOption={setSelectedOption}
@@ -37,10 +43,14 @@ export const StatusChangeButton = () => {
 
 function encounterStatusOption(
   status: EncounterNodeStatus,
-  t: TypedTFunction<LocaleKey>
+  t: TypedTFunction<LocaleKey>,
+  currentStatus?: EncounterNodeStatus
 ): SplitButtonOption<EncounterNodeStatus> {
   return {
-    label: encounterStatusTranslation(status, t),
+    label: t('label.mark-as-status', {
+      status: encounterStatusTranslation(status, t),
+    }),
     value: status,
+    isDisabled: status === currentStatus,
   };
 }

--- a/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
@@ -11,13 +11,8 @@ import {
   UserIcon,
   useFormatDateTime,
   ClinicianNode,
-  EncounterNodeStatus,
-  LocaleKey,
-  TypedTFunction,
-  Option,
   useIntlUtils,
   DocumentRegistryCategoryNode,
-  DeleteIcon,
   SxProps,
   Theme,
 } from '@openmsupply-client/common';
@@ -30,23 +25,7 @@ import {
   ClinicianSearchInput,
 } from '../../Clinician';
 import { Clinician } from '../../Clinician/utils';
-import {
-  DateTimePickerInput,
-  IconButton,
-  Select,
-  useConfirmationModal,
-} from '@common/components';
-import { encounterStatusTranslation } from '../utils';
-
-const encounterStatusOption = (
-  status: EncounterNodeStatus,
-  t: TypedTFunction<LocaleKey>
-): Option => {
-  return {
-    label: encounterStatusTranslation(status, t),
-    value: status,
-  };
-};
+import { DateTimePickerInput } from '@common/components';
 
 const Row = ({
   label,
@@ -80,17 +59,9 @@ const updateEndDatetimeFromStartDate = (
 
 interface ToolbarProps {
   onChange: (patch: Partial<EncounterFragment>) => void;
-  onDelete: () => void;
   encounter: EncounterFragment;
 }
-export const Toolbar: FC<ToolbarProps> = ({
-  encounter,
-  onChange,
-  onDelete,
-}) => {
-  const [status, setStatus] = useState<EncounterNodeStatus | undefined>(
-    encounter.status ?? undefined
-  );
+export const Toolbar: FC<ToolbarProps> = ({ encounter, onChange }) => {
   const [startDatetime, setStartDatetime] = useState<string | undefined>();
   const [endDatetime, setEndDatetime] = useState<string | undefined | null>();
   const t = useTranslation();
@@ -107,7 +78,6 @@ export const Toolbar: FC<ToolbarProps> = ({
     });
 
   useEffect(() => {
-    setStatus(encounter.status ?? undefined);
     setStartDatetime(encounter.startDatetime);
     setEndDatetime(encounter.endDatetime);
     setClinician({
@@ -119,30 +89,8 @@ export const Toolbar: FC<ToolbarProps> = ({
     });
   }, [encounter, getLocalisedFullName]);
 
-  const getDeleteConfirmation = useConfirmationModal({
-    message: t('message.confirm-delete-encounter'),
-    title: t('title.confirm-delete-encounter'),
-  });
-
-  const onDeleteClick = () => {
-    getDeleteConfirmation({
-      onConfirm: () => {
-        setStatus(EncounterNodeStatus.Deleted);
-        onDelete();
-      },
-    });
-  };
-
   const { patient } = encounter;
 
-  const statusOptions = [
-    encounterStatusOption(EncounterNodeStatus.Pending, t),
-    encounterStatusOption(EncounterNodeStatus.Visited, t),
-    encounterStatusOption(EncounterNodeStatus.Cancelled, t),
-  ];
-  if (status === EncounterNodeStatus.Deleted) {
-    statusOptions.push(encounterStatusOption(EncounterNodeStatus.Deleted, t));
-  }
   return (
     <AppBarContentPortal sx={{ display: 'flex', flex: 1, marginBottom: 1 }}>
       <Grid
@@ -186,32 +134,6 @@ export const Toolbar: FC<ToolbarProps> = ({
                     value={localisedDate(patient.dateOfBirth ?? '')}
                   />
                 }
-              />
-
-              <Row
-                label={t('label.encounter-status')}
-                sx={{ marginLeft: 'auto' }}
-                Input={
-                  <Select
-                    fullWidth
-                    onChange={event => {
-                      const newStatus = event.target
-                        .value as EncounterNodeStatus;
-                      setStatus(newStatus);
-                      onChange({
-                        status: newStatus,
-                      });
-                    }}
-                    options={statusOptions}
-                    value={status}
-                  />
-                }
-              />
-
-              <IconButton
-                icon={<DeleteIcon />}
-                onClick={onDeleteClick}
-                label={t('label.delete')}
               />
             </Box>
             <Box display="flex" gap={1.5}>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6272

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Make status change/delete workflows of encounters match those of other features.


Removes status change and delete from toolbar. 

Adds delete button to side panel, and status change to footer:
![Screenshot 2025-01-24 at 3 28 40 PM](https://github.com/user-attachments/assets/fa663afc-a8e6-46cd-a6e2-02e148d92ce0)

Pre-requisite to hooking into status change logic within vax card.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an encounter
- [ ] On detail view - there is no status dropdown or delete button in the toolbar
- [ ] Footer has new split button, says `Mark as Visited` by default
- [ ] Clicking the button changes the status
  - [ ] Status breadcrumb updates to show visited
  - [ ] You get the green success toast that it saved successfully
  - [ ] Status button for visited is now disabled
  - [ ] You can still change the button, to mark as Pending or Cancelled
- [ ] Click More to open side panel
- [ ] There is now a delete button
- [ ] Clicking delete opens a confirmation modal - confirming deletes the encounter and redirects you to the list view

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
