### PR TITLE
Open internal order edit modals in read only mode

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/DetailView.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/DetailView.tsx
@@ -67,12 +67,7 @@ export const DetailView: FC = () => {
   };
   const tabs = [
     {
-      Component: (
-        <ContentArea
-          onRowClick={!isDisabled ? onRowClick : null}
-          onAddItem={onAddItem}
-        />
-      ),
+      Component: <ContentArea onRowClick={onRowClick} onAddItem={onAddItem} />,
       value: 'Details',
     },
     {

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestEditPage.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestEditPage.tsx
@@ -55,6 +55,7 @@ export const RequestLineEditPageInner = ({
         .map(line => line.item.id)
     : [];
   const isProgram = !!requisition.programName;
+  const isDisabled = requisition.status !== 'DRAFT';
 
   // This ref is attached to the currently selected list item, and is used to
   // "scroll into view" when the Previous/Next buttons are clicked in the NavBar
@@ -108,6 +109,7 @@ export const RequestLineEditPageInner = ({
               requisitionNumber={requisition?.requisitionNumber}
               lines={lines}
               scrollIntoView={scrollSelectedItemIntoView}
+              disabled={isDisabled}
             />
           }
         />

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -20,6 +20,7 @@ import {
   useAuthContext,
   useNavigate,
   usePluginProvider,
+  useTheme,
   useToggle,
   useWindowDimensions,
 } from '@openmsupply-client/common';
@@ -51,6 +52,7 @@ interface RequestLineEditProps {
   requisitionId: string;
   insert: (patch: InsertRequestRequisitionLineInput) => void;
   scrollIntoView: () => void;
+  disabled?: boolean;
 }
 
 export const RequestLineEdit = ({
@@ -70,6 +72,7 @@ export const RequestLineEdit = ({
   requisitionId,
   insert,
   scrollIntoView,
+  disabled,
 }: RequestLineEditProps) => {
   const t = useTranslation();
   const navigate = useNavigate();
@@ -92,6 +95,7 @@ export const RequestLineEdit = ({
 
   const line = lines.find(line => line.id === draft?.id);
   const { width } = useWindowDimensions();
+  const theme = useTheme();
 
   return (
     <Box display="flex" flexDirection="column" padding={2}>
@@ -261,8 +265,15 @@ export const RequestLineEdit = ({
                       checked={isPacks}
                       onChange={(_event, checked) => setIsPacks(checked)}
                       size="small"
+                      disabled={disabled}
                     />
-                    <Box paddingLeft={2} paddingRight={2}>
+                    <Box
+                      paddingLeft={2}
+                      paddingRight={2}
+                      sx={{
+                        color: disabled ? theme.palette.text.disabled : '',
+                      }}
+                    >
                       {t('label.packs')}
                     </Box>
                   </Box>
@@ -275,7 +286,7 @@ export const RequestLineEdit = ({
                     <NumericTextInput
                       width={INPUT_WIDTH}
                       value={Math.ceil(draft?.requestedQuantity)}
-                      disabled={isPacks}
+                      disabled={isPacks || disabled}
                       onChange={value => {
                         const newValue = isNaN(Number(value)) ? 0 : value;
                         if (draft?.suggestedQuantity === newValue) {
@@ -327,7 +338,7 @@ export const RequestLineEdit = ({
                   <InputWithLabelRow
                     Input={
                       <NumericTextInput
-                        disabled={!isPacks}
+                        disabled={!isPacks || disabled}
                         value={NumUtils.round(
                           (draft?.requestedQuantity ?? 0) /
                             (draft?.defaultPackSize ?? 1),
@@ -393,7 +404,8 @@ export const RequestLineEdit = ({
                       width={200}
                       type={ReasonOptionNodeType.RequisitionLineVariance}
                       isDisabled={
-                        draft?.requestedQuantity === draft?.suggestedQuantity
+                        draft?.requestedQuantity === draft?.suggestedQuantity ||
+                        disabled
                       }
                       onBlur={save}
                     />
@@ -417,6 +429,7 @@ export const RequestLineEdit = ({
                       },
                     }}
                     onBlur={save}
+                    disabled={disabled}
                   />
                 }
                 sx={{ width: 275 }}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6929 

# 👩🏻‍💻 What does this PR do?

Allows the user to open the line edit view on any Internal order (instead of only draft status)

If the order is not in Draft status all fields are disabled for a 'read only' view

The button to view stats & graphs is still available, and the user can select the items on the left hand side 

![Screenshot 2025-03-27 at 11 13 23 AM](https://github.com/user-attachments/assets/de93ffcc-de16-4233-bbc3-ba71b28b55b1)

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Several of the fields are always disabled, is there a better name to differentiate between these?

I also looked at wrapping the section in a disabled package/context which may have been useful except for the stats button needing to be accessible, and probably more work than it's worth without additional use cases

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Replenishment -> Internal Orders -> Create a new order
- [ ] Add some items. Observe the editable fields
- [ ] Close -> Confirm Sent
- [ ] Select a line and be taken to the edit view with the details of that line
- [ ] Observe that no fields are editable, but the stats are available by clicking on the orange icon. 
- [ ] Other items can be selected on the left hand side, but no new items added
- [ ] A finalised order will be the same in this view as a Sent order

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

