### PR TITLE
Remove report changelogs

### DIFF
--- a/server/repository/src/migrations/v2_06_00/report_fix_prescriptions_report_code.rs
+++ b/server/repository/src/migrations/v2_06_00/report_fix_prescriptions_report_code.rs
@@ -4,7 +4,7 @@ pub(crate) struct Migrate;
 
 impl MigrationFragment for Migrate {
     fn identifier(&self) -> &'static str {
-        "report_fix_prescriptions_report_code"
+        "report_fix_prescriptions_report_code_updated"
     }
 
     fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
@@ -14,6 +14,15 @@ impl MigrationFragment for Migrate {
             r#"
             UPDATE report SET code = 'prescription-receipt' WHERE code = 'prescriptions';
             UPDATE report SET id = 'prescription-receipt_2_6_0_false' where id = 'prescriptions_2_6_0_false';
+            "#
+        )?;
+
+        // remove records of report from changelog to make sure we don't have issues trying to sync missing reports
+        // This is safe to do (this time) as we're removing all reports from the system in the reinitialise_reports migration
+        sql!(
+            connection,
+            r#"
+                DELETE FROM changelog WHERE table_name = 'report';
             "#
         )?;
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6824 

# 👩🏻‍💻 What does this PR do?

Removes report changelog records, as there's a risk they could cause issues with sync due to re-initialising reports in the database.

## 💌 Any notes for the reviewer?

This logic should probably be in an updated `reinitialise_reports` migraiton fragment, however there's code in there to add types to postgres which would need to be run conditionally in QA environments so I thought it was better here.

We can possibly get away with not having htis in the release, however I'm not sure if we might have some issues with some 2.5 - 2.6 upgrades? Feels safer to delete I think...

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Install RC7 on your central server
- [ ] Install RC7 on a remote site such as tablet
- [ ] Try to sync tablet, make sure we don't get an error about missing changelog record

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [X] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [X] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

