### PR TITLE
Disable pluralisation in prescription line edit view

### DIFF
--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
@@ -335,7 +335,10 @@ export const PrescriptionLineEditForm: React.FC<
                   decimalLimit={2}
                 />
                 <InputLabel sx={{ fontSize: 12 }}>
-                  {t('label.unit-plural', {
+                  {t('label.unit-plural_one', {
+                    // unit-plural_one has been specified to deactivate pluralisation.
+                    // This is to handle the case where units have not been entered for the item.
+                    // see https://github.com/msupply-foundation/open-msupply/issues/5978
                     count: issueUnitQuantity,
                     unit: item?.unitName,
                   })}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5978 

# 👩🏻‍💻 What does this PR do?

Disables pluralisation in line edit view. (Did you read the title? What did you expect? 😜)

Which means that now there are no silly 's'ses like in this sentens.

Now it looks like this for items without units:
![image](https://github.com/user-attachments/assets/0e4b246f-1d00-4477-b802-eca2ee5b7606)

And like this for items with units:
![image](https://github.com/user-attachments/assets/b8baffbe-af17-4206-84be-fcc644800d44)

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Have a nice day :)

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

- [ ] Go to Dispensary > Prescriptions > New Prscription (it's in the top right hand corner).
- [ ] In the input box which appears, type a character to search for a patient, and select a patient.
- [ ] Click 'Add item'.
- [ ] In the input box which appears, click the dropdown arrow at the end of the box, and select an item that doesn't have units (e.g. '78373 Clotrimazole cream 60 ml').
- [ ] Issue 0 units and check that there's no s after the number issued.
- [ ] Issue 1 unit and check that again.
- [ ] Issue more than 1 unit and check that again.
- [ ] Now select a medicine that _does_ have units (e.g. 030062 Acetylsalicylic Acid 300mg tabs).
- [ ] And do the same checks as before.
Thanks!
 
# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
