### PR TITLE
5713 empty inbound shipment sent to oms site

### DIFF
--- a/server/service/src/sync/test/test_data/invoice_line.rs
+++ b/server/service/src/sync/test/test_data/invoice_line.rs
@@ -868,6 +868,130 @@ fn trans_line_invalid_stockline_push_record() -> TestSyncOutgoingRecord {
     }
 }
 
+const TRANS_LINE_EMPTY_STOCKLINE: (&str, &str) = (
+    "TRANS_LINE_EMPTY_STOCKLINE",
+    r#"{        
+        "ID": "TRANS_LINE_EMPTY_STOCKLINE",
+        "transaction_ID": "outbound_shipment_a",
+        "item_ID": "item_a",
+        "batch": "",
+        "price_extension": -4000,
+        "note": "",
+        "sell_price": -200,
+        "expiry_date": "0000-00-00",
+        "cost_price": -200,
+        "pack_size": 1,
+        "quantity": -20,
+        "box_number": "",
+        "item_line_ID": "",
+        "line_number": 1,
+        "item_name": "Item A",
+        "supp_trans_line_ID_ns": "",
+        "goods_received_lines_ID": "",
+        "manufacturer_ID": "",
+        "foreign_currency_price": -200,
+        "location_ID": "",
+        "volume_per_pack": 0,
+        "repeat_ID": "",
+        "user_1": "",
+        "user_2": "",
+        "user_3": "",
+        "user_4": "",
+        "pack_size_inner": 0,
+        "pack_inners_in_outer": 0,
+        "is_from_inventory_adjustment": false,
+        "Weight": 0,
+        "source_backorder_id": "",
+        "order_lines_ID": "",
+        "donor_id": "",
+        "local_charge_line_total": 0,
+        "type": "stock_out",
+        "linked_transact_id": "",
+        "user_5_ID": "",
+        "user_6_ID": "",
+        "user_7_ID": "",
+        "user_8_ID": "",
+        "linked_trans_line_ID": "",
+        "barcodeID": "",
+        "sentQuantity": 0,
+        "optionID": "",
+        "isVVMPassed": "",
+        "prescribedQuantity": 0,
+        "vaccine_vial_monitor_status_ID": "",
+        "sent_pack_size": 0,
+        "custom_data": null,
+        "medicine_administrator_ID": "",
+        "om_item_code": "item_a_code",
+        "om_tax": null,
+        "om_total_before_tax": 4000.0,
+        "om_total_after_tax": 4000.0,
+        "om_item_variant_id": ""
+    }"#,
+);
+
+fn trans_line_empty_stockline_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
+        TABLE_NAME,
+        TRANS_LINE_EMPTY_STOCKLINE,
+        InvoiceLineRow {
+            id: TRANS_LINE_EMPTY_STOCKLINE.0.to_string(),
+            invoice_id: "outbound_shipment_a".to_string(),
+            item_link_id: mock_item_a().id,
+            item_name: mock_item_a().name,
+            item_code: mock_item_a().code,
+            stock_line_id: None,
+            location_id: None,
+            batch: None,
+            expiry_date: None,
+            pack_size: 1.0,
+            cost_price_per_pack: 200.0,
+            sell_price_per_pack: 200.0,
+            total_before_tax: 4000.0,
+            total_after_tax: 4000.0,
+            tax_percentage: None,
+            r#type: InvoiceLineType::StockIn,
+            number_of_packs: 20.0,
+            prescribed_quantity: Some(0.0),
+            note: None,
+            inventory_adjustment_reason_id: None,
+            return_reason_id: None,
+            foreign_currency_price_before_tax: Some(200.0),
+            item_variant_id: None,
+        },
+    )
+}
+
+fn trans_line_empty_stockline_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
+        table_name: TABLE_NAME.to_string(),
+        record_id: TRANS_LINE_EMPTY_STOCKLINE.0.to_string(),
+        push_data: json!(LegacyTransLineRow {
+            id: TRANS_LINE_EMPTY_STOCKLINE.0.to_string(),
+            invoice_id: "outbound_shipment_a".to_string(),
+            item_id: mock_item_a().id,
+            item_name: mock_item_a().name,
+            item_code: Some(mock_item_a().code),
+            stock_line_id: None,
+            location_id: None,
+            batch: None,
+            expiry_date: None,
+            pack_size: 1.0,
+            cost_price_per_pack: 200.0,
+            sell_price_per_pack: 200.0,
+            total_before_tax: Some(4000.0),
+            total_after_tax: Some(4000.0),
+            tax_percentage: None,
+            r#type: LegacyTransLineType::StockIn,
+            number_of_packs: 20.0,
+            prescribed_quantity: Some(0.0),
+            note: None,
+            option_id: None,
+            foreign_currency_price_before_tax: Some(200.0),
+            item_variant_id: None,
+        }),
+    }
+}
+
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
         trans_line_1_pull_record(),
@@ -877,6 +1001,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
         trans_line_negative_pull_record(),
         trans_line_prescribed_quantity_pull_record(),
         trans_line_invalid_stockline_pull_record(),
+        trans_line_empty_stockline_pull_record()
     ]
 }
 
@@ -897,5 +1022,6 @@ pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
         trans_line_negative_push_record(),
         trans_line_prescribed_quantity_push_record(),
         trans_line_invalid_stockline_push_record(),
+        trans_line_empty_stockline_push_record()
     ]
 }

--- a/server/service/src/sync/test/test_data/invoice_line.rs
+++ b/server/service/src/sync/test/test_data/invoice_line.rs
@@ -745,6 +745,129 @@ fn trans_line_prescribed_quantity_push_record() -> TestSyncOutgoingRecord {
     }
 }
 
+const TRANS_LINE_INVALID_STOCKLINE: (&str, &str) = (
+    "TRANS_LINE_INVALID_STOCKLINE",
+    r#"{        
+        "ID": "TRANS_LINE_INVALID_STOCKLINE",
+        "transaction_ID": "outbound_shipment_a",
+        "item_ID": "item_a",
+        "batch": "",
+        "price_extension": -4000,
+        "note": "",
+        "sell_price": -200,
+        "expiry_date": "0000-00-00",
+        "cost_price": -200,
+        "pack_size": 1,
+        "quantity": -20,
+        "box_number": "",
+        "item_line_ID": "some_invalid_line",
+        "line_number": 1,
+        "item_name": "Item A",
+        "supp_trans_line_ID_ns": "",
+        "goods_received_lines_ID": "",
+        "manufacturer_ID": "",
+        "foreign_currency_price": -200,
+        "location_ID": "",
+        "volume_per_pack": 0,
+        "repeat_ID": "",
+        "user_1": "",
+        "user_2": "",
+        "user_3": "",
+        "user_4": "",
+        "pack_size_inner": 0,
+        "pack_inners_in_outer": 0,
+        "is_from_inventory_adjustment": false,
+        "Weight": 0,
+        "source_backorder_id": "",
+        "order_lines_ID": "",
+        "donor_id": "",
+        "local_charge_line_total": 0,
+        "type": "stock_out",
+        "linked_transact_id": "",
+        "user_5_ID": "",
+        "user_6_ID": "",
+        "user_7_ID": "",
+        "user_8_ID": "",
+        "linked_trans_line_ID": "",
+        "barcodeID": "",
+        "sentQuantity": 0,
+        "optionID": "",
+        "isVVMPassed": "",
+        "prescribedQuantity": 0,
+        "vaccine_vial_monitor_status_ID": "",
+        "sent_pack_size": 0,
+        "custom_data": null,
+        "medicine_administrator_ID": "",
+        "om_item_code": "item_a_code",
+        "om_tax": null,
+        "om_total_before_tax": 4000.0,
+        "om_total_after_tax": 4000.0,
+        "om_item_variant_id": ""
+    }"#,
+);
+
+fn trans_line_invalid_stockline_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
+        TABLE_NAME,
+        TRANS_LINE_INVALID_STOCKLINE,
+        InvoiceLineRow {
+            id: TRANS_LINE_INVALID_STOCKLINE.0.to_string(),
+            invoice_id: "outbound_shipment_a".to_string(),
+            item_link_id: mock_item_a().id,
+            item_name: mock_item_a().name,
+            item_code: mock_item_a().code,
+            stock_line_id: None,
+            location_id: None,
+            batch: None,
+            expiry_date: None,
+            pack_size: 1.0,
+            cost_price_per_pack: 200.0,
+            sell_price_per_pack: 200.0,
+            total_before_tax: 4000.0,
+            total_after_tax: 4000.0,
+            tax_percentage: None,
+            r#type: InvoiceLineType::StockIn,
+            number_of_packs: 20.0,
+            prescribed_quantity: Some(0.0),
+            note: None,
+            inventory_adjustment_reason_id: None,
+            return_reason_id: None,
+            foreign_currency_price_before_tax: Some(200.0),
+            item_variant_id: None,
+        },
+    )
+}
+fn trans_line_invalid_stockline_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
+        table_name: TABLE_NAME.to_string(),
+        record_id: TRANS_LINE_INVALID_STOCKLINE.0.to_string(),
+        push_data: json!(LegacyTransLineRow {
+            id: TRANS_LINE_INVALID_STOCKLINE.0.to_string(),
+            invoice_id: "outbound_shipment_a".to_string(),
+            item_id: mock_item_a().id,
+            item_name: mock_item_a().name,
+            item_code: Some(mock_item_a().code),
+            stock_line_id: None,
+            location_id: None,
+            batch: None,
+            expiry_date: None,
+            pack_size: 1.0,
+            cost_price_per_pack: 200.0,
+            sell_price_per_pack: 200.0,
+            total_before_tax: Some(4000.0),
+            total_after_tax: Some(4000.0),
+            tax_percentage: None,
+            r#type: LegacyTransLineType::StockIn,
+            number_of_packs: 20.0,
+            prescribed_quantity: Some(0.0),
+            note: None,
+            option_id: None,
+            foreign_currency_price_before_tax: Some(200.0),
+            item_variant_id: None,
+        }),
+    }
+}
+
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
         trans_line_1_pull_record(),
@@ -753,6 +876,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
         trans_line_om_fields_unset_tax_pull_record(),
         trans_line_negative_pull_record(),
         trans_line_prescribed_quantity_pull_record(),
+        trans_line_invalid_stockline_pull_record(),
     ]
 }
 
@@ -772,5 +896,6 @@ pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
         trans_line_om_fields_unset_tax_push_record(),
         trans_line_negative_push_record(),
         trans_line_prescribed_quantity_push_record(),
+        trans_line_invalid_stockline_push_record(),
     ]
 }

--- a/server/service/src/sync/translations/invoice_line.rs
+++ b/server/service/src/sync/translations/invoice_line.rs
@@ -219,12 +219,11 @@ impl SyncTranslation for InvoiceLineTranslation {
         // TODO: remove the stock_line_is_valid check once central server does not generate the inbound shipment
         // omSupply should be generating the inbound, with valid stock lines.
         // Currently a uuid is assigned by central for the stock_line id which causes a foreign key constraint violation
-        let is_stock_line_valid = match stock_line_id {
-            Some(ref stock_line_id) => StockLineRowRepository::new(connection)
-                .find_one_by_id(stock_line_id)?
-                .is_some(),
-            None => false,
-        };
+        let is_stock_line_valid = stock_line_id.as_ref().is_some_and(|stock_line_id| {
+            StockLineRowRepository::new(connection)
+                .find_one_by_id(stock_line_id)
+                .is_ok_and(|stock_line| stock_line.is_some())
+        });
 
         if !is_stock_line_valid {
             log::warn!(

--- a/server/service/src/sync/translations/invoice_line.rs
+++ b/server/service/src/sync/translations/invoice_line.rs
@@ -223,7 +223,7 @@ impl SyncTranslation for InvoiceLineTranslation {
             Some(ref stock_line_id) => StockLineRowRepository::new(connection)
                 .find_one_by_id(stock_line_id)?
                 .is_some(),
-            None => true,
+            None => false,
         };
 
         if !is_stock_line_valid {
@@ -421,7 +421,7 @@ fn adjust_negative_values(line: InvoiceLineRow) -> InvoiceLineRow {
         return line;
     }
 
-    return InvoiceLineRow {
+    InvoiceLineRow {
         cost_price_per_pack: line.cost_price_per_pack.abs(),
         sell_price_per_pack: line.sell_price_per_pack.abs(),
         total_before_tax: line.total_before_tax.abs(),
@@ -430,7 +430,7 @@ fn adjust_negative_values(line: InvoiceLineRow) -> InvoiceLineRow {
         foreign_currency_price_before_tax: line.foreign_currency_price_before_tax.map(|n| n.abs()),
         r#type: InvoiceLineType::StockIn,
         ..line
-    };
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5713

# 👩🏻‍💻 What does this PR do?
Fixes stock line 
Not sure if this fixes it... but added a test and it seems fine? 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

