### PR TITLE
7480 prescription breadcrumb shows uuid on new item

### DIFF
--- a/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
@@ -79,7 +79,7 @@ export const PrescriptionLineEditView = () => {
       1: data?.invoiceNumber.toString() ?? '',
       2: currentItem?.name || '',
     });
-  }, [currentItem, data?.invoiceNumber]);
+  }, [currentItem, data?.invoiceNumber, itemId]);
 
   useConfirmOnLeaving(
     'prescription-line-edit',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7480

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Triggers the breadcrumb useEffect when the URL item id changes, so it runs when we switch to `new` item.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

Roxy commented in the issue, about one of the items remaining even after setting issue quantity to 0. This appears to only happen when the item has more than one stock line available 🫠 

Seems like pretty unlikely use case, and I think any fix would be yet another hack. Recommending we leave this one for now and consider the case when we clean up prescriptions properly?

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Add an item to a prescription, an item with stock available
- [ ] Issue some amount, save
- [ ] For that item in the prescription, expand the batches dropdown and clear the issued stock to 0
- [ ] Save
- [ ] The item should be deleted, you are redirected to new item view
- [ ] Clicking the `new item` in the left hand list does not change the breadcrumbs (still see prescription serial number)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

