### PR TITLE
#6542 dispensary label printing 

### DIFF
--- a/server/server/src/print/mod.rs
+++ b/server/server/src/print/mod.rs
@@ -1,7 +1,7 @@
 use actix_web::web;
 
 mod label;
-use label::print_label_qr;
+use label::{print_label_prescription, print_label_qr};
 
 use self::label::test_printer;
 
@@ -11,6 +11,10 @@ pub fn config_print(cfg: &mut web::ServiceConfig) {
     cfg.route(
         &format!("{}/label-qr", URL_PATH),
         web::post().to(print_label_qr),
+    );
+    cfg.route(
+        &format!("{}/label-prescription", URL_PATH),
+        web::post().to(print_label_prescription),
     );
     cfg.route(
         &format!("{}/label-test", URL_PATH),

--- a/server/service/src/auth_data.rs
+++ b/server/service/src/auth_data.rs
@@ -1,6 +1,7 @@
 use crate::token_bucket::TokenBucket;
 use std::sync::{Arc, RwLock};
 
+#[derive(Debug)]
 pub struct AuthData {
     /// Secret to sign and verify auth (JWT) tokens.
     pub auth_token_secret: String,

--- a/server/service/src/print/label.rs
+++ b/server/service/src/print/label.rs
@@ -77,27 +77,27 @@ pub fn print_prescription_label(
 ^CI28
 
 ^A0,25
-^FO20,10
-^FB550,1,0,C
-^FD{item_details}\&^FS
+^FO10,10
+^FB570,2,0,C
+^FD{item_details}^FS
 
-^FO20,50
-^GB550,2,2^FS
+^FO10,65
+^GB570,2,2^FS
 
 ^A0,25
-^FO20,60
-^FB550,6,0,L
+^FO10,75
+^FB570,6,0,L
 ^FD{item_directions}\&{warning}^FS
 
-^FO20,210
-^GB550,2,2^FS
+^FO10,210
+^GB570,2,2^FS
 
 ^A0,25
-^FO20,220
+^FO10,220
 ^FD{patient_details}^FS
 
 ^A0,25
-^FO20,250
+^FO10,250
 ^FD{details}^FS
 ^XZ
 "#

--- a/server/service/src/print/label.rs
+++ b/server/service/src/print/label.rs
@@ -47,9 +47,9 @@ pub fn print_qr_code(
 pub struct PrescriptionLabelData {
     item_name: String,
     item_directions: String,
-    patient_details: String,
-    warning: Option<String>,
-    details: String,
+    patient_details: String, // e.g patient name, possibly code etc.
+    warning: Option<String>, // Some items come with a defined warning (OG field "Message") that should be printed on all labels regardless of directions e.g. avoid sun exposure, avoid alcohol...
+    details: String, // General details to include e.g. store name, prescriber name, date/time...
 }
 
 pub fn print_prescription_label(
@@ -60,8 +60,8 @@ pub fn print_prescription_label(
         item_name,
         item_directions,
         patient_details,
-        details,
         warning,
+        details,
     } = label_data;
     let warning = warning.unwrap_or_default();
 
@@ -96,7 +96,7 @@ pub fn print_prescription_label(
         ^FD{details}^FS
         ^XZ"#
     );
-    let printer = Jetdirect::new(settings.address, settings.port); // This (and QR labels!) should be moved to using the new printer config table in some manner. Either FE sends the details or backend does query to get them (FE should probably already have them though)
+    let printer = Jetdirect::new(settings.address, settings.port);
     printer.send_string(payload, Mode::Print)
 }
 

--- a/server/service/src/print/label.rs
+++ b/server/service/src/print/label.rs
@@ -67,34 +67,32 @@ pub fn print_prescription_label(
 
     let payload = format!(
         r#"
-        ^XA
-        ^A0,40
-        ^FO20,10
-        ^FB500,1,0,C
-        ^FD{item_name}^FS
+^XA
+^A0,25
+^FO20,10
+^FB550,1,0,C
+^FD{item_name}\&^FS
 
-        ^FO20,50^GB500,1,2^FS ; Horizontal line
+^FO20,50
+^GB550,2,2^FS
 
-        ^A0,30
-        ^FO20,60
-        ^FB500,3,0,L
-        ^FD{item_directions}^FS
-        
-        ^A0,30
-        ^FO20,160
-        ^FB500,3,0,L
-        ^FD{warning}^FS
+^A0,25
+^FO20,60
+^FB550,6,0,L
+^FD{item_directions}\&{warning}^FS
 
-        ^A0,20
-        ^FO20,210
-        ^FD{patient_details}^FS
+^FO20,210
+^GB550,2,2^FS
 
-        ^FO20,230^GB500,1,2^FS ; Horizontal line
+^A0,25
+^FO20,220
+^FD{patient_details}^FS
 
-        ^A0,20
-        ^FO20,250
-        ^FD{details}^FS
-        ^XZ"#
+^A0,25
+^FO20,250
+^FD{details}^FS
+^XZ
+"#
     );
     let printer = Jetdirect::new(settings.address, settings.port);
     printer.send_string(payload, Mode::Print)

--- a/server/service/src/print/label.rs
+++ b/server/service/src/print/label.rs
@@ -49,7 +49,7 @@ pub fn print_qr_code(
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PrescriptionLabelData {
-    item_name: String,
+    item_details: String, // usually the amount of units + the item name e.g. "10Tabs Paracetamol 500mg Tablets"
     item_directions: String,
     patient_details: String, // e.g patient name, possibly code etc.
     warning: Option<String>, // Some items come with a defined warning (OG field "Message") that should be printed on all labels regardless of directions e.g. avoid sun exposure, avoid alcohol...
@@ -61,7 +61,7 @@ pub fn print_prescription_label(
     label_data: PrescriptionLabelData,
 ) -> Result<String> {
     let PrescriptionLabelData {
-        item_name,
+        item_details,
         item_directions,
         patient_details,
         warning,
@@ -79,7 +79,7 @@ pub fn print_prescription_label(
 ^A0,25
 ^FO20,10
 ^FB550,1,0,C
-^FD{item_name}\&^FS
+^FD{item_details}\&^FS
 
 ^FO20,50
 ^GB550,2,2^FS

--- a/server/service/src/print/label.rs
+++ b/server/service/src/print/label.rs
@@ -43,6 +43,63 @@ pub fn print_qr_code(
     printer.send_string(payload, Mode::Print)
 }
 
+#[derive(serde::Deserialize)]
+pub struct PrescriptionLabelData {
+    item_name: String,
+    item_directions: String,
+    patient_name: String,
+    warning: Option<String>,
+    details: String,
+}
+
+pub fn print_prescription_label(
+    settings: LabelPrinterSettingNode,
+    label_data: PrescriptionLabelData,
+) -> Result<String> {
+    let PrescriptionLabelData {
+        item_name,
+        item_directions,
+        patient_name,
+        details,
+        warning,
+    } = label_data;
+    let warning = warning.unwrap_or_default();
+
+    let payload = format!(
+        r#"
+        ^XA
+        ^A0,40
+        ^FO20,10
+        ^FB500,1,0,C
+        ^FD{item_name}^FS
+
+        ^FO20,50^GB500,1,2^FS ; Horizontal line
+
+        ^A0,30
+        ^FO20,60
+        ^FB500,3,0,L
+        ^FD{item_directions}^FS
+        
+        ^A0,30
+        ^FO20,160
+        ^FB500,3,0,L
+        ^FD{warning}^FS
+
+        ^A0,20
+        ^FO20,210
+        ^FD{patient_name}^FS
+
+        ^FO20,230^GB500,1,2^FS ; Horizontal line
+
+        ^A0,20
+        ^FO20,250
+        ^FD{details}^FS
+        ^XZ"#
+    );
+    let printer = Jetdirect::new(settings.address, settings.port); // This (and QR labels!) should be moved to using the new printer config table in some manner. Either FE sends the details or backend does query to get them (FE should probably already have them though)
+    printer.send_string(payload, Mode::Print)
+}
+
 pub fn host_status(settings: LabelPrinterSettingNode) -> Result<String> {
     let printer = Jetdirect::new(settings.address, settings.port);
     printer.send_string("~HS".to_string(), Mode::Sgd)

--- a/server/service/src/print/label.rs
+++ b/server/service/src/print/label.rs
@@ -32,6 +32,9 @@ pub fn print_qr_code(
     let payload = format!(
         r#"
         ^XA
+        ^FX CI command parameters:
+        ^FX - encoding (28 = UTF-8)
+        ^CI28
         ^FO50,{}
         ^BQN,2,4
         ^FDMA,{}^FS        
@@ -44,6 +47,7 @@ pub fn print_qr_code(
 }
 
 #[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PrescriptionLabelData {
     item_name: String,
     item_directions: String,
@@ -68,6 +72,10 @@ pub fn print_prescription_label(
     let payload = format!(
         r#"
 ^XA
+^FX CI command parameters:
+^FX - encoding (28 = UTF-8)
+^CI28
+
 ^A0,25
 ^FO20,10
 ^FB550,1,0,C

--- a/server/service/src/print/label.rs
+++ b/server/service/src/print/label.rs
@@ -47,7 +47,7 @@ pub fn print_qr_code(
 pub struct PrescriptionLabelData {
     item_name: String,
     item_directions: String,
-    patient_name: String,
+    patient_details: String,
     warning: Option<String>,
     details: String,
 }
@@ -59,7 +59,7 @@ pub fn print_prescription_label(
     let PrescriptionLabelData {
         item_name,
         item_directions,
-        patient_name,
+        patient_details,
         details,
         warning,
     } = label_data;
@@ -87,7 +87,7 @@ pub fn print_prescription_label(
 
         ^A0,20
         ^FO20,210
-        ^FD{patient_name}^FS
+        ^FD{patient_details}^FS
 
         ^FO20,230^GB500,1,2^FS ; Horizontal line
 

--- a/server/service/src/token_bucket.rs
+++ b/server/service/src/token_bucket.rs
@@ -4,6 +4,7 @@ use chrono::Utc;
 
 use util::hash::sha256;
 
+#[derive(Debug)]
 struct TokenInfo {
     token_hash: String,
     expiry_date: usize,
@@ -22,7 +23,7 @@ fn token_hash(token: &str) -> String {
 /// 1) User logs out and token is removed from the bucket
 /// 2) Token expiry time is reduce (server side), e.g. when an token has been renewed and the old
 ///     token should expiry sooner.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct TokenBucket {
     users: HashMap<String, Vec<TokenInfo>>,
 }


### PR DESCRIPTION
Fixes #6542 

# 👩🏻‍💻 What does this PR do?

Adds API for _very_ basic label printing. The API shape itself may change a lot in the future, though!

## 💌 Any notes for the reviewer?

I lost an embarrassingly long time trying to figure out why on earth my bearer tokens weren't going through (as that's how we auth the gql API):

```
Denied(
    NotAuthenticated(
        "Missing auth token",
    ),
)
```

Turns out the printing API and some file sync use cookies instead! Can't think of why we need to auth schemes. Perhaps the auth cookie had some extra data in it beyond `token`, though JWTs themselves hold extra data so it's a bit of a nesting doll situation there.

Anyway if you want to test this you need an API client that can include a cookie, like `curl` or insomnia.

Your cookie must have this JSON content shape:
```json
{
  "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE3Mzk5MzkxNzAsImF1ZCI6IkFwaSIsImlhdCI6MTczOTkzNTU3MCwiaXNzIjoib20tc3VwcGx5LXJlbW90ZS1zZXJ2ZXIiLCJzdWIiOiIwNzYzRTJFMzA1M0Q0QzQ3OEUxRTZCNkIwM0ZFQzIwNyJ9.COkzCGBJFMFNpFMDO348XRJOwad3UeTshY-j-06kt-g"
}
```

Where the token value is a JWT from the `authToken` endpoint (note for gql we just send the header `"Authorization: Bearer <JWT>"`)

# 🧪 Testing

- [ ] Setup printer in OMS Settings > Devices. Office printer is on `192.168.1.224`, port `9100` is the standard for zebras web server.
- [ ] use an http client to send a label payload and print a label

Something like

```json
{
  "patientDetails": "Chris Petty - 92e941",
  "itemDetails": "Amoxicillin Dry Powder for Suspension 125mg/5ml Bot/100ml",
  "itemDirections": "Dilute 50:1 with protein shake. Include oats for fibre and good gut health. Chug at least twice a day.",
  "warning": "Avoid excessive sun exposure",
  "details": "Amazing Store - Mr Pharmacist - 2024/02/19",
}
```

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
