### PR TITLE
Refactor plugin data structure

### DIFF
--- a/client/packages/common/src/plugins/usePluginEvents.ts
+++ b/client/packages/common/src/plugins/usePluginEvents.ts
@@ -10,9 +10,9 @@ export const usePluginEvents = <
   EventInput = { id: string },
   EventResult = void,
 >(
-  defautlState: State
+  defaultState: State
 ) => {
-  const [state, setState] = useState<State>(defautlState);
+  const [state, setState] = useState<State>(defaultState);
   const [events, setEvents] = useState<
     {
       id: string;

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -2228,12 +2228,6 @@ export type EqualFilterReasonOptionTypeInput = {
   notEqualTo?: InputMaybe<ReasonOptionNodeType>;
 };
 
-export type EqualFilterRelatedRecordTypeInput = {
-  equalAny?: InputMaybe<Array<RelatedRecordNodeType>>;
-  equalTo?: InputMaybe<RelatedRecordNodeType>;
-  notEqualTo?: InputMaybe<RelatedRecordNodeType>;
-};
-
 export type EqualFilterReportContextInput = {
   equalAny?: InputMaybe<Array<ReportContext>>;
   equalTo?: InputMaybe<ReportContext>;
@@ -2940,10 +2934,11 @@ export type InsertPatientResponse = PatientNode;
 
 export type InsertPluginDataInput = {
   data: Scalars['String']['input'];
+  dataIdentifier: Scalars['String']['input'];
   id: Scalars['String']['input'];
-  pluginName: Scalars['String']['input'];
-  relatedRecordId: Scalars['String']['input'];
-  relatedRecordType: RelatedRecordNodeType;
+  pluginCode: Scalars['String']['input'];
+  relatedRecordId?: InputMaybe<Scalars['String']['input']>;
+  storeId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type InsertPluginDataResponse = PluginDataNode;
@@ -5402,30 +5397,27 @@ export type PluginDataConnector = {
 };
 
 export type PluginDataFilterInput = {
+  dataIdentifier?: InputMaybe<EqualFilterStringInput>;
   id?: InputMaybe<EqualFilterStringInput>;
-  pluginName?: InputMaybe<EqualFilterStringInput>;
   relatedRecordId?: InputMaybe<EqualFilterStringInput>;
-  relatedRecordType?: InputMaybe<EqualFilterRelatedRecordTypeInput>;
   storeId?: InputMaybe<EqualFilterStringInput>;
 };
 
 export type PluginDataNode = {
   __typename: 'PluginDataNode';
   data: Scalars['String']['output'];
+  dataIdentifier: Scalars['String']['output'];
   id: Scalars['String']['output'];
   pluginCode: Scalars['String']['output'];
-  relatedRecordId: Scalars['String']['output'];
-  relatedRecordType: RelatedRecordNodeType;
-  storeId: Scalars['String']['output'];
+  relatedRecordId?: Maybe<Scalars['String']['output']>;
+  storeId?: Maybe<Scalars['String']['output']>;
 };
 
 export type PluginDataResponse = PluginDataConnector;
 
 export enum PluginDataSortFieldInput {
   Id = 'id',
-  PluginName = 'pluginName',
-  RelatedRecordId = 'relatedRecordId',
-  RelatedRecordType = 'relatedRecordType'
+  PluginCode = 'pluginCode'
 }
 
 export type PluginDataSortInput = {
@@ -5440,7 +5432,7 @@ export type PluginDataSortInput = {
 
 export type PluginInfoNode = {
   __typename: 'PluginInfoNode';
-  backendPluginCodes: Array<Scalars['String']['output']>;
+  pluginInfo: Scalars['JSON']['output'];
 };
 
 export type PricingNode = {
@@ -6326,9 +6318,9 @@ export type QueriesPatientsArgs = {
 
 export type QueriesPluginDataArgs = {
   filter?: InputMaybe<PluginDataFilterInput>;
+  pluginCode: Scalars['String']['input'];
   sort?: InputMaybe<Array<PluginDataSortInput>>;
   storeId: Scalars['String']['input'];
-  type: RelatedRecordNodeType;
 };
 
 
@@ -6686,10 +6678,6 @@ export type RefreshTokenErrorInterface = {
 };
 
 export type RefreshTokenResponse = RefreshToken | RefreshTokenError;
-
-export enum RelatedRecordNodeType {
-  StockLine = 'STOCK_LINE'
-}
 
 export type RepackConnector = {
   __typename: 'RepackConnector';
@@ -8422,10 +8410,11 @@ export type UpdatePatientResponse = PatientNode;
 
 export type UpdatePluginDataInput = {
   data: Scalars['String']['input'];
+  dataIdentifier: Scalars['String']['input'];
   id: Scalars['String']['input'];
   pluginName: Scalars['String']['input'];
-  relatedRecordId: Scalars['String']['input'];
-  relatedRecordType: RelatedRecordNodeType;
+  relatedRecordId?: InputMaybe<Scalars['String']['input']>;
+  storeId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type UpdatePluginDataResponse = PluginDataNode;

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -8412,7 +8412,7 @@ export type UpdatePluginDataInput = {
   data: Scalars['String']['input'];
   dataIdentifier: Scalars['String']['input'];
   id: Scalars['String']['input'];
-  pluginName: Scalars['String']['input'];
+  pluginCode: Scalars['String']['input'];
   relatedRecordId?: InputMaybe<Scalars['String']['input']>;
   storeId?: InputMaybe<Scalars['String']['input']>;
 };

--- a/server/graphql/plugin/src/lib.rs
+++ b/server/graphql/plugin/src/lib.rs
@@ -16,10 +16,11 @@ impl PluginQueries {
         &self,
         ctx: &Context<'_>,
         store_id: String,
+        plugin_code: String,
         filter: Option<PluginDataFilterInput>,
         sort: Option<Vec<PluginDataSortInput>>,
     ) -> Result<PluginDataResponse> {
-        plugin_data::query::get_plugin_data(ctx, &store_id, filter, sort)
+        plugin_data::query::get_plugin_data(ctx, &store_id, &plugin_code, filter, sort)
     }
 }
 

--- a/server/graphql/plugin/src/lib.rs
+++ b/server/graphql/plugin/src/lib.rs
@@ -3,7 +3,6 @@ pub mod plugin_data;
 mod queries;
 pub mod types;
 
-use crate::types::RelatedRecordNodeType;
 use async_graphql::*;
 use plugin_data::query::{PluginDataFilterInput, PluginDataResponse, PluginDataSortInput};
 use queries::uploaded_info::PluginInfoNode;
@@ -17,11 +16,10 @@ impl PluginQueries {
         &self,
         ctx: &Context<'_>,
         store_id: String,
-        r#type: RelatedRecordNodeType,
         filter: Option<PluginDataFilterInput>,
         sort: Option<Vec<PluginDataSortInput>>,
     ) -> Result<PluginDataResponse> {
-        plugin_data::query::get_plugin_data(ctx, &store_id, r#type, filter, sort)
+        plugin_data::query::get_plugin_data(ctx, &store_id, filter, sort)
     }
 }
 

--- a/server/graphql/plugin/src/plugin_data/mutations/mod.rs
+++ b/server/graphql/plugin/src/plugin_data/mutations/mod.rs
@@ -1,14 +1,2 @@
-use crate::types::RelatedRecordNodeType;
-use service::auth::Resource;
-
 pub mod insert;
 pub mod update;
-
-pub fn map_resource_type(from: RelatedRecordNodeType) -> Resource {
-    use RelatedRecordNodeType as from;
-    use Resource as to;
-
-    match from {
-        from::StockLine => to::MutateStockLine,
-    }
-}

--- a/server/graphql/plugin/src/plugin_data/mutations/update.rs
+++ b/server/graphql/plugin/src/plugin_data/mutations/update.rs
@@ -83,7 +83,7 @@ impl UpdatePluginDataInput {
         ServiceInput {
             id: self.id,
             store_id: self.store_id,
-            plugin_name: self.plugin_name,
+            plugin_code: self.plugin_code,
             related_record_id: self.related_record_id,
             data_identifier: self.data_identifier,
             data: self.data,

--- a/server/graphql/plugin/src/plugin_data/mutations/update.rs
+++ b/server/graphql/plugin/src/plugin_data/mutations/update.rs
@@ -1,4 +1,4 @@
-use crate::types::{PluginDataNode, RelatedRecordNodeType};
+use crate::types::PluginDataNode;
 use async_graphql::*;
 use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
@@ -6,20 +6,18 @@ use graphql_core::{
 };
 use repository::PluginData;
 use service::{
-    auth::ResourceAccessRequest,
+    auth::{Resource, ResourceAccessRequest},
     plugin_data::{UpdatePluginData as ServiceInput, UpdatePluginDataError as ServiceError},
 };
 
-use super::map_resource_type;
-
 #[derive(InputObject)]
 #[graphql(name = "UpdatePluginDataInput")]
-
 pub struct UpdatePluginDataInput {
     pub id: String,
+    pub store_id: Option<String>,
     pub plugin_name: String,
-    pub related_record_id: String,
-    pub related_record_type: RelatedRecordNodeType,
+    pub related_record_id: Option<String>,
+    pub data_identifier: String,
     pub data: String,
 }
 
@@ -39,12 +37,11 @@ pub fn update_plugin_data(
     store_id: &str,
     input: UpdatePluginDataInput,
 ) -> Result<UpdateResponse> {
-    let resource = map_resource_type(input.related_record_type);
     validate_auth(
         ctx,
         &ResourceAccessRequest {
-            resource,
             store_id: Some(store_id.to_string()),
+            resource: Resource::MutatePluginData,
         },
     )?;
 
@@ -85,9 +82,10 @@ impl UpdatePluginDataInput {
     pub fn to_domain(self) -> ServiceInput {
         ServiceInput {
             id: self.id,
+            store_id: self.store_id,
             plugin_name: self.plugin_name,
             related_record_id: self.related_record_id,
-            related_record_type: RelatedRecordNodeType::to_domain(self.related_record_type),
+            data_identifier: self.data_identifier,
             data: self.data,
         }
     }

--- a/server/graphql/plugin/src/plugin_data/mutations/update.rs
+++ b/server/graphql/plugin/src/plugin_data/mutations/update.rs
@@ -15,7 +15,7 @@ use service::{
 pub struct UpdatePluginDataInput {
     pub id: String,
     pub store_id: Option<String>,
-    pub plugin_name: String,
+    pub plugin_code: String,
     pub related_record_id: Option<String>,
     pub data_identifier: String,
     pub data: String,

--- a/server/graphql/plugin/src/types.rs
+++ b/server/graphql/plugin/src/types.rs
@@ -1,5 +1,5 @@
 use async_graphql::*;
-use repository::{PluginData, PluginDataRow, RelatedRecordType};
+use repository::{PluginData, PluginDataRow};
 use service::ListResult;
 
 #[derive(PartialEq, Debug)]
@@ -13,11 +13,6 @@ pub struct PluginDataConnector {
     nodes: Vec<PluginDataNode>,
 }
 
-#[derive(Enum, Copy, Clone, PartialEq, Eq)]
-pub enum RelatedRecordNodeType {
-    StockLine,
-}
-
 #[Object]
 impl PluginDataNode {
     pub async fn id(&self) -> &str {
@@ -28,40 +23,20 @@ impl PluginDataNode {
         &self.row().plugin_code
     }
 
-    pub async fn related_record_id(&self) -> &str {
-        &self.row().related_record_id
+    pub async fn related_record_id(&self) -> Option<String> {
+        self.row().related_record_id.to_owned()
     }
 
-    pub async fn related_record_type(&self) -> RelatedRecordNodeType {
-        RelatedRecordNodeType::from_domain(&self.row().related_record_type)
+    pub async fn data_identifier(&self) -> &str {
+        &self.row().data_identifier
     }
 
-    pub async fn store_id(&self) -> &str {
-        &self.row().store_id
+    pub async fn store_id(&self) -> Option<String> {
+        self.row().store_id.to_owned()
     }
 
     pub async fn data(&self) -> &String {
         &self.row().data
-    }
-}
-
-impl RelatedRecordNodeType {
-    pub fn from_domain(from: &RelatedRecordType) -> RelatedRecordNodeType {
-        use RelatedRecordNodeType as to;
-        use RelatedRecordType as from;
-
-        match from {
-            from::StockLine => to::StockLine,
-        }
-    }
-
-    pub fn to_domain(self) -> RelatedRecordType {
-        use RelatedRecordNodeType as from;
-        use RelatedRecordType as to;
-
-        match self {
-            from::StockLine => to::StockLine,
-        }
     }
 }
 

--- a/server/repository/src/db_diesel/plugin_data.rs
+++ b/server/repository/src/db_diesel/plugin_data.rs
@@ -2,7 +2,7 @@ use super::{plugin_data_row::plugin_data, StorageConnection};
 
 use crate::{
     diesel_macros::{apply_equal_filter, apply_sort_no_case},
-    DBType, EqualFilter, Pagination, PluginDataRow, RelatedRecordType, RepositoryError, Sort,
+    DBType, EqualFilter, Pagination, PluginDataRow, RepositoryError, Sort,
 };
 
 use diesel::prelude::*;
@@ -17,16 +17,14 @@ pub struct PluginDataFilter {
     pub id: Option<EqualFilter<String>>,
     pub plugin_code: Option<EqualFilter<String>>,
     pub related_record_id: Option<EqualFilter<String>>,
-    pub related_record_type: Option<EqualFilter<RelatedRecordType>>,
+    pub data_identifier: Option<EqualFilter<String>>,
     pub store_id: Option<EqualFilter<String>>,
 }
 
 #[derive(PartialEq, Debug)]
 pub enum PluginDataSortField {
     Id,
-    PluginName,
-    RelatedRecordId,
-    RelatedRecordType,
+    PluginCode,
 }
 
 pub type PluginDataSort = Sort<PluginDataSortField>;
@@ -67,14 +65,8 @@ impl<'a> PluginDataRepository<'a> {
                 PluginDataSortField::Id => {
                     apply_sort_no_case!(query, sort, plugin_data::id);
                 }
-                PluginDataSortField::PluginName => {
+                PluginDataSortField::PluginCode => {
                     apply_sort_no_case!(query, sort, plugin_data::plugin_code);
-                }
-                PluginDataSortField::RelatedRecordId => {
-                    apply_sort_no_case!(query, sort, plugin_data::related_record_id);
-                }
-                PluginDataSortField::RelatedRecordType => {
-                    apply_sort_no_case!(query, sort, plugin_data::related_record_type);
                 }
             }
         } else {
@@ -103,11 +95,7 @@ fn create_filtered_query(filter: Option<PluginDataFilter>) -> BoxedPluginQuery {
             filter.related_record_id,
             plugin_data::related_record_id
         );
-        apply_equal_filter!(
-            query,
-            filter.related_record_type,
-            plugin_data::related_record_type
-        );
+        apply_equal_filter!(query, filter.data_identifier, plugin_data::data_identifier);
         apply_equal_filter!(query, filter.store_id, plugin_data::store_id);
     }
 
@@ -140,8 +128,8 @@ impl PluginDataFilter {
         self
     }
 
-    pub fn related_record_type(mut self, filter: EqualFilter<RelatedRecordType>) -> Self {
-        self.related_record_type = Some(filter);
+    pub fn data_identifier(mut self, filter: EqualFilter<String>) -> Self {
+        self.data_identifier = Some(filter);
         self
     }
 }

--- a/server/repository/src/db_diesel/plugin_data_row.rs
+++ b/server/repository/src/db_diesel/plugin_data_row.rs
@@ -4,37 +4,30 @@ use crate::repository_error::RepositoryError;
 
 use diesel::prelude::*;
 
-use diesel_derive_enum::DbEnum;
 use serde::{Deserialize, Serialize};
 
 table! {
     plugin_data (id) {
         id -> Text,
+        store_id -> Nullable<Text>,
         plugin_code -> Text,
-        related_record_id -> Text,
-        related_record_type -> crate::db_diesel::plugin_data_row::RelatedRecordTypeMapping,
-        store_id -> Text,
+        related_record_id -> Nullable<Text>,
+        data_identifier -> Text,
         data -> Text,
     }
 }
 
 joinable!(plugin_data -> store (store_id));
 
-#[derive(DbEnum, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[DbValueStyle = "SCREAMING_SNAKE_CASE"]
-pub enum RelatedRecordType {
-    StockLine,
-}
-
-#[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq)]
+#[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq, Serialize, Deserialize)]
 #[diesel(treat_none_as_null = true)]
 #[diesel(table_name = plugin_data)]
 pub struct PluginDataRow {
     pub id: String,
+    pub store_id: Option<String>, // Any data without a store_id will be considered global data and synced to all stores
     pub plugin_code: String,
-    pub related_record_id: String,
-    pub related_record_type: RelatedRecordType,
-    pub store_id: String,
+    pub related_record_id: Option<String>,
+    pub data_identifier: String, // Used by the plugin to identify the data, often would be a table name
     pub data: String,
 }
 

--- a/server/repository/src/migrations/v2_06_00/plugin_data.rs
+++ b/server/repository/src/migrations/v2_06_00/plugin_data.rs
@@ -2,11 +2,6 @@ use crate::migrations::*;
 
 pub(crate) struct Migrate;
 
-#[cfg(not(feature = "postgres"))]
-const RELATED_RECORD_TYPE: &str = "TEXT";
-#[cfg(feature = "postgres")]
-const RELATED_RECORD_TYPE: &str = "related_record_type";
-
 impl MigrationFragment for Migrate {
     fn identifier(&self) -> &'static str {
         "plugin_data"
@@ -19,10 +14,10 @@ impl MigrationFragment for Migrate {
             DROP TABLE plugin_data;
             CREATE TABLE plugin_data (
                 id TEXT NOT NULL PRIMARY KEY,
+                store_id TEXT  REFERENCES store(id),
                 plugin_code TEXT NOT NULL,
-                related_record_id TEXT NOT NULL,
-                related_record_type {RELATED_RECORD_TYPE} NOT NULL,
-                store_id TEXT NOT NULL REFERENCES store(id),
+                related_record_id TEXT,
+                data_identifier TEXT NOT NULL,
                 data TEXT NOT NULL
             );
         "#,

--- a/server/repository/src/migrations/v2_06_00/plugin_data.rs
+++ b/server/repository/src/migrations/v2_06_00/plugin_data.rs
@@ -4,7 +4,7 @@ pub(crate) struct Migrate;
 
 impl MigrationFragment for Migrate {
     fn identifier(&self) -> &'static str {
-        "plugin_data"
+        "plugin_data_update"
     }
 
     fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {

--- a/server/service/src/auth.rs
+++ b/server/service/src/auth.rs
@@ -134,6 +134,9 @@ pub enum Resource {
     // contact form
     MutateContactForm,
     NoPermissionRequired,
+    // Plugin data
+    MutatePluginData,
+    ReadPluginData,
 }
 
 fn all_permissions() -> HashMap<Resource, PermissionDSL> {
@@ -597,6 +600,19 @@ fn all_permissions() -> HashMap<Resource, PermissionDSL> {
 
     // contact form
     map.insert(Resource::MutateContactForm, PermissionDSL::HasStoreAccess);
+
+    // plugin data
+    map.insert(
+        Resource::MutatePluginData,
+        PermissionDSL::Any(vec![
+            PermissionDSL::HasStoreAccess,
+            PermissionDSL::HasPermission(PermissionType::ServerAdmin), // Server admins can add data without store-relationship
+        ]),
+    );
+    map.insert(
+        Resource::ReadPluginData,
+        PermissionDSL::NoPermissionRequired, // Plugin data doesn't get any special protections...
+    );
 
     map
 }

--- a/server/service/src/plugin/mod.rs
+++ b/server/service/src/plugin/mod.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use base64::{prelude::BASE64_STANDARD, Engine};
-use log::info;
 use repository::{
     BackendPluginRowRepository, FrontendPluginFile, FrontendPluginRow, FrontendPluginRowRepository,
     RepositoryError,

--- a/server/service/src/plugin_data/insert.rs
+++ b/server/service/src/plugin_data/insert.rs
@@ -1,9 +1,9 @@
 use repository::{
     EqualFilter, PluginData, PluginDataFilter, PluginDataRepository, PluginDataRow,
-    PluginDataRowRepository, RelatedRecordType, RepositoryError,
+    PluginDataRowRepository, RepositoryError,
 };
 
-use crate::{service_provider::ServiceContext, WithDBError};
+use crate::{service_provider::ServiceContext, sync::CentralServerConfig, WithDBError};
 
 #[derive(PartialEq, Debug)]
 pub enum InsertPluginDataError {
@@ -16,9 +16,10 @@ pub enum InsertPluginDataError {
 #[derive(Clone, Debug)]
 pub struct InsertPluginData {
     pub id: String,
-    pub plugin_name: String,
-    pub related_record_id: String,
-    pub related_record_type: RelatedRecordType,
+    pub store_id: Option<String>,
+    pub plugin_code: String,
+    pub related_record_id: Option<String>,
+    pub data_identifier: String,
     pub data: String,
 }
 
@@ -29,7 +30,7 @@ pub fn insert(
     ctx.connection
         .transaction_sync(|connection| {
             validate(ctx, &input)?;
-            let data = generate(&ctx.store_id, input.clone());
+            let data = generate(input.clone());
 
             PluginDataRowRepository::new(connection)
                 .insert_one(&data)
@@ -46,21 +47,21 @@ pub fn insert(
 }
 
 fn generate(
-    store_id: &str,
     InsertPluginData {
         id,
-        plugin_name,
+        store_id,
+        plugin_code,
         related_record_id,
-        related_record_type,
+        data_identifier,
         data,
     }: InsertPluginData,
 ) -> PluginDataRow {
     PluginDataRow {
         id,
-        plugin_code: plugin_name,
+        store_id,
+        plugin_code,
         related_record_id,
-        related_record_type,
-        store_id: store_id.to_string(),
+        data_identifier,
         data,
     }
 }
@@ -71,6 +72,20 @@ fn validate(ctx: &ServiceContext, input: &InsertPluginData) -> Result<(), Insert
     if plugin_data.is_some() {
         return Err(InsertPluginDataError::PluginDataAlreadyExists);
     };
+
+    if input.store_id.is_none() && !CentralServerConfig::is_central_server() {
+        return Err(InsertPluginDataError::InternalError(
+            "Store ID is required unless on Central Server".to_string(),
+        ));
+    }
+
+    if let Some(store_id) = &input.store_id {
+        if &ctx.store_id != store_id {
+            return Err(InsertPluginDataError::InternalError(
+                "Store ID doesn't match logged in store_id".to_string(),
+            ));
+        }
+    }
 
     Ok(())
 }
@@ -98,7 +113,7 @@ mod test {
     use repository::{
         mock::{mock_store_a, mock_user_account_a, MockDataInserts},
         test_db::setup_all,
-        PluginDataRow, RelatedRecordType,
+        PluginDataRow,
     };
 
     use crate::{plugin_data::InsertPluginData, service_provider::ServiceProvider};
@@ -120,9 +135,10 @@ mod test {
                 &context,
                 InsertPluginData {
                     id: "new_id".to_string(),
-                    plugin_name: "new_plugin_name".to_string(),
-                    related_record_id: "new_related_record_id".to_string(),
-                    related_record_type: RelatedRecordType::StockLine,
+                    store_id: Some(mock_store_a().id.to_string()),
+                    plugin_code: "test_plugin".to_string(),
+                    related_record_id: Some("new_related_record_id".to_string()),
+                    data_identifier: "StockLine".to_string(),
                     data: "hogwarts".to_string(),
                 },
             )
@@ -140,11 +156,11 @@ mod test {
             plugin_data,
             PluginDataRow {
                 id: "new_id".to_string(),
-                plugin_code: "new_plugin_name".to_string(),
-                related_record_id: "new_related_record_id".to_string(),
-                related_record_type: RelatedRecordType::StockLine,
+                plugin_code: "test_plugin".to_string(),
+                related_record_id: Some("new_related_record_id".to_string()),
+                data_identifier: "StockLine".to_string(),
                 data: "hogwarts".to_string(),
-                store_id: mock_store_a().id.to_string(),
+                store_id: Some(mock_store_a().id.to_string()),
             }
         );
     }

--- a/server/service/src/plugin_data/update.rs
+++ b/server/service/src/plugin_data/update.rs
@@ -19,7 +19,7 @@ pub enum UpdatePluginDataError {
 pub struct UpdatePluginData {
     pub id: String,
     pub store_id: Option<String>,
-    pub plugin_name: String,
+    pub plugin_code: String,
     pub related_record_id: Option<String>,
     pub data_identifier: String,
     pub data: String,
@@ -60,7 +60,7 @@ fn validate(
     if input.data_identifier != plugin_data.data_identifier {
         return Err(UpdatePluginDataError::RelatedRecordTypeDoesNotMatch);
     }
-    if input.plugin_name != plugin_data.plugin_code {
+    if input.plugin_code != plugin_data.plugin_code {
         return Err(UpdatePluginDataError::PluginNameDoesNotMatch);
     }
 
@@ -89,7 +89,7 @@ fn check_plugin_data_exists(
 fn generate(
     UpdatePluginData {
         id,
-        plugin_name: _,
+        plugin_code: _,
         related_record_id: _,
         data_identifier: _,
         data,
@@ -138,7 +138,7 @@ mod test {
         fn plugin_data_donor() -> PluginDataRow {
             PluginDataRow {
                 id: "plugin_data".to_string(),
-                plugin_code: "plugin_name".to_string(),
+                plugin_code: "plugin_code".to_string(),
                 related_record_id: Some("related_record_id".to_string()),
                 data_identifier: "StockLine".to_string(),
                 store_id: Some(mock_store_a().id.clone()),
@@ -168,7 +168,7 @@ mod test {
                 UpdatePluginData {
                     id: "plugin_data".to_string(),
                     store_id: Some(mock_store_a().id.clone()),
-                    plugin_name: "plugin_name".to_string(),
+                    plugin_code: "plugin_code".to_string(),
                     related_record_id: Some("related_record_id".to_string()),
                     data_identifier: "StockLine".to_string(),
                     data: "hogwarts".to_string(),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6540

# 👩🏻‍💻 What does this PR do?

Changes the structure of the pluginData to allow more generic plugin data contexts without code code changes such as adding new types to postgres.
It also allows plugin data without storeId to allow central config for plugins

## 💌 Any notes for the reviewer?

This change loosens up permissions for accessing plugin data, as the Resource Mapping has been removed.
I've made non-store records only editable from central server for now,
And made plugin_code a required field for any plugin queries, so it's not possible to access all the plugin data without knowing their code  at least.


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create and edit plugin data via graphql

>Note: this issue is probably only for Developer Testing

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
