### PR TITLE
7339 Timeout on get_site_status v6 api call

### DIFF
--- a/server/service/src/sync/api_v6/core.rs
+++ b/server/service/src/sync/api_v6/core.rs
@@ -1,4 +1,3 @@
-use reqwest::Client;
 use thiserror::Error;
 use url::ParseError;
 use util::{with_retries, RetrySeconds};
@@ -128,7 +127,10 @@ impl SyncApiV6 {
             sync_v6_version: *sync_v6_version,
         };
 
-        let result = Client::new().post(url.clone()).json(&request).send().await;
+        let result = with_retries(RetrySeconds::default(), |client| {
+            client.post(url.clone()).json(&request)
+        })
+        .await;
 
         let error = match response_or_err(result).await {
             Ok(SiteStatusResponseV6::Data(data)) => return Ok(data),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7339

# 👩🏻‍💻 What does this PR do?

Adds the same timeout introduced in https://github.com/msupply-foundation/open-msupply/pull/7201 but to get_site_status api call

## 💌 Any notes for the reviewer?


# 🧪 Testing

As per issue


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

