### PR TITLE
6939 use callback permission hook for import button click

### DIFF
--- a/client/packages/coldchain/src/Equipment/ListView/AppBarButtons.tsx
+++ b/client/packages/coldchain/src/Equipment/ListView/AppBarButtons.tsx
@@ -22,26 +22,34 @@ import { assetsToCsv } from '../utils';
 import { AddFromScannerButton } from './AddFromScannerButton';
 import { useAssetData } from '@openmsupply-client/system';
 
+interface AppBarButtonsComponentProps {
+  importModalController: ToggleState;
+  modalController: ToggleState;
+}
+
 export const AppBarButtonsComponent = ({
   importModalController,
   modalController,
-}: {
-  importModalController: ToggleState;
-  modalController: ToggleState;
-}) => {
+}: AppBarButtonsComponentProps) => {
   const { success, error } = useNotification();
   const t = useTranslation();
   const { fetchAsync, isLoading } = useAssets.document.listAll();
   const { data: properties } = useAssetData.utils.properties();
   const isCentralServer = useIsCentralServerApi();
 
-  const onAdd = useCallbackWithPermission(
+  const handleUploadAssetClick = useCallbackWithPermission(
+    UserPermission.AssetMutate,
+    importModalController.toggleOn,
+    t('error.no-asset-import-permission')
+  );
+
+  const handleCreateAssetClick = useCallbackWithPermission(
     UserPermission.AssetMutate,
     modalController.toggleOn,
     t('error.no-asset-create-permission')
   );
 
-  const csvExport = async () => {
+  const handleCsvExportClick = async () => {
     const data = await fetchAsync();
     if (!data || !data?.nodes.length) {
       error(t('error.no-data'))();
@@ -64,19 +72,19 @@ export const AppBarButtonsComponent = ({
         <ButtonWithIcon
           Icon={<UploadIcon />}
           label={t('button.upload-assets')}
-          onClick={importModalController.toggleOn}
+          onClick={handleUploadAssetClick}
         />
         <ButtonWithIcon
           Icon={<PlusCircleIcon />}
           label={t('button.new-asset')}
-          onClick={onAdd}
+          onClick={handleCreateAssetClick}
         />
         <AddFromScannerButton />
         <LoadingButton
           startIcon={<DownloadIcon />}
           isLoading={isLoading}
           variant="outlined"
-          onClick={csvExport}
+          onClick={handleCsvExportClick}
           disabled={EnvUtils.platform === Platform.Android}
           label={t('button.export')}
         />

--- a/client/packages/coldchain/src/Equipment/ListView/ListView.tsx
+++ b/client/packages/coldchain/src/Equipment/ListView/ListView.tsx
@@ -139,14 +139,6 @@ const AssetListComponent: FC = () => {
 
   return (
     <>
-      <CreateAssetModal
-        isOpen={modalController.isOn}
-        onClose={modalController.toggleOff}
-      />
-      <EquipmentImportModal
-        isOpen={importModalController.isOn}
-        onClose={importModalController.toggleOff}
-      />
       <AppBarButtons
         importModalController={importModalController}
         modalController={modalController}
@@ -165,6 +157,14 @@ const AssetListComponent: FC = () => {
         enableColumnSelection
       />
       <Footer />
+      <CreateAssetModal
+        isOpen={modalController.isOn}
+        onClose={modalController.toggleOff}
+      />
+      <EquipmentImportModal
+        isOpen={importModalController.isOn}
+        onClose={importModalController.toggleOff}
+      />
     </>
   );
 };

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -294,6 +294,7 @@
   "error.name-program-duplicate": "Vaccine course name already exists for this program",
   "error.no-asset-create-permission": "You do not have permission to create a new asset.",
   "error.no-asset-edit-permission": "You do not have permission to edit assets.",
+  "error.no-asset-import-permission": "You do not have permission to import assets",
   "error.no-asset-log-reasons": "There are no asset log reasons to display.",
   "error.no-asset-view-permission": "You do not have permission to view assets.",
   "error.no-assets": "There are no assets to display.",


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6939 

# 👩🏻‍💻 What does this PR do?

When an accounts permissions View/Edit/Add assets are disabled. They can still click on the import button and access the modal for it. 

Applied the use of the hook `useCallbackWithPermission` to return a helpful message to the user that they don't have the right permission to take this action.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

<img width="289" alt="Screenshot 2025-03-19 at 11 22 49 AM" src="https://github.com/user-attachments/assets/1a150b52-355a-4d01-94af-d0ea9fc25940" />

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

Ensure that `View assets` and `Add/Edit assets` are turned **off** the account that you're currently logged in.

- [ ] Navigate: Cold Chain -> Equipment
- [ ] Click out or click Ok button when Authentication Error modal shows up
- [ ] Click on `Import` button
- [ ] Snackbar should show up indicating to the user - `You do not have permission to import assets`

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

