### PR TITLE
6669 Hide facility name if vaccine not given

### DIFF
--- a/client/packages/system/src/Vaccination/Components/VaccineCardTable.tsx
+++ b/client/packages/system/src/Vaccination/Components/VaccineCardTable.tsx
@@ -219,6 +219,7 @@ const VaccinationCardComponent = ({
       {
         key: 'facilityName',
         label: 'label.facility',
+        accessor: ({ rowData }) => (rowData.given ? rowData.facilityName : ''),
       },
     ],
     {},


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6669 

# 👩🏻‍💻 What does this PR do?
Clears facility when vaccine dose status changed to "not given"

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
![Screenshot 2025-04-02 at 16 54 44](https://github.com/user-attachments/assets/0143d7d6-de94-47f8-a16e-31f939b718e7)

## 💌 Any notes for the reviewer?
This seemed like the low hanging fruit fix. Not sure if it needs a deeper look? e.g clearing name on save or something along those lines

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Make sure you have Immunization Programs and Vaccination Card enabled in your store
- [ ] Create an encounter for a patient who is enrolled into a program
- [ ] Create a vaccine course for your immunization program
- [ ] In a vaccine course, make sure you have a few doses set up 
- [ ] Go back to the encounter you are testing and administer a few doses
- [ ] Then, change the second to last dose status from Given to Not Given -> provide reason -> click ok
- [ ] See that date and facility name is cleared

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

