### PR TITLE
Possible fix for electron discovery missing translations

### DIFF
--- a/client/packages/electron/webpack.plugins.ts
+++ b/client/packages/electron/webpack.plugins.ts
@@ -23,6 +23,18 @@ export const plugins = [
         from: '**/*.json',
         to: './locales/',
       },
+      {
+        context: path.resolve(
+          __dirname,
+          '..',
+          'common',
+          'src',
+          'intl',
+          'locales'
+        ),
+        from: '**/*.json',
+        to: './main_window/locales/',
+      },
     ],
   }),
 ];


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4858 

This is a re-do of https://github.com/msupply-foundation/open-msupply/pull/4946 which got closed due to no replication.

I'm suggesting we try this out on a build to see if it fixed issues that we're seeing.
Thanks @lache-melvin for the code and investigation...

# 👩🏻‍💻 What does this PR do?

Copies translation files to two locations for Electron (AKA Desktop)

## 💌 Any notes for the reviewer?

Haven't tested this yet, but change looks safe so wanted to re-create the PR.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

