### PR TITLE
#7113 Outbound alerts layout

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -210,8 +210,8 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
       {item && canAutoAllocate ? (
         <>
           <Divider margin={10} />
-          <Box display="flex" alignItems="center">
-            <Grid container alignItems="center">
+          <Box display="flex" alignItems="flex-start" gap={2}>
+            <Grid container alignItems="center" pt={1}>
               <ModalLabel label={t('label.issue')} />
               <NumericTextInput
                 autoFocus

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -210,51 +210,52 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
       {item && canAutoAllocate ? (
         <>
           <Divider margin={10} />
-          <StockOutAlerts
-            allocationAlerts={allocationAlerts}
-            showZeroQuantityConfirmation={showZeroQuantityConfirmation}
-            isAutoAllocated={isAutoAllocated}
-          />
-          <Grid container>
-            <ModalLabel label={t('label.issue')} />
-            <NumericTextInput
-              autoFocus
-              value={issueQuantity}
-              onChange={handleIssueQuantityChange}
+          <Box display="flex" alignItems="center">
+            <Grid container alignItems="center">
+              <ModalLabel label={t('label.issue')} />
+              <NumericTextInput
+                autoFocus
+                value={issueQuantity}
+                onChange={handleIssueQuantityChange}
+              />
+              <Box marginLeft={1} />
+
+              {packSizeController.options.length ? (
+                <>
+                  <Box marginLeft={1} />
+                  <Select
+                    sx={{ width: 110 }}
+                    options={packSizeController.options}
+                    value={packSizeController.selected?.value ?? ''}
+                    onChange={e => {
+                      const { value } = e.target;
+                      onChangePackSize(Number(value));
+                    }}
+                  />
+                  {packSizeController.selected?.value !== -1 && (
+                    <Grid
+                      alignItems="center"
+                      display="flex"
+                      justifyContent="flex-start"
+                    >
+                      <InputLabel style={{ fontSize: 12, marginLeft: 8 }}>
+                        {t('label.unit-plural', {
+                          count: packSizeController.selected?.value,
+                          unit: item?.unitName,
+                        })}
+                      </InputLabel>
+                    </Grid>
+                  )}
+                  <Box marginLeft="auto" />
+                </>
+              ) : null}
+            </Grid>
+            <StockOutAlerts
+              allocationAlerts={allocationAlerts}
+              showZeroQuantityConfirmation={showZeroQuantityConfirmation}
+              isAutoAllocated={isAutoAllocated}
             />
-            <Box marginLeft={1} />
-
-            {packSizeController.options.length ? (
-              <>
-                <Box marginLeft={1} />
-
-                <Select
-                  sx={{ width: 110 }}
-                  options={packSizeController.options}
-                  value={packSizeController.selected?.value ?? ''}
-                  onChange={e => {
-                    const { value } = e.target;
-                    onChangePackSize(Number(value));
-                  }}
-                />
-                {packSizeController.selected?.value !== -1 && (
-                  <Grid
-                    alignItems="center"
-                    display="flex"
-                    justifyContent="flex-start"
-                  >
-                    <InputLabel style={{ fontSize: 12, marginLeft: 8 }}>
-                      {t('label.unit-plural', {
-                        count: packSizeController.selected?.value,
-                        unit: item?.unitName,
-                      })}
-                    </InputLabel>
-                  </Grid>
-                )}
-                <Box marginLeft="auto" />
-              </>
-            ) : null}
-          </Grid>
+          </Box>
         </>
       ) : (
         <Box height={100} />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7113

# 👩🏻‍💻 What does this PR do?

Have shuffled the contents around a bit so that the alerts appear to the right of the "Issue" UI rather than push in in front of it:

![Screenshot 2025-04-07 at 11 26 23 AM](https://github.com/user-attachments/assets/33a9867c-1e46-47ac-a17b-b9a38b1136e7)

Also tweaked padding and top-alignment to make it look okay with multiple alerts

## 💌 Any notes for the reviewer?

Haven't addressed the "NaN" problem, as it seems to be due to a pack size being set to 0, as discussed in the original issue. Let me know if you find if/where this is not the case.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create outbound shipment
- [ ] Add an item
- [ ] Issue quantities such that you get an alert appearing -- confirm layout is acceptable
- [ ] Try and get 2 alerts at the same time ("Not enough stock" and "Some are expired", and also confirm layout is acceptable

# 📃 Documentation

- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

