### PR TITLE
6819 The confirm delivered option of customer returns is greyed out when it has been created from returning stock from another store

### DIFF
--- a/client/packages/invoices/src/Returns/CustomerDetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/Returns/CustomerDetailView/Footer/StatusChangeButton.tsx
@@ -53,8 +53,8 @@ const getStatusOptions = (
     },
   ];
 
-  if (currentStatus === InvoiceNodeStatus.New) {
-    // When new, can change to delivered or verified
+  if (currentStatus === InvoiceNodeStatus.Shipped) {
+    // When shipped, can change to delivered or verified
     options[3].isDisabled = false;
     options[4].isDisabled = false;
   }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6819

# 👩🏻‍💻 What does this PR do?
Changes status check since transfer invoices can never be `New` we should be checking that the status is `Shipped` to enable `Delivered` and `Verified` statuses

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a Supplier Return from Store A to Store B
- [ ] Go to Store B -> Click `Customer Return`
- [ ] Click on the transfer you just created
- [ ] Should be able to change the status to `Delivered`

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

