### PR TITLE
Add duplicate stock status and item usage reports

### DIFF
--- a/server/reports/item-usage/2_5/argument_schemas/arguments.json
+++ b/server/reports/item-usage/2_5/argument_schemas/arguments.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "StockFilters": {
+      "properties": {
+        "itemCode": {
+          "description": "Item Code",
+          "type": "string"
+        },
+        "itemName": {
+          "description": "Item Name",
+          "type": "string"
+        },
+        "monthlyConsumptionLookBackPeriod": {
+          "description": "Average Monthly Consumption Look Back Period",
+          "type": "number"
+        },
+        "sort": {
+          "description": "sort by",
+          "type": "string",
+          "enum": [
+            "code",
+            "SOH",
+            "MOS",
+            "monthConsumption",
+            "lastMonthConsumption",
+            "twoMonthsAgoConsumption",
+            "expiringInSixMonths",
+            "expiringInTwelveMonths",
+            "stockOnOrder",
+            "AMC12",
+            "AMC24"
+          ]
+        },
+        "dir": {
+          "description": "sort by dir",
+          "type": "string",
+          "enum": ["asc", "desc"]
+        }
+      }
+    }
+  },
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/StockFilters"
+    }
+  ]
+}

--- a/server/reports/item-usage/2_5/argument_schemas/arguments_ui.json
+++ b/server/reports/item-usage/2_5/argument_schemas/arguments_ui.json
@@ -1,0 +1,54 @@
+{
+  "type": "VerticalLayout",
+  "elements": [
+    {
+      "type": "Control",
+      "scope": "#/properties/itemCode",
+      "label": "T#report.item-code",
+      "options": {
+        "useDebounce": false
+      }
+    },
+    {
+      "type": "Control",
+      "scope": "#/properties/itemName",
+      "label": "T#report.item-name"
+    },
+    {
+      "type": "Control",
+      "scope": "#/properties/monthlyConsumptionLookBackPeriod",
+      "label": "T#report.amc-lookback",
+      "options": {
+        "readonly": true,
+        "inputAlignment": "end",
+        "paddingRight": 25
+      }
+    },
+    {
+      "type": "Control",
+      "scope": "#/properties/sort",
+      "label": "T#report.sort-by",
+      "options": {
+        "show": [
+          ["name", "name"],
+          ["code", "code"],
+          ["SOH", "stock on hand"],
+          ["MOS", "months cover"],
+          ["monthConsumption", "month consumption`"],
+          ["lastMonthConsumption", "last months consumption"],
+          ["twoMonthsAgoConsumption", "two months ago consumption"],
+          ["expiringInSixMonths", "expiring in 6 months"],
+          ["expiringInTwelveMonths", "expiring in 12 months"],
+          ["stockOnOrder", "stock on order"],
+          ["AMC12", "AMC12"],
+          ["AMC24", "AMC24"]
+        ]
+      }
+    },
+    {
+      "type": "Control",
+      "scope": "#/properties/dir",
+      "label": "T#report.sort-direction"
+    }
+  ]
+}

--- a/server/reports/item-usage/2_5/convert_data_js/esbuild.js
+++ b/server/reports/item-usage/2_5/convert_data_js/esbuild.js
@@ -1,0 +1,16 @@
+const esbuild = require("esbuild");
+// include this if you need some node support:
+// npm i @esbuild-plugins/node-modules-polyfill --save-dev
+// const { NodeModulesPolyfillPlugin } = require('@esbuild-plugins/node-modules-polyfill')
+
+esbuild.build({
+  // supports other types like js or ts
+  entryPoints: ["src/convert_data.js"],
+  outdir: "dist",
+  bundle: true,
+  sourcemap: true,
+  //plugins: [NodeModulesPolyfillPlugin()], // include this if you need some node support
+  minify: false, // might want to use true for production build
+  format: "cjs", // needs to be CJS for now
+  target: ["es2020"], // don't go over es2020 because quickjs doesn't support it
+});

--- a/server/reports/item-usage/2_5/convert_data_js/input.json
+++ b/server/reports/item-usage/2_5/convert_data_js/input.json
@@ -1,0 +1,145 @@
+{
+  "AMCTwelve": [
+    {
+      "quantity": 150.8,
+      "item_id": "101"
+    },
+    {
+      "quantity": 92.4,
+      "item_id": "102"
+    },
+    {
+      "quantity": 200.5,
+      "item_id": "103"
+    }
+  ],
+  "AMCTwentyFour": [
+    {
+      "quantity": 250.8,
+      "item_id": "101"
+    },
+    {
+      "quantity": 192.4,
+      "item_id": "102"
+    },
+    {
+      "quantity": 300.5,
+      "item_id": "103"
+    }
+  ],
+  "expiringInSixMonths": [
+    {
+      "id": 201,
+      "item_id": "101",
+      "quantity": 150
+    },
+    {
+      "id": 202,
+      "item_id": "102",
+      "quantity": 75
+    }
+  ],
+  "expiringInTwelveMonths": [
+    {
+      "id": 201,
+      "item_id": "101",
+      "quantity": 170
+    },
+    {
+      "id": 202,
+      "item_id": "102",
+      "quantity": 92
+    },
+    {
+      "id": 203,
+      "item_id": "103",
+      "quantity": 400
+    }
+  ],
+  "thisMonthConsumption": [
+    {
+      "quantity": 200,
+      "item_id": "101"
+    },
+    {
+      "quantity": 150,
+      "item_id": "102"
+    },
+    {
+      "quantity": 300,
+      "item_id": "103"
+    }
+  ],
+  "lastMonthConsumption": [
+    {
+      "quantity": 500,
+      "item_id": "101"
+    },
+    {
+      "quantity": 300,
+      "item_id": "102"
+    },
+    {
+      "quantity": 450,
+      "item_id": "103"
+    }
+  ],
+  "twoMonthsAgoConsumption": [
+    {
+      "quantity": 123,
+      "item_id": "101"
+    },
+    {
+      "quantity": 421,
+      "item_id": "102"
+    },
+    {
+      "quantity": 152,
+      "item_id": "103"
+    }
+  ],
+  "stockOnOrder": [
+    {
+      "quantity": 5,
+      "item_id": "101"
+    },
+    {
+      "quantity": -2,
+      "item_id": "102"
+    },
+    {
+      "quantity": 1,
+      "item_id": "103"
+    }
+  ],
+  "items": {
+    "nodes": [
+      {
+        "id": "101",
+        "code": "ITEM001",
+        "name": "Item A",
+        "stats": {
+          "totalConsumption": 1200,
+          "availableMonthsOfStockOnHand": 4.5,
+          "availableStockOnHand": 300.902,
+          "averageMonthlyConsumption": 266.7
+        },
+        "someOtherKey": ""
+      },
+      {},
+      {
+        "id": "101",
+        "code": "ITEM001",
+        "name": "Item A",
+        "stats": {
+          "totalConsumption": 100,
+          "availableMonthsOfStockOnHand": 4.5,
+          "availableStockOnHand": 200,
+          "someNestedEmptyStringKey": ""
+        },
+        "someOtherOtherKey": ""
+      },
+      {}
+    ]
+  }
+}

--- a/server/reports/item-usage/2_5/convert_data_js/output.json
+++ b/server/reports/item-usage/2_5/convert_data_js/output.json
@@ -1,0 +1,47 @@
+{
+  "items": {
+    "nodes": [
+      {
+        "id": "101",
+        "code": "ITEM001",
+        "name": "Item A",
+        "stats": {
+          "totalConsumption": 1200,
+          "availableMonthsOfStockOnHand": 4.5,
+          "availableStockOnHand": 300.902,
+          "averageMonthlyConsumption": 266.7
+        },
+        "monthConsumption": 200,
+        "lastMonthConsumption": 500,
+        "twoMonthsAgoConsumption": 123,
+        "expiringInSixMonths": 150,
+        "expiringInTwelveMonths": 170,
+        "stockOnOrder": 5,
+        "AMC12": 150.8,
+        "AMC24": 250.8,
+        "SOH": 300.9,
+        "MOS": 4.5
+      },
+      {
+        "id": "101",
+        "code": "ITEM001",
+        "name": "Item A",
+        "stats": {
+          "availableStockOnHand": 200,
+          "totalConsumption": 100,
+          "availableMonthsOfStockOnHand": 4.5
+        },
+        "stockOnOrder": 5,
+        "AMC12": 150.8,
+        "AMC24": 250.8,
+        "SOH": 200,
+        "MOS": 4.5,
+        "expiringInSixMonths": 150,
+        "expiringInTwelveMonths": 170,
+        "lastMonthConsumption": 500,
+        "monthConsumption": 200,
+        "twoMonthsAgoConsumption": 123
+      }
+    ]
+  }
+}

--- a/server/reports/item-usage/2_5/convert_data_js/package.json
+++ b/server/reports/item-usage/2_5/convert_data_js/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "convert_data_js",
+  "version": "1.0.0",
+  "main": "convert_data.js",
+  "scripts": {
+    "build": "node esbuild.js && extism-js dist/convert_data.js -i src/convert_data.d.ts -o dist/plugin.wasm"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "types": "./convert_data.d.ts",
+  "description": "",
+  "devDependencies": {
+    "esbuild": "^0.24.0"
+  }
+}

--- a/server/reports/item-usage/2_5/convert_data_js/src/convert_data.d.ts
+++ b/server/reports/item-usage/2_5/convert_data_js/src/convert_data.d.ts
@@ -1,0 +1,9 @@
+declare module 'main' {
+    // Extism exports take no params and return an I32
+    export function convert_data(): I32;
+  }
+  declare module 'extism:host' {
+    interface user {
+      sql(ptr: I64): I64;
+    }
+  }

--- a/server/reports/item-usage/2_5/convert_data_js/src/convert_data.js
+++ b/server/reports/item-usage/2_5/convert_data_js/src/convert_data.js
@@ -1,0 +1,16 @@
+import { processItemLines } from "./utils";
+
+function convert_data() {
+  const res = JSON.parse(Host.inputString());
+  res.data.items.nodes = processItemLines(
+    res.data,
+    // assign default sort values
+    res?.arguments?.sort ?? "name",
+    res?.arguments?.dir ?? "asc"
+  );
+  Host.outputString(JSON.stringify(res));
+}
+
+module.exports = {
+  convert_data,
+};

--- a/server/reports/item-usage/2_5/convert_data_js/src/utils.js
+++ b/server/reports/item-usage/2_5/convert_data_js/src/utils.js
@@ -1,0 +1,69 @@
+import { cleanUpNodes, sortNodes } from "../../../../utils";
+
+const processItemLines = (data, sort, dir) => {
+  data.items.nodes.forEach((item) => {
+    // don't add default values if empty object added
+    if (Object.keys(item).length == 0) {
+      return;
+    }
+    item.monthConsumption = calculateQuantity(
+      data.thisMonthConsumption,
+      item.id
+    );
+    item.lastMonthConsumption = calculateQuantity(
+      data.lastMonthConsumption,
+      item.id
+    );
+    item.twoMonthsAgoConsumption = calculateQuantity(
+      data.twoMonthsAgoConsumption,
+      item.id
+    );
+    item.expiringInSixMonths = calculateQuantity(
+      data.expiringInSixMonths,
+      item.id
+    );
+    item.expiringInTwelveMonths = calculateQuantity(
+      data.expiringInTwelveMonths,
+      item.id
+    );
+    item.stockOnOrder = calculateQuantity(data.stockOnOrder, item.id);
+    item.AMC12 = calculateQuantity(data.AMCTwelve, item.id);
+    item.AMC24 = calculateQuantity(data.AMCTwentyFour, item.id);
+    item.SOH = calculateStatValue(item?.stats?.availableStockOnHand);
+    item.MOS = calculateStatValue(item?.stats?.availableMonthsOfStockOnHand);
+  });
+  let cleanNodes = cleanUpNodes(data.items.nodes);
+  let sortedNodes = sortNodes(cleanNodes, sort, dir);
+  return sortedNodes;
+};
+
+// function adds month consumption to data  (either this or last month)
+const calculateQuantity = (queryResult, id) => {
+  let quantity = 0;
+  if (!!queryResult && !!id) {
+    const node = queryResult.find((element) => element.item_id == id);
+    quantity = node?.quantity ? node.quantity : 0;
+  }
+  // return 0 if quantity is less than 0. This covers use cases such as stock on order which can be negative if invoice line stock is greater than requested stock.
+  if (quantity < 0) {
+    return 0;
+  }
+  return quantity;
+};
+
+const calculateStatValue = (value) => {
+  let returnValue = 0;
+  if (!!value) {
+    // round to 1 decimal
+    returnValue = Math.round(value * 10) / 10;
+  }
+  return returnValue;
+};
+
+module.exports = {
+  calculateQuantity,
+  calculateStatValue,
+  processItemLines,
+  cleanUpNodes,
+  sortNodes,
+};

--- a/server/reports/item-usage/2_5/convert_data_js/src/utils.test.ts
+++ b/server/reports/item-usage/2_5/convert_data_js/src/utils.test.ts
@@ -1,0 +1,158 @@
+import {
+  calculateQuantity,
+  calculateStatValue,
+  processItemLines,
+} from "./utils";
+import inputData from "../input.json" assert { type: "json" };
+import outputData from "../output.json" assert { type: "json" };
+
+describe("test item lines", () => {
+  it("end to end item-usage", () => {
+    const result = processItemLines(inputData);
+    expect(result).toEqual(outputData.items.nodes);
+  });
+});
+
+describe("Adds monthlyConsumption correctly from query result", () => {
+  it("returns 0 if either are undefined", () => {
+    expect(calculateQuantity(undefined, "id")).toBe(0);
+    expect(calculateQuantity(inputData.thisMonthConsumption, undefined)).toBe(
+      0
+    );
+  });
+  it("returns month consumption if available", () => {
+    expect(calculateQuantity(inputData.thisMonthConsumption, "101")).toBe(200);
+  });
+  it("returns 0 if non existent id", () => {
+    expect(
+      calculateQuantity(inputData.thisMonthConsumption, "non existent id")
+    ).toBe(0);
+  });
+});
+
+describe("Adds lastMonthConsumption correctly from query result", () => {
+  it("returns 0 if either are undefined", () => {
+    expect(calculateQuantity(undefined, "id")).toBe(0);
+    expect(calculateQuantity(inputData.lastMonthConsumption, undefined)).toBe(
+      0
+    );
+  });
+  it("returns month consumption if available", () => {
+    expect(calculateQuantity(inputData.lastMonthConsumption, "101")).toBe(500);
+  });
+  it("returns 0 if non existent id", () => {
+    expect(
+      calculateQuantity(inputData.lastMonthConsumption, "non existent id")
+    ).toBe(0);
+  });
+});
+
+describe("Adds twoMonthsAgoConsumption correctly from query result", () => {
+  it("returns 0 if either are undefined", () => {
+    expect(calculateQuantity(undefined, "id")).toBe(0);
+    expect(
+      calculateQuantity(inputData.twoMonthsAgoConsumption, undefined)
+    ).toBe(0);
+  });
+  it("returns month consumption if available", () => {
+    expect(calculateQuantity(inputData.twoMonthsAgoConsumption, "102")).toBe(
+      421
+    );
+  });
+  it("returns 0 if non existent id", () => {
+    expect(
+      calculateQuantity(inputData.twoMonthsAgoConsumption, "non existent id")
+    ).toBe(0);
+  });
+});
+
+describe("Adds expiringInSixMonths correctly from query result", () => {
+  it("returns 0 if either are undefined", () => {
+    expect(calculateQuantity(undefined, "id")).toBe(0);
+    expect(calculateQuantity(inputData.expiringInSixMonths, undefined)).toBe(0);
+  });
+  it("returns month consumption if available", () => {
+    expect(calculateQuantity(inputData.expiringInSixMonths, "102")).toBe(75);
+  });
+  it("returns 0 if non existent id", () => {
+    expect(
+      calculateQuantity(inputData.expiringInSixMonths, "non existent id")
+    ).toBe(0);
+  });
+});
+
+describe("Adds expiringIntwelveMonths correctly from query result", () => {
+  it("returns 0 if either are undefined", () => {
+    expect(calculateQuantity(undefined, "id")).toBe(0);
+    expect(calculateQuantity(inputData.expiringInTwelveMonths, undefined)).toBe(
+      0
+    );
+  });
+  it("returns month consumption if available", () => {
+    expect(calculateQuantity(inputData.expiringInTwelveMonths, "102")).toBe(92);
+  });
+  it("returns 0 if non existent id", () => {
+    expect(
+      calculateQuantity(inputData.expiringInTwelveMonths, "non existent id")
+    ).toBe(0);
+  });
+});
+
+describe("Adds AMC12 correctly from query result", () => {
+  it("returns 0 if either are undefined", () => {
+    expect(calculateQuantity(undefined, "id")).toBe(0);
+    expect(calculateQuantity(inputData.AMCTwelve, undefined)).toBe(0);
+  });
+  it("returns month consumption if available", () => {
+    expect(calculateQuantity(inputData.AMCTwelve, "102")).toBe(92.4);
+  });
+  it("returns 0 if non existent id", () => {
+    expect(calculateQuantity(inputData.AMCTwelve, "non existent id")).toBe(0);
+  });
+});
+
+describe("Adds AMC24 correctly from query result", () => {
+  it("returns 0 if either are undefined", () => {
+    expect(calculateQuantity(undefined, "id")).toBe(0);
+    expect(calculateQuantity(inputData.AMCTwentyFour, undefined)).toBe(0);
+  });
+  it("returns month consumption if available", () => {
+    expect(calculateQuantity(inputData.AMCTwentyFour, "102")).toBe(192.4);
+  });
+  it("returns 0 if non existent id", () => {
+    expect(calculateQuantity(inputData.AMCTwentyFour, "non existent id")).toBe(
+      0
+    );
+  });
+});
+
+describe("calculate SOH", () => {
+  it("returns default 0 if undefined", () => {
+    expect(calculateStatValue(undefined)).toBe(0);
+  });
+  it("returns rounded value if value exists", () => {
+    expect(
+      calculateStatValue(inputData.items.nodes[0].stats.availableStockOnHand)
+    ).toBe(300.9);
+  });
+});
+
+describe("calculate MOS", () => {
+  it("returns default 0 if undefined", () => {
+    expect(calculateStatValue(undefined)).toBe(0);
+  });
+  it("returns rounded value if value exists", () => {
+    expect(
+      calculateStatValue(
+        inputData.items.nodes[0].stats.availableMonthsOfStockOnHand
+      )
+    ).toBe(4.5);
+  });
+});
+
+describe("calculate stockOnOrder", () => {
+  it("return  0 when calculate quantity input is negative", () => {
+    // covers possible negative cases such as where invoice line stock is greater than requisition line stock
+    expect(calculateQuantity(inputData.stockOnOrder, "102")).toBe(0);
+  });
+});

--- a/server/reports/item-usage/2_5/manifest.json
+++ b/server/reports/item-usage/2_5/manifest.json
@@ -1,0 +1,26 @@
+{
+  "is_custom": false,
+  "version": "2.3.0",
+  "code": "item-usage",
+  "context": "REPORT",
+  "sub_context": "StockAndItems",
+  "name": "Item Usage",
+  "queries": {
+    "gql": "query.graphql",
+    "sql": [
+      "thisMonthConsumption",
+      "lastMonthConsumption",
+      "twoMonthsAgoConsumption",
+      "expiringInSixMonths",
+      "expiringInTwelveMonths",
+      "stockOnOrder",
+      "AMCTwelve",
+      "AMCTwentyFour"
+    ]
+  },
+  "arguments": {
+    "schema": "argument_schemas/arguments.json",
+    "ui": "argument_schemas/arguments_ui.json"
+  },
+  "convert_data": "convert_data_js"
+}

--- a/server/reports/item-usage/2_5/src/AMCTwelve.postgres.sql
+++ b/server/reports/item-usage/2_5/src/AMCTwelve.postgres.sql
@@ -1,0 +1,10 @@
+WITH
+    twelve_months_ago AS (
+        SELECT date_trunc('month', CURRENT_DATE - interval '12 months') AS twelve_months_ago
+    )
+SELECT
+    ROUND(SUM(quantity / 12)::numeric, 1) AS quantity,
+    item_id
+FROM consumption, twelve_months_ago
+WHERE date >= twelve_months_ago AND consumption.store_id = $storeId
+GROUP BY item_id

--- a/server/reports/item-usage/2_5/src/AMCTwelve.sqlite.sql
+++ b/server/reports/item-usage/2_5/src/AMCTwelve.sqlite.sql
@@ -1,0 +1,10 @@
+WITH
+    twelve_months_ago AS (
+        SELECT date('now', 'start of month', '-12 month') AS twelve_months_ago
+    )
+SELECT
+    ROUND(SUM(quantity / 12), 1) AS quantity,
+    item_id
+FROM consumption, twelve_months_ago
+WHERE date >= twelve_months_ago AND consumption.store_id = $storeId
+GROUP BY item_id

--- a/server/reports/item-usage/2_5/src/AMCTwentyFour.postgres.sql
+++ b/server/reports/item-usage/2_5/src/AMCTwentyFour.postgres.sql
@@ -1,0 +1,10 @@
+WITH
+    twenty_four_months_ago AS (
+        SELECT date_trunc('month', CURRENT_DATE - interval '24 months') AS twenty_four_months_ago
+    )
+SELECT
+    ROUND(SUM(quantity / 24)::numeric, 1) AS quantity,
+    item_id
+FROM consumption, twenty_four_months_ago
+WHERE date >= twenty_four_months_ago AND consumption.store_id = $storeId
+GROUP BY item_id

--- a/server/reports/item-usage/2_5/src/AMCTwentyFour.sqlite.sql
+++ b/server/reports/item-usage/2_5/src/AMCTwentyFour.sqlite.sql
@@ -1,0 +1,10 @@
+WITH
+    twenty_four_months_ago AS (
+        SELECT date('now', 'start of month', '-24 month') AS twenty_four_months_ago
+    )
+SELECT
+    ROUND(SUM(quantity / 24), 1) AS quantity,    
+    item_id
+FROM consumption, twenty_four_months_ago
+WHERE date >= twenty_four_months_ago AND consumption.store_id = $storeId
+GROUP BY item_id

--- a/server/reports/item-usage/2_5/src/expiringInSixMonths.postgres.sql
+++ b/server/reports/item-usage/2_5/src/expiringInSixMonths.postgres.sql
@@ -1,0 +1,17 @@
+WITH 
+    this_month AS (
+        SELECT date_trunc('month', CURRENT_DATE) AS this_month
+    ),
+    six_months AS (
+        SELECT date_trunc('month', CURRENT_DATE + interval '6 months') AS six_months
+    )
+SELECT 
+    s.id,
+    i.item_id,
+    SUM(s.available_number_of_packs) AS quantity
+FROM stock_line s
+INNER JOIN item_link i ON i.id = s.item_link_id
+INNER JOIN this_month ON true
+INNER JOIN six_months ON true
+WHERE s.expiry_date < six_months AND s.store_id = $storeId
+GROUP BY s.id, i.item_id

--- a/server/reports/item-usage/2_5/src/expiringInSixMonths.sqlite.sql
+++ b/server/reports/item-usage/2_5/src/expiringInSixMonths.sqlite.sql
@@ -1,0 +1,15 @@
+WITH 
+    this_month AS (
+        SELECT date('now') AS this_month
+    ),
+    six_months AS (
+        SELECT date('now', '+6 months') AS six_months
+    )
+SELECT 
+    stock_line.id,
+    i.item_id,
+    SUM(stock_line.available_number_of_packs) AS quantity
+FROM stock_line, six_months, this_month
+INNER JOIN item_link i ON i.id = stock_line.item_link_id
+WHERE stock_line.expiry_date < six_months AND stock_line.store_id = $storeId
+GROUP BY i.item_id

--- a/server/reports/item-usage/2_5/src/expiringInTwelveMonths.postgres.sql
+++ b/server/reports/item-usage/2_5/src/expiringInTwelveMonths.postgres.sql
@@ -1,0 +1,17 @@
+WITH 
+    this_month AS (
+        SELECT date_trunc('month', CURRENT_DATE) AS this_month
+    ),
+    twelve_months AS (
+        SELECT date_trunc('month', CURRENT_DATE + interval '12 months') AS twelve_months
+    )
+SELECT 
+    s.id,
+    i.item_id,
+    SUM(s.available_number_of_packs) AS quantity
+FROM stock_line s
+INNER JOIN item_link i ON i.id = s.item_link_id
+INNER JOIN this_month ON true
+INNER JOIN twelve_months ON true
+WHERE s.expiry_date < twelve_months AND s.store_id = $storeId
+GROUP BY s.id, i.item_id

--- a/server/reports/item-usage/2_5/src/expiringInTwelveMonths.sqlite.sql
+++ b/server/reports/item-usage/2_5/src/expiringInTwelveMonths.sqlite.sql
@@ -1,0 +1,15 @@
+WITH 
+    this_month AS (
+        SELECT date('now') AS this_month
+    ),
+    twelve_months AS (
+        SELECT date('now', '+12 months') AS twelve_months
+    )
+SELECT 
+    stock_line.id,
+    i.item_id,
+    SUM(stock_line.available_number_of_packs) AS quantity
+FROM stock_line, twelve_months, this_month
+INNER JOIN item_link i ON i.id = stock_line.item_link_id
+WHERE stock_line.expiry_date < twelve_months AND stock_line.store_id = $storeId
+GROUP BY item_id

--- a/server/reports/item-usage/2_5/src/lastMonthConsumption.postgres.sql
+++ b/server/reports/item-usage/2_5/src/lastMonthConsumption.postgres.sql
@@ -1,0 +1,13 @@
+WITH
+    this_month AS (
+        SELECT date_trunc('month', CURRENT_DATE) AS this_month
+    ),
+    last_month AS (
+        SELECT date_trunc('month', CURRENT_DATE - interval '1 month') AS last_month
+    )
+SELECT
+    SUM(quantity) AS quantity,
+    item_id
+FROM consumption, this_month, last_month
+WHERE date >= last_month AND date < this_month AND store_id = $storeId
+GROUP BY item_id

--- a/server/reports/item-usage/2_5/src/lastMonthConsumption.sqlite.sql
+++ b/server/reports/item-usage/2_5/src/lastMonthConsumption.sqlite.sql
@@ -1,0 +1,13 @@
+WITH
+    this_month AS (
+        SELECT date('now', 'start of month') AS this_month
+    ),
+    last_month AS (
+        SELECT date('now', 'start of month', '-1 month') AS last_month
+    )
+SELECT
+    SUM(quantity) AS quantity,
+    item_id
+FROM consumption, this_month, last_month
+WHERE date >= last_month AND date < this_month AND store_id = $storeId
+GROUP BY item_id

--- a/server/reports/item-usage/2_5/src/query.graphql
+++ b/server/reports/item-usage/2_5/src/query.graphql
@@ -1,0 +1,26 @@
+query ItemUsage($storeId: String, $itemCode: String, $itemName: String) {
+  items(
+    storeId: $storeId
+    filter: {
+      code: { like: $itemCode }
+      name: { like: $itemName }
+      isVisibleOrOnHand: true
+      isActive: true
+    }
+    page: { first: 5000 }
+  ) {
+    ... on ItemConnector {
+      nodes {
+        id
+        code
+        name
+        stats(storeId: $storeId) {
+          totalConsumption
+          availableMonthsOfStockOnHand
+          availableStockOnHand
+          averageMonthlyConsumption
+        }
+      }
+    }
+  }
+}

--- a/server/reports/item-usage/2_5/src/stockOnOrder.sql
+++ b/server/reports/item-usage/2_5/src/stockOnOrder.sql
@@ -1,0 +1,11 @@
+SELECT 
+    item.id as item_id,
+    SUM(rl.requested_quantity) - COALESCE(SUM(il.pack_size * il.number_of_packs), 0) AS quantity
+FROM item
+INNER JOIN item_link i ON item.id = i.item_id
+LEFT JOIN requisition_line rl ON rl.item_link_id = i.id
+LEFT JOIN requisition r ON r.id = rl.requisition_id
+LEFT JOIN invoice ON invoice.requisition_id = r.id
+LEFT JOIN invoice_line il on invoice.id = il.invoice_id AND il.item_link_id = i.id
+WHERE r.store_id = $storeId AND r.type = 'REQUEST' AND r.status = 'SENT'
+GROUP BY 1

--- a/server/reports/item-usage/2_5/src/style.css
+++ b/server/reports/item-usage/2_5/src/style.css
@@ -1,0 +1,60 @@
+@page {
+  margin: 0;
+  size: A4 landscape;
+}
+
+.paging {
+  width: 100%;
+}
+
+.container {
+  margin: auto;
+  padding: 10px;
+  font-size: 14px;
+  font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
+  color: #555;
+}
+
+.container table {
+  width: 100%;
+  font-size: inherit;
+  font-family: inherit;
+  text-align: left;
+  margin-top: 10;
+  margin-bottom: 15;
+  border-collapse: separate;
+}
+
+.container table td {
+  padding: 10px;
+  vertical-align: top;
+  border-top: 1px solid rgb(164, 163, 163);
+}
+
+.container table tr:last-child td {
+  border-bottom: none;
+}
+
+.container>table>thead {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  background-color: #f1f1f1;
+}
+
+.container,
+body,
+.container>table {
+  margin-top: 0px;
+  padding-top: 0px;
+}
+
+.container table tr.heading td {
+  font-weight: bold;
+  margin-bottom: 15px;
+}
+
+.container table td.status span {
+  padding: 2px;
+  border-radius: 10px;
+}

--- a/server/reports/item-usage/2_5/src/template.html
+++ b/server/reports/item-usage/2_5/src/template.html
@@ -1,0 +1,49 @@
+<style>
+  {% include "style.css" %}
+</style>
+
+<div class="container">
+  <table>
+    <thead>
+      <tr class="heading">
+        <td>{{t(k="label.code", f="Code")}}</td>
+        <td>{{t(k="label.name", f="Name")}}</td>
+        <td>{{t(k="report.available-stock-on-hand", f="Available stock on hand")}}</td>
+        <td>{{t(k="report.stock-on-order", f="Stock on order")}}</td>
+        <td>{{t(k="report.amc-12-months", f="AMC (12 months)")}}</td>
+        <td>{{t(k="report.amc-24-months", f="AMC (24 months)")}}</td>
+        <td>{{t(k="report.months-cover", f="Months cover")}}</td>
+        <td>
+          {{t(k="report.usage-this-month", f="Monthly usage (this month)")}}
+        </td>
+        <td>
+          {{t(k="report.usage-last-month", f="Monthly usage (last month)")}}
+        </td>
+        <td>
+          {{t(k="report.usage-2-months-prior", f="Monthly usage (2 months
+          ago)")}}
+        </td>
+        <td>{{t(k="report.expiring-6-months", f="Expiring in 6 months")}}</td>
+        <td>{{t(k="report.expiring-12-months", f="Expiring in 12 months")}}</td>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in data.items.nodes %}
+      <tr>
+        <td>{{item.code}}</td>
+        <td>{{item.name}}</td>
+        <td>{{item.SOH}}</td>
+        <td>{{item.stockOnOrder}}</td>
+        <td>{{item.AMC12}}</td>
+        <td>{{item.AMC24}}</td>
+        <td>{{item.MOS}}</td>
+        <td>{{item.monthConsumption}}</td>
+        <td>{{item.lastMonthConsumption}}</td>
+        <td>{{item.twoMonthsAgoConsumption}}</td>
+        <td>{{item.expiringInSixMonths}}</td>
+        <td>{{item.expiringInTwelveMonths}}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>

--- a/server/reports/item-usage/2_5/src/thisMonthConsumption.postgres.sql
+++ b/server/reports/item-usage/2_5/src/thisMonthConsumption.postgres.sql
@@ -1,0 +1,10 @@
+WITH
+    this_month AS (
+        SELECT date_trunc('month', CURRENT_DATE) AS this_month
+    )
+SELECT
+    SUM(quantity) AS quantity,
+    item_id
+FROM consumption, this_month
+WHERE date >= this_month AND store_id = $storeId
+GROUP BY item_id

--- a/server/reports/item-usage/2_5/src/thisMonthConsumption.sqlite.sql
+++ b/server/reports/item-usage/2_5/src/thisMonthConsumption.sqlite.sql
@@ -1,0 +1,10 @@
+WITH
+    this_month AS (
+        SELECT date('now', 'start of month') AS this_month
+    )
+SELECT
+    SUM(quantity) AS quantity,
+    item_id
+FROM consumption, this_month
+WHERE date >= this_month AND store_id = $storeId
+GROUP BY item_id

--- a/server/reports/item-usage/2_5/src/twoMonthsAgoConsumption.postgres.sql
+++ b/server/reports/item-usage/2_5/src/twoMonthsAgoConsumption.postgres.sql
@@ -1,0 +1,13 @@
+WITH
+    last_month AS (
+        SELECT date_trunc('month', CURRENT_DATE - interval '1 month') AS last_month
+    ),
+    two_months_ago AS (
+        SELECT date_trunc('month', CURRENT_DATE - interval '2 month') AS two_months_ago
+    )
+SELECT
+    SUM(quantity) AS quantity,
+    item_id
+FROM consumption, two_months_ago, last_month
+WHERE date >= two_months_ago AND date < last_month AND store_id = $storeId
+GROUP BY item_id

--- a/server/reports/item-usage/2_5/src/twoMonthsAgoConsumption.sqlite.sql
+++ b/server/reports/item-usage/2_5/src/twoMonthsAgoConsumption.sqlite.sql
@@ -1,0 +1,13 @@
+WITH
+    last_month AS (
+        SELECT date('now', 'start of month', '-1 month') AS last_month
+    ),
+    two_months_ago AS (
+        SELECT date('now', 'start of month', '-2 month') AS two_months_ago
+    )
+SELECT
+    SUM(quantity) AS quantity,
+    item_id
+FROM consumption, two_months_ago, last_month
+WHERE date >= two_months_ago AND date < last_month AND store_id = $storeId
+GROUP BY item_id

--- a/server/reports/stock-status/2_5/argument_schemas/arguments.json
+++ b/server/reports/stock-status/2_5/argument_schemas/arguments.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "StockFilters": {
+      "properties": {
+        "itemCode": {
+          "description": "Item Code",
+          "type": "string"
+        },
+        "itemName": {
+          "description": "Item Name",
+          "type": "string"
+        },
+        "monthlyConsumptionLookBackPeriod": {
+          "description": "Average Monthly Consumption Look Back Period",
+          "type": "number"
+        },
+        "monthsOverstock": {
+          "description": "Months Overstock",
+          "type": "number"
+        },
+        "monthsUnderstock": {
+          "description": "Months Understock",
+          "type": "number"
+        },
+        "sort": {
+          "description": "sort by",
+          "type": "string",
+          "enum": ["name", "code"]
+        },
+        "dir": {
+          "description": "sort by dir",
+          "type": "string",
+          "enum": ["asc", "desc"]
+        }
+      }
+    }
+  },
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/StockFilters"
+    }
+  ]
+}

--- a/server/reports/stock-status/2_5/argument_schemas/arguments_ui.json
+++ b/server/reports/stock-status/2_5/argument_schemas/arguments_ui.json
@@ -1,0 +1,67 @@
+{
+  "type": "VerticalLayout",
+  "elements": [
+    {
+      "type": "Control",
+      "scope": "#/properties/itemCode",
+      "label": "T#report.item-code",
+      "options": {
+        "useDebounce": false
+      }
+    },
+    {
+      "type": "Control",
+      "scope": "#/properties/itemName",
+      "label": "T#report.item-name",
+      "options": {
+        "useDebounce": false
+      }
+    },
+    {
+      "type": "Control",
+      "scope": "#/properties/monthlyConsumptionLookBackPeriod",
+      "label": "T#report.amc-lookback",
+      "options": {
+        "readonly": true,
+        "inputAlignment": "end",
+        "paddingRight": 25
+      }
+    },
+    {
+      "type": "Control",
+      "scope": "#/properties/monthsOverstock",
+      "label": "T#label.max-months-of-stock",
+      "options": {
+        "readonly": true,
+        "inputAlignment": "end",
+        "paddingRight": 25
+      }
+    },
+    {
+      "type": "Control",
+      "scope": "#/properties/monthsUnderstock",
+      "label": "T#label.min-months-of-stock",
+      "options": {
+        "readonly": true,
+        "inputAlignment": "end",
+        "paddingRight": 25
+      }
+    },
+    {
+      "type": "Control",
+      "scope": "#/properties/sort",
+      "label": "T#report.sort-by",
+      "options": {
+        "show": [
+          ["name", "item"],
+          ["code", "code"]
+        ]
+      }
+    },
+    {
+      "type": "Control",
+      "scope": "#/properties/dir",
+      "label": "T#report.sort-direction"
+    }
+  ]
+}

--- a/server/reports/stock-status/2_5/convert_data_js/esbuild.js
+++ b/server/reports/stock-status/2_5/convert_data_js/esbuild.js
@@ -1,0 +1,16 @@
+const esbuild = require("esbuild");
+// include this if you need some node support:
+// npm i @esbuild-plugins/node-modules-polyfill --save-dev
+// const { NodeModulesPolyfillPlugin } = require('@esbuild-plugins/node-modules-polyfill')
+
+esbuild.build({
+  // supports other types like js or ts
+  entryPoints: ["src/convert_data.js"],
+  outdir: "dist",
+  bundle: true,
+  sourcemap: true,
+  //plugins: [NodeModulesPolyfillPlugin()], // include this if you need some node support
+  minify: false, // might want to use true for production build
+  format: "cjs", // needs to be CJS for now
+  target: ["es2020"], // don't go over es2020 because quickjs doesn't support it
+});

--- a/server/reports/stock-status/2_5/convert_data_js/input.json
+++ b/server/reports/stock-status/2_5/convert_data_js/input.json
@@ -1,0 +1,131 @@
+{
+  "AMCTwelve": [
+    {
+      "quantity": 150.8,
+      "item_id": "101"
+    },
+    {
+      "quantity": 92.4,
+      "item_id": "102"
+    },
+    {
+      "quantity": 200.5,
+      "item_id": "103"
+    }
+  ],
+  "AMCTwentyFour": [
+    {
+      "quantity": 250.8,
+      "item_id": "101"
+    },
+    {
+      "quantity": 192.4,
+      "item_id": "102"
+    },
+    {
+      "quantity": 300.5,
+      "item_id": "103"
+    }
+  ],
+  "expiringInSixMonths": [
+    {
+      "id": 201,
+      "item_id": "101",
+      "quantity": 150
+    },
+    {
+      "id": 202,
+      "item_id": "102",
+      "quantity": 75
+    }
+  ],
+  "expiringInTwelveMonths": [
+    {
+      "id": 201,
+      "item_id": "101",
+      "quantity": 170
+    },
+    {
+      "id": 202,
+      "item_id": "102",
+      "quantity": 92
+    },
+    {
+      "id": 203,
+      "item_id": "103",
+      "quantity": 400
+    }
+  ],
+  "thisMonthConsumption": [
+    {
+      "quantity": 200,
+      "item_id": "101"
+    },
+    {
+      "quantity": 150,
+      "item_id": "102"
+    },
+    {
+      "quantity": 300,
+      "item_id": "103"
+    }
+  ],
+  "lastMonthConsumption": [
+    {
+      "quantity": 500,
+      "item_id": "101"
+    },
+    {
+      "quantity": 300,
+      "item_id": "102"
+    },
+    {
+      "quantity": 450,
+      "item_id": "103"
+    }
+  ],
+  "twoMonthsAgoConsumption": [
+    {
+      "quantity": 123,
+      "item_id": "101"
+    },
+    {
+      "quantity": 421,
+      "item_id": "102"
+    },
+    {
+      "quantity": 152,
+      "item_id": "103"
+    }
+  ],
+  "items": {
+    "nodes": [
+      {
+        "id": "101",
+        "code": "ITEM001",
+        "name": "Item A",
+        "stats": {
+          "totalConsumption": 1200,
+          "availableMonthsOfStockOnHand": 4.5,
+          "availableStockOnHand": 300.902,
+          "averageMonthlyConsumption": 266.7
+        },
+        "someOtherKey": ""
+      },
+      {},
+      {
+        "id": "101",
+        "code": "ITEM001",
+        "name": "Item A",
+        "stats": {
+          "totalConsumption": 100,
+          "availableMonthsOfStockOnHand": 4.5,
+          "availableStockOnHand": 200,
+          "someNestedEmptyStringKey": ""
+        },
+        "someOtherOtherKey": ""
+      },
+      {}
+    ]
+  }
+}

--- a/server/reports/stock-status/2_5/convert_data_js/output.json
+++ b/server/reports/stock-status/2_5/convert_data_js/output.json
@@ -1,0 +1,47 @@
+{
+  "items": {
+    "nodes": [
+      {
+        "id": "101",
+        "code": "ITEM001",
+        "name": "Item A",
+        "stats": {
+          "totalConsumption": 1200,
+          "availableMonthsOfStockOnHand": 4.5,
+          "availableStockOnHand": 300.902,
+          "averageMonthlyConsumption": 266.7
+        },
+        "monthConsumption": 200,
+        "lastMonthConsumption": 500,
+        "twoMonthsAgoConsumption": 123,
+        "expiringInSixMonths": 150,
+        "expiringInTwelveMonths": 170,
+        "stockOnOrder": 0,
+        "AMC12": 150.8,
+        "AMC24": 250.8,
+        "SOH": 300.9,
+        "MOS": 4.5
+      },
+      {
+        "id": "101",
+        "code": "ITEM001",
+        "name": "Item A",
+        "stats": {
+          "availableStockOnHand": 200,
+          "totalConsumption": 100,
+          "availableMonthsOfStockOnHand": 4.5
+        },
+        "stockOnOrder": 0,
+        "AMC12": 150.8,
+        "AMC24": 250.8,
+        "SOH": 200,
+        "MOS": 4.5,
+        "expiringInSixMonths": 150,
+        "expiringInTwelveMonths": 170,
+        "lastMonthConsumption": 500,
+        "monthConsumption": 200,
+        "twoMonthsAgoConsumption": 123
+      }
+    ]
+  }
+}

--- a/server/reports/stock-status/2_5/convert_data_js/package.json
+++ b/server/reports/stock-status/2_5/convert_data_js/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "convert_data_js",
+  "version": "1.0.0",
+  "main": "convert_data.js",
+  "scripts": {
+    "build": "node esbuild.js && extism-js dist/convert_data.js -i src/convert_data.d.ts -o dist/plugin.wasm"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "types": "./convert_data.d.ts",
+  "description": "",
+  "devDependencies": {
+    "esbuild": "^0.24.0"
+  }
+}

--- a/server/reports/stock-status/2_5/convert_data_js/src/convert_data.d.ts
+++ b/server/reports/stock-status/2_5/convert_data_js/src/convert_data.d.ts
@@ -1,0 +1,9 @@
+declare module 'main' {
+    // Extism exports take no params and return an I32
+    export function convert_data(): I32;
+  }
+  declare module 'extism:host' {
+    interface user {
+      sql(ptr: I64): I64;
+    }
+  }

--- a/server/reports/stock-status/2_5/convert_data_js/src/convert_data.js
+++ b/server/reports/stock-status/2_5/convert_data_js/src/convert_data.js
@@ -1,0 +1,16 @@
+import { processItemLines } from "./utils";
+
+function convert_data() {
+  const res = JSON.parse(Host.inputString());
+  res.data.items.nodes = processItemLines(
+    res.data.items.nodes,
+    // assign default sort values
+    res?.arguments?.sort ?? "name",
+    res?.arguments?.dir ?? "asc"
+  );
+  Host.outputString(JSON.stringify(res));
+}
+
+module.exports = {
+  convert_data,
+};

--- a/server/reports/stock-status/2_5/convert_data_js/src/utils.js
+++ b/server/reports/stock-status/2_5/convert_data_js/src/utils.js
@@ -1,0 +1,11 @@
+import { cleanUpNodes, sortNodes } from "../../../../utils";
+
+const processItemLines = (nodes, sort, dir) => {
+  let cleanNodes = cleanUpNodes(nodes);
+  let sortedNodes = sortNodes(cleanNodes, sort, dir);
+  return sortedNodes;
+};
+
+module.exports = {
+  processItemLines,
+};

--- a/server/reports/stock-status/2_5/manifest.json
+++ b/server/reports/stock-status/2_5/manifest.json
@@ -1,0 +1,16 @@
+{
+  "is_custom": false,
+  "version": "2.3.0",
+  "code": "stock-status",
+  "context": "REPORT",
+  "sub_context": "StockAndItems",
+  "name": "Stock Status",
+  "queries": {
+    "gql": "query.graphql"
+  },
+  "arguments": {
+    "schema": "argument_schemas/arguments.json",
+    "ui": "argument_schemas/arguments_ui.json"
+  },
+  "convert_data": "convert_data_js"
+}

--- a/server/reports/stock-status/2_5/src/query.graphql
+++ b/server/reports/stock-status/2_5/src/query.graphql
@@ -1,0 +1,25 @@
+query StockStatus($storeId: String, $itemCode: String, $itemName: String) {
+  items(
+    storeId: $storeId
+    filter: {
+      code: { like: $itemCode }
+      name: { like: $itemName }
+      isVisibleOrOnHand: true
+      isActive: true
+    }
+    page: { first: 5000 }
+  ) {
+    ... on ItemConnector {
+      nodes {
+        code
+        name
+        stats(storeId: $storeId) {
+          totalConsumption
+          availableMonthsOfStockOnHand
+          availableStockOnHand
+          averageMonthlyConsumption
+        }
+      }
+    }
+  }
+}

--- a/server/reports/stock-status/2_5/src/style.css
+++ b/server/reports/stock-status/2_5/src/style.css
@@ -1,0 +1,120 @@
+@page {
+  margin: 0;
+  size: A4 landscape;
+}
+
+.paging {
+  width: 100%;
+}
+
+.container {
+  margin: auto;
+  padding: 10px;
+  font-size: 14px;
+  font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
+  color: #555;
+}
+
+.container table {
+  width: 100%;
+  font-size: inherit;
+  font-family: inherit;
+  text-align: left;
+  margin-top: 10;
+  margin-bottom: 15;
+  border-collapse: separate;
+}
+
+.container table td {
+  padding: 10px;
+  vertical-align: top;
+  border-top: 1px solid rgb(164, 163, 163);
+}
+
+.container table tr:last-child td {
+  border-bottom: none;
+}
+
+.container>table>thead {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  background-color: #f1f1f1;
+}
+
+.container,
+body,
+.container>table {
+  margin-top: 0px;
+  padding-top: 0px;
+}
+
+.container table tr.heading td {
+  font-weight: bold;
+  margin-bottom: 15px;
+}
+
+.container table td.status span {
+  padding: 2px;
+  border-radius: 10px;
+}
+
+
+.container table td.status span::before {
+  content: '';
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-right: 5px;
+}
+
+.container table td.status span.out-of-stock::before {
+  background-color: #f40502;
+}
+
+.container table td.status span.out-of-stock {
+   padding: 3px 10px;
+  white-space: nowrap;
+  background-color: #fbcdcc;
+}
+
+.container table td.status span.overstocked::before {
+  background-color: #0260f7;
+}
+
+.container table td.status span.overstocked {
+  padding: 3px 10px;
+  white-space: nowrap;
+  background-color: #d9d9ff;
+}
+
+.container table td.status span.understocked::before {
+  background-color: #f79a02;
+}
+
+.container table td.status span.understocked {
+  padding: 3px 10px;
+  white-space: nowrap;
+  background-color: #fdebcc;
+}
+
+.container table td.status span.well-stocked::before {
+  background-color: #33a902;
+}
+
+.container table td.status span.well-stocked {
+  padding: 3px 10px;
+  white-space: nowrap;
+  background-color: #d6eecc;
+}
+
+.container table td.status span.no-consumption::before {
+  background-color: #8f90a6;
+}
+
+.container table td.status span.no-consumption {
+  padding: 3px 10px;
+  white-space: nowrap;
+  background-color: #e9e9ed;
+}

--- a/server/reports/stock-status/2_5/src/template.html
+++ b/server/reports/stock-status/2_5/src/template.html
@@ -1,0 +1,59 @@
+<style>
+  {% include "style.css" %}
+</style>
+
+<div class="container">
+  <table>
+    <thead>
+      <tr class="heading">
+        <td>{{t(k="label.code", f="Code")}}</td>
+        <td>{{t(k="label.name", f="Name")}}</td>
+        <td>{{t(k="label.status", f="Status")}}</td>
+        <td>{{t(k="report.consumption", f="Consumption")}}
+        ({{arguments.monthlyConsumptionLookBackPeriod | default(value=3)}})
+        {{t(k="label.months", f="months")}}</td>
+        <td>{{t(k="label.soh", f="SOH")}}</td>
+        <td>{{t(k="label.amc", f="AMC")}}
+        ({{arguments.monthlyConsumptionLookBackPeriod | default(value=3)}})
+        {{t(k="label.months", f="months")}}</td>
+        <td>{{t(k="report.mos", f="MOS")}}</td>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in data.items.nodes %}
+        {% set SOH = item.stats.availableStockOnHand | default(value=0) | round(
+        precision=1) %}
+        {% set AMC = item.stats.averageMonthlyConsumption | default(value=0) |
+        round(precision=1) %}
+        {% set MOS = item.stats.availableMonthsOfStockOnHand | default(value=0) | round( precision=1) %}
+
+      <tr>
+        <td>{{item.code}}</td>
+        <td>{{item.name}}</td>
+        <td class="status"> 
+          {% if SOH == 0 and AMC > 0 %}
+            <span class="out-of-stock">{{t(k="report.out-of-stock", f="Out of Stock")}}</span>
+          {% elif AMC == 0 %}
+            <span class="no-consumption">{{t(k="report.no-consumption", f="No consumption")}}</span>
+          {% elif MOS >= arguments.monthsUnderstock | default(value=0) and MOS
+          <= arguments.monthsOverstock | default(value=0) %}
+            <span class="well-stocked">{{t(k="report.well-stocked", f="Well stocked")}}</span>
+          {% elif MOS < arguments.monthsUnderstock | default(value=0) %}
+            <span class="understocked">{{t(k="report.understocked", f="Understocked")}}</span>
+          {% elif MOS > arguments.monthsOverstock | default(value=0) %}
+            <span class="overstocked">{{t(k="report.overstocked", f="Overstocked")}}</span>
+          {% else %}
+          {% endif %}
+        </td>
+        <td>{{item.stats.totalConsumption | default(value=0) | round( precision=1)}}</td>
+        <td>{{SOH}}</td>
+        <td>{{AMC}}</td>
+        <td>
+          {{item.stats.availableMonthsOfStockOnHand | default(value=0) | round( precision=1)}}
+        </td>
+        
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

# 👩🏻‍💻 What does this PR do?

This PR is a sub PR to update major or minor report versions which is being done [here](https://github.com/msupply-foundation/open-msupply/pull/6157)

No changes are made in this PR - we are only copying the file structure of existing reports
Item-usage
Stock-status

This can be validated with the below commands:

`diff -bur --exclude=dist server/reports/item-usage/2_3_0/ server/reports/item-usage/2_5/`
`diff -bur --exclude=dist server/reports/stock-status/2_3_0/ server/reports/stock-status/2_5/`

The purpose of this PR is to create a base from which we can find an easily observable dif for report changes.

When making a PR which includes a new report version, it is difficult to see what has been edited.
By making a copying-report PR first, then using this as a base for further changes, the dif is simple.
This makes for more easeful reviewing.

# 🧪 Testing

Requires no testing

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
