### PR TITLE
5378 Able to set future death date in Patient Status History

### DIFF
--- a/client/packages/common/src/ui/components/inputs/DatePickers/DateTimePickerInput/DateTimePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/DateTimePickerInput/DateTimePickerInput.tsx
@@ -30,6 +30,7 @@ export const DateTimePickerInput: FC<
     showTime?: boolean;
     actions?: PickersActionBarAction[];
     dateAsEndOfDay?: boolean;
+    disableFuture?: boolean;
   }
 > = ({
   error,
@@ -43,6 +44,7 @@ export const DateTimePickerInput: FC<
   showTime,
   actions,
   dateAsEndOfDay,
+  disableFuture,
   ...props
 }) => {
   const theme = useAppTheme();
@@ -155,6 +157,7 @@ export const DateTimePickerInput: FC<
       }
       minDate={minDate}
       maxDate={maxDate}
+      disableFuture={disableFuture}
       {...props}
       value={value}
     />

--- a/client/packages/programs/src/JsonForms/common/components/DateTime.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/DateTime.tsx
@@ -21,6 +21,7 @@ const Options = z
      */
     dateOnly: z.boolean().optional(),
     dateAsEndOfDay: z.boolean().optional(),
+    disableFuture: z.boolean().optional(),
   })
   .strict()
   .optional();
@@ -72,6 +73,7 @@ const UIComponent = (props: ControlProps) => {
     error: zErrors ?? error ?? customError ?? props.errors,
     actions: ['clear', 'today', 'accept'] as PickersActionBarAction[],
     dateAsEndOfDay: !!props.uischema.options?.['dateAsEndOfDay'],
+    disableFuture: !!props.uischema.options?.['disableFuture'],
   };
 
   return (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5378

# 👩🏻‍💻 What does this PR do?
Add disable future selection for json datetime picker

https://github.com/user-attachments/assets/3b2f4cb3-b70e-4f8e-ad38-b1e3707a9c0f


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Load generic immunisation program from schema repo
- [ ] Enrol patient into immunisation program
- [ ] Add status
- [ ] Switch status to `Died`
- [ ] Shouldn't be able to select future dates

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

