### PR TITLE
#6997 #7014 Multiple file upload

### DIFF
--- a/server/server/src/static_files.rs
+++ b/server/server/src/static_files.rs
@@ -150,7 +150,7 @@ async fn upload_sync_file(
 
     let path_inner = path.into_inner();
 
-    let mut static_file_ids: Vec<String> = [].to_vec();
+    let mut static_file_ids: Vec<String> = vec![];
 
     for f in file {
         let static_file =

--- a/server/server/src/static_files.rs
+++ b/server/server/src/static_files.rs
@@ -39,7 +39,7 @@ use crate::middleware::limit_content_length;
 #[derive(Debug, MultipartForm)]
 pub(crate) struct UploadForm {
     #[multipart(rename = "files")]
-    pub(crate) file: TempFile,
+    pub(crate) file: Vec<TempFile>,
 }
 
 // this function could be located in different module
@@ -148,17 +148,26 @@ async fn upload_sync_file(
         )
     })?;
 
-    let static_file = upload_sync_file_inner(&service_provider, &settings, path.into_inner(), file)
-        .await
-        .map_err(|error| {
-            log::error!("Error while uploading file: {}", format_error(&error));
-            InternalError::new(
-                "Error uploading file, please check server logs",
-                StatusCode::INTERNAL_SERVER_ERROR,
-            )
-        })?;
+    let path_inner = path.into_inner();
 
-    Ok(HttpResponse::Ok().json(static_file.id))
+    let mut static_file_ids: Vec<String> = [].to_vec();
+
+    for f in file {
+        let static_file =
+            upload_sync_file_inner(&service_provider, &settings, path_inner.clone(), f)
+                .await
+                .map_err(|error| {
+                    log::error!("Error while uploading file: {}", format_error(&error));
+                    InternalError::new(
+                        "Error uploading file, please check server logs",
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                    )
+                })?;
+
+        static_file_ids.push(static_file.id);
+    }
+
+    Ok(HttpResponse::Ok().json(static_file_ids))
 }
 
 #[derive(Error, Debug)]
@@ -183,7 +192,7 @@ async fn upload_sync_file_inner(
     let mime_type = file.content_type.as_ref().map(|mime| mime.to_string());
 
     let static_file = file_service.move_temp_file(
-        file,
+        &file,
         &StaticFileCategory::SyncFile(table_name.clone(), record_id.clone()),
         None,
     )?;

--- a/server/server/src/upload.rs
+++ b/server/server/src/upload.rs
@@ -41,7 +41,7 @@ async fn upload(
     let file_service = StaticFileService::new(&settings.server.base_dir).unwrap();
 
     let static_file = file_service
-        .move_temp_file(file, &StaticFileCategory::Temporary, None)
+        .move_temp_file(&file, &StaticFileCategory::Temporary, None)
         .unwrap();
 
     HttpResponse::Ok().json(UploadedFile {

--- a/server/server/src/upload_fridge_tag.rs
+++ b/server/server/src/upload_fridge_tag.rs
@@ -68,7 +68,8 @@ fn upload_fridge_tag(
 
     let file_service = StaticFileService::new(&settings.server.base_dir)?;
 
-    let static_file = file_service.move_temp_file(file, &StaticFileCategory::Temporary, None)?;
+    let static_file =
+        file_service.move_temp_file(&file[0], &StaticFileCategory::Temporary, None)?;
 
     ctx.connection
         .transaction_sync(|con| {

--- a/server/service/src/static_files.rs
+++ b/server/service/src/static_files.rs
@@ -70,11 +70,14 @@ impl StaticFileService {
     // at the time of method creation TempFile only comes from web multipart
     pub fn move_temp_file(
         &self,
-        temp_file: TempFile,
+        temp_file: &TempFile,
         category: &StaticFileCategory,
         file_id: Option<String>,
     ) -> anyhow::Result<StaticFile> {
-        let file_name = temp_file.file_name.context("Filename not provided")?;
+        let file_name = temp_file
+            .file_name
+            .clone()
+            .context("Filename not provided")?;
         let sanitized_filename = sanitize_filename(file_name);
 
         let static_file = self.reserve_file(&sanitized_filename, category, file_id)?;

--- a/server/service/src/sync/sync_on_central/mod.rs
+++ b/server/service/src/sync/sync_on_central/mod.rs
@@ -347,7 +347,7 @@ pub async fn upload_file(
         .ok_or(Error::SyncFileNotFound(file_id.clone()))?;
 
     file_service.move_temp_file(
-        file_part,
+        &file_part,
         &StaticFileCategory::SyncFile(
             sync_file_reference.table_name.clone(),
             sync_file_reference.record_id.clone(),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6997 & #7014

# 👩🏻‍💻 What does this PR do?

Modifies the server's `upload_sync_file` endpoint function to handle an array of files rather than just the first one in the `formData` array.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to ColdChain -> Equipment -> Select an asset -> Documents tab
- [ ] Drag and drop multiple files onto the Upload box
- [ ] *All* files should appear in the Downloaded documents list below
- [ ] Repeat by clicking the "Browse files" button and selecting multiple files in the Dialog

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [x] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

