### PR TITLE
3406 Reduce site password field width in sync settings

### DIFF
--- a/client/packages/host/src/Admin/SyncSettings.tsx
+++ b/client/packages/host/src/Admin/SyncSettings.tsx
@@ -95,7 +95,7 @@ const SyncSettingsForm = ({
             onChange={e => setSettings('password', e.target.value)}
             slotProps={{ input: { autoComplete: 'sync-password' } }}
             disabled={isDisabled}
-            style={{ width: 'calc(100% - 24px)' }}
+            sx={{ width: 'calc(100% - 24px)' }}
           />
         }
       />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #3406

# 👩🏻‍💻 What does this PR do?
Reduce site password field width in sync settings so that it aligns with name and url fields

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
![Screenshot 2025-03-21 at 11 51 21](https://github.com/user-attachments/assets/73aa70e9-507b-48fe-a63a-6a73f5810f69)

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Settings in AppDrawer
- [ ] Open Synchronisation settings accordion
- [ ] Note the 'Site password' text field width is same as name and url fields

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

