### PR TITLE
#6792 #6815 Re-shuffle Prescription Toolbar and Sidebar items

### DIFF
--- a/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/PrescriptionDetailsSection.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/PrescriptionDetailsSection.tsx
@@ -8,17 +8,10 @@ import {
   BasicTextInput,
   useDebouncedValueCallback,
   useConfirmationModal,
-  DateTimePickerInput,
-  DateUtils,
-  Formatter,
 } from '@openmsupply-client/common';
-import { usePrescription, usePrescriptionLines } from '../../api';
-import {
-  Clinician,
-  ClinicianSearchInput,
-  ProgramSearchInput,
-} from '@openmsupply-client/system';
+import { ProgramSearchInput } from '@openmsupply-client/system';
 import { ProgramFragment, useProgramList } from '@openmsupply-client/programs';
+import { usePrescription, usePrescriptionLines } from '../../api';
 
 export const PrescriptionDetailsSectionComponent: FC = () => {
   const t = useTranslation();
@@ -30,14 +23,7 @@ export const PrescriptionDetailsSectionComponent: FC = () => {
     rows: items,
   } = usePrescription();
 
-  const {
-    id,
-    clinician,
-    prescriptionDate,
-    createdDatetime,
-    programId,
-    theirReference,
-  } = data ?? {};
+  const { id, createdDatetime, programId, theirReference } = data ?? {};
 
   const deleteAll = () => {
     const allRows = (items ?? []).map(({ lines }) => lines.flat()).flat() ?? [];
@@ -60,16 +46,6 @@ export const PrescriptionDetailsSectionComponent: FC = () => {
     message: t('messages.confirm-delete-prescription-lines'),
   });
 
-  const [clinicianValue, setClinicianValue] = useState<Clinician | null>(
-    clinician ?? null
-  );
-
-  const [dateValue, setDateValue] = useState(
-    DateUtils.getDateOrNull(prescriptionDate) ??
-      DateUtils.getDateOrNull(createdDatetime) ??
-      null
-  );
-
   const handleProgramChange = async (
     newProgram: ProgramFragment | undefined
   ) => {
@@ -90,46 +66,6 @@ export const PrescriptionDetailsSectionComponent: FC = () => {
     });
   };
 
-  const handleDateChange = async (newPrescriptionDate: Date | null) => {
-    const currentDateValue = dateValue; // Revert to this value if user cancels
-
-    if (!newPrescriptionDate) return;
-    setDateValue(newPrescriptionDate);
-
-    const oldPrescriptionDate = DateUtils.getDateOrNull(dateValue);
-
-    if (
-      newPrescriptionDate.toLocaleDateString() ===
-      oldPrescriptionDate?.toLocaleDateString()
-    )
-      return;
-
-    if (!items || items.length === 0) {
-      // If there are no lines, we can just update the prescription date
-      await update({
-        id,
-        prescriptionDate: Formatter.toIsoString(
-          DateUtils.endOfDayOrNull(newPrescriptionDate)
-        ),
-      });
-      return;
-    }
-
-    // Otherwise, we need to delete all the lines first
-    getConfirmation({
-      onConfirm: async () => {
-        await deleteAll();
-        await update({
-          id,
-          prescriptionDate: Formatter.toIsoString(
-            DateUtils.endOfDayOrNull(newPrescriptionDate)
-          ),
-        });
-      },
-      onCancel: () => setDateValue(currentDateValue),
-    });
-  };
-
   const [theirReferenceInput, setTheirReferenceInput] =
     useState(theirReference);
 
@@ -141,15 +77,8 @@ export const PrescriptionDetailsSectionComponent: FC = () => {
 
   useEffect(() => {
     if (!data) return;
-    const { clinician, theirReference, prescriptionDate, createdDatetime } =
-      data;
-    setClinicianValue(clinician ?? null);
+    const { theirReference } = data;
     setTheirReferenceInput(theirReference);
-    setDateValue(
-      DateUtils.getDateOrNull(prescriptionDate) ??
-        DateUtils.getDateOrNull(createdDatetime) ??
-        null
-    );
   }, [data]);
 
   return (
@@ -164,22 +93,6 @@ export const PrescriptionDetailsSectionComponent: FC = () => {
             onChange={handleProgramChange}
           />
         </PanelRow>
-
-        <PanelRow>
-          <PanelLabel>{t('label.clinician')}</PanelLabel>
-          <ClinicianSearchInput
-            disabled={isDisabled}
-            onChange={async clinician => {
-              setClinicianValue(clinician ? clinician.value : null);
-              update({
-                id,
-                clinicianId: clinician?.value?.id ?? null,
-              });
-            }}
-            clinicianValue={clinicianValue}
-          />
-        </PanelRow>
-
         <PanelRow>
           <PanelLabel>{t('label.reference')}</PanelLabel>
           <BasicTextInput
@@ -191,17 +104,6 @@ export const PrescriptionDetailsSectionComponent: FC = () => {
               setTheirReferenceInput(event.target.value);
               debouncedUpdate({ theirReference: event.target.value });
             }}
-          />
-        </PanelRow>
-
-        <PanelRow>
-          <PanelLabel>{t('label.dispensing-date')}</PanelLabel>
-          <DateTimePickerInput
-            disabled={isDisabled}
-            value={DateUtils.getDateOrNull(dateValue) ?? new Date()}
-            format="P"
-            onChange={handleDateChange}
-            maxDate={new Date()}
           />
         </PanelRow>
       </Grid>

--- a/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
@@ -9,7 +9,11 @@ import {
   DateUtils,
   useConfirmationModal,
 } from '@openmsupply-client/common';
-import { PatientSearchInput } from '@openmsupply-client/system';
+import {
+  Clinician,
+  ClinicianSearchInput,
+  PatientSearchInput,
+} from '@openmsupply-client/system';
 import { usePrescriptionLines } from '../api/hooks/usePrescriptionLines';
 import { usePrescription } from '../api';
 
@@ -20,18 +24,16 @@ export const Toolbar: FC = () => {
     isDisabled,
     rows: items,
   } = usePrescription();
-  const {
-    id,
-    patient,
-    prescriptionDate,
-    createdDatetime,
-    // theirReference,
-  } = data ?? {};
+  const { id, patient, prescriptionDate, createdDatetime, clinician } =
+    data ?? {};
 
   const [dateValue, setDateValue] = useState(
     DateUtils.getDateOrNull(prescriptionDate) ??
       DateUtils.getDateOrNull(createdDatetime) ??
       null
+  );
+  const [clinicianValue, setClinicianValue] = useState<Clinician | null>(
+    clinician ?? null
   );
 
   const {
@@ -45,13 +47,6 @@ export const Toolbar: FC = () => {
   };
 
   const t = useTranslation();
-
-  // const [theirReferenceInput, setTheirReferenceInput] =
-  //   useState(theirReference);
-
-  // const debouncedUpdate = useDebouncedValueCallback(update, [
-  //   theirReferenceInput,
-  // ]);
 
   const getConfirmation = useConfirmationModal({
     title: t('heading.are-you-sure'),
@@ -99,7 +94,9 @@ export const Toolbar: FC = () => {
   };
 
   return (
-    <AppBarContentPortal sx={{ display: 'flex', flex: 1, marginBottom: 1 }}>
+    <AppBarContentPortal
+      sx={{ display: 'flex', flex: 1, marginBottom: 1, gap: 4 }}
+    >
       <Grid container flexDirection="column" display="flex" gap={1}>
         {patient && (
           <InputWithLabelRow
@@ -127,21 +124,24 @@ export const Toolbar: FC = () => {
             />
           }
         />
-        {/* <InputWithLabelRow
-          label={t('label.reference')}
+      </Grid>
+      <Grid container flexDirection="column" display="flex" gap={1}>
+        <InputWithLabelRow
+          label={t('label.clinician')}
           Input={
-            <BasicTextInput
+            <ClinicianSearchInput
               disabled={isDisabled}
-              size="small"
-              sx={{ width: 250 }}
-              value={theirReferenceInput ?? ''}
-              onChange={event => {
-                setTheirReferenceInput(event.target.value);
-                debouncedUpdate({ theirReference: event.target.value });
+              onChange={async clinician => {
+                setClinicianValue(clinician ? clinician.value : null);
+                update({
+                  id,
+                  clinicianId: clinician?.value?.id ?? null,
+                });
               }}
+              clinicianValue={clinicianValue}
             />
           }
-        /> */}
+        />
       </Grid>
     </AppBarContentPortal>
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6792 & #6815

# 👩🏻‍💻 What does this PR do?

For Prescription detail view:
- Moves Clinician back to main Toolbar (from Side Panel)
- Remove "Date" from side panel as it's just a duplicate of the Toolbar one

## 💌 Any notes for the reviewer?

Removed a bit of commented out code that was leftover from recent dispensing changes.


# 🧪 Testing

- [x] Confirm Clinician selector in on main Prescription toolbar, and that functionality remains as expected/previous
- [x] No duplicated Date field in Side panel
- [ ] No more Clinician selector in Side panel


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [x] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [x] Frontend

