### PR TITLE
conditionally hide clinicians from encounters

### DIFF
--- a/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
@@ -17,6 +17,7 @@ import {
 } from '@openmsupply-client/common';
 import {
   EncounterFragment,
+  useClinicians,
   useDocumentRegistry,
 } from '@openmsupply-client/programs';
 import {
@@ -75,6 +76,9 @@ export const Toolbar: FC<ToolbarProps> = ({ encounter, onChange }) => {
         contextId: { equalTo: encounter?.contextId },
       },
     });
+
+  const { data: clinicians } = useClinicians.document.list({});
+  const hasClinicians = clinicians?.nodes.length !== 0;
 
   useEffect(() => {
     setStartDatetime(encounter.startDatetime);
@@ -159,20 +163,22 @@ export const Toolbar: FC<ToolbarProps> = ({ encounter, onChange }) => {
                   />
                 }
               />
-              <Row
-                label={t('label.clinician')}
-                Input={
-                  <ClinicianSearchInput
-                    onChange={clinician => {
-                      setClinician(clinician);
-                      onChange({
-                        clinician: clinician?.value as ClinicianNode,
-                      });
-                    }}
-                    clinicianValue={clinician?.value}
-                  />
-                }
-              />
+              {hasClinicians && (
+                <Row
+                  label={t('label.clinician')}
+                  Input={
+                    <ClinicianSearchInput
+                      onChange={clinician => {
+                        setClinician(clinician);
+                        onChange({
+                          clinician: clinician?.value as ClinicianNode,
+                        });
+                      }}
+                      clinicianValue={clinician?.value}
+                    />
+                  }
+                />
+              )}
             </Box>
             <Box display="flex" gap={1}>
               <Row

--- a/client/packages/system/src/Patient/Encounter/CreateEncounterForm.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterForm.tsx
@@ -7,7 +7,11 @@ import {
   Tooltip,
 } from '@openmsupply-client/common';
 import { DateUtils, useTranslation } from '@common/intl';
-import { NoteSchema, EncounterSchema } from '@openmsupply-client/programs';
+import {
+  NoteSchema,
+  EncounterSchema,
+  useClinicians,
+} from '@openmsupply-client/programs';
 import {
   ClinicianAutocompleteOption,
   ClinicianSearchInput,
@@ -71,6 +75,9 @@ export const CreateEncounterForm: FC<{
     setHasFormError(false);
   };
 
+  const { data: clinicians } = useClinicians.document.list({});
+  const hasClinicians = clinicians?.nodes.length !== 0;
+
   const setClinician = (option: ClinicianAutocompleteOption | null): void => {
     if (option === null) {
       setDraft({ ...draft, clinician: undefined });
@@ -109,17 +116,19 @@ export const CreateEncounterForm: FC<{
           />
         }
       />
-      <InputWithLabelRow
-        labelProps={{ sx: { flex: LABEL_FLEX } }}
-        label={t('label.clinician')}
-        Input={
-          <ClinicianSearchInput
-            fullWidth
-            onChange={setClinician}
-            clinicianValue={draft?.clinician}
-          />
-        }
-      />
+      {hasClinicians && (
+        <InputWithLabelRow
+          labelProps={{ sx: { flex: LABEL_FLEX } }}
+          label={t('label.clinician')}
+          Input={
+            <ClinicianSearchInput
+              fullWidth
+              onChange={setClinician}
+              clinicianValue={draft?.clinician}
+            />
+          }
+        />
+      )}
       <InputWithLabelRow
         labelProps={{ sx: { flex: LABEL_FLEX } }}
         label={t('label.visit-notes')}

--- a/client/packages/system/src/Vaccination/Components/VaccinationModal.tsx
+++ b/client/packages/system/src/Vaccination/Components/VaccinationModal.tsx
@@ -33,6 +33,7 @@ import { FacilitySearchInput, OTHER_FACILITY } from './FacilitySearchInput';
 import { SelectItemAndBatch } from './SelectItemAndBatch';
 import { getSwitchReason } from './getSwitchReason';
 import { useConfirmNoStockLineSelected } from './useConfirmNoStockLineSelected';
+import { useClinicians } from 'packages/programs/src';
 
 interface VaccinationModalProps {
   vaccinationId: string | undefined;
@@ -148,6 +149,9 @@ const VaccinationForm = ({
 }) => {
   const t = useTranslation();
 
+  const { data: clinicians } = useClinicians.document.list({});
+  const hasClinicians = clinicians?.nodes.length !== 0;
+
   if (!dose) {
     return null;
   }
@@ -216,7 +220,7 @@ const VaccinationForm = ({
           </Grid>
         }
       />
-      {!isOtherFacility && (
+      {hasClinicians && !isOtherFacility && (
         <InputWithLabelRow
           label={t('label.clinician')}
           Input={

--- a/client/packages/system/src/Vaccination/Components/VaccinationModal.tsx
+++ b/client/packages/system/src/Vaccination/Components/VaccinationModal.tsx
@@ -33,7 +33,7 @@ import { FacilitySearchInput, OTHER_FACILITY } from './FacilitySearchInput';
 import { SelectItemAndBatch } from './SelectItemAndBatch';
 import { getSwitchReason } from './getSwitchReason';
 import { useConfirmNoStockLineSelected } from './useConfirmNoStockLineSelected';
-import { useClinicians } from 'packages/programs/src';
+import { useClinicians } from '@openmsupply-client/programs';
 
 interface VaccinationModalProps {
   vaccinationId: string | undefined;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6694 

# 👩🏻‍💻 What does this PR do?


- Hides the clinician search input if there are no clinicians configured
- Becomes visible if a clinician is added in OG

Encounter Modal
<img width="668" alt="Screenshot 2025-03-14 at 1 06 39 PM" src="https://github.com/user-attachments/assets/6ebcfde0-d7e2-4ce7-9e07-4545c3679be0" />

Encounter Toolbar
<img width="1253" alt="Screenshot 2025-03-14 at 1 06 22 PM" src="https://github.com/user-attachments/assets/e1ea3ee4-e7d0-478c-a460-055fe584d169" />

Vaccine Modal
![Screenshot 2025-03-14 at 3 58 31 PM](https://github.com/user-attachments/assets/7e7a72bb-8d04-4fcc-804e-978f2986a8d0)





<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

ClinicianSearchInput is in three other places currently:
- Vaccination Modal
- New Prescription Modal
- Prescriptions Detail View (Toolbar)

Unsure if it's in the plans or not, but if we were to create the same changes in all of these, we could then pass the clinician data to the search input, rather than calling it through the api in the modal/toolbar and then again when using the search input

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have no clinicians configured for your store
- [ ] Have Vaccination card configured, and add/enroll a patient in the immunization program
- [ ] From the patient, go to Encounters -> Create Encounter. See fields Encounter, Visit Date, Notes but no Clinician input
- [ ] Create the encounter, then select it from the list
- [ ] See no clinician input in the Toolbar

- [ ] In OG, go to special -> Prescribers -> Create a new clinician
- [ ] Ensure they have visibility in your store
- [ ] In OMS -> sync -> repeat the above steps, but see and use the clinician input

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

