### PR TITLE
#7105 Improve prescription payment error

### DIFF
--- a/client/packages/common/src/plugins/prescriptionTypes.ts
+++ b/client/packages/common/src/plugins/prescriptionTypes.ts
@@ -5,5 +5,5 @@ export type PrescriptionPaymentComponentProps = {
   prescriptionData: PrescriptionRowFragment;
   totalToBePaidByInsurance: number;
   totalToBePaidByPatient: number;
-  events: UsePluginEvents<{ isDirty: boolean }>;
+  events: UsePluginEvents<{ isDirty: boolean; errorMessage: string | null }>;
 };

--- a/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
@@ -34,7 +34,6 @@ export const PaymentsModal: FC<PaymentsModalProps> = ({
   const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
 
   const [insuranceId, setInsuranceId] = useState<string | null>();
-  const [pluginError, setPluginError] = useState<string>();
 
   const {
     query: { data: prescriptionData },
@@ -55,8 +54,12 @@ export const PaymentsModal: FC<PaymentsModalProps> = ({
   const selectedInsurance = insuranceData?.find(({ id }) => id === insuranceId);
 
   const { plugins } = usePluginProvider();
-  const pluginEvents = usePluginEvents({
+  const pluginEvents = usePluginEvents<{
+    isDirty: boolean;
+    errorMessage: string | null;
+  }>({
     isDirty: false,
+    errorMessage: null,
   });
 
   const totalAfterTax = prescriptionData?.pricing.totalAfterTax ?? 0;
@@ -85,14 +88,18 @@ export const PaymentsModal: FC<PaymentsModalProps> = ({
       );
       onClose();
     } catch (error) {
-      setPluginError((error as Error).message);
+      pluginEvents.setState({
+        ...pluginEvents.state,
+        errorMessage: (error as Error).message,
+      });
     }
   };
 
   useEffect(() => {
     // Reset plugin error when modal is closed
-    setPluginError(undefined);
-  }, [isOpen]);
+    if (pluginEvents.state.errorMessage)
+      pluginEvents.setState({ ...pluginEvents.state, errorMessage: null });
+  }, [isOpen, pluginEvents]);
 
   return (
     <Modal
@@ -189,9 +196,9 @@ export const PaymentsModal: FC<PaymentsModalProps> = ({
             ) : null
           )}
         </Grid>
-        {pluginError && (
+        {pluginEvents.state.errorMessage && (
           <Box sx={{ pt: 4, display: 'flex', justifyContent: 'center' }}>
-            <Alert severity="error">{pluginError}</Alert>
+            <Alert severity="error">{pluginEvents.state.errorMessage}</Alert>
           </Box>
         )}
       </>

--- a/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Payments/PaymentsModal.tsx
@@ -99,7 +99,8 @@ export const PaymentsModal: FC<PaymentsModalProps> = ({
     // Reset plugin error when modal is closed
     if (pluginEvents.state.errorMessage)
       pluginEvents.setState({ ...pluginEvents.state, errorMessage: null });
-  }, [isOpen, pluginEvents]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
 
   return (
     <Modal


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7105

# 👩🏻‍💻 What does this PR do?

Updated the plugin behaviour so that the Error message goes away as soon as the entered value is enough to complete the payment.

## 💌 Any notes for the reviewer?

Need to have this plugin branch checked out as well: https://github.com/msupply-foundation/civ-plugins/pull/5

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have patients with Insurance
- [ ] Create prescription (with at least one item that costs $$$)
- [ ] Attempt to verify prescription, should bring up Payment modal
- [ ] Attempt to "Save" with an "Amount paid" value that is too low (or 0)
- [ ] The error message "Amount paid is less than the amount outstanding" should be displayed
- [ ] Start typing in the "Amount paid" input. As long as the entered value is still too low, the error should remain
- [ ] As soon as the entered value is sufficient, the error message should disappear


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

