### PR TITLE
Translations: datepicker's buttons show in English #7241

### DIFF
--- a/client/packages/common/src/ui/components/inputs/DatePickers/DateTimePickerInput/DateTimePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/DateTimePickerInput/DateTimePickerInput.tsx
@@ -155,6 +155,12 @@ export const DateTimePickerInput: FC<
         },
         ...(actions ? { actionBar: { actions } } : {}),
       }}
+      localeText={{
+        okButtonLabel: t('button.ok'),
+        cancelButtonLabel: t('button.cancel'),
+        clearButtonLabel: t('button.clear'),
+        todayButtonLabel: t('button.today'),
+      }}
       views={
         showTime
           ? ['year', 'month', 'day', 'hours', 'minutes']


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7241

# 👩🏻‍💻 What does this PR do?
Merge got rid of the translations in datetime picker

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Test translations for buttons still work in date time picker (in prescriptions, transport section, or create encounter form)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

