### PR TITLE
6263 suggest next date from vax card

### DIFF
--- a/client/packages/system/src/Encounter/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Encounter/DetailView/DetailView.tsx
@@ -37,6 +37,8 @@ import { getLogicalStatus } from '../utils';
 import { PatientTabValue } from '../../Patient/PatientView/PatientView';
 import { VaccinationCard } from '../../Vaccination/Components/VaccinationCard';
 import { ScheduleNextEncounterModal } from './ScheduleNextEncounterModal';
+import { usePatientVaccineCard } from '../../Vaccination/api/usePatientVaccineCard';
+import { getNextVaccinationEncounterDate } from './helpers';
 
 const getPatientBreadcrumbSuffix = (
   encounter: EncounterFragment,
@@ -165,6 +167,15 @@ export const DetailView: FC = () => {
     isSuccess,
     isError,
   } = useEncounter.document.byId(id);
+
+  // If this is a vaccination encounter, we want to use the suggested
+  // next vaccination dates for the next encounter
+  const {
+    query: { data: vaccineCard },
+  } = usePatientVaccineCard(encounter?.programEnrolment?.id ?? '');
+  const suggestedNextEncounterDate = getNextVaccinationEncounterDate(
+    vaccineCard?.items ?? []
+  );
 
   const handleSave = useEncounter.document.upsertDocument(
     encounter?.patient.id ?? '',
@@ -363,6 +374,7 @@ export const DetailView: FC = () => {
               encounterConfig={encounter.document.documentRegistry}
               onClose={nextEncounterModal.toggleOff}
               patientId={encounter.patient.id ?? ''}
+              suggestedDate={suggestedNextEncounterDate}
             />
           )}
           <Toolbar onChange={updateEncounter} encounter={encounter} />

--- a/client/packages/system/src/Encounter/DetailView/ScheduleNextEncounterModal.tsx
+++ b/client/packages/system/src/Encounter/DetailView/ScheduleNextEncounterModal.tsx
@@ -23,15 +23,18 @@ export const ScheduleNextEncounterModal = ({
   patientId,
   encounterConfig,
   onClose,
+  suggestedDate,
 }: {
   patientId: string;
   encounterConfig: DocumentRegistryFragment;
   onClose: () => void;
+  suggestedDate: Date | null;
 }) => {
   const { user, storeId } = useAuthContext();
   const t = useTranslation();
   const [draft, setDraft] = useState<EncounterSchema>({
     createdDatetime: new Date().toISOString(),
+    startDatetime: suggestedDate?.toISOString(),
     createdBy: { id: user?.id ?? '', username: user?.name ?? '' },
     status: EncounterNodeStatus.Pending,
     location: {

--- a/client/packages/system/src/Encounter/DetailView/helpers.test.ts
+++ b/client/packages/system/src/Encounter/DetailView/helpers.test.ts
@@ -1,0 +1,45 @@
+import { DateUtils } from '@common/intl';
+import { VaccinationCardItemFragment } from '../../Vaccination/api/operations.generated';
+import { getNextVaccinationEncounterDate } from './helpers';
+
+describe('getNextVaccinationEncounterDate', () => {
+  it('should return null if there are no items', () => {
+    const items: VaccinationCardItemFragment[] = [];
+    expect(getNextVaccinationEncounterDate(items)).toBeNull();
+  });
+
+  it('should return null if there are no suggested dates', () => {
+    const items = [
+      { id: '1', suggestedDate: null },
+      { id: '2', suggestedDate: null },
+    ] as VaccinationCardItemFragment[];
+    expect(getNextVaccinationEncounterDate(items)).toBeNull();
+  });
+
+  it('should return null if all suggested dates are in the past', () => {
+    const items = [
+      { id: '1', suggestedDate: '2021-01-01' },
+      { id: '2', suggestedDate: '2021-01-02' },
+    ] as VaccinationCardItemFragment[];
+    expect(getNextVaccinationEncounterDate(items)).toBeNull();
+  });
+
+  it('should return the nearest suggested date', () => {
+    const oneMonthFromNow = DateUtils.addMonths(new Date(), 1);
+    const items = [
+      {
+        id: '1',
+        suggestedDate: DateUtils.addMonths(new Date(), 4).toISOString(),
+      },
+      {
+        id: '2',
+        suggestedDate: oneMonthFromNow.toISOString(),
+      },
+      {
+        id: '3',
+        suggestedDate: DateUtils.addMonths(new Date(), 2).toISOString(),
+      },
+    ] as VaccinationCardItemFragment[];
+    expect(getNextVaccinationEncounterDate(items)).toEqual(oneMonthFromNow);
+  });
+});

--- a/client/packages/system/src/Encounter/DetailView/helpers.ts
+++ b/client/packages/system/src/Encounter/DetailView/helpers.ts
@@ -1,0 +1,23 @@
+import { VaccinationCardItemFragment } from '../../Vaccination/api/operations.generated';
+
+export function getNextVaccinationEncounterDate(
+  items: VaccinationCardItemFragment[]
+): Date | null {
+  const nextSuggestedDate = items.reduce<Date | null>(
+    (nextSuggestedDate, vaccination) => {
+      if (!vaccination.suggestedDate) return nextSuggestedDate;
+
+      const vaccinationDate = new Date(vaccination.suggestedDate);
+
+      if (vaccinationDate < new Date()) return nextSuggestedDate;
+
+      if (!nextSuggestedDate || vaccinationDate < nextSuggestedDate) {
+        return vaccinationDate;
+      }
+      return nextSuggestedDate;
+    },
+    null
+  );
+
+  return nextSuggestedDate;
+}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6263

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Use next vaccination date for encounter suggested date:
![Screenshot 2025-01-28 at 5 57 51 PM](https://github.com/user-attachments/assets/0babddad-a7e2-48d4-9fea-75678540528a)

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have some vaccine course doses configured for the vax card
- [ ] Give vaccinations so that the suggested date of one of the doses is in the future
- [ ] Mark encounter as visited
- [ ] Schedule next encounter modal should recommend that date for the next encounter
- [ ] From new encounter, set up so suggest date in past
- [ ] No recommended date in the next encounter modal
- [ ] From new encounter, give all doses so there are no suggested dates
- [ ] No recommended date in the next encounter modal

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
