### PR TITLE
#7327 Prescription loading fix

### DIFF
--- a/client/packages/invoices/src/Prescriptions/api/hooks/usePrescription.ts
+++ b/client/packages/invoices/src/Prescriptions/api/hooks/usePrescription.ts
@@ -135,7 +135,7 @@ const useGetById = (invoiceId: string | undefined) => {
     if (invoice?.__typename === 'InvoiceNode') {
       return invoice;
     } else {
-      console.log('No invoice found', invoiceId);
+      console.error('No invoice found', invoiceId);
       throw new Error(`Could not find invoice ${invoiceId}`);
     }
   };

--- a/client/packages/invoices/src/Prescriptions/api/hooks/usePrescription.ts
+++ b/client/packages/invoices/src/Prescriptions/api/hooks/usePrescription.ts
@@ -135,7 +135,8 @@ const useGetById = (invoiceId: string | undefined) => {
     if (invoice?.__typename === 'InvoiceNode') {
       return invoice;
     } else {
-      throw new Error('Could not find invoice');
+      console.log('No invoice found', invoiceId);
+      throw new Error(`Could not find invoice ${invoiceId}`);
     }
   };
 

--- a/client/packages/programs/src/JsonForms/components/Prescription/Prescription.tsx
+++ b/client/packages/programs/src/JsonForms/components/Prescription/Prescription.tsx
@@ -58,7 +58,10 @@ const UIComponent = (props: ControlProps) => {
   const prescriptionIdPath = options?.prescriptionIdPath;
   const prescriptionId = extractProperty(core?.data, prescriptionIdPath ?? '');
   const {
-    query: { data: prescription, loading },
+    query: {
+      data: prescription,
+      // loading
+    },
     create: { create },
   } = usePrescription(prescriptionId);
 

--- a/client/packages/programs/src/JsonForms/components/Prescription/Prescription.tsx
+++ b/client/packages/programs/src/JsonForms/components/Prescription/Prescription.tsx
@@ -5,7 +5,7 @@ import {
   Box,
   DetailInputWithLabelRow,
   FnUtils,
-  InlineSpinner,
+  // InlineSpinner,
   InvoiceNodeStatus,
   TextWithLabelRow,
   extractProperty,
@@ -49,7 +49,7 @@ type Options = z.infer<typeof Options>;
 
 const UIComponent = (props: ControlProps) => {
   const t = useTranslation();
-  const { handleChange, label, path, uischema, config } = props;
+  const { handleChange, path, uischema, config } = props;
   const { options } = useZodOptionsValidation(Options, uischema.options);
 
   const { formActions } = config;
@@ -153,7 +153,9 @@ const UIComponent = (props: ControlProps) => {
             patch: { id: prescriptionId, status: InvoiceNodeStatus.Picked },
           });
           success(
-            t('messages.prescription-created', { count: prescription.invoiceNumber })
+            t('messages.prescription-created', {
+              count: prescription.invoiceNumber,
+            })
           )();
         }
       },
@@ -165,15 +167,20 @@ const UIComponent = (props: ControlProps) => {
     return null;
   }
 
-  if (loading)
-    return (
-      <DetailInputWithLabelRow
-        sx={DefaultFormRowSx}
-        label={label}
-        inputAlignment={'start'}
-        Input={<InlineSpinner />}
-      />
-    );
+  // NOTE: This is temporarily disabled due to a bug in React Query in which the
+  // "loading" state is not correctly updated after an error, but only in
+  // production build. This *should* be fixed after upgrading React Query, so
+  // please re-instate this loader once that is in place.
+
+  // if (loading)
+  //   return (
+  //     <DetailInputWithLabelRow
+  //       sx={DefaultFormRowSx}
+  //       label={label}
+  //       inputAlignment={'start'}
+  //       Input={<InlineSpinner />}
+  //     />
+  //   );
 
   if (!prescription)
     return (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7327 (sort of)

# 👩🏻‍💻 What does this PR do?

I'm just putting in a temporary workaround to remove the immediate problem (for impending demo). Will need to get to the bottom of the React Query issues at some point

## 💌 Any notes for the reviewer?

The bug **only appears in production builds**. I've narrowed this down to inconsistent behaviour in React Query -- the `loading` and `error` values are not being updated correctly after the invoice is not found (`loading` stays `true`, so the spinner never goes away).

So for now I've just hidden the "Loading" indicator completely. I tried a couple of other things, namely returning a custom loading property from the hook, but it caused other problems, so leaving that out for now.

I'll post a link to this PR in the Update Tanstack issue.

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

Must be tested on Production build:
- run `yarn build` from the client folder
- run the server `cargo run`, and then the built front-end will be served at `localhost:8000` (or whatever port you're using)

Need to be set up with Family Planning module

- [ ] Go to an encounter, or create a new one
- [ ] Click on "Méthode contraceptive"
- [ ] Select something in "Méthode Retenue:" which should enable the "Prescription" line
- [ ] Select an item from the list
- [ ] You should see Prescription form
- [ ] Issue some items, close the modal, then "Save" the enounter
- [ ] Prescription should be created (A toast notification, plus check in Prescriptions)

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

