### PR TITLE
update icon color to white on orange buttons

### DIFF
--- a/client/packages/common/src/ui/components/buttons/standard/ShrinkableBaseButton.tsx
+++ b/client/packages/common/src/ui/components/buttons/standard/ShrinkableBaseButton.tsx
@@ -26,12 +26,13 @@ export const StyledShrinkableBaseButton = styled(StyledBaseButton, {
           marginLeft: 8,
         }
       : {},
-
-    '&.MuiButton-root:not(:hover) .MuiSvgIcon-root': {
-      color:
-        color === 'primary' && !disabled
-          ? translateColor(theme, color)
-          : undefined,
+    '&.MuiButton-outlined': {
+      '&.MuiButton-root:not(:hover) .MuiSvgIcon-root': {
+        color:
+          color === 'primary' && !disabled
+            ? translateColor(theme, color)
+            : undefined,
+      },
     },
   })
 );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6005

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
Fixes buttons that are orange and not showing icons (without hover). Icons were displaying as orange on orange background, where the icons should be white

I had a look at if there was a quick refactor as the icons colors are now being controlled by two different components, and the icons being in parent components to these. This is probably a separate refactor issue though

<!-- why are the changes needed -->

Buttons that had an orange background, also had an orange icon which was not visible. Icon is now white

<!-- Add a screenshot if there are UI changes  -->
<img width="201" alt="Screenshot 2025-01-28 at 6 29 46 PM" src="https://github.com/user-attachments/assets/3727ef2f-2559-4573-b5ed-0d132997f275" />

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] See Sync modal, Sync button should have a white icon
- [ ] See Settings -> Devices -> 'Save' button should be orange with white icon (may need to fill IP address)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
