### PR TITLE
Add find_all_active pattern

### DIFF
--- a/server/repository/src/db_diesel/insurance_provider_row.rs
+++ b/server/repository/src/db_diesel/insurance_provider_row.rs
@@ -63,6 +63,15 @@ impl<'a> InsuranceProviderRowRepository<'a> {
         Ok(result)
     }
 
+    pub fn find_all_active(&self) -> Result<Vec<InsuranceProviderRow>, RepositoryError> {
+        let result = insurance_provider::table
+            .load(self.connection.lock().connection())?
+            .into_iter()
+            .filter(|row: &InsuranceProviderRow| row.is_active == true)
+            .collect();
+        Ok(result)
+    }
+
     pub fn upsert_one(&self, row: &InsuranceProviderRow) -> Result<i64, RepositoryError> {
         diesel::insert_into(insurance_provider::table)
             .values(row)

--- a/server/repository/src/db_diesel/insurance_provider_row.rs
+++ b/server/repository/src/db_diesel/insurance_provider_row.rs
@@ -65,10 +65,8 @@ impl<'a> InsuranceProviderRowRepository<'a> {
 
     pub fn find_all_active(&self) -> Result<Vec<InsuranceProviderRow>, RepositoryError> {
         let result = insurance_provider::table
-            .load(self.connection.lock().connection())?
-            .into_iter()
-            .filter(|row: &InsuranceProviderRow| row.is_active == true)
-            .collect();
+            .filter(insurance_provider::is_active.eq(true))
+            .load(self.connection.lock().connection())?;
         Ok(result)
     }
 

--- a/server/service/src/insurance_provider/query.rs
+++ b/server/service/src/insurance_provider/query.rs
@@ -6,6 +6,6 @@ use repository::{
 pub fn insurance_providers(
     connection: &StorageConnection,
 ) -> Result<Vec<InsuranceProviderRow>, RepositoryError> {
-    let result = InsuranceProviderRowRepository::new(connection).find_all()?;
+    let result = InsuranceProviderRowRepository::new(connection).find_all_active()?;
     Ok(result)
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6691

# 👩🏻‍💻 What does this PR do?

Adds option for filter for is_active in insurance_provider_row.

Replaces insurance provider query to search for find_all_active in stead of find_all

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Not a sync related issue after all

I notice that we don't use any filtering for is_active in find_all in any of our row repositories, and would typically use a repository file to handle queries with filtering.

We do do find_active_by_id in row repositories, but never a list.

That being said, I'm not sure if what I've done is an acceptable pattern as it isn't used elsewhere.

I added this because adding a repository layer with query + filtering etc seemed like a lot of overhead if we aren't going to use any of the other functionality (pagination, custom filters, etc).

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Add an insurance provider (on mSupply if you wanted to confirm not sync related).
- [ ] See that the insurance provider is visible in omSupply.
- [ ] Set the insurance provider is_active status to be false in mSupply
- [ ] See that the insurance provider is no longer visible in omSupply.


# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

