### PR TITLE
5914 selected row actions should clear the selected state on completion

### DIFF
--- a/client/packages/coldchain/src/Equipment/api/hooks/document/useAssetsDelete.ts
+++ b/client/packages/coldchain/src/Equipment/api/hooks/document/useAssetsDelete.ts
@@ -10,13 +10,13 @@ import { useAssets } from './useAssets';
 import { AssetFragment } from '../../operations.generated';
 
 export const useAssetsDelete = () => {
+  const t = useTranslation();
   const queryClient = useQueryClient();
-  const { data: rows } = useAssets();
   const api = useAssetApi();
+  const { data: rows } = useAssets();
   const { mutateAsync } = useMutation(async (id: string) =>
     api.delete(id, api.storeId)
   );
-  const t = useTranslation();
 
   const { selectedRows } = useTableStore(state => ({
     selectedRows: Object.keys(state.rowState)
@@ -24,10 +24,14 @@ export const useAssetsDelete = () => {
       .map(selectedId => rows?.nodes?.find(({ id }) => selectedId === id))
       .filter(Boolean) as AssetFragment[],
   }));
+  const { clearSelected } = useTableStore();
 
   const deleteAction = async () => {
     await Promise.all(selectedRows.map(row => mutateAsync(row.id)))
-      .then(() => queryClient.invalidateQueries(api.keys.base()))
+      .then(() => {
+        queryClient.invalidateQueries(api.keys.base());
+        clearSelected();
+      })
       .catch(err => {
         throw err;
       });

--- a/client/packages/common/src/ui/components/footer/ActionsFooter.tsx
+++ b/client/packages/common/src/ui/components/footer/ActionsFooter.tsx
@@ -70,9 +70,11 @@ export const ActionsFooter: FC<ActionsFooterProps> = ({
           shouldShrink,
           disabledToastMessage,
         }) => (
-          <div onClick={handleDisabledClick(disabled, disabledToastMessage)}>
+          <div
+            key={label}
+            onClick={handleDisabledClick(disabled, disabledToastMessage)}
+          >
             <FlatButton
-              key={label}
               startIcon={icon}
               label={label}
               disabled={disabled}

--- a/client/packages/common/src/ui/layout/tables/context/TableContext.tsx
+++ b/client/packages/common/src/ui/layout/tables/context/TableContext.tsx
@@ -36,6 +36,7 @@ export interface TableStore {
     shouldReset?: boolean
   ) => void;
   updateRowStyles: (ids: string[], style: AppSxProp) => void;
+  clearSelected: () => void;
 }
 
 export const tableContext = createContext<UseBoundStore<StoreApi<TableStore>>>(
@@ -310,6 +311,22 @@ export const createTableStore = () =>
             (newState, id) => ({
               ...newState,
               [id]: getRowState(state, id, { isExpanded }),
+            }),
+            state.rowState
+          ),
+        };
+      });
+    },
+
+    clearSelected: () => {
+      set(state => {
+        return {
+          ...state,
+          numberSelected: 0,
+          rowState: Object.keys(state.rowState).reduce(
+            (newState, id) => ({
+              ...newState,
+              [id]: getRowState(state, id, { isSelected: false }),
             }),
             state.rowState
           ),

--- a/client/packages/inventory/src/Stocktake/DetailView/ChangeLocationModal.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/ChangeLocationModal.tsx
@@ -15,11 +15,13 @@ import { useStocktake } from '../api';
 interface ChangeLocationConfirmationModalProps {
   isOpen: boolean;
   onCancel: () => void;
+  clearSelected: () => void;
 }
 
 export const ChangeLocationConfirmationModal = ({
   isOpen,
   onCancel,
+  clearSelected,
 }: ChangeLocationConfirmationModalProps) => {
   const t = useTranslation();
 
@@ -42,6 +44,7 @@ export const ChangeLocationConfirmationModal = ({
               variant="ok"
               onClick={async () => {
                 await onChangeLocation(location);
+                clearSelected();
                 onCancel();
               }}
             />

--- a/client/packages/inventory/src/Stocktake/DetailView/Footer/Footer.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/Footer/Footer.tsx
@@ -11,6 +11,7 @@ import {
   DeleteIcon,
   useEditModal,
   ActionsFooter,
+  useTableStore,
 } from '@openmsupply-client/common';
 import { stocktakeStatuses, getStocktakeTranslator } from '../../../utils';
 import { StocktakeFragment, useStocktake } from '../../api';
@@ -36,6 +37,7 @@ export const Footer = () => {
   const changeLocationModal = useEditModal();
 
   const selectedRows = useStocktake.utils.selectedRows();
+  const { clearSelected } = useTableStore();
 
   const actions: Action[] = [
     {
@@ -79,12 +81,14 @@ export const Footer = () => {
                 <ReduceLinesToZeroConfirmationModal
                   isOpen={reduceModal.isOpen}
                   onCancel={reduceModal.onClose}
+                  clearSelected={clearSelected}
                 />
               )}
               {changeLocationModal.isOpen && (
                 <ChangeLocationConfirmationModal
                   isOpen={changeLocationModal.isOpen}
                   onCancel={changeLocationModal.onClose}
+                  clearSelected={clearSelected}
                 />
               )}
             </>

--- a/client/packages/inventory/src/Stocktake/DetailView/ReduceLinesToZeroModal.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/ReduceLinesToZeroModal.tsx
@@ -17,11 +17,13 @@ import { useStocktake } from '../api';
 interface ReduceLinesToZeroConfirmationModalProps {
   isOpen: boolean;
   onCancel: () => void;
+  clearSelected: () => void;
 }
 
 export const ReduceLinesToZeroConfirmationModal = ({
   isOpen,
   onCancel,
+  clearSelected,
 }: ReduceLinesToZeroConfirmationModalProps) => {
   const t = useTranslation();
 
@@ -49,6 +51,7 @@ export const ReduceLinesToZeroConfirmationModal = ({
               disabled={reasonIsRequired && !reason}
               onClick={async () => {
                 await onZeroQuantities(reason);
+                clearSelected();
                 onCancel();
               }}
             />

--- a/client/packages/inventory/src/Stocktake/api/hooks/document/useStocktakeDeleteSelected.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/document/useStocktakeDeleteSelected.ts
@@ -19,11 +19,14 @@ export const useStocktakeDeleteSelected = () => {
       .map(selectedId => rows?.nodes?.find(({ id }) => selectedId === id))
       .filter(Boolean) as StocktakeRowFragment[],
   }));
+  const { clearSelected } = useTableStore();
 
   const deleteAction = async () => {
-    await mutateAsync(selectedRows).catch(err => {
-      throw err;
-    });
+    await mutateAsync(selectedRows)
+      .then(() => clearSelected())
+      .catch(err => {
+        throw err;
+      });
   };
 
   const confirmAndDelete = useDeleteConfirmation({

--- a/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeDeleteSelectedLines.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeDeleteSelectedLines.ts
@@ -8,9 +8,9 @@ import { useStocktakeDeleteLines } from './useStocktakeDeleteLines';
 import { useStocktakeRows } from './useStocktakeRows';
 
 export const useStocktakeDeleteSelectedLines = (): (() => void) => {
+  const t = useTranslation();
   const { isDisabled, lines } = useStocktakeRows();
   const { mutateAsync } = useStocktakeDeleteLines();
-  const t = useTranslation();
 
   const { selectedRows } = useTableStore(state => {
     return {
@@ -20,11 +20,14 @@ export const useStocktakeDeleteSelectedLines = (): (() => void) => {
         .filter(Boolean) as StocktakeLineFragment[],
     };
   });
+  const { clearSelected } = useTableStore();
 
   const onDelete = async () => {
-    await mutateAsync(selectedRows).catch(err => {
-      throw err;
-    });
+    await mutateAsync(selectedRows)
+      .then(() => clearSelected())
+      .catch(err => {
+        throw err;
+      });
   };
 
   const confirmAndDelete = useDeleteConfirmation({

--- a/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -32,6 +32,8 @@ import { canReturnInboundLines } from '../../utils';
 type InboundLineItem = InboundLineFragment['item'];
 
 export const DetailView: FC = () => {
+  const t = useTranslation();
+  const navigate = useNavigate();
   const { data, isLoading } = useInbound.document.get();
   const isDisabled = useInbound.utils.isDisabled();
   const { onOpen, onClose, mode, entity, isOpen } =
@@ -44,8 +46,6 @@ export const DetailView: FC = () => {
     mode: returnModalMode,
     setMode: setReturnMode,
   } = useEditModal<string[]>();
-  const navigate = useNavigate();
-  const t = useTranslation();
   const { info, error } = useNotification();
 
   const onRowClick = React.useCallback(

--- a/client/packages/invoices/src/InboundShipment/DetailView/Footer/Footer.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Footer/Footer.tsx
@@ -12,6 +12,7 @@ import {
   RewindIcon,
   Action,
   ActionsFooter,
+  useTableStore,
 } from '@openmsupply-client/common';
 
 import React, { FC } from 'react';
@@ -72,6 +73,7 @@ export const FooterComponent: FC<FooterComponentProps> = ({
   const onDelete = useInbound.lines.deleteSelected();
   const onZeroQuantities = useInbound.lines.zeroQuantities();
   const selectedLines = useInbound.utils.selectedLines();
+  const { clearSelected } = useTableStore();
 
   const actions: Action[] = [
     {
@@ -86,7 +88,10 @@ export const FooterComponent: FC<FooterComponentProps> = ({
     {
       label: t('button.return-lines'),
       icon: <ArrowLeftIcon />,
-      onClick: () => onReturnLines(selectedLines),
+      onClick: () => {
+        onReturnLines(selectedLines);
+        clearSelected();
+      },
       shouldShrink: false,
     },
     {

--- a/client/packages/invoices/src/InboundShipment/api/hooks/document/useInboundDeleteRows.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/document/useInboundDeleteRows.ts
@@ -11,23 +11,27 @@ import { useInboundApi } from '../utils/useInboundApi';
 import { useInbounds } from './useInbounds';
 
 export const useInboundDeleteRows = () => {
+  const t = useTranslation();
   const queryClient = useQueryClient();
+  const api = useInboundApi();
   const { queryParams } = useUrlQueryParams({
     initialSort: { key: 'createdDatetime', dir: 'desc' },
   });
   const { data: rows } = useInbounds(queryParams);
-  const api = useInboundApi();
   const { mutateAsync } = useMutation(api.delete);
-  const t = useTranslation();
 
   const selectedRows = useTableStore(
     state =>
       rows?.nodes.filter(({ id }) => state.rowState[id]?.isSelected) ?? []
   );
+  const { clearSelected } = useTableStore();
 
   const deleteAction = async () => {
     await mutateAsync(selectedRows)
-      .then(() => queryClient.invalidateQueries(api.keys.base()))
+      .then(() => {
+        queryClient.invalidateQueries(api.keys.base());
+        clearSelected();
+      })
       .catch(err => {
         throw err;
       });

--- a/client/packages/invoices/src/InboundShipment/api/hooks/line/useDeleteSelectedLines.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/line/useDeleteSelectedLines.ts
@@ -9,10 +9,10 @@ import { useDeleteInboundLines } from './useDeleteInboundLines';
 import { useInboundRows } from './useInboundRows';
 
 export const useDeleteSelectedLines = (): (() => void) => {
+  const t = useTranslation();
   const { items, lines } = useInboundRows();
   const { mutateAsync } = useDeleteInboundLines();
   const isDisabled = useIsInboundDisabled();
-  const t = useTranslation();
 
   const selectedRows =
     useTableStore(state => {
@@ -35,6 +35,7 @@ export const useDeleteSelectedLines = (): (() => void) => {
               isDeleted: true,
             }));
     }) || [];
+  const { clearSelected } = useTableStore();
 
   const onDelete = async () => {
     const result = await mutateAsync(selectedRows).catch(err => {
@@ -55,7 +56,6 @@ export const useDeleteSelectedLines = (): (() => void) => {
                 itemCode: row?.item.code ?? '?',
               })
             );
-            break;
           case 'TransferredShipment':
             throw Error(t('messages.cant-delete-transferred'));
           case 'CannotEditInvoice':
@@ -68,6 +68,7 @@ export const useDeleteSelectedLines = (): (() => void) => {
         }
       }
     }
+    clearSelected();
   };
 
   const confirmAndDelete = useDeleteConfirmation({

--- a/client/packages/invoices/src/InboundShipment/api/hooks/line/useZeroInboundLinesQuantity.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/line/useZeroInboundLinesQuantity.ts
@@ -8,10 +8,10 @@ import { useInboundRows } from './useInboundRows';
 import { useSaveInboundLines } from './useSaveInboundLines';
 
 export const useZeroInboundLinesQuantity = (): (() => void) => {
+  const t = useTranslation();
   const { items, lines } = useInboundRows();
   const { mutateAsync } = useSaveInboundLines();
   const isDisabled = useIsInboundDisabled();
-  const t = useTranslation();
 
   const selectedRows =
     useTableStore(state => {
@@ -36,11 +36,14 @@ export const useZeroInboundLinesQuantity = (): (() => void) => {
               isUpdated: true,
             }));
     }) || [];
+  const { clearSelected } = useTableStore();
 
   const onZeroQuantities = async () => {
-    await mutateAsync(selectedRows).catch(err => {
-      throw err;
-    });
+    await mutateAsync(selectedRows)
+      .then(() => clearSelected())
+      .catch(err => {
+        throw err;
+      });
   };
 
   const confirmAndZeroLines = useDeleteConfirmation({

--- a/client/packages/invoices/src/OutboundShipment/DetailView/Footer/Footer.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Footer/Footer.tsx
@@ -120,7 +120,10 @@ export const FooterComponent: FC<FooterComponentProps> = ({
     {
       label: t('button.return-lines'),
       icon: <ArrowLeftIcon />,
-      onClick: () => onReturnLines(selectedLines),
+      onClick: () => {
+        onReturnLines(selectedLines);
+        clearSelected();
+      },
       shouldShrink: false,
     },
   ];

--- a/client/packages/invoices/src/OutboundShipment/DetailView/Footer/Footer.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Footer/Footer.tsx
@@ -14,6 +14,9 @@ import {
   InvoiceNodeStatus,
   useBreadcrumbs,
   useConfirmationModal,
+  useTableStore,
+  useNotification,
+  InvoiceLineNodeType,
 } from '@openmsupply-client/common';
 import { getStatusTranslator, outboundStatuses } from '../../../utils';
 import { useOutbound, OutboundFragment } from '../../api';
@@ -70,14 +73,13 @@ export const FooterComponent: FC<FooterComponentProps> = ({
   const isDisabled = useOutbound.utils.isDisabled();
   const onDelete = useOutbound.line.deleteSelected();
   const { onAllocate } = useOutbound.line.allocateSelected();
+  const { info } = useNotification();
 
   const selectedLines = useOutbound.utils.selectedLines();
+  const { clearSelected } = useTableStore();
 
   const selectedUnallocatedEmptyLines = selectedLines
-    .filter(
-      ({ type, numberOfPacks }) =>
-        type === 'UNALLOCATED_STOCK' && numberOfPacks === 0
-    )
+    .filter(({ type }) => type === InvoiceLineNodeType.UnallocatedStock)
     .flat()
     .map(row => row.id);
 
@@ -92,7 +94,11 @@ export const FooterComponent: FC<FooterComponentProps> = ({
   const confirmAllocate = () => {
     if (selectedUnallocatedEmptyLines.length !== 0) {
       getConfirmation();
-    } else onAllocate();
+    } else {
+      const infoSnack = info(t('label.no-unallocated-rows-selected'));
+      infoSnack();
+    }
+    clearSelected();
   };
 
   const actions: Action[] = [

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/document/useOutboundDeleteRows.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/document/useOutboundDeleteRows.ts
@@ -12,14 +12,14 @@ import { useOutbounds } from './useOutbounds';
 import { canDeleteInvoice } from '../../../../utils';
 
 export const useOutboundDeleteRows = () => {
+  const t = useTranslation();
   const queryClient = useQueryClient();
+  const api = useOutboundApi();
   const { queryParams } = useUrlQueryParams({
     initialSort: { key: 'createdDatetime', dir: 'desc' },
   });
   const { data: rows } = useOutbounds(queryParams);
-  const api = useOutboundApi();
   const { mutateAsync } = useMutation(api.delete);
-  const t = useTranslation();
 
   const { selectedRows } = useTableStore(state => ({
     selectedRows: Object.keys(state.rowState)
@@ -27,10 +27,14 @@ export const useOutboundDeleteRows = () => {
       .map(selectedId => rows?.nodes?.find(({ id }) => selectedId === id))
       .filter(Boolean) as OutboundRowFragment[],
   }));
+  const { clearSelected } = useTableStore();
 
   const deleteAction = async () => {
     await mutateAsync(selectedRows)
-      .then(() => queryClient.invalidateQueries(api.keys.base()))
+      .then(() => {
+        queryClient.invalidateQueries(api.keys.base());
+        clearSelected();
+      })
       .catch(err => {
         throw err;
       });

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/line/useOutboundAllocateSelectedLines.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/line/useOutboundAllocateSelectedLines.ts
@@ -61,12 +61,6 @@ export const useOutboundAllocateSelectedLines = (): {
       return;
     }
 
-    if (selectedUnallocatedLines.length === 0) {
-      const infoSnack = info(t('label.no-unallocated-rows-selected'));
-      infoSnack();
-      return;
-    }
-
     const batchResponse = await mutateAsync(selectedUnallocatedLines);
 
     if (batchResponse?.__typename === 'BatchOutboundShipmentResponse') {

--- a/client/packages/invoices/src/Prescriptions/DetailView/Footer/Footer.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Footer/Footer.tsx
@@ -69,14 +69,19 @@ export const FooterComponent: FC = () => {
         .map(({ lines }) => lines.flat())
         .flat();
     }) || [];
+  const { clearSelected } = useTableStore();
 
   const {
     delete: { deleteLines },
   } = usePrescriptionLines();
 
+  const deleteAction = async () => {
+    await deleteLines(selectedRows).then(() => clearSelected());
+  };
+
   const confirmAndDelete = useDeleteConfirmation({
     selectedRows,
-    deleteAction: () => deleteLines(selectedRows),
+    deleteAction,
     canDelete: !isDisabled,
     messages: {
       confirmMessage: t('messages.confirm-delete-lines', {

--- a/client/packages/invoices/src/Prescriptions/api/hooks/usePrescriptionList.ts
+++ b/client/packages/invoices/src/Prescriptions/api/hooks/usePrescriptionList.ts
@@ -71,6 +71,7 @@ export const usePrescriptionList = (queryParams: ListParams) => {
       .map(selectedId => data?.nodes?.find(({ id }) => selectedId === id))
       .filter(Boolean) as PrescriptionRowFragment[],
   }));
+  const { clearSelected } = useTableStore();
 
   const {
     mutateAsync: deleteMutation,
@@ -79,7 +80,9 @@ export const usePrescriptionList = (queryParams: ListParams) => {
   } = useDelete();
 
   const deletePrescriptions = async () => {
-    await deleteMutation(selectedRows);
+    await deleteMutation(selectedRows).then(() => {
+      clearSelected();
+    });
   };
 
   return {

--- a/client/packages/invoices/src/Returns/api/hooks/document/useCustomerDeleteRows.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/document/useCustomerDeleteRows.ts
@@ -11,23 +11,27 @@ import { useReturnsApi } from '../utils/useReturnsApi';
 import { useCustomerReturns } from './useCustomerReturns';
 
 export const useCustomerDeleteRows = () => {
+  const t = useTranslation();
   const queryClient = useQueryClient();
+  const api = useReturnsApi();
   const { queryParams } = useUrlQueryParams({
     initialSort: { key: 'createdDatetime', dir: 'desc' },
   });
   const { data: rows } = useCustomerReturns(queryParams);
-  const api = useReturnsApi();
   const { mutateAsync } = useMutation(api.deleteCustomer);
-  const t = useTranslation();
 
   const selectedRows = useTableStore(
     state =>
       rows?.nodes.filter(({ id }) => state.rowState[id]?.isSelected) ?? []
   );
+  const { clearSelected } = useTableStore();
 
   const deleteAction = async () => {
     await Promise.all(selectedRows.map(row => mutateAsync(row.id)))
-      .then(() => queryClient.invalidateQueries(api.keys.base()))
+      .then(() => {
+        queryClient.invalidateQueries(api.keys.base());
+        clearSelected();
+      })
       .catch(err => {
         throw err;
       });

--- a/client/packages/invoices/src/Returns/api/hooks/document/useSupplierDeleteRows.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/document/useSupplierDeleteRows.ts
@@ -11,23 +11,27 @@ import { canDeleteSupplierReturn } from '../../../../utils';
 import { useSupplierReturns } from './useSupplierReturns';
 
 export const useSupplierDeleteRows = () => {
+  const t = useTranslation();
   const queryClient = useQueryClient();
+  const api = useReturnsApi();
   const { queryParams } = useUrlQueryParams({
     initialSort: { key: 'createdDatetime', dir: 'desc' },
   });
   const { data: rows } = useSupplierReturns(queryParams);
-  const api = useReturnsApi();
   const { mutateAsync } = useMutation(api.deleteSupplier);
-  const t = useTranslation();
 
   const selectedRows = useTableStore(
     state =>
       rows?.nodes.filter(({ id }) => state.rowState[id]?.isSelected) ?? []
   );
+  const { clearSelected } = useTableStore();
 
   const deleteAction = async () => {
     await Promise.all(selectedRows.map(row => mutateAsync(row.id)))
-      .then(() => queryClient.invalidateQueries(api.keys.base()))
+      .then(() => {
+        queryClient.invalidateQueries(api.keys.base());
+        clearSelected();
+      })
       .catch(err => {
         throw err;
       });

--- a/client/packages/invoices/src/Returns/api/hooks/line/useDeleteSelectedCustomerLines.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/line/useDeleteSelectedCustomerLines.ts
@@ -43,14 +43,17 @@ export const useDeleteSelectedCustomerReturnLines = ({
       expiryDate,
       numberOfPacksReturned: 0,
     })) || [];
+  const { clearSelected } = useTableStore();
 
   const onDelete = async () => {
     await updateLines({
       customerReturnId: returnId,
       customerReturnLines: selectedRows,
-    }).catch(err => {
-      throw err;
-    });
+    })
+      .then(() => clearSelected())
+      .catch(err => {
+        throw err;
+      });
   };
 
   const confirmAndDelete = useDeleteConfirmation({

--- a/client/packages/invoices/src/Returns/api/hooks/line/useDeleteSelectedSupplierLines.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/line/useDeleteSelectedSupplierLines.ts
@@ -40,14 +40,17 @@ export const useDeleteSelectedSupplierReturnLines = ({
       stockLineId: '',
       numberOfPacksToReturn: 0,
     })) || [];
+  const { clearSelected } = useTableStore();
 
   const onDelete = async () => {
     await updateLines({
       supplierReturnId: returnId,
       supplierReturnLines: selectedRows,
-    }).catch(err => {
-      throw err;
-    });
+    })
+      .then(() => clearSelected())
+      .catch(err => {
+        throw err;
+      });
   };
 
   const confirmAndDelete = useDeleteConfirmation({

--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/document/useDeleteSelectedRequisitions.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/document/useDeleteSelectedRequisitions.ts
@@ -22,10 +22,13 @@ export const useDeleteSelectedRequisitions = () => {
       .map(selectedId => rows?.nodes?.find(({ id }) => selectedId === id))
       .filter(Boolean) as RequestRowFragment[],
   }));
+  const { clearSelected } = useTableStore();
   const deleteAction = async () => {
-    await mutateAsync(selectedRows).catch(err => {
-      throw err;
-    });
+    await mutateAsync(selectedRows)
+      .then(() => clearSelected())
+      .catch(err => {
+        throw err;
+      });
   };
 
   const confirmAndDelete = useDeleteConfirmation({

--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/line/useDeleteRequestLines.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/line/useDeleteRequestLines.ts
@@ -11,25 +11,28 @@ import { useRequestApi } from '../utils/useRequestApi';
 import { useRequestLines } from './useRequestLines';
 
 export const useDeleteRequestLines = () => {
-  const { lines } = useRequestLines();
+  const t = useTranslation();
   const api = useRequestApi();
+  const queryClient = useQueryClient();
   const requestNumber = useRequestNumber();
   const isDisabled = useIsRequestDisabled();
-  const queryClient = useQueryClient();
+  const { lines } = useRequestLines();
   const { mutateAsync } = useMutation(api.deleteLines, {
     onSettled: () =>
       queryClient.invalidateQueries(api.keys.detail(requestNumber)),
   });
-  const t = useTranslation();
 
   const selectedRows = useTableStore(state =>
     lines.filter(({ id }) => state.rowState[id]?.isSelected)
   );
+  const { clearSelected } = useTableStore();
 
   const onDelete = async () => {
-    mutateAsync(selectedRows).catch(err => {
-      throw err;
-    });
+    mutateAsync(selectedRows)
+      .then(() => clearSelected())
+      .catch(err => {
+        throw err;
+      });
   };
 
   const confirmAndDelete = useDeleteConfirmation({

--- a/client/packages/requisitions/src/ResponseRequisition/api/hooks/document/useDeleteSelectedResponseRequisitions.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/api/hooks/document/useDeleteSelectedResponseRequisitions.ts
@@ -22,6 +22,7 @@ export const useDeleteSelectedResponseRequisitions = () => {
       .map(selectedId => rows?.nodes?.find(({ id }) => selectedId === id))
       .filter(Boolean) as ResponseFragment[],
   }));
+  const { clearSelected } = useTableStore();
   const deleteAction = async () => {
     let result = await mutateAsync(selectedRows).catch(err => {
       throw err;
@@ -41,6 +42,7 @@ export const useDeleteSelectedResponseRequisitions = () => {
         }
       }
     });
+    clearSelected();
   };
 
   const confirmAndDelete = useDeleteConfirmation({

--- a/client/packages/requisitions/src/ResponseRequisition/api/hooks/line/useDeleteResponseLines.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/api/hooks/line/useDeleteResponseLines.ts
@@ -28,6 +28,7 @@ export const useDeleteResponseLines = () => {
   const selectedRows = useTableStore(state =>
     lines.filter(({ id }) => state.rowState[id]?.isSelected)
   );
+  const { clearSelected } = useTableStore();
 
   const onDelete = async () => {
     let result = await mutateAsync(selectedRows).catch(err => {
@@ -55,6 +56,7 @@ export const useDeleteResponseLines = () => {
           noOtherVariants(error);
       }
     });
+    clearSelected();
   };
 
   const confirmAndDelete = useDeleteConfirmation({

--- a/client/packages/system/src/Asset/AssetLogReasons/Footer.tsx
+++ b/client/packages/system/src/Asset/AssetLogReasons/Footer.tsx
@@ -33,6 +33,7 @@ export const FooterComponent: FC<{ data: AssetLogReasonNode[] }> = ({
       .map(selectedId => data?.find(({ id }) => selectedId === id))
       .filter(Boolean) as AssetLogReasonNode[],
   }));
+  const { clearSelected } = useTableStore();
 
   const deleteAction = () => {
     const numberSelected = selectedRows.length;
@@ -60,6 +61,7 @@ export const FooterComponent: FC<{ data: AssetLogReasonNode[] }> = ({
             });
             const successSnack = success(deletedMessage);
             successSnack();
+            clearSelected();
           }
         })
         .catch(_ =>

--- a/client/packages/system/src/Asset/api/hooks/document/useAssetsDelete.ts
+++ b/client/packages/system/src/Asset/api/hooks/document/useAssetsDelete.ts
@@ -10,11 +10,11 @@ import { useAssets } from './useAssets';
 import { AssetCatalogueItemFragment } from '../../operations.generated';
 
 export const useAssetsDelete = () => {
-  const queryClient = useQueryClient();
-  const { data: rows } = useAssets();
-  const api = useAssetApi();
-  const { mutateAsync } = useMutation(async (id: string) => api.delete(id));
   const t = useTranslation();
+  const queryClient = useQueryClient();
+  const api = useAssetApi();
+  const { data: rows } = useAssets();
+  const { mutateAsync } = useMutation(async (id: string) => api.delete(id));
 
   const { selectedRows } = useTableStore(state => ({
     selectedRows: Object.keys(state.rowState)
@@ -22,10 +22,14 @@ export const useAssetsDelete = () => {
       .map(selectedId => rows?.nodes?.find(({ id }) => selectedId === id))
       .filter(Boolean) as AssetCatalogueItemFragment[],
   }));
+  const { clearSelected } = useTableStore();
 
   const deleteAction = async () => {
     await Promise.all(selectedRows.map(row => mutateAsync(row.id)))
-      .then(() => queryClient.invalidateQueries(api.keys.base()))
+      .then(() => {
+        queryClient.invalidateQueries(api.keys.base());
+        clearSelected();
+      })
       .catch(err => {
         console.error(err);
         throw err;

--- a/client/packages/system/src/Location/ListView/Footer.tsx
+++ b/client/packages/system/src/Location/ListView/Footer.tsx
@@ -31,6 +31,7 @@ export const FooterComponent: FC<{ data: LocationRowFragment[] }> = ({
       .map(selectedId => data?.find(({ id }) => selectedId === id))
       .filter(Boolean) as LocationRowFragment[],
   }));
+  const { clearSelected } = useTableStore();
 
   const deleteAction = () => {
     const numberSelected = selectedRows.length;
@@ -56,6 +57,7 @@ export const FooterComponent: FC<{ data: LocationRowFragment[] }> = ({
             });
             const successSnack = success(deletedMessage);
             successSnack();
+            clearSelected();
           }
         })
         .catch(_ =>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5914

# 👩🏻‍💻 What does this PR do?
Clear selections after an action if there has been no error, so that the actions footer disappears.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Select a row in all areas (e.g. Inbound Shipment)
- [ ] Click an action (such as delete)
- [ ] See that the action footer is now gone if the action was successful

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

