### PR TITLE
Split button drop down now clickable across entire component

### DIFF
--- a/client/packages/common/src/ui/components/buttons/standard/SplitButton.tsx
+++ b/client/packages/common/src/ui/components/buttons/standard/SplitButton.tsx
@@ -149,14 +149,12 @@ export const SplitButton = <T,>({
             key={option.label}
             disabled={option?.isDisabled}
             selected={option.value === selectedOption.value}
+            onClick={() => {
+              onSelectOption(option);
+              setAnchorEl(null);
+            }}
           >
-            <FlatButton
-              label={option.label}
-              onClick={e => {
-                onSelectOption(option, e);
-                setAnchorEl(null);
-              }}
-            />
+            <FlatButton label={option.label} onClick={() => {}} />
           </MenuItem>
         ))}
       </Menu>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7278

# 👩🏻‍💻 What does this PR do?

Makes full menu item in new split button functionality clickable.
Previously only text was clickable.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to a AppBarButton split button where there are multiple options of different text length
(A good example of this is in inboundShipments -> open a shipment -> and see the 'add item' split button drop down
- [ ] Try clicking on the menu item - but to the right of the text.
- [ ] Should still action click

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

