### PR TITLE
restore the border

### DIFF
--- a/client/packages/common/src/ui/components/inputs/TextArea/TextArea.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextArea/TextArea.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { StandardTextFieldProps } from '@mui/material/TextField';
 import { BasicTextInput } from '../TextInput';
+import merge from 'lodash/merge';
 
 export const TextArea: FC<StandardTextFieldProps> = ({
   value,
@@ -14,12 +15,14 @@ export const TextArea: FC<StandardTextFieldProps> = ({
   <BasicTextInput
     sx={{ width: '100%' }}
     slotProps={{
-      input: {
-        ...slotProps?.input,
-        sx: {
-          backgroundColor: 'white',
+      input: merge(
+        {
+          sx: {
+            backgroundColor: 'background.white',
+          },
         },
-      },
+        slotProps?.input
+      ),
     }}
     multiline
     value={value}

--- a/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
@@ -102,7 +102,12 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { BasicTextInput, BasicTextInputProps } from './BasicTextInput';
-import { NumUtils, RegexUtils, UNDEFINED_STRING_VALUE } from '@common/utils';
+import {
+  merge,
+  NumUtils,
+  RegexUtils,
+  UNDEFINED_STRING_VALUE,
+} from '@common/utils';
 import { useFormatNumber, useCurrency } from '@common/intl';
 import { InputAdornment } from '@common/components';
 
@@ -267,37 +272,33 @@ export const NumericTextInput = React.forwardRef<
     return (
       <BasicTextInput
         ref={ref}
-        sx={{
-          '& .MuiInput-input': {
-            textAlign: 'right',
-            width: fullWidth ? undefined : `${width}px`,
-            backgroundColor: theme =>
-              props.disabled
-                ? theme?.palette?.background?.toolbar
-                : theme?.palette?.background?.menu,
-            borderRadius: 2,
-          },
-          ...sx,
-        }}
+        sx={sx}
         inputMode={inputMode ?? 'numeric'}
-        slotProps={{
-          input: {
-            endAdornment: endAdornment ? (
-              <InputAdornment position="end" sx={{ paddingBottom: '2px' }}>
-                {endAdornment}
-              </InputAdornment>
-            ) : undefined,
-            sx: {
-              backgroundColor: theme =>
-                props.disabled
-                  ? theme.palette.background.toolbar
-                  : theme.palette.background.menu,
-              borderRadius: 2,
-              padding: 0.5,
+        textAlign="right"
+        slotProps={merge(
+          {
+            input: {
+              endAdornment: endAdornment ? (
+                <InputAdornment position="end" sx={{ paddingBottom: '2px' }}>
+                  {endAdornment}
+                </InputAdornment>
+              ) : undefined,
+              sx: {
+                borderRadius: 2,
+                padding: 0.5,
+                width: fullWidth ? undefined : `${width}px`,
+              },
+            },
+            htmlInput: {
+              sx: {
+                backgroundColor: props.disabled
+                  ? 'background.toolbar'
+                  : 'background.menu',
+              },
             },
           },
-          ...slotProps,
-        }}
+          slotProps
+        )}
         onChange={e => {
           if (!isDirty) setIsDirty(true);
 

--- a/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
@@ -7,6 +7,7 @@ import {
 } from '@common/components';
 import { RecordWithId } from '@common/types';
 import { useBufferState, useDebounceCallback } from '@common/hooks';
+import { merge } from '@common/utils';
 
 export const NumberInputCell = <T extends RecordWithId>({
   rowData,
@@ -28,13 +29,16 @@ export const NumberInputCell = <T extends RecordWithId>({
   width,
   endAdornment,
   error,
+  slotProps,
 }: CellProps<T> &
   NumericInputProps & {
     id?: string;
     TextInputProps?: StandardTextFieldProps;
     endAdornment?: string;
     error?: boolean;
-  }): React.ReactElement<CellProps<T>> => {
+  } & Pick<StandardTextFieldProps, 'slotProps'>): React.ReactElement<
+  CellProps<T>
+> => {
   const [buffer, setBuffer] = useBufferState(column.accessor({ rowData }));
   const updater = useDebounceCallback(column.setter, [column.setter], 250);
 
@@ -46,12 +50,15 @@ export const NumberInputCell = <T extends RecordWithId>({
       disabled={isDisabled}
       autoFocus={autoFocus}
       {...TextInputProps}
-      slotProps={{
-        input: {
-          sx: { '& .MuiInput-input': { textAlign: 'right' } },
-          ...TextInputProps?.InputProps,
+      slotProps={merge(
+        {
+          input: {
+            sx: { '& .MuiInput-input': { textAlign: 'right' } },
+            ...TextInputProps?.InputProps,
+          },
         },
-      }}
+        slotProps
+      )}
       onChange={num => {
         const newValue = num === undefined ? min : num;
         if (buffer === newValue) return;

--- a/client/packages/host/src/Admin/SettingTextArea.tsx
+++ b/client/packages/host/src/Admin/SettingTextArea.tsx
@@ -75,11 +75,9 @@ export const SettingTextArea: React.FC<SettingTextAreaProps> = ({
               minRows={10}
               style={{ padding: '0 0 0 50px' }}
               slotProps={{
-                htmlInput: {
+                input: {
                   sx: {
-                    borderColor: 'gray.main',
-                    borderStyle: 'solid',
-                    borderWidth: '1px',
+                    border: theme => `1px solid ${theme.palette.gray.main}`,
                     borderRadius: '5px',
                     padding: '3px',
                   },

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
@@ -344,6 +344,15 @@ export const PrescriptionLineEditForm: React.FC<
                   onChange={handleIssueQuantityChange}
                   min={0}
                   decimalLimit={2}
+                  slotProps={{
+                    htmlInput: {
+                      sx: {
+                        backgroundColor: disabled
+                          ? undefined
+                          : 'background.white',
+                      },
+                    },
+                  }}
                 />
                 <InputLabel sx={{ fontSize: 12 }}>
                   {t('label.unit-plural_one', {

--- a/client/packages/invoices/src/StockOut/utils.tsx
+++ b/client/packages/invoices/src/StockOut/utils.tsx
@@ -459,6 +459,13 @@ export const UnitQuantityCell = (props: CellProps<DraftStockOutLine>) => (
     id={getPackQuantityCellId(props.rowData.stockLine?.batch)}
     min={0}
     decimalLimit={2}
+    slotProps={{
+      htmlInput: {
+        sx: {
+          backgroundColor: props.isDisabled ? undefined : 'background.white',
+        },
+      },
+    }}
   />
 );
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6449

# 👩🏻‍💻 What does this PR do?
Restores the border on the settings inputs

<!-- Explain the changes you made -->
It's another MUI6 problem. 
* The slotProps needed to be on the `input` rather than the `htmlInput`
* Within the props, the `sx` provided by the caller was being overwritten 

<!-- why are the changes needed -->
The borders were missing and it's hard to see where the input is now!

<!-- Add a screenshot if there are UI changes  -->
### Side quest
Fix the background colour on the numeric inputs for prescriptions. These are showing as grey and should be white:

<img width="1146" alt="Screenshot 2025-02-09 at 4 52 59 PM" src="https://github.com/user-attachments/assets/5b168b8e-9a1a-4e3f-bcf9-55baed8f0ab7" />


## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Check the settings multi-line inputs; they should have a border
- Check other usages to see if they look ok:
  - [ ] help form email body input
  - [ ] create encounter form notes input
  - [ ] Customer requisition comment input
  - [ ] Internal order comment input

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
