### PR TITLE
6069 fix suggested quantities replacing requested quantities - internal order

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1610,7 +1610,7 @@
   "messages.reduced-to-zero_other": "Reduced {{ count }} lines to quantity of 0",
   "messages.regenerate-id-confirm": "This will create a new ID and cannot be undone.",
   "messages.repack-log-info": "Repacked from stock line",
-  "messages.requested-to-suggested": "This will set all lines requested quantity to the suggested quantity.",
+  "messages.requested-to-suggested": "This will set requested quantity to the suggested quantity for lines where requested quantity is 0.",
   "messages.requisition-item-information-amc": "Customer's average monthly consumption. For your store it is the sum of the customers' average monthly consumption.",
   "messages.requisition-no-stock": "There is currently no stock available",
   "messages.results-found": "{{totalCount}} results found",

--- a/client/packages/host/src/components/Sync/SyncModal.tsx
+++ b/client/packages/host/src/components/Sync/SyncModal.tsx
@@ -213,9 +213,9 @@ const FormattedSyncDate = ({ date }: { date: Date | null }) => {
 
   if (!date) return UNDEFINED_STRING_VALUE;
 
-  const relativeTime = `( ${t('messages.ago', {
+  const relativeTime = `(${t('messages.ago', {
     time: localisedDistanceToNow(date),
-  })} )`;
+  })})`;
 
   return (
     <Grid display="flex" flexDirection="row" container gap={1}>

--- a/server/service/src/requisition/request_requisition/use_suggested_quantity.rs
+++ b/server/service/src/requisition/request_requisition/use_suggested_quantity.rs
@@ -89,7 +89,10 @@ fn generate(
                  mut requisition_line_row,
                  ..
              }| {
-                requisition_line_row.requested_quantity = requisition_line_row.suggested_quantity;
+                if requisition_line_row.requested_quantity == 0.00 {
+                    requisition_line_row.requested_quantity =
+                        requisition_line_row.suggested_quantity;
+                }
 
                 requisition_line_row
             },


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6069 

# 👩🏻‍💻 What does this PR do?
Update suggested quantitiy button to only update requested quantities with suggested quantities if requested quantity value is 0
<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
![Screenshot 2025-03-06 at 17 22 06](https://github.com/user-attachments/assets/18da8fe2-4e93-4d53-9fcb-5ce9c9625bed)

## 💌 Any notes for the reviewer?

I couldn't find anything that states that response requisitions has the same functionality of using suggested quantities to update requested quantity. If I'm wrong in how I've understood it, then happy to find and make the change in this PR.

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an internal order
- [ ] Add some requested quantity
- [ ] Click on the button "Use suggested quantities"
- [ ] See updated confirmation message
- [ ] See that only lines with requested quantity of 0 being updated by suggested quantity

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

