### PR TITLE
Refactor utils to have overridable name as displaying report name

### DIFF
--- a/client/packages/reports/src/utils.ts
+++ b/client/packages/reports/src/utils.ts
@@ -2,8 +2,8 @@ import { LocaleKey, useTranslation } from '@common/intl';
 
 export const translateReportName = (
   t: ReturnType<typeof useTranslation>,
-  reportName: String
+  reportName: string
 ) => {
   let key = `report.${reportName.replace(/ /g, '-').toLowerCase()}` as LocaleKey
-  return (key == t(key)) ? reportName.toString() : t(key);
+  return (key == t(key)) ? reportName : t(key);
 };

--- a/client/packages/reports/src/utils.ts
+++ b/client/packages/reports/src/utils.ts
@@ -2,7 +2,8 @@ import { LocaleKey, useTranslation } from '@common/intl';
 
 export const translateReportName = (
   t: ReturnType<typeof useTranslation>,
-  reportName: string
+  reportName: String
 ) => {
-  return t(`report.${reportName.replace(/ /g, '-').toLowerCase()}` as LocaleKey);
+  let key = `report.${reportName.replace(/ /g, '-').toLowerCase()}` as LocaleKey
+  return (key == t(key)) ? reportName.toString() : t(key);
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6385 

# 👩🏻‍💻 What does this PR do?

Alternative front end translation manipulation so that raw name is displayed when translation function goes to fallback.

I had wondered about changing translation to work on code rather than name, and have the name field as an optional override. This would allow consolidation of translation manipulation into less places.
However, this is so much more simple and is backwards compatible, so opted for this option.

Allows reports to show raw name field as name without adding client specific translation strings for custom reports.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Try editing the name of a report to a custom name. Any standard report is suitable for this (must be the latest version of that report to display
- [ ] Regenerate reports with `cargo build && ./target/debug/remote_server_cli build-reports && ./target/debug/remote_server_cli upsert-reports -o`
- [ ] View raw report name on OMS

# 📃 Documentation

- [ ] **Part of an epic**: Readme to be updated after [readme update PR](https://github.com/msupply-foundation/open-msupply/issues/6385) is merged
