### PR TITLE
7455 Infinite loading in requisition when clicking on Next item

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -423,7 +423,7 @@ export const ResponseLineEdit = ({
                     width={INPUT_WIDTH}
                     value={Math.max(
                       (draft?.supplyQuantity ?? 0) -
-                      (draft?.alreadyIssued ?? 0),
+                        (draft?.alreadyIssued ?? 0),
                       0
                     )}
                     disabled
@@ -545,7 +545,7 @@ export const ResponseLineEdit = ({
           next={next}
           hasPrevious={hasPrevious}
           previous={previous}
-          requisitionId={draft?.id}
+          requisitionId={draft?.requisitionId}
           scrollIntoView={scrollIntoView}
         />
       </Box>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7455

# 👩🏻‍💻 What does this PR do?
Id being passed into the footer was the line id not the requisition id

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a requisition with a few lines
- [ ] Click on a line -> go to the line edit page
- [ ] Click `next`
- [ ] Should navigate to next item

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

