### PR TITLE
7410 Extend total timeout in sync api

### DIFF
--- a/server/util/src/api_helper.rs
+++ b/server/util/src/api_helper.rs
@@ -20,7 +20,9 @@ where
     loop {
         let client = Client::builder()
             .connect_timeout(Duration::from_secs(connection_timeouts.0[index]))
-            .timeout(Duration::from_secs(300)) // generous because some sync records may have big payloads like reports that take a long time to sync on low bandwidth
+            // generous because some sync records may have big payloads like reports that take a long time to sync on low bandwidth
+            // we also had issues with batch size = 500 taking more then 5 minutes to generate during testing, maybe due to 4d flushing
+            .timeout(Duration::from_secs(60 * 30))
             .build()
             .unwrap(); // This method fails if a TLS backend cannot be initialized, or the resolver cannot load the system configuration.
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7410 

# 👩🏻‍💻 What does this PR do?

Extend sync api timeout to 30 minutes

## 💌 Any notes for the reviewer?

See issue for more details

# 🧪 Testing

Can potentially replicate consistently on setup that @alainsussol had, or you can put a breakpoint in a sync method in 4d. Basically we allow up to 5 minutes (before this PR) for a round trip of a request, now it's extended to 30 minutes. 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [x] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [x] Postgres
- [x] SQLite
- [x] Frontend

