### PR TITLE
6764 internal orders review

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/CustomerIndicatorInfo.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/CustomerIndicatorInfo.tsx
@@ -18,7 +18,7 @@ import { indicatorColumnNameToLocal } from '../../../utils';
 
 interface CustomerIndicatorInfoProps {
   columns: IndicatorColumnFragment[];
-  customerInfos: CustomerIndicatorInfoFragment[];
+  customerInfos?: CustomerIndicatorInfoFragment[];
 }
 
 const CustomerIndicatorInfo = ({

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
@@ -119,7 +119,8 @@ export const IndicatorLineEdit = ({
   const { store } = useAuthContext();
   const showInfo =
     store?.preferences.useConsumptionAndStockFromCustomersForInternalOrders &&
-    !!currentLine?.customerIndicatorInfo;
+    store?.preferences?.extraFieldsInRequisition;
+  !!currentLine?.customerIndicatorInfo;
   const { width } = useWindowDimensions();
 
   return (

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -79,7 +79,10 @@ export const RequestLineEdit = ({
     store?.preferences?.useConsumptionAndStockFromCustomersForInternalOrders;
   const isNew = !draft?.id;
   const showItemInformation =
-    useConsumptionData && !!draft?.itemInformation && isProgram;
+    useConsumptionData &&
+    !!draft?.itemInformation &&
+    isProgram &&
+    store?.preferences?.extraFieldsInRequisition;
   const itemInformationSorted = draft?.itemInformation
     ?.sort((a, b) => a.name.name.localeCompare(b.name.name))
     .sort((a, b) => b.amcInUnits - a.amcInUnits)

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
@@ -18,6 +18,7 @@ import {
   useFormatDateTime,
   ColumnFormat,
   CurrencyCell,
+  NumUtils,
 } from '@openmsupply-client/common';
 import { getStatusTranslation } from '@openmsupply-client/invoices/src/utils';
 
@@ -99,12 +100,14 @@ const ItemLedgerTable = ({
         label: 'label.unit-quantity',
         sortable: false,
         description: 'description.unit-quantity',
+        accessor: ({ rowData }) => NumUtils.round(rowData.quantity, 2),
       },
 
       {
         key: 'balance',
         label: 'label.balance',
         sortable: false,
+        accessor: ({ rowData }) => NumUtils.round(rowData.balance, 2),
       },
       {
         key: 'costPricePerPack',

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
@@ -50,6 +50,11 @@ const ItemLedgerTable = ({
         sortable: false,
       },
       {
+        key: 'invoiceNumber',
+        label: 'label.invoice-number',
+        sortable: false,
+      },
+      {
         key: 'datetime',
         label: 'label.date',
         format: ColumnFormat.Date,

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
@@ -45,7 +45,7 @@ const ItemLedgerTable = ({
         key: 'type',
         label: 'label.type',
         accessor: ({ rowData }) =>
-          `${t(getInvoiceLocalisationKey(rowData.invoiceType))} #${rowData.invoiceNumber}`,
+          t(getInvoiceLocalisationKey(rowData.invoiceType)),
         sortable: false,
       },
       {

--- a/server/repository/src/db_diesel/indicator_value.rs
+++ b/server/repository/src/db_diesel/indicator_value.rs
@@ -28,6 +28,7 @@ pub struct IndicatorValueFilter {
     pub indicator_column_id: Option<EqualFilter<String>>,
 }
 
+#[derive(Debug)]
 pub struct IndicatorValue {
     pub indicator_value_row: IndicatorValueRow,
     pub name_row: NameRow,

--- a/server/service/src/requisition/common.rs
+++ b/server/service/src/requisition/common.rs
@@ -105,6 +105,7 @@ pub struct CheckExceededOrdersForPeriod<'a> {
     pub max_orders_per_period: i64,
     pub requisition_type: RequisitionType,
     pub other_party_id: Option<&'a str>,
+    pub store_id: &'a str,
 }
 
 pub fn check_exceeded_max_orders_for_period(
@@ -121,6 +122,7 @@ pub fn check_exceeded_max_orders_for_period(
                 .program_id(EqualFilter::equal_to(input.program_id))
                 .order_type(EqualFilter::equal_to(&order_type.name))
                 .period_id(EqualFilter::equal_to(input.period_id))
+                .store_id(EqualFilter::equal_to(&input.store_id))
                 .r#type(input.requisition_type.equal_to());
 
             if let Some(other_party_id) = input.other_party_id {

--- a/server/service/src/requisition/request_requisition/indicator_information.rs
+++ b/server/service/src/requisition/request_requisition/indicator_information.rs
@@ -46,7 +46,8 @@ pub fn get_indicator_information(
         Some(
             NameFilter::new()
                 .supplying_store_id(EqualFilter::equal_to(store_id))
-                .is_customer(true),
+                .is_customer(true)
+                .is_store(true),
         ),
         None,
     )?;

--- a/server/service/src/requisition/request_requisition/insert_program.rs
+++ b/server/service/src/requisition/request_requisition/insert_program.rs
@@ -322,7 +322,6 @@ fn generate_program_indicator_values(
                                 && v.indicator_value_row.indicator_column_id == column.id
                         })
                         .map(|v| {
-                            println!("v: {:?}", v.indicator_value_row);
                             v.indicator_value_row
                                 .value
                                 .parse::<f64>()
@@ -333,7 +332,6 @@ fn generate_program_indicator_values(
                 } else {
                     default_indicator_value(&line.line, &column)
                 };
-                println!("value: {:?}", value);
 
                 let indicator_value = IndicatorValueRow {
                     id: uuid(),

--- a/server/service/src/requisition/request_requisition/insert_program.rs
+++ b/server/service/src/requisition/request_requisition/insert_program.rs
@@ -143,6 +143,7 @@ fn validate(
             program_order_type_id: &input.program_order_type_id,
             max_orders_per_period: i64::from(order_type.order_type.max_order_per_period),
             requisition_type: RequisitionType::Request,
+            store_id: &ctx.store_id,
             other_party_id: None,
         },
     )? {

--- a/server/service/src/requisition/request_requisition/insert_program.rs
+++ b/server/service/src/requisition/request_requisition/insert_program.rs
@@ -267,7 +267,8 @@ fn generate_program_indicator_values(
             Some(
                 NameFilter::new()
                     .supplying_store_id(EqualFilter::equal_to(store_id))
-                    .is_customer(true),
+                    .is_customer(true)
+                    .is_store(true),
             ),
             None,
         )?
@@ -310,6 +311,7 @@ fn generate_program_indicator_values(
                 let value_type = indicator_value_type(&line.line, &column);
                 let value = if store_pref
                     .use_consumption_and_stock_from_customers_for_internal_orders
+                    && store_pref.extra_fields_in_requisition
                     && value_type == &Some(IndicatorValueType::Number)
                     && !customer_name_ids.is_empty()
                 {
@@ -320,6 +322,7 @@ fn generate_program_indicator_values(
                                 && v.indicator_value_row.indicator_column_id == column.id
                         })
                         .map(|v| {
+                            println!("v: {:?}", v.indicator_value_row);
                             v.indicator_value_row
                                 .value
                                 .parse::<f64>()
@@ -330,6 +333,7 @@ fn generate_program_indicator_values(
                 } else {
                     default_indicator_value(&line.line, &column)
                 };
+                println!("value: {:?}", value);
 
                 let indicator_value = IndicatorValueRow {
                     id: uuid(),

--- a/server/service/src/requisition/response_requisition/insert_program.rs
+++ b/server/service/src/requisition/response_requisition/insert_program.rs
@@ -149,6 +149,7 @@ fn validate(
             program_order_type_id: &input.program_order_type_id,
             max_orders_per_period: i64::from(order_type.order_type.max_order_per_period),
             requisition_type: RequisitionType::Response,
+            store_id: &ctx.store_id,
             other_party_id: Some(&input.other_party_id),
         },
     )? {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Part 1 #6764

# 👩🏻‍💻 What does this PR do?
- Filter outindicator info by customers with stores since we don't create indicators for customers without stores, so shouldn't show them
- Fix bug with limiting orders 
- Remove number from ledger

## 💌 Any notes for the reviewer?
Other requests in issue pending confirmation

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have 'use consumption' & 'extra fields' pref on
- [ ] Have indicators set for a program
- [ ] Create some requisitions in your store
- [ ] Create an Internal Order for same program + period 
- [ ] Click to Indicator page
- [ ] Shouldn't see non-store customers in information window
- [ ] Check ledger, shouldn't see number anymore
- [ ] BUG FIX INSTRUCTIONS
- [ ] Should be able to create program orders to suppliers if you've never created one before

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Item Ledger screenshots
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

