### PR TITLE
#6677 Don't show expired or inactive insurances in Prescription payment

### DIFF
--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -149,7 +149,8 @@ export const DateUtils = {
     fromUnixTime(Math.max(...dates.map(d => getUnixTime(d as Date)))),
   isPast,
   isFuture,
-  isExpired: (expiryDate: Date): boolean => isPast(expiryDate),
+  isExpired: (expiryDate: Date | string | number): boolean =>
+    isPast(expiryDate),
   isAlmostExpired: (
     expiryDate: Date,
     threshold = MINIMUM_EXPIRY_MONTHS

--- a/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
@@ -15,7 +15,7 @@ import {
   usePluginProvider,
 } from '@openmsupply-client/common';
 import { useDialog } from '@common/hooks';
-import { useTranslation } from '@common/intl';
+import { DateUtils, useTranslation } from '@common/intl';
 import { PrescriptionRowFragment, usePrescription } from '../../api';
 import { useInsurances } from '@openmsupply-client/system/src';
 
@@ -44,8 +44,15 @@ export const PaymentsModal: FC<PaymentsModalProps> = ({
 
   const nameId = prescriptionData?.patientId ?? '';
   const {
-    query: { data: insuranceData },
+    query: { data },
   } = useInsurances(nameId);
+
+  // Would normally add this filtering to query, but because the list is short
+  // and doesn't involve any pagination, this is appropriate in this case.
+  const insuranceData = data?.filter(
+    insurance =>
+      insurance.isActive && !DateUtils.isExpired(insurance.expiryDate)
+  );
 
   const selectedInsurance = insuranceData?.find(
     ({ insuranceProviders }) => insuranceProviders?.id === insuranceId

--- a/client/packages/system/src/Patient/apiModern/hooks/useInsurances.ts
+++ b/client/packages/system/src/Patient/apiModern/hooks/useInsurances.ts
@@ -22,7 +22,7 @@ const defaultDraftInsurance: DraftInsurance = {
   policyNumberPerson: '',
   insuranceProviderId: '',
   policyType: '' as InsurancePolicyNodeType,
-  isActive: false,
+  isActive: true,
   discountPercentage: 0,
   expiryDate: '',
   nameId: '',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6677 (& #6692)

# 👩🏻‍💻 What does this PR do?

I just did the quick and dirty approach here and filtered out in the front-end rather than creating a whole new Filter structure on the server. Seemed acceptable given that the insurance list for a given patient should be pretty short and doesn't involve any pagination.

Also squeezed in a quick fix for #6692, since it's literally a one word change.

## 💌 Any notes for the reviewer?

See inline 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Set up a patient with multiple insurances, make some of them expired, some inactive, some both
- [ ] Create a prescription for that patient, add some items, then "Verify"
- [ ] In the Payments modal that pops up, the list of "Insurance Schemes" should not include any that are expired or inactive

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

