### PR TITLE
7196 sync http request timeout

### DIFF
--- a/server/util/src/api_helper.rs
+++ b/server/util/src/api_helper.rs
@@ -20,6 +20,7 @@ where
     loop {
         let client = Client::builder()
             .connect_timeout(Duration::from_secs(connection_timeouts.0[index]))
+            .read_timeout(Duration::from_secs(30)) // If there is no read from the socket after 30s abort
             .timeout(Duration::from_secs(300)) // generous because some sync records may have big payloads like reports that take a long time to sync on low bandwidth
             .build()
             .unwrap(); // This method fails if a TLS backend cannot be initialized, or the resolver cannot load the system configuration.

--- a/server/util/src/api_helper.rs
+++ b/server/util/src/api_helper.rs
@@ -20,8 +20,9 @@ where
     loop {
         let client = Client::builder()
             .connect_timeout(Duration::from_secs(connection_timeouts.0[index]))
+            .timeout(Duration::from_secs(30))
             .build()
-            .unwrap();// This method fails if a TLS backend cannot be initialized, or the resolver cannot load the system configuration.
+            .unwrap(); // This method fails if a TLS backend cannot be initialized, or the resolver cannot load the system configuration.
 
         let result = f(client).send().await;
 

--- a/server/util/src/api_helper.rs
+++ b/server/util/src/api_helper.rs
@@ -20,7 +20,7 @@ where
     loop {
         let client = Client::builder()
             .connect_timeout(Duration::from_secs(connection_timeouts.0[index]))
-            .timeout(Duration::from_secs(30))
+            .timeout(Duration::from_secs(300)) // generous because some sync records may have big payloads like reports that take a long time to sync on low bandwidth
             .build()
             .unwrap(); // This method fails if a TLS backend cannot be initialized, or the resolver cannot load the system configuration.
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7196

# 👩🏻‍💻 What does this PR do?

Adds total timeout of 5mins to sync http requests using the api helper. Long duration in case reading big response on low bandwidth, and otherwise covers all bases such as getting stuck writing body in the request.

read_timeout too of 30s. If it stops reading anything from the connection for over 30s we timeout. 

<img width="565" alt="image" src="https://github.com/user-attachments/assets/3d5b595c-f97a-4e5c-9e56-985adc980732" />

You will see an error like this. We can make it pretty by handling it properly later.

## 💌 Any notes for the reviewer?


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] OG interpreted
- [ ] Init OMS central
- [ ] Sync - all good
- [ ] put breakpoint in `Web Authenticate` method
- [ ] Sync - should timeout after 30s
- [ ] It's quite hard to effectively manually test the 300s overall timeout... need to limit bandwidth really

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

