### PR TITLE
6398 display existing doses from deleted vaccine courses

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -2989,7 +2989,7 @@ export type InsertPrescriptionInput = {
   diagnosisId?: InputMaybe<Scalars['String']['input']>;
   id: Scalars['String']['input'];
   patientId: Scalars['String']['input'];
-  prescriptionDate?: InputMaybe<Scalars['NaiveDateTime']['input']>;
+  prescriptionDate?: InputMaybe<Scalars['DateTime']['input']>;
   programId?: InputMaybe<Scalars['String']['input']>;
   theirReference?: InputMaybe<Scalars['String']['input']>;
 };
@@ -4018,7 +4018,6 @@ export type LedgerConnector = {
 };
 
 export type LedgerFilterInput = {
-  datetime?: InputMaybe<DatetimeFilterInput>;
   itemId?: InputMaybe<EqualFilterStringInput>;
   stockLineId?: InputMaybe<EqualFilterStringInput>;
 };
@@ -9373,6 +9372,7 @@ export type VaccineCourseDoseNode = {
   maxAgeMonths: Scalars['Float']['output'];
   minAgeMonths: Scalars['Float']['output'];
   minIntervalDays: Scalars['Int']['output'];
+  /** Will return deleted vaccine courses as well, to support display of existing vaccinations. */
   vaccineCourse: VaccineCourseNode;
 };
 

--- a/server/graphql/core/src/loader/vaccine_course.rs
+++ b/server/graphql/core/src/loader/vaccine_course.rs
@@ -7,6 +7,10 @@ use async_graphql::dataloader::*;
 use async_graphql::*;
 use std::collections::HashMap;
 
+/**
+Includes deleted vaccine courses in the response,
+to support Vaccine Card displaying existing vaccinations.
+*/
 pub struct VaccineCourseLoader {
     pub connection_manager: StorageConnectionManager,
 }
@@ -20,7 +24,11 @@ impl Loader<String> for VaccineCourseLoader {
         let repo = VaccineCourseRepository::new(&connection);
 
         let result = repo
-            .query_by_filter(VaccineCourseFilter::new().id(EqualFilter::equal_any(ids.to_owned())))?
+            .query_by_filter(
+                VaccineCourseFilter::new()
+                    .id(EqualFilter::equal_any(ids.to_owned()))
+                    .include_deleted(true),
+            )?
             .into_iter()
             .map(|course| {
                 let id = course.id.clone();

--- a/server/graphql/types/src/types/vaccine_course_dose.rs
+++ b/server/graphql/types/src/types/vaccine_course_dose.rs
@@ -46,6 +46,7 @@ impl VaccineCourseDoseNode {
         &self.row().min_interval_days
     }
 
+    /// Will return deleted vaccine courses as well, to support display of existing vaccinations.
     pub async fn vaccine_course(&self, ctx: &Context<'_>) -> Result<VaccineCourseNode> {
         let loader = ctx.get_loader::<DataLoader<VaccineCourseLoader>>();
         let course_option = loader

--- a/server/graphql/vaccine_course/src/vaccine_course_queries.rs
+++ b/server/graphql/vaccine_course/src/vaccine_course_queries.rs
@@ -42,16 +42,6 @@ pub struct VaccineCourseFilterInput {
     pub program_id: Option<EqualFilterStringInput>,
 }
 
-impl From<VaccineCourseFilterInput> for VaccineCourseFilter {
-    fn from(f: VaccineCourseFilterInput) -> Self {
-        VaccineCourseFilter {
-            id: f.id.map(EqualFilter::from),
-            name: f.name.map(StringFilter::from),
-            program_id: f.program_id.map(EqualFilter::from),
-        }
-    }
-}
-
 pub fn vaccine_courses(
     ctx: &Context<'_>,
     page: Option<PaginationInput>,
@@ -114,6 +104,7 @@ impl VaccineCourseFilterInput {
             id: id.map(EqualFilter::from),
             name: name.map(StringFilter::from),
             program_id: program_id.map(EqualFilter::from),
+            include_deleted: None,
         }
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6398

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

We soft delete vaccine courses/doses, so that we can still show these doses in a patient's vaccine card if they have already received them (even if future patients should no longer receive them)

We were handling when doses were deleted from a course, but not if a whole course was deleted. This PR adds an `include_deleted` filter to the vaccine courses, when querying a vaccine course dose.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

Dose from deleted course can now load:

![Screenshot 2025-02-24 at 9 29 56 AM](https://github.com/user-attachments/assets/fee1776c-5743-4167-9d60-c47f8a846195)

## 💌 Any notes for the reviewer?


<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Setup vax card as per https://github.com/msupply-foundation/open-msupply/issues/4642
- [ ] On OMS Central, under Programs > Immunisations, add a new vaccine course to your immunisation program
- [ ] Add at least one dose to this course
- [ ] Under Dispensary > Patients, enrol a patient in this program and create an encounter
- [ ] In the encounter, give the patient the dose from this new course
- [ ] Go back to Programs > Immunisations > your program, and delete the vaccine course
- [ ] Go back to the encounter
  - [ ] The dose from the deleted course is still there
  - [ ] Click this dose to view details, the modal content loads correctly, and you can still edit if needed
- [ ] Ensure in another encounter for a different patient, you cannot see the dose for the deleted course in their vax card, because they haven't received the dose

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
