### PR TITLE
7164 add name id into insurance policies query keys

### DIFF
--- a/client/packages/system/src/Patient/apiModern/hooks/useInsurancesPolicies.ts
+++ b/client/packages/system/src/Patient/apiModern/hooks/useInsurancesPolicies.ts
@@ -28,8 +28,8 @@ const defaultDraftInsurance: DraftInsurance = {
   nameId: '',
 };
 
-export const useInsurancePolicies = (id: string) => {
-  const { data, isLoading, error } = useGet(id);
+export const useInsurancePolicies = (nameId: string) => {
+  const { data, isLoading, error } = useGet(nameId);
 
   const {
     mutateAsync: createMutation,
@@ -51,8 +51,8 @@ export const useInsurancePolicies = (id: string) => {
   const selectedInsurance = data?.nodes.find(({ id }) => id === insuranceId);
 
   const draft = data
-    ? { ...defaultDraftInsurance, ...selectedInsurance, ...patch, nameId: id }
-    : { ...defaultDraftInsurance, ...patch, nameId: id };
+    ? { ...defaultDraftInsurance, ...selectedInsurance, ...patch, nameId }
+    : { ...defaultDraftInsurance, ...patch, nameId };
 
   const create = async () => {
     const result = await createMutation(draft);
@@ -79,13 +79,13 @@ export const useInsurancePolicies = (id: string) => {
   };
 };
 
-const useGet = (id: string) => {
+const useGet = (nameId: string) => {
   const { patientApi, storeId } = usePatientGraphQL();
 
   const queryFn = async () => {
     const result = await patientApi.insurancePolicies({
       storeId,
-      nameId: id,
+      nameId,
     });
 
     if (result.insurancePolicies.__typename === 'InsuranceConnector') {
@@ -93,7 +93,7 @@ const useGet = (id: string) => {
     }
   };
 
-  const query = useQuery({ queryKey: [INSURANCE_POLICIES], queryFn });
+  const query = useQuery({ queryKey: [INSURANCE_POLICIES, nameId], queryFn });
 
   return query;
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7164 

# 👩🏻‍💻 What does this PR do?

Add `nameId` to insurance policies query keys, ensuring caching happens, and refetches when `nameId` changes

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have some patients with active insurance policies set up
- [ ] Create a prescription for a patient who doesn't have insurance (needs to have items that cost $$ in order to require a payment)
- [ ] Attempt to "Verify" the prescription, which should bring up the payment modal. Note "No options" in Insurance Policy drop-down
- [ ] Close the modal without saving
- [ ] Change the patient (in the Toolbar) to a patient that does have insurance
- [ ] "Verify" again to bring up modal
- [ ] Insurance policies related to the patient now renders in the list!

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

