### PR TITLE
6160 disable patient save while fields required

### DIFF
--- a/client/packages/system/src/Patient/PatientView/PatientView.tsx
+++ b/client/packages/system/src/Patient/PatientView/PatientView.tsx
@@ -146,6 +146,7 @@ const PatientDetailView = ({
           address1: createNewPatient.address1,
           isDeceased: createNewPatient.isDeceased,
           dateOfDeath: createNewPatient.dateOfDeath,
+          extension: {},
         },
         isCreating: true,
       };
@@ -173,6 +174,7 @@ const PatientDetailView = ({
                   name: currentPatient.nextOfKinName ?? undefined,
                 }
               : undefined,
+          extension: {},
         },
         isCreating: false,
       };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6160

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Disable Save button while required fields rendered:

<img width="714" alt="Screenshot 2025-02-28 at 4 26 38 PM" src="https://github.com/user-attachments/assets/2a8cbc2d-3935-4749-8bca-d223505842fd" />

This adds extension to the new patient documents, which allows the validation of custom fields before save/correct rendering of the errors under the fields. 

I think the issue was actually poorly configured JSON schema, can't seem to replicate error text showing but save but enabled now. 


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Upload patient schema to OG document registry, which has required fields. Example below
- [ ] Create new patient
- [ ] Both nationality and patient id show an error, save button is disabled
- [ ] It enables when filled out

### TEST SCHEMA:
data: [required-test.json](https://github.com/user-attachments/files/19020192/test.json)
ui: [required-test-ui.json](https://github.com/user-attachments/files/19020194/test.json)



# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

