### PR TITLE
6353 prescribed quantity improvements

### DIFF
--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
@@ -293,7 +293,6 @@ export const PrescriptionLineEditForm: React.FC<
                     {t('label.issue')}
                   </InputLabel>
                   <NumericTextInput
-                    autoFocus
                     disabled={disabled}
                     value={issueUnitQuantity}
                     onChange={handleIssueQuantityChange}

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
@@ -197,15 +197,16 @@ export const PrescriptionLineEditForm: React.FC<
   };
 
   useEffect(() => {
-    const newPrescribedQuantity = items.find(
+    const selectedItem = items.find(
       prescriptionItem => prescriptionItem.id === item?.id
-    )?.lines[0]?.prescribedQuantity;
+    );
+    const newPrescribedQuantity: number =
+      selectedItem?.lines?.find(
+        ({ prescribedQuantity }) =>
+          prescribedQuantity != null && prescribedQuantity > 0
+      )?.prescribedQuantity ?? 0;
 
-    if (newPrescribedQuantity != null) {
-      setPrescribedQuantity(newPrescribedQuantity);
-    } else {
-      setPrescribedQuantity(0);
-    }
+    setPrescribedQuantity(newPrescribedQuantity);
 
     const newIssueQuantity = Math.round(
       allocatedUnits / Math.abs(Number(packSizeController.selected?.value || 1))

--- a/client/packages/invoices/src/Prescriptions/api/hooks/usePrescriptionLines.ts
+++ b/client/packages/invoices/src/Prescriptions/api/hooks/usePrescriptionLines.ts
@@ -79,11 +79,10 @@ const useSaveLines = (id: string, invoiceNum: number) => {
     const input = {
       insertPrescriptionLines: draftPrescriptionLines
         .filter(
-          ({ type, isCreated, numberOfPacks, prescribedQuantity }) =>
+          ({ type, isCreated, numberOfPacks }) =>
             isCreated &&
             type === InvoiceLineNodeType.StockOut &&
-            numberOfPacks > 0 &&
-            !prescribedQuantity
+            numberOfPacks > 0
         )
         .map(
           line =>
@@ -96,7 +95,7 @@ const useSaveLines = (id: string, invoiceNum: number) => {
             isUpdated &&
             type === InvoiceLineNodeType.StockOut &&
             numberOfPacks > 0 &&
-            (prescribedQuantity ?? 0) > 0
+            (prescribedQuantity ?? 0) >= 0
         )
         .map(
           line =>

--- a/client/packages/invoices/src/StockOut/utils.test.ts
+++ b/client/packages/invoices/src/StockOut/utils.test.ts
@@ -876,22 +876,37 @@ describe('Allocated quantities - assign prescribed quantity', () => {
 
   it('should save to a placeholder if no stock is allocated', () => {
     const placeholder = getPlaceholder();
+    const newLine1 = createTestLine({
+      id: '1',
+      availableNumberOfPacks: 0,
+      numberOfPacks: 0,
+    });
+    const newLine2 = createTestLine({
+      id: '2',
+      availableNumberOfPacks: 0,
+      numberOfPacks: 0,
+    });
+    const newLine3 = createTestLine({
+      id: '3',
+      availableNumberOfPacks: 0,
+      numberOfPacks: 0,
+    });
 
     const allocate = allocateQuantities(InvoiceNodeStatus.New, [
-      { ...Line1, numberOfPacks: 0 },
-      { ...Line2, numberOfPacks: 0 },
-      { ...Line3, numberOfPacks: 0 },
+      newLine1,
+      newLine2,
+      newLine3,
       placeholder,
     ]);
 
-    const newDraftStockOutLines = allocate(0, 0, false, prescribedQuantity);
+    const newDraftStockOutLines = allocate(5, 0, false, prescribedQuantity);
 
     const lineWithPrescribedQuantity = newDraftStockOutLines?.filter(
       line => line.prescribedQuantity === 15
     );
 
     expect(lineWithPrescribedQuantity).toEqual([
-      { ...placeholder, prescribedQuantity },
+      { ...placeholder, numberOfPacks: 5, prescribedQuantity },
     ]);
   });
 });

--- a/client/packages/invoices/src/StockOut/utils.tsx
+++ b/client/packages/invoices/src/StockOut/utils.tsx
@@ -420,10 +420,6 @@ export const assignPrescribedQuantity = (
     }
   });
 
-  console.log('newDraftStockOutlines', newDraftStockOutLines);
-  console.log('prescribedQuantityAssigned', prescribedQuantityAssigned);
-  console.log('placeholder', placeholder);
-
   // If no stock is allocated, assign it to the placeholder stock
   if (!prescribedQuantityAssigned && placeholder) {
     const placeholderIdx = newDraftStockOutLines.findIndex(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6353 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

This improves the logic for assigning the prescribed quantity. Instead of assigning it to each issued line, it only assigns the prescribed quantity to the first line that is issued.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

https://github.com/user-attachments/assets/3ecb44f4-8cd3-407c-8d5f-3e9a6c738417

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

Check the network tab or through GraphQL Network plugin to check which issued line prescribed quantity is getting assigned to.

- [ ] Edit or create a new prescription
- [ ] A field called Prescribed Quantity is on the screen
- [ ] The field should either be pre-filled with a default value or zero if there's none
- [ ] The field can be updated to our desired prescribed quantity
  - [ ] Prescribed Quantity should only be saved on the first allocated line in the prescription.
  - [ ] Only 1 line should have prescribed quantity per prescription per item.
  - [ ] If the line containing the prescribed quantity is deleted or allocated 0 stock, the prescribed quantity should be saved to the next line.
  - [ ] Prescribed quantity can be saved against a placeholder line if no stock is allocated for that item
  

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
