### PR TITLE
Update utils.ts

### DIFF
--- a/client/packages/reports/src/utils.ts
+++ b/client/packages/reports/src/utils.ts
@@ -4,5 +4,5 @@ export const translateReportName = (
   t: ReturnType<typeof useTranslation>,
   reportName: string
 ) => {
-  return t(`report.${reportName.replace(' ', '-').toLowerCase()}` as LocaleKey);
+  return t(`report.${reportName.replace(/ /g, '-').toLowerCase()}` as LocaleKey);
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6382 

# 👩🏻‍💻 What does this PR do?

Fix to how report names (code) is translated in the front end.

Currently only replaces first instance of ' ' in string with '-'. Should replace all

## 💌 Any notes for the reviewer?


# 🧪 Testing

You can test this by adding multiple words to a report 'code' in your database, then view how it appears in the list view on the front end with both this branch and develop.
You will see this branch searches and replaces all spaces rather than just the first.


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole

