### PR TITLE
6856 Auto-generated comment field is not relevant for all (and is unclear)

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
@@ -79,10 +79,10 @@ const useStatusChangeButton = () => {
     'comment',
     'lines',
   ]);
+  const t = useTranslation();
   const { mutateAsync: update } = useRequest.document.update();
   const { success, error } = useNotification();
-  const t = useTranslation();
-  const { user } = useAuthContext();
+  const { user, store } = useAuthContext();
   const { getLocalisedFullName } = useIntlUtils();
   const errorsContext = useRequestRequisitionLineErrorContext();
 
@@ -105,12 +105,16 @@ const useStatusChangeButton = () => {
       getLocalisedFullName(user?.firstName, user?.lastName) || user?.name;
     const job = !!user?.jobTitle ? ` (${user?.jobTitle})` : '';
 
-    return `${comment ? comment + '\n' : ''}${t('template.requisition-sent', {
-      name,
-      job,
-      phone: user?.phoneNumber ?? UNDEFINED_STRING_VALUE,
-      email: user?.email ?? UNDEFINED_STRING_VALUE,
-    })}`;
+    if (comment) return comment;
+
+    return store?.preferences.requestRequisitionRequiresAuthorisation
+      ? t('template.requisition-sent', {
+          name,
+          job,
+          phone: user?.phoneNumber ?? UNDEFINED_STRING_VALUE,
+          email: user?.email ?? UNDEFINED_STRING_VALUE,
+        })
+      : '';
   };
 
   const mapStructuredErrors = (result: Awaited<ReturnType<typeof update>>) => {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6856

# 👩🏻‍💻 What does this PR do?
Only generate comment for Internal Orders if the user has remote auth enabled

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an IO 
- [ ] Request some
- [ ] Send -> Comment shouldn't be populated
- [ ] Go to OG, turn on `Include requisitions from this store in suppliers' remote authorisation process` store pref
- [ ] Sync
- [ ] Sign out/sign back in
- [ ] Create IO
- [ ] Request some
- [ ] Send -> Comment should be generated

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

