### PR TITLE
#6689 Always clear directions abbreviation field

### DIFF
--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
@@ -228,8 +228,7 @@ export const PrescriptionLineEditForm: React.FC<
       setIssueUnitQuantity(newIssueQuantity);
     setAllocationAlerts([]);
 
-    if (items.find(prescriptionItem => prescriptionItem.id === item?.id))
-      setAbbreviation('');
+    setAbbreviation('');
     setDefaultDirection('');
   }, [item?.id]);
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6689

# 👩🏻‍💻 What does this PR do?

This seems to fix the problem. I'm not sure why the conditional was put there originally, but it caused the `setDefaultDirection("")` to skip out the "New" case. Now we just clear all these fields when the item switches.

# 🧪 Testing

- [ ] See problem described in [the issue](https://github.com/msupply-foundation/open-msupply/issues/6689) -- confirm no longer happens

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

