### PR TITLE
6086 Unclear which store's SOH & AMC are shown when clicking on an item in Requisitions

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -115,7 +115,6 @@ export const RequestLineEdit = ({
                     width={INPUT_WIDTH}
                     value={draft?.itemStats.availableStockOnHand}
                     disabled
-                    autoFocus
                   />
                 }
                 labelWidth={LABEL_WIDTH}

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -119,7 +119,7 @@ export const RequestLineEdit = ({
                   />
                 }
                 labelWidth={LABEL_WIDTH}
-                label={t('label.stock-on-hand')}
+                label={t('label.our-soh')}
                 sx={{ marginBottom: 1 }}
               />
               {isProgram && useConsumptionData && (

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -114,6 +114,19 @@ export const ResponseLineEdit = ({
           <>
             <Box paddingLeft={4} paddingRight={7}>
               {/* Left column content */}
+              <InputWithLabelRow
+                Input={
+                  <NumericTextInput
+                    width={INPUT_WIDTH}
+                    value={data?.responseStoreStats.stockOnHand}
+                    disabled={true}
+                    autoFocus
+                  />
+                }
+                labelWidth={LABEL_WIDTH}
+                label={t('label.our-soh')}
+                sx={{ marginBottom: 1 }}
+              />
               {!isProgram ? (
                 <InputWithLabelRow
                   Input={
@@ -129,7 +142,7 @@ export const ResponseLineEdit = ({
                     />
                   }
                   labelWidth={LABEL_WIDTH}
-                  label={t('label.stock-on-hand')}
+                  label={t('label.customer-soh')}
                   sx={{ marginBottom: 1 }}
                 />
               ) : (

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -120,7 +120,6 @@ export const ResponseLineEdit = ({
                     width={INPUT_WIDTH}
                     value={data?.responseStoreStats.stockOnHand}
                     disabled={true}
-                    autoFocus
                   />
                 }
                 labelWidth={LABEL_WIDTH}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6086

# 👩🏻‍💻 What does this PR do?
Add their/our stock on hand label instead of just stock on hand for Requisitions and Internal Orders + show our stock on hand for Requisitions

![Screenshot 2025-02-11 at 2 56 11 PM](https://github.com/user-attachments/assets/8c4212b3-1bee-4ed1-91e6-3896d2eb789a)

![Screenshot 2025-02-11 at 2 56 05 PM](https://github.com/user-attachments/assets/58b19821-2dad-40f3-993a-6b76801a2b2c)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to requisition line edit
- [ ] See label has clear labelling now 
- [ ] See that there is a column representing store's soh
- [ ] Go to Internal Orders
- [ ] See label has clear labelling now

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Screenshots for requisition and internal order line edit page
  2.
