### PR TITLE
Prevent simultaneous installs by removing application id suffix

### DIFF
--- a/client/packages/android/app/build.gradle
+++ b/client/packages/android/app/build.gradle
@@ -65,7 +65,6 @@ android {
     productFlavors {
         arm64 {
             dimension "abi"
-            applicationIdSuffix ".arm64"
             versionNameSuffix "-arm64"
             ndk {
                 abiFilters "arm64-v8a"
@@ -73,7 +72,6 @@ android {
         }
         universal {
             dimension "abi"
-            applicationIdSuffix ".universal"
             versionNameSuffix "-universal"
             ndk {
                 abiFilters "armeabi-v7a", "arm64-v8a"


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7496 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Ensures when a new version of the app is installed, the existing app is replaced, regardless of the build type. 

To achieve this, I removed the applicationIdSuffix from the arm64 and universal build flavors. This ensures that all app versions use the same applicationId as defined in the defaultConfig of the build.gradle file

When installing an apk on a device, the applicationId determines if the app is 'new' or not. If the applicationId matches exactly, the app will update. If the applicationId does not match exactly, a new version will be installed. As the versions had different suffixes, android could have each of these apps installed simultaneously

Apks with the same version number eg v2.7.0-RC7-arm64 and v2.7.0-RC7-universal can overwrite each other, however as standard behaviour v2.6.1 (being a lower version number) cannot overwrite a v2.7.0

Tested with 2.6.1 in the video here

https://github.com/user-attachments/assets/7c0ee25b-3623-4e22-bb28-d565b8c87096


I retained the versionNameSuffix - this does not affect the install behaviour but it does allow the version to be seen in Settings -> Apps -> Open mSupply if needed for support & determining which one is installed


![Screenshot 2025-04-28 at 1 37 37 PM Medium](https://github.com/user-attachments/assets/c60e5702-99c8-47ed-a6f1-756db9aceb60)
![Screenshot 2025-04-28 at 1 37 25 PM Medium](https://github.com/user-attachments/assets/a3da2488-e160-40f6-90e2-5da5c0785948)



<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have 2.6.1 installed on Android
- [ ] Download apks with this fix here: https://github.com/msupply-foundation/open-msupply/actions/runs/14697956009
- [ ] Install one of the new apks (universal or arm64). Note the prompt says 'update' rather than 'install'
- [ ] See only one instance of Open mSupply installed
- [ ] Repeat with the the other new apk - still have only one app version installed

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

