### PR TITLE
refactor: use enum for valid vaccination actions

### DIFF
--- a/server/repository/src/db_diesel/vaccination_row.rs
+++ b/server/repository/src/db_diesel/vaccination_row.rs
@@ -74,6 +74,7 @@ pub struct VaccinationRow {
     pub invoice_id: Option<String>,
     pub stock_line_id: Option<String>,
     pub clinician_link_id: Option<String>,
+    /// Event date (e.g. date given, or date marked not given)
     pub vaccination_date: NaiveDate,
     pub given: bool,
     pub not_given_reason: Option<String>,

--- a/server/service/src/vaccination/update/generate.rs
+++ b/server/service/src/vaccination/update/generate.rs
@@ -1,4 +1,4 @@
-use repository::{InvoiceLine, StockLine, VaccinationRow};
+use repository::{InvoiceLine, StockLineRow, VaccinationRow};
 use util::uuid::uuid;
 
 use crate::{
@@ -12,16 +12,10 @@ use crate::{
     NullableUpdate,
 };
 
-use super::UpdateVaccination;
-
-pub struct GenerateInput {
-    pub patient_id: String,
-    pub existing_vaccination: VaccinationRow,
-    pub update_input: UpdateVaccination,
-    pub existing_stock_line: Option<StockLine>,
-    pub new_stock_line: Option<StockLine>,
-    pub existing_prescription_line: Option<InvoiceLine>,
-}
+use super::{
+    validate::{ChangeStockLine, ChangeToGiven, ChangeToNotGiven, ValidateResult},
+    UpdateVaccination,
+};
 
 #[derive(Debug)]
 pub struct CreateCustomerReturn {
@@ -36,93 +30,179 @@ pub struct GenerateResult {
 }
 
 pub fn generate(
-    GenerateInput {
-        patient_id,
-        existing_vaccination,
-        update_input,
-        existing_stock_line,
-        new_stock_line,
-        existing_prescription_line,
-    }: GenerateInput,
+    validate_result: ValidateResult,
+    update_input: UpdateVaccination,
 ) -> GenerateResult {
-    // Update from input, or keep existing
-    let clinician_id = match update_input.clinician_id {
-        Some(NullableUpdate { value }) => value,
-        None => existing_vaccination.clinician_link_id.clone(),
-    };
+    match validate_result {
+        ValidateResult::ChangeToGiven(change) => generate_given(change, update_input),
+        ValidateResult::ChangeToNotGiven(change) => generate_not_given(change, update_input),
+        ValidateResult::ChangeStockLine(change) => generate_change_stock_line(change, update_input),
+        ValidateResult::NoStatusChangeEdit(existing_vaccination) => {
+            generate_no_status_change(existing_vaccination, update_input)
+        }
+    }
+}
 
-    let new_stock_line_id = new_stock_line
+fn generate_given(
+    ChangeToGiven {
+        existing_vaccination,
+        patient_id,
+        new_stock_line,
+    }: ChangeToGiven,
+    update_input: UpdateVaccination,
+) -> GenerateResult {
+    let stock_line_id = new_stock_line
         .as_ref()
         .map(|sl| sl.stock_line_row.id.clone());
 
-    let stock_line_has_changed = match (&existing_stock_line, &new_stock_line) {
-        (Some(existing), Some(new)) => existing.stock_line_row.id != new.stock_line_row.id,
-        (Some(_), None) => true,
-        (None, Some(_)) => true,
-        (None, None) => false,
-    };
+    let update_transactions = update_input.update_transactions.clone().unwrap_or(false);
 
-    let update_transactions = update_input.update_transactions.unwrap_or(false);
+    let vaccination = get_vaccination_with_updated_base_fields(existing_vaccination, update_input);
 
-    let should_revert = new_stock_line.is_none() && existing_prescription_line.is_some();
-
-    // Reverse prescription if it existed, and the stock line is changing
-    let create_customer_return = if (stock_line_has_changed || should_revert) && update_transactions
-    {
-        existing_prescription_line.and_then(|invoice_line| {
-            let stock_line_row = match invoice_line.stock_line_option {
-                Some(stock_line) => stock_line,
-                None => return None,
-            };
-
-            let amount = get_dose_as_number_of_packs(&invoice_line.item_row, &stock_line_row);
-
-            let create_return = InsertCustomerReturn {
-                id: uuid(),
-                other_party_id: patient_id.clone(),
-                is_patient_return: true,
-                outbound_shipment_id: None,
-                customer_return_lines: vec![CustomerReturnLineInput {
-                    id: uuid(),
-                    stock_line_id: Some(stock_line_row.id),
-                    item_id: stock_line_row.item_link_id,
-                    item_variant_id: stock_line_row.item_variant_id,
-                    expiry_date: stock_line_row.expiry_date,
-                    batch: stock_line_row.batch,
-                    pack_size: stock_line_row.pack_size,
-                    number_of_packs: amount,
-                    reason_id: None,
-                    note: None,
-                }],
-            };
-            let finalise_return = UpdateCustomerReturn {
-                id: create_return.id.clone(),
-                status: Some(UpdateCustomerReturnStatus::Verified),
-                comment: Some("Reversed vaccination prescription".to_string()),
-                on_hold: None,
-                colour: None,
-                their_reference: None,
-                other_party_id: None,
-            };
-
-            Some(CreateCustomerReturn {
-                create_return,
-                finalise_return,
-            })
-        })
-    } else {
-        None
-    };
-
-    // Create new prescription if stock line is changing to a new Some value
-    let create_prescription = if stock_line_has_changed && update_transactions {
+    let create_prescription = if update_transactions {
         new_stock_line.map(|stock_line| {
-            generate_create_prescription(stock_line, patient_id, clinician_id.clone())
+            generate_create_prescription(
+                stock_line,
+                patient_id,
+                vaccination.clinician_link_id.clone(),
+            )
         })
     } else {
         None
     };
 
+    // apply given status, stock and invoice ids
+    let vaccination = VaccinationRow {
+        given: true,
+        stock_line_id,
+        invoice_id: create_prescription
+            .as_ref()
+            .map(|p| p.create_prescription.id.clone()),
+
+        ..vaccination
+    };
+
+    GenerateResult {
+        vaccination,
+        create_prescription,
+        create_customer_return: None,
+    }
+}
+
+fn generate_not_given(
+    ChangeToNotGiven {
+        existing_vaccination,
+        patient_id,
+        existing_prescription,
+    }: ChangeToNotGiven,
+    update_input: UpdateVaccination,
+) -> GenerateResult {
+    let not_given_reason = update_input
+        .not_given_reason
+        .clone()
+        .or(existing_vaccination.not_given_reason.clone());
+
+    let update_transactions = update_input.update_transactions.clone().unwrap_or(false);
+
+    let vaccination = get_vaccination_with_updated_base_fields(existing_vaccination, update_input);
+
+    let create_customer_return = if update_transactions {
+        existing_prescription
+            .map(|p| generate_customer_return(p.prescription_line, p.stock_line_row, patient_id))
+    } else {
+        None
+    };
+
+    // clear given status, stock and invoice ids, apply reason
+
+    let vaccination = VaccinationRow {
+        given: false,
+        not_given_reason,
+
+        stock_line_id: None,
+        invoice_id: None,
+
+        ..vaccination
+    };
+
+    GenerateResult {
+        vaccination,
+        create_customer_return,
+        create_prescription: None,
+    }
+}
+
+fn generate_change_stock_line(
+    ChangeStockLine {
+        existing_vaccination,
+        patient_id,
+        existing_prescription,
+        new_stock_line,
+    }: ChangeStockLine,
+    update_input: UpdateVaccination,
+) -> GenerateResult {
+    let stock_line_id = new_stock_line
+        .as_ref()
+        .map(|sl| sl.stock_line_row.id.clone());
+
+    let update_transactions = update_input.update_transactions.clone().unwrap_or(false);
+
+    let vaccination = get_vaccination_with_updated_base_fields(existing_vaccination, update_input);
+
+    let create_customer_return = if update_transactions {
+        existing_prescription.map(|p| {
+            generate_customer_return(p.prescription_line, p.stock_line_row, patient_id.clone())
+        })
+    } else {
+        None
+    };
+
+    let create_prescription = if update_transactions {
+        new_stock_line.map(|stock_line| {
+            generate_create_prescription(
+                stock_line,
+                patient_id,
+                vaccination.clinician_link_id.clone(),
+            )
+        })
+    } else {
+        None
+    };
+
+    // apply new stock and invoice ids
+    let vaccination = VaccinationRow {
+        stock_line_id,
+        invoice_id: create_prescription
+            .as_ref()
+            .map(|p| p.create_prescription.id.clone()),
+
+        ..vaccination
+    };
+
+    GenerateResult {
+        vaccination,
+        create_prescription,
+        create_customer_return,
+    }
+}
+
+fn generate_no_status_change(
+    existing_vaccination: VaccinationRow,
+    update_input: UpdateVaccination,
+) -> GenerateResult {
+    let vaccination = get_vaccination_with_updated_base_fields(existing_vaccination, update_input);
+
+    GenerateResult {
+        vaccination,
+        create_customer_return: None,
+        create_prescription: None,
+    }
+}
+
+fn get_vaccination_with_updated_base_fields(
+    existing_vaccination: VaccinationRow,
+    update_input: UpdateVaccination,
+) -> VaccinationRow {
     let VaccinationRow {
         id,
         store_id,
@@ -136,32 +216,39 @@ pub fn generate(
         vaccination_date,
         given,
         not_given_reason,
-        comment,
         invoice_id,
+        stock_line_id,
+
+        comment,
         facility_name_link_id,
         facility_free_text,
-
-        clinician_link_id: _,
-        stock_line_id: _,
+        clinician_link_id,
     } = existing_vaccination;
 
-    let vaccination = VaccinationRow {
+    VaccinationRow {
         // always copy from existing
         id,
         store_id,
         program_enrolment_id,
-        patient_link_id,
-        user_id,
-        created_datetime,
         encounter_id,
         vaccine_course_dose_id,
+        user_id,
+        patient_link_id,
+        created_datetime,
 
-        // Update, or default to existing
-        clinician_link_id: clinician_id,
-        vaccination_date: update_input.vaccination_date.unwrap_or(vaccination_date),
-        given: update_input.given.unwrap_or(given),
+        // Copy from existing, could be overwritten by further generate logic
+        given,
+        invoice_id,
+        stock_line_id,
+
+        // Update metadata/base fields
         comment: update_input.comment.or(comment),
-
+        vaccination_date: update_input.vaccination_date.unwrap_or(vaccination_date),
+        // TODO - these name link ids should be queried! Not assigned directly
+        clinician_link_id: match update_input.clinician_id {
+            Some(NullableUpdate { value }) => value,
+            None => clinician_link_id,
+        },
         facility_name_link_id: match update_input.facility_name_id {
             Some(NullableUpdate { value }) => value,
             None => facility_name_link_id,
@@ -171,29 +258,48 @@ pub fn generate(
             None => facility_free_text,
         },
 
-        // new_stock_line already defaults to existing, or will be None if changed to not given
-        stock_line_id: new_stock_line_id,
+        // Consider not_given_reason as base field (if updating the reason when not updating status)
+        not_given_reason: update_input.not_given_reason.or(not_given_reason),
+    }
+}
 
-        not_given_reason: match update_input.given {
-            // If we updated to given, clear the reason
-            Some(true) => None,
-            _ => update_input.not_given_reason.or(not_given_reason),
-        },
+fn generate_customer_return(
+    prescription_line: InvoiceLine,
+    stock_line_row: StockLineRow,
+    patient_id: String,
+) -> CreateCustomerReturn {
+    let amount = get_dose_as_number_of_packs(&prescription_line.item_row, &stock_line_row);
 
-        invoice_id: match create_prescription
-            .as_ref()
-            .map(|p| p.create_prescription.id.clone())
-        {
-            Some(id) => Some(id),
-            // If we create a return (reverse the prescription) and didn't create a new prescription, clear the invoice
-            None if create_customer_return.is_some() => None,
-            None => invoice_id,
-        },
+    let create_return = InsertCustomerReturn {
+        id: uuid(),
+        other_party_id: patient_id.clone(),
+        is_patient_return: true,
+        outbound_shipment_id: None,
+        customer_return_lines: vec![CustomerReturnLineInput {
+            id: uuid(),
+            stock_line_id: Some(stock_line_row.id),
+            item_id: stock_line_row.item_link_id,
+            item_variant_id: stock_line_row.item_variant_id,
+            expiry_date: stock_line_row.expiry_date,
+            batch: stock_line_row.batch,
+            pack_size: stock_line_row.pack_size,
+            number_of_packs: amount,
+            reason_id: None,
+            note: None,
+        }],
+    };
+    let finalise_return = UpdateCustomerReturn {
+        id: create_return.id.clone(),
+        status: Some(UpdateCustomerReturnStatus::Verified),
+        comment: Some("Reversed vaccination prescription".to_string()),
+        on_hold: None,
+        colour: None,
+        their_reference: None,
+        other_party_id: None,
     };
 
-    GenerateResult {
-        vaccination,
-        create_prescription,
-        create_customer_return,
+    CreateCustomerReturn {
+        create_return,
+        finalise_return,
     }
 }

--- a/server/service/src/vaccination/update/validate.rs
+++ b/server/service/src/vaccination/update/validate.rs
@@ -1,6 +1,6 @@
 use repository::{
     EqualFilter, InvoiceLine, InvoiceLineFilter, InvoiceLineRepository, RepositoryError, StockLine,
-    StorageConnection, VaccinationRow,
+    StockLineRow, StorageConnection, Vaccination, VaccinationRow,
 };
 
 use crate::{
@@ -10,17 +10,39 @@ use crate::{
         check_clinician_exists, check_encounter_exists, check_item_belongs_to_vaccine_course,
         check_vaccination_exists, get_related_vaccinations,
     },
-    NullableUpdate,
 };
 
 use super::{UpdateVaccination, UpdateVaccinationError};
 
-pub struct ValidateResult {
-    pub vaccination: VaccinationRow,
+pub enum ValidateResult {
+    ChangeToGiven(ChangeToGiven),
+    ChangeToNotGiven(ChangeToNotGiven),
+    ChangeStockLine(ChangeStockLine),
+    NoStatusChangeEdit(VaccinationRow),
+}
+
+pub struct ChangeToGiven {
+    pub existing_vaccination: VaccinationRow,
     pub patient_id: String,
-    pub existing_stock_line: Option<StockLine>,
     pub new_stock_line: Option<StockLine>,
-    pub existing_prescription_line: Option<InvoiceLine>,
+}
+
+pub struct ChangeToNotGiven {
+    pub existing_vaccination: VaccinationRow,
+    pub patient_id: String,
+    pub existing_prescription: Option<PrescriptionAndStockLine>,
+}
+
+pub struct PrescriptionAndStockLine {
+    pub prescription_line: InvoiceLine,
+    pub stock_line_row: StockLineRow,
+}
+
+pub struct ChangeStockLine {
+    pub existing_vaccination: VaccinationRow,
+    pub patient_id: String,
+    pub existing_prescription: Option<PrescriptionAndStockLine>,
+    pub new_stock_line: Option<StockLine>,
 }
 
 pub fn validate(
@@ -55,73 +77,142 @@ pub fn validate(
         };
     };
 
-    // Validate existing stock line
-    let existing_stock_line = match &vaccination.vaccination_row.stock_line_id {
-        Some(stock_line_id) => match check_stock_line_exists(connection, store_id, stock_line_id) {
-            Ok(stock_line) => {
-                check_doses_defined(&stock_line)?;
-                Some(stock_line)
-            }
-            // Assume that if stock line doesn't exist, this vaccination was synced from another store
-            Err(_) => None,
-        },
-        None => None,
-    };
+    let vaccination_row = vaccination.vaccination_row.clone();
+    let vaccine_course_id = vaccination
+        .vaccine_course_dose_row
+        .vaccine_course_id
+        .clone();
+    let stock_line_id = input.stock_line_id.clone().and_then(|u| u.value);
 
-    // Validate existing stock line
-    let not_given = !input
-        .given
-        .unwrap_or(vaccination.vaccination_row.given.clone());
+    let result = match (vaccination_row.given, input.given) {
+        // Changing not given -> given
+        (false, Some(true)) => {
+            validate_can_change_given_status(connection, &vaccination, true)?;
 
-    let new_stock_line = if not_given {
-        // If not given, stock line should not get set
-        None
-    } else {
-        match &input.stock_line_id {
-            // If no new stock line provided, existing stock line should be used
-            None => existing_stock_line.clone(),
-            // Setting to None
-            Some(NullableUpdate { value: None }) => None,
-            // Setting to new stock line, validate it
-            Some(NullableUpdate {
-                value: Some(stock_line_id),
-            }) => {
-                let stock_line = check_stock_line_exists(connection, store_id, stock_line_id)?;
-
-                if !check_item_belongs_to_vaccine_course(
-                    &stock_line.stock_line_row.item_link_id,
-                    &vaccination.vaccine_course_dose_row.vaccine_course_id,
+            ValidateResult::ChangeToGiven(ChangeToGiven {
+                existing_vaccination: vaccination_row,
+                patient_id: encounter.patient_link_id,
+                new_stock_line: validate_new_stock_line(
                     connection,
-                )? {
-                    return Err(UpdateVaccinationError::ItemDoesNotBelongToVaccineCourse);
-                };
+                    store_id,
+                    &vaccine_course_id,
+                    stock_line_id,
+                )?,
+            })
+        }
+        // Changing given -> not given
+        (true, Some(false)) => {
+            validate_can_change_given_status(connection, &vaccination, false)?;
 
-                check_doses_defined(&stock_line)?;
-
-                Some(stock_line)
+            ValidateResult::ChangeToNotGiven(ChangeToNotGiven {
+                existing_vaccination: vaccination_row.clone(),
+                patient_id: encounter.patient_link_id,
+                existing_prescription: validate_existing_prescription(
+                    connection,
+                    store_id,
+                    &vaccination_row.invoice_id,
+                )?,
+            })
+        }
+        (true, Some(true)) | (true, None) => {
+            // If still given, check if selected stock line has changed
+            if input.stock_line_id.is_some() && vaccination_row.stock_line_id != stock_line_id {
+                ValidateResult::ChangeStockLine(ChangeStockLine {
+                    existing_vaccination: vaccination_row.clone(),
+                    patient_id: encounter.patient_link_id,
+                    existing_prescription: validate_existing_prescription(
+                        connection,
+                        store_id,
+                        &vaccination_row.invoice_id,
+                    )?,
+                    new_stock_line: validate_new_stock_line(
+                        connection,
+                        store_id,
+                        &vaccine_course_id,
+                        stock_line_id,
+                    )?,
+                })
+            } else {
+                ValidateResult::NoStatusChangeEdit(vaccination_row)
             }
         }
+        _ => ValidateResult::NoStatusChangeEdit(vaccination_row),
     };
 
+    Ok(result)
+}
+
+fn validate_existing_prescription(
+    connection: &StorageConnection,
+    store_id: &str,
+    invoice_id: &Option<String>,
+) -> Result<Option<PrescriptionAndStockLine>, UpdateVaccinationError> {
     // Get prescription line
-    let existing_prescription_line = match &vaccination.vaccination_row.invoice_id {
+    let prescription_line = match invoice_id {
         Some(invoice_id) => {
             InvoiceLineRepository::new(connection)
                 // Vaccination prescription should only ever have 1 line
                 .query_one(InvoiceLineFilter::new().invoice_id(EqualFilter::equal_to(invoice_id)))?
+                .ok_or(RepositoryError::NotFound)?
+        }
+        None => return Ok(None),
+    };
 
-            // Don't error if not found, assume that if invoice line not found,
-            // this vaccination was synced from another store
+    let stock_line = match prescription_line.stock_line_option.clone().map(|s| s.id) {
+        Some(stock_line_id) => {
+            let stock_line = check_stock_line_exists(connection, store_id, &stock_line_id)?;
+            check_doses_defined(&stock_line)?;
+            stock_line
+        }
+        None => return Err(UpdateVaccinationError::StockLineDoesNotExist),
+    };
+
+    Ok(Some(PrescriptionAndStockLine {
+        prescription_line,
+        stock_line_row: stock_line.stock_line_row,
+    }))
+}
+
+fn validate_new_stock_line(
+    connection: &StorageConnection,
+    store_id: &str,
+    vaccine_course_id: &str,
+    stock_line_id: Option<String>,
+) -> Result<Option<StockLine>, UpdateVaccinationError> {
+    let stock_line = match stock_line_id {
+        Some(stock_line_id) => {
+            let stock_line = check_stock_line_exists(connection, store_id, &stock_line_id)?;
+
+            if !check_item_belongs_to_vaccine_course(
+                &stock_line.stock_line_row.item_link_id,
+                vaccine_course_id,
+                connection,
+            )? {
+                return Err(UpdateVaccinationError::ItemDoesNotBelongToVaccineCourse);
+            };
+
+            check_doses_defined(&stock_line)?;
+            Some(stock_line)
         }
         None => None,
     };
 
-    // Check we can give/un-give this dose, based on previous and next doses
+    Ok(stock_line)
+}
+
+// Check we can give/un-give this dose, based on previous and next doses
+pub fn validate_can_change_given_status(
+    connection: &StorageConnection,
+    current_vaccination: &Vaccination,
+    new_given_status: bool,
+) -> Result<(), UpdateVaccinationError> {
     let (previous_vaccination, next_vaccination) = get_related_vaccinations(
         connection,
-        &vaccination.vaccine_course_dose_row.vaccine_course_id,
-        &vaccination.vaccine_course_dose_row.id,
-        &vaccination.vaccination_row.program_enrolment_id,
+        &current_vaccination
+            .vaccine_course_dose_row
+            .vaccine_course_id,
+        &current_vaccination.vaccine_course_dose_row.id,
+        &current_vaccination.vaccination_row.program_enrolment_id,
     )
     .map_err(|err| match err {
         // If there was a previous dose, but a vaccination for it wasn't found
@@ -129,24 +220,36 @@ pub fn validate(
         _ => UpdateVaccinationError::DatabaseError(err),
     })?;
 
+    match new_given_status {
+        true => validate_change_to_given(previous_vaccination),
+        false => validate_change_to_not_given(next_vaccination),
+    }
+}
+
+fn validate_change_to_given(
+    previous_vaccination: Option<Vaccination>,
+) -> Result<(), UpdateVaccinationError> {
+    // Should only be able to change to given if all previous doses in the course are given
     if let Some(previous_vaccination) = previous_vaccination {
-        if !previous_vaccination.vaccination_row.given && input.given == Some(true) {
+        if !previous_vaccination.vaccination_row.given {
             return Err(UpdateVaccinationError::NotNextDose);
         }
     }
+
+    Ok(())
+}
+
+fn validate_change_to_not_given(
+    next_vaccination: Option<Vaccination>,
+) -> Result<(), UpdateVaccinationError> {
+    // Should only be able to change to not given if all next doses in the course are not given
     if let Some(next_vaccination) = next_vaccination {
-        if next_vaccination.vaccination_row.given && input.given == Some(false) {
+        if next_vaccination.vaccination_row.given {
             return Err(UpdateVaccinationError::NotMostRecentGivenDose);
         }
     }
 
-    Ok(ValidateResult {
-        vaccination: vaccination.vaccination_row,
-        patient_id: encounter.patient_link_id,
-        existing_stock_line,
-        new_stock_line,
-        existing_prescription_line,
-    })
+    Ok(())
 }
 
 fn check_doses_defined(stock_line: &StockLine) -> Result<(), UpdateVaccinationError> {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Part of #7285

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Refactor update vaccination logic, use enum to determine valid updates to a vaccination.

Reasoning:

- It was already very confusing to follow the validation and generation logic in the vaccination updates
- This issue will be adding more constraints, what you can do as the "giving" store vs other store
- Some checks (like stock_line_exists) should really only need to run if you were to giving store, and are wanting to ungive, but they were running every time
- This should improve maintainability going forward

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Automated tests still passing
- [ ] In UI - can give a vaccination
- [ ] A prescription is created for the vaccination
- [ ] Go back and change selected stock line for the vaccine item
- [ ] A customer return is created for the first stock line, and a new prescription for the new one
- [ ] Go back and mark as not given
- [ ] Customer return is created
- [ ] Can also make simple updates, like add comment

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

