### PR TITLE
Prescription Creation with more fields!

### DIFF
--- a/server/graphql/batch_mutations/src/batch_prescription.rs
+++ b/server/graphql/batch_mutations/src/batch_prescription.rs
@@ -496,6 +496,8 @@ mod test {
                         diagnosis_id: None,
                         program_id: None,
                         their_reference: None,
+                        clinician_id: None,
+                        prescription_date: None,
                     },
                     result: Err(InsertPrescriptionError::PatientDoesNotExist),
                 }],

--- a/server/graphql/invoice/src/mutations/prescription/insert.rs
+++ b/server/graphql/invoice/src/mutations/prescription/insert.rs
@@ -1,5 +1,6 @@
 use async_graphql::*;
 
+use chrono::NaiveDateTime;
 use graphql_core::standard_graphql_error::{validate_auth, StandardGraphqlError};
 use graphql_core::ContextExt;
 use graphql_types::types::InvoiceNode;
@@ -17,6 +18,8 @@ pub struct InsertInput {
     pub diagnosis_id: Option<String>,
     pub program_id: Option<String>,
     pub their_reference: Option<String>,
+    pub clinician_id: Option<String>,
+    pub prescription_date: Option<NaiveDateTime>,
 }
 
 #[derive(Union)]
@@ -52,6 +55,8 @@ impl InsertInput {
             their_reference,
             diagnosis_id,
             program_id,
+            clinician_id,
+            prescription_date,
         } = self;
 
         ServiceInput {
@@ -60,6 +65,8 @@ impl InsertInput {
             their_reference,
             diagnosis_id,
             program_id,
+            clinician_id,
+            prescription_date,
         }
     }
 }

--- a/server/service/src/invoice/prescription/insert/generate.rs
+++ b/server/service/src/invoice/prescription/insert/generate.rs
@@ -5,7 +5,7 @@ use repository::{
     RepositoryError, StorageConnection,
 };
 
-use crate::number::next_number;
+use crate::{invoice::invoice_date_utils::handle_new_backdated_datetime, number::next_number};
 
 use super::InsertPrescription;
 
@@ -19,6 +19,8 @@ pub fn generate(
         diagnosis_id,
         program_id,
         their_reference,
+        clinician_id,
+        prescription_date,
     }: InsertPrescription,
 ) -> Result<InvoiceRow, RepositoryError> {
     let current_datetime = Utc::now().naive_utc();
@@ -27,7 +29,7 @@ pub fn generate(
         .pop()
         .ok_or(RepositoryError::NotFound)?;
 
-    let result = InvoiceRow {
+    let mut invoice = InvoiceRow {
         id,
         user_id: Some(user_id.to_string()),
         name_link_id: patient_id,
@@ -54,7 +56,7 @@ pub fn generate(
         cancelled_datetime: None,
         linked_invoice_id: None,
         requisition_id: None,
-        clinician_link_id: None,
+        clinician_link_id: clinician_id,
         original_shipment_id: None,
         backdated_datetime: None,
         diagnosis_id,
@@ -65,5 +67,9 @@ pub fn generate(
         is_cancellation: false,
     };
 
-    Ok(result)
+    if let Some(date) = prescription_date {
+        handle_new_backdated_datetime(&mut invoice, date, current_datetime);
+    }
+
+    Ok(invoice)
 }

--- a/server/service/src/invoice/prescription/insert/mod.rs
+++ b/server/service/src/invoice/prescription/insert/mod.rs
@@ -2,6 +2,7 @@ use crate::activity_log::activity_log_entry;
 use crate::invoice::query::get_invoice;
 use crate::service_provider::ServiceContext;
 use crate::WithDBError;
+use chrono::NaiveDateTime;
 use repository::{ActivityLogType, Invoice};
 use repository::{InvoiceRowRepository, RepositoryError};
 
@@ -17,6 +18,8 @@ pub struct InsertPrescription {
     pub diagnosis_id: Option<String>,
     pub program_id: Option<String>,
     pub their_reference: Option<String>,
+    pub clinician_id: Option<String>,
+    pub prescription_date: Option<NaiveDateTime>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/server/service/src/invoice/prescription/invoice_date_utils.rs
+++ b/server/service/src/invoice/prescription/invoice_date_utils.rs
@@ -1,0 +1,100 @@
+use chrono::NaiveDateTime;
+use repository::InvoiceRow;
+
+// Replace datetimes that are not null with the new status_datetime
+fn replace_status_datetimes(invoice: &mut InvoiceRow, new_status_datetime: NaiveDateTime) {
+    invoice.allocated_datetime = invoice.allocated_datetime.map(|_| new_status_datetime);
+    invoice.picked_datetime = invoice.picked_datetime.map(|_| new_status_datetime);
+    invoice.verified_datetime = invoice.verified_datetime.map(|_| new_status_datetime);
+}
+
+// Handle a change to backdated_time
+pub(crate) fn handle_new_backdated_datetime(
+    invoice: &mut InvoiceRow,
+    backdated_datetime: NaiveDateTime,
+    now: NaiveDateTime,
+) {
+    if backdated_datetime > now {
+        // If the backdated_datetime is in the future, we unset the backdated_datetime as it isn't possible to future date.
+        invoice.backdated_datetime = None;
+        replace_status_datetimes(invoice, now);
+    } else {
+        // Otherwise, we need to update the backdated_datetime to the new one, and replace existing status times
+        invoice.backdated_datetime = Some(backdated_datetime);
+        replace_status_datetimes(invoice, backdated_datetime);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use chrono::Utc;
+    use repository::InvoiceRow;
+    use repository::InvoiceStatus;
+    use repository::InvoiceType;
+
+    #[actix_rt::test]
+    async fn handle_new_backdated_datetime_test() {
+        let now = Utc::now().naive_utc();
+        // Create a new invoice 2 days ago
+        let invoice_time = Utc::now().naive_utc() - chrono::Duration::days(2);
+
+        let mut invoice = InvoiceRow {
+            id: "test_invoice_id".to_string(),
+            status: InvoiceStatus::Picked,
+            created_datetime: invoice_time,
+            allocated_datetime: Some(invoice_time),
+            picked_datetime: Some(invoice_time),
+            verified_datetime: None,
+            backdated_datetime: None,
+            name_link_id: "test_patient_id".to_string(),
+            clinician_link_id: None,
+            comment: None,
+            colour: None,
+            name_store_id: None,
+            store_id: String::new(),
+            user_id: None,
+            invoice_number: 0,
+            r#type: InvoiceType::Prescription,
+            on_hold: false,
+            their_reference: None,
+            transport_reference: None,
+            shipped_datetime: None,
+            delivered_datetime: None,
+            requisition_id: None,
+            linked_invoice_id: None,
+            tax_percentage: None,
+            currency_id: None,
+            currency_rate: 0.0,
+            original_shipment_id: None,
+            ..Default::default()
+        };
+
+        // Check that we can backdate to 3 days ago
+        let backdated_datetime = Utc::now().naive_utc() - chrono::Duration::days(3);
+        super::handle_new_backdated_datetime(&mut invoice, backdated_datetime, now);
+
+        assert_eq!(invoice.backdated_datetime, Some(backdated_datetime));
+        assert_eq!(invoice.allocated_datetime, Some(backdated_datetime));
+        assert_eq!(invoice.picked_datetime, Some(backdated_datetime));
+        assert_eq!(invoice.verified_datetime, None);
+
+        // Check that we can't backdate to tomorrow, this should unset the backdated_datetime
+        // and set the status times to now
+        let backdated_datetime = Utc::now().naive_utc() + chrono::Duration::days(1);
+        super::handle_new_backdated_datetime(&mut invoice, backdated_datetime, now);
+
+        assert_eq!(invoice.backdated_datetime, None);
+        assert_eq!(invoice.allocated_datetime, Some(now));
+        assert_eq!(invoice.picked_datetime, Some(now));
+        assert_eq!(invoice.verified_datetime, None);
+
+        // Check that we can backdate to 2 days ago
+        let backdated_datetime = Utc::now().naive_utc() - chrono::Duration::days(2);
+        super::handle_new_backdated_datetime(&mut invoice, backdated_datetime, now);
+
+        assert_eq!(invoice.backdated_datetime, Some(backdated_datetime));
+        assert_eq!(invoice.allocated_datetime, Some(backdated_datetime));
+        assert_eq!(invoice.picked_datetime, Some(backdated_datetime));
+        assert_eq!(invoice.verified_datetime, None);
+    }
+}

--- a/server/service/src/invoice/prescription/mod.rs
+++ b/server/service/src/invoice/prescription/mod.rs
@@ -9,3 +9,5 @@ pub use self::delete::*;
 
 pub mod batch;
 pub use self::batch::*;
+
+pub(crate) mod invoice_date_utils;

--- a/server/service/src/invoice/prescription/update/generate.rs
+++ b/server/service/src/invoice/prescription/update/generate.rs
@@ -1,13 +1,16 @@
-use chrono::{NaiveDateTime, Utc};
+use chrono::Utc;
 
 use repository::{
     EqualFilter, InvoiceLineFilter, InvoiceLineRepository, InvoiceLineRow, InvoiceRow,
     InvoiceStatus, RepositoryError, StockLineRow, StorageConnection,
 };
 
-use crate::invoice::common::{
-    generate_batches_total_number_of_packs_update, get_invoice_status_datetime,
-    InvoiceLineHasNoStockLine,
+use crate::invoice::{
+    common::{
+        generate_batches_total_number_of_packs_update, get_invoice_status_datetime,
+        InvoiceLineHasNoStockLine,
+    },
+    invoice_date_utils::handle_new_backdated_datetime,
 };
 
 use super::{UpdatePrescription, UpdatePrescriptionError, UpdatePrescriptionStatus};
@@ -51,7 +54,6 @@ pub(crate) fn generate(
     set_new_status_datetime(&mut update_invoice, &input_status);
 
     update_invoice.name_link_id = input_patient_id.unwrap_or(update_invoice.name_link_id);
-    // update_invoice.clinician_link_id = input_clinician_id.or(update_invoice.clinician_link_id);
     if let Some(clinician_link_id) = input_clinician_id {
         update_invoice.clinician_link_id = clinician_link_id.value;
     }
@@ -111,29 +113,6 @@ fn should_update_batches_total_number_of_packs(
             && invoice_status_index < InvoiceStatus::Picked.index()
     } else {
         false
-    }
-}
-// Replace datetimes that are not null with the new status_datetime
-fn replace_status_datetimes(invoice: &mut InvoiceRow, new_status_datetime: NaiveDateTime) {
-    invoice.allocated_datetime = invoice.allocated_datetime.map(|_| new_status_datetime);
-    invoice.picked_datetime = invoice.picked_datetime.map(|_| new_status_datetime);
-    invoice.verified_datetime = invoice.verified_datetime.map(|_| new_status_datetime);
-}
-
-// Handle a change to backdated_time
-fn handle_new_backdated_datetime(
-    invoice: &mut InvoiceRow,
-    backdated_datetime: NaiveDateTime,
-    now: NaiveDateTime,
-) {
-    if backdated_datetime > now {
-        // If the backdated_datetime is in the future, we unset the backdated_datetime as it isn't possible to future date.
-        invoice.backdated_datetime = None;
-        replace_status_datetimes(invoice, now);
-    } else {
-        // Otherwise, we need to update the backdated_datetime to the new one, and replace existing status times
-        invoice.backdated_datetime = Some(backdated_datetime);
-        replace_status_datetimes(invoice, backdated_datetime);
     }
 }
 
@@ -206,78 +185,4 @@ fn lines_to_trim(
         .map(|l| l.invoice_line_row)
         .collect();
     Ok(Some(invoice_line_rows))
-}
-
-#[cfg(test)]
-mod test {
-    use chrono::Utc;
-    use repository::InvoiceRow;
-    use repository::InvoiceStatus;
-    use repository::InvoiceType;
-
-    #[actix_rt::test]
-    async fn handle_new_backdated_datetime_test() {
-        let now = Utc::now().naive_utc();
-        // Create a new invoice 2 days ago
-        let invoice_time = Utc::now().naive_utc() - chrono::Duration::days(2);
-
-        let mut invoice = InvoiceRow {
-            id: "test_invoice_id".to_string(),
-            status: InvoiceStatus::Picked,
-            created_datetime: invoice_time,
-            allocated_datetime: Some(invoice_time),
-            picked_datetime: Some(invoice_time),
-            verified_datetime: None,
-            backdated_datetime: None,
-            name_link_id: "test_patient_id".to_string(),
-            clinician_link_id: None,
-            comment: None,
-            colour: None,
-            name_store_id: None,
-            store_id: String::new(),
-            user_id: None,
-            invoice_number: 0,
-            r#type: InvoiceType::Prescription,
-            on_hold: false,
-            their_reference: None,
-            transport_reference: None,
-            shipped_datetime: None,
-            delivered_datetime: None,
-            requisition_id: None,
-            linked_invoice_id: None,
-            tax_percentage: None,
-            currency_id: None,
-            currency_rate: 0.0,
-            original_shipment_id: None,
-            ..Default::default()
-        };
-
-        // Check that we can backdate to 3 days ago
-        let backdated_datetime = Utc::now().naive_utc() - chrono::Duration::days(3);
-        super::handle_new_backdated_datetime(&mut invoice, backdated_datetime, now);
-
-        assert_eq!(invoice.backdated_datetime, Some(backdated_datetime));
-        assert_eq!(invoice.allocated_datetime, Some(backdated_datetime));
-        assert_eq!(invoice.picked_datetime, Some(backdated_datetime));
-        assert_eq!(invoice.verified_datetime, None);
-
-        // Check that we can't backdate to tomorrow, this should unset the backdated_datetime
-        // and set the status times to now
-        let backdated_datetime = Utc::now().naive_utc() + chrono::Duration::days(1);
-        super::handle_new_backdated_datetime(&mut invoice, backdated_datetime, now);
-
-        assert_eq!(invoice.backdated_datetime, None);
-        assert_eq!(invoice.allocated_datetime, Some(now));
-        assert_eq!(invoice.picked_datetime, Some(now));
-        assert_eq!(invoice.verified_datetime, None);
-
-        // Check that we can backdate to 2 days ago
-        let backdated_datetime = Utc::now().naive_utc() - chrono::Duration::days(2);
-        super::handle_new_backdated_datetime(&mut invoice, backdated_datetime, now);
-
-        assert_eq!(invoice.backdated_datetime, Some(backdated_datetime));
-        assert_eq!(invoice.allocated_datetime, Some(backdated_datetime));
-        assert_eq!(invoice.picked_datetime, Some(backdated_datetime));
-        assert_eq!(invoice.verified_datetime, None);
-    }
 }

--- a/server/service/src/vaccination/generate.rs
+++ b/server/service/src/vaccination/generate.rs
@@ -27,6 +27,8 @@ pub fn generate_create_prescription(
         diagnosis_id: None,
         program_id: None,
         their_reference: None,
+        clinician_id: None,
+        prescription_date: None,
     };
 
     let number_of_packs =


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6545

# 👩🏻‍💻 What does this PR do?

Adds two new fields in Prescriptions

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
