### PR TITLE
6712 safely deserialise invoice_line.item_variant_id

### DIFF
--- a/server/service/src/sync/translations/invoice_line.rs
+++ b/server/service/src/sync/translations/invoice_line.rs
@@ -84,6 +84,7 @@ pub struct LegacyTransLineRow {
     pub option_id: Option<String>,
     #[serde(rename = "foreign_currency_price")]
     pub foreign_currency_price_before_tax: Option<f64>,
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     #[serde(rename = "om_item_variant_id")]
     pub item_variant_id: Option<String>,
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6712 

# 👩🏻‍💻 What does this PR do?

OG/Mobile remote sites munge null fields to empty values e.g. strings to `""`. This breaks inbound shipment invoice line FK constraints in OMS when a OG supplier remote site makes a CI to a OMS site. Unless the FK field has     `#[serde(deserialize_with = "empty_str_as_option_string")]`!

## 💌 Any notes for the reviewer?

Suppliers on OG central server will not exhibit this bug, it must be a remote site OG supplier (or old mobile)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] OG or mobile supplier, OMS customer on remote (central OMS probably OK for this test)
- [ ] Make a CI to OMS customer.
- [ ] Sync both 
- [ ] Inbound shipment should have all the lines from the CI
- [ ] For completeness repeat with a CI generated from a customer requisition that was from OMS internal order (as per the original issue)

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

