### PR TITLE
Set is dirty state when updating quantity

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
@@ -102,6 +102,7 @@ export const OutboundLineEdit: React.FC<ItemDetailsModalProps> = ({
   const onUpdateQuantity = (batchId: string, quantity: number) => {
     updateQuantity(batchId, quantity);
     setIsAutoAllocated(false);
+    setIsDirty(true);
   };
 
   const onSave = async () => {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6552

# 👩🏻‍💻 What does this PR do?
Issuing pack size straight from the batch line wasn't updating the dirty state, thus the api call never gets called 😅 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an Outbound Shipment 
- [ ] Add from master list to get quick lines
- [ ] Click on a line, allocate from batch level. 
- [ ] Click ok
- [ ] API should be called and line should be updated

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [x] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [x] Frontend

