### PR TITLE
6784 report arguments selected program is not repopulated

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteWithPagination.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteWithPagination.tsx
@@ -93,7 +93,7 @@ export function AutocompleteWithPagination<T extends RecordWithId>({
     lastOptions.current = newOptions;
 
     return newOptions;
-  }, [pages]);
+  }, [pages, value]);
 
   const defaultRenderInput = (props: AutocompleteRenderInputParams) => (
     <BasicTextInput

--- a/client/packages/programs/src/Components/PatientProgramSearchInput.tsx
+++ b/client/packages/programs/src/Components/PatientProgramSearchInput.tsx
@@ -6,11 +6,15 @@ import { useDocumentRegistry } from '../api';
 type PatientProgramSearchInputProps = {
   value: DocumentRegistryFragment | null;
   onChange: (newProgram: DocumentRegistryFragment) => void;
+  setProgram: (newProgram: DocumentRegistryFragment) => void;
+  programId: string | null;
 };
 
 export const PatientProgramSearchInput = ({
   value,
   onChange,
+  setProgram,
+  programId,
 }: PatientProgramSearchInputProps) => {
   const { data, isLoading } = useDocumentRegistry.get.programRegistries();
 
@@ -20,6 +24,13 @@ export const PatientProgramSearchInput = ({
       onChange(data.nodes[0]!); // if length is 1, the first element must exist
     }
   }, [data?.nodes.length]);
+
+  if (programId && !value) {
+    const program = data?.nodes.find(program => program.id === programId);
+    if (program) {
+      setProgram(program);
+    }
+  }
 
   return (
     <Autocomplete

--- a/client/packages/programs/src/JsonForms/components/PatientProgramSearch.tsx
+++ b/client/packages/programs/src/JsonForms/components/PatientProgramSearch.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { rankWith, ControlProps, uiTypeIs } from '@jsonforms/core';
-import { withJsonFormsControlProps } from '@jsonforms/react';
-import { Box, DetailInputWithLabelRow } from '@openmsupply-client/common';
+import { useJsonForms, withJsonFormsControlProps } from '@jsonforms/react';
+import {
+  Box,
+  DetailInputWithLabelRow,
+  extractProperty,
+} from '@openmsupply-client/common';
 import { DefaultFormRowSx, FORM_GAP, FORM_LABEL_WIDTH } from '../common';
 import { PatientProgramSearchInput } from '../../Components';
 import { DocumentRegistryFragment } from '../../api';
@@ -13,10 +17,12 @@ export const patientProgramSearchTester = rankWith(
 
 const UIComponent = (props: ControlProps) => {
   const { handleChange, label, path } = props;
+  const { core } = useJsonForms();
 
   const [program, setProgram] = React.useState<DocumentRegistryFragment | null>(
     null
   );
+  const programId = extractProperty(core?.data, 'programId');
 
   const onChangeProgram = async (program: DocumentRegistryFragment) => {
     setProgram(program);
@@ -34,6 +40,8 @@ const UIComponent = (props: ControlProps) => {
           <PatientProgramSearchInput
             onChange={onChangeProgram}
             value={program}
+            programId={programId}
+            setProgram={setProgram}
           />
         </Box>
       }

--- a/client/packages/programs/src/JsonForms/components/PeriodSearch.tsx
+++ b/client/packages/programs/src/JsonForms/components/PeriodSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { rankWith, ControlProps, uiTypeIs } from '@jsonforms/core';
 import { z } from 'zod';
 import {
@@ -31,8 +31,9 @@ const UIComponent = (props: ControlProps) => {
   const programId = options?.findByProgram
     ? extractProperty(core?.data, 'programId')
     : null;
+
   const today = new Date();
-  const { data, isFetching, fetchNextPage } = usePeriodList(
+  const { data, isFetching, fetchNextPage, isRefetching } = usePeriodList(
     RECORDS_PER_PAGE,
     programId,
     options?.findByProgram ? !!programId : true,
@@ -42,16 +43,21 @@ const UIComponent = (props: ControlProps) => {
       },
     }
   );
-  const periodId = extractProperty(core?.data, 'periodId');
 
-  if (periodId && !period) {
-    const period = data?.pages
-      ?.find(page => page.data.nodes.some(period => period.id === periodId))
-      ?.data.nodes.find(period => period.id === periodId);
-    if (period) {
-      setPeriod(period);
+  const periodId = extractProperty(core?.data, 'periodId');
+  useMemo(() => {
+    if (periodId && !period) {
+      const period = data?.pages
+        ?.find(page => page.data.nodes.some(period => period.id === periodId))
+        ?.data.nodes.find(period => period.id === periodId);
+      if (period) {
+        setPeriod(period);
+      }
     }
-  }
+    if (isRefetching) {
+      setPeriod(null);
+    }
+  }, [periodId, period, data, isRefetching]);
 
   const pageNumber = data?.pages?.length
     ? (data.pages[data.pages.length - 1]?.pageNumber ?? 0)

--- a/client/packages/programs/src/JsonForms/components/PeriodSearch.tsx
+++ b/client/packages/programs/src/JsonForms/components/PeriodSearch.tsx
@@ -42,6 +42,16 @@ const UIComponent = (props: ControlProps) => {
       },
     }
   );
+  const periodId = extractProperty(core?.data, 'periodId');
+
+  if (periodId && !period) {
+    const period = data?.pages
+      ?.find(page => page.data.nodes.some(period => period.id === periodId))
+      ?.data.nodes.find(period => period.id === periodId);
+    if (period) {
+      setPeriod(period);
+    }
+  }
 
   const pageNumber = data?.pages?.length
     ? (data.pages[data.pages.length - 1]?.pageNumber ?? 0)

--- a/client/packages/programs/src/JsonForms/components/ProgramSearch.tsx
+++ b/client/packages/programs/src/JsonForms/components/ProgramSearch.tsx
@@ -3,6 +3,7 @@ import { rankWith, ControlProps, uiTypeIs } from '@jsonforms/core';
 import {
   Autocomplete,
   DetailInputWithLabelRow,
+  extractProperty,
   Typography,
 } from '@openmsupply-client/common';
 import {
@@ -11,7 +12,7 @@ import {
   useZodOptionsValidation,
 } from '../common';
 import { ProgramFragment, useProgramList } from '../../api';
-import { withJsonFormsControlProps } from '@jsonforms/react';
+import { useJsonForms, withJsonFormsControlProps } from '@jsonforms/react';
 import { z } from 'zod';
 
 export const programSearchTester = rankWith(10, uiTypeIs('ProgramSearch'));
@@ -29,10 +30,12 @@ const UIComponent = (props: ControlProps) => {
   );
 
   const { handleChange, label, path } = props;
+  const { core } = useJsonForms();
   const { data, isLoading } = useProgramList({
     isImmunisation: props.uischema.options?.['programType'] === 'immunisation',
   });
   const [program, setProgram] = useState<ProgramFragment | null>(null);
+  const programId = extractProperty(core?.data, 'programId');
 
   const onChange = async (program: ProgramFragment) => {
     setProgram(program);
@@ -40,7 +43,15 @@ const UIComponent = (props: ControlProps) => {
     handleChange('elmisCode', program.elmisCode);
   };
 
+  if (programId && !program) {
+    const program = data?.nodes.find(program => program.id === programId);
+    if (program) {
+      setProgram(program);
+    }
+  }
+
   if (zErrors) return <Typography color="error">{zErrors}</Typography>;
+  console.log('program', program);
 
   return (
     <DetailInputWithLabelRow

--- a/client/packages/programs/src/JsonForms/components/ProgramSearch.tsx
+++ b/client/packages/programs/src/JsonForms/components/ProgramSearch.tsx
@@ -51,7 +51,6 @@ const UIComponent = (props: ControlProps) => {
   }
 
   if (zErrors) return <Typography color="error">{zErrors}</Typography>;
-  console.log('program', program);
 
   return (
     <DetailInputWithLabelRow

--- a/client/packages/programs/src/JsonForms/components/ProgramSearch.tsx
+++ b/client/packages/programs/src/JsonForms/components/ProgramSearch.tsx
@@ -40,7 +40,7 @@ const UIComponent = (props: ControlProps) => {
   const onChange = async (program: ProgramFragment) => {
     setProgram(program);
     handleChange(path, program.id);
-    handleChange('elmisCode', program.elmisCode);
+    handleChange('elmisCode', program.elmisCode ?? '');
   };
 
   if (programId && !program) {

--- a/client/packages/programs/src/api/hooks/usePeriodList.ts
+++ b/client/packages/programs/src/api/hooks/usePeriodList.ts
@@ -14,7 +14,7 @@ export const usePeriodList = (
 ) => {
   const { api, storeId } = useProgramsGraphQL();
 
-  const queryKey = [PERIOD, LIST];
+  const queryKey = [PERIOD, LIST, programId];
   const queryFn = async ({
     pageParam,
   }: {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6784 & Fixes #6760

# 👩🏻‍💻 What does this PR do?
Retain program/period information when re-filtering 

https://github.com/user-attachments/assets/61c12fa1-1524-4486-8f23-6819feec35de

Also fixes periods not loading correctly

https://github.com/user-attachments/assets/33a34ee2-a977-4b2e-80ef-2136b1406811




# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to a report that has program or period filtering
- [ ] Select a program/period
- [ ] Wait for report to load, then click filter at the top of the report page
- [ ] Should see information retained
- [ ] Have different periods for each program
- [ ] Change between programs and check that periods are loading correctly

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

