### PR TITLE
Translate labels

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/CustomerIndicatorInfo.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/CustomerIndicatorInfo.tsx
@@ -8,12 +8,13 @@ import {
   TableProvider,
   TooltipTextCell,
   useColumns,
+  useTranslation,
 } from '@openmsupply-client/common';
 import {
   CustomerIndicatorInfoFragment,
   IndicatorColumnFragment,
 } from '../../api';
-import { indicatorColumnNameToLocaleKey } from '../../../utils';
+import { indicatorColumnNameToLocal } from '../../../utils';
 
 interface CustomerIndicatorInfoProps {
   columns: IndicatorColumnFragment[];
@@ -24,6 +25,7 @@ const CustomerIndicatorInfo = ({
   columns,
   customerInfos,
 }: CustomerIndicatorInfoProps) => {
+  const t = useTranslation();
   const columnDefinitions: ColumnDescription<CustomerIndicatorInfoFragment>[] =
     [
       [
@@ -40,7 +42,7 @@ const CustomerIndicatorInfo = ({
   columns.forEach(({ name, id }) => {
     columnDefinitions.push({
       key: name,
-      label: indicatorColumnNameToLocaleKey(name),
+      label: indicatorColumnNameToLocal(name, t),
       sortable: false,
       accessor: ({ rowData }) => {
         const indicator = rowData?.indicatorInformation?.find(

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/CustomerIndicatorInfo.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/CustomerIndicatorInfo.tsx
@@ -13,7 +13,7 @@ import {
   CustomerIndicatorInfoFragment,
   IndicatorColumnFragment,
 } from '../../api';
-import { indicatorColumnNameToLocal } from '../../../utils';
+import { indicatorColumnNameToLocaleKey } from '../../../utils';
 
 interface CustomerIndicatorInfoProps {
   columns: IndicatorColumnFragment[];
@@ -40,7 +40,7 @@ const CustomerIndicatorInfo = ({
   columns.forEach(({ name, id }) => {
     columnDefinitions.push({
       key: name,
-      label: indicatorColumnNameToLocal(name),
+      label: indicatorColumnNameToLocaleKey(name),
       sortable: false,
       accessor: ({ rowData }) => {
         const indicator = rowData?.indicatorInformation?.find(

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../api';
 import { useDraftIndicatorValue } from './hooks';
 import { CustomerIndicatorInfoView } from './CustomerIndicatorInfo';
-import { indicatorColumnNameToLocaleKey } from '../../../utils';
+import { indicatorColumnNameToLocal } from '../../../utils';
 
 interface IndicatorLineEditProps {
   requisitionNumber: number;
@@ -95,7 +95,7 @@ const InputWithLabel = ({
     <InputWithLabelRow
       Input={inputComponent}
       labelWidth={LABEL_WIDTH}
-      label={t(indicatorColumnNameToLocaleKey(data.name))}
+      label={indicatorColumnNameToLocal(data.name, t)}
       sx={{ marginBottom: 1 }}
     />
   );

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../api';
 import { useDraftIndicatorValue } from './hooks';
 import { CustomerIndicatorInfoView } from './CustomerIndicatorInfo';
-import { indicatorColumnNameToLocal } from '../../../utils';
+import { indicatorColumnNameToLocaleKey } from '../../../utils';
 
 interface IndicatorLineEditProps {
   requisitionNumber: number;
@@ -95,7 +95,7 @@ const InputWithLabel = ({
     <InputWithLabelRow
       Input={inputComponent}
       labelWidth={LABEL_WIDTH}
-      label={indicatorColumnNameToLocal(data.name)}
+      label={t(indicatorColumnNameToLocaleKey(data.name))}
       sx={{ marginBottom: 1 }}
     />
   );

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
@@ -15,7 +15,7 @@ import {
   IndicatorLineRowFragment,
   IndicatorLineWithColumnsFragment,
 } from '../../../RequestRequisition/api';
-import { indicatorColumnNameToLocaleKey } from '../../../utils';
+import { indicatorColumnNameToLocal } from '../../../utils';
 
 interface IndicatorLineEditProps {
   requisitionNumber: number;
@@ -92,7 +92,7 @@ const InputWithLabel = ({
     <InputWithLabelRow
       Input={inputComponent}
       labelWidth={LABEL_WIDTH}
-      label={indicatorColumnNameToLocaleKey(data.name)}
+      label={indicatorColumnNameToLocal(data.name, t)}
       sx={{ marginBottom: 1 }}
     />
   );

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
@@ -15,7 +15,7 @@ import {
   IndicatorLineRowFragment,
   IndicatorLineWithColumnsFragment,
 } from '../../../RequestRequisition/api';
-import { indicatorColumnNameToLocal } from '../../../utils';
+import { indicatorColumnNameToLocaleKey } from '../../../utils';
 
 interface IndicatorLineEditProps {
   requisitionNumber: number;
@@ -92,7 +92,7 @@ const InputWithLabel = ({
     <InputWithLabelRow
       Input={inputComponent}
       labelWidth={LABEL_WIDTH}
-      label={indicatorColumnNameToLocal(data.name)}
+      label={indicatorColumnNameToLocaleKey(data.name)}
       sx={{ marginBottom: 1 }}
     />
   );

--- a/client/packages/requisitions/src/utils.ts
+++ b/client/packages/requisitions/src/utils.ts
@@ -155,13 +155,16 @@ enum IndicatorColumnName {
   Value = 'Value',
 }
 
-export const indicatorColumnNameToLocaleKey = (
-  columnName: string
-): LocaleKey => {
+export const indicatorColumnNameToLocal = (
+  columnName: string,
+  t: TypedTFunction<LocaleKey>
+) => {
   switch (columnName) {
     case IndicatorColumnName.Comment:
-      return 'label.comment';
+      return t('label.comment');
+    case IndicatorColumnName.Value:
+      return t('label.value');
     default:
-      return 'label.value';
+      return columnName;
   }
 };

--- a/client/packages/requisitions/src/utils.ts
+++ b/client/packages/requisitions/src/utils.ts
@@ -165,3 +165,15 @@ export const indicatorColumnNameToLocal = (columnName: string) => {
       return columnName;
   }
 };
+
+export const indicatorColumnNameToLocaleKey = (
+  columnName: string
+): LocaleKey => {
+  switch (columnName) {
+    case IndicatorColumnName.Comment:
+      return 'label.comment';
+    case IndicatorColumnName.Value:
+    default:
+      return 'label.value';
+  }
+};

--- a/client/packages/requisitions/src/utils.ts
+++ b/client/packages/requisitions/src/utils.ts
@@ -155,24 +155,12 @@ enum IndicatorColumnName {
   Value = 'Value',
 }
 
-export const indicatorColumnNameToLocal = (columnName: string) => {
-  switch (columnName) {
-    case IndicatorColumnName.Comment:
-      return 'label.comment';
-    case IndicatorColumnName.Value:
-      return 'label.value';
-    default:
-      return columnName;
-  }
-};
-
 export const indicatorColumnNameToLocaleKey = (
   columnName: string
 ): LocaleKey => {
   switch (columnName) {
     case IndicatorColumnName.Comment:
       return 'label.comment';
-    case IndicatorColumnName.Value:
     default:
       return 'label.value';
   }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6496

# 👩🏻‍💻 What does this PR do?
The labels were being provided with a string that is supposed to be a translation key, but isn't.

I've changed the utility method to return a LocaleKey rather than a string, as that can be used as a string when required. It does remove the fallback, but we only have comment and value so I think it's ok.

<img width="697" alt="image" src="https://github.com/user-attachments/assets/b4d40df4-e6ac-4f26-b34f-f8de2f61cca3" />

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a program based internal order and check that the labels are correct in the indicators tab

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
