### PR TITLE
Automatically create a location for new CCE assets

### DIFF
--- a/server/repository/src/db_diesel/assets/asset_internal_location_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_internal_location_row.rs
@@ -80,7 +80,7 @@ impl<'a> AssetInternalLocationRowRepository<'a> {
 
     pub fn find_all_by_asset(
         &self,
-        some_asset_id: String,
+        some_asset_id: &str,
     ) -> Result<Vec<AssetInternalLocationRow>, RepositoryError> {
         let result = asset_internal_location
             .filter(asset_id.eq(some_asset_id))

--- a/server/service/src/asset/insert.rs
+++ b/server/service/src/asset/insert.rs
@@ -3,6 +3,7 @@ use super::{
     query::get_asset,
     validate::{check_asset_exists, check_asset_number_exists},
 };
+use crate::sync::ActiveStoresOnSite;
 use crate::{
     activity_log::activity_log_entry, service_provider::ServiceContext, SingleRecordError,
 };
@@ -77,25 +78,37 @@ pub fn insert_asset(
             let new_asset = generate(input);
             AssetRowRepository::new(connection).upsert_one(&new_asset)?;
 
-            // Automatically create a location for this asset (if it's a cold chain asset)
+            // Automatically create a location for this asset (if it's a cold chain asset, and store is active on this site)
             if new_asset.asset_class_id == Some(COLD_CHAIN_EQUIPMENT_UUID.to_string()) {
+                let active_stores = ActiveStoresOnSite::get(&ctx.connection);
+                let active_store_ids = match active_stores {
+                    Ok(active_stores) => active_stores.store_ids(),
+                    Err(_) => {
+                        // If we can't get the active stores, just assume the asset is in this store (mainly for test cases)
+                        vec![new_asset.store_id.clone().unwrap_or_default()]
+                    }
+                };
+
+                // Check if the asset is in a store that is active before creating a location
                 if let Some(store_id) = new_asset.store_id {
-                    let new_location = LocationRow {
-                        id: uuid(),
-                        name: new_asset
-                            .asset_number
-                            .clone()
-                            .unwrap_or_else(|| "Asset".to_string()),
-                        code: new_asset
-                            .asset_number
-                            .clone()
-                            .unwrap_or_else(|| "Asset".to_string()),
-                        on_hold: false,
-                        store_id,
-                        cold_storage_type_id: None, // TODO(future): Based on asset type try to determine cold storage type
-                    };
-                    new_location.upsert(connection)?;
-                    set_asset_location(connection, &new_asset.id, vec![new_location.id])?;
+                    if active_store_ids.contains(&store_id) {
+                        let new_location = LocationRow {
+                            id: uuid(),
+                            name: new_asset
+                                .asset_number
+                                .clone()
+                                .unwrap_or_else(|| "Asset".to_string()),
+                            code: new_asset
+                                .asset_number
+                                .clone()
+                                .unwrap_or_else(|| "Asset".to_string()),
+                            on_hold: false,
+                            store_id,
+                            cold_storage_type_id: None, // TODO(future): Based on asset type try to determine cold storage type
+                        };
+                        new_location.upsert(connection)?;
+                        set_asset_location(connection, &new_asset.id, vec![new_location.id])?;
+                    }
                 }
             }
 

--- a/server/service/src/asset/tests/insert.rs
+++ b/server/service/src/asset/tests/insert.rs
@@ -51,8 +51,8 @@ mod query {
 
         // Check that the asset has an internal location assigned
         let internal_location_repo = AssetInternalLocationRowRepository::new(&ctx.connection);
-        let internal_location = internal_location_repo.find_one_by_id(&id).unwrap().unwrap();
-        assert_eq!(internal_location.asset_id, id);
+        let internal_locations = internal_location_repo.find_all_by_asset(&id).unwrap();
+        assert_eq!(internal_locations.len(), 1);
 
         // 2. Check we can't create an asset with the same id
         assert_eq!(

--- a/server/service/src/asset/tests/insert.rs
+++ b/server/service/src/asset/tests/insert.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod query {
     use repository::{
+        asset_internal_location_row::AssetInternalLocationRowRepository,
         mock::{mock_store_a, MockDataInserts},
         test_db::setup_all,
     };
@@ -47,6 +48,11 @@ mod query {
             asset.modified_datetime
                 >= chrono::Utc::now().naive_utc() - chrono::Duration::seconds(5)
         );
+
+        // Check that the asset has an internal location assigned
+        let internal_location_repo = AssetInternalLocationRowRepository::new(&ctx.connection);
+        let internal_location = internal_location_repo.find_one_by_id(&id).unwrap().unwrap();
+        assert_eq!(internal_location.asset_id, id);
 
         // 2. Check we can't create an asset with the same id
         assert_eq!(

--- a/server/service/src/asset/tests/update.rs
+++ b/server/service/src/asset/tests/update.rs
@@ -126,7 +126,7 @@ mod query {
             )
             .unwrap();
         let asset_location_ids: Vec<String> = asset_location_repository
-            .find_all_by_asset(id.clone())
+            .find_all_by_asset(&id)
             .unwrap()
             .into_iter()
             .map(|location| location.location_id)
@@ -148,7 +148,7 @@ mod query {
             .unwrap();
 
         let asset_location_ids: Vec<String> = asset_location_repository
-            .find_all_by_asset(id.clone())
+            .find_all_by_asset(&id)
             .unwrap()
             .into_iter()
             .map(|location| location.location_id)
@@ -187,7 +187,7 @@ mod query {
             )
             .unwrap();
         let asset_location_ids: Vec<String> = asset_location_repository
-            .find_all_by_asset(id.clone())
+            .find_all_by_asset(&id)
             .unwrap()
             .into_iter()
             .map(|location| location.location_id)
@@ -209,7 +209,7 @@ mod query {
             .unwrap();
 
         let asset_location_ids: Vec<String> = asset_location_repository
-            .find_all_by_asset(id.clone())
+            .find_all_by_asset(&id)
             .unwrap()
             .into_iter()
             .map(|location| location.location_id)


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7001

# 👩🏻‍💻 What does this PR do?

Automatically creates a location for any newly created assets.

![image](https://github.com/user-attachments/assets/1ae55e8e-5333-4027-b456-0b8864b0397c)

Location is named after the assetNumber.

## 💌 Any notes for the reviewer?

I feel like it would be nice to have an asset `Name` field that we could use here?
Having a name like Fridge 1 would be much nicer than a location named asset ABCE1234 I don't think it would be meaningful.

@mark-prins @adamdewey  what do you think about that idea?

We also create an initial status log for the asset in the frontend code. Should we move this to the backend?
I suspect it might have been done this way to allow using the translations in the comment. I feel like we could probably just leave the comment blank? Or maybe it's ok how it is...

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a Cold Chain Equipment (test via import and manually)
- [ ] Check that a location is automatically created for the asset.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [X] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [X] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [x] Postgres
- [x] SQLite
- [ ] Frontend

