### PR TITLE
6459 Can send blank internal orders 

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1254,7 +1254,7 @@
   "messages.cant-download-android": "File cannot be downloaded on this device",
   "messages.cant-return-shipment": "Cannot process return of lines until the status is 'Shipped'",
   "messages.cant-return-shipment-replenishment": "Cannot return lines until the status is 'Delivered'",
-  "messages.cant-send-order": "Cannot send Internal Order because there are no lines",
+  "messages.cant-send-order": "Cannot send Internal Order because there are no lines or because all lines have a requested quantity of 0",
   "messages.catalogue-property": "This property is defined in the catalogue",
   "messages.cce-created": "CCE created successfully",
   "messages.change-server": "Change server",

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
@@ -191,12 +191,13 @@ const useStatusChangeButton = () => {
 };
 
 export const StatusChangeButton = () => {
+  const t = useTranslation();
   const { selectedOption, getConfirmation, lines } = useStatusChangeButton();
   const isDisabled = useRequest.utils.isDisabled();
   const { userHasPermission } = useAuthContext();
-  const t = useTranslation();
-  const cantSend = lines?.totalCount === 0;
-
+  const cantSend =
+    lines?.totalCount === 0 ||
+    lines?.nodes?.every(line => line?.requestedQuantity === 0);
   const showPermissionDenied = useDisabledNotificationToast(
     t('auth.permission-denied')
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6459

# 👩🏻‍💻 What does this PR do?
Don't allow users to finalise Internal Orders if:
1. There are no lines
2. All lines have requested quantity = 0

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an Internal Order
- [ ] Shouldn't be able to send IO
- [ ] Add lines but don't put anything for requested quantity
- [ ] Shouldn't be able to send

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  3.
