### PR TITLE
6772 Save changes on patient

### DIFF
--- a/client/packages/system/src/Patient/PatientView/PatientView.tsx
+++ b/client/packages/system/src/Patient/PatientView/PatientView.tsx
@@ -216,7 +216,10 @@ const PatientDetailView = ({
           const patientData = data as PatientSchema;
           const newData = Object.fromEntries(
             Object.entries(data ?? {}).filter(
-              ([key]) => key !== 'dateOfBirthIsEstimated' && key !== 'nextOfKin'
+              ([key]) =>
+                key !== 'dateOfBirthIsEstimated' &&
+                key !== 'nextOfKin' &&
+                key !== 'extension'
             )
           );
           // map nextOfKin object to individual fields


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6772, #6774 

# 👩🏻‍💻 What does this PR do?

Aligns the saved data structure with the schema so that it can save correctly

The user can add next of kin, edit phone, address etc to a fetched patient and it will save with the new information

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

There was a comment in issue #6772 about no space between the code and hyphen in the next of kin dropdown. I had a look to fix this but was not an obvious/related fix. Probably best as a separate issue!
![Screenshot 2025-03-04 at 12 55 00 PM](https://github.com/user-attachments/assets/f6f5c225-a099-448c-a823-a38284607f47)

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have at least one patient in OMS, take note of the name
- [ ] Create a new patient in OG, add detail such as a phone number
- [ ] Create a new patient in OMS -> enter the same first and last name as OG -> Ok
- [ ] See matching patient -> fetch -> Ok
- [ ] In `Next of Kin`, enter the name of the existing OMS patient from step 1 and select them from the dropdown
- [ ] Change the phone number, add an address etc
- [ ] Save -> See success notification
- [ ] Navigate away and then go back to the patient -> the next of kin and updated details should all be saved!

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

