### PR TITLE
Revert "Use 30 instead of number of days in month"

### DIFF
--- a/server/service/src/sync/translations/requisition.rs
+++ b/server/service/src/sync/translations/requisition.rs
@@ -271,7 +271,7 @@ impl SyncTranslation for RequisitionTranslation {
                 date_and_time_to_datetime(data.date_entered, 0),
                 from_legacy_sent_datetime(data.last_modified_at, &r#type),
                 from_legacy_finalised_datetime(data.last_modified_at, &r#type),
-                data.daysToSupply as f64 / MSUPPLY_NUMBER_OF_DAYS_IN_A_MONTH,
+                data.daysToSupply as f64 / NUMBER_OF_DAYS_IN_A_MONTH,
                 from_legacy_status(&data.r#type, &data.status).ok_or(anyhow::Error::msg(
                     format!("Unsupported requisition status: {:?}", data.status),
                 ))?,
@@ -404,7 +404,7 @@ impl SyncTranslation for RequisitionTranslation {
             requester_reference: their_reference,
             linked_requisition_id,
             thresholdMOS: min_months_of_stock,
-            daysToSupply: (MSUPPLY_NUMBER_OF_DAYS_IN_A_MONTH * max_months_of_stock) as i64,
+            daysToSupply: (NUMBER_OF_DAYS_IN_A_MONTH * max_months_of_stock) as i64,
             max_months_of_stock: Some(max_months_of_stock),
             om_colour: colour.clone(),
             comment,


### PR DESCRIPTION
This reverts commit 4997f50e8d44eb4884427bf2f41390c7e583014a.

<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Reverts the change to use 30 days for number of days in a month, pending better fix  under #6930 

# 👩🏻‍💻 What does this PR do?

Reverts the changes

## 💌 Any notes for the reviewer?

Better to have 2.6 in a broken but known state rather than creating another scenario to worry about in future.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Check that I didn't break something!

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

