### PR TITLE
6517 App crashes when I click on disabled Reason dropdown Supplier return edit modal

### DIFF
--- a/client/packages/system/src/ReturnReason/Components/ReturnReasonSearchInput.tsx
+++ b/client/packages/system/src/ReturnReason/Components/ReturnReasonSearchInput.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 import {
   Autocomplete,
-  BasicTextInput,
   Box,
   defaultOptionMapper,
   getDefaultOptionRenderer,
@@ -20,7 +19,6 @@ export const ReturnReasonSearchInput: FC<ReturnReasonSearchInputProps> = ({
   selectedReasonId,
   onChange,
   autoFocus = false,
-  isError,
   isDisabled,
 }) => {
   const { data, isLoading } = useReturnReason.document.listAllActive();
@@ -47,20 +45,6 @@ export const ReturnReasonSearchInput: FC<ReturnReasonSearchInputProps> = ({
         onChange={(_, reason) => {
           onChange(reason?.id ?? '');
         }}
-        renderInput={props => (
-          <BasicTextInput
-            {...props}
-            autoFocus={autoFocus}
-            slotProps={{
-              input: {
-                disableUnderline: false,
-                style: props.disabled ? { paddingLeft: 0 } : {},
-                ...props.InputProps,
-              },
-            }}
-            error={isError}
-          />
-        )}
         options={defaultOptionMapper(reasons, 'reason')}
         renderOption={getDefaultOptionRenderer('reason')}
         isOptionEqualToValue={(option, value) => option?.id === value?.id}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6517

# 👩🏻‍💻 What does this PR do?
Removes the custom renderer... it's the same as the AutoComplete input but with extra padding??

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Set up return reasons
- [ ] Create a supplier return
- [ ] Should be able to choose return reason

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
