### PR TITLE
6321 block prescription line edit refresh

### DIFF
--- a/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.ts
+++ b/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.ts
@@ -56,7 +56,7 @@ export const useBlockNavigation = () => {
       // If there is a custom check on one of the registered blockers, use that
       if (b.options?.customCheck) {
         setActiveBlocker(b);
-        return b.options.customCheck(currentLocation, nextLocation);
+        return b.options.customCheck.navigate(currentLocation, nextLocation);
       }
 
       if (b.shouldBlock && currentLocation.pathname !== nextLocation.pathname) {
@@ -69,9 +69,12 @@ export const useBlockNavigation = () => {
     return false;
   });
 
-  const shouldBlockRefresh = blockers.some(
-    b => b.shouldBlock && !b.options?.allowRefresh
-  );
+  const shouldBlockRefresh = blockers.some(b => {
+    if (b.options?.customCheck) {
+      return b.options.customCheck.refresh();
+    }
+    return b.shouldBlock && !b.options?.allowRefresh;
+  });
 
   // handle page refresh events
   useBeforeUnload(
@@ -103,7 +106,10 @@ interface BlockerOptions {
    * Only one registered customCheck will be used at a time, the first one,
    * even if multiple blockers are registered
    */
-  customCheck?: (currentLocation: Location, nextLocation: Location) => boolean;
+  customCheck?: {
+    navigate: (currentLocation: Location, nextLocation: Location) => boolean;
+    refresh: () => boolean;
+  };
   customConfirmation?: (proceed: () => void) => void;
   /**
    * Will block when navigating away from the page, but not when refreshing

--- a/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.ts
+++ b/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useBeforeUnload, useBlocker } from 'react-router-dom';
 import { create } from 'zustand';
 import { useTranslation } from '@common/intl';
@@ -69,22 +69,18 @@ export const useBlockNavigation = () => {
     return false;
   });
 
-  const shouldBlockRefresh = blockers.some(b => {
-    if (b.options?.customCheck) {
-      return b.options.customCheck.refresh();
-    }
-    return b.shouldBlock && !b.options?.allowRefresh;
-  });
-
   // handle page refresh events
   useBeforeUnload(
-    useCallback(
-      event => {
-        // Cancel the refresh
-        if (shouldBlockRefresh) event.preventDefault();
-      },
-      [shouldBlockRefresh]
-    ),
+    event => {
+      const shouldBlockRefresh = blockers.some(b => {
+        if (b.options?.customCheck) {
+          return b.options.customCheck.refresh();
+        }
+        return b.shouldBlock && !b.options?.allowRefresh;
+      });
+      // Cancel the refresh
+      if (shouldBlockRefresh) event.preventDefault();
+    },
     { capture: true }
   );
 

--- a/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
@@ -86,15 +86,18 @@ export const PrescriptionLineEditView = () => {
     // Need a custom checking method here, as we don't want to warn user when
     // switching to a different item within this page
     {
-      customCheck: (current, next) => {
-        if (!isDirty.current) return false;
+      customCheck: {
+        navigate: (current, next) => {
+          if (!isDirty.current) return false;
 
-        const currentPathParts = current.pathname.split('/');
-        const nextPathParts = next.pathname.split('/');
-        // Compare URLS, but don't include the last part, which is the ItemID
-        currentPathParts.pop();
-        nextPathParts.pop();
-        return !isEqual(currentPathParts, nextPathParts);
+          const currentPathParts = current.pathname.split('/');
+          const nextPathParts = next.pathname.split('/');
+          // Compare URLS, but don't include the last part, which is the ItemID
+          currentPathParts.pop();
+          nextPathParts.pop();
+          return !isEqual(currentPathParts, nextPathParts);
+        },
+        refresh: () => isDirty.current,
       },
     }
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6321

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Turns out custom check for confirm on leaving wasn't being used for refresh, have added this:

![Screenshot 2025-03-27 at 12 49 10 PM](https://github.com/user-attachments/assets/041ecaeb-22f6-49db-b61c-8a8bfc5dbdaf)


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to a prescription, edit line view
- [ ] Make a change to a line
- [ ] Refresh the page
- [ ] You see unsaved changes warning

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [x] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [x] Frontend

