### PR TITLE
6280 fix exporting and importing coldchain equipment

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/Footer/Footer.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/Footer/Footer.tsx
@@ -8,6 +8,7 @@ import {
   useBreadcrumbs,
   DeleteIcon,
   LoadingButton,
+  SaveIcon,
   // useAuthContext,
   // UserPermission,
 } from '@openmsupply-client/common';
@@ -66,6 +67,7 @@ export const FooterComponent = ({
                   // !userHasPermission(UserPermission.AssetMutate)
                 }
                 isLoading={isSaving}
+                startIcon={<SaveIcon />}
                 onClick={showSaveConfirmation}
                 label={t('button.save')}
               />

--- a/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
@@ -55,6 +55,14 @@ const formatDate = (value: string): string | null => {
   return Formatter.naiveDate(DateUtils.getDateOrNull(value, 'dd/MM/yyyy'));
 };
 
+const formatNeedsReplacement = (value: string): boolean | null => {
+  if (value.match(/true/i)) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
 function getImportHelpers<T, P>(
   row: P,
   rows: T[],
@@ -325,7 +333,11 @@ export const EquipmentUploadTab: FC<ImportPanel & EquipmentUploadTabProps> = ({
         'label.status',
         status => parseStatusFromString(status, t) ?? StatusType.Functioning
       );
-      addCell('needsReplacement', 'label.needs-replacement');
+      addCell(
+        'needsReplacement',
+        'label.needs-replacement',
+        formatNeedsReplacement
+      );
       processProperties(properties ?? [], row, importRow, rowErrors, t);
       importRow.errorMessage = rowErrors.join(',');
       importRow.warningMessage = rowWarnings.join(',');

--- a/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
@@ -56,11 +56,8 @@ const formatDate = (value: string): string | null => {
 };
 
 const formatNeedsReplacement = (value: string): boolean | null => {
-  if (value.match(/true/i)) {
-    return true;
-  } else {
-    return false;
-  }
+  if (value.match(/true/i)) return true;
+  else return false;
 };
 
 function getImportHelpers<T, P>(

--- a/client/packages/coldchain/src/Equipment/utils.ts
+++ b/client/packages/coldchain/src/Equipment/utils.ts
@@ -49,7 +49,7 @@ export const assetsToCsv = (
 
     const status =
       node.statusLog?.status && parseLogStatus(node.statusLog.status);
-
+      
     return [
       node.id,
       ...(isCentralServer ? [node.store?.code] : []),
@@ -61,7 +61,7 @@ export const assetsToCsv = (
       Formatter.csvDateString(node.warrantyEnd),
       node.serialNumber,
       status ? t(status.key) : '',
-      node.needsReplacement ? node.needsReplacement?.toString() : 'false',
+      node.needsReplacement ? node.needsReplacement : false,
       node.notes,
       Formatter.csvDateTimeString(node.createdDatetime),
       Formatter.csvDateTimeString(node.modifiedDatetime),

--- a/client/packages/coldchain/src/Equipment/utils.ts
+++ b/client/packages/coldchain/src/Equipment/utils.ts
@@ -61,7 +61,7 @@ export const assetsToCsv = (
       Formatter.csvDateString(node.warrantyEnd),
       node.serialNumber,
       status ? t(status.key) : '',
-      node.needsReplacement,
+      node.needsReplacement ? node.needsReplacement?.toString() : 'false',
       node.notes,
       Formatter.csvDateTimeString(node.createdDatetime),
       Formatter.csvDateTimeString(node.modifiedDatetime),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6280 

# 👩🏻‍💻 What does this PR do?

This PR makes sure that the needs replacement field of cold chain equipment is correctly imported and exported.
It achieves this by adding a formatting function to the 'needs replacement' field in one of the functions that processes the data imported from the csv data.
You'll find that function in line 336 of client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx.

## 💌 Any notes for the reviewer?

It seems the side bug of the issue (that sometimes a blank was inserted instead of 'false' in the needs replacement column in the exported CSV file) was resolved as well as, when I checked it, it seemed that false was consistently added to the correct rows in the CSV file.

# 🧪 Testing

- [ ] In open mSupply, go to Coldchain > Equipment and add at least three assets (the button is in the top right hand corner).
- [ ] Open one of those assets and tick the 'needs replacement' box.
- [ ] Back on the Equipment page, click export.
- [ ] Open the exported CSV using a spreadsheet app or similar (it will be in your downloads folder) and check that it has 'true' in the needs replacement column where it should.
- [ ] Back on the Equipment page in open mSupply, delete all the assets you added.
- [ ] Click import (top right hand corner) and select the file you just exported.
- [ ] Once you've imported the assets, make sure each one has the 'needs replacement' box ticked or not ticked as it should be.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

