### PR TITLE
#6706 Make prescription date filtering consistent with date shown in table

### DIFF
--- a/client/packages/invoices/src/Prescriptions/ListView/ListView.tsx
+++ b/client/packages/invoices/src/Prescriptions/ListView/ListView.tsx
@@ -48,7 +48,7 @@ const PrescriptionListViewComponent: FC = () => {
       { key: 'otherPartyName' },
       { key: 'invoiceNumber', condition: 'equalTo', isNumber: true },
       {
-        key: 'pickedDatetime',
+        key: 'createdOrBackdatedDatetime',
         condition: 'between',
       },
       {

--- a/client/packages/invoices/src/Prescriptions/ListView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/ListView/Toolbar.tsx
@@ -60,14 +60,14 @@ export const Toolbar: FC<{ filter: FilterController }> = () => {
                 {
                   type: 'date',
                   name: t('label.from-date'),
-                  urlParameter: 'pickedDatetime',
+                  urlParameter: 'createdOrBackdatedDatetime',
                   range: 'from',
                   isDefault: true,
                 },
                 {
                   type: 'date',
                   name: t('label.to-date'),
-                  urlParameter: 'pickedDatetime',
+                  urlParameter: 'createdOrBackdatedDatetime',
                   range: 'to',
                   isDefault: true,
                 },

--- a/server/graphql/invoice/src/invoice_queries.rs
+++ b/server/graphql/invoice/src/invoice_queries.rs
@@ -90,6 +90,7 @@ pub struct InvoiceFilterInput {
     pub shipped_datetime: Option<DatetimeFilterInput>,
     pub delivered_datetime: Option<DatetimeFilterInput>,
     pub verified_datetime: Option<DatetimeFilterInput>,
+    pub created_or_backdated_datetime: Option<DatetimeFilterInput>,
     pub colour: Option<EqualFilterStringInput>,
     pub requisition_id: Option<EqualFilterStringInput>,
     pub linked_invoice_id: Option<EqualFilterStringInput>,
@@ -222,6 +223,9 @@ impl InvoiceFilterInput {
             shipped_datetime: self.shipped_datetime.map(DatetimeFilter::from),
             delivered_datetime: self.delivered_datetime.map(DatetimeFilter::from),
             verified_datetime: self.verified_datetime.map(DatetimeFilter::from),
+            created_or_backdated_datetime: self
+                .created_or_backdated_datetime
+                .map(DatetimeFilter::from),
             colour: self.colour.map(EqualFilter::from),
             requisition_id: self.requisition_id.map(EqualFilter::from),
             linked_invoice_id: self.linked_invoice_id.map(EqualFilter::from),

--- a/server/repository/src/db_diesel/invoice.rs
+++ b/server/repository/src/db_diesel/invoice.rs
@@ -49,6 +49,7 @@ pub struct InvoiceFilter {
     pub shipped_datetime: Option<DatetimeFilter>,
     pub delivered_datetime: Option<DatetimeFilter>,
     pub verified_datetime: Option<DatetimeFilter>,
+    pub created_or_backdated_datetime: Option<DatetimeFilter>,
     pub colour: Option<EqualFilter<String>>,
     pub requisition_id: Option<EqualFilter<String>>,
     pub linked_invoice_id: Option<EqualFilter<String>>,
@@ -243,6 +244,7 @@ fn create_filtered_query(filter: Option<InvoiceFilter>) -> BoxedInvoiceQuery {
             shipped_datetime,
             delivered_datetime,
             verified_datetime,
+            created_or_backdated_datetime,
             colour,
             requisition_id,
             linked_invoice_id,
@@ -277,6 +279,11 @@ fn create_filtered_query(filter: Option<InvoiceFilter>) -> BoxedInvoiceQuery {
         apply_date_time_filter!(query, shipped_datetime, invoice::shipped_datetime);
         apply_date_time_filter!(query, delivered_datetime, invoice::delivered_datetime);
         apply_date_time_filter!(query, verified_datetime, invoice::verified_datetime);
+        apply_date_time_filter!(
+            query,
+            created_or_backdated_datetime,
+            datetime_coalesce::coalesce(invoice::backdated_datetime, invoice::created_datetime)
+        );
 
         if let Some(stock_line_id) = stock_line_id {
             let invoice_line_query = invoice_line::table


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6706

# 👩🏻‍💻 What does this PR do?

- Added a new input field to the Invoice filter (createdOrBackdatedDatetime) to explicitly filter by this field (which is what the front-end is showing in the table
- Update front-end filters to use this field when filtering by date

## 💌 Any notes for the reviewer?

Considered doing some more complex logic in back-end, but after discussion with @jmbrunskill this was considered the simplest way to fix the immediate bug.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [x] Go to the Prescriptions list
- [x] Make sure there are some "New" prescriptions
- [x] Change the date filter such that at least some of the New prescriptions should appear
- [x] Confirm they do (and all the other prescriptions are filtered correctly too)

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [x] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [x] Postgres
- [x] SQLite
- [x] Frontend

