### PR TITLE
6527 change test config default search location

### DIFF
--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -582,7 +582,7 @@ async fn main() -> anyhow::Result<()> {
             let test_config_path = if let Some(config) = config {
                 config
             } else {
-                Path::new("reports").to_path_buf()
+                Path::new("../standard_reports").to_path_buf()
             };
 
             let test_config_file = fs::File::open(test_config_path.join("test-config.json"))


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6527 

# 👩🏻‍💻 What does this PR do?

Fixes `show-report` cli command where test-config file was moved in restructure.
Now looks in the correct place.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?



# 🧪 Testing

You can test this report by trying to show a report with the show command using default test-config file location :

For example:

`cargo build && ./target/debug/remote_server_cli show-report --path ~"/Documents/GitHub/open-msupply-reports/clients/Ivory-Coast/satisfaction_per_program/2_6_0"` 

Where the relative location of the report repo may differ.

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

