### PR TITLE
7208 fix import asset and equipment csv error

### DIFF
--- a/client/packages/coldchain/src/Equipment/ImportAsset/EquipmentImportModal.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/EquipmentImportModal.tsx
@@ -305,7 +305,7 @@ export const EquipmentImportModal: FC<EquipmentImportModalProps> = ({
           steps={importSteps}
           activeStep={activeStep}
           onClickStep={onClickStep}
-        ></ClickableStepper>
+        />
         {errorMessage ? <Alert severity="error">{errorMessage}</Alert> : null}
         <TabContext value={currentTab}>
           <Grid container flex={1} flexDirection="column" gap={1}>

--- a/client/packages/system/src/Asset/ListView/Footer.tsx
+++ b/client/packages/system/src/Asset/ListView/Footer.tsx
@@ -8,16 +8,13 @@ import {
   useIsCentralServerApi,
   useDeleteConfirmation,
 } from '@openmsupply-client/common';
-import { useAssetList } from '../api/hooks';
+import { useAssetDelete } from '../api/hooks';
 
 export const FooterComponent: FC = () => {
   const t = useTranslation();
   const isCentralServer = useIsCentralServerApi();
 
-  const {
-    delete: { deleteAssets },
-    selectedRows,
-  } = useAssetList();
+  const { deleteAssets, selectedRows } = useAssetDelete();
 
   const confirmAndDelete = useDeleteConfirmation({
     selectedRows,

--- a/client/packages/system/src/Asset/api/hooks/index.ts
+++ b/client/packages/system/src/Asset/api/hooks/index.ts
@@ -3,6 +3,7 @@ export * from './useAssetList';
 export * from './useAssetInsert';
 export * from './useAssetLogReasonList';
 export * from './useAssetLogReason';
+export * from './useAssetDelete';
 
 export const useAssetData = {
   utils: {

--- a/client/packages/system/src/Asset/api/hooks/useAssetDelete.ts
+++ b/client/packages/system/src/Asset/api/hooks/useAssetDelete.ts
@@ -1,0 +1,55 @@
+import { useMutation } from 'packages/common/src';
+import { useAssetGraphQL } from '../useAssetGraphQL';
+import { ASSET } from './keys';
+import { useAssetList } from './useAssetList';
+import { useTableStore } from '@openmsupply-client/common';
+import { AssetCatalogueItemFragment } from '../operations.generated';
+
+export const useAssetDelete = () => {
+  const { assetApi, queryClient } = useAssetGraphQL();
+  const {
+    query: { data },
+  } = useAssetList();
+
+  const { selectedRows } = useTableStore(state => ({
+    selectedRows: Object.keys(state.rowState)
+      .filter(id => state.rowState[id]?.isSelected)
+      .map(selectedId => data?.nodes?.find(({ id }) => selectedId === id))
+      .filter(Boolean) as AssetCatalogueItemFragment[],
+  }));
+
+  const mutationFn = async (id: string) => {
+    const result = await assetApi.deleteAssetCatalogueItem({
+      assetCatalogueItemId: id,
+    });
+
+    return result.centralServer.assetCatalogue.deleteAssetCatalogueItem;
+  };
+
+  const {
+    mutateAsync: deleteMutation,
+    isLoading,
+    error,
+  } = useMutation({
+    mutationFn,
+    onSuccess: () => {
+      queryClient.invalidateQueries([ASSET]);
+    },
+  });
+
+  const deleteAssets = async () => {
+    await Promise.all(selectedRows.map(row => deleteMutation(row.id))).catch(
+      err => {
+        console.error(err);
+        throw err;
+      }
+    );
+  };
+
+  return {
+    deleteAssets,
+    isLoading,
+    error,
+    selectedRows,
+  };
+};

--- a/client/packages/system/src/Asset/api/hooks/useAssetDelete.ts
+++ b/client/packages/system/src/Asset/api/hooks/useAssetDelete.ts
@@ -1,4 +1,4 @@
-import { useMutation } from 'packages/common/src';
+import { useMutation } from '@openmsupply-client/common';
 import { useAssetGraphQL } from '../useAssetGraphQL';
 import { ASSET } from './keys';
 import { useAssetList } from './useAssetList';

--- a/client/packages/system/src/Asset/api/hooks/useAssetList.ts
+++ b/client/packages/system/src/Asset/api/hooks/useAssetList.ts
@@ -24,7 +24,26 @@ export type useAssetsProps = {
 };
 
 export const useAssetList = (queryParams?: ListParams) => {
-  const { data, isLoading, isError } = useGetList(queryParams);
+  const { assetApi, storeId } = useAssetGraphQL();
+  const { first, offset, sortBy, filterBy } = queryParams ?? {};
+  const queryKey = [ASSET, storeId, LIST, first, offset, sortBy, filterBy];
+
+  const queryFn = async () => {
+    const query = await assetApi.assetCatalogueItems({
+      first: first ?? 1000,
+      offset: offset ?? 0,
+      key: toSortField(sortBy),
+      desc: sortBy?.isDesc,
+      filter: filterBy,
+    });
+    const { nodes, totalCount } = query?.assetCatalogueItems;
+    return { nodes, totalCount };
+  };
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey,
+    queryFn,
+  });
 
   return {
     query: { data, isLoading, isError },
@@ -65,30 +84,6 @@ export const useInfiniteAssets = ({
     queryFn,
   });
   return infiniteQuery;
-};
-
-export const useGetList = (queryParams?: ListParams) => {
-  const { assetApi, storeId } = useAssetGraphQL();
-  const { first, offset, sortBy, filterBy } = queryParams ?? {};
-  const queryKey = [ASSET, storeId, LIST, first, offset, sortBy, filterBy];
-
-  const queryFn = async () => {
-    const query = await assetApi.assetCatalogueItems({
-      first: first ?? 1000,
-      offset: offset ?? 0,
-      key: toSortField(sortBy),
-      desc: sortBy?.isDesc,
-      filter: filterBy,
-    });
-    const { nodes, totalCount } = query?.assetCatalogueItems;
-    return { nodes, totalCount };
-  };
-
-  const query = useQuery({
-    queryKey,
-    queryFn,
-  });
-  return query;
 };
 
 const toSortField = (sortBy?: SortBy<AssetCatalogueItemFragment>) => {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7208 

# 👩🏻‍💻 What does this PR do?

Importing an asset or equipment CSV returns an error. This happens because `useTableStore` is called within `useAssetList`, which causes a bunch of re-renders. 

These re-renders occur due to the state or data in `useTableStore` being updated/populated when a new file is imported.

Created a `useAssetDelete` hook to separate the concern of managing `useTableStore's` state. Keeping `useTableStore` within `useAssetList` was causing unnecessary re-renders, so moving the delete logic to its own hook resolves this issue.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

Applying memoization techniques (`useMemo`, `useCallback`) didn't produce any luck in terms of solving this issue, hence created a dedicated hook for it instead

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate ColdChain -> Equipment -> Click on Import Button -> Drop CSV File -> Works!
- [ ] Navigate Catalogue -> Asset -> Click on Import Button -> Drop CSV File -> Works!
- [ ] Navigate Catalogue -> Asset -> Select an asset -> Delete -> Works!
- [ ] Navigate Catalogue -> Asset -> Select a bunch of assets -> Delete -> Works!

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

