### PR TITLE
change background colour to white

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
@@ -7,6 +7,7 @@ import {
   AutocompleteInputChangeReason,
   AutocompleteProps as MuiAutocompleteProps,
   PopperProps,
+  SxProps,
 } from '@mui/material';
 import {
   AutocompleteOption,
@@ -48,6 +49,7 @@ export interface AutocompleteProps<T>
   popperMinWidth?: number;
   inputProps?: BasicTextInputProps;
   required?: boolean;
+  textSx?: SxProps;
 }
 
 export function Autocomplete<T>({
@@ -75,6 +77,7 @@ export function Autocomplete<T>({
   popperMinWidth,
   inputProps,
   required,
+  textSx,
   ...restOfAutocompleteProps
 }: PropsWithChildren<AutocompleteProps<T>>): JSX.Element {
   const filter = filterOptions ?? createFilterOptions(filterOptionConfig);
@@ -90,6 +93,7 @@ export function Autocomplete<T>({
           disableUnderline: false,
           sx: {
             padding: '4px !important',
+            ...textSx != null ? textSx : {},
           },
           ...props.InputProps,
         },

--- a/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/PrescriptionDetailsSection.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/PrescriptionDetailsSection.tsx
@@ -151,7 +151,7 @@ export const PrescriptionDetailsSectionComponent: FC = () => {
         null
     );
   }, [data]);
-
+ 
   return (
     <DetailPanelSection title={t('heading.prescription-details')}>
       <Grid container gap={0.5} key="prescription-details">
@@ -186,6 +186,13 @@ export const PrescriptionDetailsSectionComponent: FC = () => {
             disabled={isDisabled}
             size="small"
             sx={{ width: 250 }}
+            slotProps={{
+              input: {
+                sx: {
+                  backgroundColor: 'white',
+                }
+              }
+            }}
             value={theirReferenceInput ?? ''}
             onChange={event => {
               setTheirReferenceInput(event.target.value);
@@ -202,6 +209,13 @@ export const PrescriptionDetailsSectionComponent: FC = () => {
             format="P"
             onChange={handleDateChange}
             maxDate={new Date()}
+            textFieldProps={{
+              sx: {
+                '& .MuiInputBase-root': {
+                  backgroundColor: 'white',
+                },
+              }
+            }}
           />
         </PanelRow>
       </Grid>

--- a/client/packages/system/src/Clinician/ClinicianSearchInput.tsx
+++ b/client/packages/system/src/Clinician/ClinicianSearchInput.tsx
@@ -54,6 +54,7 @@ export const ClinicianSearchInput: FC<ClinicianSearchInputProps> = ({
         })
       )}
       sx={{ minWidth: width }}
+      textSx={{ backgroundColor: 'white' }}
       disabled={disabled}
       fullWidth={fullWidth}
     />

--- a/client/packages/system/src/Program/ProgramSearchInput.tsx
+++ b/client/packages/system/src/Program/ProgramSearchInput.tsx
@@ -42,6 +42,7 @@ export const ProgramSearchInput: FC<ProgramSearchInputProps> = ({
         value: program,
       }))}
       sx={{ minWidth: width }}
+      textSx={{ backgroundColor: 'white' }}
       disabled={disabled}
       fullWidth={fullWidth}
     />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6795 

# 👩🏻‍💻 What does this PR do?

This issue gives inputs in the prescription sidebar (the 'more' panel) white backgrounds so that they look different from the normal text fields.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Have a good weekend!

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] In Open mSupply, go to Dispensary > Prescriptions
- [ ] Select a prescription (or make one if you don't have any, by clicking on the 'add prescription' button in the top right)
- [ ] Click 'more' in the top right.
- [ ] Check that the inputs in the sidebar all have white backgrounds.
- [ ] Navigate to another part of mSupply and check the inputs in the toolbar are as they were before: only the inputs in the prescriptions sidepanel should be changed.
Thanks!

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: Screenshots of the prescriptions' sidepanel should be updated to be consistent with the UI changes.

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

