### PR TITLE
6896 Deleting an immunization program master list in OG is not reflected in OMS

### DIFF
--- a/server/service/src/sync/translations/program_requisition_settings.rs
+++ b/server/service/src/sync/translations/program_requisition_settings.rs
@@ -29,6 +29,7 @@ pub struct LegacyListMasterRow {
     #[serde(rename = "programSettings")]
     program_settings: Option<LegacyProgramSettings>,
     is_immunisation: Option<bool>,
+    inactive: Option<bool>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -205,10 +206,10 @@ fn generate_requisition_program(
         context_id: context_row.id.clone(),
         is_immunisation: master_list.is_immunisation.unwrap_or(false),
         elmis_code: program_settings.elmis_code.clone(),
-        deleted_datetime: if master_list.is_program {
-            None
-        } else {
+        deleted_datetime: if master_list.inactive.unwrap_or(false) {
             Some(chrono::Utc::now().naive_utc())
+        } else {
+            None
         },
     };
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6896

# 👩🏻‍💻 What does this PR do?
Save deleted_datetime based on inactive field for program master lists

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have an immunisation program master list 
- [ ] Go to immunisation page, see that it is there
- [ ] Go to OG central and delete the immunisation master list 
- [ ] Sync OMS and refresh immunisation page
- [ ] Deleted program master list should be gone

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

