### PR TITLE
6533 pagination for period

### DIFF
--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -41,6 +41,7 @@ import {
   Locale,
   FirstWeekContainsDate,
   ParseOptions,
+  lastDayOfMonth,
 } from 'date-fns';
 import { getTimezoneOffset } from 'date-fns-tz';
 
@@ -190,6 +191,7 @@ export const DateUtils = {
   getCurrentYear: () => getYear(new Date()),
   formatDuration: (date: Date | string | number): string =>
     formatIfValid(dateInputHandler(date), 'HH:mm:ss'),
+  lastDayOfMonth,
 
   /** Number of milliseconds in one second, i.e. SECOND = 1000*/
   SECOND,

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -41,7 +41,6 @@ import {
   Locale,
   FirstWeekContainsDate,
   ParseOptions,
-  lastDayOfMonth,
 } from 'date-fns';
 import { getTimezoneOffset } from 'date-fns-tz';
 
@@ -191,7 +190,6 @@ export const DateUtils = {
   getCurrentYear: () => getYear(new Date()),
   formatDuration: (date: Date | string | number): string =>
     formatIfValid(dateInputHandler(date), 'HH:mm:ss'),
-  lastDayOfMonth,
 
   /** Number of milliseconds in one second, i.e. SECOND = 1000*/
   SECOND,

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -680,6 +680,7 @@ export type BatchInboundShipmentInput = {
   deleteInboundShipmentLines?: InputMaybe<Array<DeleteInboundShipmentLineInput>>;
   deleteInboundShipmentServiceLines?: InputMaybe<Array<DeleteInboundShipmentServiceLineInput>>;
   deleteInboundShipments?: InputMaybe<Array<DeleteInboundShipmentInput>>;
+  insertFromInternalOrderLines?: InputMaybe<Array<InsertInboundShipmentLineFromInternalOrderLineInput>>;
   insertInboundShipmentLines?: InputMaybe<Array<InsertInboundShipmentLineInput>>;
   insertInboundShipmentServiceLines?: InputMaybe<Array<InsertInboundShipmentServiceLineInput>>;
   insertInboundShipments?: InputMaybe<Array<InsertInboundShipmentInput>>;
@@ -693,6 +694,7 @@ export type BatchInboundShipmentResponse = {
   deleteInboundShipmentLines?: Maybe<Array<DeleteInboundShipmentLineResponseWithId>>;
   deleteInboundShipmentServiceLines?: Maybe<Array<DeleteInboundShipmentServiceLineResponseWithId>>;
   deleteInboundShipments?: Maybe<Array<DeleteInboundShipmentResponseWithId>>;
+  insertFromInternalOrderLines?: Maybe<Array<InsertInboundShipmentLineFromInternalOrderLineResponseWithId>>;
   insertInboundShipmentLines?: Maybe<Array<InsertInboundShipmentLineResponseWithId>>;
   insertInboundShipmentServiceLines?: Maybe<Array<InsertInboundShipmentServiceLineResponseWithId>>;
   insertInboundShipments?: Maybe<Array<InsertInboundShipmentResponseWithId>>;
@@ -2706,6 +2708,8 @@ export type InsertFormSchemaInput = {
 
 export type InsertFormSchemaResponse = FormSchemaNode;
 
+export type InsertFromInternalOrderResponse = InvoiceLineNode;
+
 export type InsertInboundShipmentError = {
   __typename: 'InsertInboundShipmentError';
   error: InsertInboundShipmentErrorInterface;
@@ -2732,6 +2736,17 @@ export type InsertInboundShipmentLineError = {
 
 export type InsertInboundShipmentLineErrorInterface = {
   description: Scalars['String']['output'];
+};
+
+export type InsertInboundShipmentLineFromInternalOrderLineInput = {
+  invoiceId: Scalars['String']['input'];
+  requisitionLineId: Scalars['String']['input'];
+};
+
+export type InsertInboundShipmentLineFromInternalOrderLineResponseWithId = {
+  __typename: 'InsertInboundShipmentLineFromInternalOrderLineResponseWithId';
+  id: Scalars['String']['output'];
+  response: InsertFromInternalOrderResponse;
 };
 
 export type InsertInboundShipmentLineInput = {
@@ -3462,6 +3477,7 @@ export type InvoiceLineConnector = {
 
 export type InvoiceLineFilterInput = {
   id?: InputMaybe<EqualFilterStringInput>;
+  inventoryAdjustmentReason?: InputMaybe<EqualFilterStringInput>;
   invoiceId?: InputMaybe<EqualFilterStringInput>;
   invoiceStatus?: InputMaybe<EqualFilterInvoiceStatusInput>;
   invoiceType?: InputMaybe<EqualFilterInvoiceTypeInput>;
@@ -3472,6 +3488,7 @@ export type InvoiceLineFilterInput = {
   stockLineId?: InputMaybe<EqualFilterStringInput>;
   storeId?: InputMaybe<EqualFilterStringInput>;
   type?: InputMaybe<EqualFilterInvoiceLineTypeInput>;
+  verifiedDatetime?: InputMaybe<DatetimeFilterInput>;
 };
 
 export type InvoiceLineNode = {
@@ -3481,6 +3498,7 @@ export type InvoiceLineNode = {
   expiryDate?: Maybe<Scalars['NaiveDate']['output']>;
   foreignCurrencyPriceBeforeTax?: Maybe<Scalars['Float']['output']>;
   id: Scalars['String']['output'];
+  inventoryAdjustmentReason?: Maybe<InventoryAdjustmentReasonNode>;
   invoiceId: Scalars['String']['output'];
   item: ItemNode;
   itemCode: Scalars['String']['output'];
@@ -3569,6 +3587,7 @@ export type InvoiceNode = {
   pickedDatetime?: Maybe<Scalars['DateTime']['output']>;
   pricing: PricingNode;
   program?: Maybe<ProgramNode>;
+  programId?: Maybe<Scalars['String']['output']>;
   /**
    * Response Requisition that is the origin of this Outbound Shipment
    * Or Request Requisition for Inbound Shipment that Originated from Outbound Shipment (linked through Response Requisition)
@@ -5428,6 +5447,10 @@ export type PeriodConnector = {
   totalCount: Scalars['Int']['output'];
 };
 
+export type PeriodFilterInput = {
+  endDate?: InputMaybe<DateFilterInput>;
+};
+
 export type PeriodNode = {
   __typename: 'PeriodNode';
   endDate: Scalars['NaiveDate']['output'];
@@ -6277,7 +6300,6 @@ export type QueriesInvoiceCountsArgs = {
 
 export type QueriesInvoiceLinesArgs = {
   filter?: InputMaybe<InvoiceLineFilterInput>;
-  invoiceId: Scalars['String']['input'];
   page?: InputMaybe<PaginationInput>;
   reportSort?: InputMaybe<PrintReportSortInput>;
   sort?: InputMaybe<Array<InvoiceLineSortInput>>;
@@ -6392,6 +6414,8 @@ export type QueriesPatientsArgs = {
 
 
 export type QueriesPeriodsArgs = {
+  filter?: InputMaybe<PeriodFilterInput>;
+  page?: InputMaybe<PaginationInput>;
   programId?: InputMaybe<Scalars['String']['input']>;
   storeId: Scalars['String']['input'];
 };

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -5449,6 +5449,7 @@ export type PeriodConnector = {
 
 export type PeriodFilterInput = {
   endDate?: InputMaybe<DateFilterInput>;
+  startDate?: InputMaybe<DateFilterInput>;
 };
 
 export type PeriodNode = {

--- a/client/packages/programs/src/JsonForms/components/PeriodSearch.tsx
+++ b/client/packages/programs/src/JsonForms/components/PeriodSearch.tsx
@@ -3,7 +3,6 @@ import { rankWith, ControlProps, uiTypeIs } from '@jsonforms/core';
 import { z } from 'zod';
 import {
   AutocompleteWithPagination,
-  DateUtils,
   DetailInputWithLabelRow,
   extractProperty,
   Formatter,
@@ -33,14 +32,13 @@ const UIComponent = (props: ControlProps) => {
     ? extractProperty(core?.data, 'programId')
     : null;
   const today = new Date();
-  const lastDayOfMonth = DateUtils.lastDayOfMonth(today);
   const { data, isFetching, fetchNextPage } = usePeriodList(
     RECORDS_PER_PAGE,
     programId,
     options?.findByProgram ? !!programId : true,
     {
-      endDate: {
-        beforeOrEqualTo: Formatter.naiveDate(lastDayOfMonth),
+      startDate: {
+        beforeOrEqualTo: Formatter.naiveDate(today),
       },
     }
   );

--- a/client/packages/programs/src/JsonForms/components/PeriodSearch.tsx
+++ b/client/packages/programs/src/JsonForms/components/PeriodSearch.tsx
@@ -2,9 +2,11 @@ import React, { useState } from 'react';
 import { rankWith, ControlProps, uiTypeIs } from '@jsonforms/core';
 import { z } from 'zod';
 import {
-  Autocomplete,
+  AutocompleteWithPagination,
+  DateUtils,
   DetailInputWithLabelRow,
   extractProperty,
+  Formatter,
 } from '@openmsupply-client/common';
 import {
   DefaultFormRowSx,
@@ -15,6 +17,7 @@ import { useJsonForms, withJsonFormsControlProps } from '@jsonforms/react';
 import { usePeriodList } from '../../api/hooks/usePeriodList';
 import { PeriodFragment } from '@openmsupply-client/requisitions';
 
+const RECORDS_PER_PAGE = 15;
 export const periodSearchTester = rankWith(10, uiTypeIs('PeriodSearch'));
 
 const Options = z.object({
@@ -29,10 +32,22 @@ const UIComponent = (props: ControlProps) => {
   const programId = options?.findByProgram
     ? extractProperty(core?.data, 'programId')
     : null;
-  const { data, isLoading } = usePeriodList(
+  const today = new Date();
+  const lastDayOfMonth = DateUtils.lastDayOfMonth(today);
+  const { data, isFetching, fetchNextPage } = usePeriodList(
+    RECORDS_PER_PAGE,
     programId,
-    options?.findByProgram ? !!programId : true
+    options?.findByProgram ? !!programId : true,
+    {
+      endDate: {
+        beforeOrEqualTo: Formatter.naiveDate(lastDayOfMonth),
+      },
+    }
   );
+
+  const pageNumber = data?.pages?.length
+    ? (data.pages[data.pages.length - 1]?.pageNumber ?? 0)
+    : 0;
 
   const onChange = async (period: PeriodFragment) => {
     setPeriod(period);
@@ -55,18 +70,22 @@ const UIComponent = (props: ControlProps) => {
       labelWidthPercentage={FORM_LABEL_WIDTH}
       inputAlignment={'start'}
       Input={
-        <Autocomplete
-          fullWidth
-          loading={isLoading}
-          options={data?.nodes ?? []}
+        <AutocompleteWithPagination
+          width={'100%'}
+          pages={data?.pages ?? []}
+          pageNumber={pageNumber}
+          rowsPerPage={RECORDS_PER_PAGE}
+          totalRows={data?.pages?.[0]?.data.totalCount ?? 0}
+          loading={isFetching}
           optionKey="name"
-          onChange={(_, newVal) =>
-            newVal && newVal.id !== period?.id && onChange(newVal)
-          }
+          onChange={(_, value) => value && onChange(value)}
+          getOptionLabel={option => option.name}
           value={period ? { label: period.name ?? '', ...period } : null}
           isOptionEqualToValue={(option, value) => option.id === value.id}
           clearable={false}
           disabled={options?.findByProgram ? !programId : false}
+          onPageChange={pageNumber => fetchNextPage({ pageParam: pageNumber })}
+          paginationDebounce={300}
         />
       }
     />

--- a/client/packages/programs/src/api/operations.generated.ts
+++ b/client/packages/programs/src/api/operations.generated.ts
@@ -25,6 +25,9 @@ export type ProgramsQuery = { __typename: 'Queries', programs: { __typename: 'Pr
 export type PeriodsQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
   programId?: Types.InputMaybe<Types.Scalars['String']['input']>;
+  first?: Types.InputMaybe<Types.Scalars['Int']['input']>;
+  offset?: Types.InputMaybe<Types.Scalars['Int']['input']>;
+  filter?: Types.InputMaybe<Types.PeriodFilterInput>;
 }>;
 
 
@@ -610,8 +613,13 @@ export const ProgramsDocument = gql`
 }
     ${ProgramFragmentDoc}`;
 export const PeriodsDocument = gql`
-    query periods($storeId: String!, $programId: String) {
-  periods(storeId: $storeId, programId: $programId) {
+    query periods($storeId: String!, $programId: String, $first: Int, $offset: Int, $filter: PeriodFilterInput) {
+  periods(
+    storeId: $storeId
+    programId: $programId
+    page: {first: $first, offset: $offset}
+    filter: $filter
+  ) {
     ... on PeriodConnector {
       __typename
       nodes {

--- a/client/packages/programs/src/api/operations.graphql
+++ b/client/packages/programs/src/api/operations.graphql
@@ -58,8 +58,19 @@ query programs(
   }
 }
 
-query periods($storeId: String!, $programId: String) {
-  periods(storeId: $storeId, programId: $programId) {
+query periods(
+  $storeId: String!
+  $programId: String
+  $first: Int
+  $offset: Int
+  $filter: PeriodFilterInput
+) {
+  periods(
+    storeId: $storeId
+    programId: $programId
+    page: { first: $first, offset: $offset }
+    filter: $filter
+  ) {
     ... on PeriodConnector {
       __typename
       nodes {

--- a/server/graphql/programs/src/lib.rs
+++ b/server/graphql/programs/src/lib.rs
@@ -20,6 +20,7 @@ use graphql_types::types::program_enrolment::ProgramEventFilterInput;
 use graphql_types::types::program_event::ProgramEventResponse;
 use graphql_types::types::program_event::ProgramEventSortInput;
 use graphql_types::types::vaccination::VaccinationNode;
+use graphql_types::types::PeriodFilterInput;
 use graphql_types::types::PeriodsResponse;
 use mutations::allocate_number::allocate_program_number;
 use mutations::allocate_number::AllocateProgramNumberInput;
@@ -268,8 +269,10 @@ impl ProgramsQueries {
         ctx: &Context<'_>,
         store_id: String,
         program_id: Option<String>,
+        page: Option<PaginationInput>,
+        filter: Option<PeriodFilterInput>,
     ) -> Result<PeriodsResponse> {
-        periods(ctx, store_id, program_id)
+        periods(ctx, store_id, program_id, page, filter)
     }
 
     pub async fn r_and_r_forms(

--- a/server/graphql/programs/src/queries/program.rs
+++ b/server/graphql/programs/src/queries/program.rs
@@ -5,7 +5,7 @@ use graphql_core::{
     ContextExt,
 };
 
-use graphql_types::types::{PeriodConnector, PeriodsResponse};
+use graphql_types::types::{PeriodConnector, PeriodFilterInput, PeriodsResponse};
 use repository::{PaginationOption, ProgramFilter};
 use service::{
     auth::{Resource, ResourceAccessRequest},
@@ -52,6 +52,8 @@ pub fn periods(
     ctx: &Context<'_>,
     store_id: String,
     program_id: Option<String>,
+    page: Option<PaginationInput>,
+    filter: Option<PeriodFilterInput>,
 ) -> Result<PeriodsResponse> {
     validate_auth(
         ctx,
@@ -63,8 +65,14 @@ pub fn periods(
     let service_provider = ctx.service_provider();
     let context = service_provider.basic_context()?;
 
-    let result = get_periods(&context.connection, store_id, program_id)
-        .map_err(StandardGraphqlError::from_list_error)?;
+    let result = get_periods(
+        &context.connection,
+        store_id,
+        program_id,
+        page.map(PaginationOption::from),
+        filter.map(|f| f.to_domain()),
+    )
+    .map_err(StandardGraphqlError::from_list_error)?;
 
     Ok(PeriodsResponse::Response(PeriodConnector::from_domain(
         result,

--- a/server/graphql/types/src/types/period.rs
+++ b/server/graphql/types/src/types/period.rs
@@ -1,6 +1,7 @@
 use async_graphql::*;
 use chrono::NaiveDate;
-use repository::PeriodRow;
+use graphql_core::generic_filters::DateFilterInput;
+use repository::{DateFilter, PeriodFilter, PeriodRow};
 use service::ListResult;
 
 #[derive(PartialEq, Debug)]
@@ -57,6 +58,22 @@ impl PeriodConnector {
                 .map(PeriodNode::from_domain)
                 .collect(),
             total_count: periods.count,
+        }
+    }
+}
+
+#[derive(InputObject)]
+pub struct PeriodFilterInput {
+    pub end_date: Option<DateFilterInput>,
+}
+
+impl PeriodFilterInput {
+    pub fn to_domain(self) -> PeriodFilter {
+        PeriodFilter {
+            end_date: self.end_date.map(DateFilter::from),
+            id: None,
+            period_schedule_id: None,
+            rnr_form_program_id: None,
         }
     }
 }

--- a/server/graphql/types/src/types/period.rs
+++ b/server/graphql/types/src/types/period.rs
@@ -64,6 +64,7 @@ impl PeriodConnector {
 
 #[derive(InputObject)]
 pub struct PeriodFilterInput {
+    pub start_date: Option<DateFilterInput>,
     pub end_date: Option<DateFilterInput>,
 }
 
@@ -71,6 +72,7 @@ impl PeriodFilterInput {
     pub fn to_domain(self) -> PeriodFilter {
         PeriodFilter {
             end_date: self.end_date.map(DateFilter::from),
+            start_date: self.start_date.map(DateFilter::from),
             id: None,
             period_schedule_id: None,
             rnr_form_program_id: None,

--- a/server/repository/src/db_diesel/period/period.rs
+++ b/server/repository/src/db_diesel/period/period.rs
@@ -24,6 +24,7 @@ pub struct Period {
 pub struct PeriodFilter {
     pub id: Option<EqualFilter<String>>,
     pub period_schedule_id: Option<EqualFilter<String>>,
+    pub start_date: Option<DateFilter>,
     pub end_date: Option<DateFilter>,
     pub rnr_form_program_id: Option<EqualFilter<String>>,
 }
@@ -131,12 +132,14 @@ fn create_filtered_query(
         let PeriodFilter {
             id,
             period_schedule_id,
+            start_date,
             end_date,
             rnr_form_program_id,
         } = filter;
 
         apply_equal_filter!(query, id, period::id);
         apply_equal_filter!(query, period_schedule_id, period::period_schedule_id);
+        apply_date_filter!(query, start_date, period::start_date);
         apply_date_filter!(query, end_date, period::end_date);
 
         apply_equal_filter!(query, rnr_form_program_id, rnr_form::program_id);

--- a/server/service/src/rnr_form/schedules_with_periods.rs
+++ b/server/service/src/rnr_form/schedules_with_periods.rs
@@ -2,7 +2,7 @@ use crate::service_provider::ServiceContext;
 
 use chrono::Utc;
 use repository::{
-    DateFilter, EqualFilter, Period, PeriodFilter, PeriodRepository, PeriodScheduleRow,
+    DateFilter, EqualFilter, Pagination, Period, PeriodFilter, PeriodRepository, PeriodScheduleRow,
     PeriodScheduleRowRepository, PeriodSort, PeriodSortField,
     ProgramRequisitionSettingsRowRepository, RepositoryError,
 };
@@ -44,6 +44,7 @@ pub fn get_schedules_with_periods_by_program(
             let closed_periods = period_repo.query(
                 store_id.to_string(),
                 Some(program_id.to_string()),
+                Pagination::all(),
                 Some(period_filter),
                 Some(PeriodSort {
                     key: PeriodSortField::EndDate,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6533

# 👩🏻‍💻 What does this PR do?
Defaults shown periods to 15 and only show past periods. 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have lots of periods over 30? 
- [ ] Set up CIV stocktake report 
- [ ] Go to report and click on stocktake report
- [ ] Only limited of periods shown until you keep scrolling

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
