### PR TITLE
Prevents render of too many years

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Filters/DateFilter.tsx
+++ b/client/packages/common/src/ui/components/inputs/Filters/DateFilter.tsx
@@ -19,15 +19,14 @@ export type RangeOption = 'from' | 'to';
 export const DateFilter: FC<{ filterDefinition: DateFilterDefinition }> = ({
   filterDefinition,
 }) => {
-  const currentYear = new Date().getFullYear()
   const {
     type,
     urlParameter,
     name,
     range,
     displayAs = type,
-    maxDate = `${currentYear + 10}-12-31`,
-    minDate = `${currentYear - 120}-01-01`,
+    maxDate,
+    minDate,
   } = filterDefinition;
   const { urlQuery, updateQuery } = useUrlQuery();
   const { customDate, urlQueryDate, urlQueryDateTime } = useFormatDateTime();

--- a/client/packages/common/src/ui/components/inputs/Filters/DateFilter.tsx
+++ b/client/packages/common/src/ui/components/inputs/Filters/DateFilter.tsx
@@ -19,14 +19,15 @@ export type RangeOption = 'from' | 'to';
 export const DateFilter: FC<{ filterDefinition: DateFilterDefinition }> = ({
   filterDefinition,
 }) => {
+  const currentYear = new Date().getFullYear()
   const {
     type,
     urlParameter,
     name,
     range,
     displayAs = type,
-    maxDate = '9999-12-31',
-    minDate = '0000-01-01',
+    maxDate = `${currentYear + 10}-12-31`,
+    minDate = `${currentYear - 120}-01-01`,
   } = filterDefinition;
   const { urlQuery, updateQuery } = useUrlQuery();
   const { customDate, urlQueryDate, urlQueryDateTime } = useFormatDateTime();


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5280 

# 👩🏻‍💻 What does this PR do?

Renders a select amount of years rather than 10,000

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

I've arbitrarily chosen the limit of 50 years ahead, and 120 years behind (to capture a reasonable date of birth option).

These values could be customised for a specific filter by passing in custom end ranges if we wanted to be more specific (ie it doesn't necessarily make sense to have a date of birth year option in the future).

This issue only fixes the described issue of render time

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] open up any filter (ie patients, date of birth filter)
- [ ] Select to change the year - see it renders much more quickly.

# 📃 Documentation

- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour



# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

