### PR TITLE
7147 Fix plugin sql helpers to be postgres compliant

### DIFF
--- a/client/packages/plugins/backendCommon/utils.ts
+++ b/client/packages/plugins/backendCommon/utils.ts
@@ -3,8 +3,8 @@ const wrapSql = (fields: string[], sqlStatement: string) => {
     sql_type() === 'sqlite' ? 'json_object' : 'json_build_object';
 
   return `
-      SELECT ${jsonObjectFunction}(${fields.map(field => `'${field}', ${field}`)}) AS json_row 
-      FROM (${sqlStatement})
+      SELECT ${jsonObjectFunction}(${fields.map(field => `'${field}', inner_statement.${field}`)}) AS json_row 
+      FROM (${sqlStatement}) AS inner_statement
   `;
 };
 

--- a/client/packages/plugins/backendCommon/utils.ts
+++ b/client/packages/plugins/backendCommon/utils.ts
@@ -1,19 +1,11 @@
 const wrapSql = (fields: string[], sqlStatement: string) => {
-  if (sql_type() === 'sqlite') {
-    return `
-            SELECT json_object(${fields.map(field => `'${field}', ${field}`)}) AS json_row 
-            FROM (${sqlStatement})
-            `;
-  }
+  const jsonObjectFunction =
+    sql_type() === 'sqlite' ? 'json_object' : 'json_build_object';
 
-  if (sql_type() === 'postgres') {
-    return `
-            SELECT json_agg(inner) AS json_row 
-            FROM (${sqlStatement}) AS inner
-            `;
-  }
-
-  throw new Error('Unknown sql_type');
+  return `
+      SELECT ${jsonObjectFunction}(${fields.map(field => `'${field}', ${field}`)}) AS json_row 
+      FROM (${sqlStatement})
+  `;
 };
 
 export const sqlQuery = <K extends string>(
@@ -46,7 +38,7 @@ export const sqlDateTime = (date: Date) =>
 export const localDate = (date: Date) => {
   return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
 };
-export const sqlList = (list: string[]) => '("' + list.join('","') + '")';
+export const sqlList = (list: string[]) => `('${list.join(`','`)}')`;
 export const fromSqlDateTime = (datetime: string) => {
   // Will map '2023-01-01 10:10:10' to UTC '2023-01-01T10:10:10Z'
   return new Date(`${datetime.split(' ').join('T')}Z`);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7147 

# 👩🏻‍💻 What does this PR do?

Fix plugin sql helpers to be plugin compliant.

I also found that json_agg will return [null] if there are no rows, which cause deserialization error, actually json_build_object is simpler, it's the same as sqlite

## 💌 Any notes for the reviewer?

# 🧪 Testing

I've udpated [plugin examples](https://github.com/msupply-foundation/open-msupply-plugins/pull/14) to be postgres compliant too, you can grab that plugin repo, with generate and install command or just use [this bundle](https://github.com/msupply-foundation/open-msupply-plugins/blob/3980359242909713cee03389a30633689b3ba5f2/bundle.json) with `cargo run --bin remote_server_cli -- install-plugin-bundle -p bundle.json --url 'http://localhost:8000' --username admin --password pass`

Use postgres

You may need to delete your exisiting backend plugins before running above (backend_plugin table)

Basic test is to create manual requisition for customer make sure you add some AMC. Create internal order and add that item, see aggregatedAMC shown up a column and in edit line view you should see a table with how aggregate AMC is calculated


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

