### PR TITLE
6668 fix context type in report migration

### DIFF
--- a/server/repository/src/db_diesel/report_row.rs
+++ b/server/repository/src/db_diesel/report_row.rs
@@ -10,10 +10,12 @@ use diesel_derive_enum::DbEnum;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(DbEnum, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
+#[derive(DbEnum, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ValueEnum, Default)]
+#[cfg_attr(test, derive(strum::EnumIter))]
 #[DbValueStyle = "SCREAMING_SNAKE_CASE"]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ContextType {
+    #[default]
     Asset,
     InboundShipment,
     OutboundShipment,
@@ -51,7 +53,7 @@ joinable!(report -> form_schema (argument_schema_id));
 allow_tables_to_appear_in_same_query!(report, form_schema);
 
 #[derive(
-    Clone, Insertable, Queryable, Debug, PartialEq, Eq, AsChangeset, Serialize, Deserialize,
+    Clone, Insertable, Queryable, Debug, PartialEq, Eq, AsChangeset, Serialize, Deserialize, Default,
 )]
 #[diesel(table_name = report)]
 pub struct ReportRow {
@@ -67,24 +69,6 @@ pub struct ReportRow {
     pub version: String,
     pub code: String,
 }
-
-impl Default for ReportRow {
-    fn default() -> Self {
-        Self {
-            id: Default::default(),
-            name: Default::default(),
-            template: Default::default(),
-            context: ContextType::InboundShipment,
-            comment: Default::default(),
-            sub_context: Default::default(),
-            argument_schema_id: Default::default(),
-            is_custom: true,
-            version: Default::default(),
-            code: Default::default(),
-        }
-    }
-}
-
 #[derive(Clone, Insertable, Queryable, Debug, PartialEq, Eq, AsChangeset, Selectable)]
 #[diesel(table_name = report)]
 pub struct ReportMetaDataRow {
@@ -178,5 +162,41 @@ impl Upsert for ReportRow {
             ReportRowRepository::new(con).find_one_by_id(&self.id),
             Ok(Some(self.clone()))
         )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use strum::IntoEnumIterator;
+    use util::assert_matches;
+
+    use crate::{mock::MockDataInserts, test_db::setup_all};
+
+    #[actix_rt::test]
+    async fn report_context_enum_postgres() {
+        let (_, connection, _, _) =
+            setup_all("report_context_enum_postgres", MockDataInserts::none()).await;
+
+        let repo = ReportRowRepository::new(&connection);
+        // Try upsert all variants, confirm that diesel enums match postgres
+        for variant in ContextType::iter() {
+            let id = format!("{variant:?}");
+            let result = repo.upsert_one(&ReportRow {
+                id: id.clone(),
+                context: variant.clone(),
+                ..Default::default()
+            });
+            assert_matches!(result, Ok(_));
+
+            assert_eq!(
+                repo.find_one_by_id(&id),
+                Ok(Some(ReportRow {
+                    id,
+                    context: variant.clone(),
+                    ..Default::default()
+                }))
+            );
+        }
     }
 }

--- a/server/repository/src/migrations/v2_06_00/reinitialise_reports.rs
+++ b/server/repository/src/migrations/v2_06_00/reinitialise_reports.rs
@@ -4,10 +4,26 @@ pub(crate) struct Migrate;
 
 impl MigrationFragment for Migrate {
     fn identifier(&self) -> &'static str {
-        "reinitialise_reports"
+        "reinitialise_reports_updated"
     }
 
     fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        const TYPE: &str = if cfg!(feature = "postgres") {
+            "context_type"
+        } else {
+            "TEXT"
+        };
+
+        if cfg!(feature = "postgres") {
+            sql!(
+                connection,
+                r#"
+                ALTER TYPE context_type ADD VALUE 'OUTBOUND_RETURN';
+                ALTER TYPE context_type ADD VALUE 'INBOUND_RETURN';
+                "#,
+            )?;
+        }
+
         // Dropping report table to remove duplicate legacy reports.
         sql!(
             connection,
@@ -20,7 +36,7 @@ impl MigrationFragment for Migrate {
                     comment TEXT,
                     sub_context TEXT,
                     argument_schema_id TEXT REFERENCES form_schema(id),
-                    context TEXT NOT NULL,
+                    context {TYPE} NOT NULL,
                     is_custom BOOLEAN NOT NULL DEFAULT true,
                     version TEXT NOT NULL DEFAULT 1.0,
                     code TEXT NOT NULL DEFAULT ''


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6668

# 👩🏻‍💻 What does this PR do?

Update fragment to set context to be enum for postgres.
Changing fragment name will mean it will re-run

## 💌 Any notes for the reviewer?

Custom report will be lost, but that is ok
For some reason this migration did not run so we had to add it again

https://github.com/msupply-foundation/open-msupply/blob/342394370b71b799f9af617022f128262a9a5427/server/repository/src/migrations/v2_00_00/returns/return_context_types.rs#L8-L9

# 🧪 Testing

Make sure reports work in postgres


