### PR TITLE
6981 Additional translations for "Loading"

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteList.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteList.tsx
@@ -106,7 +106,6 @@ export const AutocompleteList = <T,>({
   } else {
     mappedOptions = options;
   }
-  const noOptions = noOptionsText ?? t('label.no-options');
 
   return (
     <>
@@ -125,8 +124,8 @@ export const AutocompleteList = <T,>({
         disableClearable={disableClearable}
         autoSelect={false}
         loading={loading}
-        loadingText={loadingText}
-        noOptionsText={noOptions}
+        loadingText={loadingText ?? t('loading')}
+        noOptionsText={noOptionsText ?? t('label.no-options')}
         onChange={onChange}
         onInputChange={onInputChange}
         sx={{

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteMulti.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteMulti.tsx
@@ -119,7 +119,8 @@ export function AutocompleteMulti<
           borderRadius: 2,
         },
       }}
-      noOptionsText={t('label.no-options')}
+      noOptionsText={noOptionsText ?? t('label.no-options')}
+      loadingText={loadingText ?? t('loading')}
     />
   );
 }

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteMulti.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteMulti.tsx
@@ -49,6 +49,8 @@ export function AutocompleteMulti<
   width = 'auto',
   slotProps,
   inputProps,
+  loadingText,
+  noOptionsText,
   ...restOfAutocompleteProps
 }: PropsWithChildren<
   AutocompleteMultiProps<T, true, DisableClearable, FreeSolo, ChipComponent>

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteWithPagination.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteWithPagination.tsx
@@ -179,7 +179,6 @@ export function AutocompleteWithPagination<T extends RecordWithId>({
   useEffect(() => {
     setTimeout(() => setIsLoading(false), LOADER_HIDE_TIMEOUT);
   }, [options]);
-  const noOptions = noOptionsText ?? t('label.no-options');
 
   return (
     <MuiAutocomplete
@@ -195,8 +194,8 @@ export function AutocompleteWithPagination<T extends RecordWithId>({
       getOptionDisabled={getOptionDisabled}
       filterOptions={filter}
       loading={loading}
-      loadingText={loadingText}
-      noOptionsText={noOptions}
+      loadingText={loadingText ?? t('loading')}
+      noOptionsText={noOptionsText ?? t('label.no-options')}
       options={options}
       size="small"
       renderInput={renderInput || defaultRenderInput}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6981 

# 👩🏻‍💻 What does this PR do?

This is a follow-up PR as there were a couple of other cases we missed.

## 💌 Any notes for the reviewer?

I've updated the remaining Autocomplete components and done a global search for `loadingText` and can't see any others.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Try as many different Autocompletes as you can find and check they have correctly translated "Loading" text.

The original one noticed [in issue](https://github.com/msupply-foundation/open-msupply/issues/6981#issuecomment-2749976470) was:

> Thanks! one i came to talk to you about is under Equipment -> Add New Equipment -> Category (Loading briefly shows in English)



# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

