### PR TITLE
6818 Fix autocomplete appearance on Android

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteList.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteList.tsx
@@ -118,6 +118,7 @@ export const AutocompleteList = <T,>({
       )}
       <MuiAutocomplete
         {...openOverrides}
+        open
         disableClearable={disableClearable}
         autoSelect={false}
         loading={loading}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6818

# 👩🏻‍💻 What does this PR do?

This just ensures the "Autocomplete" is opened, rather than relying on the value returned from `useOpenStateWithKeyboard` hook

## 💌 Any notes for the reviewer?

I'm not particularly happy with this fix, but I think it will take too long to investigate more thoroughly, and this works.

I'm reasonably sure that we don't actually need the `useOpenStateWithKeyboard` hook and that the root of the problem is to do with this: https://github.com/msupply-foundation/open-msupply/issues/6311. But fixing that will require a bit more time.

# 🧪 Testing

Equally important here is that we haven't caused any regressions. Please ensure the modal behaves correctly, by which I mean:

- [ ] Autocomplete list appears when launching the modal
- [ ] Clicking into the input brings up the keyboard, and the list re-sizes accordingly so it stays on screen

Please check that behaviour in the following scenarios, on both Android AND desktop browser:

- [ ] Inbound shipment -> New shipment
- [ ] Requisitions -> New Requisition (General tab if given option) -- Check both the full-screen and non-fullscreen versions of the Modal on Desktop)
- [ ] Any other modals you can think of that launch an Autocomplete list

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

