### PR TITLE
Change the button style (orange text on white) to have black text

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/AppBarButtons.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/AppBarButtons.tsx
@@ -66,6 +66,7 @@ export const AppBarButtonsComponent = () => {
           isLoading={isPrinting}
           onClick={onClick}
           label={t('button.print-asset-label')}
+          variant="outlined"
         />
       </Grid>
       <DisabledNotification />

--- a/client/packages/coldchain/src/Monitoring/ListView/AppBarButtons.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/AppBarButtons.tsx
@@ -110,6 +110,7 @@ export const AppBarButtons = () => {
           iconColor: 'background.white',
         }}
         label={t('button.import-fridge-tag')}
+        variant="outlined"
       />
     </AppBarButtonsPortal>
   );

--- a/client/packages/common/src/ui/components/buttons/standard/LoadingButton.tsx
+++ b/client/packages/common/src/ui/components/buttons/standard/LoadingButton.tsx
@@ -16,6 +16,7 @@ export const LoadingButton: React.FC<
 > = ({
   children,
   color = 'primary',
+  variant = 'outlined',
   disabled,
   endIcon,
   isLoading,
@@ -48,6 +49,7 @@ export const LoadingButton: React.FC<
       startIcon={startIcon}
       shouldShrink={shouldShrink}
       shrinkThreshold={shrinkThreshold}
+      variant={variant}
       {...rest}
     >
       {children}

--- a/client/packages/common/src/ui/components/buttons/standard/SplitButton.tsx
+++ b/client/packages/common/src/ui/components/buttons/standard/SplitButton.tsx
@@ -5,6 +5,7 @@ import MenuItem from '@mui/material/MenuItem';
 import { ChevronDownIcon } from '../../../icons';
 import { ButtonWithIcon, ButtonWithIconProps } from './ButtonWithIcon';
 import { ShrinkableBaseButton, Tooltip } from '@common/components';
+import { PopoverOrigin } from '@mui/material';
 
 export interface SplitButtonOption<T> {
   label: string;
@@ -23,6 +24,7 @@ export interface SplitButtonProps<T> {
   selectedOption: SplitButtonOption<T>;
   onSelectOption: (option: SplitButtonOption<T>) => void;
   label?: string;
+  openFrom?: PopoverOrigin['vertical'];
 }
 
 export const SplitButton = <T,>({
@@ -36,10 +38,19 @@ export const SplitButton = <T,>({
   selectedOption,
   onSelectOption,
   label,
+  openFrom = 'top',
 }: SplitButtonProps<T>) => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const buttonLabel = selectedOption.label;
   const open = !!anchorEl;
+
+  const popoverOrigin: {
+    anchorOrigin: PopoverOrigin['vertical'];
+    transformOrigin: PopoverOrigin['vertical'];
+  } =
+    openFrom === 'top'
+      ? { anchorOrigin: 'top', transformOrigin: 'bottom' }
+      : { anchorOrigin: 'bottom', transformOrigin: 'top' };
 
   return (
     <>
@@ -63,6 +74,7 @@ export const SplitButton = <T,>({
           <ShrinkableBaseButton
             shouldShrink={true}
             shrinkThreshold="md"
+            variant="outlined"
             disabled={isDisabled}
             color={color}
             size="small"
@@ -89,11 +101,11 @@ export const SplitButton = <T,>({
         onClose={() => setAnchorEl(null)}
         elevation={5}
         anchorOrigin={{
-          vertical: 'top',
+          vertical: popoverOrigin.anchorOrigin,
           horizontal: 'right',
         }}
         transformOrigin={{
-          vertical: 'bottom',
+          vertical: popoverOrigin.transformOrigin,
           horizontal: 'right',
         }}
       >

--- a/client/packages/common/src/ui/components/buttons/standard/SplitButton.tsx
+++ b/client/packages/common/src/ui/components/buttons/standard/SplitButton.tsx
@@ -42,73 +42,75 @@ export const SplitButton = <T,>({
   const open = !!anchorEl;
 
   return (
-    <Tooltip title={label}>
-      <ButtonGroup color={color} variant="outlined" aria-label={ariaLabel}>
-        <ButtonWithIcon
-          color={color}
-          disabled={isDisabled}
-          sx={{
-            borderRadius: 0,
-            borderStartStartRadius: '24px',
-            borderEndStartRadius: '24px',
-          }}
-          onClick={() => {
-            onClick(selectedOption);
-          }}
-          label={buttonLabel}
-          Icon={Icon}
-        />
+    <>
+      <Tooltip title={label}>
+        <ButtonGroup color={color} variant="outlined" aria-label={ariaLabel}>
+          <ButtonWithIcon
+            color={color}
+            disabled={isDisabled}
+            sx={{
+              borderRadius: 0,
+              borderStartStartRadius: '24px',
+              borderEndStartRadius: '24px',
+            }}
+            onClick={() => {
+              onClick(selectedOption);
+            }}
+            label={buttonLabel}
+            Icon={Icon}
+          />
 
-        <ShrinkableBaseButton
-          shouldShrink={true}
-          shrinkThreshold="md"
-          disabled={isDisabled}
-          color={color}
-          size="small"
-          aria-controls={open ? ariaControlLabel : undefined}
-          aria-expanded={open ? 'true' : undefined}
-          aria-label={ariaLabel}
-          aria-haspopup="menu"
-          onClick={e => {
-            setAnchorEl(e.currentTarget);
-          }}
-          sx={{
-            borderRadius: 0,
-            borderStartEndRadius: '24px',
-            borderEndEndRadius: '24px',
-          }}
-          label=""
-          startIcon={<ChevronDownIcon />}
-        />
-        <Menu
-          anchorEl={anchorEl}
-          open={open}
-          onClose={() => setAnchorEl(null)}
-          elevation={5}
-          anchorOrigin={{
-            vertical: 'top',
-            horizontal: 'right',
-          }}
-          transformOrigin={{
-            vertical: 'bottom',
-            horizontal: 'right',
-          }}
-        >
-          {options.map(option => (
-            <MenuItem
-              key={option.label}
-              disabled={option?.isDisabled}
-              selected={option.value === selectedOption.value}
-              onClick={() => {
-                onSelectOption(option);
-                setAnchorEl(null);
-              }}
-            >
-              {option.label}
-            </MenuItem>
-          ))}
-        </Menu>
-      </ButtonGroup>
-    </Tooltip>
+          <ShrinkableBaseButton
+            shouldShrink={true}
+            shrinkThreshold="md"
+            disabled={isDisabled}
+            color={color}
+            size="small"
+            aria-controls={open ? ariaControlLabel : undefined}
+            aria-expanded={open ? 'true' : undefined}
+            aria-label={ariaLabel}
+            aria-haspopup="menu"
+            onClick={e => {
+              setAnchorEl(e.currentTarget);
+            }}
+            sx={{
+              borderRadius: 0,
+              borderStartEndRadius: '24px',
+              borderEndEndRadius: '24px',
+            }}
+            label=""
+            startIcon={<ChevronDownIcon />}
+          />
+        </ButtonGroup>
+      </Tooltip>
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={() => setAnchorEl(null)}
+        elevation={5}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        transformOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+      >
+        {options.map(option => (
+          <MenuItem
+            key={option.label}
+            disabled={option?.isDisabled}
+            selected={option.value === selectedOption.value}
+            onClick={() => {
+              onSelectOption(option);
+              setAnchorEl(null);
+            }}
+          >
+            {option.label}
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
   );
 };

--- a/client/packages/system/src/Patient/PatientView/AddButton.tsx
+++ b/client/packages/system/src/Patient/PatientView/AddButton.tsx
@@ -86,6 +86,7 @@ export const AddButton: React.FC<AddButtonProps> = ({
     <>
       <SplitButton
         color="primary"
+        openFrom={'bottom'}
         isDisabled={disabled}
         options={options}
         selectedOption={selectedOption}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5806 

# 👩🏻‍💻 What does this PR do?

Added specified variant type to the two buttons found in testing that hadn't updated to new coloring of orange icon with black text
Added a default variant type to the Loading Button to catch any in the future

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

Cold Chain -> Equipment -> Detail View
<img width="389" alt="Screenshot 2025-01-28 at 12 04 56 PM" src="https://github.com/user-attachments/assets/34f28cf9-df6f-4b3b-ae82-e606699b17b2" />

Cold Chain -> Monitoring
<img width="234" alt="Screenshot 2025-01-28 at 12 04 39 PM" src="https://github.com/user-attachments/assets/c3bafd55-e626-463c-aa7a-b7c2060bb7c6" />


Side Quest:
Updated the Split button to have rounded corners on the right hand side
This was mentioned in #6276 - I am not set up on encounters currently to test in this area but this is a split button from Inbound Shipment -> Detail View
<img width="266" alt="Screenshot 2025-01-28 at 1 23 26 PM" src="https://github.com/user-attachments/assets/9f7e6296-a2f0-4809-8816-f09146415e02" />
<img width="266" alt="Screenshot 2025-01-28 at 1 44 44 PM" src="https://github.com/user-attachments/assets/f19735ba-3304-4cbc-98e3-c898e8a665b1" />


## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ]  Go to Cold Chain -> Equipment -> Detail View
- [ ] See 'Print Asset' with orange icon and black text
- [ ] Cold Chain -> Monitoring
- [ ] See 'Import Fridge Tag' with orange icon and black text


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
