### PR TITLE
6612 prescribed quantity gets overriden

### DIFF
--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
@@ -210,19 +210,21 @@ export const PrescriptionLineEditForm: React.FC<
   const note = prescriptionLineWithNote?.note ?? '';
 
   useEffect(() => {
-    const selectedItem = items.find(
-      prescriptionItem => prescriptionItem.id === item?.id
-    );
+    // sets prescribed quantity on initial load
     if (preferences?.editPrescribedQuantityOnPrescription) {
-      const newPrescribedQuantity: number =
+      const selectedItem = items.find(
+        prescriptionItem => prescriptionItem.id === item?.id
+      );
+      const newPrescribedQuantity =
         selectedItem?.lines?.find(
           ({ prescribedQuantity }) =>
             prescribedQuantity != null && prescribedQuantity > 0
         )?.prescribedQuantity ?? 0;
-
       setPrescribedQuantity(newPrescribedQuantity);
     }
+  }, []);
 
+  useEffect(() => {
     const newIssueQuantity = Math.round(
       allocatedUnits / Math.abs(Number(packSizeController.selected?.value || 1))
     );
@@ -328,6 +330,13 @@ export const PrescriptionLineEditForm: React.FC<
                     min={0}
                     decimalLimit={2}
                     onBlur={() => {}}
+                    slotProps={{
+                      htmlInput: {
+                        sx: {
+                          backgroundColor: 'background.white',
+                        },
+                      },
+                    }}
                   />
                 </Grid>
               )}
@@ -345,18 +354,13 @@ export const PrescriptionLineEditForm: React.FC<
                   slotProps={{
                     htmlInput: {
                       sx: {
-                        backgroundColor: disabled
-                          ? undefined
-                          : 'background.white',
+                        backgroundColor: 'background.white',
                       },
                     },
                   }}
                 />
                 <InputLabel sx={{ fontSize: 12 }}>
-                  {t('label.unit-plural_one', {
-                    // unit-plural_one has been specified to deactivate pluralisation.
-                    // This is to handle the case where units have not been entered for the item.
-                    // see https://github.com/msupply-foundation/open-msupply/issues/5978
+                  {t('label.unit-plural', {
                     count: issueUnitQuantity,
                     unit: item?.unitName,
                   })}

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
@@ -211,7 +211,10 @@ export const PrescriptionLineEditForm: React.FC<
 
   useEffect(() => {
     // sets prescribed quantity on initial load
-    if (preferences?.editPrescribedQuantityOnPrescription) {
+    if (
+      preferences?.editPrescribedQuantityOnPrescription &&
+      prescribedQuantity === null
+    ) {
       const selectedItem = items.find(
         prescriptionItem => prescriptionItem.id === item?.id
       );
@@ -222,7 +225,16 @@ export const PrescriptionLineEditForm: React.FC<
         )?.prescribedQuantity ?? 0;
       setPrescribedQuantity(newPrescribedQuantity);
     }
-  }, []);
+
+    if (!isAutoAllocated) {
+      setIssueUnitQuantity(allocatedUnits);
+      return;
+    }
+
+    if (items.find(prescriptionItem => prescriptionItem.id === item?.id))
+      setAbbreviation('');
+    setDefaultDirection('');
+  }, [item?.id, allocatedUnits, packSizeController.selected?.value]);
 
   useEffect(() => {
     const newIssueQuantity = Math.round(
@@ -231,17 +243,7 @@ export const PrescriptionLineEditForm: React.FC<
     if (newIssueQuantity !== issueUnitQuantity)
       setIssueUnitQuantity(newIssueQuantity);
     setAllocationAlerts([]);
-  }, [item?.id, allocatedUnits]);
-
-  useEffect(() => {
-    if (items.find(prescriptionItem => prescriptionItem.id === item?.id))
-      setAbbreviation('');
-    setDefaultDirection('');
   }, [item?.id]);
-
-  useEffect(() => {
-    if (!isAutoAllocated) setIssueUnitQuantity(allocatedUnits);
-  }, [packSizeController.selected?.value, allocatedUnits]);
 
   const key = item?.id ?? 'new';
 

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
@@ -234,8 +234,8 @@ export const PrescriptionLineEditForm: React.FC<
   }, [item?.id]);
 
   useEffect(() => {
-    if (!isAutoAllocated) setIssueUnitQuantity(allocatedUnits);
-  }, [packSizeController.selected?.value, allocatedUnits]);
+    setIssueUnitQuantity(allocatedUnits);
+  }, [allocatedUnits]);
 
   const key = item?.id ?? 'new';
 

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
@@ -210,40 +210,32 @@ export const PrescriptionLineEditForm: React.FC<
   const note = prescriptionLineWithNote?.note ?? '';
 
   useEffect(() => {
-    // sets prescribed quantity on initial load
-    if (
-      preferences?.editPrescribedQuantityOnPrescription &&
-      prescribedQuantity === null
-    ) {
+    if (preferences?.editPrescribedQuantityOnPrescription) {
       const selectedItem = items.find(
         prescriptionItem => prescriptionItem.id === item?.id
       );
       const newPrescribedQuantity =
         selectedItem?.lines?.find(
-          ({ prescribedQuantity }) =>
-            prescribedQuantity != null && prescribedQuantity > 0
+          ({ prescribedQuantity }) => prescribedQuantity != null
         )?.prescribedQuantity ?? 0;
       setPrescribedQuantity(newPrescribedQuantity);
     }
 
-    if (!isAutoAllocated) {
-      setIssueUnitQuantity(allocatedUnits);
-      return;
-    }
-
-    if (items.find(prescriptionItem => prescriptionItem.id === item?.id))
-      setAbbreviation('');
-    setDefaultDirection('');
-  }, [item?.id, allocatedUnits, packSizeController.selected?.value]);
-
-  useEffect(() => {
     const newIssueQuantity = Math.round(
       allocatedUnits / Math.abs(Number(packSizeController.selected?.value || 1))
     );
     if (newIssueQuantity !== issueUnitQuantity)
       setIssueUnitQuantity(newIssueQuantity);
     setAllocationAlerts([]);
+
+    if (items.find(prescriptionItem => prescriptionItem.id === item?.id))
+      setAbbreviation('');
+    setDefaultDirection('');
   }, [item?.id]);
+
+  useEffect(() => {
+    if (!isAutoAllocated) setIssueUnitQuantity(allocatedUnits);
+  }, [packSizeController.selected?.value, allocatedUnits]);
 
   const key = item?.id ?? 'new';
 

--- a/client/packages/invoices/src/Prescriptions/api/hooks/utils.tsx
+++ b/client/packages/invoices/src/Prescriptions/api/hooks/utils.tsx
@@ -514,6 +514,13 @@ export const UnitQuantityCell = (props: CellProps<DraftPrescriptionLine>) => (
     id={getPackQuantityCellId(props.rowData.stockLine?.batch)}
     min={0}
     decimalLimit={2}
+    slotProps={{
+      htmlInput: {
+        sx: {
+          backgroundColor: 'background.white',
+        },
+      },
+    }}
   />
 );
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6612 

# 👩🏻‍💻 What does this PR do?

Prescribed Quantity gets overriden on initial changes of its input. This is happening due to the logic that's within a `useEffect`.  It has a dependency that gets updated when we initially change prescribed quantity. Which re-triggers the prescribed quantity logic that's only meant to run on initial load.

Moved the initial setting of prescribed quantity logic to its own `useEffect` without any dependencies. Triggering the logic only on initial load

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

https://github.com/user-attachments/assets/9788dca0-5642-4e02-a5da-b794825bc653

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to a prescription
- [ ] Add a new item
- [ ] Edit the prescribed quantity field
- [ ] It should retain the initial value that the user inputs
- [ ] It should auto allocate quantity to lines
- [ ] Click save
- [ ] Item gets created!

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
