### PR TITLE
Make print errors translatable and add translations

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1637,6 +1637,7 @@
   "messages.no-stock-available": "There is no stock available",
   "messages.no-transaction-other-facility": "Stock transactions are not recorded for vaccinations given in other facilities",
   "messages.no-vaccine-items-configured": "No vaccine items configured for this vaccine course. Stock transactions will not be recorded.",
+  "messages.error-printing-report": "Unable to print report",
   "messages.not-applicable": "N/A",
   "messages.not-configured": "Not configured",
   "messages.not-initialised": "[ Not configured ]",

--- a/client/packages/common/src/intl/locales/fr/common.json
+++ b/client/packages/common/src/intl/locales/fr/common.json
@@ -1531,6 +1531,7 @@
   "messages.error-deleting-reasons_other": "{{count}} raisons n'ont pas pu être supprimées",
   "messages.error-generic_one": "{{count}} erreur",
   "messages.error-generic_other": "{{count}} erreurs",
+  "messages.error-printing-report": "Impossible d'imprimer le document",
   "messages.error-no-file-selected": "Aucun fichier sélectionné",
   "messages.error-not-valid-email": "Veuillez saisir une adresse électronique valide",
   "messages.error-saving-insurances": "Erreur lors de l'enregistrement des assurances 🥺",

--- a/client/packages/system/src/Report/api/hooks/usePrintReport.ts
+++ b/client/packages/system/src/Report/api/hooks/usePrintReport.ts
@@ -7,6 +7,7 @@ import {
   useIntlUtils,
   useMutation,
   useNotification,
+  useTranslation,
 } from '@openmsupply-client/common';
 import { Environment } from '@openmsupply-client/config';
 import { Printer } from '@bcyesil/capacitor-plugin-printer';
@@ -63,6 +64,7 @@ const printPage = (url: string) => {
 };
 
 export const usePrintReport = () => {
+  const t = useTranslation();
   const { reportApi, storeId } = useReportGraphQL();
   const { error } = useNotification();
   const { currentLanguage } = useIntlUtils();
@@ -89,13 +91,13 @@ export const usePrintReport = () => {
       return result.generateReport.fileId;
     }
 
-    throw new Error('Unable to print report');
+    throw new Error(t('messages.error-printing-report'));
   };
 
   const { mutate, isLoading } = useMutation({
     mutationFn,
     onSuccess: (fileId, { format = EnvUtils.printFormat }) => {
-      if (!fileId) throw new Error('Error printing report');
+      if (!fileId) throw new Error(t('messages.error-printing-report'));
       const url = `${Environment.FILE_URL}${fileId}`;
       if (format === PrintFormat.Html) {
         printPage(url);


### PR DESCRIPTION
Fixes #7235 

# 👩🏻‍💻 What does this PR do?

This PR makes the printing error messages translatable and adds a french translation for them.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ]     Go to Distribution -> Outbound Shipments
- [ ]     Create a new one or click on an existing one
- [ ]     Change the language to French
- [ ]     Click the print button (labelled 'Imprimer') in the top right corner, select a report to print, and check the error message says 'Impossible d'imprimer le document'.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

