### PR TITLE
Make Program Search options optional

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1772,7 +1772,6 @@
   "report.requested-from": "Requested from",
   "report.requested-qty": "Requested Qty",
   "report.requisition-category-message": "Requisition Category: Category Value",
-  "report.satisfaction-rate-per-program": "Satisfaction rate per program",
   "report.sell-price": "Sell price",
   "report.shipped-date": "Shipped date",
   "report.snapshot-packs": "Snapshot packs",

--- a/client/packages/common/src/intl/locales/pt/common.json
+++ b/client/packages/common/src/intl/locales/pt/common.json
@@ -1840,7 +1840,6 @@
   "button.select": "Selecionar",
   "header.add-lines-from-internal-order": "Adicionar linhas de um Pedido Interno",
   "title.new-sensor": "Novo sensor adicionado",
-  "report.satisfaction-rate-per-program": "Taxa de satisfação por programa",
   "title.patient-retrieval-modal": "Recuperação dos dados do paciente",
   "tooltip.import-fridge-tag": "Importar registos do ficheiro do Berlinger Fridge-tag e Q-tag. Um sensor será criado, se necessário, para cada ficheiro importado.",
   "warning.cannot-create-placeholder-units": "Há um total de {{allocatedQuantity}} unidades disponíveis. Não foi possível alocar {{requestedQuantity}} unidades.",

--- a/client/packages/common/src/intl/locales/ru/common.json
+++ b/client/packages/common/src/intl/locales/ru/common.json
@@ -1742,7 +1742,6 @@
   "report.requested-from": "Запрошено от",
   "report.requested-qty": "Запрошенное кол-во",
   "report.requisition-category-message": "Категория запросов: значение категории",
-  "report.satisfaction-rate-per-program": "Уровень удовлетворенности по каждой программе",
   "report.sell-price": "Цена продажи",
   "report.shipped-date": "Отправлено",
   "report.snapshot-packs": "Упаковки в данный момент",

--- a/client/packages/programs/src/JsonForms/components/ProgramSearch.tsx
+++ b/client/packages/programs/src/JsonForms/components/ProgramSearch.tsx
@@ -16,9 +16,11 @@ import { z } from 'zod';
 
 export const programSearchTester = rankWith(10, uiTypeIs('ProgramSearch'));
 
-const PatientProgramSearchOptions = z.object({
-  programType: z.enum(['immunisation']).optional(),
-});
+const PatientProgramSearchOptions = z
+  .object({
+    programType: z.enum(['immunisation']).optional(),
+  })
+  .optional();
 
 const UIComponent = (props: ControlProps) => {
   const { errors: zErrors } = useZodOptionsValidation(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #

# 👩🏻‍💻 What does this PR do?
Fixes the required option in Program Search.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have civ reports upserted
- [ ] Check filters still work for satisfaction report

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

