### PR TITLE
Delete records with null vaccination dates and their changelogs

### DIFF
--- a/server/repository/src/migrations/v2_06_02/mod.rs
+++ b/server/repository/src/migrations/v2_06_02/mod.rs
@@ -26,11 +26,11 @@ impl Migration for V2_06_02 {
 #[cfg(test)]
 #[actix_rt::test]
 async fn migration_2_06_02() {
-    use crate::migrations::v2_06_00::V2_06_00;
+    use crate::migrations::v2_06_01::V2_06_01;
     use crate::migrations::*;
     use crate::test_db::*;
 
-    let previous_version = V2_06_00.version();
+    let previous_version = V2_06_01.version();
     let version = V2_06_02.version();
 
     let SetupResult { connection, .. } = setup_test(SetupOption {

--- a/server/repository/src/migrations/v2_07_00/change_vaccination_date_to_not_nullable.rs
+++ b/server/repository/src/migrations/v2_07_00/change_vaccination_date_to_not_nullable.rs
@@ -12,6 +12,13 @@ impl MigrationFragment for Migrate {
             sql!(
                 connection,
                 r#"
+                    -- prepare to make the vaccination_date column not null by deleting 
+                    -- all records with null vaccination_dates and their changelogs.
+                    DELETE FROM changelog WHERE record_id IS (
+                        SELECT id FROM vaccination WHERE vaccination_date IS NULL
+                    );
+                    DELETE FROM vaccination WHERE vaccination_date IS NULL;
+                    -- make the vaccination_date column not null
                     ALTER TABLE vaccination ALTER COLUMN vaccination_date SET NOT NULL;
                 "#,
             )?;
@@ -19,6 +26,13 @@ impl MigrationFragment for Migrate {
             sql!(
                 connection,
                 r#"
+                -- prepare to make the vaccination_date column not null by deleting 
+                -- all records with null vaccination_dates and their changelogs.
+                DELETE FROM changelog WHERE record_id IS (
+                    SELECT id FROM vaccination WHERE vaccination_date IS NULL
+                );
+                DELETE FROM vaccination WHERE vaccination_date IS NULL;
+                -- make the vaccination_date column not null
                 PRAGMA foreign_keys = OFF;
                 ALTER TABLE vaccination RENAME TO vaccination_old;
                 CREATE TABLE vaccination (

--- a/server/repository/src/migrations/v2_07_00/change_vaccination_date_to_not_nullable.rs
+++ b/server/repository/src/migrations/v2_07_00/change_vaccination_date_to_not_nullable.rs
@@ -12,13 +12,12 @@ impl MigrationFragment for Migrate {
             sql!(
                 connection,
                 r#"
-                    -- prepare to make the vaccination_date column not null by deleting 
-                    -- all records with null vaccination_dates and their changelogs.
-                    DELETE FROM changelog WHERE record_id IS (
-                        SELECT id FROM vaccination WHERE vaccination_date IS NULL
+                    DELETE FROM changelog AS c WHERE c.record_id IN (
+                            SELECT v.id FROM vaccination AS v WHERE v.vaccination_date IS NULL
                     );
+
                     DELETE FROM vaccination WHERE vaccination_date IS NULL;
-                    -- make the vaccination_date column not null
+
                     ALTER TABLE vaccination ALTER COLUMN vaccination_date SET NOT NULL;
                 "#,
             )?;
@@ -26,74 +25,78 @@ impl MigrationFragment for Migrate {
             sql!(
                 connection,
                 r#"
-                -- prepare to make the vaccination_date column not null by deleting 
-                -- all records with null vaccination_dates and their changelogs.
-                DELETE FROM changelog WHERE record_id IS (
-                    SELECT id FROM vaccination WHERE vaccination_date IS NULL
-                );
-                DELETE FROM vaccination WHERE vaccination_date IS NULL;
-                -- make the vaccination_date column not null
-                PRAGMA foreign_keys = OFF;
-                ALTER TABLE vaccination RENAME TO vaccination_old;
-                CREATE TABLE vaccination (
-                    id TEXT NOT NULL PRIMARY KEY,
-                    store_id TEXT NOT NULL,
-                    program_enrolment_id TEXT NOT NULL,
-                    patient_link_id TEXT NOT NULL DEFAULT '',
-                    encounter_id TEXT NOT NULL,
-                    user_id TEXT NOT NULL,
-                    vaccine_course_dose_id TEXT NOT NULL REFERENCES vaccine_course_dose(id),
-                    created_datetime {DATETIME} NOT NULL,
-                    facility_name_link_id TEXT,
-                    facility_free_text TEXT,
-                    invoice_id TEXT,
-                    stock_line_id TEXT,
-                    clinician_link_id TEXT,
-                    vaccination_date {DATE} NOT NULL,
-                    given BOOLEAN NOT NULL,
-                    not_given_reason TEXT,
-                    comment TEXT
-                );
-                INSERT INTO vaccination (
-                    id,
-                    store_id,
-                    program_enrolment_id,
-                    patient_link_id,
-                    encounter_id,
-                    user_id,
-                    vaccine_course_dose_id,
-                    created_datetime,
-                    facility_name_link_id,
-                    facility_free_text,
-                    invoice_id,
-                    stock_line_id,
-                    clinician_link_id,
-                    vaccination_date,
-                    given,
-                    not_given_reason,
-                    comment
-                )
-                SELECT
-                    id,
-                    store_id,
-                    program_enrolment_id,
-                    patient_link_id,
-                    encounter_id,
-                    user_id,
-                    vaccine_course_dose_id,
-                    created_datetime,
-                    facility_name_link_id,
-                    facility_free_text,
-                    invoice_id,
-                    stock_line_id,
-                    clinician_link_id,
-                    vaccination_date,
-                    given,
-                    not_given_reason,
-                    comment
-                FROM vaccination_old;
-                DROP TABLE vaccination_old;
-                PRAGMA foreign_keys = ON;
+                    DELETE FROM changelog AS c WHERE c.record_id IN (
+                            SELECT v.id FROM vaccination AS v WHERE v.vaccination_date IS NULL
+                    );
+
+                    DELETE FROM vaccination WHERE vaccination_date IS NULL;
+
+                    PRAGMA foreign_keys = OFF;
+
+                    ALTER TABLE vaccination RENAME TO vaccination_old;
+                    
+                    CREATE TABLE vaccination (
+                        id TEXT NOT NULL PRIMARY KEY,
+                        store_id TEXT NOT NULL,
+                        program_enrolment_id TEXT NOT NULL,
+                        patient_link_id TEXT NOT NULL DEFAULT '',
+                        encounter_id TEXT NOT NULL,
+                        user_id TEXT NOT NULL,
+                        vaccine_course_dose_id TEXT NOT NULL REFERENCES vaccine_course_dose(id),
+                        created_datetime {DATETIME} NOT NULL,
+                        facility_name_link_id TEXT,
+                        facility_free_text TEXT,
+                        invoice_id TEXT,
+                        stock_line_id TEXT,
+                        clinician_link_id TEXT,
+                        vaccination_date {DATE} NOT NULL,
+                        given BOOLEAN NOT NULL,
+                        not_given_reason TEXT,
+                        comment TEXT
+                    );
+
+                    INSERT INTO vaccination (
+                        id,
+                        store_id,
+                        program_enrolment_id,
+                        patient_link_id,
+                        encounter_id,
+                        user_id,
+                        vaccine_course_dose_id,
+                        created_datetime,
+                        facility_name_link_id,
+                        facility_free_text,
+                        invoice_id,
+                        stock_line_id,
+                        clinician_link_id,
+                        vaccination_date,
+                        given,
+                        not_given_reason,
+                        comment
+                    )
+                    SELECT
+                        id,
+                        store_id,
+                        program_enrolment_id,
+                        patient_link_id,
+                        encounter_id,
+                        user_id,
+                        vaccine_course_dose_id,
+                        created_datetime,
+                        facility_name_link_id,
+                        facility_free_text,
+                        invoice_id,
+                        stock_line_id,
+                        clinician_link_id,
+                        vaccination_date,
+                        given,
+                        not_given_reason,
+                        comment
+                    FROM vaccination_old;
+
+                    DROP TABLE vaccination_old;
+
+                    PRAGMA foreign_keys = ON;
                 "#,
             )?;
         };

--- a/server/repository/src/migrations/v2_07_00/mod.rs
+++ b/server/repository/src/migrations/v2_07_00/mod.rs
@@ -41,24 +41,122 @@ impl Migration for V2_07_00 {
 }
 
 #[cfg(test)]
-#[actix_rt::test]
-async fn migration_2_07_00() {
-    use v2_06_00::V2_06_00;
+mod test {
+    use crate::{migrations::sql, StorageConnection};
 
-    use crate::migrations::*;
-    use crate::test_db::*;
+    #[actix_rt::test]
+    async fn migration_2_07_00() {
+        use v2_06_02::V2_06_02;
+        use v2_07_00::V2_07_00;
 
-    let previous_version = V2_06_00.version();
-    let version = V2_07_00.version();
+        use crate::migrations::*;
+        use crate::test_db::*;
 
-    let SetupResult { connection, .. } = setup_test(SetupOption {
-        db_name: &format!("migration_{version}"),
-        version: Some(previous_version.clone()),
-        ..Default::default()
-    })
-    .await;
+        let previous_version = V2_06_02.version();
+        let version = V2_07_00.version();
 
-    // Run this migration
-    migrate(&connection, Some(version.clone())).unwrap();
-    assert_eq!(get_database_version(&connection), version);
+        let SetupResult { connection, .. } = setup_test(SetupOption {
+            db_name: &format!("migration_{version}"),
+            version: Some(previous_version.clone()),
+            ..Default::default()
+        })
+        .await;
+
+        insert_2_6_2_vaccinations(&connection, "some_store_id").unwrap();
+
+        // Run this migration
+        migrate(&connection, Some(version.clone())).unwrap();
+
+        assert_eq!(get_database_version(&connection), version);
+    }
+
+    // Insert given (with vaccination date) and not given (without vaccination date) vaccinations
+    // Ensure migration to add not-null constraint on vaccination_date works
+    fn insert_2_6_2_vaccinations(
+        connection: &StorageConnection,
+        store_id: &str,
+    ) -> anyhow::Result<()> {
+        let context_id = "context_1".to_string();
+        let program_id = "program_id".to_string();
+        let course_id = "course_id".to_string();
+        let dose_id = "dose_id".to_string();
+
+        sql!(
+            connection,
+            r#"
+            INSERT INTO context (
+                id,
+                name
+            ) VALUES (
+                '{context_id}',
+                'context 1'
+            );
+
+            INSERT INTO program (
+                id,
+                name,
+                context_id,
+                is_immunisation
+            ) VALUES (
+                '{program_id}',
+                'program 1',
+                '{context_id}',
+                TRUE
+            );
+
+            INSERT INTO vaccine_course (
+                id,
+                name,
+                program_id
+            ) VALUES (
+                '{course_id}',
+                'course 1',
+                '{program_id}'
+            );
+
+            INSERT INTO vaccine_course_dose (
+                id,
+                vaccine_course_id,
+                label
+            ) VALUES (
+                '{dose_id}',
+                '{course_id}',
+                'dose 1'
+            );
+
+            INSERT INTO vaccination (
+                id,
+                store_id,
+                program_enrolment_id,
+                encounter_id,
+                user_id,
+                vaccine_course_dose_id,
+                created_datetime,
+                vaccination_date,
+                given
+            ) VALUES (
+                '2.6.2-given',
+                '{store_id}',
+                'program_enrolment_1',
+                'encounter_1',
+                'user_1',
+                '{dose_id}',
+                '2025-01-01 00:00:00',
+                '2025-01-01',
+                TRUE
+            ), (
+                '2.6.2-not-given',
+                '{store_id}',
+                'program_enrolment_1',
+                'encounter_1',
+                'user_1',
+                '{dose_id}',
+                '2025-01-01 00:00:00',
+                NULL,
+                FALSE
+    );
+        "#,
+        )?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
Fixes #7299 

# 👩🏻‍💻 What does this PR do?

In 2.6.1, vaccination date was allowed to be nullable (for not given records). This has been removed in 2.7, we always record the date for reporting. If you created vaccination records after 2.6.1, will null date, the change_vaccination_date_to_not_nullable migration will fail:

`UNKNOWN ("NOT NULL constraint failed: vaccination.vaccination_date      0"`

This PR Fixes a migration so it no longer breaks OMS when you update from v2.6.1 to v2.7.0.
The migration now deletes records in the vaccination table with null vaccination dates and their changelogs, so the vaccination date can then be made not null

This needs to be recorded in the release notes obviously, as data could be lost.

Specifically:
- Vaccinations with no date (which can only have been created in version 2.6.1) will be lost when upgrading to version 2.7.0.
- For sites running 2.6.1, any sync records from vaccines without vaccine dates (i.e. those that have status 'not given' in version 2.6.1) will not be processed by the central server.

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

- [ ] Install 2.6.1
- [ ] Create some vaccinations in not given status
- [ ] Upgrade to latest 2.7 RC 2
- [ ] Check that the migration should succeeds

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: release notes (see [above](# what-does-this-pr-do)).


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

