### PR TITLE
7186 Add confirmation on leaving modal when navigating with unsaved changes - View stock

### DIFF
--- a/client/packages/system/src/Stock/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Stock/DetailView/DetailView.tsx
@@ -14,6 +14,7 @@ import {
   useCallbackWithPermission,
   UserPermission,
   usePluginEvents,
+  useConfirmOnLeaving,
 } from '@openmsupply-client/common';
 import { ActivityLogList } from '@openmsupply-client/system';
 import { AppBarButtons } from './AppBarButtons';
@@ -76,6 +77,14 @@ export const StockLineDetailView: React.FC = () => {
     message: t('messages.confirm-cancel-generic'),
     title: t('heading.are-you-sure'),
   });
+
+  const { setIsDirty } = useConfirmOnLeaving('view-stock');
+
+  useEffect(() => {
+    // Getting isDirty from 'draftStockLine' rather than from 'useConfirmOnLeaving' hook
+    // so need to update it manually to sync external isDirty state with hook's isDirty state
+    setIsDirty(isDirty);
+  }, [isDirty]);
 
   const openInventoryAdjustmentModal = useCallbackWithPermission(
     UserPermission.InventoryAdjustmentMutate,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7186 

# 👩🏻‍💻 What does this PR do?
Display confirmation modal if user navigates away from or refreshes page with unsaved changes

<!-- Explain the changes you made -->
Added a `useEffect` that syncs stockLine `isDirty` state with `useConfirmationOnLeaving` hook's internal `isDirty` state

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

https://github.com/user-attachments/assets/6db79f22-01b5-4aba-8a21-301a383c5b73


## 💌 Any notes for the reviewer?
I did some reading and tried to see if I could do this without using the `useEffect`. Unfortunately, I wasn't able to figure that out. Please let me know if I've missed something! 

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Inventory -> view stock
- [ ] Click on an item
- [ ] Make a change
- [ ] Navigate away from page or refresh without saving
- [ ] See that alert modal for unsaved changes appears (modal for refresh looks different and has been raised)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

