### PR TITLE
6891 stocktake line edit move expiry date column to right of batch column

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -171,6 +171,13 @@ export const BatchTable: FC<StocktakeLineEditTableProps> = ({
     const columnDefinitions: ColumnDescription<DraftStocktakeLine>[] = [
       getCountThisLineColumn(update, theme),
       getBatchColumn(update, theme),
+      [
+        expiryDateColumn,
+        {
+          width: 150,
+          setter: patch => update({ ...patch, countThisLine: true }),
+        },
+      ],
     ];
     if (itemVariantsEnabled) {
       columnDefinitions.push({
@@ -201,7 +208,6 @@ export const BatchTable: FC<StocktakeLineEditTableProps> = ({
         setter: patch => update({ ...patch, countThisLine: true }),
         accessor: ({ rowData }) => rowData.snapshotNumberOfPacks || '0',
       },
-
       {
         key: 'countedNumberOfPacks',
         label: 'description.counted-num-of-packs',
@@ -224,13 +230,6 @@ export const BatchTable: FC<StocktakeLineEditTableProps> = ({
         },
         accessor: ({ rowData }) => rowData.countedNumberOfPacks,
       },
-      [
-        expiryDateColumn,
-        {
-          width: 150,
-          setter: patch => update({ ...patch, countThisLine: true }),
-        },
-      ],
       getInventoryAdjustmentReasonInputColumn(update, errorsContext)
     );
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6891

# 👩🏻‍💻 What does this PR do?

stocktake line edit move expiry date column to right of batch column

![image](https://github.com/user-attachments/assets/e8679258-855c-4ad8-af09-50977ffa5d4c)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Stocktake edit a line
- [ ] New column order
- [ ] Editing works

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Need to update images to reflect new column order in docs
  2. And column description markdown tables and/or lists

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

