### PR TITLE
4884 vaccine age range fixes

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -245,6 +245,7 @@
   "error.date_maxDate": "Date value is too large",
   "error.date_minDate": "Date value is too low",
   "error.dose-ages-out-of-order": "Each dose needs a higher minimum age than the previous dose",
+  "error.dose-max-lower-than-min": "Dose \"{{label}}\" must have a higher maximum age than minimum age",
   "error.duplicate-asset-number": "duplicate asset number in csv",
   "error.duplicate-item-variant-name": "Item variant with the same name already exists for this item",
   "error.duplicated-field": "{{field}} already exists in the import file",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -245,7 +245,7 @@
   "error.date_maxDate": "Date value is too large",
   "error.date_minDate": "Date value is too low",
   "error.dose-ages-out-of-order": "Each dose needs a higher minimum age than the previous dose",
-  "error.dose-max-lower-than-min": "Dose \"{{label}}\" must have a higher maximum age than minimum age",
+  "error.dose-max-lower-than-min": "Dose {{doseIndex}} must have a higher maximum age than minimum age",
   "error.duplicate-asset-number": "duplicate asset number in csv",
   "error.duplicate-item-variant-name": "Item variant with the same name already exists for this item",
   "error.duplicated-field": "{{field}} already exists in the import file",

--- a/client/packages/programs/src/VaccineCourseEditModal/VaccineCourseEditModal.tsx
+++ b/client/packages/programs/src/VaccineCourseEditModal/VaccineCourseEditModal.tsx
@@ -81,6 +81,13 @@ interface VaccineCourseEditModalProps {
   mode: ModalMode | null;
 }
 
+function doseIndex(
+  doses: VaccineCourseDoseFragment[],
+  dose: VaccineCourseDoseFragment
+) {
+  return doses.indexOf(dose) + 1;
+}
+
 export const VaccineCourseEditModal: FC<VaccineCourseEditModalProps> = ({
   vaccineCourse,
   isOpen,
@@ -99,6 +106,8 @@ export const VaccineCourseEditModal: FC<VaccineCourseEditModalProps> = ({
     isDirty,
     resetDraft,
   } = useVaccineCourse(vaccineCourse?.id ?? undefined);
+  const doses = draft.vaccineCourseDoses ?? [];
+
   const { data: demographicData } = useDemographicData.demographics.list();
 
   const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
@@ -112,10 +121,7 @@ export const VaccineCourseEditModal: FC<VaccineCourseEditModalProps> = ({
     value: draft.demographic?.name ?? '',
     label: draft.demographic?.name ?? '',
   };
-
   const save = async () => {
-    const doses = draft.vaccineCourseDoses ?? [];
-
     const agesAreInOrder = doses.every((dose, index, doses) => {
       const prevDoseAge = doses[index - 1]?.minAgeMonths ?? -0.01;
       return dose.minAgeMonths > prevDoseAge;
@@ -128,7 +134,11 @@ export const VaccineCourseEditModal: FC<VaccineCourseEditModalProps> = ({
 
     for (const dose of doses) {
       if (dose.minAgeMonths > dose.maxAgeMonths) {
-        error(t('error.dose-max-lower-than-min', { label: dose.label }))();
+        error(
+          t('error.dose-max-lower-than-min', {
+            doseIndex: doseIndex(doses, dose),
+          })
+        )();
         return;
       }
     }
@@ -206,7 +216,7 @@ export const VaccineCourseEditModal: FC<VaccineCourseEditModalProps> = ({
         </Row>
         <VaccineCourseDoseTable
           courseName={draft.name}
-          doses={draft.vaccineCourseDoses ?? []}
+          doses={doses}
           updatePatch={updatePatch}
         />
       </Container>
@@ -291,7 +301,7 @@ const VaccineCourseDoseTable = ({
         Cell: NumberCell,
         width: 80,
         label: 'label.dose-number',
-        accessor: ({ rowData }) => doses.indexOf(rowData) + 1,
+        accessor: ({ rowData }) => doseIndex(doses, rowData),
       },
       {
         key: 'label',

--- a/client/packages/programs/src/VaccineCourseEditModal/VaccineCourseEditModal.tsx
+++ b/client/packages/programs/src/VaccineCourseEditModal/VaccineCourseEditModal.tsx
@@ -114,16 +114,23 @@ export const VaccineCourseEditModal: FC<VaccineCourseEditModalProps> = ({
   };
 
   const save = async () => {
-    const agesAreInOrder = (draft.vaccineCourseDoses ?? []).every(
-      (dose, index, doses) => {
-        const prevDoseAge = doses[index - 1]?.minAgeMonths ?? -0.01;
-        return dose.minAgeMonths > prevDoseAge;
-      }
-    );
+    const doses = draft.vaccineCourseDoses ?? [];
+
+    const agesAreInOrder = doses.every((dose, index, doses) => {
+      const prevDoseAge = doses[index - 1]?.minAgeMonths ?? -0.01;
+      return dose.minAgeMonths > prevDoseAge;
+    });
 
     if (!agesAreInOrder) {
       error(t('error.dose-ages-out-of-order'))();
       return;
+    }
+
+    for (const dose of doses) {
+      if (dose.minAgeMonths > dose.maxAgeMonths) {
+        error(t('error.dose-max-lower-than-min', { label: dose.label }))();
+        return;
+      }
     }
 
     try {


### PR DESCRIPTION

Fixes #4884 

# 👩🏻‍💻 What does this PR do?

Adds this validation check before save ("OK")

![image](https://github.com/user-attachments/assets/3c9678db-9235-4cbe-8bea-337cef54b6fd)


## 💌 Any notes for the reviewer?

I could make the other validation nice and indicate which row is nasty.

Will make an issue for renaming the columns Min/Max age to match the errors and flag stakeholders.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] central OMS server
- [ ] Edit program > immunisations
- [ ] Add a dose to a vaccine course
- [ ] Set the "From age" to be greater than the "To age"
- [ ] Press OK - get error
- [ ] Add another dose and make the from age lower than the first dose's
- [ ] Press OK - get the other error  

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

