### PR TITLE
6446 nav sync badge after period of error

### DIFF
--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -86,6 +86,7 @@ const DAY = 24 * HOUR;
 
 export const DateUtils = {
   differenceInMinutes,
+  differenceInDays,
   addMinutes,
   addDays,
   addHours,

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -2633,6 +2633,7 @@ export type FrontendPluginMetadataNode = {
 export type FullSyncStatusNode = {
   __typename: 'FullSyncStatusNode';
   error?: Maybe<SyncErrorNode>;
+  errorThreshold: Scalars['Int']['output'];
   integration?: Maybe<SyncStatusWithProgressNode>;
   isSyncing: Scalars['Boolean']['output'];
   lastSuccessfulSync?: Maybe<SyncStatusNode>;
@@ -2643,6 +2644,7 @@ export type FullSyncStatusNode = {
   push?: Maybe<SyncStatusWithProgressNode>;
   pushV6?: Maybe<SyncStatusWithProgressNode>;
   summary: SyncStatusNode;
+  warningThreshold: Scalars['Int']['output'];
 };
 
 export enum GenderType {
@@ -9755,7 +9757,7 @@ export type VaccinationNode = {
   invoiceId?: Maybe<Scalars['String']['output']>;
   notGivenReason?: Maybe<Scalars['String']['output']>;
   stockLine?: Maybe<StockLineNode>;
-  vaccinationDate?: Maybe<Scalars['NaiveDate']['output']>;
+  vaccinationDate: Scalars['NaiveDate']['output'];
 };
 
 export type VaccineCourseConnector = {

--- a/client/packages/host/src/utils.ts
+++ b/client/packages/host/src/utils.ts
@@ -1,7 +1,0 @@
-import { ReactNode } from 'react';
-
-export const getBadgeProps = (value?: number) => ({
-  badgeContent: (value ?? 0) as ReactNode,
-  max: 99,
-  color: 'primary' as 'primary' | 'default',
-});

--- a/client/packages/system/src/Sync/api/operations.generated.ts
+++ b/client/packages/system/src/Sync/api/operations.generated.ts
@@ -86,6 +86,8 @@ export type SyncStatusWithProgressFragment = {
 export type FullSyncStatusFragment = {
   __typename: 'FullSyncStatusNode';
   isSyncing: boolean;
+  errorThreshold: number;
+  warningThreshold: number;
   error?: {
     __typename: 'SyncErrorNode';
     variant: Types.SyncErrorVariant;
@@ -161,6 +163,8 @@ export type SyncInfoQuery = {
   syncStatus?: {
     __typename: 'FullSyncStatusNode';
     isSyncing: boolean;
+    errorThreshold: number;
+    warningThreshold: number;
     error?: {
       __typename: 'SyncErrorNode';
       variant: Types.SyncErrorVariant;
@@ -236,6 +240,8 @@ export type SyncStatusQuery = {
   syncStatus?: {
     __typename: 'FullSyncStatusNode';
     isSyncing: boolean;
+    errorThreshold: number;
+    warningThreshold: number;
     error?: {
       __typename: 'SyncErrorNode';
       variant: Types.SyncErrorVariant;
@@ -377,6 +383,8 @@ export const FullSyncStatusFragmentDoc = gql`
     lastSuccessfulSync {
       ...SyncStatus
     }
+    errorThreshold
+    warningThreshold
   }
   ${SyncErrorFragmentDoc}
   ${SyncStatusWithProgressFragmentDoc}

--- a/client/packages/system/src/Sync/api/operations.graphql
+++ b/client/packages/system/src/Sync/api/operations.graphql
@@ -89,6 +89,8 @@ fragment FullSyncStatus on FullSyncStatusNode {
   lastSuccessfulSync {
     ...SyncStatus
   }
+  errorThreshold
+  warningThreshold
 }
 
 query syncInfo {

--- a/client/packages/system/src/Vaccination/api/operations.generated.ts
+++ b/client/packages/system/src/Vaccination/api/operations.generated.ts
@@ -25,7 +25,7 @@ export type VaccinationDetailFragment = {
   id: string;
   facilityNameId?: string | null;
   facilityFreeText?: string | null;
-  vaccinationDate?: string | null;
+  vaccinationDate: string;
   given: boolean;
   notGivenReason?: string | null;
   comment?: string | null;
@@ -139,7 +139,7 @@ export type VaccinationQuery = {
     id: string;
     facilityNameId?: string | null;
     facilityFreeText?: string | null;
-    vaccinationDate?: string | null;
+    vaccinationDate: string;
     given: boolean;
     notGivenReason?: string | null;
     comment?: string | null;

--- a/server/graphql/general/src/queries/sync_status.rs
+++ b/server/graphql/general/src/queries/sync_status.rs
@@ -73,6 +73,8 @@ pub struct FullSyncStatusNode {
     push: Option<SyncStatusWithProgressNode>,
     push_v6: Option<SyncStatusWithProgressNode>,
     last_successful_sync: Option<SyncStatusNode>,
+    warning_threshold: i64,
+    error_threshold: i64,
 }
 
 pub fn latest_sync_status(
@@ -147,14 +149,13 @@ pub fn latest_sync_status(
             total: status.total,
             done: status.done,
         }),
-        last_successful_sync: match last_successful_sync_status {
-            None => None,
-            Some(last_successful_sync_status) => Some(SyncStatusNode {
+        last_successful_sync: last_successful_sync_status.map(|last_successful_sync_status| {
+            SyncStatusNode {
                 started: last_successful_sync_status.summary.started,
                 duration_in_seconds: last_successful_sync_status.summary.duration_in_seconds,
                 finished: last_successful_sync_status.summary.finished,
-            }),
-        },
+            }
+        }),
         pull_v6: pull_v6.map(|status| SyncStatusWithProgressNode {
             started: status.started,
             finished: status.finished,
@@ -167,6 +168,8 @@ pub fn latest_sync_status(
             total: status.total,
             done: status.done,
         }),
+        warning_threshold: 1, // constant for now, may be some sort of pref later
+        error_threshold: 3,
     };
 
     Ok(Some(result))

--- a/server/service/src/sync/sync_status/status.rs
+++ b/server/service/src/sync/sync_status/status.rs
@@ -207,7 +207,7 @@ impl SyncStatusTrait for SyncStatusService {}
 
 /// * If there are no sync logs then: PreInitialisation
 /// * If sync log sorted by done datetime has a value in done datetime: Initialised
-/// * If sync log sorted by done datetime has not valule in done datetime: Initialising
+/// * If sync log sorted by done datetime has not value in done datetime: Initialising
 fn get_initialisation_status(
     ctx: &ServiceContext,
 ) -> Result<InitialisationStatus, RepositoryError> {


### PR DESCRIPTION

Fixes #6446 

# 👩🏻‍💻 What does this PR do?

No longer show the badge if there are simply pending records

If connection has failed for over a day show a warning icon with warning colour (orange)

![image](https://github.com/user-attachments/assets/37397cc3-c687-47a7-90cf-0c6e94b883c3)

If connection has failed for over 3 days show a warning icon with error colour (red)

![image](https://github.com/user-attachments/assets/9ac24866-e8fb-422f-8a92-f624aaa06996)

If there is any error OTHER than an a connection error (i.e. unreachable due to bad internet) then immediately show a warning icon with error colour 


## 💌 Any notes for the reviewer?

I've left some scaffolding for the opportunity to implement prefs for the warning/error thresholds. Can be another issue when we have time for it? If we care enough for it? heh.

Frankly, the red and orange colours don't look much different on such a small icon. I think this feature could be simplified as one threshold.

I think due to buttons not having borders the badges being on top right of the button looks a bit disjointed. I'm not sure how best to address this other than having borders, different colour to background or moving the badge to be over the top right of the last character (though this would look odd when you press/hover the button and it shows the badge is in the middle of the button). Nothing to do with this PR though, so something for another time.

# 🧪 Testing

This PR is a bit annoying to test because it turns out we cache the last sync_log. So modifying the DB alone isn't enough to get the `lastSuccessfulSyncDate` to change in the frontend.

I ended up just modifying `or_latest_row` to `return self` at the start and modifying the DB to test this worked fine:
https://github.com/msupply-foundation/open-msupply/blob/5e34e099c87935fa2acd622df085dca1cfdab41a/server/repository/src/db_diesel/sync_log_row.rs#L184-L202

You could also just remove this map but I only just thought of that now:

https://github.com/msupply-foundation/open-msupply/blob/5e34e099c87935fa2acd622df085dca1cfdab41a/server/repository/src/db_diesel/sync_log_row.rs#L171.

Then you can modify `finished_datetime` with -2 or -4 days to reach each of the thresholds:

![image](https://github.com/user-attachments/assets/1d14433f-9622-478b-b190-533c41f65f44)

- [ ] OMS sync (I was just testing this with OMS central server sync. would be wise to do a proper remote site too)
- [ ] Modify some records in OMS
- [ ] No badge with any number. YAY.
- [ ] Now either have hacked OMS backend to not cache and modify records to test each threshold or...
- [ ] Turn off OG server
- [ ] Wait 24hrs for first warning in orange colour 😆 
- [ ] Wait 72hrs for second warning (error) in red colour 😭 
- [ ] turn on OG server
- [ ] Sync (clearing the warning/error badge from above)
- [ ] Change the site password on OG central
- [ ] Sync OMS - error immediately in sync modal and error sync badge displayed on nav button immediately.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. The nav bar showing badge with number count of pending records anywhere.
  2. Perhaps some explanation about when the badge will show! 

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

