### PR TITLE
6970 translations 'no options' text when no options are shown needs to be translatable

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1672,6 +1672,7 @@
   "paymentMethod.Cash": "Cash",
   "paymentMethod.Cheque": "Cheque",
   "paymentMethod.Mobile": "Mobile Payment",
+  "label.no-options": "No options",
   "placeholder.enter-an-item-code-or-name": "Enter item code or name",
   "placeholder.enter-facility-code-or-name": "Enter facility code or name",
   "placeholder.enter-facility-name": "Enter facility name",

--- a/client/packages/common/src/intl/locales/fr/common.json
+++ b/client/packages/common/src/intl/locales/fr/common.json
@@ -110,6 +110,7 @@
   "button.update-status": "Mettre à jour le statut",
   "button.upload-assets": "Importer",
   "button.view": "Afficher",
+  "label.no-options": "Aucune option",
   "button.view-all-breaches": "Voir toutes les anomalies",
   "button.view-details": "Vue détaillée",
   "button.view-patient": "Voir Patient",

--- a/client/packages/programs/src/JsonForms/common/components/Autocomplete.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Autocomplete.tsx
@@ -131,6 +131,7 @@ const UIComponent = (props: ControlProps) => {
             return option.label === value.label;
           }}
           disabled={!props.enabled}
+          noOptionsText={t('label.no-options')}
         />
       }
     />

--- a/client/packages/system/src/Patient/ContactTrace/Components/ContactTraceSearchInput.tsx
+++ b/client/packages/system/src/Patient/ContactTrace/Components/ContactTraceSearchInput.tsx
@@ -6,6 +6,7 @@ import {
   DefaultAutocompleteItemOption,
   DocumentRegistryCategoryNode,
   Typography,
+  useTranslation,
 } from '@openmsupply-client/common';
 import {
   useDocumentRegistry,
@@ -36,6 +37,7 @@ export const ContactTraceSearchInput: FC<ContactTraceSearchInputProps> = ({
   width = 250,
   disabled = false,
 }) => {
+  const t = useTranslation();
   const { data, isLoading } = useDocumentRegistry.get.documentRegistries({
     filter: {
       category: {
@@ -77,6 +79,7 @@ export const ContactTraceSearchInput: FC<ContactTraceSearchInputProps> = ({
       width={`${width}px`}
       popperMinWidth={width}
       isOptionEqualToValue={(option, value) => option.id === value.id}
+      noOptionsText={t('label.no-options')}
     />
   );
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6970

# 👩🏻‍💻 What does this PR do?
Adds no options translations. 

![Screenshot 2025-03-19 at 10 24 56 AM](https://github.com/user-attachments/assets/50d9c589-5e0f-44cc-a319-473d7f3cb38e)


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to a patient
- [ ] Switch language to French
- [ ] Add contact tracing
- [ ] See no options translated in french

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

