### PR TITLE
Add can add when no internal orders exist

### DIFF
--- a/client/packages/invoices/src/InboundShipment/ListView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/AppBarButtons.tsx
@@ -76,10 +76,18 @@ export const AppBarButtons = ({
     );
   };
 
-  const handleRowClick = async (row: NameRowFragment): Promise<void> => {
+  const handleSupplierSelected = async (
+    row: NameRowFragment
+  ): Promise<void> => {
     invoiceModalController.toggleOff();
+    if (!manuallyLinkInternalOrder) {
+      createInvoice(row.id);
+      return;
+    }
+
     const data = await fetchInternalOrders(row.id);
-    if (data?.internalOrders.totalCount === 0 || !manuallyLinkInternalOrder) {
+
+    if (data?.internalOrders.totalCount === 0) {
       createInvoice(row.id);
     } else {
       setName(row);
@@ -121,9 +129,7 @@ export const AppBarButtons = ({
       <SupplierSearchModal
         open={invoiceModalController.isOn}
         onClose={invoiceModalController.toggleOff}
-        onChange={async nameRow => {
-          handleRowClick(nameRow);
-        }}
+        onChange={handleSupplierSelected}
       />
     </AppBarButtonsPortal>
   );

--- a/client/packages/invoices/src/InboundShipment/ListView/LinkInternalOrderModal.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/LinkInternalOrderModal.tsx
@@ -11,7 +11,7 @@ import {
   DialogButton,
   Typography,
 } from '@openmsupply-client/common';
-import { NameRowFragment } from 'packages/system/src';
+import { NameRowFragment } from '@openmsupply-client/system';
 
 interface LinkInternalOrderModalProps {
   isOpen: boolean;

--- a/client/packages/invoices/src/InboundShipment/ListView/LinkInternalOrderModal.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/LinkInternalOrderModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LinkedRequestRowFragment } from '../api';
+import { LinkedRequestRowFragment, useInbound } from '../api';
 import {
   useColumns,
   getNotePopoverColumn,
@@ -11,27 +11,29 @@ import {
   DialogButton,
   Typography,
 } from '@openmsupply-client/common';
+import { NameRowFragment } from 'packages/system/src';
 
 interface LinkInternalOrderModalProps {
   isOpen: boolean;
   onClose: () => void;
-  requestRequisitions?: LinkedRequestRowFragment[];
   onRowClick: (row: LinkedRequestRowFragment) => void;
-  isLoading: boolean;
   onNextClick: () => void;
+  name: NameRowFragment | null;
 }
 
 export const LinkInternalOrderModal = ({
   isOpen,
   onClose,
-  requestRequisitions: data,
   onRowClick,
-  isLoading,
   onNextClick: createInvoice,
+  name,
 }: LinkInternalOrderModalProps) => {
   const t = useTranslation();
   const { width, height } = useWindowDimensions();
   const { Modal } = useDialog({ isOpen, onClose });
+  const { data, isLoading } = useInbound.document.listInternalOrders(
+    name?.id ?? ''
+  );
 
   const columns = useColumns<LinkedRequestRowFragment>([
     {
@@ -83,7 +85,7 @@ export const LinkInternalOrderModal = ({
         <DataTable
           id="link-internal-order-to-inbound"
           columns={columns}
-          data={data ?? []}
+          data={data?.nodes ?? []}
           dense
           onRowClick={onRowClick}
           isLoading={isLoading}

--- a/client/packages/invoices/src/InboundShipment/api/hooks/document/index.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/document/index.ts
@@ -8,7 +8,7 @@ import { useNextItem } from './useNextItem';
 import { useUpdateInbound } from './useUpdateInbound';
 import { useUpdateInboundServiceTax } from './useInboundUpdateServiceTax';
 import { useInboundDelete } from './useInboundDelete';
-import { useListInternalOrders } from './useListInternalOrders';
+import { useListInternalOrders, useListInternalOrdersPromise } from './useListInternalOrders';
 import { useListInternalOrderLines } from './useListInternalOrderLines';
 
 export const Document = {
@@ -23,5 +23,6 @@ export const Document = {
   useUpdateInbound,
   useUpdateInboundServiceTax,
   useListInternalOrders,
+  useListInternalOrdersPromise,
   useListInternalOrderLines,
 };

--- a/client/packages/invoices/src/InboundShipment/api/hooks/document/useListInternalOrders.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/document/useListInternalOrders.ts
@@ -1,9 +1,20 @@
-import { useQuery } from '@openmsupply-client/common';
+import { useMutation, useQuery } from '@openmsupply-client/common';
 import { useInboundApi } from '../utils/useInboundApi';
 
 const MILLISECONDS_PER_MINUTE = 60 * 1000;
 const POLLING_INTERVAL_MS = 3 * MILLISECONDS_PER_MINUTE;
 const STALE_TIME_MS = 1 * MILLISECONDS_PER_MINUTE;
+
+export const useListInternalOrdersPromise = () => {
+  const api = useInboundApi();
+
+  return useMutation(async (otherPartyId: string) => {
+    const internalOrders = await api.get.listInternalOrders(otherPartyId);
+    return {
+      internalOrders,
+    };
+  });
+};
 
 export const useListInternalOrders = (otherPartyId: string) => {
   const api = useInboundApi();

--- a/client/packages/invoices/src/InboundShipment/api/hooks/index.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/index.ts
@@ -18,6 +18,7 @@ export const useInbound = {
     next: Document.useNextItem,
 
     listInternalOrders: Document.useListInternalOrders,
+    listInternalOrdersPromise: Document.useListInternalOrdersPromise,
     listInternalOrderLines: Document.useListInternalOrderLines,
   },
   lines: {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7434

# 👩🏻‍💻 What does this PR do?

Fixes cannot create inbound shipment when there are no internal orders to link AND store preference is to manually link inboundshipment to other party's internal order

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Set up a store with preference 'manuallyLinkInternalOrderToInboundShipment' active
- [ ] Open inbound shipments in store A 
- [ ] Manually create a shipment from a store B where that store B has no internal order to the receiving store A (might require manually deleting internal orders from store B)

# 📃 Documentation

- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

