### PR TITLE
6863 patient list view gender & deceased fields are not translated to respective languages

### DIFF
--- a/client/packages/system/src/Patient/CreatePatientModal/PatientResultsTab.tsx
+++ b/client/packages/system/src/Patient/CreatePatientModal/PatientResultsTab.tsx
@@ -2,7 +2,9 @@ import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   BasicSpinner,
   Box,
+  ColumnAlign,
   DataTable,
+  DotCell,
   DownloadIcon,
   FnUtils,
   GenderType,
@@ -155,6 +157,9 @@ export const PatientResultsTab: FC<PatientPanel & { active: boolean }> = ({
     {
       key: 'isDeceased',
       label: 'label.deceased',
+      align: ColumnAlign.Center,
+      Cell: DotCell,
+      sortable: false,
     },
     {
       key: 'isOnCentral',

--- a/client/packages/system/src/Patient/CreatePatientModal/PatientResultsTab.tsx
+++ b/client/packages/system/src/Patient/CreatePatientModal/PatientResultsTab.tsx
@@ -24,6 +24,7 @@ import { CentralPatientSearchResponse } from '../api/api';
 import { AppRoute } from '@openmsupply-client/config';
 import { Gender, usePatientStore } from '@openmsupply-client/programs';
 import { usePrescription } from '@openmsupply-client/invoices/src/Prescriptions';
+import { getGenderTranslationKey } from '../PatientView/utils';
 
 const genderToGenderType = (gender: Gender): GenderType => {
   switch (gender) {
@@ -149,6 +150,7 @@ export const PatientResultsTab: FC<PatientPanel & { active: boolean }> = ({
     {
       key: 'gender',
       label: 'label.gender',
+      formatter: gender => t(getGenderTranslationKey(gender as GenderType)),
     },
     {
       key: 'isDeceased',

--- a/client/packages/system/src/Patient/ListView/ListView.tsx
+++ b/client/packages/system/src/Patient/ListView/ListView.tsx
@@ -13,13 +13,15 @@ import {
   useAuthContext,
   useNavigate,
   ColumnDescription,
-  Formatter,
+  useTranslation,
+  GenderType,
 } from '@openmsupply-client/common';
 import { usePatient, PatientRowFragment } from '../api';
 import { AppBarButtons } from './AppBarButtons';
 import { Toolbar } from './Toolbar';
 import { usePatientStore } from '@openmsupply-client/programs';
 import { ChipTableCell } from '../Components';
+import { getGenderTranslationKey } from '../PatientView/utils';
 
 export const programEnrolmentLabelAccessor: ColumnDataAccessor<
   PatientRowFragment,
@@ -33,7 +35,8 @@ export const programEnrolmentLabelAccessor: ColumnDataAccessor<
   });
 };
 
-const PatientListComponent: FC = () => {
+const PatientListComponent = () => {
+  const t = useTranslation();
   const {
     updateSortQuery,
     updatePaginationQuery,
@@ -94,7 +97,7 @@ const PatientListComponent: FC = () => {
     {
       key: 'gender',
       label: 'label.gender',
-      formatter: gender => Formatter.enumCase((gender as string) ?? ''),
+      formatter: gender => t(getGenderTranslationKey(gender as GenderType)),
     },
     {
       key: 'dateOfBirth',

--- a/client/packages/system/src/Patient/PatientView/index.ts
+++ b/client/packages/system/src/Patient/PatientView/index.ts
@@ -1,1 +1,2 @@
 export { PatientView } from './PatientView';
+export { getGenderTranslationKey } from './utils';


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6863

# 👩🏻‍💻 What does this PR do?
- Translate gender in list view and in the search modal
- Change deceased in search modal to a dot cell to match with list view
![Screenshot 2025-03-14 at 8 32 42 AM](https://github.com/user-attachments/assets/6823cbe3-2c66-4bca-b374-7e2822cf123a)
![Screenshot 2025-03-14 at 8 32 49 AM](https://github.com/user-attachments/assets/74947291-cc66-4393-9ff1-b9b2f74275d5)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to patient list view
- [ ] Change language
- [ ] Gender should be translated
- [ ] Try create a new patient with existing patient name
- [ ] See that gender is translated and deceased should be dot or empty

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

