### PR TITLE
fix confirm on leaving with multiple blockers

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/DetailView.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/DetailView.tsx
@@ -50,10 +50,9 @@ export const EquipmentDetailView = () => {
   const t = useTranslation();
   const { setCustomBreadcrumbs } = useBreadcrumbs();
   const [draft, setDraft] = useState<DraftAsset>();
-  const [isDirty, setIsDirty] = useState(false);
   const { error, success } = useNotification();
 
-  useConfirmOnLeaving(isDirty);
+  const { isDirty, setIsDirty } = useConfirmOnLeaving('equipment-detail-view');
 
   const save = async () => {
     if (!draft) return;

--- a/client/packages/coldchain/src/Monitoring/ListView/AppBarButtons.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/AppBarButtons.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import {
   AppBarButtonsPortal,
   LoadingButton,
@@ -22,7 +22,6 @@ export const AppBarButtons = () => {
   const t = useTranslation();
   const hiddenFileInput = useRef<HTMLInputElement>(null);
   const { storeId } = useAuthContext();
-  const [isUploadingFridgeTag, setIsUploadingFridgeTag] = useState(false);
   const { success, error } = useNotification();
   const queryClient = useQueryClient();
   const sensorApi = useSensor.utils.api();
@@ -34,7 +33,8 @@ export const AppBarButtons = () => {
     title: t('title.new-sensor'),
   });
   // prevent a user reloading the page while uploading
-  useConfirmOnLeaving(isUploadingFridgeTag);
+  const { isDirty: isUploadingFridgeTag, setIsDirty: setIsUploadingFridgeTag } =
+    useConfirmOnLeaving('upload-fridge-tag');
 
   const onUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e?.target?.files?.[0];

--- a/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.stories.tsx
+++ b/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Grid } from '@mui/material';
 import { StoryFn } from '@storybook/react';
 import { useConfirmOnLeaving } from './useConfirmOnLeaving';
@@ -10,14 +10,13 @@ export default {
 };
 
 const Template: StoryFn = () => {
-  const [isUnsaved, setIsUnsaved] = useState(false);
-  useConfirmOnLeaving(isUnsaved);
+  const { isDirty, setIsDirty } = useConfirmOnLeaving('storybook');
 
   return (
     <Grid>
       <ToggleButton
-        selected={isUnsaved}
-        onClick={() => setIsUnsaved(!isUnsaved)}
+        selected={isDirty}
+        onClick={() => setIsDirty(!isDirty)}
         label="Prompt if leaving this page"
         value="dirty"
       />

--- a/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.ts
+++ b/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.ts
@@ -1,5 +1,6 @@
 import { useCallback, useContext, useEffect } from 'react';
 import { useBeforeUnload, useBlocker } from 'react-router-dom';
+import { create } from 'zustand';
 import { useTranslation } from '@common/intl';
 import { ConfirmationModalContext, Location } from '@openmsupply-client/common';
 
@@ -8,28 +9,54 @@ import { ConfirmationModalContext, Location } from '@openmsupply-client/common';
  * navigate away from, or refresh the page, when there are unsaved changes.
  */
 export const useConfirmOnLeaving = (
-  isUnsaved?: boolean,
+  key: string,
   customCheck?: (currentLocation: Location, nextLocation: Location) => boolean
 ) => {
+  const { blocking, setBlocking, clearKey } = useBlockNavigationState();
+
+  // Register the key for blocking navigation
+  useEffect(() => {
+    setBlocking(key, false, customCheck);
+
+    // Cleanup
+    return () => clearKey(key);
+  }, []);
+
+  const isDirty = blocking.get(key)?.shouldBlock ?? false;
+  const setIsDirty = (dirty: boolean) => setBlocking(key, dirty, customCheck);
+
+  return { isDirty, setIsDirty };
+};
+
+/**
+ * useBlocker only allows one blocker to be active at a time, despite the fact that
+ * we might want to block from multiple sources.
+ *
+ * So we render this hook in `Site`, at the root of the app, and handle the different
+ * blocking conditions with BlockNavigation zustand state
+ */
+export const useBlockNavigation = () => {
   const t = useTranslation();
-  const customConfirm = (onOk: () => void) => {
-    setOnConfirm(onOk);
-    showConfirmation();
-  };
+  const { blocking } = useBlockNavigationState();
 
   const { setOpen, setMessage, setOnConfirm, setTitle } = useContext(
     ConfirmationModalContext
   );
 
   const showConfirmation = useCallback(() => {
-    setMessage(t('heading.are-you-sure'));
-    setTitle(t('messages.confirm-cancel-generic'));
+    setTitle(t('heading.are-you-sure'));
+    setMessage(t('messages.confirm-cancel-generic'));
     setOpen(true);
   }, [setMessage, setTitle, setOpen]);
 
+  const blockers: BlockingState[] = Array.from(blocking.values());
+  const shouldBlock = blockers.some(b => b.shouldBlock);
+
   const blocker = useBlocker(({ currentLocation, nextLocation }) => {
-    if (customCheck) return customCheck(currentLocation, nextLocation);
-    return !!isUnsaved && currentLocation.pathname !== nextLocation.pathname;
+    for (const b of blockers) {
+      if (b.customCheck) return b.customCheck(currentLocation, nextLocation);
+    }
+    return !!shouldBlock && currentLocation.pathname !== nextLocation.pathname;
   });
 
   // handle page refresh events
@@ -37,9 +64,9 @@ export const useConfirmOnLeaving = (
     useCallback(
       event => {
         // Cancel the refresh
-        if (isUnsaved) event.preventDefault();
+        if (shouldBlock) event.preventDefault();
       },
-      [isUnsaved]
+      [shouldBlock]
     ),
     { capture: true }
   );
@@ -50,6 +77,48 @@ export const useConfirmOnLeaving = (
       showConfirmation();
     }
   }, [blocker]);
-
-  return { showConfirmation: customConfirm };
 };
+
+interface BlockingState {
+  shouldBlock: boolean;
+  customCheck?: (currentLocation: Location, nextLocation: Location) => boolean;
+}
+interface BlockNavigationControl {
+  blocking: Map<string, BlockingState>;
+  setBlocking: (
+    key: string,
+    blocking: boolean,
+    /**
+     * Only one registered customCheck will be used at a time, the first one,
+     * even if multiple blockers are registered
+     */
+    customCheck?: (currentLocation: Location, nextLocation: Location) => boolean
+  ) => void;
+  clearKey: (key: string) => void;
+}
+
+const useBlockNavigationState = create<BlockNavigationControl>(set => {
+  return {
+    blocking: new Map(),
+    setBlocking: (key, blocking, customCheck) => {
+      set(state => {
+        const blockingState = new Map(state.blocking);
+        blockingState.set(key, { shouldBlock: blocking, customCheck });
+        return {
+          ...state,
+          blocking: blockingState,
+        };
+      });
+    },
+    clearKey: key => {
+      set(state => {
+        const blockingState = new Map(state.blocking);
+        blockingState.delete(key);
+        return {
+          ...state,
+          blocking: blockingState,
+        };
+      });
+    },
+  };
+});

--- a/client/packages/common/src/ui/components/navigation/Tabs/DetailTabs.tsx
+++ b/client/packages/common/src/ui/components/navigation/Tabs/DetailTabs.tsx
@@ -2,7 +2,6 @@ import React, { FC, ReactNode, useState, useEffect, useCallback } from 'react';
 import TabContext from '@mui/lab/TabContext';
 import { Box } from '@mui/material';
 import {
-  useConfirmOnLeaving,
   UrlQueryObject,
   UrlQuerySort,
   useDetailPanelStore,
@@ -13,6 +12,7 @@ import { AppBarTabsPortal } from '../../portals';
 import { DetailTab } from './DetailTab';
 import { ShortTabList, Tab } from './Tabs';
 import { useUrlQuery } from '@common/hooks';
+import { useConfirmationModal } from '../../modals';
 
 export type TabDefinition = {
   Component: ReactNode;
@@ -44,8 +44,12 @@ export const DetailTabs: FC<DetailTabsProps> = ({
   const currentUrlTab = urlQuery['tab'] as string | undefined;
   const currentTab = isValidTab(currentUrlTab)
     ? currentUrlTab
-    : tabs[0]?.value ?? '';
-  const { showConfirmation } = useConfirmOnLeaving(false);
+    : (tabs[0]?.value ?? '');
+
+  const showConfirmation = useConfirmationModal({
+    title: t('heading.are-you-sure'),
+    message: t('messages.confirm-cancel-generic'),
+  });
 
   // Inelegant hack to force the "Underline" indicator for the currently active
   // tab to re-render in the correct position when one of the side "drawers" is
@@ -76,11 +80,11 @@ export const DetailTabs: FC<DetailTabsProps> = ({
 
     // restore the query params for the tab
     const query: UrlQueryObject = restoreTabQuery
-      ? tabQueryParams[tab] ?? getDefaultTabQueryParams(tab)
+      ? (tabQueryParams[tab] ?? getDefaultTabQueryParams(tab))
       : { tab };
 
     if (!!tabConfirm?.confirmOnLeaving && requiresConfirmation(currentTab)) {
-      showConfirmation(() => updateQuery(query, overwriteQuery));
+      showConfirmation({ onConfirm: () => updateQuery(query, overwriteQuery) });
     } else {
       updateQuery(query, overwriteQuery);
     }

--- a/client/packages/host/src/Site.tsx
+++ b/client/packages/host/src/Site.tsx
@@ -18,6 +18,7 @@ import {
   SnackbarProvider,
   BarcodeScannerProvider,
   DetailLoadingSkeleton,
+  useBlockNavigation,
 } from '@openmsupply-client/common';
 import { AppDrawer, AppBar, Footer, NotFound } from './components';
 import { CommandK } from './CommandK';
@@ -68,6 +69,8 @@ export const Site: FC = () => {
   useEffect(() => {
     setPageTitle(pageTitle);
   }, [location, pageTitle, setPageTitle]);
+
+  useBlockNavigation();
 
   return (
     <RequireAuthentication>

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
@@ -7,7 +7,6 @@ import {
   useDialog,
   useNotification,
   ModalMode,
-  useDirtyCheck,
   useConfirmOnLeaving,
   TableProvider,
   createTableStore,
@@ -36,8 +35,9 @@ const useDraftInboundLines = (item: InboundLineItem | null) => {
   const { id } = useInbound.document.fields('id');
   const { mutateAsync, isLoading } = useInbound.lines.save();
   const [draftLines, setDraftLines] = useState<DraftInboundLine[]>([]);
-  const { isDirty, setIsDirty } = useDirtyCheck();
-  useConfirmOnLeaving(isDirty);
+  const { isDirty, setIsDirty } = useConfirmOnLeaving(
+    'inbound-shipment-line-edit'
+  );
 
   const defaultPackSize = item?.defaultPackSize || 1;
 

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
@@ -3,7 +3,6 @@ import {
   InvoiceLineNodeType,
   InvoiceNodeStatus,
   useConfirmOnLeaving,
-  useDirtyCheck,
   SortUtils,
 } from '@openmsupply-client/common';
 import { useStockLines } from '@openmsupply-client/system';
@@ -31,7 +30,6 @@ export const useDraftOutboundLines = (
   const { data: lines, isLoading: outboundLinesLoading } =
     useOutbound.line.stockLines(item?.id ?? '');
   const { data, isLoading } = useStockLines(item?.id);
-  const { isDirty, setIsDirty } = useDirtyCheck();
   const [draftStockOutLines, setDraftStockOutLines] = useState<
     DraftStockOutLine[]
   >([]);
@@ -42,7 +40,7 @@ export const useDraftOutboundLines = (
     itemId: item?.id || '',
   });
 
-  useConfirmOnLeaving(isDirty);
+  const { setIsDirty } = useConfirmOnLeaving('outbound-shipment-line-edit');
 
   useEffect(() => {
     // Check placed in since last else in the map is needed to show placeholder row,

--- a/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
@@ -7,7 +7,6 @@ import {
   RouteBuilder,
   useBreadcrumbs,
   useConfirmOnLeaving,
-  useDirtyCheck,
   useNavigate,
   useParams,
 } from '@openmsupply-client/common';
@@ -46,8 +45,6 @@ export const PrescriptionLineEditView = () => {
     // the list before scrolling to it
     setTimeout(() => scrollRef.current?.scrollIntoView(), 100);
 
-  const { isDirty, setIsDirty } = useDirtyCheck();
-
   const lines =
     data?.lines.nodes.sort((a, b) => a.id.localeCompare(b.id)) ?? [];
 
@@ -82,8 +79,9 @@ export const PrescriptionLineEditView = () => {
     });
   }, [currentItem]);
 
-  useConfirmOnLeaving(
-    isDirty,
+  // tODO: does the state turn up right lol
+  const { isDirty, setIsDirty } = useConfirmOnLeaving(
+    'prescription-line-edit',
     // Need a custom checking method here, as we don't want to warn user when
     // switching to a different item within this page
     (current, next) => {

--- a/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
@@ -24,6 +24,7 @@ import { NavBar } from './NavBar';
 export const PrescriptionLineEditView = () => {
   const { invoiceNumber, itemId } = useParams();
   const { setCustomBreadcrumbs } = useBreadcrumbs();
+  const isDirty = useRef(false);
   const navigate = useNavigate();
 
   const {
@@ -79,13 +80,12 @@ export const PrescriptionLineEditView = () => {
     });
   }, [currentItem]);
 
-  // tODO: does the state turn up right lol
-  const { isDirty, setIsDirty } = useConfirmOnLeaving(
+  useConfirmOnLeaving(
     'prescription-line-edit',
     // Need a custom checking method here, as we don't want to warn user when
     // switching to a different item within this page
     (current, next) => {
-      if (!isDirty) return false;
+      if (!isDirty.current) return false;
 
       const currentPathParts = current.pathname.split('/');
       const nextPathParts = next.pathname.split('/');
@@ -106,7 +106,7 @@ export const PrescriptionLineEditView = () => {
   };
 
   const onSave = async () => {
-    if (!isDirty) return;
+    if (!isDirty.current) return;
 
     const flattenedLines = Object.values(allDraftLines).flat();
 
@@ -143,7 +143,7 @@ export const PrescriptionLineEditView = () => {
           .build()
       );
     }
-    setIsDirty(false);
+    isDirty.current = false;
     setAllDraftLines({});
   };
 
@@ -166,7 +166,7 @@ export const PrescriptionLineEditView = () => {
               .addPart(String(invoiceNumber))}
             enteredLineIds={enteredLineIds}
             showNew={status !== InvoiceNodeStatus.Verified}
-            isDirty={isDirty}
+            isDirty={isDirty.current}
             handleSaveNew={onSave}
             scrollRef={scrollRef}
           />
@@ -177,7 +177,9 @@ export const PrescriptionLineEditView = () => {
               item={currentItem ?? null}
               draftLines={allDraftLines[itemId] ?? []}
               updateLines={updateAllLines}
-              setIsDirty={setIsDirty}
+              setIsDirty={dirty => {
+                isDirty.current = dirty;
+              }}
             />
             <NavBar
               items={itemIdList}
@@ -198,7 +200,7 @@ export const PrescriptionLineEditView = () => {
       />
       <Footer
         isSaving={isSavingLines}
-        isDirty={isDirty}
+        isDirty={isDirty.current}
         handleSave={onSave}
         handleCancel={() =>
           navigate(

--- a/client/packages/programs/src/JsonForms/useFormActions.tsx
+++ b/client/packages/programs/src/JsonForms/useFormActions.tsx
@@ -20,7 +20,7 @@
  * need to be directly reflected in the UI should be stored here.
  */
 
-import { Dispatch, SetStateAction, useCallback, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { ObjUtils } from '@common/utils';
 
 export type SubmitActionRegistry = Record<
@@ -39,7 +39,7 @@ export interface FormActionStructure {
 }
 
 export const useFormActions = (
-  setIsDirty: Dispatch<SetStateAction<boolean | undefined>>
+  setIsDirty: (isDirty: boolean) => void
 ): FormActionStructure => {
   const state = useRef<Record<string, unknown>>({});
   const submitActions = useRef<SubmitActionRegistry>({});

--- a/client/packages/programs/src/JsonForms/useJsonFormsHandler.tsx
+++ b/client/packages/programs/src/JsonForms/useJsonFormsHandler.tsx
@@ -219,7 +219,5 @@ export const useJsonFormsHandler = <R,>(
     error,
     validationError,
     formActions,
-    // exposing so we can hook into the confirmOnLeaving with external changes as well!
-    setIsDirty,
   };
 };

--- a/client/packages/programs/src/JsonForms/useJsonFormsHandler.tsx
+++ b/client/packages/programs/src/JsonForms/useJsonFormsHandler.tsx
@@ -126,13 +126,12 @@ export const useJsonFormsHandler = <R,>(
   // current modified data
   const [data, setData] = useState<JsonData | undefined>();
   const [isSaving, setSaving] = useState(false);
-  const [isDirty, setIsDirty] = useState<boolean>();
-  const formActions = useFormActions(setIsDirty);
   const t = useTranslation();
   const [validationError, setValidationError] = useState<string | false>(false);
   const { success, error: errorNotification } = useNotification();
 
-  useConfirmOnLeaving(isDirty ?? false);
+  const { isDirty, setIsDirty } = useConfirmOnLeaving('json-forms');
+  const formActions = useFormActions(setIsDirty);
 
   // returns the document name
   const saveData = async (deletion?: boolean): Promise<R | undefined> => {
@@ -220,5 +219,7 @@ export const useJsonFormsHandler = <R,>(
     error,
     validationError,
     formActions,
+    // exposing so we can hook into the confirmOnLeaving with external changes as well!
+    setIsDirty,
   };
 };

--- a/client/packages/requisitions/src/RnRForms/DetailView/DetailView.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/DetailView.tsx
@@ -62,12 +62,18 @@ const RnRFormDetailViewComponent = ({
   const t = useTranslation();
   const { setCustomBreadcrumbs } = useBreadcrumbs();
 
-  const { isDirty, clearAllDraftLines } = useRnRFormContext(state => ({
-    isDirty: !!Object.values(state.draftLines).length,
+  const { rnrFormIsDirty, clearAllDraftLines } = useRnRFormContext(state => ({
+    rnrFormIsDirty: !!Object.values(state.draftLines).length,
     clearAllDraftLines: state.clearAllDraftLines,
   }));
 
-  useConfirmOnLeaving(isDirty);
+  const { setIsDirty } = useConfirmOnLeaving('rnr-form');
+
+  useEffect(() => {
+    // Usually we track isDirty state from `useConfirmOnLeaving` hook
+    // In this case we derive from the draft line context, so we need to update it manually
+    setIsDirty(rnrFormIsDirty);
+  }, [rnrFormIsDirty]);
 
   useEffect(() => {
     return () => clearAllDraftLines();
@@ -107,7 +113,7 @@ const RnRFormDetailViewComponent = ({
       <SidePanel rnrFormId={data.id} />
       <Footer
         rnrFormId={data.id}
-        unsavedChanges={isDirty}
+        unsavedChanges={rnrFormIsDirty}
         linesUnconfirmed={linesUnconfirmed}
       />
     </>


### PR DESCRIPTION
Fixes #6321

# 👩🏻‍💻 What does this PR do?

useBlocker can only have one active instance at a time. In encounters, there were two blockers (one from JSON form, one from `DetailTabs`) - so neither were working. You could edit encounter, then navigate away without saving with no warning.

This updates the implementation so that we can register multiple blockers in as many places as we need, and this informs the one `useBlocker` call at the base of the app. 


## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

Actually ended up fixing the detail tabs so that it doesn't use the confirm on leaving hook - see comment - but will have the same multiple blockers rendered problem with my next vax card PR. Just didn't want this bloat in that PR 🙏 


<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Setup for vaccine card - see testing setup: #4642 
- [ ] Create/go to a vaccination encounter
- [ ] Make a change e.g. set visit type or start time
- [ ] Try to navigate away - you get the are you sure confirmation modal
- [ ] Also test it still works in the other places:
  - [ ] Refreshing page in inbound/outbound shipment edit modals
  - [ ] R&R form
  - [ ] Editing CCE
  - [ ] Editing prescription
    - [ ] Check you still _can_ change between items in prescription, just not to a different page

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
