### PR TITLE
7249 2.6.2 migration reintegrate store, skip transfers on linked_invoice_id.is_some()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "2.6.01",
+  "version": "2.6.02",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/repository/src/migrations/mod.rs
+++ b/server/repository/src/migrations/mod.rs
@@ -30,6 +30,7 @@ mod v2_04_01;
 mod v2_05_00;
 mod v2_06_00;
 mod v2_06_01;
+mod v2_06_02;
 mod version;
 mod views;
 
@@ -131,6 +132,7 @@ pub fn migrate(
         Box::new(v2_05_00::V2_05_00),
         Box::new(v2_06_00::V2_06_00),
         Box::new(v2_06_01::V2_06_01),
+        Box::new(v2_06_02::V2_06_02),
     ];
 
     // Historic diesel migrations

--- a/server/repository/src/migrations/v2_06_02/mod.rs
+++ b/server/repository/src/migrations/v2_06_02/mod.rs
@@ -1,0 +1,42 @@
+use super::{version::Version, Migration, MigrationFragment};
+use crate::StorageConnection;
+
+mod store_reintegrate_for_created_date;
+
+pub(crate) struct V2_06_02;
+
+impl Migration for V2_06_02 {
+    fn version(&self) -> Version {
+        Version::from_str("2.6.2")
+    }
+
+    fn migrate(&self, _connection: &StorageConnection) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn migrate_fragments(&self) -> Vec<Box<dyn MigrationFragment>> {
+        vec![Box::new(store_reintegrate_for_created_date::Migrate)]
+    }
+}
+
+#[cfg(test)]
+#[actix_rt::test]
+async fn migration_2_06_02() {
+    use crate::migrations::v2_06_00::V2_06_00;
+    use crate::migrations::*;
+    use crate::test_db::*;
+
+    let previous_version = V2_06_00.version();
+    let version = V2_06_02.version();
+
+    let SetupResult { connection, .. } = setup_test(SetupOption {
+        db_name: &format!("migration_{version}"),
+        version: Some(previous_version.clone()),
+        ..Default::default()
+    })
+    .await;
+
+    // Run this migration
+    migrate(&connection, Some(version.clone())).unwrap();
+    assert_eq!(get_database_version(&connection), version);
+}

--- a/server/repository/src/migrations/v2_06_02/store_reintegrate_for_created_date.rs
+++ b/server/repository/src/migrations/v2_06_02/store_reintegrate_for_created_date.rs
@@ -1,0 +1,22 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "store_reintegrate_for_created_date"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        sql!(
+            connection,
+            r#"
+                UPDATE sync_buffer
+                SET integration_datetime = NULL
+                WHERE table_name = 'store';
+            "#
+        )?;
+
+        Ok(())
+    }
+}

--- a/server/service/src/processors/transfer/invoice/create_inbound_invoice.rs
+++ b/server/service/src/processors/transfer/invoice/create_inbound_invoice.rs
@@ -47,7 +47,7 @@ impl InvoiceTransferProcessor for CreateInboundInvoiceProcessor {
         record_for_processing: &InvoiceTransferProcessorRecord,
     ) -> Result<Option<String>, RepositoryError> {
         // Check can execute
-        let (outbound_invoice, _linked_invoice, request_requisition, original_shipment) =
+        let (outbound_invoice, linked_invoice, request_requisition, original_shipment) =
             match &record_for_processing.operation {
                 Operation::Upsert {
                     invoice: outbound_invoice,
@@ -78,7 +78,7 @@ impl InvoiceTransferProcessor for CreateInboundInvoiceProcessor {
             return Ok(None);
         }
         // 4.
-        if outbound_invoice.invoice_row.linked_invoice_id.is_some() {
+        if linked_invoice.is_some() {
             return Ok(None);
         }
         // 5.

--- a/server/util/src/api_helper.rs
+++ b/server/util/src/api_helper.rs
@@ -20,7 +20,6 @@ where
     loop {
         let client = Client::builder()
             .connect_timeout(Duration::from_secs(connection_timeouts.0[index]))
-            .read_timeout(Duration::from_secs(30)) // If there is no read from the socket after 30s abort
             .timeout(Duration::from_secs(300)) // generous because some sync records may have big payloads like reports that take a long time to sync on low bandwidth
             .build()
             .unwrap(); // This method fails if a TLS backend cannot be initialized, or the resolver cannot load the system configuration.


### PR DESCRIPTION
Fixes #7249
Fixes #7200 
Fixes #7234 

# 👩🏻‍💻 What does this PR do?

- store table reintegrated to ensure store.created_date is populated
- only create transfers if the `linked_invoice_id` is blank
- remove `read_timeout` from sync http requests to avoid dropping connection when 4D is taking it's time flushing memory to DB.

## 💌 Any notes for the reviewer?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have an old OMS database with `store.created_date` null for all store records
- [ ] Migrate the database by installing/starting 2.6.2
- [ ] The records now all have a created_date value (if there was one in the sync_buffer, anyway)

---

- [ ] Have an old OMS (ideally  1.5.3) running with `store.created_date` null for all store records. You will need to have some suppliers that have past confirmed or finalised CIs (i.e. entry_date greater than a day old) to the store on the OMS site.
- [ ] In 4D run this [footrunner](https://github.com/msupply-foundation/msupply/pull/16380) with `$dDate` as current date (this will set `linked_invoice_id` to "prevent_transfer" most customer invoices).
- [ ] Sync - hopefully not spammed with inbound shipments
- [ ] Upgrade to 2.6.2
- [ ] should not be spammed with inbound shipments

---

- [ ] Have a breakpoint on OG web process
- [ ] Sync OMS
- [ ] Should timeout no sooner than 5mins later

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

