### PR TITLE
6159 add filters to prescription list view

### DIFF
--- a/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
+++ b/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
@@ -27,6 +27,7 @@ interface Filter {
   key: string;
   condition?: string;
   value?: string;
+  isNumber?: boolean;
 }
 interface UrlQueryParams {
   initialSort?: UrlQuerySort;
@@ -51,6 +52,7 @@ export const useUrlQueryParams = ({
   const { urlQuery, updateQuery } = useUrlQuery({
     skipParse,
   });
+
   const [storedRowsPerPage] = useLocalStorage(
     '/pagination/rowsperpage',
     DEFAULT_RECORDS_PER_PAGE
@@ -85,7 +87,11 @@ export const useUrlQueryParams = ({
 
   const getFilterBy = (): FilterByWithBoolean =>
     filters.reduce<FilterByWithBoolean>((prev, filter) => {
-      const filterValue = getFilterValue(urlQuery, filter.key);
+      const filterValue = getFilterValue(
+        urlQuery,
+        filter.key,
+        filter?.isNumber
+      );
       if (filterValue === undefined) return prev;
       // create a new object to prevent mutating the existing filter
       const f = { ...filter };
@@ -154,15 +160,20 @@ export const useUrlQueryParams = ({
 
 const getFilterValue = (
   urlQuery: Record<string, UrlQueryValue>,
-  key: string
+  key: string,
+  isNumber?: boolean
 ) => {
-  switch (urlQuery[key]) {
-    case 'true':
-      return true;
-    case 'false':
-      return false;
-    default:
-      return urlQuery[key];
+  if (isNumber === true) {
+    return Number(urlQuery[key]);
+  } else {
+    switch (urlQuery[key]) {
+      case 'true':
+        return true;
+      case 'false':
+        return false;
+      default:
+        return urlQuery[key];
+    }
   }
 };
 

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1582,6 +1582,7 @@
   "placeholder.search-by-name": "Search by name",
   "placeholder.search-by-name-or-code": "Search by name or code",
   "placeholder.search-by-notes": "Search by notes",
+  "placeholder.search-by-invoice-number": "Search by invoice number",
   "preferences": "Preferences",
   "prescription": "Prescription",
   "prescriptions": "Prescriptions",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1054,6 +1054,8 @@
   "label.to-created-datetime": "To created date / time",
   "label.to-datetime": "To date / time",
   "label.to-expiry": "To expiry",
+  "label.from-date": "From date",
+  "label.to-date": "To date",
   "label.to-start-datetime": "To start date / time",
   "label.today": "Today",
   "label.toggle-password-visibility": "Toggle password visibility",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1584,7 +1584,6 @@
   "placeholder.search-by-name": "Search by name",
   "placeholder.search-by-name-or-code": "Search by name or code",
   "placeholder.search-by-notes": "Search by notes",
-  "placeholder.search-by-invoice-number": "Search by invoice number",
   "preferences": "Preferences",
   "prescription": "Prescription",
   "prescriptions": "Prescriptions",

--- a/client/packages/invoices/src/Prescriptions/ListView/ListView.tsx
+++ b/client/packages/invoices/src/Prescriptions/ListView/ListView.tsx
@@ -41,21 +41,26 @@ const PrescriptionListViewComponent: FC = () => {
     updateSortQuery,
     updatePaginationQuery,
     filter,
-    queryParams: { sortBy, page, first, offset },
+    queryParams: { page, first, offset, sortBy, filterBy },
   } = useUrlQueryParams({
-    filters: [{ key: 'otherPartyName' }],
     initialSort: { key: 'prescriptionDatetime', dir: 'desc' },
+    filters: [
+      { key: 'otherPartyName' },
+      { key: 'invoiceNumber', condition: 'equalTo', isNumber: true },
+      {
+        key: 'pickedDatetime',
+        condition: 'between',
+      },
+    ],
   });
-  const navigate = useNavigate();
-  const modalController = useToggle();
-
   const listParams = {
     sortBy,
     first,
     offset,
-    filterBy: filter.filterBy,
+    filterBy,
   };
-
+  const navigate = useNavigate();
+  const modalController = useToggle();
   const {
     query: { data, isError, isLoading },
   } = usePrescriptionList(listParams);

--- a/client/packages/invoices/src/Prescriptions/ListView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/ListView/Toolbar.tsx
@@ -2,20 +2,37 @@ import React, { FC } from 'react';
 import {
   useTranslation,
   AppBarContentPortal,
-  SearchBar,
+  FilterMenu,
   FilterController,
-  FilterRule,
+  Box,
+  FilterDefinition,
 } from '@openmsupply-client/common';
-import { PrescriptionRowFragment } from '../api';
 
-export const Toolbar: FC<{
-  filter: FilterController;
-}> = ({ filter }) => {
+export const Toolbar: FC<{ filter: FilterController }> = () => {
   const t = useTranslation();
 
-  const key = 'otherPartyName' as keyof PrescriptionRowFragment;
-  const filterString =
-    ((filter.filterBy?.[key] as FilterRule)?.like as string) || '';
+  const filters: FilterDefinition[] = [
+    {
+      type: 'text',
+      name: t('label.name'),
+      urlParameter: 'otherPartyName',
+      placeholder: t('placeholder.search-by-name'),
+      isDefault: true,
+    },
+    {
+      type: 'text',
+      name: t('label.invoice-number'),
+      urlParameter: 'invoiceNumber',
+      placeholder: t('placeholder.search-by-invoice-number'),
+      isDefault: true,
+    },
+    {
+      type: 'date',
+      name: t('label.date'),
+      urlParameter: 'prescriptionDatetime',
+      isDefault: true,
+    },
+  ];
 
   return (
     <AppBarContentPortal
@@ -26,13 +43,9 @@ export const Toolbar: FC<{
         display: 'flex',
       }}
     >
-      <SearchBar
-        placeholder={t('placeholder.search-by-name')}
-        value={filterString}
-        onChange={newValue => {
-          filter.onChangeStringFilterRule('otherPartyName', 'like', newValue);
-        }}
-      />
+      <Box display="flex" gap={1}>
+        <FilterMenu filters={filters} />
+      </Box>
     </AppBarContentPortal>
   );
 };

--- a/client/packages/invoices/src/Prescriptions/ListView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/ListView/Toolbar.tsx
@@ -5,34 +5,10 @@ import {
   FilterMenu,
   FilterController,
   Box,
-  FilterDefinition,
 } from '@openmsupply-client/common';
 
 export const Toolbar: FC<{ filter: FilterController }> = () => {
   const t = useTranslation();
-
-  const filters: FilterDefinition[] = [
-    {
-      type: 'text',
-      name: t('label.name'),
-      urlParameter: 'otherPartyName',
-      placeholder: t('placeholder.search-by-name'),
-      isDefault: true,
-    },
-    {
-      type: 'text',
-      name: t('label.invoice-number'),
-      urlParameter: 'invoiceNumber',
-      placeholder: t('placeholder.search-by-invoice-number'),
-      isDefault: true,
-    },
-    {
-      type: 'date',
-      name: t('label.date'),
-      urlParameter: 'prescriptionDatetime',
-      isDefault: true,
-    },
-  ];
 
   return (
     <AppBarContentPortal
@@ -44,7 +20,43 @@ export const Toolbar: FC<{ filter: FilterController }> = () => {
       }}
     >
       <Box display="flex" gap={1}>
-        <FilterMenu filters={filters} />
+        <FilterMenu
+          filters={[
+            {
+              type: 'text',
+              name: t('label.name'),
+              urlParameter: 'otherPartyName',
+              placeholder: t('placeholder.search-by-name'),
+              isDefault: true,
+            },
+            {
+              type: 'number',
+              name: t('label.invoice-number'),
+              urlParameter: 'invoiceNumber', // remove placeholder sort by invoice number
+              isDefault: true,
+            },
+            {
+              type: 'group',
+              name: t('label.date'),
+              elements: [
+                {
+                  type: 'date',
+                  name: t('label.from-date'), // TODO translate this
+                  urlParameter: 'pickedDatetime',
+                  range: 'from',
+                  isDefault: true,
+                },
+                {
+                  type: 'date',
+                  name: t('label.to-date'), // TODO translate this
+                  urlParameter: 'pickedDatetime',
+                  range: 'to',
+                  isDefault: true,
+                },
+              ],
+            },
+          ]}
+        />
       </Box>
     </AppBarContentPortal>
   );

--- a/client/packages/invoices/src/Prescriptions/ListView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/ListView/Toolbar.tsx
@@ -26,13 +26,12 @@ export const Toolbar: FC<{ filter: FilterController }> = () => {
               type: 'text',
               name: t('label.name'),
               urlParameter: 'otherPartyName',
-              placeholder: t('placeholder.search-by-name'),
               isDefault: true,
             },
             {
               type: 'number',
               name: t('label.invoice-number'),
-              urlParameter: 'invoiceNumber', // remove placeholder sort by invoice number
+              urlParameter: 'invoiceNumber',
               isDefault: true,
             },
             {
@@ -41,14 +40,14 @@ export const Toolbar: FC<{ filter: FilterController }> = () => {
               elements: [
                 {
                   type: 'date',
-                  name: t('label.from-date'), // TODO translate this
+                  name: t('label.from-date'),
                   urlParameter: 'pickedDatetime',
                   range: 'from',
                   isDefault: true,
                 },
                 {
                   type: 'date',
-                  name: t('label.to-date'), // TODO translate this
+                  name: t('label.to-date'),
                   urlParameter: 'pickedDatetime',
                   range: 'to',
                   isDefault: true,

--- a/client/packages/invoices/src/Prescriptions/ListView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/ListView/Toolbar.tsx
@@ -32,7 +32,7 @@ export const Toolbar: FC<{ filter: FilterController }> = () => {
               type: 'number',
               name: t('label.invoice-number'),
               urlParameter: 'invoiceNumber',
-              isDefault: true,
+              isDefault: false,
             },
             {
               type: 'group',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6159 

# 👩🏻‍💻 What does this PR do?

Adds filters to the prescription list view, so now you can filter by patient name, invoice number and prescription date.
Since the search box was there to search by patient name, and that's now done by the filter, I removed the search box because it seemed to be redundant.

![image](https://github.com/user-attachments/assets/303dfe56-a7e9-4b6b-92b8-e3daa56468c2)

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Have a nice day :)

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] navigate to dispensary>prescriptions.
- [ ] create a prescription if you don't have any already.
- [ ] in the name filter box, try an input that should show a result. Check that the result is shown as expected, then try one that should show nothing, and check that nothing is shown.
- [ ] do the same for the other filter boxes.
- [ ] now try all the possible combinations:
    - [ ] an unmatched name and an unmatched number (should show nothing)
    - [ ] a matched name and an unmatched number (should show nothing)
    - [ ] a matched name and a matched number (should show only the matched lines)
    - [ ] an unmatched name and number and date range (should show nothing)
    - [ ] a matched name and unmatched number and date range (should show nothing)
    - [ ] a matched name and number and unmatched date range (should show nothing)
    - [ ] a matched name, number and date range (should show only the matched lines)
    - [ ]  and so on if you want to, but by now you've proved that in principle everything is working.
    
# 📃 Documentation

- [ x ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ x ] **These areas should be updated or checked**: New filters for the prescriptions list view.
