### PR TITLE
Add check exclusive of other customer or supplier stores

### DIFF
--- a/server/service/src/requisition/common.rs
+++ b/server/service/src/requisition/common.rs
@@ -104,6 +104,7 @@ pub struct CheckExceededOrdersForPeriod<'a> {
     pub program_order_type_id: &'a str,
     pub max_orders_per_period: i64,
     pub requisition_type: RequisitionType,
+    pub other_party_id: &'a str,
 }
 
 pub fn check_exceeded_max_orders_for_period(
@@ -120,6 +121,7 @@ pub fn check_exceeded_max_orders_for_period(
                 .program_id(EqualFilter::equal_to(input.program_id))
                 .order_type(EqualFilter::equal_to(&order_type.name))
                 .period_id(EqualFilter::equal_to(input.period_id))
+                .name_id(EqualFilter::equal_to(input.other_party_id))
                 .r#type(input.requisition_type.equal_to());
 
             let current_orders = RequisitionRepository::new(connection).count(Some(filter))?;

--- a/server/service/src/requisition/common.rs
+++ b/server/service/src/requisition/common.rs
@@ -104,7 +104,7 @@ pub struct CheckExceededOrdersForPeriod<'a> {
     pub program_order_type_id: &'a str,
     pub max_orders_per_period: i64,
     pub requisition_type: RequisitionType,
-    pub other_party_id: &'a str,
+    pub other_party_id: Option<&'a str>,
 }
 
 pub fn check_exceeded_max_orders_for_period(
@@ -117,12 +117,15 @@ pub fn check_exceeded_max_orders_for_period(
     // TODO add check which matches lower case as per in period_is_available function
     match order_type {
         Some(order_type) => {
-            let filter = RequisitionFilter::new()
+            let mut filter = RequisitionFilter::new()
                 .program_id(EqualFilter::equal_to(input.program_id))
                 .order_type(EqualFilter::equal_to(&order_type.name))
                 .period_id(EqualFilter::equal_to(input.period_id))
-                .name_id(EqualFilter::equal_to(input.other_party_id))
                 .r#type(input.requisition_type.equal_to());
+
+            if let Some(other_party_id) = input.other_party_id {
+                filter = filter.name_id(EqualFilter::equal_to(other_party_id));
+            };
 
             let current_orders = RequisitionRepository::new(connection).count(Some(filter))?;
 

--- a/server/service/src/requisition/request_requisition/insert_program.rs
+++ b/server/service/src/requisition/request_requisition/insert_program.rs
@@ -143,7 +143,7 @@ fn validate(
             program_order_type_id: &input.program_order_type_id,
             max_orders_per_period: i64::from(order_type.order_type.max_order_per_period),
             requisition_type: RequisitionType::Request,
-            other_party_id: &input.other_party_id,
+            other_party_id: None,
         },
     )? {
         return Err(OutError::MaxOrdersReachedForPeriod);

--- a/server/service/src/requisition/request_requisition/insert_program.rs
+++ b/server/service/src/requisition/request_requisition/insert_program.rs
@@ -143,6 +143,7 @@ fn validate(
             program_order_type_id: &input.program_order_type_id,
             max_orders_per_period: i64::from(order_type.order_type.max_order_per_period),
             requisition_type: RequisitionType::Request,
+            other_party_id: &input.other_party_id,
         },
     )? {
         return Err(OutError::MaxOrdersReachedForPeriod);

--- a/server/service/src/requisition/response_requisition/insert_program.rs
+++ b/server/service/src/requisition/response_requisition/insert_program.rs
@@ -149,6 +149,7 @@ fn validate(
             program_order_type_id: &input.program_order_type_id,
             max_orders_per_period: i64::from(order_type.order_type.max_order_per_period),
             requisition_type: RequisitionType::Response,
+            other_party_id: &input.other_party_id,
         },
     )? {
         return Err(OutError::MaxOrdersReachedForPeriod);

--- a/server/service/src/requisition/response_requisition/insert_program.rs
+++ b/server/service/src/requisition/response_requisition/insert_program.rs
@@ -149,7 +149,7 @@ fn validate(
             program_order_type_id: &input.program_order_type_id,
             max_orders_per_period: i64::from(order_type.order_type.max_order_per_period),
             requisition_type: RequisitionType::Response,
-            other_party_id: &input.other_party_id,
+            other_party_id: Some(&input.other_party_id),
         },
     )? {
         return Err(OutError::MaxOrdersReachedForPeriod);


### PR DESCRIPTION
When checking for maximum program orders for a period

<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6422

# 👩🏻‍💻 What does this PR do?

Previously back end checks for if maximum orders per program requisition period didn't take into account different suppliers or customers.

This PR adds a filter for for other_party_name_id during check for maximum orders per period reached. This is added in both request and response program requisitions.

Now checks for orders per period are on a per customer basis.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

On develop branch:
- [ ] Add a supplying store and 2 customer stores to a program
- [ ] Create a response requisition from the supplying store for one of the stores on a program order type with only 1 order per period allowed.
- [ ] Attempt to create another response requisition from the supplying store for the other customer store
- [ ] See error that maximum orders per period is already reached
- [ ] Create a request requisition from a custom to a supplying store on a program order type with only 1 order per period allowed.
- [ ] Attempt to create a second request requisition from the customer store to another supplying store
- [ ] See that maximum orders per period is reached

On new branch:
- [ ] Add a supplying store and 2 customer stores to a program
- [ ] Create a response requisition from the supplying store for one of the stores on a program order type with only 1 order per period allowed.
- [ ] Create another response requisition from the supplying store for the other customer store
- [ ] See this can be created.
- [ ] Create a request requisition from a custom to a supplying store on a program order type with only 1 order per period allowed.
- [ ] Create a second request requisition from the customer store to another supplying store
- [ ] See this can be created.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
