### PR TITLE
Add translation changes for insurance

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -812,6 +812,7 @@
   "label.expiring-soon_other": "Batches expiring in a month",
   "label.expiry": "Expiry",
   "label.expiry-date": "Expiry date",
+  "label.insurance-expiry-date": "Expiry date",
   "label.facility": "Facility",
   "label.fc-cost-price": "FC Cost Price",
   "label.fc-line-total": "FC Line Total",

--- a/client/packages/common/src/intl/locales/fr/common.json
+++ b/client/packages/common/src/intl/locales/fr/common.json
@@ -791,6 +791,7 @@
   "label.expiring-soon_other": "Lots périmant dans les 30 jours",
   "label.expiry": "Péremption",
   "label.expiry-date": "Date de péremption",
+  "label.insurance-expiry-date": "Date de validité",
   "label.facility": "Facilité",
   "label.fc-cost-price": "Prix d'achat en DE",
   "label.fc-line-total": "Total ligne en DE",

--- a/client/packages/system/src/Patient/Insurance/InsuranceModal.tsx
+++ b/client/packages/system/src/Patient/Insurance/InsuranceModal.tsx
@@ -144,7 +144,7 @@ export const InsuranceModal: FC = (): ReactElement => {
         </Box>
         <Box display="flex" flexDirection="column" gap={2}>
           <InputWithLabelRow
-            label={t('label.expiry-date')}
+            label={t('label.insurance-expiry-date')}
             Input={
               <BaseDatePickerInput
                 required
@@ -167,7 +167,7 @@ export const InsuranceModal: FC = (): ReactElement => {
             }}
           />
           <InputWithLabelRow
-            label={t('label.discount-rate')}
+            label={t('label.coverage-rate')}
             Input={
               <NumericTextInput
                 required


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7225 partially

Fixes insurance related feedback changes

# 👩🏻‍💻 What does this PR do?

Adds insurance specific expiration date translation key
Changes discount rate to coverage rate key

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Open an instance of OMS with insurance features active
- [ ] Navigate to dispensary, patients, and select a patient.
- [ ] Navigate to insurance tab, and add insurance
- [ ] See that modal translations in french are as expected ("Date de validité" for expiration date, and "Taux de couverture" for coverage rate)

# 📃 Documentation

- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

