### PR TITLE
6795 prescription sidebar styling

### DIFF
--- a/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/AdditionalInfoSection.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/AdditionalInfoSection.tsx
@@ -57,6 +57,7 @@ export const AdditionalInfoSectionComponent: FC = () => {
 
         <PanelLabel>{t('heading.comment')}</PanelLabel>
         <BufferedTextArea
+          fullWidth
           disabled={isDisabled}
           onChange={e => {
             setCommentBuffer(e.target.value);

--- a/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/PatientDetails.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/PatientDetails.tsx
@@ -8,6 +8,7 @@ import {
   PanelField,
   UNDEFINED_STRING_VALUE,
   Grid,
+  useTheme,
 } from '@openmsupply-client/common';
 import { usePrescription } from '../../api';
 import { useDiagnosisOptions } from '../../api/hooks/useDiagnosisOptions';
@@ -29,6 +30,8 @@ export const PatientDetailsComponent = () => {
   const {
     query: { data: diagnosisOptions },
   } = useDiagnosisOptions();
+
+  const theme = useTheme();
 
   const displayValue =
     selected === undefined
@@ -81,6 +84,7 @@ export const PatientDetailsComponent = () => {
               }
             }}
             disabled={isDisabled}
+            textSx={{ backgroundColor: theme.palette.background.white }}
           />
         </PanelRow>
       </Grid>

--- a/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/PrescriptionDetailsSection.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/PrescriptionDetailsSection.tsx
@@ -98,7 +98,7 @@ export const PrescriptionDetailsSectionComponent: FC = () => {
           <BasicTextInput
             disabled={isDisabled}
             size="small"
-            sx={{ width: 250 }}
+            fullWidth
             slotProps={{
               input: {
                 sx: {

--- a/client/packages/system/src/Program/ProgramSearchInput.tsx
+++ b/client/packages/system/src/Program/ProgramSearchInput.tsx
@@ -18,7 +18,6 @@ export const ProgramSearchInput: FC<ProgramSearchInputProps> = ({
   onChange,
   width = 250,
   disabled,
-  fullWidth,
 }) => {
   const theme = useTheme();
 
@@ -35,7 +34,6 @@ export const ProgramSearchInput: FC<ProgramSearchInputProps> = ({
       isOptionEqualToValue={(option, value) =>
         option.value.id === value.value?.id
       }
-      width={`${width}px`}
       onChange={(_, option) => {
         onChange(option?.value);
       }}
@@ -43,10 +41,10 @@ export const ProgramSearchInput: FC<ProgramSearchInputProps> = ({
         label: program.name,
         value: program,
       }))}
+      fullWidth
       sx={{ minWidth: width }}
       textSx={{ backgroundColor: theme.palette.background.white }}
       disabled={disabled}
-      fullWidth={fullWidth}
     />
   );
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6795 

# 👩🏻‍💻 What does this PR do?

Makes background of the diagnosis input in the prescriptions' sidebar white.
Make the width of the inputs consistent.
Further work might be done to improve the sidebar as other problems do remain (e.g. the spacing between the input labels and the inputs is inconsistent).
The intention is that this PR will get RC2.6.1 over the line in time.

## 💌 Any notes for the reviewer?


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Open the sidebar in prescriptions and  check the diagnosis input box is white (screenshot below) and all the inputs have the same width:
![image](https://github.com/user-attachments/assets/0a70851b-ea9f-47ac-b360-3ed6a2bb6a45)


# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: screenshots of the prescriptions' sidebar.

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

