### PR TITLE
6482 i can't remove lines or set them to zero on an automatically generated inbound shipment (even if i added the line myself)

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -4391,6 +4391,12 @@ export type LineDeleteError = DeleteResponseRequisitionErrorInterface & {
   description: Scalars['String']['output'];
 };
 
+export type LineLinkedToTransferredInvoice =
+  DeleteInboundShipmentLineErrorInterface & {
+    __typename: 'LineLinkedToTransferredInvoice';
+    description: Scalars['String']['output'];
+  };
+
 export type LinkPatientPatientToStoreError = {
   __typename: 'LinkPatientPatientToStoreError';
   error: LinkPatientPatientToStoreErrorInterface;
@@ -8403,11 +8409,6 @@ export type TokenExpired = RefreshTokenErrorInterface & {
 
 export type TransferredRequisition = DeleteResponseRequisitionErrorInterface & {
   __typename: 'TransferredRequisition';
-  description: Scalars['String']['output'];
-};
-
-export type TransferredShipment = DeleteInboundShipmentLineErrorInterface & {
-  __typename: 'TransferredShipment';
   description: Scalars['String']['output'];
 };
 

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -10,10 +10,12 @@ import {
   TooltipTextCell,
   useColumnUtils,
   CurrencyCell,
+  getLinesFromRow,
 } from '@openmsupply-client/common';
 import { InboundItem } from './../../../types';
 import { InboundLineFragment } from '../../api';
 import { isInboundPlaceholderRow } from '../../../utils';
+import { useInboundShipmentLineErrorContext } from '../../context/inboundShipmentLineError';
 
 const getUnitQuantity = (row: InboundLineFragment) =>
   row.packSize * row.numberOfPacks;
@@ -40,10 +42,19 @@ export const useInboundShipmentColumns = () => {
   const getCostPrice = (row: InboundLineFragment) =>
     isInboundPlaceholderRow(row) ? 0 : row.costPricePerPack / row.packSize;
   const { getColumnPropertyAsString, getColumnProperty } = useColumnUtils();
+  const { getError } = useInboundShipmentLineErrorContext();
 
   const columns = useColumns<InboundLineFragment | InboundItem>(
     [
-      GenericColumnKey.Selection,
+      [
+        GenericColumnKey.Selection,
+        {
+          getIsError: row =>
+            getLinesFromRow(row).some(
+              r => getError(r)?.__typename === 'LineLinkedToTransferredInvoice'
+            ),
+        },
+      ],
       [
         getNotePopoverColumn(),
         {

--- a/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -29,6 +29,7 @@ import { InboundItem } from '../../types';
 import { useInbound, InboundLineFragment } from '../api';
 import { SupplierReturnEditModal } from '../../Returns';
 import { canReturnInboundLines } from '../../utils';
+import { InboundShipmentLineErrorProvider } from '../context/inboundShipmentLineError';
 
 type InboundLineItem = InboundLineFragment['item'];
 
@@ -109,38 +110,40 @@ const DetailViewInner = () => {
     >
       {data ? (
         <>
-          <AppBarButtons onAddItem={() => onOpen()} />
+          <InboundShipmentLineErrorProvider>
+            <AppBarButtons onAddItem={() => onOpen()} />
 
-          <Toolbar />
+            <Toolbar />
 
-          <DetailTabs tabs={tabs} />
+            <DetailTabs tabs={tabs} />
 
-          <Footer onReturnLines={onReturn} />
-          <SidePanel />
+            <Footer onReturnLines={onReturn} />
+            <SidePanel />
 
-          {isOpen && (
-            <InboundLineEdit
-              isDisabled={isDisabled}
-              isOpen={isOpen}
-              onClose={onClose}
-              mode={mode}
-              item={entity}
-              currency={data.currency}
-              isExternalSupplier={!data.otherParty.store}
-            />
-          )}
-          {returnsIsOpen && (
-            <SupplierReturnEditModal
-              isOpen={returnsIsOpen}
-              onCreate={clearSelected}
-              onClose={onCloseReturns}
-              stockLineIds={stockLineIds || []}
-              supplierId={data.otherParty.id}
-              modalMode={returnModalMode}
-              inboundShipmentId={data.id}
-              isNewReturn
-            />
-          )}
+            {isOpen && (
+              <InboundLineEdit
+                isDisabled={isDisabled}
+                isOpen={isOpen}
+                onClose={onClose}
+                mode={mode}
+                item={entity}
+                currency={data.currency}
+                isExternalSupplier={!data.otherParty.store}
+              />
+            )}
+            {returnsIsOpen && (
+              <SupplierReturnEditModal
+                isOpen={returnsIsOpen}
+                onCreate={clearSelected}
+                onClose={onCloseReturns}
+                stockLineIds={stockLineIds || []}
+                supplierId={data.otherParty.id}
+                modalMode={returnModalMode}
+                inboundShipmentId={data.id}
+                isNewReturn
+              />
+            )}
+          </InboundShipmentLineErrorProvider>
         </>
       ) : (
         <AlertModal

--- a/client/packages/invoices/src/InboundShipment/api/operations.generated.ts
+++ b/client/packages/invoices/src/InboundShipment/api/operations.generated.ts
@@ -592,6 +592,11 @@ export type InsertInboundShipmentMutation = {
     | { __typename: 'InvoiceNode'; id: string; invoiceNumber: number };
 };
 
+export type LineLinkedToTransferredInvoiceErrorFragment = {
+  __typename: 'LineLinkedToTransferredInvoice';
+  description: string;
+};
+
 export type DeleteInboundShipmentLinesMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
   input: Types.BatchInboundShipmentInput;
@@ -615,8 +620,11 @@ export type DeleteInboundShipmentLinesMutation = {
                   description: string;
                   key: Types.ForeignKey;
                 }
-              | { __typename: 'RecordNotFound'; description: string }
-              | { __typename: 'TransferredShipment'; description: string };
+              | {
+                  __typename: 'LineLinkedToTransferredInvoice';
+                  description: string;
+                }
+              | { __typename: 'RecordNotFound'; description: string };
           }
         | { __typename: 'DeleteResponse'; id: string };
     }> | null;
@@ -785,8 +793,11 @@ export type UpsertInboundShipmentMutation = {
                   description: string;
                   key: Types.ForeignKey;
                 }
-              | { __typename: 'RecordNotFound'; description: string }
-              | { __typename: 'TransferredShipment'; description: string };
+              | {
+                  __typename: 'LineLinkedToTransferredInvoice';
+                  description: string;
+                }
+              | { __typename: 'RecordNotFound'; description: string };
           }
         | { __typename: 'DeleteResponse'; id: string };
     }> | null;
@@ -1096,6 +1107,12 @@ export const InboundRowFragmentDoc = gql`
     currencyRate
   }
 `;
+export const LineLinkedToTransferredInvoiceErrorFragmentDoc = gql`
+  fragment LineLinkedToTransferredInvoiceError on LineLinkedToTransferredInvoice {
+    __typename
+    description
+  }
+`;
 export const LinkedRequestRowFragmentDoc = gql`
   fragment LinkedRequestRow on RequisitionNode {
     __typename
@@ -1338,9 +1355,8 @@ export const DeleteInboundShipmentLinesDocument = gql`
                 __typename
                 description
               }
-              ... on TransferredShipment {
-                __typename
-                description
+              ... on LineLinkedToTransferredInvoice {
+                ...LineLinkedToTransferredInvoiceError
               }
               ... on CannotEditInvoice {
                 __typename
@@ -1361,6 +1377,7 @@ export const DeleteInboundShipmentLinesDocument = gql`
       }
     }
   }
+  ${LineLinkedToTransferredInvoiceErrorFragmentDoc}
 `;
 export const UpsertInboundShipmentDocument = gql`
   mutation upsertInboundShipment(

--- a/client/packages/invoices/src/InboundShipment/api/operations.graphql
+++ b/client/packages/invoices/src/InboundShipment/api/operations.graphql
@@ -346,6 +346,11 @@ mutation insertInboundShipment(
   }
 }
 
+fragment LineLinkedToTransferredInvoiceError on LineLinkedToTransferredInvoice {
+  __typename
+  description
+}
+
 mutation deleteInboundShipmentLines(
   $storeId: String!
   $input: BatchInboundShipmentInput!
@@ -366,9 +371,8 @@ mutation deleteInboundShipmentLines(
               __typename
               description
             }
-            ... on TransferredShipment {
-              __typename
-              description
+            ... on LineLinkedToTransferredInvoice {
+              ...LineLinkedToTransferredInvoiceError
             }
             ... on CannotEditInvoice {
               __typename

--- a/client/packages/invoices/src/InboundShipment/context/inboundShipmentLineError.tsx
+++ b/client/packages/invoices/src/InboundShipment/context/inboundShipmentLineError.tsx
@@ -1,0 +1,59 @@
+import React, { createContext, useContext, useState } from 'react';
+import { PropsWithChildrenOnly, RecordWithId } from '@common/types';
+import { LineLinkedToTransferredInvoiceErrorFragment } from '../api';
+
+export type InboundShipmentLineError =
+  LineLinkedToTransferredInvoiceErrorFragment;
+
+const useInboundShipmentLineErrors = () => {
+  const [errors, setErrors] = useState<{
+    [InboundShipmentLineId: string]: InboundShipmentLineError | undefined;
+  }>({});
+
+  const getError = ({
+    id,
+  }: RecordWithId): InboundShipmentLineError | undefined => {
+    return errors[id];
+  };
+
+  const setError = (id: string, error: InboundShipmentLineError) => {
+    setErrors(errors => ({ ...errors, [id]: error }));
+  };
+
+  const unsetError = (id: string) => {
+    setErrors(errors => ({ ...errors, [id]: undefined }));
+  };
+
+  const unsetAll = () => {
+    setErrors({});
+  };
+
+  return { errors, setError, setErrors, getError, unsetError, unsetAll };
+};
+
+export type UseInboundShipmentLineErrors = ReturnType<
+  typeof useInboundShipmentLineErrors
+>;
+
+const InboundShipmentLineErrorContext =
+  createContext<UseInboundShipmentLineErrors>({} as any);
+
+export const useInboundShipmentLineErrorContext = () => {
+  const context = useContext(InboundShipmentLineErrorContext);
+
+  if (!context) throw new Error('Context does not exist');
+
+  return context;
+};
+
+export const InboundShipmentLineErrorProvider: React.FC<
+  PropsWithChildrenOnly
+> = ({ children }) => {
+  const state = useInboundShipmentLineErrors();
+
+  return (
+    <InboundShipmentLineErrorContext.Provider value={state}>
+      {children}
+    </InboundShipmentLineErrorContext.Provider>
+  );
+};

--- a/client/packages/invoices/src/InboundShipment/context/index.ts
+++ b/client/packages/invoices/src/InboundShipment/context/index.ts
@@ -1,0 +1,1 @@
+export * from './inboundShipmentLineError';

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/delete.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/delete.rs
@@ -1,4 +1,4 @@
-use super::{BatchIsReserved, TransferredShipment};
+use super::{BatchIsReserved, LineLinkedToTransferredInvoice};
 use async_graphql::*;
 use graphql_core::standard_graphql_error::{validate_auth, StandardGraphqlError};
 use graphql_core::{
@@ -58,7 +58,7 @@ pub enum DeleteErrorInterface {
     ForeignKeyError(ForeignKeyError),
     CannotEditInvoice(CannotEditInvoice),
     BatchIsReserved(BatchIsReserved),
-    TransferredShipment(TransferredShipment),
+    LineLinkedToTransferredInvoice(LineLinkedToTransferredInvoice),
 }
 
 impl DeleteInput {
@@ -104,9 +104,9 @@ fn map_error(error: ServiceError) -> Result<DeleteErrorInterface> {
         ServiceError::BatchIsReserved => {
             return Ok(DeleteErrorInterface::BatchIsReserved(BatchIsReserved {}))
         }
-        ServiceError::TransferredShipment => {
-            return Ok(DeleteErrorInterface::TransferredShipment(
-                TransferredShipment {},
+        ServiceError::LineLinkedToTransferredInvoice => {
+            return Ok(DeleteErrorInterface::LineLinkedToTransferredInvoice(
+                LineLinkedToTransferredInvoice {},
             ))
         }
         // Standard Graphql Errors
@@ -313,13 +313,15 @@ mod test {
             Some(service_provider(test_service, &connection_manager))
         );
 
-        // TransferredShipment
-        let test_service = TestService(Box::new(|_| Err(ServiceError::TransferredShipment)));
+        // LineLinkedToTransferredInvoice
+        let test_service = TestService(Box::new(|_| {
+            Err(ServiceError::LineLinkedToTransferredInvoice)
+        }));
 
         let expected = json!({
             "deleteInboundShipmentLine": {
               "error": {
-                "__typename": "TransferredShipment"
+                "__typename": "LineLinkedToTransferredInvoice"
               }
             }
           }

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/mod.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/mod.rs
@@ -13,10 +13,10 @@ impl BatchIsReserved {
     }
 }
 
-pub struct TransferredShipment;
+pub struct LineLinkedToTransferredInvoice;
 #[Object]
-impl TransferredShipment {
+impl LineLinkedToTransferredInvoice {
     pub async fn description(&self) -> &str {
-        "Cannot delete an inbound shipment transferred from another store"
+        "Cannot delete line generated from a generated invoice"
     }
 }

--- a/server/repository/src/db_diesel/invoice_line_row.rs
+++ b/server/repository/src/db_diesel/invoice_line_row.rs
@@ -42,6 +42,7 @@ table! {
         return_reason_id -> Nullable<Text>,
         foreign_currency_price_before_tax -> Nullable<Double>,
         item_variant_id -> Nullable<Text>,
+        linked_invoice_id -> Nullable<Text>,
     }
 }
 
@@ -95,6 +96,7 @@ pub struct InvoiceLineRow {
     pub return_reason_id: Option<String>,
     pub foreign_currency_price_before_tax: Option<f64>,
     pub item_variant_id: Option<String>,
+    pub linked_invoice_id: Option<String>,
 }
 
 pub struct InvoiceLineRowRepository<'a> {

--- a/server/repository/src/migrations/v2_07_00/add_linked_invoice_id_to_invoice_line.rs
+++ b/server/repository/src/migrations/v2_07_00/add_linked_invoice_id_to_invoice_line.rs
@@ -1,0 +1,20 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_linked_invoice_id_to_invoice_line"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        sql!(
+            connection,
+            r#"
+                ALTER TABLE invoice_line ADD COLUMN linked_invoice_id TEXT;
+            "#
+        )?;
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_07_00/mod.rs
+++ b/server/repository/src/migrations/v2_07_00/mod.rs
@@ -1,6 +1,7 @@
 use super::{version::Version, Migration, MigrationFragment};
 use crate::StorageConnection;
 
+mod add_linked_invoice_id_to_invoice_line;
 mod add_preference_table;
 
 pub(crate) struct V2_07_00;
@@ -15,7 +16,10 @@ impl Migration for V2_07_00 {
     }
 
     fn migrate_fragments(&self) -> Vec<Box<dyn MigrationFragment>> {
-        vec![Box::new(add_preference_table::Migrate)]
+        vec![
+            Box::new(add_preference_table::Migrate),
+            Box::new(add_linked_invoice_id_to_invoice_line::Migrate),
+        ]
     }
 }
 

--- a/server/repository/src/mock/invoice_line.rs
+++ b/server/repository/src/mock/invoice_line.rs
@@ -466,6 +466,7 @@ pub fn mock_transferred_inbound_shipment_a_line_b() -> InvoiceLineRow {
         tax_percentage: None,
         r#type: InvoiceLineType::StockIn,
         number_of_packs: 2.0,
+        linked_invoice_id: Some("trasnferred_outbound_shipment_a".to_string()),
         ..Default::default()
     }
 }

--- a/server/service/src/invoice/inbound_shipment/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/generate.rs
@@ -44,6 +44,7 @@ pub fn generate_empty_invoice_lines(
                     return_reason_id: None,
                     foreign_currency_price_before_tax: None,
                     item_variant_id: None,
+                    linked_invoice_id: None,
                 });
             }
             Ok(None) => {}

--- a/server/service/src/invoice/inbound_shipment/update/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/update/generate.rs
@@ -330,6 +330,7 @@ pub fn generate_lines_and_stock_lines(
             return_reason_id: _,
             foreign_currency_price_before_tax: _,
             item_variant_id,
+            linked_invoice_id: _,
         }: InvoiceLineRow = invoice_lines;
 
         if number_of_packs > 0.0 {

--- a/server/service/src/invoice/outbound_shipment/generate.rs
+++ b/server/service/src/invoice/outbound_shipment/generate.rs
@@ -38,6 +38,7 @@ pub fn generate_unallocated_invoice_lines(
                     return_reason_id: None,
                     foreign_currency_price_before_tax: None,
                     item_variant_id: None,
+                    linked_invoice_id: None,
                 });
             }
             Ok(None) => {}

--- a/server/service/src/invoice/validate.rs
+++ b/server/service/src/invoice/validate.rs
@@ -10,10 +10,6 @@ pub fn check_invoice_type(invoice: &InvoiceRow, r#type: InvoiceType) -> bool {
     false
 }
 
-pub fn check_invoice_is_not_linked(invoice: &InvoiceRow) -> bool {
-    invoice.linked_invoice_id.is_none()
-}
-
 pub fn check_store(invoice: &InvoiceRow, store_id: &str) -> bool {
     if invoice.store_id == store_id {
         return true;

--- a/server/service/src/invoice_line/inbound_shipment_from_internal_order_lines/generate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_from_internal_order_lines/generate.rs
@@ -88,5 +88,6 @@ fn generate_line(
         inventory_adjustment_reason_id: None,
         return_reason_id: None,
         foreign_currency_price_before_tax: None,
+        linked_invoice_id: None,
     }
 }

--- a/server/service/src/invoice_line/inbound_shipment_service_line/insert/generate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_service_line/insert/generate.rs
@@ -49,5 +49,6 @@ pub fn generate(
         inventory_adjustment_reason_id: None,
         return_reason_id: None,
         item_variant_id: None,
+        linked_invoice_id: None,
     })
 }

--- a/server/service/src/invoice_line/outbound_shipment_service_line/insert/generate.rs
+++ b/server/service/src/invoice_line/outbound_shipment_service_line/insert/generate.rs
@@ -49,5 +49,6 @@ pub fn generate(
         inventory_adjustment_reason_id: None,
         return_reason_id: None,
         item_variant_id: None,
+        linked_invoice_id: None,
     })
 }

--- a/server/service/src/invoice_line/outbound_shipment_unallocated_line/insert.rs
+++ b/server/service/src/invoice_line/outbound_shipment_unallocated_line/insert.rs
@@ -126,6 +126,7 @@ fn generate(
         foreign_currency_price_before_tax: None,
         item_variant_id: None,
         prescribed_quantity: None,
+        linked_invoice_id: None,
     };
 
     Ok(new_line)

--- a/server/service/src/invoice_line/stock_in_line/delete/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/delete/mod.rs
@@ -56,7 +56,7 @@ pub enum DeleteStockInLineError {
     BatchIsReserved,
     NotThisInvoiceLine(String),
     LineUsedInStocktake,
-    TransferredShipment,
+    LineLinkedToTransferredInvoice,
 }
 
 impl From<RepositoryError> for DeleteStockInLineError {
@@ -195,7 +195,7 @@ mod test {
                     r#type: StockInType::InboundShipment,
                 },
             ),
-            Err(ServiceError::TransferredShipment)
+            Err(ServiceError::LineLinkedToTransferredInvoice)
         );
 
         // NotThisStoreInvoice

--- a/server/service/src/invoice_line/stock_in_line/delete/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/delete/validate.rs
@@ -1,8 +1,5 @@
 use crate::{
-    invoice::{
-        check_invoice_exists, check_invoice_is_editable, check_invoice_is_not_linked,
-        check_invoice_type, check_store,
-    },
+    invoice::{check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store},
     invoice_line::{
         stock_in_line::check_batch,
         validate::{
@@ -43,9 +40,13 @@ pub fn validate(
     if !check_line_not_associated_with_stocktake(connection, &line.id, store_id.to_string()) {
         return Err(LineUsedInStocktake);
     }
-    if !check_invoice_is_not_linked(&invoice) {
-        return Err(TransferredShipment);
+    if check_line_linked(&line) {
+        return Err(LineLinkedToTransferredInvoice);
     }
 
     Ok((invoice, line))
+}
+
+fn check_line_linked(line: &InvoiceLineRow) -> bool {
+    line.linked_invoice_id.is_some()
 }

--- a/server/service/src/invoice_line/stock_in_line/insert/generate.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/generate.rs
@@ -124,6 +124,7 @@ fn generate_line(
         inventory_adjustment_reason_id: None,
         return_reason_id: None,
         foreign_currency_price_before_tax: None,
+        linked_invoice_id: None,
     }
 }
 

--- a/server/service/src/invoice_line/stock_in_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/validate.rs
@@ -52,15 +52,13 @@ pub fn validate(
     if !check_location_exists(connection, store_id, &input.location)? {
         return Err(LocationDoesNotExist);
     }
-    match &input.item_variant_id {
-        Some(NullableUpdate {
-            value: Some(item_variant_id),
-        }) => {
-            if check_item_variant_exists(connection, item_variant_id)?.is_none() {
-                return Err(ItemVariantDoesNotExist);
-            }
+    if let Some(NullableUpdate {
+        value: Some(item_variant_id),
+    }) = &input.item_variant_id
+    {
+        if check_item_variant_exists(connection, item_variant_id)?.is_none() {
+            return Err(ItemVariantDoesNotExist);
         }
-        _ => {} //  We don't need to check item_variant if it's not being updated, or if it's being updated to None
     }
 
     if !check_line_belongs_to_invoice(line_row, &invoice) {

--- a/server/service/src/invoice_line/stock_out_line/insert/generate.rs
+++ b/server/service/src/invoice_line/stock_out_line/insert/generate.rs
@@ -174,6 +174,7 @@ fn generate_line(
         return_reason_id: None,
         foreign_currency_price_before_tax,
         item_variant_id,
+        linked_invoice_id: None,
     })
 }
 

--- a/server/service/src/invoice_line/stock_out_line/set_prescribed_quantity/generate.rs
+++ b/server/service/src/invoice_line/stock_out_line/set_prescribed_quantity/generate.rs
@@ -37,6 +37,7 @@ pub fn generate(
         return_reason_id: None,
         foreign_currency_price_before_tax: None,
         item_variant_id: None,
+        linked_invoice_id: None,
     };
 
     Ok(invoice_line)

--- a/server/service/src/invoice_line/stock_out_line/update/generate.rs
+++ b/server/service/src/invoice_line/stock_out_line/update/generate.rs
@@ -134,6 +134,7 @@ fn generate_line(
         return_reason_id: None,
         foreign_currency_price_before_tax,
         item_variant_id,
+        linked_invoice_id: None,
     };
 
     if let Some(number_of_packs) = input.number_of_packs {

--- a/server/service/src/invoice_line/stock_out_line/update/mod.rs
+++ b/server/service/src/invoice_line/stock_out_line/update/mod.rs
@@ -75,7 +75,7 @@ pub fn update_stock_out_line(
                 stock_line_repo.upsert_one(&previous_batch.stock_line_row)?;
             }
 
-            update_picked_date(&connection, &invoice)?;
+            update_picked_date(connection, &invoice)?;
 
             get_invoice_line(ctx, &update_line.id)
                 .map_err(OutError::DatabaseError)?

--- a/server/service/src/processors/transfer/invoice/common.rs
+++ b/server/service/src/processors/transfer/invoice/common.rs
@@ -45,6 +45,7 @@ pub(crate) fn generate_inbound_lines(
                  return_reason_id,
                  foreign_currency_price_before_tax,
                  item_variant_id,
+                 linked_invoice_id: _,
              }| {
                 let cost_price_per_pack = sell_price_per_pack;
 
@@ -78,6 +79,7 @@ pub(crate) fn generate_inbound_lines(
                     foreign_currency_price_before_tax,
                     return_reason_id,
                     item_variant_id,
+                    linked_invoice_id: Some(source_invoice.invoice_row.id.to_string()),
                     // Default
                     stock_line_id: None,
                     location_id: None,

--- a/server/service/src/requisition/response_requisition/create_requisition_shipment/generate.rs
+++ b/server/service/src/requisition/response_requisition/create_requisition_shipment/generate.rs
@@ -108,6 +108,7 @@ pub fn generate_invoice_lines(
             foreign_currency_price_before_tax: None,
             item_variant_id: None,
             prescribed_quantity: None,
+            linked_invoice_id: None,
         });
     }
 

--- a/server/service/src/sync/test/test_data/invoice_line.rs
+++ b/server/service/src/sync/test/test_data/invoice_line.rs
@@ -97,6 +97,7 @@ fn trans_line_1_pull_record() -> TestSyncIncomingRecord {
             return_reason_id: None,
             foreign_currency_price_before_tax: Some(0.0),
             item_variant_id: None,
+            linked_invoice_id: None,
         },
     )
 }
@@ -127,6 +128,7 @@ fn trans_line_1_push_record() -> TestSyncOutgoingRecord {
             option_id: None,
             foreign_currency_price_before_tax: Some(0.0),
             item_variant_id: None,
+            linked_invoice_id: None,
         }),
     }
 }
@@ -217,6 +219,7 @@ fn trans_line_2_pull_record() -> TestSyncIncomingRecord {
             return_reason_id: None,
             foreign_currency_price_before_tax: Some(0.0),
             item_variant_id: None,
+            linked_invoice_id: None,
         },
     )
 }
@@ -247,6 +250,7 @@ fn trans_line_2_push_record() -> TestSyncOutgoingRecord {
             option_id: None,
             foreign_currency_price_before_tax: Some(0.0),
             item_variant_id: None,
+            linked_invoice_id: None,
         }),
     }
 }
@@ -340,6 +344,7 @@ fn trans_line_om_fields_pull_record() -> TestSyncIncomingRecord {
             return_reason_id: None,
             foreign_currency_price_before_tax: Some(0.0),
             item_variant_id: Some("5fb99f9c-03f4-47f2-965b-c9ecd083c675".to_string()),
+            linked_invoice_id: None,
         },
     )
 }
@@ -370,6 +375,7 @@ fn trans_line_om_fields_push_record() -> TestSyncOutgoingRecord {
             option_id: None,
             foreign_currency_price_before_tax: Some(0.0),
             item_variant_id: Some("5fb99f9c-03f4-47f2-965b-c9ecd083c675".to_string()),
+            linked_invoice_id: None,
         }),
     }
 }
@@ -463,6 +469,7 @@ fn trans_line_om_fields_unset_tax_pull_record() -> TestSyncIncomingRecord {
             return_reason_id: None,
             foreign_currency_price_before_tax: Some(0.0),
             item_variant_id: None,
+            linked_invoice_id: None,
         },
     )
 }
@@ -493,6 +500,7 @@ fn trans_line_om_fields_unset_tax_push_record() -> TestSyncOutgoingRecord {
             option_id: None,
             foreign_currency_price_before_tax: Some(0.0),
             item_variant_id: None,
+            linked_invoice_id: None,
         }),
     }
 }
@@ -586,6 +594,7 @@ fn trans_line_negative_pull_record() -> TestSyncIncomingRecord {
             return_reason_id: None,
             foreign_currency_price_before_tax: Some(200.0),
             item_variant_id: None,
+            linked_invoice_id: None,
         },
     )
 }
@@ -616,6 +625,7 @@ fn trans_line_negative_push_record() -> TestSyncOutgoingRecord {
             option_id: None,
             foreign_currency_price_before_tax: Some(200.0),
             item_variant_id: None,
+            linked_invoice_id: None,
         }),
     }
 }
@@ -710,6 +720,7 @@ fn trans_line_prescribed_quantity_pull_record() -> TestSyncIncomingRecord {
             return_reason_id: None,
             foreign_currency_price_before_tax: Some(0.0),
             item_variant_id: None,
+            linked_invoice_id: None,
         },
     )
 }
@@ -741,6 +752,7 @@ fn trans_line_prescribed_quantity_push_record() -> TestSyncOutgoingRecord {
             foreign_currency_price_before_tax: Some(0.0),
             option_id: None,
             item_variant_id: None,
+            linked_invoice_id: None,
         }),
     }
 }
@@ -834,6 +846,7 @@ fn trans_line_invalid_stockline_pull_record() -> TestSyncIncomingRecord {
             return_reason_id: None,
             foreign_currency_price_before_tax: Some(200.0),
             item_variant_id: None,
+            linked_invoice_id: None,
         },
     )
 }
@@ -864,6 +877,7 @@ fn trans_line_invalid_stockline_push_record() -> TestSyncOutgoingRecord {
             option_id: None,
             foreign_currency_price_before_tax: Some(200.0),
             item_variant_id: None,
+            linked_invoice_id: None,
         }),
     }
 }
@@ -957,6 +971,7 @@ fn trans_line_empty_stockline_pull_record() -> TestSyncIncomingRecord {
             return_reason_id: None,
             foreign_currency_price_before_tax: Some(200.0),
             item_variant_id: None,
+            linked_invoice_id: None,
         },
     )
 }
@@ -988,6 +1003,7 @@ fn trans_line_empty_stockline_push_record() -> TestSyncOutgoingRecord {
             option_id: None,
             foreign_currency_price_before_tax: Some(200.0),
             item_variant_id: None,
+            linked_invoice_id: None,
         }),
     }
 }
@@ -1001,7 +1017,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
         trans_line_negative_pull_record(),
         trans_line_prescribed_quantity_pull_record(),
         trans_line_invalid_stockline_pull_record(),
-        trans_line_empty_stockline_pull_record()
+        trans_line_empty_stockline_pull_record(),
     ]
 }
 
@@ -1022,6 +1038,6 @@ pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
         trans_line_negative_push_record(),
         trans_line_prescribed_quantity_push_record(),
         trans_line_invalid_stockline_push_record(),
-        trans_line_empty_stockline_push_record()
+        trans_line_empty_stockline_push_record(),
     ]
 }

--- a/server/service/src/sync/translations/invoice_line.rs
+++ b/server/service/src/sync/translations/invoice_line.rs
@@ -87,6 +87,9 @@ pub struct LegacyTransLineRow {
     #[serde(deserialize_with = "empty_str_as_option_string")]
     #[serde(rename = "om_item_variant_id")]
     pub item_variant_id: Option<String>,
+    #[serde(deserialize_with = "empty_str_as_option_string")]
+    #[serde(rename = "linked_trans_line_ID")]
+    pub linked_invoice_id: Option<String>,
 }
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -144,6 +147,7 @@ impl SyncTranslation for InvoiceLineTranslation {
             option_id,
             foreign_currency_price_before_tax,
             item_variant_id,
+            linked_invoice_id,
         } = serde_json::from_str::<LegacyTransLineRow>(&sync_record.data)?;
         let line_type = match to_invoice_line_type(&r#type) {
             Some(line_type) => line_type,
@@ -284,6 +288,7 @@ impl SyncTranslation for InvoiceLineTranslation {
             },
             foreign_currency_price_before_tax,
             item_variant_id,
+            linked_invoice_id,
         };
 
         let result = adjust_negative_values(result);
@@ -339,6 +344,7 @@ impl SyncTranslation for InvoiceLineTranslation {
                     return_reason_id,
                     foreign_currency_price_before_tax,
                     item_variant_id,
+                    linked_invoice_id,
                 },
             item_row,
             invoice_row,
@@ -376,6 +382,7 @@ impl SyncTranslation for InvoiceLineTranslation {
             foreign_currency_price_before_tax,
             item_variant_id,
             option_id,
+            linked_invoice_id,
         };
         Ok(PushTranslateResult::upsert(
             changelog,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6482

# 👩🏻‍💻 What does this PR do?
- Allows deletion of lines in a transferred Inbound Shipment if the line was added by the store (i.e. not from the Outbound Shipment)
- If the line is from an Outbound Shipment, only allows 0'ing out (already implemented)
![Screenshot 2025-03-20 at 9 07 56 AM](https://github.com/user-attachments/assets/f781f222-2892-43be-8750-384a194ed308)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an Outbound Shipment from Store A to Store B
- [ ] Go to Store B: Click on Inbound Shipment 
- [ ] Confirm Delivered
- [ ] Try to delete lines that current exist -> Shouldn't be able to
- [ ] Try zero'ing one of the lines -> Should be able to
- [ ] Add new line
- [ ] Try delete -> Should be able to

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Probably should add a line about what can be done in transfered invoices
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

