### PR TITLE
6823 compile host only

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,6 @@
     "build-stats": "lerna run --scope @openmsupply-client/* build-stats",
     "build-plugins": "lerna run --scope @openmsupply-client/* build-plugin",
     "serve": "lerna run --scope @openmsupply-client/* --parallel serve",
-    "clean": "lerna run --scope @openmsupply-client/* --parallel clean",
     "re-compile": "tsc --project packages/host/tsconfig.json --noEmit",
     "compile-full": "lerna run --scope @openmsupply-client/* --parallel tsc",
     "test": "jest --config ./jest.config.js --maxWorkers=50% --env=jsdom",

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,6 @@
     "build-plugins": "lerna run --scope @openmsupply-client/* build-plugin",
     "serve": "lerna run --scope @openmsupply-client/* --parallel serve",
     "clean": "lerna run --scope @openmsupply-client/* --parallel clean",
-    "compile": "lerna run --scope @openmsupply-client/* --parallel tsc --since HEAD -- --noEmit",
     "re-compile": "tsc --project packages/host/tsconfig.json --noEmit",
     "compile-full": "lerna run --scope @openmsupply-client/* --parallel tsc",
     "test": "jest --config ./jest.config.js --maxWorkers=50% --env=jsdom",


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6823

# 👩🏻‍💻 What does this PR do?

Client directory script changes.

Removed `yarn compile` script, compilation takes longer than needed and doesn't provide click through. We've decided to just stick with using `yarn re-compile` which only focuses on compiling the `host` directory. 

Have removed the use of `yarn clean` script as it's currently not being used anywhere

![Screenshot 2025-03-31 at 9 08 31 AM](https://github.com/user-attachments/assets/0157c0a5-77c9-4980-9004-d07b854ffee6)

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

Checked if `start-local` and `start-remote` in the client directory need Lerna. There’s only one instance of each in OMS, so running them with Lerna and parallel doesn’t seem necessary? Updated and tested `start-local` to `cd` into `host` and run directly (e.g., `cd packages/host && yarn start-local`). It worked fine without errors. We can likely simplify these to standalone commands but leaving that up for a discussion for now.

Also noticed that `yarn start` and `yarn start-local` in the client directory are essentially the same command. `start` just calls `start-local` internally (`"start": "yarn start-local",`). Wondering if we actually need both?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

Dev specific changes

- [ ] Removed `yarn compile`
- [ ] Removed `yarn clean`

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

