### PR TITLE
5836 server front end plugins from database

### DIFF
--- a/server/cli/src/graphql/queries_mutations.rs
+++ b/server/cli/src/graphql/queries_mutations.rs
@@ -4,7 +4,7 @@ mutation Query($fileId: String!) {
     __typename
     plugins {
       installUploadedPlugin(fileId: $fileId) {
-        backendPluginCodes
+        pluginInfo
       }
     }
   }

--- a/server/cli/src/plugins.rs
+++ b/server/cli/src/plugins.rs
@@ -91,6 +91,7 @@ pub(crate) fn generate_plugin_bundle(
 
     let mut bundle = PluginBundle {
         backend_plugins: Vec::new(),
+        frontend_plugins: Vec::new(),
     };
 
     generate_bundle_recursive(&mut bundle, &ignore_paths, manifest_name, &in_dir)?;

--- a/server/graphql/general/src/lib.rs
+++ b/server/graphql/general/src/lib.rs
@@ -337,8 +337,11 @@ impl GeneralQueries {
         last_successful_user_sync(ctx)
     }
 
-    pub async fn plugins(&self, ctx: &Context<'_>) -> Result<Vec<PluginNode>> {
-        get_plugins(ctx)
+    pub async fn frontend_plugin_metadata(
+        &self,
+        ctx: &Context<'_>,
+    ) -> Result<Vec<FrontendPluginMetadataNode>> {
+        frontend_plugin_metadata(ctx)
     }
 
     pub async fn currencies(

--- a/server/server/src/serve_frontend_plugins.rs
+++ b/server/server/src/serve_frontend_plugins.rs
@@ -1,0 +1,42 @@
+use actix_web::{
+    error, get,
+    web::{self, Data},
+    Error, HttpResponse,
+};
+
+use repository::RepositoryError;
+use service::{
+    plugin::{FrontendPluginFileRequest, FrontendPluginFileRequestError},
+    service_provider::ServiceProvider,
+};
+
+pub fn config_server_frontend_plugins(cfg: &mut web::ServiceConfig) {
+    cfg.service(serve);
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error(transparent)]
+struct DatabaseError(RepositoryError);
+impl error::ResponseError for DatabaseError {}
+
+#[derive(thiserror::Error, Debug)]
+#[error(transparent)]
+struct FetchFileError(FrontendPluginFileRequestError);
+impl error::ResponseError for FetchFileError {}
+
+#[get(r#"/frontend_plugins/{plugin_code}/{filename:.*\..+$}"#)]
+async fn serve(
+    service_provider: Data<ServiceProvider>,
+    plugin_info: web::Path<FrontendPluginFileRequest>,
+) -> Result<HttpResponse, Error> {
+    let ctx = service_provider.basic_context().map_err(DatabaseError)?;
+
+    let file_content = service_provider
+        .plugin_service
+        .get_frontend_plugin_file(&ctx, &plugin_info)
+        .map_err(FetchFileError)?;
+
+    Ok(HttpResponse::Ok()
+        .content_type("application/javascript; charset=utf-8")
+        .body(file_content))
+}

--- a/server/server/src/static_files.rs
+++ b/server/server/src/static_files.rs
@@ -1,6 +1,5 @@
 use std::io::ErrorKind;
 use std::sync::Arc;
-use std::sync::Mutex;
 
 use actix_files as fs;
 use actix_multipart::form::tempfile::TempFile;
@@ -22,8 +21,6 @@ use serde::Deserialize;
 use repository::sync_file_reference_row::SyncFileReferenceRow;
 
 use service::auth_data::AuthData;
-use service::plugin::plugin_files::{PluginFileService, PluginInfo};
-use service::plugin::validation::ValidatedPluginBucket;
 use service::service_provider::ServiceProvider;
 use service::settings::Settings;
 use service::static_files::StaticFile;
@@ -48,7 +45,6 @@ pub(crate) struct UploadForm {
 // this function could be located in different module
 pub fn config_static_files(cfg: &mut web::ServiceConfig) {
     cfg.service(web::resource("/files").guard(guard::Get()).to(files));
-    cfg.service(plugins);
     cfg.service(
         web::scope("/sync_files")
             .service(download_sync_file)
@@ -82,28 +78,6 @@ async fn files(
             disposition: DispositionType::Inline,
             parameters: vec![DispositionParam::Filename(file.name)],
         })
-        .into_response(&req);
-
-    Ok(response)
-}
-
-#[get(r#"/plugins/{plugin}/{filename:.*\..+$}"#)]
-async fn plugins(
-    req: HttpRequest,
-    settings: Data<Settings>,
-    plugin_info: web::Path<PluginInfo>,
-    plugin_bucket: Data<Mutex<ValidatedPluginBucket>>,
-) -> Result<HttpResponse, Error> {
-    let file = PluginFileService::find_file(
-        plugin_bucket.as_ref(),
-        &settings.server.base_dir,
-        &plugin_info,
-    )
-    .map_err(|err| InternalError::new(err, StatusCode::INTERNAL_SERVER_ERROR))?
-    .ok_or(std::io::Error::new(ErrorKind::NotFound, "Plugin not found"))?;
-
-    let response = fs::NamedFile::open(file)?
-        .set_content_type("application/javascript; charset=utf-8".parse().unwrap())
         .into_response(&req);
 
     Ok(response)

--- a/server/service/src/backend_plugin/plugin_provider.rs
+++ b/server/service/src/backend_plugin/plugin_provider.rs
@@ -4,7 +4,7 @@ use actix_web::web::Data;
 
 use base64::{prelude::BASE64_STANDARD, Engine};
 
-use repository::{BackendPluginRow, PluginType, PluginTypes, PluginVariantType};
+use repository::{BackendPluginRow, FrontendPluginRow, PluginType, PluginTypes, PluginVariantType};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use thiserror::Error;
 
@@ -86,9 +86,10 @@ where
     })
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct PluginBundle {
     pub backend_plugins: Vec<BackendPluginRow>,
+    pub frontend_plugins: Vec<FrontendPluginRow>,
 }
 
 impl PluginInstance {

--- a/server/service/src/plugin/mod.rs
+++ b/server/service/src/plugin/mod.rs
@@ -164,7 +164,6 @@ pub trait PluginServiceTrait: Sync + Send {
                 files_content,
             },
         );
-        info!("{}", plugins.len());
     }
 
     fn get_frontend_plugins_metadata(&self, ctx: &ServiceContext) -> Vec<FrontendPluginMetadata> {

--- a/server/service/src/processors/contact_form/queue_email.rs
+++ b/server/service/src/processors/contact_form/queue_email.rs
@@ -1,7 +1,7 @@
 use repository::{
     contact_form::{ContactForm, ContactFormFilter, ContactFormRepository},
     contact_form_row::ContactType,
-    ChangelogRow, ChangelogTableName, EqualFilter, KeyType, StorageConnection,
+    ChangelogRow, ChangelogTableName, EqualFilter, KeyType,
 };
 use tera::{Context, Tera};
 use util::constants::{FEEDBACK_EMAIL, SUPPORT_EMAIL};
@@ -12,6 +12,7 @@ use crate::{
         EmailServiceError,
     },
     processors::general_processor::{Processor, ProcessorError},
+    service_provider::{ServiceContext, ServiceProvider},
     sync::CentralServerConfig,
 };
 use nanohtml2text::html2text;
@@ -29,9 +30,11 @@ impl Processor for QueueContactEmailProcessor {
     /// Changelog will only be processed once
     fn try_process_record(
         &self,
-        connection: &StorageConnection,
+        ctx: &ServiceContext,
+        _: &ServiceProvider,
         changelog: &ChangelogRow,
     ) -> Result<Option<String>, ProcessorError> {
+        let connection = &ctx.connection;
         let filter = ContactFormFilter::new().id(EqualFilter::equal_to(&changelog.record_id));
 
         let contact_form = ContactFormRepository::new(connection)

--- a/server/service/src/processors/load_plugin/load_plugin.rs
+++ b/server/service/src/processors/load_plugin/load_plugin.rs
@@ -1,10 +1,12 @@
 use repository::{
-    BackendPluginRowRepository, ChangelogRow, ChangelogTableName, KeyType, StorageConnection,
+    BackendPluginRowRepository, ChangelogRow, ChangelogTableName, FrontendPluginRowRepository,
+    KeyType,
 };
 
 use crate::{
     backend_plugin::plugin_provider::PluginInstance,
     processors::general_processor::{Processor, ProcessorError},
+    service_provider::{ServiceContext, ServiceProvider},
 };
 
 const DESCRIPTION: &str = "Load plugins";
@@ -18,23 +20,44 @@ impl Processor for LoadPlugin {
 
     fn try_process_record(
         &self,
-        connection: &StorageConnection,
+        ctx: &ServiceContext,
+        service_provider: &ServiceProvider,
         changelog: &ChangelogRow,
     ) -> Result<Option<String>, ProcessorError> {
-        let plugin = BackendPluginRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(ProcessorError::RecordNotFound(
-                "Backend plugin".to_string(),
-                changelog.record_id.clone(),
-            ))?;
+        match changelog.table_name {
+            ChangelogTableName::BackendPlugin => {
+                let plugin = BackendPluginRowRepository::new(&ctx.connection)
+                    .find_one_by_id(&changelog.record_id)?
+                    .ok_or(ProcessorError::RecordNotFound(
+                        "Backend plugin".to_string(),
+                        changelog.record_id.clone(),
+                    ))?;
 
-        PluginInstance::bind(plugin);
+                PluginInstance::bind(plugin);
+            }
+            ChangelogTableName::FrontendPlugin => {
+                let plugin = FrontendPluginRowRepository::new(&ctx.connection)
+                    .find_one_by_id(&changelog.record_id)?
+                    .ok_or(ProcessorError::RecordNotFound(
+                        "Frontend plugin".to_string(),
+                        changelog.record_id.clone(),
+                    ))?;
+
+                service_provider
+                    .plugin_service
+                    .bind_frontend_plugin(ctx, plugin);
+            }
+            _ => {}
+        }
 
         Ok(Some("success".to_string()))
     }
 
     fn change_log_table_names(&self) -> Vec<ChangelogTableName> {
-        vec![ChangelogTableName::BackendPlugin]
+        vec![
+            ChangelogTableName::BackendPlugin,
+            ChangelogTableName::FrontendPlugin,
+        ]
     }
 
     fn cursor_type(&self) -> KeyType {

--- a/server/service/src/service_provider.rs
+++ b/server/service/src/service_provider.rs
@@ -32,7 +32,7 @@ use crate::{
     log_service::{LogService, LogServiceTrait},
     master_list::{MasterListService, MasterListServiceTrait},
     name::{NameService, NameServiceTrait},
-    plugin::{PluginService, PluginServiceTrait},
+    plugin::{FrontendPluginCache, PluginService, PluginServiceTrait},
     plugin_data::{PluginDataService, PluginDataServiceTrait},
     pricing::{PricingService, PricingServiceTrait},
     processors::ProcessorsTrigger,
@@ -167,11 +167,14 @@ pub struct ServiceProvider {
     pub email_service: Box<dyn EmailServiceTrait>,
     // Contact Form
     pub contact_form_service: Box<dyn ContactFormServiceTrait>,
+    // Cache
+    pub(crate) frontend_plugins_cache: FrontendPluginCache,
 }
 
 pub struct ServiceContext {
     pub connection: StorageConnection,
     pub(crate) processors_trigger: ProcessorsTrigger,
+    pub(crate) frontend_plugins_cache: FrontendPluginCache,
     pub user_id: String,
     pub store_id: String,
 }
@@ -263,6 +266,7 @@ impl ServiceProvider {
             email_service: Box::new(EmailService::new(mail_settings.clone())),
             contact_form_service: Box::new(ContactFormService {}),
             plugin_service: Box::new(PluginService {}),
+            frontend_plugins_cache: FrontendPluginCache::new(),
         }
     }
 
@@ -273,6 +277,7 @@ impl ServiceProvider {
             processors_trigger: self.processors_trigger.clone(),
             user_id: "".to_string(),
             store_id: "".to_string(),
+            frontend_plugins_cache: self.frontend_plugins_cache.clone(),
         })
     }
 
@@ -286,6 +291,7 @@ impl ServiceProvider {
             processors_trigger: self.processors_trigger.clone(),
             user_id,
             store_id,
+            frontend_plugins_cache: self.frontend_plugins_cache.clone(),
         })
     }
 
@@ -303,6 +309,7 @@ impl ServiceContext {
             processors_trigger: ProcessorsTrigger::new_void(),
             user_id: "".to_string(),
             store_id: "".to_string(),
+            frontend_plugins_cache: FrontendPluginCache::new(),
         }
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

This PR is ready for review but ~~I haven't self reviewed it yet sorry~~ or fixed unit tests (tests fixed downstream), downstream PR has all of the changes in the stacked PRs, with documentation at some test examples: https://github.com/msupply-foundation/open-msupply/pull/6485

Fixes #5836 

# 👩🏻‍💻 What does this PR do?

Doesn't fully solve the above issue, it's fully solve in the follow up issue: 

## 💌 Any notes for the reviewer?

Unlike the PLUGIN global constant that is used for backend plugins, just using service provider and cache, backend plugins need to be accessed 'everywhere', places where it's hard to pass service provider, whereas front end plugins are always served via API, so it's best to reduce global constants where possible. Otherwise works the same way as backend plugins, after database rows are edited a trigger will load plugins to the cache, this also happen on app startup

