### PR TITLE
v2.6.0 Postgres tests fix

### DIFF
--- a/server/cli/src/refresh_dates.rs
+++ b/server/cli/src/refresh_dates.rs
@@ -33,6 +33,7 @@ fn get_timestamp_fields() -> Vec<TableAndFieldName> {
         ("invoice", "picked_datetime"),
         ("invoice", "delivered_datetime"),
         ("invoice", "verified_datetime"),
+        ("invoice", "cancelled_datetime"),
         ("location_movement", "enter_datetime"),
         ("location_movement", "exit_datetime"),
         ("requisition", "created_datetime"),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

FIx for failing Postgres test.

# 👩🏻‍💻 What does this PR do?

Fixes the "refresh_dates" test to handle the new "cancelled_datetime" field.

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Something to note: when running the test in isolation by clicking the test runner in VSCode, a compilation error occurs:
```
   Compiling graphql_stock_line v0.1.0 (/Users/carl/GitHub/open-msupply/server/graphql/stock_line)
error[E0308]: mismatched types
   --> graphql/reports/src/print.rs:332:9
    |
331 |     let data = query_json(
    |                ---------- arguments to this function are incorrect
332 |         &ctx.get_settings().database,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&StorageConnection`, found `&DatabaseSettings`
    |
    = note: expected reference `&StorageConnection`
               found reference `&DatabaseSettings`
note: function defined here
   --> /Users/carl/GitHub/open-msupply/server/repository/src/db_diesel/report_query.rs:15:8
```

This error does *not* happen when running the full suite with `cargo test --features postgres`, (@jmbrunskill to maybe have a look at during Cooldown period)

# 🧪 Testing

- [ ] Run `cargo test --features postgres`, confirm no failed tests or compilation errors