### PR TITLE
6637 fix date translations

### DIFF
--- a/client/packages/common/src/intl/context/IntlContext.tsx
+++ b/client/packages/common/src/intl/context/IntlContext.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren } from 'react';
+import React, { PropsWithChildren } from 'react';
 import i18next from 'i18next';
 import Backend from 'i18next-chained-backend';
 import LocalStorageBackend from 'i18next-localstorage-backend';
@@ -14,86 +14,80 @@ const appVersion = require('../../../../../../package.json').version; // eslint-
 declare const LANG_VERSION: string;
 
 const defaultNS = 'common';
+const minuteInMilliseconds = 60 * 1000;
+const isDevelopment = process.env['NODE_ENV'] === 'development';
+const expirationTime = isDevelopment ? 0 : 7 * 24 * 60 * minuteInMilliseconds; // Cache for 7 days, on rebuild we should get a new language version so we can use a reasonably long cache
 
-type IntlProviderProps = PropsWithChildren<{ isElectron?: boolean }>;
+const languageVersion =
+  typeof LANG_VERSION === 'undefined' ? appVersion : LANG_VERSION;
+
+/** Must be initialised outside of react */
+export function initialiseI18n({
+  isElectron = false,
+}: {
+  isElectron?: boolean;
+} = {}) {
+  const languageDetector = new LanguageDetector();
+  languageDetector.addDetector(browserLanguageDetector);
+
+  // Electron `main` window translations should be served with relative path
+  const loadPath = `${!!isElectron ? '.' : ''}/locales/{{lng}}/{{ns}}.json`;
+
+  i18next
+    .use(initReactI18next) // passes i18n down to react-i18next
+    .use(Backend)
+    .use(languageDetector)
+    .init({
+      backend: {
+        backends: [
+          LocalStorageBackend, // primary backend
+          HttpApi, // fallback backend
+        ],
+        backendOptions: [
+          {
+            /* options for primary backend */
+            expirationTime,
+            defaultVersion: 'v0.1',
+            versions: {
+              en: languageVersion,
+            },
+          },
+          {
+            /* options for secondary backend */
+            loadPath,
+          },
+        ],
+      },
+      debug: isDevelopment,
+      defaultNS,
+      detection: {
+        order: [
+          'querystring',
+          'cookie',
+          'localStorage',
+          'sessionStorage',
+          'omsBrowserLanguageDetector',
+          'htmlTag',
+        ],
+      },
+
+      ns: defaultNS, // behaving as I expect defaultNS should. Without specifying ns here, a request is made to 'translation.json'
+      fallbackLng: 'en',
+      fallbackNS: 'common',
+      // the following option was used to assist the browser language detection; but it prevents regional variations, so has been removed
+      // load: 'languageOnly', // if requested language is 'en-US' then we load 'en'; change to the default value of 'all' to load 'en-US' and 'en'
+      interpolation: {
+        escapeValue: false, // not needed for react!!
+      },
+    });
+}
 
 export const IntlContext = createRegisteredContext<I18nextProviderProps>(
   'i18nextProvider',
   { i18n: i18next }
 );
 
-export const IntlProvider: FC<IntlProviderProps> = ({
-  isElectron,
-  children,
-}) => {
-  React.useEffect(() => {
-    if (i18next.isInitialized) return;
-
-    const languageDetector = new LanguageDetector();
-    languageDetector.addDetector(browserLanguageDetector);
-
-    const minuteInMilliseconds = 60 * 1000;
-    const isDevelopment = process.env['NODE_ENV'] === 'development';
-    const expirationTime = isDevelopment
-      ? 0
-      : 7 * 24 * 60 * minuteInMilliseconds; // Cache for 7 days, on rebuild we should get a new language version so we can use a reasonably long cache
-
-    const languageVersion =
-      typeof LANG_VERSION === 'undefined' ? appVersion : LANG_VERSION;
-
-    // Electron `main` window translations should be served with relative path
-    const loadPath = `${!!isElectron ? '.' : ''}/locales/{{lng}}/{{ns}}.json`;
-
-    i18next
-      .use(initReactI18next) // passes i18n down to react-i18next
-      .use(Backend)
-      .use(languageDetector)
-      .init({
-        backend: {
-          backends: [
-            LocalStorageBackend, // primary backend
-            HttpApi, // fallback backend
-          ],
-          backendOptions: [
-            {
-              /* options for primary backend */
-              expirationTime,
-              defaultVersion: 'v0.1',
-              versions: {
-                en: languageVersion,
-              },
-            },
-            {
-              /* options for secondary backend */
-              loadPath,
-            },
-          ],
-        },
-        debug: isDevelopment,
-        defaultNS,
-        detection: {
-          order: [
-            'querystring',
-            'cookie',
-            'localStorage',
-            'sessionStorage',
-            'omsBrowserLanguageDetector',
-            'htmlTag',
-          ],
-        },
-
-        ns: defaultNS, // behaving as I expect defaultNS should. Without specifying ns here, a request is made to 'translation.json'
-        fallbackLng: 'en',
-        fallbackNS: 'common',
-        // the following option was used to assist the browser language detection; but it prevents regional variations, so has been removed
-        // load: 'languageOnly', // if requested language is 'en-US' then we load 'en'; change to the default value of 'all' to load 'en-US' and 'en'
-        interpolation: {
-          escapeValue: false, // not needed for react!!
-        },
-      });
-    console.info(`i18next initialized, language=${i18next.language}`);
-  }, []);
-
+export const IntlProvider = ({ children }: PropsWithChildren) => {
   return (
     <IntlContext.Provider value={{ i18n: i18next }}>
       {children}

--- a/client/packages/electron/src/home.tsx
+++ b/client/packages/electron/src/home.tsx
@@ -4,6 +4,7 @@ import '@fontsource-variable/inter';
 import {
   AppThemeProvider,
   HashRouter,
+  initialiseI18n,
   IntlProvider,
   QueryClient,
   QueryClientProvider,
@@ -15,9 +16,11 @@ import {
 import { Viewport } from '@openmsupply-client/host/src/components';
 import { ErrorPage } from './error';
 
+initialiseI18n({ isElectron: true });
+
 const ClientHomeScreen = () => (
   <React.Suspense fallback={<div />}>
-    <IntlProvider isElectron={true}>
+    <IntlProvider>
       <React.Suspense fallback={<RandomLoader />}>
         <AppThemeProvider>
           <QueryClientProvider client={new QueryClient()}>

--- a/client/packages/host/src/Host.tsx
+++ b/client/packages/host/src/Host.tsx
@@ -23,6 +23,7 @@ import {
   createBrowserRouter,
   createRoutesFromElements,
   RouterProvider,
+  initialiseI18n,
 } from '@openmsupply-client/common';
 import { AppRoute, Environment } from '@openmsupply-client/config';
 import { Initialise, Login, Viewport } from './components';
@@ -107,6 +108,8 @@ const router = createBrowserRouter(
     />
   )
 );
+
+initialiseI18n();
 
 const Host = () => (
   <React.Suspense fallback={<div />}>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6637

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Initialises the i18n-next singleton outside of React, as intended usage. 

It's initialisation doesn't trigger a re-render, it's only because child components are re-rendering/querying the Intl context again that they end up with updated values. Higher in the component tree = higher risk that it is not initialised when you are first rendered.


This was the case with getting language settings in time to configure date translations. I wonder if this was also the actual cause of that translation keys on the discovery page bug?

Months now translated
<img width="208" alt="Screenshot 2025-02-28 at 10 29 55 AM" src="https://github.com/user-attachments/assets/1c5bcd17-2762-4dfc-a67d-ebc66d6e241f" />


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Set language to something other than english, e.g. french
- [ ] Open date picker (e.g. stock expiry date filter)
- [ ] Months are in selected language 
- [ ] Given translation set up has changed please double check discovery page on electron (desktop app) is also translated!

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [x] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [x] Frontend

