### PR TITLE
add Open_mSupply prefix to APK zip files

### DIFF
--- a/.github/workflows/build-android-apk.yaml
+++ b/.github/workflows/build-android-apk.yaml
@@ -1,8 +1,8 @@
 on:
- push:
-  tags: 
-   - 'v*'
- workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
 
 name: Android Build
 
@@ -11,67 +11,66 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Read .nvmrc
-      run: echo "##[set-output name=NVMRC;]$(cat ./client/.nvmrc)"
-      id: nvm
+      - name: Read .nvmrc
+        run: echo "##[set-output name=NVMRC;]$(cat ./client/.nvmrc)"
+        id: nvm
 
-    - name: Use Node.js (.nvmrc)
-      uses: actions/setup-node@v1
-      with:
-        node-version: "${{ steps.nvm.outputs.NVMRC }}"
+      - name: Use Node.js (.nvmrc)
+        uses: actions/setup-node@v1
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
 
-    - name: Install deps
-      uses: borales/actions-yarn@v4
-      with:
-        cmd: install
-        dir: 'client'
-      env:
-       NODE_AUTH_TOKEN: ${{secrets.TOKEN_REPO}}
+      - name: Install deps
+        uses: borales/actions-yarn@v4
+        with:
+          cmd: install
+          dir: "client"
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.TOKEN_REPO}}
 
-    - name: Get Properties
-      id: properties
-      run: |
-        cp "$HOME/android/local.properties" ./client/packages/android
-        cp "$HOME/android/release.keystore" ./client/packages/android/app
+      - name: Get Properties
+        id: properties
+        run: |
+          cp "$HOME/android/local.properties" ./client/packages/android
+          cp "$HOME/android/release.keystore" ./client/packages/android/app
 
-    - name: Set Up Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        targets:
-         aarch64-linux-android
-         armv7-linux-androideabi
-      # Targets need to match in the config.toml of the self-hosted machine
+      - name: Set Up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          targets: aarch64-linux-android
+            armv7-linux-androideabi
+        # Targets need to match in the config.toml of the self-hosted machine
 
-    - name: Set Up Java
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '17'
+      - name: Set Up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
 
-    - name: Build Android App
-      uses: borales/actions-yarn@v4
-      with:
-        cmd: android:build:release
-        dir: 'client'
-      env: 
-       NDK_BIN: /Users/tmfmacmini/android/ndk/27.2.12479018/toolchains/llvm/prebuilt/darwin-x86_64/bin/
-      # Update this version when upgrading the NDK version on the self-hosted machine
-        
-    - name: Upload Universal APK
-      uses: actions/upload-artifact@v4
-      with:
-        name: Universal_Build
-        path: ./client/packages/android/app/build/outputs/apk/universal/release/*.apk
-        retention-days: 3
+      - name: Build Android App
+        uses: borales/actions-yarn@v4
+        with:
+          cmd: android:build:release
+          dir: "client"
+        env:
+          NDK_BIN: /Users/tmfmacmini/android/ndk/27.2.12479018/toolchains/llvm/prebuilt/darwin-x86_64/bin/
+        # Update this version when upgrading the NDK version on the self-hosted machine
 
-    - name: Upload Arm64 APK
-      uses: actions/upload-artifact@v4
-      with:
-        name: Arm64_Build
-        path: ./client/packages/android/app/build/outputs/apk/arm64/release/*.apk
-        retention-days: 3
+      - name: Upload Universal APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: Open_mSupply_Universal_Build
+          path: ./client/packages/android/app/build/outputs/apk/universal/release/*.apk
+          retention-days: 3
+
+      - name: Upload Arm64 APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: Open_mSupply_Arm64_Build
+          path: ./client/packages/android/app/build/outputs/apk/arm64/release/*.apk
+          retention-days: 3


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Soz, lil side quest

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

When downloading our installers, they're all co-located because of Open_mSupply prefix, but these zip files were harder to find in downloads folder, just called "Universal_Build"

Adds prefix so all installers are together

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

Apologies, formatter had a field day - its actually just the names that changed

I think would be good to also put the version in the name? So if you download multiple, you can see which version they are for rather than `Open_mSupply_Universal_Build(2)`

Would require getting version in action outputs though - #7450 

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] See Artifacts from this action: https://github.com/msupply-foundation/open-msupply/actions/runs/14605776894
- [ ] Output has the updated names for the zipped artifacts
- [ ] Download - if your downloads are sorted alphabetically, the zip files will be chilling with the other installers

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

