### PR TITLE
#6829 Fix for Kbar context error

### DIFF
--- a/client/packages/host/src/CommandK.tsx
+++ b/client/packages/host/src/CommandK.tsx
@@ -10,7 +10,6 @@ import {
   KBarAnimator,
   KBarResults,
   KBarSearch,
-  KBarProvider,
   KBarPositioner,
   KBarPortal,
   PropsWithChildrenOnly,
@@ -356,7 +355,11 @@ const Actions = () => {
 export const CommandK: FC<PropsWithChildrenOnly> = ({ children }) => {
   const t = useTranslation();
   return (
-    <KBarProvider actions={[]}>
+    // This should be inside KBar's own <KbarProvider>, and it is, but we're now
+    // rendering that at the top level of <Host> as it needs to be defined in
+    // order to be used within certain dialogs/modals which MUI renders outside
+    // the main DOM content.
+    <>
       <Actions />
       <KBarPortal>
         <KBarPositioner style={{ zIndex: 1001 }}>
@@ -367,6 +370,6 @@ export const CommandK: FC<PropsWithChildrenOnly> = ({ children }) => {
         </KBarPositioner>
       </KBarPortal>
       {children}
-    </KBarProvider>
+    </>
   );
 };

--- a/client/packages/host/src/Host.tsx
+++ b/client/packages/host/src/Host.tsx
@@ -24,6 +24,7 @@ import {
   createRoutesFromElements,
   RouterProvider,
   initialiseI18n,
+  KBarProvider,
 } from '@openmsupply-client/common';
 import { AppRoute, Environment } from '@openmsupply-client/config';
 import { Initialise, Login, Viewport } from './components';
@@ -113,30 +114,32 @@ initialiseI18n();
 
 const Host = () => (
   <React.Suspense fallback={<div />}>
-    <IntlProvider>
-      <AppThemeProvider>
-        <React.Suspense fallback={<RandomLoader />}>
-          <ErrorBoundary Fallback={GenericErrorFallback}>
-            <QueryClientProvider client={queryClient}>
-              <GqlProvider
-                url={Environment.GRAPHQL_URL}
-                skipRequest={skipRequest}
-              >
-                <AuthProvider>
-                  <Init />
-                  <ConfirmationModalProvider>
-                    <AlertModalProvider>
-                      <RouterProvider router={router} />
-                    </AlertModalProvider>
-                  </ConfirmationModalProvider>
-                </AuthProvider>
-                {/* <ReactQueryDevtools initialIsOpen /> */}
-              </GqlProvider>
-            </QueryClientProvider>
-          </ErrorBoundary>
-        </React.Suspense>
-      </AppThemeProvider>
-    </IntlProvider>
+    <KBarProvider actions={[]}>
+      <IntlProvider>
+        <AppThemeProvider>
+          <React.Suspense fallback={<RandomLoader />}>
+            <ErrorBoundary Fallback={GenericErrorFallback}>
+              <QueryClientProvider client={queryClient}>
+                <GqlProvider
+                  url={Environment.GRAPHQL_URL}
+                  skipRequest={skipRequest}
+                >
+                  <AuthProvider>
+                    <Init />
+                    <ConfirmationModalProvider>
+                      <AlertModalProvider>
+                        <RouterProvider router={router} />
+                      </AlertModalProvider>
+                    </ConfirmationModalProvider>
+                  </AuthProvider>
+                  {/* <ReactQueryDevtools initialIsOpen /> */}
+                </GqlProvider>
+              </QueryClientProvider>
+            </ErrorBoundary>
+          </React.Suspense>
+        </AppThemeProvider>
+      </IntlProvider>
+    </KBarProvider>
   </React.Suspense>
 );
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6829

# 👩🏻‍💻 What does this PR do?

Turns out that when the DialogButton component is rendered inside the confirmation modal, it actually gets rendered outside the main component tree of the DOM, so it's not with the `<CommandK>` Provider boundary, and so attempts to register shortcuts with KBar's `useRegisterActions` throw an error.

Have now moved the `<KBarProvider>` to the top the of the Provider tree in `Host.tsx`, and decoupled it from the `CommandK` file where we define and provide a custom implementation of KBar.

## 💌 Any notes for the reviewer?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Confirm original issue is fixed (can delete items from invoices)
- [ ] Confirm Dialog Button behaviour is correct throughout the app (just check a few spots)
- [ ] Confirm Cmd-K behaviour is correct (Cmd-K launches command palette, commands can be selected, and launched via the defined shortcuts)
- [ ] When in a prescription (or any other form with a "Save" button, check that the "Save" shortcut is available in the Cmd-K list

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

