### PR TITLE
Fix typo in gql errors for document registry

### DIFF
--- a/server/graphql/programs/src/mutations/contact_trace/insert.rs
+++ b/server/graphql/programs/src/mutations/contact_trace/insert.rs
@@ -91,7 +91,7 @@ pub fn insert_contact_trace(
                 UpsertContactTraceError::InvalidParentId => {
                     StandardGraphqlError::InternalError(formatted_error)
                 }
-                UpsertContactTraceError::DocumentTypeDoesNotExit => {
+                UpsertContactTraceError::DocumentTypeDoesNotExist => {
                     StandardGraphqlError::BadUserInput(formatted_error)
                 }
             };

--- a/server/graphql/programs/src/mutations/contact_trace/update.rs
+++ b/server/graphql/programs/src/mutations/contact_trace/update.rs
@@ -94,7 +94,7 @@ pub fn update_contact_trace(
                 UpsertContactTraceError::InvalidContactPatientId => {
                     StandardGraphqlError::BadUserInput(formatted_error)
                 }
-                UpsertContactTraceError::DocumentTypeDoesNotExit => {
+                UpsertContactTraceError::DocumentTypeDoesNotExist => {
                     StandardGraphqlError::BadUserInput(formatted_error)
                 }
             };

--- a/server/graphql/programs/src/mutations/program_enrolment/insert.rs
+++ b/server/graphql/programs/src/mutations/program_enrolment/insert.rs
@@ -86,7 +86,7 @@ pub fn insert_program_enrolment(
                 UpsertProgramEnrolmentError::DatabaseError(_) => {
                     StandardGraphqlError::InternalError(formatted_error)
                 }
-                UpsertProgramEnrolmentError::DocumentTypeDoesNotExit => {
+                UpsertProgramEnrolmentError::DocumentTypeDoesNotExist => {
                     StandardGraphqlError::BadUserInput(formatted_error)
                 }
                 UpsertProgramEnrolmentError::ProgramDoesNotExist => {

--- a/server/graphql/programs/src/mutations/program_enrolment/update.rs
+++ b/server/graphql/programs/src/mutations/program_enrolment/update.rs
@@ -87,7 +87,7 @@ pub fn update_program_enrolment(
                 UpsertProgramEnrolmentError::DatabaseError(_) => {
                     StandardGraphqlError::InternalError(formatted_error)
                 }
-                UpsertProgramEnrolmentError::DocumentTypeDoesNotExit => {
+                UpsertProgramEnrolmentError::DocumentTypeDoesNotExist => {
                     StandardGraphqlError::BadUserInput(formatted_error)
                 }
                 UpsertProgramEnrolmentError::ProgramDoesNotExist => {

--- a/server/graphql/programs/src/mutations/program_patient/insert.rs
+++ b/server/graphql/programs/src/mutations/program_patient/insert.rs
@@ -79,7 +79,7 @@ pub fn insert_program_patient(
                 UpdateProgramPatientError::InvalidParentId => {
                     StandardGraphqlError::BadUserInput(formatted_error)
                 }
-                UpdateProgramPatientError::PatientDocumentRegistryDoesNotExit => {
+                UpdateProgramPatientError::PatientDocumentRegistryDoesNotExist => {
                     StandardGraphqlError::BadUserInput(formatted_error)
                 }
             };

--- a/server/graphql/programs/src/mutations/program_patient/update.rs
+++ b/server/graphql/programs/src/mutations/program_patient/update.rs
@@ -80,7 +80,7 @@ pub fn update_program_patient(
                 UpdateProgramPatientError::InvalidParentId => {
                     StandardGraphqlError::BadUserInput(formatted_error)
                 }
-                UpdateProgramPatientError::PatientDocumentRegistryDoesNotExit => {
+                UpdateProgramPatientError::PatientDocumentRegistryDoesNotExist => {
                     StandardGraphqlError::BadUserInput(formatted_error)
                 }
             };

--- a/server/service/src/programs/contact_trace/upsert.rs
+++ b/server/service/src/programs/contact_trace/upsert.rs
@@ -24,7 +24,7 @@ pub enum UpsertContactTraceError {
     /// Invalid document parent id
     InvalidParentId,
     InvalidDataSchema(String),
-    DocumentTypeDoesNotExit,
+    DocumentTypeDoesNotExist,
     DataSchemaDoesNotExist,
 
     InternalError(String),
@@ -210,7 +210,7 @@ fn validate(
 
     let document_registry = match validate_document_type(ctx, &input.r#type)? {
         Some(document_registry) => document_registry,
-        None => return Err(UpsertContactTraceError::DocumentTypeDoesNotExit),
+        None => return Err(UpsertContactTraceError::DocumentTypeDoesNotExist),
     };
 
     let program_row = match validate_program(ctx, &document_registry.context_id)? {

--- a/server/service/src/programs/patient/upsert_program_patient.rs
+++ b/server/service/src/programs/patient/upsert_program_patient.rs
@@ -23,7 +23,7 @@ pub enum UpdateProgramPatientError {
     InvalidParentId,
     PatientExists,
     InvalidDataSchema(String),
-    PatientDocumentRegistryDoesNotExit,
+    PatientDocumentRegistryDoesNotExist,
     DataSchemaDoesNotExist,
     InternalError(String),
     DatabaseError(RepositoryError),
@@ -192,7 +192,7 @@ fn validate(
 
     let document_registry = match validate_document_type(ctx)? {
         Some(document_registry) => document_registry,
-        None => return Err(UpdateProgramPatientError::PatientDocumentRegistryDoesNotExit),
+        None => return Err(UpdateProgramPatientError::PatientDocumentRegistryDoesNotExist),
     };
 
     if input.parent.is_none() && !validate_patient_not_exists(ctx, service_provider, &patient.id)? {

--- a/server/service/src/programs/program_enrolment/upsert.rs
+++ b/server/service/src/programs/program_enrolment/upsert.rs
@@ -24,7 +24,7 @@ pub enum UpsertProgramEnrolmentError {
     ProgramEnrolmentExists,
     ProgramDoesNotExist,
     InvalidDataSchema(String),
-    DocumentTypeDoesNotExit,
+    DocumentTypeDoesNotExist,
     DataSchemaDoesNotExist,
     InternalError(String),
     DatabaseError(RepositoryError),
@@ -186,7 +186,7 @@ fn validate(
 
     let document_registry = match validate_document_type(ctx, &input.r#type)? {
         Some(document_registry) => document_registry,
-        None => return Err(UpsertProgramEnrolmentError::DocumentTypeDoesNotExit),
+        None => return Err(UpsertProgramEnrolmentError::DocumentTypeDoesNotExist),
     };
 
     let program_row = match validate_program(ctx, &document_registry.context_id)? {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6030 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
Fixed a typo in error messages relating to DocumentTypeDoesNotExit and PatientDocumentRegistryDoesNotExit
Both now say 'Exist' rather than 'Exit'

I found more instances of this than was in the original issue

These are backend errors only, and should not appear to a user. They had in the original issue, however this has not been replicated

Error expected to see in testing steps:
![Screenshot 2025-04-01 at 10 47 50 AM](https://github.com/user-attachments/assets/b17dbbdb-fd25-4d53-a024-e6c22657bbc7)

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have the new patient schemas configured incorrectly (so you are able to replicate the error) (for example, the name of the document can be Patient1 and not just Patient)
- [ ] Navigate to your omSupply store and try to add a new patient under Dispensary
- [ ] When adding, click OK and see one error "An error occurred: there was a problem saving the data." appear

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

