### PR TITLE
6510 add fields to prescription more panel

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -431,6 +431,7 @@
   "heading.add-cold-chain-equipment": "Add new CCE",
   "heading.add-item": "Add Item",
   "heading.additional-info": "Additional info",
+  "heading.prescription-details": "Prescription Details",
   "heading.are-you-sure": "Are you sure?",
   "heading.asset-identification": "Asset Identification",
   "heading.barcode-scanners": "Barcode Scanners",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -957,6 +957,7 @@
   "label.pricing": "Pricing",
   "label.primary": "Primary",
   "label.program": "Program",
+  "label.dispensing-date": "Dispensing Date",
   "label.program-enrolment": "Program Enrolment",
   "label.program-enrolments": "Program Enrolments",
   "label.program-name": "Program name",

--- a/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/PrescriptionDetailsSection.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/PrescriptionDetailsSection.tsx
@@ -1,0 +1,197 @@
+import React, { FC, memo, useState } from 'react';
+import {
+  Grid,
+  DetailPanelSection,
+  PanelLabel,
+  PanelRow,
+  useTranslation,
+  Tooltip,
+  BasicTextInput,
+  useDebouncedValueCallback,
+  useConfirmationModal,
+  DateTimePickerInput,
+  DateUtils,
+  Formatter,
+} from '@openmsupply-client/common';
+import { usePrescription, usePrescriptionLines } from '../../api';
+import {
+  Clinician,
+  ClinicianSearchInput,
+  ProgramSearchInput,
+} from '@openmsupply-client/system';
+import { ProgramFragment, useProgramList } from '@openmsupply-client/programs';
+// import {
+//   Clinician,
+//   ClinicianSearchInput,
+// } from '../../../../../system/src/Clinician';
+
+export const PrescriptionDetailsSectionComponent: FC = () => {
+  const t = useTranslation();
+  const {
+    query: { data },
+    isDisabled,
+    update: { update },
+    rows: items,
+  } = usePrescription();
+  const {
+    id,
+    clinician,
+    prescriptionDate,
+    createdDatetime,
+    programId,
+    theirReference,
+  } = data ?? {};
+  const deleteAll = () => {
+    const allRows = (items ?? []).map(({ lines }) => lines.flat()).flat() ?? [];
+    if (allRows.length === 0) return;
+    deleteLines(allRows);
+  };
+  const { data: programData } = useProgramList(true);
+  const programs = programData?.nodes ?? [];
+  const selectedProgram = programs.find(prog => prog.id === programId);
+  const {
+    delete: { deleteLines },
+  } = usePrescriptionLines();
+  const getConfirmation = useConfirmationModal({
+    title: t('heading.are-you-sure'),
+    message: t('messages.confirm-delete-prescription-lines'),
+  });
+  const [clinicianValue, setClinicianValue] = useState<Clinician | null>(
+    clinician ?? null
+  );
+  const [dateValue, setDateValue] = useState(
+    DateUtils.getDateOrNull(prescriptionDate) ??
+      DateUtils.getDateOrNull(createdDatetime) ??
+      null
+  );
+
+  const handleProgramChange = async (
+    newProgram: ProgramFragment | undefined
+  ) => {
+    if (!newProgram || !items || items.length === 0) {
+      // It's okay to *clear* program without losing current items
+      await update({ id, programId: newProgram?.id ?? null });
+      return;
+    }
+
+    getConfirmation({
+      onConfirm: async () => {
+        // For simplicity, we currently delete all items that have already been
+        // added when switching programs. We may wish to improve this in the
+        // future to only remove items that don't belong to the new program
+        await deleteAll();
+        await update({ id, programId: newProgram?.id });
+      },
+    });
+  };
+
+  const handleDateChange = async (newPrescriptionDate: Date | null) => {
+    const currentDateValue = dateValue; // Revert to this value if user cancels
+
+    if (!newPrescriptionDate) return;
+    setDateValue(newPrescriptionDate);
+
+    const oldPrescriptionDate = DateUtils.getDateOrNull(dateValue);
+
+    if (
+      newPrescriptionDate.toLocaleDateString() ===
+      oldPrescriptionDate?.toLocaleDateString()
+    )
+      return;
+
+    if (!items || items.length === 0) {
+      // If there are no lines, we can just update the prescription date
+      await update({
+        id,
+        prescriptionDate: Formatter.toIsoString(
+          DateUtils.endOfDayOrNull(newPrescriptionDate)
+        ),
+      });
+      return;
+    }
+
+    // Otherwise, we need to delete all the lines first
+    getConfirmation({
+      onConfirm: async () => {
+        await deleteAll();
+        await update({
+          id,
+          prescriptionDate: Formatter.toIsoString(
+            DateUtils.endOfDayOrNull(newPrescriptionDate)
+          ),
+        });
+      },
+      onCancel: () => setDateValue(currentDateValue),
+    });
+  };
+
+  const [theirReferenceInput, setTheirReferenceInput] =
+    useState(theirReference);
+  const debouncedUpdate = useDebouncedValueCallback(update, [
+    theirReferenceInput,
+  ]);
+
+  if (!createdDatetime) return null;
+
+  return (
+    <DetailPanelSection title={t('heading.prescription-details')}>
+      <Grid container gap={0.5} key="prescription-details">
+        <PanelRow>
+          <PanelLabel>{t('label.program')}</PanelLabel>
+          <ProgramSearchInput
+            disabled={isDisabled}
+            programs={programs}
+            selectedProgram={selectedProgram}
+            onChange={handleProgramChange}
+          />
+        </PanelRow>
+
+        <PanelRow>
+          <PanelLabel>{t('label.clinician')}</PanelLabel>
+          <ClinicianSearchInput
+            disabled={isDisabled}
+            onChange={async clinician => {
+              setClinicianValue(clinician ? clinician.value : null);
+              update({
+                id,
+                clinicianId: clinician?.value?.id ?? null,
+              });
+            }}
+            clinicianValue={clinicianValue}
+          />
+        </PanelRow>
+
+        <PanelRow>
+          <PanelLabel>{t('label.reference')}</PanelLabel>
+          <Tooltip title={theirReferenceInput} placement="bottom-start">
+            <BasicTextInput
+              disabled={isDisabled}
+              size="small"
+              sx={{ width: 250 }}
+              value={theirReferenceInput ?? ''}
+              onChange={event => {
+                setTheirReferenceInput(event.target.value);
+                debouncedUpdate({ theirReference: event.target.value });
+              }}
+            />
+          </Tooltip>
+        </PanelRow>
+
+        <PanelRow>
+          <PanelLabel>{t('label.dispensing-date')}</PanelLabel>
+          <DateTimePickerInput
+            disabled={isDisabled}
+            value={DateUtils.getDateOrNull(dateValue) ?? new Date()}
+            format="P"
+            onChange={handleDateChange}
+            maxDate={new Date()}
+          />
+        </PanelRow>
+      </Grid>
+    </DetailPanelSection>
+  );
+};
+
+export const PrescriptionDetailsSection = memo(
+  PrescriptionDetailsSectionComponent
+);

--- a/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/PrescriptionDetailsSection.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/PrescriptionDetailsSection.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useState } from 'react';
+import React, { FC, memo, useEffect, useState } from 'react';
 import {
   Grid,
   DetailPanelSection,
@@ -23,12 +23,14 @@ import { ProgramFragment, useProgramList } from '@openmsupply-client/programs';
 
 export const PrescriptionDetailsSectionComponent: FC = () => {
   const t = useTranslation();
+
   const {
     query: { data },
     isDisabled,
     update: { update },
     rows: items,
   } = usePrescription();
+
   const {
     id,
     clinician,
@@ -37,24 +39,32 @@ export const PrescriptionDetailsSectionComponent: FC = () => {
     programId,
     theirReference,
   } = data ?? {};
+
   const deleteAll = () => {
     const allRows = (items ?? []).map(({ lines }) => lines.flat()).flat() ?? [];
     if (allRows.length === 0) return;
     deleteLines(allRows);
   };
+
   const { data: programData } = useProgramList(true);
+
   const programs = programData?.nodes ?? [];
+
   const selectedProgram = programs.find(prog => prog.id === programId);
+
   const {
     delete: { deleteLines },
   } = usePrescriptionLines();
+
   const getConfirmation = useConfirmationModal({
     title: t('heading.are-you-sure'),
     message: t('messages.confirm-delete-prescription-lines'),
   });
+
   const [clinicianValue, setClinicianValue] = useState<Clinician | null>(
     clinician ?? null
   );
+
   const [dateValue, setDateValue] = useState(
     DateUtils.getDateOrNull(prescriptionDate) ??
       DateUtils.getDateOrNull(createdDatetime) ??
@@ -123,11 +133,28 @@ export const PrescriptionDetailsSectionComponent: FC = () => {
 
   const [theirReferenceInput, setTheirReferenceInput] =
     useState(theirReference);
+
   const debouncedUpdate = useDebouncedValueCallback(update, [
     theirReferenceInput,
   ]);
 
   if (!createdDatetime) return null;
+
+  useEffect(() => {
+    setClinicianValue(clinician ?? null);
+  }, [clinician]);
+
+  useEffect(() => {
+    setTheirReferenceInput(theirReference);
+  }, [theirReference]);
+
+  useEffect(() => {
+    setDateValue(
+      DateUtils.getDateOrNull(prescriptionDate) ??
+        DateUtils.getDateOrNull(createdDatetime) ??
+        null
+    );
+  }, [prescriptionDate]);
 
   return (
     <DetailPanelSection title={t('heading.prescription-details')}>

--- a/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/PrescriptionDetailsSection.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/PrescriptionDetailsSection.tsx
@@ -20,10 +20,6 @@ import {
   ProgramSearchInput,
 } from '@openmsupply-client/system';
 import { ProgramFragment, useProgramList } from '@openmsupply-client/programs';
-// import {
-//   Clinician,
-//   ClinicianSearchInput,
-// } from '../../../../../system/src/Clinician';
 
 export const PrescriptionDetailsSectionComponent: FC = () => {
   const t = useTranslation();

--- a/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/SidePanel.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/SidePanel.tsx
@@ -16,6 +16,7 @@ import {
 } from '@openmsupply-client/common';
 import { usePrescription } from '../../api';
 import { AdditionalInfoSection } from './AdditionalInfoSection';
+import { PrescriptionDetailsSection } from './PrescriptionDetailsSection';
 import { PricingSection } from './PricingSection';
 import { canCancelInvoice, canDeleteInvoice } from '../../../utils';
 import { PatientDetails } from './PatientDetails';
@@ -92,6 +93,7 @@ export const SidePanelComponent = () => {
         </>
       }
     >
+      <PrescriptionDetailsSection />
       <AdditionalInfoSection />
       <PricingSection />
       <PatientDetails />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6510 

# 👩🏻‍💻 What does this PR do?

Adds functionality to the sidebar of Prescriptions' detail view. It now has inputs for
- program
- clinician
- reference
- dispensing date
within a new section called 'Prescription Details'.

Here's a screenshot:
![image](https://github.com/user-attachments/assets/f4b25d7c-68ea-4ff5-863e-bb1198e48c1c)

## 💌 Any notes for the reviewer?

1. You may have noticed that we also have a section called 'Additional info' that might be good to combine with Prescription Details. I wasn't sure this was desired, which is why I didn't do it, but it will be easy to do if it is desired, all I need to do is revert a commit and un-comment-out some code. Just let me know.
2. If you update the reference, date or clinician in the toolbar, it doesn't update in the sidebar and vice versa. It will only change when you refresh the page. This means that it is possible to input two different values, which conflict when saving them to the database. I am unsure how to solve this and didn't know if it was worth spending the time to find out due to the closeness of the merge deadline.
3. And, as always, have a nice day :)

# 🧪 Testing


- [ ] In open mSupply, go to Dispensary > Prescriptions.
- [ ] Select a prescription (click add new in the top right if you don't already have one).

### Check the Program Input

- [ ] Add an item to the prescription.
- [ ] Click 'More' in the top right corner to reveal the sidebar.
- [ ] Attempt to change the program in the sidebar.
- [ ] Check that a modal appears, asking for confirmation.
- [ ] Give confirmation, and check that the item is deleted and the program changes to the one you selected in both the sidebar and the top bar.

### Check the Clinician Input
- [ ] In the sidebar, click the down arrow in the 'Clinician' input.
- [ ] Check it displays a list of all the prescribers available at your store.
- [ ] If you don't have any prescribers available to select, you can get some! Instructions are in the next heading underneath this one 👍.
- [ ] Add a prescriber.
- [ ] Exit the prescription's detail view by clicking close in the bottom center.
- [ ] Re-enter the prescription's detail view.
- [ ] Check that the prescriber is what you set in the sidebar.

### If you Don't Have one Already: Make a Prescriber Available in Your Store

- [ ] In 4D mSupply, go to Special > Prescribers > and click on a prescriber to use for this test. (If you don't have one, just click on 'New' and make one).
- [ ] Click on the Visibility tab and make it visible in the store you will use for this test.
- [ ] Accept all the changes by clicking 'ok' on all the menus you opened.
- [ ] In open mSupply, log in to the store you made the prescriber visible in.

### Check the Reference and Date Input

- [ ] In the sidebar, enter something in the 'Reference' input and the 'Dispensing Date' input.
- [ ] Exit the prescription and then re-enter it.
- [ ] Check that the Reference and date in the sidebar and the top bar are both what you entered.

Done, nice one, thanks!

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: New inputs column in Prescription Sidebar.
