### PR TITLE
6267 add toolbar rendered encounter fields

### DIFF
--- a/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.ts
+++ b/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.ts
@@ -45,7 +45,6 @@ export const useBlockNavigation = () => {
   });
 
   const blockers: BlockingState[] = Array.from(blocking.values());
-  const shouldBlock = blockers.some(b => b.shouldBlock);
 
   const blocker = useBlocker(({ currentLocation, nextLocation }) => {
     for (const b of blockers) {
@@ -65,14 +64,18 @@ export const useBlockNavigation = () => {
     return false;
   });
 
+  const shouldBlockRefresh = blockers.some(
+    b => b.shouldBlock && !b.options?.allowRefresh
+  );
+
   // handle page refresh events
   useBeforeUnload(
     useCallback(
       event => {
         // Cancel the refresh
-        if (shouldBlock) event.preventDefault();
+        if (shouldBlockRefresh) event.preventDefault();
       },
-      [shouldBlock]
+      [shouldBlockRefresh]
     ),
     { capture: true }
   );
@@ -97,6 +100,10 @@ interface BlockerOptions {
    */
   customCheck?: (currentLocation: Location, nextLocation: Location) => boolean;
   customConfirmation?: (proceed: () => void) => void;
+  /**
+   * Will block when navigating away from the page, but not when refreshing
+   */
+  allowRefresh?: boolean;
 }
 
 interface BlockingState {

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
@@ -139,6 +139,7 @@ export function Autocomplete<T>({
         popper: popper,
       }}
       sx={{
+        ...restOfAutocompleteProps.sx,
         background: theme =>
           disabled
             ? theme.palette.background.toolbar

--- a/client/packages/programs/src/JsonForms/common/JsonForm.tsx
+++ b/client/packages/programs/src/JsonForms/common/JsonForm.tsx
@@ -58,6 +58,7 @@ import {
   FORM_LABEL_COLUMN_WIDTH,
 } from './styleConstants';
 import { FormActionStructure } from '../useFormActions';
+import { ToolbarLayout, toolbarLayoutTester } from './components/ToolbarLayout';
 
 export type JsonType = string | number | boolean | null | undefined;
 
@@ -202,6 +203,7 @@ const renderers = [
   { tester: noteTester, renderer: Note },
   { tester: spacerTester, renderer: Spacer },
   { tester: headerTester, renderer: Header },
+  { tester: toolbarLayoutTester, renderer: ToolbarLayout },
   // We should be able to remove materialRenderers once we are sure we have custom components to cover all cases.
   ...materialRenderers,
 ];

--- a/client/packages/programs/src/JsonForms/common/JsonForm.tsx
+++ b/client/packages/programs/src/JsonForms/common/JsonForm.tsx
@@ -262,6 +262,9 @@ export const JsonForm: FC<
           textAlign: 'right',
           whiteSpace: 'nowrap',
         },
+        '&:empty': {
+          display: 'none',
+        },
       }}
     >
       <ScrollFix />

--- a/client/packages/programs/src/JsonForms/common/JsonForm.tsx
+++ b/client/packages/programs/src/JsonForms/common/JsonForm.tsx
@@ -45,6 +45,8 @@ import {
   Spacer,
   keyedItemArrayTester,
   KeyedItemArray,
+  ToolbarLayout,
+  toolbarLayoutTester,
 } from './components';
 import {
   AccordionGroup,
@@ -58,7 +60,6 @@ import {
   FORM_LABEL_COLUMN_WIDTH,
 } from './styleConstants';
 import { FormActionStructure } from '../useFormActions';
-import { ToolbarLayout, toolbarLayoutTester } from './components/ToolbarLayout';
 
 export type JsonType = string | number | boolean | null | undefined;
 

--- a/client/packages/programs/src/JsonForms/common/components/ToolbarLayout.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/ToolbarLayout.tsx
@@ -1,0 +1,61 @@
+import React, { FC } from 'react';
+import {
+  and,
+  LayoutProps,
+  optionIs,
+  RankedTester,
+  rankWith,
+  uiTypeIs,
+  VerticalLayout,
+} from '@jsonforms/core';
+import { withJsonFormsLayoutProps } from '@jsonforms/react';
+import { Grid, AppBarContentPortal } from '@openmsupply-client/common';
+import {
+  AjvProps,
+  renderLayoutElements,
+  withAjvProps,
+} from '@jsonforms/material-renderers';
+
+export const toolbarLayoutTester: RankedTester = rankWith(
+  2,
+  and(uiTypeIs('VerticalLayout'), optionIs('variant', 'toolbar'))
+);
+
+const UIComponent: FC<LayoutProps & AjvProps> = ({
+  path,
+  renderers,
+  schema,
+  uischema,
+  cells,
+}) => {
+  const layout = uischema as VerticalLayout;
+
+  const enabled = true;
+
+  return (
+    <AppBarContentPortal>
+      <Grid
+        display="flex"
+        justifyContent="center"
+        alignContent="center"
+        flex={1}
+        flexWrap="wrap"
+        gap={2}
+        padding={2}
+      >
+        {renderLayoutElements(
+          layout.elements,
+          schema,
+          path,
+          enabled,
+          renderers,
+          cells
+        )}
+      </Grid>
+    </AppBarContentPortal>
+  );
+};
+
+export const ToolbarLayout = withJsonFormsLayoutProps(
+  withAjvProps(UIComponent)
+);

--- a/client/packages/programs/src/JsonForms/common/components/ToolbarLayout.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/ToolbarLayout.tsx
@@ -16,9 +16,14 @@ import {
   withAjvProps,
 } from '@jsonforms/material-renderers';
 
+export const unrankedToolbarTester = and(
+  uiTypeIs('VerticalLayout'),
+  optionIs('variant', 'toolbar')
+);
+
 export const toolbarLayoutTester: RankedTester = rankWith(
   2,
-  and(uiTypeIs('VerticalLayout'), optionIs('variant', 'toolbar'))
+  unrankedToolbarTester
 );
 
 const UIComponent: FC<LayoutProps & AjvProps> = ({

--- a/client/packages/programs/src/JsonForms/common/components/ToolbarLayout.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/ToolbarLayout.tsx
@@ -31,11 +31,10 @@ const UIComponent: FC<LayoutProps & AjvProps> = ({
   renderers,
   schema,
   uischema,
+  enabled,
   cells,
 }) => {
   const layout = uischema as VerticalLayout;
-
-  const enabled = true;
 
   return (
     <AppBarContentPortal>

--- a/client/packages/programs/src/JsonForms/common/components/index.ts
+++ b/client/packages/programs/src/JsonForms/common/components/index.ts
@@ -10,3 +10,4 @@ export * from './CategorizationTabLayout';
 export * from './Autocomplete';
 export * from './ConditionalSelect';
 export * from './Spacer';
+export * from './ToolbarLayout';

--- a/client/packages/programs/src/JsonForms/common/index.ts
+++ b/client/packages/programs/src/JsonForms/common/index.ts
@@ -2,3 +2,4 @@ export * from './JsonForm';
 export { JsonSchema, UISchemaElement } from '@jsonforms/core';
 export * from './styleConstants';
 export * from './hooks/useZodOptionsValidation';
+export * from './components';

--- a/client/packages/system/src/Encounter/DetailView/AppBarButtons.tsx
+++ b/client/packages/system/src/Encounter/DetailView/AppBarButtons.tsx
@@ -17,7 +17,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonsProp> = ({
 
   return (
     <AppBarButtonsPortal>
-      <Grid container gap={1}>
+      <Grid container gap={1} flexWrap="nowrap">
         {!!logicalStatus && (
           <Typography color={'secondary.main'} padding={1} fontWeight={'bold'}>
             {logicalStatus}

--- a/client/packages/system/src/Encounter/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Encounter/DetailView/DetailView.tsx
@@ -27,6 +27,7 @@ import {
   useDocumentDataAccessor,
   EncounterSchema,
   JsonData,
+  unrankedToolbarTester,
 } from '@openmsupply-client/programs';
 import { AppRoute } from '@openmsupply-client/config';
 import { Toolbar } from './Toolbar';
@@ -328,29 +329,30 @@ export const DetailView: FC = () => {
       dataStatus === EncounterNodeStatus.Pending
     : false;
 
-  // For Immunization Programs, we display as two different tabs - Vaccinations
-  // card, and the normal "Encounter" page (if defined)
-  const tabs = [];
-  if (encounter && encounter.programEnrolment?.isImmunisationProgram) {
-    tabs.push({
-      Component: (
-        <VaccinationCard
-          encounterId={encounter.id}
-          programEnrolmentId={encounter.programEnrolment.id}
-          clinician={encounter.clinician ?? undefined}
-          onOk={() => {
-            // After changes to vax card, if the encounter is still pending
-            // we should prompt to mark as visited on leaving
-            if (encounter.status === EncounterNodeStatus.Pending)
-              setShouldMarkVisited(true);
-          }}
-        />
-      ),
-      value: t('label.vaccinations'),
-    });
-    if (encounter.document.documentRegistry?.uiSchema.elements.length > 0)
-      tabs.push({ Component: JsonForm, value: t('label.details') });
-  }
+  const VaxCard = encounter?.programEnrolment?.isImmunisationProgram ? (
+    <VaccinationCard
+      encounterId={encounter.id}
+      programEnrolmentId={encounter.programEnrolment.id}
+      clinician={encounter.clinician ?? undefined}
+      onOk={() => {
+        // After changes to vax card, if the encounter is still pending
+        // we should prompt to mark as visited on leaving
+        if (encounter.status === EncounterNodeStatus.Pending)
+          setShouldMarkVisited(true);
+      }}
+    />
+  ) : null;
+
+  // Some Immunisation Program Encounters require minimal extra data
+  // and may choose to display these inputs in the toolbar rather than the full form tab
+  const { uiSchema, jsonSchema } = JsonForm.props;
+  const usingToolbarFormLayout = unrankedToolbarTester(uiSchema, jsonSchema, {
+    rootSchema: jsonSchema,
+    config: {},
+  });
+
+  // If we need to show both vax card and forms page, we need to use tabs
+  const asTabs = !!VaxCard && !usingToolbarFormLayout;
 
   return (
     <React.Suspense fallback={<DetailViewSkeleton />}>
@@ -379,7 +381,20 @@ export const DetailView: FC = () => {
             />
           )}
           <Toolbar onChange={updateEncounter} encounter={encounter} />
-          {tabs.length > 0 ? <DetailTabs tabs={tabs} /> : JsonForm}
+          {asTabs ? (
+            <DetailTabs
+              tabs={[
+                { Component: VaxCard, value: t('label.vaccinations') },
+                { Component: JsonForm, value: t('label.details') },
+              ]}
+            />
+          ) : (
+            <>
+              {VaxCard}
+              {JsonForm}
+            </>
+          )}
+
           <SidePanel
             encounter={encounter}
             onChange={updateEncounter}

--- a/client/packages/system/src/Encounter/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Encounter/DetailView/DetailView.tsx
@@ -260,6 +260,7 @@ export const DetailView: FC = () => {
   // confirm to mark as visited
   const { isDirty: shouldMarkVisited, setIsDirty: setShouldMarkVisited } =
     useConfirmOnLeaving('encounter', {
+      allowRefresh: true,
       customConfirmation: proceed =>
         promptToMarkVisitedOnLeaving({
           onCancel: proceed,

--- a/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
@@ -101,16 +101,19 @@ export const Toolbar: FC<ToolbarProps> = ({ encounter, onChange }) => {
         alignItems="center"
       >
         <Grid
-          sx={{
+          sx={theme => ({
             alignItems: 'center',
             backgroundColor: 'background.menu',
             borderRadius: '50%',
-            display: 'flex',
+            display: 'none',
             height: '100px',
             justifyContent: 'center',
             marginRight: 2,
             width: '100px',
-          }}
+            [theme.breakpoints.up('lg')]: {
+              display: 'flex',
+            },
+          })}
         >
           <Box>
             <UserIcon fontSize="large" style={{ flex: 1 }} />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6267
Also little side quest for section one of #6332


# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Moves `Type of visit` from modal on the encounter `Details` tab, to the toolbar!

![Screenshot 2025-02-04 at 4 30 11 PM](https://github.com/user-attachments/assets/ad9c4ea6-a7b2-4888-82cb-fa8757b5c4af)



<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

I AM aware that if you make your screen too small, some of this jank ensues:
![Screenshot 2025-02-04 at 4 15 34 PM](https://github.com/user-attachments/assets/9b7bd423-fb0f-4907-807b-fdd39b86ee6f)

However upcoming issues are to remove some of the fields, so it will end up like this so I think we gucci:
![Screenshot 2025-02-04 at 4 15 21 PM](https://github.com/user-attachments/assets/64d3df84-c8e3-47d9-b191-6a8bdbb47c1a)




<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Plz DM me, you'll either need to upload latest client encounter schema to OG, or get a new sqlite file from me to test
- [ ] There is no `Details` tab 
- [ ] The type of visit selector is in the toolbar
- [ ] You can save your selection/it persists on refresh

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
