### PR TITLE
6441 fix add item variant

### DIFF
--- a/client/packages/common/src/ui/components/errors/NothingHere.tsx
+++ b/client/packages/common/src/ui/components/errors/NothingHere.tsx
@@ -22,7 +22,7 @@ export const NothingHere: React.FC<NothingHereProps> = ({
   const createButtonText = buttonText || t('button.create-a-new-one');
 
   const CreateButton = !!onCreate ? (
-    <Button sx={{ textTransform: 'none' }} onClick={onCreate}>
+    <Button sx={{ textTransform: 'none' }} onClick={() => onCreate()}>
       {createButtonText}
     </Button>
   ) : undefined;

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantsTab.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantsTab.tsx
@@ -50,7 +50,7 @@ export const ItemVariantsTab = ({
         {itemVariants.length === 0 ? (
           <NothingHere
             body={t('messages.no-item-variants')}
-            onCreate={onOpen}
+            onCreate={() => onOpen()}
           />
         ) : (
           itemVariants.map(v => (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6441 (maybe???)

# 👩🏻‍💻 What does this PR do?


Change the way we open the modal to be consistent with the other button.
Not sure why it would matter though...


## 💌 Any notes for the reviewer?

This probably isn't the right fix, I don't understand how we have different behaviour with this change!

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Open the Catalogue -> Items -> Variants tab on OMS Central Server
- [ ] Choose an item that has no variants
- [ ] Click the `Create a new one` button

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

