### PR TITLE
7232 unable to access linked prescription from vax card from another store

### DIFF
--- a/client/packages/invoices/src/Prescriptions/api/operations.generated.ts
+++ b/client/packages/invoices/src/Prescriptions/api/operations.generated.ts
@@ -145,6 +145,7 @@ export type PrescriptionRowFragment = {
       providerName: string;
     } | null;
   } | null;
+  store?: { __typename: 'StoreNode'; id: string } | null;
 };
 
 export type PrescriptionLineFragment = {
@@ -408,6 +409,7 @@ export type PrescriptionsQuery = {
           providerName: string;
         } | null;
       } | null;
+      store?: { __typename: 'StoreNode'; id: string } | null;
     }>;
   };
 };
@@ -562,6 +564,7 @@ export type PrescriptionByNumberQuery = {
             providerName: string;
           } | null;
         } | null;
+        store?: { __typename: 'StoreNode'; id: string } | null;
       }
     | {
         __typename: 'NodeError';
@@ -725,6 +728,7 @@ export type PrescriptionByIdQuery = {
             providerName: string;
           } | null;
         } | null;
+        store?: { __typename: 'StoreNode'; id: string } | null;
       }
     | {
         __typename: 'NodeError';
@@ -1192,6 +1196,9 @@ export const PrescriptionRowFragmentDoc = gql`
         providerName
       }
       policyNumber
+    }
+    store {
+      id
     }
   }
   ${PrescriptionLineFragmentDoc}

--- a/client/packages/invoices/src/Prescriptions/api/operations.graphql
+++ b/client/packages/invoices/src/Prescriptions/api/operations.graphql
@@ -87,6 +87,10 @@ fragment PrescriptionRow on InvoiceNode {
     }
     policyNumber
   }
+
+  store {
+    id
+  }
 }
 
 fragment PrescriptionLine on InvoiceLineNode {

--- a/client/packages/programs/src/JsonForms/components/Prescription/PrescriptionInfo.tsx
+++ b/client/packages/programs/src/JsonForms/components/Prescription/PrescriptionInfo.tsx
@@ -5,6 +5,7 @@ import {
   ChevronDownIcon,
   Link,
   RouteBuilder,
+  useAuthContext,
   useFormatDateTime,
   useTranslation,
 } from '@openmsupply-client/common';
@@ -18,6 +19,8 @@ interface PrescriptionInfoProps {
 export const PrescriptionInfo = ({ prescription }: PrescriptionInfoProps) => {
   const t = useTranslation();
   const { localisedDate } = useFormatDateTime();
+  const { store } = useAuthContext();
+  const prescriptionCreatedAtStore = store?.id === prescription?.store?.id;
 
   const getPrescriptionInfo = () => {
     const prescriptionLine = prescription?.lines.nodes[0];
@@ -61,7 +64,7 @@ export const PrescriptionInfo = ({ prescription }: PrescriptionInfoProps) => {
     >
       <Box display="flex" alignItems="center" justifyContent="space-between">
         {getPrescriptionInfo()}
-        {prescription.id && (
+        {prescription.id && prescriptionCreatedAtStore && (
           <Link
             style={{
               paddingLeft: 6,

--- a/client/packages/system/src/Vaccination/Components/VaccinationModal.tsx
+++ b/client/packages/system/src/Vaccination/Components/VaccinationModal.tsx
@@ -348,6 +348,9 @@ const VaccineInfoBox = ({
 }) => {
   const t = useTranslation();
   const { localisedDate } = useFormatDateTime();
+  const { store } = useAuthContext();
+  const prescriptionCreatedAtStore =
+    vaccination?.invoice?.store?.id === store?.id;
 
   return vaccination?.given ? (
     <Alert severity="success">
@@ -355,7 +358,7 @@ const VaccineInfoBox = ({
         {t('messages.vaccination-was-given', {
           date: localisedDate(vaccination.vaccinationDate ?? ''),
         })}
-        {vaccination.invoice && (
+        {vaccination.invoice && prescriptionCreatedAtStore && (
           <Link
             style={{
               marginLeft: 6,

--- a/client/packages/system/src/Vaccination/api/operations.generated.ts
+++ b/client/packages/system/src/Vaccination/api/operations.generated.ts
@@ -42,7 +42,11 @@ export type VaccinationDetailFragment = {
     itemName: string;
     batch?: string | null;
   } | null;
-  invoice?: { __typename: 'InvoiceNode'; id: string } | null;
+  invoice?: {
+    __typename: 'InvoiceNode';
+    id: string;
+    store?: { __typename: 'StoreNode'; id: string } | null;
+  } | null;
 };
 
 export type VaccinationCardItemFragment = {
@@ -156,7 +160,11 @@ export type VaccinationQuery = {
       itemName: string;
       batch?: string | null;
     } | null;
-    invoice?: { __typename: 'InvoiceNode'; id: string } | null;
+    invoice?: {
+      __typename: 'InvoiceNode';
+      id: string;
+      store?: { __typename: 'StoreNode'; id: string } | null;
+    } | null;
   } | null;
 };
 
@@ -258,6 +266,9 @@ export const VaccinationDetailFragmentDoc = gql`
     }
     invoice {
       id
+      store {
+        id
+      }
     }
     notGivenReason
     comment

--- a/client/packages/system/src/Vaccination/api/operations.graphql
+++ b/client/packages/system/src/Vaccination/api/operations.graphql
@@ -30,6 +30,9 @@ fragment VaccinationDetail on VaccinationNode {
   }
   invoice {
     id
+    store {
+      id
+    }
   }
   notGivenReason
   comment


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7232

# 👩🏻‍💻 What does this PR do?
Hide link to prescription if the prescription was created at a different store. Both in vaccination cards and the reproductive health encounter UI

![Screenshot 2025-04-10 at 12 35 13 PM](https://github.com/user-attachments/assets/265e07fe-5f68-41d7-b3a2-49d2d7c4de1c)

![Screenshot 2025-04-10 at 12 35 00 PM](https://github.com/user-attachments/assets/2487def2-8b86-4cbf-95b9-6d2c1eee263b)

## 💌 Any notes for the reviewer?
Feels like we should be disabling the facility input if the vax was given at another store... to eliminate someone accidentally changing it but 🤷🏻 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a vax encounter for Patient in Store A, and give Patient vax (this records prescription entry)
- [ ] Switch to Store B
- [ ] Go to the encounter from Store B, and click the `given` vaccination
- [ ] Shouldn't see `View prescription` link

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Document that the prescription link won't be available if it was created at another store
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

