### PR TITLE
7286 fix finding prescription

### DIFF
--- a/client/packages/invoices/src/Prescriptions/ListView/NewPrescriptionModal.tsx
+++ b/client/packages/invoices/src/Prescriptions/ListView/NewPrescriptionModal.tsx
@@ -70,7 +70,7 @@ export const NewPrescriptionModal: FC<NewPrescriptionModalProps> = ({
   const handleSave = async () => {
     try {
       if (!patient) return;
-      const prescriptionNumber = await create({
+      const prescription = await create({
         id: FnUtils.generateUUID(),
         patientId: patient.id,
         theirReference,
@@ -79,7 +79,7 @@ export const NewPrescriptionModal: FC<NewPrescriptionModalProps> = ({
         prescriptionDate: Formatter.toIsoString(DateUtils.endOfDayOrNull(date)),
       });
       handleClose();
-      navigate(String(prescriptionNumber));
+      prescription?.id && navigate(prescription.id);
     } catch (e) {
       const errorSnack = error(
         t('error.failed-to-create-prescription') + (e as Error).message


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7286

# 👩🏻‍💻 What does this PR do?

Fixes navigation via id rather than number for prescription

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

I think this one snuck through the cracks of [this fix](https://github.com/msupply-foundation/open-msupply/pull/6899) because the create hook returned 'prescription' which wasn't picked up by the searching for numbers to substitute with ids.

I've just had another look with some different regex searches, and can't find any similar patterns which might cause this error elsewhere. 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to dispensary -> Prescriptions
- [ ] Create a new prescription
- [ ] See that navigation works to new prescription on creation

# 📃 Documentation

- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

