### PR TITLE
6889 enable insurance tab even when program module off

### DIFF
--- a/client/packages/system/src/Patient/PatientView/AddButton.tsx
+++ b/client/packages/system/src/Patient/PatientView/AddButton.tsx
@@ -72,30 +72,23 @@ export const AddButton: React.FC<AddButtonProps> = ({
     SplitButtonOption<PatientModal> | undefined
   >(options[0]);
 
+  const optionMap: Partial<Record<PatientTabValue, PatientModal>> = {
+    [PatientTabValue.Programs]: PatientModal.ProgramSearch,
+    [PatientTabValue.Vaccinations]: PatientModal.ProgramSearch,
+    [PatientTabValue.Encounters]: PatientModal.Encounter,
+    [PatientTabValue.ContactTracing]: PatientModal.ContactTraceSearch,
+    [PatientTabValue.Insurance]: PatientModal.Insurance,
+  };
+
   useEffect(() => {
     if (options.length === 0) return;
 
-    const optionMap: {
-      [key: string]: SplitButtonOption<PatientModal> | undefined;
-    } = {
-      [PatientTabValue.Programs]: options.find(
-        option => option.value === PatientModal.ProgramSearch
-      ),
-      [PatientTabValue.Vaccinations]: options.find(
-        option => option.value === PatientModal.ProgramSearch
-      ),
-      [PatientTabValue.Encounters]: options.find(
-        option => option.value === PatientModal.Encounter
-      ),
-      [PatientTabValue.ContactTracing]: options.find(
-        option => option.value === PatientModal.ContactTraceSearch
-      ),
-      [PatientTabValue.Insurance]: options.find(
-        option => option.value === PatientModal.Insurance
-      ),
-    };
-
-    setSelectedOption(optionMap[currentUrlTab as string] || options[0]);
+    setSelectedOption(
+      options.find(
+        option => option.value === optionMap[currentUrlTab as PatientTabValue]
+      ) || options[0]
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentUrlTab, options]);
 
   const onSelectOption = (option: SplitButtonOption<PatientModal>) => {

--- a/client/packages/system/src/Patient/PatientView/AddButton.tsx
+++ b/client/packages/system/src/Patient/PatientView/AddButton.tsx
@@ -33,7 +33,7 @@ export const AddButton: React.FC<AddButtonProps> = ({
   const { createNewPatient } = usePatientStore();
   const { setModal: selectModal, reset } = usePatientModalStore();
   const {
-    query: { data: InsuranceProvidersData },
+    query: { data: insuranceProvidersData },
   } = useInsuranceProviders();
 
   const options: SplitButtonOption<PatientModal>[] = useMemo(() => {
@@ -58,7 +58,7 @@ export const AddButton: React.FC<AddButtonProps> = ({
       );
     }
 
-    if (InsuranceProvidersData?.length > 0) {
+    if (insuranceProvidersData?.length > 0) {
       baseOptions.push({
         value: PatientModal.Insurance,
         label: t('button.add-insurance'),
@@ -66,7 +66,7 @@ export const AddButton: React.FC<AddButtonProps> = ({
     }
 
     return baseOptions;
-  }, [disableEncounterButton, t, store, InsuranceProvidersData]);
+  }, [disableEncounterButton, t, store, insuranceProvidersData]);
 
   const [selectedOption, setSelectedOption] = useState<
     SplitButtonOption<PatientModal> | undefined
@@ -111,20 +111,16 @@ export const AddButton: React.FC<AddButtonProps> = ({
     selectModal(selectedOption?.value);
   };
 
-  return (
-    <>
-      {options.length > 0 && selectedOption && !createNewPatient && (
-        <SplitButton
-          color="primary"
-          openFrom={'bottom'}
-          isDisabled={disabled}
-          options={options}
-          selectedOption={selectedOption}
-          onSelectOption={onSelectOption}
-          Icon={<PlusCircleIcon />}
-          onClick={onClick}
-        />
-      )}
-    </>
-  );
+  return options.length > 0 && selectedOption && !createNewPatient ? (
+    <SplitButton
+      color="primary"
+      openFrom={'bottom'}
+      isDisabled={disabled}
+      options={options}
+      selectedOption={selectedOption}
+      onSelectOption={onSelectOption}
+      Icon={<PlusCircleIcon />}
+      onClick={onClick}
+    />
+  ) : null;
 };

--- a/client/packages/system/src/Patient/PatientView/AddButton.tsx
+++ b/client/packages/system/src/Patient/PatientView/AddButton.tsx
@@ -5,77 +5,98 @@ import {
   SplitButtonOption,
   PlusCircleIcon,
   useUrlQuery,
+  UserStoreNodeFragment,
 } from '@openmsupply-client/common';
 import {
   PatientModal,
   usePatientModalStore,
+  usePatientStore,
 } from '@openmsupply-client/programs';
 import { PatientTabValue } from './PatientView';
+import { useInsuranceProviders } from '../apiModern';
 
 interface AddButtonProps {
   /** Disable the whole control */
   disabled: boolean;
   disableEncounterButton: boolean;
+  store?: UserStoreNodeFragment;
 }
 
 export const AddButton: React.FC<AddButtonProps> = ({
   disabled,
   disableEncounterButton,
+  store,
 }) => {
   const t = useTranslation();
   const { urlQuery, updateQuery } = useUrlQuery();
   const currentUrlTab = urlQuery['tab'];
+  const { createNewPatient } = usePatientStore();
   const { setModal: selectModal, reset } = usePatientModalStore();
+  const {
+    query: { data: InsuranceProvidersData },
+  } = useInsuranceProviders();
 
-  const options: [
-    SplitButtonOption<PatientModal>,
-    SplitButtonOption<PatientModal>,
-    SplitButtonOption<PatientModal>,
-    SplitButtonOption<PatientModal>,
-  ] = useMemo(
-    () => [
-      {
-        value: PatientModal.ProgramSearch,
-        label: t('button.add-program'),
-        isDisabled: false,
-      },
-      {
-        value: PatientModal.Encounter,
-        label: t('button.add-encounter'),
-        isDisabled: disableEncounterButton,
-      },
-      {
-        value: PatientModal.ContactTraceSearch,
-        label: t('button.add-contact-trace'),
-      },
-      { value: PatientModal.Insurance, label: t('button.add-insurance') },
-    ],
-    [disableEncounterButton, t]
-  );
-  const [programOption, encounterOption, contactTraceOption, insuranceOption] =
-    options;
+  const options: SplitButtonOption<PatientModal>[] = useMemo(() => {
+    const baseOptions: SplitButtonOption<PatientModal>[] = [];
+
+    if (store?.preferences.omProgramModule) {
+      baseOptions.push(
+        {
+          value: PatientModal.ProgramSearch,
+          label: t('button.add-program'),
+          isDisabled: false,
+        },
+        {
+          value: PatientModal.Encounter,
+          label: t('button.add-encounter'),
+          isDisabled: disableEncounterButton,
+        },
+        {
+          value: PatientModal.ContactTraceSearch,
+          label: t('button.add-contact-trace'),
+        }
+      );
+    }
+
+    if (InsuranceProvidersData?.length > 0) {
+      baseOptions.push({
+        value: PatientModal.Insurance,
+        label: t('button.add-insurance'),
+      });
+    }
+
+    return baseOptions;
+  }, [disableEncounterButton, t, store, InsuranceProvidersData]);
 
   const [selectedOption, setSelectedOption] = useState<
-    SplitButtonOption<PatientModal>
+    SplitButtonOption<PatientModal> | undefined
   >(options[0]);
 
   useEffect(() => {
-    switch (currentUrlTab) {
-      case PatientTabValue.Programs:
-      case PatientTabValue.Vaccinations:
-        setSelectedOption(programOption);
-        break;
-      case PatientTabValue.Encounters:
-        setSelectedOption(encounterOption);
-        break;
-      case PatientTabValue.ContactTracing:
-        setSelectedOption(contactTraceOption);
-        break;
-      case PatientTabValue.Insurance:
-        setSelectedOption(insuranceOption);
-        break;
-    }
-  }, [contactTraceOption, currentUrlTab, encounterOption, programOption]);
+    if (options.length === 0) return;
+
+    const optionMap: {
+      [key: string]: SplitButtonOption<PatientModal> | undefined;
+    } = {
+      [PatientTabValue.Programs]: options.find(
+        option => option.value === PatientModal.ProgramSearch
+      ),
+      [PatientTabValue.Vaccinations]: options.find(
+        option => option.value === PatientModal.ProgramSearch
+      ),
+      [PatientTabValue.Encounters]: options.find(
+        option => option.value === PatientModal.Encounter
+      ),
+      [PatientTabValue.ContactTracing]: options.find(
+        option => option.value === PatientModal.ContactTraceSearch
+      ),
+      [PatientTabValue.Insurance]: options.find(
+        option => option.value === PatientModal.Insurance
+      ),
+    };
+
+    setSelectedOption(optionMap[currentUrlTab as string] || options[0]);
+  }, [currentUrlTab, options]);
 
   const onSelectOption = (option: SplitButtonOption<PatientModal>) => {
     updateQuery({ insuranceId: undefined });
@@ -92,16 +113,18 @@ export const AddButton: React.FC<AddButtonProps> = ({
 
   return (
     <>
-      <SplitButton
-        color="primary"
-        openFrom={'bottom'}
-        isDisabled={disabled}
-        options={options}
-        selectedOption={selectedOption}
-        onSelectOption={onSelectOption}
-        Icon={<PlusCircleIcon />}
-        onClick={onClick}
-      />
+      {options.length > 0 && selectedOption && !createNewPatient && (
+        <SplitButton
+          color="primary"
+          openFrom={'bottom'}
+          isDisabled={disabled}
+          options={options}
+          selectedOption={selectedOption}
+          onSelectOption={onSelectOption}
+          Icon={<PlusCircleIcon />}
+          onClick={onClick}
+        />
+      )}
     </>
   );
 };

--- a/client/packages/system/src/Patient/PatientView/AppBarButtons.tsx
+++ b/client/packages/system/src/Patient/PatientView/AppBarButtons.tsx
@@ -36,26 +36,26 @@ export const AppBarButtons: FC<{
     },
   });
   const disableEncounterButton = enrolmentData?.nodes?.length === 0;
-  if (!store?.preferences.omProgramModule) return null;
 
   return (
     <AppBarButtonsPortal>
       <Grid container gap={1}>
+        <AddButton
+          disabled={disabled}
+          disableEncounterButton={disableEncounterButton}
+          store={store}
+        />
         {store?.preferences.omProgramModule && (
-          <AddButton
-            disabled={disabled}
-            disableEncounterButton={disableEncounterButton}
-          />
+          <ReportSelector context={ReportContext.Patient} onPrint={printReport}>
+            <LoadingButton
+              disabled={disabled}
+              variant="outlined"
+              startIcon={<PrinterIcon />}
+              isLoading={isPrinting}
+              label={t('button.print')}
+            />
+          </ReportSelector>
         )}
-        <ReportSelector context={ReportContext.Patient} onPrint={printReport}>
-          <LoadingButton
-            disabled={disabled}
-            variant="outlined"
-            startIcon={<PrinterIcon />}
-            isLoading={isPrinting}
-            label={t('button.print')}
-          />
-        </ReportSelector>
       </Grid>
     </AppBarButtonsPortal>
   );

--- a/client/packages/system/src/Patient/PatientView/PatientDetailView.tsx
+++ b/client/packages/system/src/Patient/PatientView/PatientDetailView.tsx
@@ -1,0 +1,284 @@
+import React, { useCallback, useEffect, useMemo } from 'react';
+import {
+  useConfirmationModal,
+  Box,
+  useTranslation,
+  InsertPatientInput,
+  UpdatePatientInput,
+  BasicSpinner,
+  DocumentRegistryCategoryNode,
+  useNavigate,
+  RouteBuilder,
+  FnUtils,
+  useUrlQuery,
+} from '@openmsupply-client/common';
+import { AppRoute } from '@openmsupply-client/config';
+import { usePatient } from '../api';
+import {
+  JsonFormData,
+  FormInputData,
+  SaveDocumentMutation,
+  SavedDocument,
+  SchemaData,
+  useDocumentRegistry,
+  useJsonFormsHandler,
+  usePatientStore,
+  PatientSchema,
+} from '@openmsupply-client/programs';
+import { Footer } from './Footer';
+
+import defaultPatientSchema from './DefaultPatientSchema.json';
+import defaultPatientUISchema from './DefaultPatientUISchema.json';
+import { usePrescription } from '@openmsupply-client/invoices/src/Prescriptions';
+
+const DEFAULT_SCHEMA: SchemaData = {
+  formSchemaId: undefined,
+  jsonSchema: defaultPatientSchema,
+  uiSchema: defaultPatientUISchema,
+};
+
+const useUpsertPatient = (
+  create: boolean
+): ((input: unknown) => Promise<void>) => {
+  const { mutateAsync: insertPatient } = usePatient.document.insert();
+  const { mutateAsync: updatePatient } = usePatient.document.update();
+  return async (input: unknown) => {
+    if (create) {
+      await insertPatient(input as InsertPatientInput);
+    } else {
+      await updatePatient(input as UpdatePatientInput);
+    }
+  };
+};
+
+const useUpsertProgramPatient = (): SaveDocumentMutation => {
+  const { mutateAsync: insertPatient } =
+    usePatient.document.insertProgramPatient();
+  const { mutateAsync: updatePatient } =
+    usePatient.document.updateProgramPatient();
+  return async (jsonData: unknown, schemaId: string, parent?: string) => {
+    if (parent === undefined) {
+      const result = await insertPatient({
+        data: jsonData,
+        schemaId,
+      });
+      if (!result.document) throw Error('Inserted document not set!');
+      return result.document;
+    } else {
+      const result = await updatePatient({
+        data: jsonData,
+        parent,
+        schemaId,
+      });
+      if (!result.document) throw Error('Inserted document not set!');
+      return result.document;
+    }
+  };
+};
+
+export const PatientDetailView = ({
+  onEdit,
+}: {
+  onEdit: (isDirty: boolean) => void;
+}) => {
+  const t = useTranslation();
+  const {
+    documentName,
+    setDocumentName,
+    createNewPatient,
+    setCreateNewPatient,
+  } = usePatientStore();
+
+  const navigate = useNavigate();
+  const { urlQuery } = useUrlQuery();
+  const fromPrescription = urlQuery['previousPath'] === AppRoute.Prescription;
+
+  const patientId = usePatient.utils.id();
+  const { data: currentPatient, isLoading: isCurrentPatientLoading } =
+    usePatient.document.get(patientId);
+  const { data: patientRegistries, isLoading: isPatientRegistryLoading } =
+    useDocumentRegistry.get.documentRegistries({
+      filter: {
+        category: { equalTo: DocumentRegistryCategoryNode.Patient },
+      },
+    });
+  const {
+    create: { create: createPrescription },
+  } = usePrescription();
+
+  const isLoading = isCurrentPatientLoading || isPatientRegistryLoading;
+
+  const patientRegistry = patientRegistries?.nodes[0];
+  const isCreatingPatient = !!createNewPatient;
+  // we have to memo the data to avoid an infinite render loop
+  const inputData = useMemo<FormInputData | undefined>(() => {
+    if (!!createNewPatient) {
+      // Use the unsaved patient information from createNewPatient, i.e. from a "create patient"
+      // request
+      return {
+        schema: patientRegistry ?? DEFAULT_SCHEMA,
+        data: {
+          id: createNewPatient.id,
+          code: createNewPatient.code,
+          code2: createNewPatient.code2,
+          firstName: createNewPatient.firstName,
+          lastName: createNewPatient.lastName,
+          gender: createNewPatient.gender,
+          dateOfBirth: createNewPatient.dateOfBirth,
+          phone: createNewPatient.phone,
+          address1: createNewPatient.address1,
+          isDeceased: createNewPatient.isDeceased,
+          dateOfDeath: createNewPatient.dateOfDeath,
+          extension: {},
+        },
+        isCreating: true,
+      };
+    } else if (!!currentPatient && !currentPatient.document) {
+      // The loaded patient doesn't has a document. Use the information we got
+      // (from the name table).
+      return {
+        schema: patientRegistry ?? DEFAULT_SCHEMA,
+        data: {
+          id: currentPatient.id,
+          code: currentPatient.code,
+          code2: currentPatient.code2 ?? undefined,
+          firstName: currentPatient.firstName ?? undefined,
+          lastName: currentPatient.lastName ?? undefined,
+          gender: currentPatient.gender ?? undefined,
+          dateOfBirth: currentPatient.dateOfBirth ?? undefined,
+          dateOfDeath: currentPatient.dateOfDeath ?? undefined,
+          isDeceased: currentPatient.isDeceased ?? undefined,
+          phone: currentPatient.phone ?? undefined,
+          address1: currentPatient.address1 ?? undefined,
+          nextOfKin:
+            currentPatient.nextOfKinId || currentPatient.nextOfKinName
+              ? {
+                  id: currentPatient.nextOfKinId ?? undefined,
+                  name: currentPatient.nextOfKinName ?? undefined,
+                }
+              : undefined,
+          extension: {},
+        },
+        isCreating: false,
+      };
+    } else if (currentPatient?.document) {
+      // Take the data from the document
+      return {
+        schema: patientRegistry ?? DEFAULT_SCHEMA,
+        data: currentPatient.documentDraft,
+        isCreating: false,
+      };
+    }
+  }, [createNewPatient, currentPatient, patientRegistry]);
+
+  const handleProgramPatientSave = useUpsertProgramPatient();
+  const handlePatientSave = useUpsertPatient(isCreatingPatient);
+
+  const accessor: JsonFormData<SavedDocument | void> = patientRegistry
+    ? {
+        loadedData: inputData?.data,
+        isLoading: false,
+        error: undefined,
+        isCreating: isCreatingPatient,
+        schema: patientRegistry,
+        save: async (data: unknown) => {
+          await handleProgramPatientSave(
+            data,
+            patientRegistry.formSchemaId,
+            currentPatient?.document?.id
+          );
+        },
+      }
+    : {
+        loadedData: inputData?.data,
+        isLoading: false,
+        error: undefined,
+        isCreating: isCreatingPatient,
+        schema: DEFAULT_SCHEMA,
+        save: async (data: unknown) => {
+          const patientData = data as PatientSchema;
+          const newData = Object.fromEntries(
+            Object.entries(data ?? {}).filter(
+              ([key]) =>
+                key !== 'dateOfBirthIsEstimated' &&
+                key !== 'nextOfKin' &&
+                key !== 'extension'
+            )
+          );
+          // map nextOfKin object to individual fields
+          await handlePatientSave({
+            ...newData,
+            nextOfKinId: patientData?.nextOfKin?.id,
+            nextOfKinName: patientData?.nextOfKin?.name,
+          });
+        },
+      };
+
+  const { JsonForm, saveData, isSaving, isDirty, validationError } =
+    useJsonFormsHandler(
+      {
+        documentName: createNewPatient ? undefined : documentName,
+        patientId: patientId,
+      },
+      accessor
+    );
+
+  useEffect(() => {
+    return () => setCreateNewPatient(undefined);
+  }, [setCreateNewPatient]);
+
+  const save = useCallback(async () => {
+    const savedDocument = await saveData();
+    // patient has been created => unset the create request data
+    setCreateNewPatient(undefined);
+    if (savedDocument) {
+      setDocumentName(savedDocument.name);
+    }
+    // Creates a new prescription and redirects to the prescriptions page
+    // if the patient was created from there.
+    if (fromPrescription) {
+      const invoiceNumber = await createPrescription({
+        id: FnUtils.generateUUID(),
+        patientId,
+      });
+      navigate(
+        RouteBuilder.create(AppRoute.Dispensary)
+          .addPart(AppRoute.Prescription)
+          .addPart(String(invoiceNumber))
+          .build()
+      );
+    }
+  }, [saveData, setCreateNewPatient, setDocumentName]);
+
+  useEffect(() => {
+    if (!documentName && currentPatient) {
+      setDocumentName(currentPatient?.document?.name);
+    }
+  }, [currentPatient, documentName, setDocumentName]);
+
+  useEffect(() => {
+    onEdit(isDirty);
+  }, [isDirty, onEdit]);
+
+  const showSaveConfirmation = useConfirmationModal({
+    onConfirm: save,
+    message: t('messages.confirm-save-generic'),
+    title: t('heading.are-you-sure'),
+  });
+
+  if (isLoading) return <BasicSpinner />;
+
+  return (
+    <Box flex={1} display="flex" justifyContent="center">
+      <Box style={{ maxWidth: 1200, flex: 1 }}>{JsonForm}</Box>
+      <Footer
+        documentName={documentName}
+        isSaving={isSaving}
+        isDirty={isDirty}
+        validationError={validationError}
+        inputData={inputData}
+        showSaveConfirmation={showSaveConfirmation}
+      />
+    </Box>
+  );
+};

--- a/client/packages/system/src/Patient/PatientView/PatientView.tsx
+++ b/client/packages/system/src/Patient/PatientView/PatientView.tsx
@@ -1,304 +1,31 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   DetailTabs,
   DetailViewSkeleton,
-  useConfirmationModal,
-  Box,
-  useTranslation,
   EncounterSortFieldInput,
   ProgramEnrolmentSortFieldInput,
   useAuthContext,
-  InsertPatientInput,
   ContactTraceSortFieldInput,
-  UpdatePatientInput,
-  BasicSpinner,
-  DocumentRegistryCategoryNode,
-  useNavigate,
-  RouteBuilder,
-  FnUtils,
-  useUrlQuery,
+  TabDefinition,
 } from '@openmsupply-client/common';
-import { AppRoute } from '@openmsupply-client/config';
 import { usePatient } from '../api';
 import { AppBarButtons } from './AppBarButtons';
 import { PatientSummary } from './PatientSummary';
 import { ProgramDetailModal, ProgramListView } from '../ProgramEnrolment';
 import { CreateEncounterModal, EncounterListView } from '../Encounter';
 import {
-  JsonFormData,
-  FormInputData,
   PatientModal,
   ProgramSearchModal,
-  SaveDocumentMutation,
-  SavedDocument,
-  SchemaData,
-  useDocumentRegistry,
-  useJsonFormsHandler,
   usePatientModalStore,
   usePatientStore,
   useProgramEnrolments,
-  PatientSchema,
 } from '@openmsupply-client/programs';
-import { Footer } from './Footer';
 import { ContactTraceListView, CreateContactTraceModal } from '../ContactTrace';
 
-import defaultPatientSchema from './DefaultPatientSchema.json';
-import defaultPatientUISchema from './DefaultPatientUISchema.json';
 import { VaccinationCardsListView } from '../VaccinationCard/ListView';
-import { usePrescription } from '@openmsupply-client/invoices/src/Prescriptions';
 import { InsuranceListView, InsuranceModal } from '../Insurance';
-
-const DEFAULT_SCHEMA: SchemaData = {
-  formSchemaId: undefined,
-  jsonSchema: defaultPatientSchema,
-  uiSchema: defaultPatientUISchema,
-};
-
-const useUpsertPatient = (
-  create: boolean
-): ((input: unknown) => Promise<void>) => {
-  const { mutateAsync: insertPatient } = usePatient.document.insert();
-  const { mutateAsync: updatePatient } = usePatient.document.update();
-  return async (input: unknown) => {
-    if (create) {
-      await insertPatient(input as InsertPatientInput);
-    } else {
-      await updatePatient(input as UpdatePatientInput);
-    }
-  };
-};
-
-const useUpsertProgramPatient = (): SaveDocumentMutation => {
-  const { mutateAsync: insertPatient } =
-    usePatient.document.insertProgramPatient();
-  const { mutateAsync: updatePatient } =
-    usePatient.document.updateProgramPatient();
-  return async (jsonData: unknown, schemaId: string, parent?: string) => {
-    if (parent === undefined) {
-      const result = await insertPatient({
-        data: jsonData,
-        schemaId,
-      });
-      if (!result.document) throw Error('Inserted document not set!');
-      return result.document;
-    } else {
-      const result = await updatePatient({
-        data: jsonData,
-        parent,
-        schemaId,
-      });
-      if (!result.document) throw Error('Inserted document not set!');
-      return result.document;
-    }
-  };
-};
-
-const PatientDetailView = ({
-  onEdit,
-}: {
-  onEdit: (isDirty: boolean) => void;
-}) => {
-  const t = useTranslation();
-  const {
-    documentName,
-    setDocumentName,
-    createNewPatient,
-    setCreateNewPatient,
-  } = usePatientStore();
-
-  const navigate = useNavigate();
-  const { urlQuery } = useUrlQuery();
-  const fromPrescription = urlQuery['previousPath'] === AppRoute.Prescription;
-
-  const patientId = usePatient.utils.id();
-  const { data: currentPatient, isLoading: isCurrentPatientLoading } =
-    usePatient.document.get(patientId);
-  const { data: patientRegistries, isLoading: isPatientRegistryLoading } =
-    useDocumentRegistry.get.documentRegistries({
-      filter: {
-        category: { equalTo: DocumentRegistryCategoryNode.Patient },
-      },
-    });
-  const {
-    create: { create: createPrescription },
-  } = usePrescription();
-
-  const isLoading = isCurrentPatientLoading || isPatientRegistryLoading;
-
-  const patientRegistry = patientRegistries?.nodes[0];
-  const isCreatingPatient = !!createNewPatient;
-  // we have to memo the data to avoid an infinite render loop
-  const inputData = useMemo<FormInputData | undefined>(() => {
-    if (!!createNewPatient) {
-      // Use the unsaved patient information from createNewPatient, i.e. from a "create patient"
-      // request
-      return {
-        schema: patientRegistry ?? DEFAULT_SCHEMA,
-        data: {
-          id: createNewPatient.id,
-          code: createNewPatient.code,
-          code2: createNewPatient.code2,
-          firstName: createNewPatient.firstName,
-          lastName: createNewPatient.lastName,
-          gender: createNewPatient.gender,
-          dateOfBirth: createNewPatient.dateOfBirth,
-          phone: createNewPatient.phone,
-          address1: createNewPatient.address1,
-          isDeceased: createNewPatient.isDeceased,
-          dateOfDeath: createNewPatient.dateOfDeath,
-          extension: {},
-        },
-        isCreating: true,
-      };
-    } else if (!!currentPatient && !currentPatient.document) {
-      // The loaded patient doesn't has a document. Use the information we got
-      // (from the name table).
-      return {
-        schema: patientRegistry ?? DEFAULT_SCHEMA,
-        data: {
-          id: currentPatient.id,
-          code: currentPatient.code,
-          code2: currentPatient.code2 ?? undefined,
-          firstName: currentPatient.firstName ?? undefined,
-          lastName: currentPatient.lastName ?? undefined,
-          gender: currentPatient.gender ?? undefined,
-          dateOfBirth: currentPatient.dateOfBirth ?? undefined,
-          dateOfDeath: currentPatient.dateOfDeath ?? undefined,
-          isDeceased: currentPatient.isDeceased ?? undefined,
-          phone: currentPatient.phone ?? undefined,
-          address1: currentPatient.address1 ?? undefined,
-          nextOfKin:
-            currentPatient.nextOfKinId || currentPatient.nextOfKinName
-              ? {
-                  id: currentPatient.nextOfKinId ?? undefined,
-                  name: currentPatient.nextOfKinName ?? undefined,
-                }
-              : undefined,
-          extension: {},
-        },
-        isCreating: false,
-      };
-    } else if (currentPatient?.document) {
-      // Take the data from the document
-      return {
-        schema: patientRegistry ?? DEFAULT_SCHEMA,
-        data: currentPatient.documentDraft,
-        isCreating: false,
-      };
-    }
-  }, [createNewPatient, currentPatient, patientRegistry]);
-
-  const handleProgramPatientSave = useUpsertProgramPatient();
-  const handlePatientSave = useUpsertPatient(isCreatingPatient);
-
-  const accessor: JsonFormData<SavedDocument | void> = patientRegistry
-    ? {
-        loadedData: inputData?.data,
-        isLoading: false,
-        error: undefined,
-        isCreating: isCreatingPatient,
-        schema: patientRegistry,
-        save: async (data: unknown) => {
-          await handleProgramPatientSave(
-            data,
-            patientRegistry.formSchemaId,
-            currentPatient?.document?.id
-          );
-        },
-      }
-    : {
-        loadedData: inputData?.data,
-        isLoading: false,
-        error: undefined,
-        isCreating: isCreatingPatient,
-        schema: DEFAULT_SCHEMA,
-        save: async (data: unknown) => {
-          const patientData = data as PatientSchema;
-          const newData = Object.fromEntries(
-            Object.entries(data ?? {}).filter(
-              ([key]) =>
-                key !== 'dateOfBirthIsEstimated' &&
-                key !== 'nextOfKin' &&
-                key !== 'extension'
-            )
-          );
-          // map nextOfKin object to individual fields
-          await handlePatientSave({
-            ...newData,
-            nextOfKinId: patientData?.nextOfKin?.id,
-            nextOfKinName: patientData?.nextOfKin?.name,
-          });
-        },
-      };
-
-  const { JsonForm, saveData, isSaving, isDirty, validationError } =
-    useJsonFormsHandler(
-      {
-        documentName: createNewPatient ? undefined : documentName,
-        patientId: patientId,
-      },
-      accessor
-    );
-
-  useEffect(() => {
-    return () => setCreateNewPatient(undefined);
-  }, [setCreateNewPatient]);
-
-  const save = useCallback(async () => {
-    const savedDocument = await saveData();
-    // patient has been created => unset the create request data
-    setCreateNewPatient(undefined);
-    if (savedDocument) {
-      setDocumentName(savedDocument.name);
-    }
-    // Creates a new prescription and redirects to the prescriptions page
-    // if the patient was created from there.
-    if (fromPrescription) {
-      const invoiceNumber = await createPrescription({
-        id: FnUtils.generateUUID(),
-        patientId,
-      });
-      navigate(
-        RouteBuilder.create(AppRoute.Dispensary)
-          .addPart(AppRoute.Prescription)
-          .addPart(String(invoiceNumber))
-          .build()
-      );
-    }
-  }, [saveData, setCreateNewPatient, setDocumentName]);
-
-  useEffect(() => {
-    if (!documentName && currentPatient) {
-      setDocumentName(currentPatient?.document?.name);
-    }
-  }, [currentPatient, documentName, setDocumentName]);
-
-  useEffect(() => {
-    onEdit(isDirty);
-  }, [isDirty, onEdit]);
-
-  const showSaveConfirmation = useConfirmationModal({
-    onConfirm: save,
-    message: t('messages.confirm-save-generic'),
-    title: t('heading.are-you-sure'),
-  });
-
-  if (isLoading) return <BasicSpinner />;
-
-  return (
-    <Box flex={1} display="flex" justifyContent="center">
-      <Box style={{ maxWidth: 1200, flex: 1 }}>{JsonForm}</Box>
-      <Footer
-        documentName={documentName}
-        isSaving={isSaving}
-        isDirty={isDirty}
-        validationError={validationError}
-        inputData={inputData}
-        showSaveConfirmation={showSaveConfirmation}
-      />
-    </Box>
-  );
-};
+import { PatientDetailView } from './PatientDetailView';
+import { useInsuranceProviders } from '../apiModern';
 
 export enum PatientTabValue {
   Details = 'details',
@@ -309,9 +36,6 @@ export enum PatientTabValue {
   Insurance = 'insurance',
 }
 
-/**
- * Main patient view containing patient details and program tabs
- */
 export const PatientView = () => {
   const { current, setCreationModal, reset } = usePatientModalStore();
   const patientId = usePatient.utils.id();
@@ -323,6 +47,10 @@ export const PatientView = () => {
   const [isDirtyPatient, setIsDirtyPatient] = useState(false);
   const { store, storeId } = useAuthContext();
 
+  const {
+    query: { data: insuranceProvidersData },
+  } = useInsuranceProviders();
+
   const requiresConfirmation = (tab: string) => {
     return tab === PatientTabValue.Details && isDirtyPatient;
   };
@@ -332,12 +60,7 @@ export const PatientView = () => {
     setCurrentPatient(currentPatient);
   }, [currentPatient, setCurrentPatient]);
 
-  const tabs = [
-    {
-      Component: <PatientDetailView onEdit={setIsDirtyPatient} />,
-      value: PatientTabValue.Details,
-      confirmOnLeaving: isDirtyPatient,
-    },
+  const programTabs: TabDefinition[] = [
     {
       Component: <ProgramListView />,
       value: PatientTabValue.Programs,
@@ -370,16 +93,37 @@ export const PatientView = () => {
         dir: 'desc' as 'desc' | 'asc',
       },
     },
-    {
-      Component: <InsuranceListView />,
-      value: PatientTabValue.Insurance,
-    },
   ];
 
-  // Note: unmount modals when not used because they have some internal state
-  // that shouldn't be reused across calls.
+  const tabs: TabDefinition[] = [
+    {
+      Component: <PatientDetailView onEdit={setIsDirtyPatient} />,
+      value: PatientTabValue.Details,
+      confirmOnLeaving: isDirtyPatient,
+    },
+    // Display program tabs only if the Program module is enabled and the patient is saved
+    ...(store?.preferences.omProgramModule ? programTabs : []),
+    // Display insurance tab only if insurance providers are available and the patient is saved
+    insuranceProvidersData.length > 0
+      ? {
+          Component: <InsuranceListView />,
+          value: PatientTabValue.Insurance,
+        }
+      : ({} as TabDefinition),
+  ];
+
   return (
     <React.Suspense fallback={<DetailViewSkeleton />}>
+      <AppBarButtons disabled={!!createNewPatient} store={store} />
+      <PatientSummary />
+      {/* Renders specific tabs on specific cases */}
+      {!createNewPatient ? (
+        <DetailTabs tabs={tabs} requiresConfirmation={requiresConfirmation} />
+      ) : (
+        <PatientDetailView onEdit={setIsDirtyPatient} />
+      )}
+      {/* Note: unmount modals when not used because they have some internal
+      state that shouldn't be reused across calls. */}
       {current === PatientModal.Program ? <ProgramDetailModal /> : null}
       {current === PatientModal.Encounter ? <CreateEncounterModal /> : null}
       {current === PatientModal.ProgramSearch ? (
@@ -409,17 +153,6 @@ export const PatientView = () => {
         <CreateContactTraceModal />
       ) : null}
       {current === PatientModal.Insurance ? <InsuranceModal /> : null}
-
-      <AppBarButtons disabled={!!createNewPatient} store={store} />
-      <PatientSummary />
-      {/* Only show tabs if program module is on and patient is saved.
-      TODO: Prescription tab? - would need tab refactoring since also seems useful in programs
-      */}
-      {!createNewPatient && store?.preferences.omProgramModule ? (
-        <DetailTabs tabs={tabs} requiresConfirmation={requiresConfirmation} />
-      ) : (
-        <PatientDetailView onEdit={setIsDirtyPatient} />
-      )}
     </React.Suspense>
   );
 };

--- a/client/packages/system/src/Patient/PatientView/PatientView.tsx
+++ b/client/packages/system/src/Patient/PatientView/PatientView.tsx
@@ -101,16 +101,17 @@ export const PatientView = () => {
       value: PatientTabValue.Details,
       confirmOnLeaving: isDirtyPatient,
     },
-    // Display program tabs only if the Program module is enabled and the patient is saved
-    ...(store?.preferences.omProgramModule ? programTabs : []),
-    // Display insurance tab only if insurance providers are available and the patient is saved
-    insuranceProvidersData.length > 0
-      ? {
-          Component: <InsuranceListView />,
-          value: PatientTabValue.Insurance,
-        }
-      : ({} as TabDefinition),
   ];
+
+  // Display program tabs only if the Program module is enabled and the patient is saved
+  if (store?.preferences.omProgramModule) tabs.push(...programTabs);
+
+  // Display insurance tab only if insurance providers are available and the patient is saved
+  if (insuranceProvidersData.length > 0)
+    tabs.push({
+      Component: <InsuranceListView />,
+      value: PatientTabValue.Insurance,
+    });
 
   return (
     <React.Suspense fallback={<DetailViewSkeleton />}>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6889 

# 👩🏻‍💻 What does this PR do?

If insuranceProviders are available, the tab should show for insurance, even if the Uses Program Module is turned off.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

Side Quest: I've moved `PatientDetailView` to its own file. `PatientView` had a lot going on for it, navigating can be a bit overwhelming

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

If you have insurance providers in your store and programs module is on
- [ ] Turn off `Open mSupply: Uses Program Module` within legacy mSupply for your store
- [ ] Navigate to a Patient
- [ ] Should be able to see any Programs related component
   - [ ] E.g. programs tab, encounter button in dropdown of `AddButton` 
- [ ] Should be able to navigate to insurance tab and add insurance

If you don't have insurance providers in your store and programs module is off
- [ ] Turn off `Open mSupply: Uses Program Module` within legacy mSupply for your store
- [ ] Navigate to a Patient
- [ ] Should not be able to see any programs related component
- [ ] Should not be able to add insurance or visit insurance tab

If you don't have insurance providers in your store but programs module is on
- [ ] Navigate to a Patient
- [ ] Should be able to see any Programs related component
   - [ ] E.g. programs tab, encounter button in dropdown of `AddButton` 
- [ ] Should not be able to navigate to insurance tab or add insurance

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

