### PR TITLE
6600 Able to link yourself as a patient in Next of Kin

### DIFF
--- a/client/packages/programs/src/JsonForms/components/Search/SearchWithUserSource.tsx
+++ b/client/packages/programs/src/JsonForms/components/Search/SearchWithUserSource.tsx
@@ -17,7 +17,7 @@ import { FORM_INPUT_COLUMN_WIDTH } from '../../common/styleConstants';
 import { usePatientSearchQuery } from './usePatientSearchQuery';
 import { UserOptions } from './Search';
 import { JsonFormsDispatch } from '@jsonforms/react';
-import { PatientSchema } from '@openmsupply-client/programs';
+import { PatientSchema, usePatientStore } from '@openmsupply-client/programs';
 
 const { formatTemplateString } = RegexUtils;
 
@@ -35,8 +35,12 @@ export const SearchWithUserSource = (
     renderers,
   } = props;
   const t = useTranslation();
+  const { currentPatient } = usePatientStore();
   const isPatientSelected = !!data?.id;
   const { results, error: queryError, mutateAsync } = usePatientSearchQuery();
+  const filteredResult = results.filter(
+    result => result.id !== currentPatient?.id
+  );
 
   useEffect(() => {
     const searchFilter = !isPatientSelected
@@ -96,14 +100,14 @@ export const SearchWithUserSource = (
         renderers={renderers}
         enabled={!isPatientSelected}
       />
-      {(isPatientSelected || results.length > 0) &&
+      {(isPatientSelected || filteredResult.length > 0) &&
         (!isPatientSelected ? (
           <Box>
             <Typography variant="body2" mt={1} mb={1} sx={{ textWrap: 'wrap' }}>
               <em>{t('control.search.matching-patients')}</em>
             </Typography>
             <Select
-              options={results.map(res => ({
+              options={filteredResult.map(res => ({
                 label: getOptionLabel(res) ?? '',
                 value: res.id,
               }))}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6600

# 👩🏻‍💻 What does this PR do?
Filter out current patient from the next of kin search

![Screenshot 2025-03-17 at 11 34 33 AM](https://github.com/user-attachments/assets/253f5d33-eb2e-454e-bd41-56d1fc14c3a6)

![Screenshot 2025-03-17 at 11 34 22 AM](https://github.com/user-attachments/assets/2d111970-0743-4426-ba86-b18523f269bb)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have some patients
- [ ] Click on a patient and try search them as a next of kin
- [ ] Shouldn't see a result
- [ ] Have lots of patients with same last name
- [ ] Go to one of those patients
- [ ] Search the last name
- [ ] Shouldn't see the current patient in the selection for next of kin

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

