### PR TITLE
7501 cant edit vaccine given at other store

### DIFF
--- a/client/packages/system/src/Vaccination/Components/useConfirmNoStockLineSelected.ts
+++ b/client/packages/system/src/Vaccination/Components/useConfirmNoStockLineSelected.ts
@@ -1,7 +1,9 @@
-import { useConfirmationModal } from '@common/components';
-import { useTranslation } from '@common/intl';
+import {
+  useAuthContext,
+  useConfirmationModal,
+  useTranslation,
+} from '@openmsupply-client/common';
 import { VaccinationDraft } from '../api';
-import { OTHER_FACILITY } from './FacilitySearchInput';
 
 export const useConfirmNoStockLineSelected = (
   draft: VaccinationDraft,
@@ -9,6 +11,7 @@ export const useConfirmNoStockLineSelected = (
   onConfirm: () => Promise<void>
 ) => {
   const t = useTranslation('dispensary');
+  const { store } = useAuthContext();
   const showConfirmation = useConfirmationModal({
     onConfirm,
     message: t('messages.no-batch-selected'),
@@ -16,7 +19,11 @@ export const useConfirmNoStockLineSelected = (
   });
 
   return () => {
-    const shouldShowConfirmation = getShouldShowConfirmation(draft, hasItems);
+    const shouldShowConfirmation = getShouldShowConfirmation(
+      draft,
+      hasItems,
+      store?.nameId ?? ''
+    );
 
     if (shouldShowConfirmation) {
       showConfirmation();
@@ -28,14 +35,16 @@ export const useConfirmNoStockLineSelected = (
 
 const getShouldShowConfirmation = (
   draft: VaccinationDraft,
-  hasItems: boolean
+  hasItems: boolean,
+  facilityId: string
 ) => {
   const noSelectedBatch =
     // If the vaccine course has vaccine items configured
     // vaccinations given at this facility should have an associated stock line
     hasItems &&
     draft.given &&
-    draft.facilityId !== OTHER_FACILITY &&
+    // Should only warn if vaccination given at the current store
+    draft.facilityId === facilityId &&
     !draft.stockLine;
 
   const isHistorical = draft.date?.toDateString() !== new Date().toDateString();

--- a/server/service/src/programs/patient/README.md
+++ b/server/service/src/programs/patient/README.md
@@ -54,6 +54,8 @@ Risks: the `link_patient_to_store` is a one time mutation, and can't be done in 
 
 - Both central servers are on same server, if can connect to one, should be able to connect to both, and shouldn't be a connectivity risk between the two central servers. This can't be guaranteed in all cases though.
 
+OMS Central stores would need to be running in dispensary mode, in order to receive the synced patient records.
+
 ## New patient created in OMS remote site
 
 Creating a new patient on OMS remote site will create new name and name_store_join records. We sync this to both Legacy mSupply Central and OMS Central. All future records will have constraints met.

--- a/server/service/src/programs/patient/README.md
+++ b/server/service/src/programs/patient/README.md
@@ -33,6 +33,8 @@ Existing OMS remote sites may have patients, which may have related vaccination 
 - However, now patient `name` could exist on OMS central, without its related records. It also wouldn't get updated via sync (as Legacy mSupply doesn't know to sync patient data to OMS Central). Would be a problem if a central store is used as a dispensary.
   - So, we add a central only processor - sees name record has been upserted, and looks up whether that patient is visible on the Central site. If not - call Legacy mSupply to add name_store_join between OMS Central and the patient. This ensures patient data is all synced correctly to OMS Central going forward.
 
+> Note: ideally, patients wouldn't be visible for a store on OMS Central, unless specifically set up to be. OMS Central should have a mechanism where data can exist there, be synced there, without it being visible in any of its own stores. This should either be as a central "ghost store" (would also resolve any risk of a store being moved off of OMS Central), or resolved via the v7 sync (where all data is synced through OMS Central).
+
 ## Fetching Legacy mSupply patients
 
 This applies where:


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7501

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Strips the update vaccination payload if you are editing a given vaccination from other stores. Save now works (API call is not trying to change more than it is permitted to).

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

I think this raises a bit of a design question - @andreievg would be keen to jam on this at some point...

We've designed our backend update mutations to support partial patches, but our frontend tends to send entire payloads. In this case this caused an error - frontend expected backend to only use the relevant fields, backend expected frontend only to send the permitted fields.

Nullable update also adds complexity if we actually always send the full payload. Useful for some kinds of records, e.g. when editing subset of values from the toolbar, and useful if we expect API to have other consumers than our frontend. Otherwise, would help to align front and back end....


<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a patient, enrolled in vaccination program, visible in two stores
- [ ] From store 1, give a vaccination
- [ ] From store 2, edit vaccination - only enabled field is the comment field, edit this
- [ ] You can save the vaccination, your comment saves
- [ ] You can edit all fields if you gave the vaccination from your store, or if it is not given

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

