### PR TITLE
Only run pre-commit lint if there are actually changes in the client dir

### DIFF
--- a/client/.husky/pre-commit
+++ b/client/.husky/pre-commit
@@ -1,4 +1,9 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-cd ./client && yarn pre-commit-lint
+SRC_PATTERN="client/"
+
+if git diff --cached --name-only | grep --quiet "$SRC_PATTERN"
+then
+  cd ./client && yarn pre-commit-lint
+fi


### PR DESCRIPTION
This was just annoying me when working on `server` code. Why lint something that hasn't been changed?