### PR TITLE
7421 breadcrumbs show uuids

### DIFF
--- a/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
@@ -79,7 +79,7 @@ export const PrescriptionLineEditView = () => {
       1: data?.invoiceNumber.toString() ?? '',
       2: currentItem?.name || '',
     });
-  }, [currentItem]);
+  }, [currentItem, data?.invoiceNumber]);
 
   useConfirmOnLeaving(
     'prescription-line-edit',

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEdit.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEdit.tsx
@@ -79,8 +79,18 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditProps> = ({
     if (showZeroQuantityConfirmation && numPacks !== 0)
       setShowZeroQuantityConfirmation(false);
 
-    // Don't allow save if both prescribed quantity and allocated packs are zero
-    if (prescribedQuantity === 0 && numPacks === 0) setIsDirty(false);
+    // TODO: refactor prescription view
+    // Validation should be managed against overall `draft`, and not using `isDirty`
+    if (
+      newAllocateQuantities?.some(
+        line =>
+          // Don't allow save if both prescribed quantity and allocated packs are zero
+          line.numberOfPacks === 0 &&
+          (!line.prescribedQuantity || line.prescribedQuantity === 0)
+      )
+    ) {
+      setIsDirty(false);
+    }
 
     return newAllocateQuantities;
   };

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEdit.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEdit.tsx
@@ -85,9 +85,9 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditProps> = ({
     // TODO: refactor prescription view
     // Validation should be managed against overall `draft`, and not using `isDirty`
     if (
-      newAllocateQuantities?.some(
+      // Don't allow save if both prescribed quantity and allocated packs are zero for all lines
+      newAllocateQuantities?.every(
         line =>
-          // Don't allow save if both prescribed quantity and allocated packs are zero
           line.numberOfPacks === 0 &&
           (!line.prescribedQuantity || line.prescribedQuantity === 0)
       )

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEdit.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEdit.tsx
@@ -40,7 +40,7 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditProps> = ({
     query: { data },
     isDisabled,
   } = usePrescription();
-  const { status = InvoiceNodeStatus.New, prescriptionDate } = data ?? {};
+  const { prescriptionDate } = data ?? {};
   const { isLoading, updateQuantity, updateNotes } = useDraftPrescriptionLines(
     currentItem,
     draftPrescriptionLines,
@@ -69,7 +69,10 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditProps> = ({
     prescribedQuantity: number | null
   ) => {
     const newAllocateQuantities = allocateQuantities(
-      status,
+      // Hack - we're using shared allocateQuantities function, which supports placeholder lines in
+      // New status. Placeholder lines aren't supported for prescriptions though, so we'll just pretend
+      // we're already in pick :)
+      InvoiceNodeStatus.Picked,
       draftPrescriptionLines
     )(numPacks, packSize, true, prescribedQuantity);
 

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
@@ -185,7 +185,12 @@ export const PrescriptionLineEditForm: React.FC<
     // this method is also called onBlur... check that there actually has been a
     // change in quantity (to prevent triggering auto allocation if only focus
     // has moved)
-    if (inputUnitQuantity === issueUnitQuantity) return;
+    if (
+      quantityType === 'issue'
+        ? inputUnitQuantity === issueUnitQuantity
+        : inputUnitQuantity === prescribedQuantity
+    )
+      return;
 
     const quantity = inputUnitQuantity === undefined ? 0 : inputUnitQuantity;
     setIssueUnitQuantity(quantity);
@@ -204,9 +209,8 @@ export const PrescriptionLineEditForm: React.FC<
   };
 
   const handlePrescribedQuantityChange = (inputPrescribedQuantity?: number) => {
-    if (inputPrescribedQuantity == null) return;
-    setPrescribedQuantity(inputPrescribedQuantity);
-    handleIssueQuantityChange(inputPrescribedQuantity, 'prescribed');
+    setPrescribedQuantity(inputPrescribedQuantity ?? 0);
+    handleIssueQuantityChange(inputPrescribedQuantity ?? 0, 'prescribed');
   };
 
   const prescriptionLineWithNote = draftPrescriptionLines.find(l => !!l.note);

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
@@ -95,6 +95,7 @@ export const PrescriptionLineEditForm: React.FC<
   const { format } = useFormatNumber();
   const { rows: items } = usePrescription();
   const { store: { preferences } = {} } = useAuthContext();
+  preferences.editPrescribedQuantityOnPrescription = true;
 
   const [issueUnitQuantity, setIssueUnitQuantity] = useState(0);
   const [prescribedQuantity, setPrescribedQuantity] = useState<number | null>(

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
@@ -95,7 +95,6 @@ export const PrescriptionLineEditForm: React.FC<
   const { format } = useFormatNumber();
   const { rows: items } = usePrescription();
   const { store: { preferences } = {} } = useAuthContext();
-  preferences.editPrescribedQuantityOnPrescription = true;
 
   const [issueUnitQuantity, setIssueUnitQuantity] = useState(0);
   const [prescribedQuantity, setPrescribedQuantity] = useState<number | null>(

--- a/client/packages/invoices/src/Prescriptions/LineEditView/hooks/useDraftPrescriptionLines.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/hooks/useDraftPrescriptionLines.tsx
@@ -63,9 +63,7 @@ export const useDraftPrescriptionLines = (
       item?.id ?? ''
     );
 
-    // In cases where there are no valid stock lines to allocate we should
-    // use a placeholder - for prescribed quantities
-    if (noStockLines || !item || allStockLinesExpired) {
+    if (noStockLines || !item) {
       return updateDraftLines([placeholderLine]);
     }
 
@@ -90,6 +88,12 @@ export const useDraftPrescriptionLines = (
       })
       .filter(stockLine => !stockLine.location?.onHold)
       .sort(SortUtils.byExpiryAsc);
+
+    // In cases where there are no valid stock lines to allocate we should
+    // append a placeholder line in case of user setting prescribed quantity
+    if (allStockLinesExpired) {
+      rows.push(placeholderLine);
+    }
 
     updateDraftLines(rows);
   }, [data, item, prescriptionData]);

--- a/client/packages/invoices/src/Prescriptions/LineEditView/hooks/useDraftPrescriptionLines.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/hooks/useDraftPrescriptionLines.tsx
@@ -53,10 +53,6 @@ export const useDraftPrescriptionLines = (
     ).filter(stockLine => !stockLine.onHold); // Filter out on hold stock lines
 
     const noStockLines = stockLines.length == 0;
-    const allStockLinesExpired = stockLines.every(
-      stockLine =>
-        stockLine.expiryDate && DateUtils.isExpired(stockLine.expiryDate)
-    );
 
     const placeholderLine = createPrescriptionPlaceholderRow(
       invoiceId ?? '',
@@ -88,6 +84,11 @@ export const useDraftPrescriptionLines = (
       })
       .filter(stockLine => !stockLine.location?.onHold)
       .sort(SortUtils.byExpiryAsc);
+
+    const allStockLinesExpired = stockLines.every(
+      stockLine =>
+        stockLine.expiryDate && DateUtils.isExpired(stockLine.expiryDate)
+    );
 
     // In cases where there are no valid stock lines to allocate we should
     // append a placeholder line in case of user setting prescribed quantity


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7421

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Fixes the onAllocate check, was enabling the save button based on _attempted_ allocated number of packs, instead of actual allocated packs. Shouldn't be able to save if num packs is 0 (unless prescribed quan is set)

Also fixes - couldn't backspace the prescribed quan field

And fixes setBreadcrumb, wasn't setting the prescription number if you refreshed/opened on the new item page.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

This area realllly needs refactoring, we should just be saving the item we are currently looking at, with a draft state we can easily run validation against before save/disable the save button until valid.

But currently prescription draft contains a draft line for every item/stock line touched (you can switch items, it doesn't remove the previous draft lines) - so it's "valid" to have invalid lines in the draft state! They get ignored in backend, but we should only enable save in valid states 😭 This makes it hard to determine valid states to enable/disable the save button - so we just enable via `isDirty` (semantically incorrectly - the form is dirty! Just not valid...)

Not a 2.7 change tho :/

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Add item to prescription with no stock available
- [ ] Try to allocate stock, but none available, so input resets to 0
- [ ] Save button stays disabled
- [ ] Enable editPrescribedQuantityOnPrescription store pref
- [ ] You _can_ save a 0 issue quantity, if you have prescribed quantity > 0
- [ ] If you edit prescribed quantity back to 0, the save button disables
- [ ] After save, you are redirected to item, breadcrumb shows invoice number and item name correctly
- [ ] Click new item, then refresh
- [ ] Invoice number shows in breadcrumb

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

