### PR TITLE
#6366 Fix patient sorting

### DIFF
--- a/server/repository/src/db_diesel/patient.rs
+++ b/server/repository/src/db_diesel/patient.rs
@@ -122,9 +122,9 @@ impl<'a> PatientRepository<'a> {
                     apply_sort_no_case!(query, sort, name::first_name)
                 }
                 PatientSortField::LastName => apply_sort_no_case!(query, sort, name::last_name),
-                PatientSortField::Gender => apply_sort_no_case!(query, sort, name::gender),
+                PatientSortField::Gender => apply_sort!(query, sort, name::gender),
                 PatientSortField::DateOfBirth => {
-                    apply_sort_no_case!(query, sort, name::date_of_birth)
+                    apply_sort!(query, sort, name::date_of_birth)
                 }
                 PatientSortField::Phone => apply_sort_no_case!(query, sort, name::phone),
                 PatientSortField::Address1 => apply_sort_no_case!(query, sort, name::address1),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6366

# 👩🏻‍💻 What does this PR do?

Looks like the "gender" and "date_of_birth" fields had the wrong "sort" method applied, and it was trying to COLLATE the result on a field where collate makes no sense.

Have changed to `apply_sort` rather `apply_sort_no_case` for those two fields (same as what's already on "date_of_death" and "created_date_time".

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Patients list page `/dispensary/patients`
- [ ] Click on column headers for "Gender", then "Date of Birth"
- [ ] Confirm no errors, no infinite loading, and that patients are sorted in correct order