### PR TITLE
Add config option to disable discovery

### DIFF
--- a/server/android/src/android.rs
+++ b/server/android/src/android.rs
@@ -9,7 +9,7 @@ pub mod android {
     use jni::sys::jchar;
     use repository::database_settings::DatabaseSettings;
     use server::{logging_init, start_server};
-    use service::settings::{LogMode, LoggingSettings, ServerSettings, Settings};
+    use service::settings::{DiscoveryMode, LogMode, LoggingSettings, ServerSettings, Settings};
     use tokio::sync::mpsc;
 
     use self::jni::objects::{JClass, JString};
@@ -42,7 +42,7 @@ pub mod android {
             server: ServerSettings {
                 port,
                 danger_allow_http: false,
-                disable_discovery: true,
+                discovery: DiscoveryMode::Disabled,
                 debug_no_access_control: false,
                 cors_origins: vec!["http://localhost".to_string()],
                 base_dir: Some(files_dir.to_str().unwrap().to_string()),

--- a/server/android/src/android.rs
+++ b/server/android/src/android.rs
@@ -42,7 +42,7 @@ pub mod android {
             server: ServerSettings {
                 port,
                 danger_allow_http: false,
-                disable_discovery: false,
+                disable_discovery: true,
                 debug_no_access_control: false,
                 cors_origins: vec!["http://localhost".to_string()],
                 base_dir: Some(files_dir.to_str().unwrap().to_string()),

--- a/server/android/src/android.rs
+++ b/server/android/src/android.rs
@@ -42,6 +42,7 @@ pub mod android {
             server: ServerSettings {
                 port,
                 danger_allow_http: false,
+                disable_discovery: false,
                 debug_no_access_control: false,
                 cors_origins: vec!["http://localhost".to_string()],
                 base_dir: Some(files_dir.to_str().unwrap().to_string()),

--- a/server/configuration/base.yaml
+++ b/server/configuration/base.yaml
@@ -1,6 +1,7 @@
 server:
   port: 8000
-  # disable_discovery: true # enable this if you don't want to use the discovery service, mainly for development
+  #   one of: Auto | Enabled | Disabled - Auto will enable discovery if the server is running in development mode
+  # discovery: Auto
   # debug_no_access_control: true # enable this if you want to ignore API authorisation (dummy user will be used for all operations)
   # danger_allow_http: true # allow http in production mode
   cors_origins: [

--- a/server/configuration/base.yaml
+++ b/server/configuration/base.yaml
@@ -1,5 +1,6 @@
 server:
   port: 8000
+  # disable_discovery: true # enable this if you don't want to use the discovery service, mainly for development
   # debug_no_access_control: true # enable this if you want to ignore API authorisation (dummy user will be used for all operations)
   # danger_allow_http: true # allow http in production mode
   cors_origins: [

--- a/server/configuration/example.yaml
+++ b/server/configuration/example.yaml
@@ -4,6 +4,7 @@
 #   host: 127.0.0.1
 #   develop: true
 #   port: 8000
+#   # disable_discovery: true # enable this if you don't want to use the discovery service, mainly for development
 #   # debug_no_access_control: true # enable this if you want to ignore API authorisation (dummy user will be used for all operations)
 #   # danger_allow_http: true # allow http in production mode
 #   cors_origins: [

--- a/server/configuration/example.yaml
+++ b/server/configuration/example.yaml
@@ -4,7 +4,7 @@
 #   host: 127.0.0.1
 #   develop: true
 #   port: 8000
-#   # disable_discovery: true # enable this if you don't want to use the discovery service, mainly for development
+#   # discovery: Enabled # Enabled, Disabled, or Auto
 #   # debug_no_access_control: true # enable this if you want to ignore API authorisation (dummy user will be used for all operations)
 #   # danger_allow_http: true # allow http in production mode
 #   cors_origins: [

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -270,8 +270,13 @@ pub async fn start_server(
     // Don't do discovery in android
     #[cfg(not(target_os = "android"))]
     {
-        info!("Starting server DNS-SD discovery",);
-        discovery::start_discovery(certificates.protocol(), settings.server.port, machine_uid);
+        if !settings.server.disable_discovery {
+            info!("Starting server DNS-SD discovery",);
+            discovery::start_discovery(certificates.protocol(), settings.server.port, machine_uid);
+        }
+        else{
+            info!("Server DNS-SD discovery disabled",);
+        }
     }
 
     info!("Starting discovery graphql server",);

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -274,7 +274,6 @@ pub async fn start_server(
             DiscoveryMode::Disabled => false,
             DiscoveryMode::Enabled => true,
             DiscoveryMode::Auto => {
-                // Only disable discovery if we are not in develop mode and have AUTO mode
                 if is_develop() {
                     log::warn!("DNS-SD discovery is automatically disabled in dev mode, add `discovery: Enabled` to local.yaml to turn it on");
                     false

--- a/server/service/src/settings.rs
+++ b/server/service/src/settings.rs
@@ -23,6 +23,8 @@ pub struct ServerSettings {
     /// Only used in development mode
     #[serde(default)]
     pub debug_no_access_control: bool,
+    #[serde(default)]
+    pub disable_discovery: bool,
     /// Sets the allowed origin for cors requests
     pub cors_origins: Vec<String>,
     /// Directory where the server stores its data, e.g. sqlite DB file or certs

--- a/server/service/src/settings.rs
+++ b/server/service/src/settings.rs
@@ -24,7 +24,7 @@ pub struct ServerSettings {
     #[serde(default)]
     pub debug_no_access_control: bool,
     #[serde(default)]
-    pub disable_discovery: bool,
+    pub discovery: DiscoveryMode,
     /// Sets the allowed origin for cors requests
     pub cors_origins: Vec<String>,
     /// Directory where the server stores its data, e.g. sqlite DB file or certs
@@ -65,6 +65,14 @@ pub enum LogMode {
     All,
     Console,
     File,
+}
+
+#[derive(serde::Deserialize, Clone, Default)]
+pub enum DiscoveryMode {
+    #[default]
+    Auto,
+    Enabled,
+    Disabled,
 }
 
 #[derive(serde::Deserialize, Clone, Debug)]

--- a/server/service/src/test_helpers.rs
+++ b/server/service/src/test_helpers.rs
@@ -10,7 +10,7 @@ use repository::{
 use crate::{
     processors::Processors,
     service_provider::{ServiceContext, ServiceProvider},
-    settings::{MailSettings, ServerSettings, Settings},
+    settings::{DiscoveryMode, MailSettings, ServerSettings, Settings},
     sync::{
         file_sync_driver::FileSyncDriver,
         synchroniser_driver::{SiteIsInitialisedCallback, SynchroniserDriver},
@@ -42,7 +42,7 @@ pub(crate) async fn setup_all_with_data_and_service_provider(
     let settings = Settings {
         server: ServerSettings {
             port: 0,
-            disable_discovery: true,
+            discovery: DiscoveryMode::Disabled,
             danger_allow_http: false,
             debug_no_access_control: false,
             cors_origins: vec![],

--- a/server/service/src/test_helpers.rs
+++ b/server/service/src/test_helpers.rs
@@ -42,6 +42,7 @@ pub(crate) async fn setup_all_with_data_and_service_provider(
     let settings = Settings {
         server: ServerSettings {
             port: 0,
+            disable_discovery: true,
             danger_allow_http: false,
             debug_no_access_control: false,
             cors_origins: vec![],


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5018 

# 👩🏻‍💻 What does this PR do?

Adds a new option you can put in your local.yaml file to turn on/off discovery.

The default `Auto` will disable discovery in Debug Build (normal workflow for devs)
```
server:
    discovery: Auto 
```


```
server:
    discovery: Enabled 
```

```
server:
    discovery: Disabled
```

## 💌 Any notes for the reviewer?

Haven't removed my old `catch_panic_unwind` code in this PR, should I?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Start server in the office see if we get any crashes due to astro-dns in Auto mode
- [ ] Check you can turn on the discovery service with discovery: Enabled

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
