### PR TITLE
6768 labels undefined clinician and trunc

### DIFF
--- a/client/packages/invoices/src/Prescriptions/DetailView/hooks/utils.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/hooks/utils.tsx
@@ -56,7 +56,9 @@ export const generateLabel = (
   prescription: PrescriptionRowFragment,
   store: string
 ): Label[] => {
-  const clinicianDetails = `- ${prescription.clinician?.lastName}, ${prescription.clinician?.firstName}`;
+  const clinicianDetails = prescription.clinician
+    ? ` - ${prescription.clinician.lastName}, ${prescription.clinician.firstName}`
+    : '';
   const patientDetails = `${prescription.patient?.name} - ${prescription.patient?.code}`;
 
   return results.map((result: ItemDetails): Label => {
@@ -66,7 +68,7 @@ export const generateLabel = (
       itemDetails: itemDetails,
       itemDirections: result.itemDirections,
       patientDetails: patientDetails,
-      details: `${store} - ${new Date(prescription.createdDatetime).toLocaleDateString()} ${clinicianDetails}`,
+      details: `${store} - ${new Date(prescription.createdDatetime).toLocaleDateString()}${clinicianDetails}`,
     };
     return finishedLabel;
   });

--- a/server/service/src/print/label.rs
+++ b/server/service/src/print/label.rs
@@ -79,26 +79,26 @@ pub fn print_prescription_label(
                 ^CI28
 
                 ^A0,25
-                ^FO10,10
-                ^FB570,2,0,C
+                ^FO5,10
+                ^FB550,2,0,C
                 ^FD{item_details}\&^FS
 
                 ^FX Line
-                ^FO10,65
+                ^FO5,65
                 ^GB570,2,2^FS
 
                 ^A0,25
-                ^FO10,75
-                ^FB570,5,0,L
+                ^FO5,75
+                ^FB550,5,0,L
                 ^FD{item_directions}\&{warning}\&^FS
 
                 ^FX Line
-                ^FO10,210
+                ^FO5,210
                 ^GB570,2,2^FS
 
                 ^A0,20
-                ^FO10,220
-                ^FB570,3,0,C
+                ^FO5,220
+                ^FB550,3,0,C
                 ^FD{patient_details}\&{details}\&^FS
 
                 ^XZ

--- a/server/service/src/print/label.rs
+++ b/server/service/src/print/label.rs
@@ -89,16 +89,16 @@ pub fn print_prescription_label(
 
                 ^A0,25
                 ^FO10,75
-                ^FB570,6,0,L
+                ^FB570,5,0,L
                 ^FD{item_directions}\&{warning}\&^FS
 
                 ^FX Line
-                ^FO10,180
+                ^FO10,210
                 ^GB570,2,2^FS
 
                 ^A0,20
-                ^FO10,195
-                ^FB570,2,0,C
+                ^FO10,220
+                ^FB570,3,0,C
                 ^FD{patient_details}\&{details}\&^FS
 
                 ^XZ

--- a/server/service/src/print/label.rs
+++ b/server/service/src/print/label.rs
@@ -52,7 +52,8 @@ pub struct PrescriptionLabelData {
     item_details: String, // usually the amount of units + the item name e.g. "10Tabs Paracetamol 500mg Tablets"
     item_directions: String,
     patient_details: String, // e.g patient name, possibly code etc.
-    warning: Option<String>, // Some items come with a defined warning (OG field "Message") that should be printed on all labels regardless of directions e.g. avoid sun exposure, avoid alcohol...
+    #[allow(dead_code)] // Warnings will come in the future... this API will likely change!
+    warning: Option<String>, // Some items come with a defined warning that should be printed on all labels regardless of directions e.g. avoid sun exposure, avoid alcohol...
     details: String, // General details to include e.g. store name, prescriber name, date/time...
 }
 
@@ -67,10 +68,9 @@ pub fn print_prescription_label(
                 item_details,
                 item_directions,
                 patient_details,
-                warning,
+                warning: _,
                 details,
             } = d;
-            let warning = warning.unwrap_or_default();
             format!(
                 r#"
                 ^XA
@@ -79,26 +79,26 @@ pub fn print_prescription_label(
                 ^CI28
 
                 ^A0,25
-                ^FO5,10
-                ^FB550,2,0,C
+                ^FO,10
+                ^FB575,3,0,C
                 ^FD{item_details}\&^FS
 
                 ^FX Line
-                ^FO5,65
-                ^GB570,2,2^FS
+                ^FO,65
+                ^GB575,2,2^FS
 
                 ^A0,25
-                ^FO5,75
-                ^FB550,5,0,L
-                ^FD{item_directions}\&{warning}\&^FS
+                ^FO,75
+                ^TB,575,125
+                ^FD{item_directions}^FS
 
                 ^FX Line
-                ^FO5,210
-                ^GB570,2,2^FS
+                ^FO,210
+                ^GB575,2,2^FS
 
                 ^A0,20
-                ^FO5,220
-                ^FB550,3,0,C
+                ^FO,220
+                ^FB575,3,0,C
                 ^FD{patient_details}\&{details}\&^FS
 
                 ^XZ

--- a/server/service/src/print/label.rs
+++ b/server/service/src/print/label.rs
@@ -81,26 +81,26 @@ pub fn print_prescription_label(
                 ^A0,25
                 ^FO10,10
                 ^FB570,2,0,C
-                ^FD{item_details}^FS
+                ^FD{item_details}\&^FS
 
+                ^FX Line
                 ^FO10,65
                 ^GB570,2,2^FS
 
                 ^A0,25
                 ^FO10,75
                 ^FB570,6,0,L
-                ^FD{item_directions}\&{warning}^FS
+                ^FD{item_directions}\&{warning}\&^FS
 
-                ^FO10,210
+                ^FX Line
+                ^FO10,180
                 ^GB570,2,2^FS
 
-                ^A0,25
-                ^FO10,220
-                ^FD{patient_details}^FS
+                ^A0,20
+                ^FO10,195
+                ^FB570,2,0,C
+                ^FD{patient_details}\&{details}\&^FS
 
-                ^A0,25
-                ^FO10,250
-                ^FD{details}^FS
                 ^XZ
                 "#
             )


### PR DESCRIPTION
Fixes #6768 

# 👩🏻‍💻 What does this PR do?

- Only print clinician if it exists
- 3 lines for details, 5 line for item directions+warning
- Some layout tweaks

Gist of the layout as per rendering on Labelary previewer:
![image](https://github.com/user-attachments/assets/61b5cf92-115c-4cc4-8def-c9b4b717d791)

A crude example of what that might look like (just duplicated field content on FE):

![20250303_144845](https://github.com/user-attachments/assets/176e9ca3-15a3-409a-89c9-64871834a9a1)



## 💌 Any notes for the reviewer?

# 🧪 Testing

- [ ] Print some labels with clinician. Looks good
- [ ] Print some labels without clinician. Looks good

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [x] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

