### PR TITLE
7228 cant access encounter if clinician not visible

### DIFF
--- a/server/graphql/types/src/types/program/encounter.rs
+++ b/server/graphql/types/src/types/program/encounter.rs
@@ -300,12 +300,13 @@ impl EncounterNode {
             .load_one(ClinicianLoaderInput::new(&self.store_id, clinician_id))
             .await?
             .map(ClinicianNode::from_domain)
-            .ok_or(Error::new(format!(
-                "Failed to load clinician: {}",
-                clinician_id
-            )))?;
+            .or_else(|| {
+                // Likely this encounter synced from another store, and we don't have visibility of that clinician here
+                println!("Clinician {} not found for store {}", clinician_id, self.store_id);
+                None
+            });
 
-        Ok(Some(result))
+        Ok(result)
     }
 
     /// Returns the matching program enrolment for the patient of this encounter

--- a/server/repository/src/migrations/v2_07_00/mod.rs
+++ b/server/repository/src/migrations/v2_07_00/mod.rs
@@ -8,6 +8,7 @@ mod add_preference_table;
 mod asset_data_matrix_locked_fields;
 mod asset_data_matrix_permission;
 mod new_stocktake_fields;
+mod remove_encounter_clinician_constraint;
 mod remove_name_store_join_constraint;
 
 pub(crate) struct V2_07_00;
@@ -31,6 +32,7 @@ impl Migration for V2_07_00 {
             Box::new(asset_data_matrix_locked_fields::Migrate),
             Box::new(add_patient_link_id_to_vaccination::Migrate),
             Box::new(remove_name_store_join_constraint::Migrate),
+            Box::new(remove_encounter_clinician_constraint::Migrate),
         ]
     }
 }

--- a/server/repository/src/migrations/v2_07_00/remove_encounter_clinician_constraint.rs
+++ b/server/repository/src/migrations/v2_07_00/remove_encounter_clinician_constraint.rs
@@ -1,0 +1,81 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "remove_encounter_clinician_link_constraint"
+    }
+
+    // Patient encounters can be synced to many sites, and one of those sites may not
+    // have visibility of the associated clinician. This means that the clinician link id
+    // may not exist on all sites. Therefore we need to remove the foreign key constraint
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        if cfg!(feature = "postgres") {
+            let result = sql!(
+                connection,
+                r#"
+                    ALTER TABLE encounter CONSTRAINT encounter_clinician_link_id_fkey;
+                "#
+            );
+            if result.is_err() {
+                log::warn!("Failed to drop FK constraint on clinician_link_id column of encounter table, please check name of constraint");
+            }
+        } else {
+            sql!(
+                connection,
+                r#"
+                PRAGMA foreign_keys = OFF;              
+                ALTER TABLE encounter RENAME TO encounter_old;
+
+                CREATE TABLE encounter (
+                    id TEXT NOT NULL PRIMARY KEY,
+                    document_name TEXT NOT NULL,
+                    created_datetime {DATETIME} NOT NULL,
+                    start_datetime {DATETIME} NOT NULL,
+                    end_datetime {DATETIME},
+                    status TEXT NULL,
+                    store_id TEXT,
+                    document_type TEXT NOT NULL,
+                    program_id TEXT,
+                    patient_link_id TEXT NOT NULL,
+                    clinician_link_id TEXT
+                );
+                
+                INSERT INTO encounter (
+                    id,
+                    document_name,
+                    created_datetime,
+                    start_datetime,
+                    end_datetime,
+                    status,
+                    store_id,
+                    document_type,
+                    program_id,
+                    patient_link_id,
+                    clinician_link_id
+                )
+                SELECT 
+                    id,
+                    document_name,
+                    created_datetime,
+                    start_datetime,
+                    end_datetime,
+                    status,
+                    store_id,
+                    document_type,
+                    program_id,
+                    patient_link_id,
+                    clinician_link_id
+                 FROM encounter_old;
+
+                DROP TABLE encounter_old;
+                PRAGMA foreign_keys = ON;
+                "#
+            )?;
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7228

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->


Store A (Site Y) created an encounter which has an associated clinician. 

Store B (Site Z) tries to pull the encounter, as it also has visibility of the patient.

Fixes 2 cases:

- No stores on Site Z have visibility of the linked clinician. The om_document failed sync translation, and no encounter was visible in store B
- A different store on Site Z has visibility of the linked clinician, but not Store B. The translation passes, you can see the encounter in the list view, but when you click it to go to the detail view, got not found error (as clinician not exist for store).

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

I tried to to add store_id to encounter create_filtered_query, and only left_join onto clinicians table where clinicians visible via clinician store join. But it was a diesel type error rabbit hole, felt I was already wasting too much time. 

So just swallowing the error at graphql layer, hopefully ok for now?

Also per issue... should I open a secondary issue to handle "display clinician name even if not actually a visible/active clinician for this store"?

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a patient enrolled in a program, visible on two stores on different sites
- [ ] For site 1/store 1, ensure there is a clinician (OG prescriber) that is not visible on any of the stores on the other site
- [ ] Create an encounter for the patient from store 1, with the clinician
- [ ] Sync to store 2
- [ ] You can see the encounter
- [ ] Now make the clinician visible on a different store on site 2 (not the store currently looking at the patient record)
- [ ] Sync again
- [ ] You can open the encounter detail view, no error

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

