### PR TITLE
Add soft delete translations

### DIFF
--- a/server/repository/src/db_diesel/assets/asset_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_row.rs
@@ -92,7 +92,7 @@ impl<'a> AssetRowRepository<'a> {
         self.insert_changelog(
             asset_row.id.to_owned(),
             RowActionType::Upsert,
-            Some(asset_row.clone()),
+            asset_row.store_id.clone(),
         )
     }
 
@@ -100,13 +100,13 @@ impl<'a> AssetRowRepository<'a> {
         &self,
         asset_id: String,
         action: RowActionType,
-        row: Option<AssetRow>,
+        asset_store_id: Option<String>,
     ) -> Result<i64, RepositoryError> {
         let row = ChangeLogInsertRow {
             table_name: ChangelogTableName::Asset,
             record_id: asset_id,
             row_action: action,
-            store_id: row.map(|r| r.store_id).unwrap_or(None),
+            store_id: asset_store_id,
             ..Default::default()
         };
         ChangelogRepository::new(self.connection).insert(&row)
@@ -131,7 +131,14 @@ impl<'a> AssetRowRepository<'a> {
         diesel::update(asset.filter(id.eq(asset_id)))
             .set(deleted_datetime.eq(Some(chrono::Utc::now().naive_utc())))
             .execute(self.connection.lock().connection())?;
-        self.insert_changelog(asset_id.to_owned(), RowActionType::Upsert, None)
+
+        let asset_row = AssetRowRepository::find_one_by_id(&self, asset_id)?;
+
+        self.insert_changelog(
+            asset_id.to_owned(),
+            RowActionType::Upsert,
+            asset_row.and_then(|row| row.store_id),
+        )
     }
 }
 

--- a/server/repository/src/db_diesel/assets/asset_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_row.rs
@@ -127,12 +127,11 @@ impl<'a> AssetRowRepository<'a> {
         Ok(result)
     }
 
-    pub fn delete(&self, asset_id: &str) -> Result<(), RepositoryError> {
+    pub fn mark_deleted(&self, asset_id: &str) -> Result<i64, RepositoryError> {
         diesel::update(asset.filter(id.eq(asset_id)))
             .set(deleted_datetime.eq(Some(chrono::Utc::now().naive_utc())))
             .execute(self.connection.lock().connection())?;
-        _ = self.insert_changelog(asset_id.to_owned(), RowActionType::Delete, None); // TODO: return this and enable delete sync...
-        Ok(())
+        self.insert_changelog(asset_id.to_owned(), RowActionType::Upsert, None)
     }
 }
 

--- a/server/service/src/asset/delete.rs
+++ b/server/service/src/asset/delete.rs
@@ -1,4 +1,5 @@
 use super::validate::check_asset_exists;
+use crate::sync::CentralServerConfig;
 use crate::{activity_log::activity_log_entry, service_provider::ServiceContext};
 use repository::assets::asset_internal_location_row::AssetInternalLocationRowRepository;
 use repository::{
@@ -55,7 +56,7 @@ pub fn validate(
     };
 
     if let Some(store_id) = &asset_row.store_id {
-        if ctx_store_id != store_id {
+        if ctx_store_id != store_id && !CentralServerConfig::is_central_server() {
             return Err(DeleteAssetError::AssetDoesNotBelongToCurrentStore);
         }
     }

--- a/server/service/src/asset/delete.rs
+++ b/server/service/src/asset/delete.rs
@@ -37,7 +37,7 @@ pub fn delete_asset(ctx: &ServiceContext, asset_id: String) -> Result<String, De
                 .delete_all_for_asset_id(&asset_id);
 
             AssetRowRepository::new(connection)
-                .delete(&asset_id)
+                .mark_deleted(&asset_id)
                 .map_err(DeleteAssetError::from)
         })
         .map_err(|error| error.to_inner_error())?;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5314 

# 👩🏻‍💻 What does this PR do?

- Adds delete sync for assets
- Remote sites can delete their assets. This is synced to OMS central server.
- Central server can delete assets from any site. This is synced to remote sites.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have OMS set up on central and remote sites
- [ ] Create an asset from central server for a remote site
- [ ] See the asset is visible on both sites
- [ ] Delete the asset from central server
- [ ] See that this change is made for both sites.

Repeat the above steps for each permutation of creation and deleting:
Create from central - delete from remote
Create from remote - delete from central
Create from remote - delete from remote

In all cases the asset will show up on both when created from either central and remote when created, and will be removed from both when deleted from either.

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

