### PR TITLE
6729 fix remove option when no location selected

### DIFF
--- a/client/packages/common/src/ui/components/errors/NothingHere.tsx
+++ b/client/packages/common/src/ui/components/errors/NothingHere.tsx
@@ -21,7 +21,10 @@ export const NothingHere: React.FC<NothingHereProps> = ({
   const createButtonText = buttonText || t('button.create-a-new-one');
 
   const CreateButton = !!onCreate ? (
-    <Button sx={{ textTransform: 'none' }} onClick={() => onCreate()}>
+    <Button
+      sx={{ textTransform: 'none', color: 'secondary.main' }}
+      onClick={() => onCreate()}
+    >
       {createButtonText}
     </Button>
   ) : undefined;
@@ -29,7 +32,7 @@ export const NothingHere: React.FC<NothingHereProps> = ({
   const Body = !!body ? (
     <Typography
       fontSize={14}
-      sx={{ color: 'gray.light' }}
+      sx={{ color: 'gray.main' }}
       display="flex"
       alignItems="center"
     >

--- a/client/packages/system/src/Location/Components/LocationSearchInput.tsx
+++ b/client/packages/system/src/Location/Components/LocationSearchInput.tsx
@@ -78,7 +78,11 @@ export const LocationSearchInput: FC<LocationSearchInputProps> = ({
     code: l.code,
   }));
 
-  if (locations.length > 0 && selectedLocation !== undefined) {
+  if (
+    locations.length > 0 &&
+    selectedLocation !== null &&
+    selectedLocation !== undefined
+  ) {
     options.push({ value: null, label: t('label.remove') });
   }
 

--- a/client/packages/system/src/Location/Components/LocationSearchInput.tsx
+++ b/client/packages/system/src/Location/Components/LocationSearchInput.tsx
@@ -78,7 +78,7 @@ export const LocationSearchInput: FC<LocationSearchInputProps> = ({
     code: l.code,
   }));
 
-  if (locations.length > 0 && selectedLocation !== null) {
+  if (locations.length > 0 && selectedLocation !== undefined) {
     options.push({ value: null, label: t('label.remove') });
   }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6729 

# 👩🏻‍💻 What does this PR do?
Fix check for an undefined location so that "remove" option does not show in list if no location selected.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
![Screenshot 2025-03-13 at 16 26 53](https://github.com/user-attachments/assets/e428738b-55ff-461b-997a-cbcab2ae73f4)

Sidequest:
Update colours based on @mariyamsupply feedback for nothing here view to make link colour consistent with other links and message more accessible.
![Screenshot 2025-03-13 at 16 27 48](https://github.com/user-attachments/assets/3c98a885-298d-4da1-a47c-35fdc4d17075)

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an inbound shipment
- [ ] Add an item to shipment
- [ ] Go over to location tab
- [ ] See that 'remove' option is no longer visible when no location is selected
- [ ] Select a location
- [ ] Remove location
- [ ] Open dropdown again -> See that 'remove' option does not display when location has been cleared

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [x] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [x] Frontend

