### PR TITLE
6915 Target MOS is slightly different after migration

### DIFF
--- a/server/service/src/sync/translations/requisition.rs
+++ b/server/service/src/sync/translations/requisition.rs
@@ -7,7 +7,9 @@ use repository::{
 };
 
 use serde::{Deserialize, Serialize};
-use util::constants::{MISSING_PROGRAM, NUMBER_OF_DAYS_IN_A_MONTH};
+use util::constants::{
+    MISSING_PROGRAM, MSUPPLY_NUMBER_OF_DAYS_IN_A_MONTH, NUMBER_OF_DAYS_IN_A_MONTH,
+};
 
 use crate::sync::{
     sync_serde::{
@@ -269,7 +271,7 @@ impl SyncTranslation for RequisitionTranslation {
                 date_and_time_to_datetime(data.date_entered, 0),
                 from_legacy_sent_datetime(data.last_modified_at, &r#type),
                 from_legacy_finalised_datetime(data.last_modified_at, &r#type),
-                data.daysToSupply as f64 / 30.0,
+                data.daysToSupply as f64 / MSUPPLY_NUMBER_OF_DAYS_IN_A_MONTH,
                 from_legacy_status(&data.r#type, &data.status).ok_or(anyhow::Error::msg(
                     format!("Unsupported requisition status: {:?}", data.status),
                 ))?,
@@ -402,7 +404,7 @@ impl SyncTranslation for RequisitionTranslation {
             requester_reference: their_reference,
             linked_requisition_id,
             thresholdMOS: min_months_of_stock,
-            daysToSupply: (30.0 * max_months_of_stock) as i64,
+            daysToSupply: (MSUPPLY_NUMBER_OF_DAYS_IN_A_MONTH * max_months_of_stock) as i64,
             max_months_of_stock: Some(max_months_of_stock),
             om_colour: colour.clone(),
             comment,

--- a/server/service/src/sync/translations/requisition.rs
+++ b/server/service/src/sync/translations/requisition.rs
@@ -269,7 +269,7 @@ impl SyncTranslation for RequisitionTranslation {
                 date_and_time_to_datetime(data.date_entered, 0),
                 from_legacy_sent_datetime(data.last_modified_at, &r#type),
                 from_legacy_finalised_datetime(data.last_modified_at, &r#type),
-                data.daysToSupply as f64 / NUMBER_OF_DAYS_IN_A_MONTH,
+                data.daysToSupply as f64 / 30.0,
                 from_legacy_status(&data.r#type, &data.status).ok_or(anyhow::Error::msg(
                     format!("Unsupported requisition status: {:?}", data.status),
                 ))?,
@@ -402,7 +402,7 @@ impl SyncTranslation for RequisitionTranslation {
             requester_reference: their_reference,
             linked_requisition_id,
             thresholdMOS: min_months_of_stock,
-            daysToSupply: (NUMBER_OF_DAYS_IN_A_MONTH * max_months_of_stock) as i64,
+            daysToSupply: (30.0 * max_months_of_stock) as i64,
             max_months_of_stock: Some(max_months_of_stock),
             om_colour: colour.clone(),
             comment,

--- a/server/util/src/constants.rs
+++ b/server/util/src/constants.rs
@@ -6,6 +6,7 @@ pub const INVENTORY_ADJUSTMENT_NAME_CODE: &str = "invad";
 pub const REPACK_NAME_CODE: &str = "repack";
 /// Number of days in a month (used in AMC calculation)
 pub const NUMBER_OF_DAYS_IN_A_MONTH: f64 = 365.25 / 12.0;
+pub const MSUPPLY_NUMBER_OF_DAYS_IN_A_MONTH: f64 = 30.0;
 /// For use when service item is not specified in service invoice line
 pub const DEFAULT_SERVICE_ITEM_CODE: &str = "service";
 /// System names to not be included in name query


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6915

# 👩🏻‍💻 What does this PR do?
Use 30 instead of days in month const. Min threshold seems to be correct and doesn't need changing

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a store in OG site
- [ ] Create IO for that store, adjust threshold/target MOS
- [ ] Transfer store to OMS site
- [ ] Sync
- [ ] Check threshold/target MOS match OG record

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

