### PR TITLE
6758 Vaccine dose UI updates

### DIFF
--- a/client/packages/system/src/Vaccination/Components/SelectBatch.tsx
+++ b/client/packages/system/src/Vaccination/Components/SelectBatch.tsx
@@ -35,8 +35,7 @@ export const SelectBatch = ({
     }
   }, [data]);
 
-  // Show checkbox as disabled if only one batch to choose from
-  const isCheckboxDisabled = data?.nodes?.length === 1;
+  const hasSingleBatch = data?.nodes?.length === 1;
 
   const columns = useColumns<StockLineFragment>(
     [
@@ -45,7 +44,7 @@ export const SelectBatch = ({
         key: 'select',
         Cell: ({ rowData, isDisabled }) => (
           <Checkbox
-            disabled={isDisabled || isCheckboxDisabled}
+            disabled={isDisabled || hasSingleBatch}
             checked={rowData.id === stockLine?.id}
           />
         ),

--- a/client/packages/system/src/Vaccination/Components/SelectBatch.tsx
+++ b/client/packages/system/src/Vaccination/Components/SelectBatch.tsx
@@ -104,6 +104,7 @@ const BatchTable = ({
         height: 'unset',
         '& td': {
           paddingY: 0,
+          paddingLeft: '16',
         },
       }
     );

--- a/client/packages/system/src/Vaccination/Components/SelectBatch.tsx
+++ b/client/packages/system/src/Vaccination/Components/SelectBatch.tsx
@@ -35,6 +35,9 @@ export const SelectBatch = ({
     }
   }, [data]);
 
+  // Show checkbox as disabled if only one batch to choose from
+  const isCheckboxDisabled = data?.nodes?.length === 1;
+
   const columns = useColumns<StockLineFragment>(
     [
       {
@@ -42,7 +45,7 @@ export const SelectBatch = ({
         key: 'select',
         Cell: ({ rowData, isDisabled }) => (
           <Checkbox
-            disabled={isDisabled}
+            disabled={isDisabled || isCheckboxDisabled}
             checked={rowData.id === stockLine?.id}
           />
         ),
@@ -101,7 +104,7 @@ const BatchTable = ({
         // Make the table a little more compact
         height: 'unset',
         '& td': {
-          padding: 0,
+          paddingY: 0,
         },
       }
     );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6758 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Two changes within the vaccine batch selection table:
- Fixed the alignment of the table headers with table columns
- disabled the checkbox if there is only one batch of the vaccine item 

The checkbox was already auto-selected and unable to be unticked, this adds the visual 'greyed out' so the user knows it is unable to be changed, vs with multiple batches it can be changed

Multiple batches
![Screenshot 2025-03-13 at 12 53 34 PM](https://github.com/user-attachments/assets/0d27827c-be2b-4289-87af-7a541537cf23)


One batch
![Screenshot 2025-03-13 at 12 52 12 PM](https://github.com/user-attachments/assets/990fdc3d-4d8e-4c2a-a513-7ccf2fb7dbcf)

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Make sure you have Immunization Program and Vaccination Card enabled for your datafile
- [ ] Have a patient enrolled into a program
- [ ] Have vaccine courses configured for an immunization program. One should have only a single batch, and another vaccine should have multiple batches of the vaccine available (and an expiry).
- [ ] Create an encounter for that patient -> administer a dose of vaccine
- [ ] See the multiple batches allows selection of a batch and has aligned table headers
- [ ] See the vaccine with a single batch is automatically checked, and disabled/greyed out

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

