### PR TITLE
6224 create dummy users on sync

### DIFF
--- a/server/service/src/sync/test/test_data/invoice.rs
+++ b/server/service/src/sync/test/test_data/invoice.rs
@@ -155,7 +155,7 @@ fn transact_1_push_record() -> TestSyncOutgoingRecord {
         record_id: TRANSACT_1.0.to_string(),
         push_data: json!(LegacyTransactRow {
             ID: TRANSACT_1.0.to_string(),
-            user_id: None,
+            user_id: Some("MISSING_USER_ID".to_string()),
             name_ID: "name_store_a".to_string(),
             store_ID: "store_b".to_string(),
             invoice_num: 1,

--- a/server/service/src/sync/test/test_data/invoice.rs
+++ b/server/service/src/sync/test/test_data/invoice.rs
@@ -85,7 +85,7 @@ const TRANSACT_1: (&str, &str) = (
       "user2": "",
       "user3": "",
       "user4": "",
-      "user_ID": "",
+      "user_ID": "MISSING_USER_ID",
       "wardID": "",
       "waybill_number": "",
       "om_allocated_datetime": "",
@@ -103,7 +103,7 @@ fn transact_1_pull_record() -> TestSyncIncomingRecord {
         TRANSACT_1,
         InvoiceRow {
             id: TRANSACT_1.0.to_string(),
-            user_id: None,
+            user_id: Some("MISSING_USER_ID".to_string()),
             store_id: "store_b".to_string(),
             name_link_id: "name_store_a".to_string(),
             name_store_id: Some("store_a".to_string()),

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -867,6 +867,13 @@ mod tests {
 
             assert_eq!(translation_result, record.translated_record);
         }
+
+        // Check missing user got created
+        let user = UserAccountRowRepository::new(&connection)
+            .find_one_by_id("MISSING_USER_ID")
+            .unwrap()
+            .unwrap();
+        assert_eq!(user.id, "MISSING_USER_ID");
     }
 
     #[actix_rt::test]


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6224

# 👩🏻‍💻 What does this PR do?

If a transaction comes in via sync,and we don't have the associated user_id, a default user is created with blank details

## 💌 Any notes for the reviewer?

I haven't really tested this with a real scenario, I assume that's ok as @alainsussol  can test his real world scenario?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

See issue #6224 for testing steps

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [X] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [x] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [X] SQLite
- [ ] Frontend

