### PR TITLE
5032 add siteName to OG login v4 requests

### DIFF
--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -304,7 +304,7 @@ async fn main() -> anyhow::Result<()> {
                 };
                 synced_user_info_rows.push((
                     input.clone(),
-                    LoginService::fetch_user_from_central(&input)
+                    LoginService::fetch_user_from_central(&service_provider.clone(), &input)
                         .await
                         .unwrap_or_else(|_| panic!("Cannot find user {:?}", input)),
                 ));
@@ -423,8 +423,10 @@ async fn main() -> anyhow::Result<()> {
         Action::BuildReports { path } => {
             let dir_list = match path.clone() {
                 Some(path) => path,
-                None => vec![PathBuf::new().join("../standard_reports"),
-                             PathBuf::new().join("../standard_forms")],
+                None => vec![
+                    PathBuf::new().join("../standard_reports"),
+                    PathBuf::new().join("../standard_forms"),
+                ],
             };
 
             for base_dir in dir_list {
@@ -466,7 +468,10 @@ async fn main() -> anyhow::Result<()> {
                 if path.is_some() {
                     info!("All reports built in custom path {:?}", base_dir.display());
                 } else {
-                    info!("All standard reports built in path {:?}", base_dir.display())
+                    info!(
+                        "All standard reports built in path {:?}",
+                        base_dir.display()
+                    )
                 };
             }
         }
@@ -485,16 +490,13 @@ async fn main() -> anyhow::Result<()> {
 
             for file_path in file_list {
                 let json_file = fs::File::open(file_path.clone())
-                .unwrap_or_else(|_| panic!(
-                    "{} not found for report",
-                    file_path.display()
-                ));
-                let reports_data: ReportsData =
-                    serde_json::from_reader(json_file).expect("json incorrectly formatted for report");
-    
+                    .unwrap_or_else(|_| panic!("{} not found for report", file_path.display()));
+                let reports_data: ReportsData = serde_json::from_reader(json_file)
+                    .expect("json incorrectly formatted for report");
+
                 let connection_manager = get_storage_connection_manager(&settings.database);
                 let con = connection_manager.connection()?;
-    
+
                 StandardReports::upsert_reports(reports_data, &con, overwrite)?;
             }
         }

--- a/server/cli/src/test_connection.rs
+++ b/server/cli/src/test_connection.rs
@@ -226,6 +226,7 @@ impl Test for LoginTest {
             username,
             password,
             login_type: LoginUserTypeV4::User,
+            site_name: None,
         };
 
         let _info = login_api

--- a/server/service/src/apis/login_v4.rs
+++ b/server/service/src/apis/login_v4.rs
@@ -36,11 +36,12 @@ pub struct LoginResponseErrorV4 {
 }
 
 #[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LoginInputV4 {
     pub username: String,
     pub password: String,
-    #[serde(rename = "loginType")]
     pub login_type: LoginUserTypeV4,
+    pub site_name: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/server/service/src/sync/sync_user.rs
+++ b/server/service/src/sync/sync_user.rs
@@ -40,11 +40,14 @@ impl SyncUser {
             ));
         }
 
-        match LoginService::fetch_user_from_central(&LoginInput {
-            username,
-            password: password.clone(),
-            central_server_url,
-        })
+        match LoginService::fetch_user_from_central(
+            service_provider,
+            &LoginInput {
+                username,
+                password: password.clone(),
+                central_server_url,
+            },
+        )
         .await
         {
             Ok(user_info) => {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5032 

# 👩🏻‍💻 What does this PR do?

This PR https://github.com/msupply-foundation/msupply/pull/16188 adds `siteName` to the login API to allow filtering by site, reducing the store permission records sent to just those of active stores on the site.

## 💌 Any notes for the reviewer?

I could have made the API a set of store IDs instead. Maybe that'd have been better. 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Checkout https://github.com/msupply-foundation/msupply/pull/16188
- [ ] run OMS and OG central servers
- [ ] Sync an OMS remote site on android
- [ ] Can login with android fine (and other versions)
- [ ] If your user on OG happens to have login rights to 500+ stores, login is still fast provided your site only has a few active stores (if OMS has 500+ active stores then the original problem will still exist)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

