### PR TITLE
7057 create new inbound shipment firing twice and creates two shipments

### DIFF
--- a/client/packages/invoices/src/InboundShipment/ListView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/AppBarButtons.tsx
@@ -63,25 +63,11 @@ export const AppBarButtons = ({
     success(t('success'))();
   };
 
-  const createInvoice = async (nameId: string) => {
+  const createInvoice = async (nameId: string, requisitionId?: string) => {
     const invoiceNumber = await onCreate({
       id: FnUtils.generateUUID(),
       otherPartyId: nameId,
-    });
-
-    navigate(
-      RouteBuilder.create(AppRoute.Replenishment)
-        .addPart(AppRoute.InboundShipment)
-        .addPart(String(invoiceNumber))
-        .build()
-    );
-  };
-
-  const onRowClick = async (row: LinkedRequestRowFragment) => {
-    const invoiceNumber = await onCreate({
-      id: FnUtils.generateUUID(),
-      otherPartyId: name?.id ?? '',
-      requisitionId: row.id,
+      requisitionId,
     });
 
     navigate(
@@ -115,7 +101,10 @@ export const AppBarButtons = ({
           requestRequisitions={data?.nodes}
           isOpen={linkRequestModalController.isOn}
           onClose={linkRequestModalController.toggleOff}
-          onRowClick={onRowClick}
+          onRowClick={row => {
+            createInvoice(name?.id ?? '', row.id);
+            linkRequestModalController.toggleOff();
+          }}
           isLoading={internalOrderIsLoading}
           onNextClick={() => {
             if (name) {

--- a/client/packages/invoices/src/InboundShipment/ListView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/AppBarButtons.tsx
@@ -22,7 +22,7 @@ import {
   NameRowFragment,
   SupplierSearchModal,
 } from '@openmsupply-client/system';
-import { LinkedRequestRowFragment, useInbound } from '../api';
+import { useInbound } from '../api';
 import { inboundsToCsv } from '../../utils';
 import { LinkInternalOrderModal } from './LinkInternalOrderModal';
 

--- a/client/packages/invoices/src/InboundShipment/ListView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/AppBarButtons.tsx
@@ -48,6 +48,8 @@ export const AppBarButtons = ({
     useInbound.document.listInternalOrders(name?.id ?? '');
   const manuallyLinkInternalOrder =
     store?.preferences.manuallyLinkInternalOrderToInboundShipment;
+  const showManuallyLinkModal =
+    data?.totalCount !== 0 && manuallyLinkInternalOrder;
 
   const csvExport = async () => {
     const data = await fetchAsync();
@@ -108,7 +110,7 @@ export const AppBarButtons = ({
         />
       </Grid>
 
-      {data?.totalCount !== 0 && manuallyLinkInternalOrder && (
+      {showManuallyLinkModal && (
         <LinkInternalOrderModal
           requestRequisitions={data?.nodes}
           isOpen={linkRequestModalController.isOn}

--- a/client/packages/invoices/src/InboundShipment/ListView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/AppBarButtons.tsx
@@ -78,7 +78,7 @@ export const AppBarButtons = ({
     if (name && (data?.totalCount === 0 || !manuallyLinkInternalOrder)) {
       createInvoice(name.id);
     }
-  }, [name, data]);
+  }, [name, data, manuallyLinkInternalOrder]);
 
   const onRowClick = async (row: LinkedRequestRowFragment) => {
     const invoiceNumber = await onCreate({

--- a/client/packages/invoices/src/InboundShipment/ListView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/AppBarButtons.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { AppRoute } from '@openmsupply-client/config';
 import {
   FnUtils,
@@ -61,24 +61,28 @@ export const AppBarButtons = ({
     success(t('success'))();
   };
 
-  const createInvoice = async (nameId: string) => {
-    const invoiceNumber = await onCreate({
-      id: FnUtils.generateUUID(),
-      otherPartyId: nameId,
-    });
+  const createInvoice = useCallback(
+    async (nameId: string) => {
+      const invoiceNumber = await onCreate({
+        id: FnUtils.generateUUID(),
+        otherPartyId: nameId,
+      });
 
-    navigate(
-      RouteBuilder.create(AppRoute.Replenishment)
-        .addPart(AppRoute.InboundShipment)
-        .addPart(String(invoiceNumber))
-        .build()
-    );
-  };
+      navigate(
+        RouteBuilder.create(AppRoute.Replenishment)
+          .addPart(AppRoute.InboundShipment)
+          .addPart(String(invoiceNumber))
+          .build()
+      );
+    },
+    [onCreate]
+  );
+
   useEffect(() => {
     if (name && (data?.totalCount === 0 || !manuallyLinkInternalOrder)) {
       createInvoice(name.id);
     }
-  }, [name, data, manuallyLinkInternalOrder]);
+  }, [name, data, manuallyLinkInternalOrder, createInvoice]);
 
   const onRowClick = async (row: LinkedRequestRowFragment) => {
     const invoiceNumber = await onCreate({

--- a/client/packages/invoices/src/InboundShipment/ListView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/AppBarButtons.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { AppRoute } from '@openmsupply-client/config';
 import {
   FnUtils,
@@ -61,28 +61,19 @@ export const AppBarButtons = ({
     success(t('success'))();
   };
 
-  const createInvoice = useCallback(
-    async (nameId: string) => {
-      const invoiceNumber = await onCreate({
-        id: FnUtils.generateUUID(),
-        otherPartyId: nameId,
-      });
+  const createInvoice = async (nameId: string) => {
+    const invoiceNumber = await onCreate({
+      id: FnUtils.generateUUID(),
+      otherPartyId: nameId,
+    });
 
-      navigate(
-        RouteBuilder.create(AppRoute.Replenishment)
-          .addPart(AppRoute.InboundShipment)
-          .addPart(String(invoiceNumber))
-          .build()
-      );
-    },
-    [onCreate]
-  );
-
-  useEffect(() => {
-    if (name && (data?.totalCount === 0 || !manuallyLinkInternalOrder)) {
-      createInvoice(name.id);
-    }
-  }, [name, data, manuallyLinkInternalOrder, createInvoice]);
+    navigate(
+      RouteBuilder.create(AppRoute.Replenishment)
+        .addPart(AppRoute.InboundShipment)
+        .addPart(String(invoiceNumber))
+        .build()
+    );
+  };
 
   const onRowClick = async (row: LinkedRequestRowFragment) => {
     const invoiceNumber = await onCreate({
@@ -134,11 +125,13 @@ export const AppBarButtons = ({
       <SupplierSearchModal
         open={invoiceModalController.isOn}
         onClose={invoiceModalController.toggleOff}
-        onChange={nameRow => {
+        onChange={async nameRow => {
           setName(nameRow);
           invoiceModalController.toggleOff();
           if (manuallyLinkInternalOrder) {
             linkRequestModalController.toggleOn();
+          } else {
+            createInvoice(nameRow.id);
           }
         }}
       />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7057

# 👩🏻‍💻 What does this PR do?
Memorize createInvoice method and add as dependency to useEffect so it doesn't fire twice. 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have one store with `link Inbound Shipment to IO` store pref and one without for easy testing
- [ ] Create IS shipment on both 
- [ ] Shouldn't have 2 invoices created

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

