### PR TITLE
7412 add max discount percentage graphql node in ItemNode

### DIFF
--- a/server/graphql/core/src/loader/loader_registry.rs
+++ b/server/graphql/core/src/loader/loader_registry.rs
@@ -403,6 +403,12 @@ pub async fn get_loaders(
         async_std::task::spawn,
     ));
     loaders.insert(DataLoader::new(
+        DiscountMasterListByItemIdLoader {
+            service_provider: service_provider.clone(),
+        },
+        async_std::task::spawn,
+    ));
+    loaders.insert(DataLoader::new(
         ReasonOptionLoader {
             connection_manager: connection_manager.clone(),
         },

--- a/server/graphql/types/src/types/item.rs
+++ b/server/graphql/types/src/types/item.rs
@@ -5,10 +5,10 @@ use async_graphql::dataloader::DataLoader;
 use async_graphql::*;
 use graphql_core::{
     loader::{
-        ItemDirectionsByItemIdLoader, ItemStatsLoaderInput, ItemVariantsByItemIdLoader,
-        ItemsStatsForItemLoader, ItemsStockOnHandLoader, ItemsStockOnHandLoaderInput,
-        MasterListByItemIdLoader, MasterListByItemIdLoaderInput, StockLineByItemAndStoreIdLoader,
-        StockLineByItemAndStoreIdLoaderInput,
+        DiscountMasterListByItemIdLoader, ItemDirectionsByItemIdLoader, ItemStatsLoaderInput,
+        ItemVariantsByItemIdLoader, ItemsStatsForItemLoader, ItemsStockOnHandLoader,
+        ItemsStockOnHandLoaderInput, MasterListByItemIdLoader, MasterListByItemIdLoaderInput,
+        StockLineByItemAndStoreIdLoader, StockLineByItemAndStoreIdLoaderInput,
     },
     simple_generic_errors::InternalError,
     standard_graphql_error::StandardGraphqlError,
@@ -211,6 +211,18 @@ impl ItemNode {
                 .map(MasterListNode::from_domain)
                 .collect()
         }))
+    }
+
+    pub async fn max_discount_percentage(&self, ctx: &Context<'_>) -> Result<f64> {
+        let loader = ctx.get_loader::<DataLoader<DiscountMasterListByItemIdLoader>>();
+        let max_discount_percentage = loader.load_one(self.row().id.clone()).await?.ok_or(
+            StandardGraphqlError::InternalError(format!(
+                "Cannot find max discount percentage for item {}",
+                &self.row().id
+            ))
+            .extend(),
+        )?;
+        Ok(max_discount_percentage)
     }
 }
 

--- a/server/graphql/types/src/types/master_list.rs
+++ b/server/graphql/types/src/types/master_list.rs
@@ -39,6 +39,7 @@ impl MasterListFilterInput {
             item_id: self.item_id.map(EqualFilter::from),
             is_discount_list: None,
             is_default_price_list: None,
+            include_inactive: None,
         }
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7412 

# 👩🏻‍💻 What does this PR do?
Added `maxDiscountPercentage` graphql node in the `ItemNode` which returns max. value of discount percentage from all linked master lists to the given item. Would be used in https://github.com/msupply-foundation/open-msupply-reports/pull/204
<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->
- [ ] Make sure you have a master list setup in the mSupply and linked to any customer in the oms site.
- [ ] Set a discount % in the master list from the mSupply as shown in this image:
![Screenshot 2025-03-25 at 12 57 54 PM](https://github.com/user-attachments/assets/fdab61be-1b39-4ac3-b667-adacedd9469b)
- [ ] Sync to the oms site and create an outbound shipment > add items from master list
- [ ] Confirm deliver that outbound shipment.
- [ ] In the graphql editor.
- [ ] Run the below `invoiceLines` graphql query:
```graphql
query invoice_lines(
  $storeId: String!
  $invoiceId: String!
) {
  invoiceLines(
    storeId: $storeId
    filter: { invoiceId: { equalTo: $invoiceId } }
  ) {
    ... on InvoiceLineConnector {
      nodes {
        item {
          maxDiscountPercentage
        }
      }
    }
}
```
- [ ] Now goto the mSupply and goto that oms store
- [ ] Double click it and in the `Master lists` tab check that master list which has discount percentage linked to your item
- [ ] Again the above graphql query and now you should still see the max discount percentage for each invoice line

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

