### PR TITLE
6230 not all periods shows up on first load

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1179,6 +1179,7 @@
   "message.nothing-to-save": "Nothing to save",
   "message.placeholder-line": "A placeholder line has been created for additional requested quantity",
   "message.placeholder-lines-cannot-be-returned": "Placeholder lines cannot be returned",
+  "message.program-period": "Only the first five historic and future periods are available for selection.",
   "messages": "Messages",
   "messages.acknowledge-breach-helptext": "Enter a comment and click OK to acknowledge the breach.",
   "messages.ago": "{{time}} ago",

--- a/client/packages/requisitions/src/RequestRequisition/ListView/ProgramRequisitionOptions.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/ListView/ProgramRequisitionOptions.tsx
@@ -205,7 +205,20 @@ export const ProgramRequisitionOptions = ({
       />
       <LabelAndOptions {...suppliers} optionKey="name" />
       <LabelAndOptions {...orderTypes} optionKey="name" />
-      <LabelAndOptions {...periods} optionKey="name" />
+      <Grid item width={'100%'}>
+        <Typography
+          sx={{
+            fontStyle: 'italic',
+            color: 'gray.main',
+            fontSize: '12px',
+            paddingLeft: 20,
+            marginBottom: 0,
+          }}
+        >
+          {t('message.program-period')}
+        </Typography>
+        <LabelAndOptions {...periods} optionKey="name" />
+      </Grid>
       <Grid item>
         <ButtonWithIcon
           Icon={<PlusCircleIcon />}

--- a/client/packages/requisitions/src/ResponseRequisition/ListView/ProgramRequisitionOptions.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/ListView/ProgramRequisitionOptions.tsx
@@ -187,7 +187,20 @@ export const ProgramRequisitionOptions = ({
       />
       <LabelAndOptions {...customers} optionKey="name" />
       <LabelAndOptions {...orderTypes} optionKey="name" />
-      <LabelAndOptions {...periods} optionKey="name" />
+      <Grid item width={'100%'}>
+        <Typography
+          sx={{
+            fontStyle: 'italic',
+            color: 'gray.main',
+            fontSize: '12px',
+            paddingLeft: 20,
+            marginBottom: 0,
+          }}
+        >
+          {t('message.program-period')}
+        </Typography>
+        <LabelAndOptions {...periods} optionKey="name" />
+      </Grid>
       <Grid item>
         <ButtonWithIcon
           Icon={<PlusCircleIcon />}

--- a/server/service/src/requisition/program_settings/common.rs
+++ b/server/service/src/requisition/program_settings/common.rs
@@ -5,8 +5,8 @@ use repository::{
 use util::date_now;
 
 // History = historic and current
-const MAX_NUMBER_OF_HISTORIC_PERIODS: usize = 2;
-const MAX_NUMBER_OF_FUTURE_PERIODS: usize = 2;
+const MAX_NUMBER_OF_HISTORIC_PERIODS: usize = 5;
+const MAX_NUMBER_OF_FUTURE_PERIODS: usize = 5;
 
 /// Deduce if period is available for order_type based on
 /// matching period_schedule_id and number of requisition that exists for this


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6230

# 👩🏻‍💻 What does this PR do?
Up max periods shown historically/future. Also add message to clearly state why periods are missing from selection.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have more than 5 periods both in the past and future
- [ ] Create program requisitions
- [ ] Only first 5 historic/future periods should show

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
