### PR TITLE
6176 payments modal select insurance

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1080,6 +1080,7 @@
   "label.total-items_many": "Total items",
   "label.total-items_one": "Total item",
   "label.total-items_other": "Total items",
+  "label.total-to-be-paid": "Total to be paid",
   "label.total-quantity": "Total quantity",
   "label.trace-status-done": "Done",
   "label.trace-status-pending": "Pending",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1778,6 +1778,7 @@
   "title.new-sensor": "New sensor added",
   "title.packaging": "Packaging",
   "title.patient-retrieval-modal": "Patient Data Retrieval",
+  "title.payment": "Payment",
   "title.pricing": "Pricing",
   "title.repack-complete": "Repack complete",
   "title.repack-details": "Repack Details",

--- a/client/packages/invoices/src/Prescriptions/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Footer/StatusChangeButton.tsx
@@ -146,6 +146,7 @@ const useStatusChangeButton = () => {
     isEmptyLines,
     isDisabled,
     showPaymentWindow,
+    onConfirmStatusChange,
   };
 };
 
@@ -161,6 +162,7 @@ export const StatusChangeButton = () => {
     isEmptyLines,
     isDisabled,
     showPaymentWindow,
+    onConfirmStatusChange,
   } = useStatusChangeButton();
 
   const emptyLinesNotifications = useDisabledNotificationToast(
@@ -186,7 +188,11 @@ export const StatusChangeButton = () => {
         Icon={<ArrowRightIcon />}
         onClick={onStatusClick}
       />
-      <PaymentsModal isOpen={isOpen} onClose={onClose} />
+      <PaymentsModal
+        isOpen={isOpen}
+        onClose={onClose}
+        handleConfirm={onConfirmStatusChange}
+      />
     </>
   );
 };

--- a/client/packages/invoices/src/Prescriptions/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Footer/StatusChangeButton.tsx
@@ -9,12 +9,15 @@ import {
   useConfirmationModal,
   InvoiceLineNodeType,
   useDisabledNotificationToast,
+  useEditModal,
 } from '@openmsupply-client/common';
 import {
   getNextPrescriptionStatus,
   getStatusTranslation,
 } from '../../../utils';
 import { usePrescription } from '../../api';
+import { PaymentsModal } from '../Payments';
+import { Draft } from '../../..';
 
 const getStatusOptions = (
   currentStatus: InvoiceNodeStatus | undefined,
@@ -75,8 +78,8 @@ const getButtonLabel =
   };
 
 const useStatusChangeButton = () => {
-  const { success, error } = useNotification();
   const t = useTranslation();
+  const { success, error } = useNotification();
   const {
     query: { data },
     update: { update },
@@ -84,9 +87,20 @@ const useStatusChangeButton = () => {
   } = usePrescription();
 
   const { status, lines } = data ?? {};
+
   const hasLinesToPrune =
     data?.status !== InvoiceNodeStatus.Verified &&
     (data?.lines?.nodes ?? []).some(line => line.numberOfPacks === 0);
+
+  const showPaymentWindow =
+    lines != null &&
+    lines.nodes.filter(({ totalAfterTax }) => totalAfterTax > 0).length > 0;
+
+  const isEmptyLines =
+    lines?.totalCount === 0 ||
+    lines?.nodes?.every(
+      line => line.type === InvoiceLineNodeType.UnallocatedStock
+    );
 
   const options = useMemo(
     () => getStatusOptions(status, getButtonLabel(t)),
@@ -129,44 +143,50 @@ const useStatusChangeButton = () => {
     selectedOption,
     setSelectedOption,
     getConfirmation,
-    lines,
+    isEmptyLines,
     isDisabled,
+    showPaymentWindow,
   };
 };
 
 export const StatusChangeButton = () => {
+  const t = useTranslation();
+  const { onOpen, onClose, isOpen } = useEditModal<Draft>();
+
   const {
     options,
     selectedOption,
     setSelectedOption,
     getConfirmation,
-    lines,
+    isEmptyLines,
     isDisabled,
+    showPaymentWindow,
   } = useStatusChangeButton();
-  const t = useTranslation();
-  const noLines =
-    lines?.totalCount === 0 ||
-    lines?.nodes?.every(l => l.type === InvoiceLineNodeType.UnallocatedStock);
 
-  const noLinesNotification = useDisabledNotificationToast(
+  const emptyLinesNotifications = useDisabledNotificationToast(
     t('messages.no-lines')
   );
 
   const onStatusClick = () => {
-    if (noLines) return noLinesNotification();
+    if (isEmptyLines) return emptyLinesNotifications();
+    if (showPaymentWindow) return onOpen();
     return getConfirmation();
   };
+
   if (!selectedOption) return null;
   if (isDisabled) return null;
 
   return (
-    <SplitButton
-      label={noLines ? t('messages.no-lines') : ''}
-      options={options}
-      selectedOption={selectedOption}
-      onSelectOption={setSelectedOption}
-      Icon={<ArrowRightIcon />}
-      onClick={onStatusClick}
-    />
+    <>
+      <SplitButton
+        label={isEmptyLines ? t('messages.no-lines') : ''}
+        options={options}
+        selectedOption={selectedOption}
+        onSelectOption={setSelectedOption}
+        Icon={<ArrowRightIcon />}
+        onClick={onStatusClick}
+      />
+      <PaymentsModal isOpen={isOpen} onClose={onClose} />
+    </>
   );
 };

--- a/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC, ReactElement, useState } from 'react';
+import React, { FC, ReactElement } from 'react';
 import { DialogButton } from '@common/components';
 import { Grid, TextField } from '@openmsupply-client/common';
 import { useDialog } from '@common/hooks';
@@ -23,18 +23,11 @@ export const PaymentsModal: FC<PaymentsModalProps> = ({
     query: { data },
   } = usePrescription();
 
-  const [totalAfterTax, setTotalAfterTax] = useState(
-    data?.pricing.totalAfterTax
-  );
-
   const fields = [
     {
       label: 'Total to be paid',
       type: 'number',
-      value: totalAfterTax,
-      onChange: (
-        event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-      ): void => setTotalAfterTax(Number(event.target.value)),
+      value: data?.pricing.totalAfterTax,
     },
     // Data not available yet!
     // { label: 'Outstanding payment' }
@@ -62,14 +55,13 @@ export const PaymentsModal: FC<PaymentsModalProps> = ({
       }
     >
       <Grid container spacing={3}>
-        {fields.map(({ type, label, value, onChange }, index) => (
+        {fields.map(({ type, label, value }, index) => (
           <Grid key={index} size={4}>
             <TextField
               fullWidth
               type={type}
               label={label}
               value={value}
-              onChange={onChange}
               sx={{
                 '& .MuiInputBase-root': {
                   borderRadius: 2,

--- a/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
@@ -8,11 +8,13 @@ import { usePrescription } from '../../api';
 interface PaymentsModalProps {
   isOpen: boolean;
   onClose: () => void;
+  handleConfirm: () => void;
 }
 
 export const PaymentsModal: FC<PaymentsModalProps> = ({
   isOpen,
   onClose,
+  handleConfirm,
 }): ReactElement => {
   const t = useTranslation();
   const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
@@ -49,7 +51,15 @@ export const PaymentsModal: FC<PaymentsModalProps> = ({
     <Modal
       width={900}
       title={t('title.payment')}
-      okButton={<DialogButton variant="save" onClick={onClose} />}
+      okButton={
+        <DialogButton
+          variant="save"
+          onClick={() => {
+            handleConfirm();
+            onClose();
+          }}
+        />
+      }
     >
       <Grid container spacing={3}>
         {fields.map(({ type, label, value, onChange }, index) => (

--- a/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
@@ -5,12 +5,6 @@ import { useDialog } from '@common/hooks';
 import { useTranslation } from '@common/intl';
 import { usePrescription } from '../../api';
 
-// When there's a 0 cost for the prescription, no Payment window shows on finalise
-// If there are no insurance providers configured, no Payment window shows on finalise
-// Payment window shows correct total price for the prescription
-// The user can select an insurance policy (if configured for the current patient)
-// Insurance policy should show the discount rate and policy type (Family or Personal)
-
 interface PaymentsModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -31,8 +25,6 @@ export const PaymentsModal: FC<PaymentsModalProps> = ({
     data?.pricing.totalAfterTax
   );
 
-  console.log('lines', data);
-
   const fields = [
     {
       label: 'Total to be paid',
@@ -42,14 +34,15 @@ export const PaymentsModal: FC<PaymentsModalProps> = ({
         event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
       ): void => setTotalAfterTax(Number(event.target.value)),
     },
-    { label: 'Outstanding payment' }, // amount outstanding
-    { label: 'Type of payment' },
-    { label: 'Amount paid' },
-    { label: 'Change' },
-    { label: 'Note' },
-    { label: 'Insurance Scheme' },
-    { label: '% Covered' },
-    { label: 'Total to be paid by insurance' },
+    // Data not available yet!
+    // { label: 'Outstanding payment' }
+    // { label: 'Type of payment' },
+    // { label: 'Amount paid' },
+    // { label: 'Change' },
+    // { label: 'Note' },
+    // { label: 'Insurance Scheme' },
+    // { label: '% Covered' },
+    // { label: 'Total to be paid by insurance' },
   ];
 
   return (

--- a/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
@@ -1,9 +1,17 @@
 import React, { FC, ReactElement } from 'react';
-import { DialogButton } from '@common/components';
-import { Grid, TextField } from '@openmsupply-client/common';
+import { DialogButton, InputWithLabelRow } from '@common/components';
+import { Grid, CurrencyInput } from '@openmsupply-client/common';
 import { useDialog } from '@common/hooks';
 import { useTranslation } from '@common/intl';
 import { usePrescription } from '../../api';
+import { noop } from 'lodash';
+
+interface PaymentModalField {
+  label: string;
+  value?: number;
+  disabled?: boolean;
+  onChange: (value: number) => void;
+}
 
 interface PaymentsModalProps {
   isOpen: boolean;
@@ -23,11 +31,12 @@ export const PaymentsModal: FC<PaymentsModalProps> = ({
     query: { data },
   } = usePrescription();
 
-  const fields = [
+  const fields: PaymentModalField[] = [
     {
       label: t('label.total-to-be-paid'),
-      type: 'number',
       value: data?.pricing.totalAfterTax,
+      disabled: true,
+      onChange: noop,
     },
     // Data not available yet!
     // { label: 'Outstanding payment' }
@@ -54,19 +63,18 @@ export const PaymentsModal: FC<PaymentsModalProps> = ({
         />
       }
     >
-      <Grid container spacing={3}>
-        {fields.map(({ type, label, value }, index) => (
+      <Grid container spacing={3} justifyContent="center">
+        {fields.map(({ label, value, disabled = false, onChange }, index) => (
           <Grid key={index} size={4}>
-            <TextField
-              fullWidth
-              type={type}
+            <InputWithLabelRow
               label={label}
-              value={value}
-              sx={{
-                '& .MuiInputBase-root': {
-                  borderRadius: 2,
-                },
-              }}
+              Input={
+                <CurrencyInput
+                  value={value}
+                  disabled={disabled}
+                  onChangeNumber={onChange}
+                />
+              }
             />
           </Grid>
         ))}

--- a/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
@@ -1,0 +1,81 @@
+import React, { ChangeEvent, FC, ReactElement, useState } from 'react';
+import { DialogButton } from '@common/components';
+import { Grid, TextField } from '@openmsupply-client/common';
+import { useDialog } from '@common/hooks';
+import { useTranslation } from '@common/intl';
+import { usePrescription } from '../../api';
+
+// When there's a 0 cost for the prescription, no Payment window shows on finalise
+// If there are no insurance providers configured, no Payment window shows on finalise
+// Payment window shows correct total price for the prescription
+// The user can select an insurance policy (if configured for the current patient)
+// Insurance policy should show the discount rate and policy type (Family or Personal)
+
+interface PaymentsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const PaymentsModal: FC<PaymentsModalProps> = ({
+  isOpen,
+  onClose,
+}): ReactElement => {
+  const t = useTranslation();
+  const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
+
+  const {
+    query: { data },
+  } = usePrescription();
+
+  const [totalAfterTax, setTotalAfterTax] = useState(
+    data?.pricing.totalAfterTax
+  );
+
+  console.log('lines', data);
+
+  const fields = [
+    {
+      label: 'Total to be paid',
+      type: 'number',
+      value: totalAfterTax,
+      onChange: (
+        event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+      ): void => setTotalAfterTax(Number(event.target.value)),
+    },
+    { label: 'Outstanding payment' }, // amount outstanding
+    { label: 'Type of payment' },
+    { label: 'Amount paid' },
+    { label: 'Change' },
+    { label: 'Note' },
+    { label: 'Insurance Scheme' },
+    { label: '% Covered' },
+    { label: 'Total to be paid by insurance' },
+  ];
+
+  return (
+    <Modal
+      width={900}
+      title={t('title.payment')}
+      okButton={<DialogButton variant="save" onClick={onClose} />}
+    >
+      <Grid container spacing={3}>
+        {fields.map(({ type, label, value, onChange }, index) => (
+          <Grid key={index} size={4}>
+            <TextField
+              fullWidth
+              type={type}
+              label={label}
+              value={value}
+              onChange={onChange}
+              sx={{
+                '& .MuiInputBase-root': {
+                  borderRadius: 2,
+                },
+              }}
+            />
+          </Grid>
+        ))}
+      </Grid>
+    </Modal>
+  );
+};

--- a/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
@@ -25,7 +25,7 @@ export const PaymentsModal: FC<PaymentsModalProps> = ({
 
   const fields = [
     {
-      label: 'Total to be paid',
+      label: t('label.total-to-be-paid'),
       type: 'number',
       value: data?.pricing.totalAfterTax,
     },

--- a/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
@@ -4,7 +4,6 @@ import { Grid, CurrencyInput } from '@openmsupply-client/common';
 import { useDialog } from '@common/hooks';
 import { useTranslation } from '@common/intl';
 import { usePrescription } from '../../api';
-import { noop } from 'lodash';
 
 interface PaymentModalField {
   label: string;
@@ -36,7 +35,7 @@ export const PaymentsModal: FC<PaymentsModalProps> = ({
       label: t('label.total-to-be-paid'),
       value: data?.pricing.totalAfterTax,
       disabled: true,
-      onChange: noop,
+      onChange: () => {},
     },
     // Data not available yet!
     // { label: 'Outstanding payment' }

--- a/client/packages/invoices/src/Prescriptions/DetailView/Payments/index.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Payments/index.ts
@@ -1,0 +1,1 @@
+export * from './PaymentsModal';


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6176

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

This PR sets up the necessary groundwork to render various text fields in the payments modal. This modal will only be displayed when the cost is greater than $0 upon finalise/verified. Currently, it only shows the total amount that a patient is required to pay.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

The remaining fields can be added once #6289 have been worked on

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to a prescription with an issued line(s)
- [ ] Click on Confirm Verified Button
- [ ] A new modal title Payments is shown on the screen
- [ ] Total to be paid is rendered on the screen
- [ ] A save button can be click which finalises/verifies the prescription

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
