### PR TITLE
6358 nw/sg internal orders should not have sent datetime populated

### DIFF
--- a/server/service/src/sync/translations/requisition.rs
+++ b/server/service/src/sync/translations/requisition.rs
@@ -267,8 +267,8 @@ impl SyncTranslation for RequisitionTranslation {
             ),
             None => (
                 date_and_time_to_datetime(data.date_entered, 0),
-                from_legacy_sent_datetime(data.last_modified_at, &r#type),
                 from_legacy_finalised_datetime(data.last_modified_at, &r#type),
+                from_legacy_sent_datetime(data.last_modified_at, &r#type, &data.status),
                 data.daysToSupply as f64 / APPROX_NUMBER_OF_DAYS_IN_A_MONTH_IS_30,
                 from_legacy_status(&data.r#type, &data.status).ok_or(anyhow::Error::msg(
                     format!("Unsupported requisition status: {:?}", data.status),
@@ -432,10 +432,13 @@ impl SyncTranslation for RequisitionTranslation {
 fn from_legacy_sent_datetime(
     last_modified_at: i64,
     r#type: &RequisitionType,
+    status: &LegacyRequisitionStatus,
 ) -> Option<NaiveDateTime> {
     match r#type {
         RequisitionType::Request => {
-            if last_modified_at > 0 {
+            // In OG, a finalised "fn" request requisition is the equivalent of a "sent" request requisition in OMS.
+            // There are no date/time fields in OG requisition table for this, there are logs though. Hence using last_modified_at.
+            if last_modified_at > 0 && matches!(status, LegacyRequisitionStatus::Fn) {
                 Some(
                     DateTime::from_timestamp(last_modified_at, 0)
                         .unwrap()
@@ -445,6 +448,7 @@ fn from_legacy_sent_datetime(
                 None
             }
         }
+        // In OMS a response requisition should never be "sent" so the concept doesn't map here
         RequisitionType::Response => None,
     }
 }

--- a/server/service/src/sync/translations/requisition.rs
+++ b/server/service/src/sync/translations/requisition.rs
@@ -267,8 +267,8 @@ impl SyncTranslation for RequisitionTranslation {
             ),
             None => (
                 date_and_time_to_datetime(data.date_entered, 0),
-                from_legacy_finalised_datetime(data.last_modified_at, &r#type),
                 from_legacy_sent_datetime(data.last_modified_at, &r#type, &data.status),
+                from_legacy_finalised_datetime(data.last_modified_at, &r#type, &data.status),
                 data.daysToSupply as f64 / APPROX_NUMBER_OF_DAYS_IN_A_MONTH_IS_30,
                 from_legacy_status(&data.r#type, &data.status).ok_or(anyhow::Error::msg(
                     format!("Unsupported requisition status: {:?}", data.status),
@@ -456,11 +456,12 @@ fn from_legacy_sent_datetime(
 fn from_legacy_finalised_datetime(
     last_modified_at: i64,
     r#type: &RequisitionType,
+    status: &LegacyRequisitionStatus,
 ) -> Option<NaiveDateTime> {
     match r#type {
         RequisitionType::Request => None,
         RequisitionType::Response => {
-            if last_modified_at > 0 {
+            if last_modified_at > 0 && matches!(status, LegacyRequisitionStatus::Fn) {
                 Some(
                     DateTime::from_timestamp(last_modified_at, 0)
                         .unwrap()


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6358 

# 👩🏻‍💻 What does this PR do?

Small changes to integrate internal order fields from OG correctly.

- request "sent" is finalised in OG, so populate the sent_datetime if the OG status is fn
- response "finalised" should only be populated if OG status is finalised

## 💌 Any notes for the reviewer?

I've debugged but can't work out how it populates the "finalised_datetime" for a response requisition that was finalised in OG and then migrated to OMS. As far as I can tell, we should be doing `None` in this match expression:

https://github.com/msupply-foundation/open-msupply/blob/e7f983576de2acb2f08c76a05e01a492be19b765/server/service/src/sync/translations/requisition.rs#L293-L302

I presume the sync requisition processor is doing it.

But empirically it gets set 🤷 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

Here is my data file configured with everything before "initialise OMS" though feel free to set it up from scratch yourself it only takes a few mins:
[demo_data req integration.zip](https://github.com/user-attachments/files/19544864/demo_data.req.integration.zip)


- [ ] OG server. Fine to use OMS central as your remote site (initialise it later though)
- [ ] In OG have 2 stores active
- [ ] Create an internal order from one to the other and leave as suggested (req A)
- [ ] Create an internal order from one to the other and finalise (req B)
- [ ] Login to the other store and finalise the generated response requisition (req C)
- [ ] Create an internal order from one store to the other and finalise (req D)
- [ ] Don't touch the other store's response (req E)
- [ ] Move the stores to your OMS site
- [ ] Initialise OMS
- [ ] req A is "draft" and has no sent or finalise date
- [ ] req B is "finalised" and has sent date and finalised date (finalising the response (C) updates the request to be finalised too)
- [ ] req C is "finalised" and has finalised date but no sent date
- [ ] req D is "sent" and has sent date but no finalise date
- [ ] req E is "new" and has no sent or finalise date

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

