### PR TITLE
Print Labels Button in App Bar

### DIFF
--- a/client/packages/invoices/src/Prescriptions/DetailView/AppBarButton.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/AppBarButton.tsx
@@ -7,6 +7,8 @@ import {
   useDetailPanel,
   useTranslation,
   InfoOutlineIcon,
+  LoadingButton,
+  PrinterIcon,
 } from '@openmsupply-client/common';
 import { usePrescription } from '../api';
 import { Draft } from '../..';
@@ -26,6 +28,12 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   return (
     <AppBarButtonsPortal>
       <Grid container gap={1}>
+        <LoadingButton
+          variant="outlined"
+          startIcon={<PrinterIcon />}
+          isLoading={false}
+          label={t('button.print-prescription-label')}
+        />
         <ButtonWithIcon
           label={t('button.history')}
           Icon={<InfoOutlineIcon />}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6341 

# 👩🏻‍💻 What does this PR do?


Adds a 'Print Labels' button to the App Bar of Prescriptions -> Detail View. This will be connected to an API to print the directions for all prescription items

- Is not yet hooked up to do anything when clicked
- Will then need to be connected to loading state, which will show the spinner icon when loading

<img width="1247" alt="Screenshot 2025-02-04 at 10 28 09 AM" src="https://github.com/user-attachments/assets/6601d670-2e69-4672-afd0-3a23dc3d1151" />

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Dispensary -> Prescriptions -> Open a prescription
- [ ] See the button in the App Bar

Testing on functionality will be done once this is connected to the API

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
