### PR TITLE
6941 fix stock quantity rounding

### DIFF
--- a/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
+++ b/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
@@ -144,7 +144,7 @@ export const InventoryAdjustmentModal: FC<InventoryAdjustmentModalProps> = ({
               <NumericTextInput
                 width={INPUT_WIDTH}
                 disabled={true}
-                value={parseInt(
+                value={parseFloat(
                   (
                     stockLine.totalNumberOfPacks +
                     (draft.adjustmentType === AdjustmentTypeInput.Addition

--- a/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
+++ b/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
@@ -28,7 +28,7 @@ export const InventoryAdjustmentModal: FC<InventoryAdjustmentModalProps> = ({
   const t = useTranslation();
   const { success, error } = useNotification();
   const { Modal } = useDialog({ isOpen, onClose });
-  const { format } = useFormatNumber();
+  const { round } = useFormatNumber();
 
   const { draft, setDraft, create } = useInventoryAdjustment(stockLine);
 
@@ -107,13 +107,13 @@ export const InventoryAdjustmentModal: FC<InventoryAdjustmentModalProps> = ({
         >
           <TextWithLabelRow
             label={t('label.pack-quantity')}
-            text={format(stockLine.totalNumberOfPacks)}
+            text={round(stockLine.totalNumberOfPacks, 2)}
             textProps={{ textAlign: 'end' }}
             labelProps={{ sx: { textWrap: 'wrap' } }}
           />
           <TextWithLabelRow
             label={t('label.available-packs')}
-            text={format(stockLine.availableNumberOfPacks)}
+            text={round(stockLine.availableNumberOfPacks, 2)}
             textProps={{ textAlign: 'end' }}
             labelProps={{ sx: { textWrap: 'wrap' } }}
           />
@@ -144,12 +144,14 @@ export const InventoryAdjustmentModal: FC<InventoryAdjustmentModalProps> = ({
               <NumericTextInput
                 width={INPUT_WIDTH}
                 disabled={true}
-                value={
-                  stockLine.totalNumberOfPacks +
-                  (draft.adjustmentType === AdjustmentTypeInput.Addition
-                    ? draft.adjustment
-                    : -draft.adjustment)
-                }
+                value={parseInt(
+                  (
+                    stockLine.totalNumberOfPacks +
+                    (draft.adjustmentType === AdjustmentTypeInput.Addition
+                      ? draft.adjustment
+                      : -draft.adjustment)
+                  ).toFixed(2)
+                )}
               />
             }
           />

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -108,7 +108,7 @@ export const StockLineForm: FC<StockLineFormProps> = ({
                 autoFocus
                 disabled={!packEditable}
                 width={160}
-                value={draft.totalNumberOfPacks}
+                value={parseFloat(draft.totalNumberOfPacks.toFixed(2))}
                 onChange={totalNumberOfPacks =>
                   onUpdate({ totalNumberOfPacks })
                 }
@@ -122,7 +122,7 @@ export const StockLineForm: FC<StockLineFormProps> = ({
                 autoFocus
                 disabled={!packEditable}
                 width={160}
-                value={draft.availableNumberOfPacks}
+                value={parseFloat(draft.availableNumberOfPacks.toFixed(2))}
                 onChange={availableNumberOfPacks =>
                   onUpdate({ availableNumberOfPacks })
                 }

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -116,7 +116,7 @@ const StockListComponent: FC = () => {
     [
       'numberOfPacks',
       {
-        accessor: ({ rowData }) => rowData.totalNumberOfPacks,
+        accessor: ({ rowData }) => rowData.totalNumberOfPacks.toFixed(2),
         width: 125,
       },
     ],
@@ -124,7 +124,7 @@ const StockListComponent: FC = () => {
       'stockOnHand',
       {
         accessor: ({ rowData }) =>
-          rowData.totalNumberOfPacks * rowData.packSize,
+          (rowData.totalNumberOfPacks * rowData.packSize).toFixed(2),
         sortable: false,
         width: 125,
       },
@@ -135,7 +135,7 @@ const StockListComponent: FC = () => {
         label: 'label.available-soh',
         description: 'description.available-soh',
         accessor: ({ rowData }) =>
-          rowData.availableNumberOfPacks * rowData.packSize,
+          (rowData.availableNumberOfPacks * rowData.packSize).toFixed(2),
         sortable: false,
         width: 125,
       },


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6941 

# 👩🏻‍💻 What does this PR do?

This PR makes sure that Open mSupply rounds the pack quantities to 2 decimal places when it displays them.

It adds rounding functions to the pack quantities where they are displayed, in the:
- stock list view
- stock detail view
- inventory adjustment menu

Before (from a comment in the original issue discussion):

https://private-user-images.githubusercontent.com/163234798/424233451-cd0a0dae-81d0-416e-a327-7f42fa0d1b52.mov?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDM3Mjk3MjgsIm5iZiI6MTc0MzcyOTQyOCwicGF0aCI6Ii8xNjMyMzQ3OTgvNDI0MjMzNDUxLWNkMGEwZGFlLTgxZDAtNDE2ZS1hMzI3LTdmNDJmYTBkMWI1Mi5tb3Y_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwNDA0JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDQwNFQwMTE3MDhaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT0wYzMyMGQ2OTY3NTczNGMyNDJhNGQ3NDllYzkyM2ZiODU0MjgyZDY0Y2ZkNzQ3ZjZhMzA4MDEyYmVlNjExZjY1JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.zWDmr9Gaur-yM-BPwjAb3-nPAhbOfq9FMHMOWAY_US0

After:

https://github.com/user-attachments/assets/b4fe9818-3312-4f8c-bb35-ae96c7afdf4d

## 💌 Any notes for the reviewer?

Have a nice day :)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] In Open mSupply, create an stock item with a pack quantity which is a number with more than 2 d.p., e.g. 19.3333333333333366666666667.
- [ ] Go to Inventory > View Stock.
- [ ] Check that item's pack quantity is displayed with 2 d.p. (e.g. 19.33).
- [ ] Double click on that item to see its detail view.
- [ ] Check that the item's 'Pack Qty' and 'Available (packs)' fields are displayed with 2 d.p.
- [ ] Click on the adjust button in the top right corner to see the inventory adjustment modal.
- [ ] Check that the 'Pack Qty' and 'Available (packs)' fields are displayed with 2 d.p.
- [ ] Adjust the amount of packs by every possible second decimal place (e.g. 0.31, 0.32, 0.33 and so on) and check that with each adjustment the 'New Pack Qty' field only has 2 d.p., never more.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

