### PR TITLE
Remove db triggers in version 2.0 instead of version 2.2

### DIFF
--- a/server/repository/src/migrations/v2_00_00/mod.rs
+++ b/server/repository/src/migrations/v2_00_00/mod.rs
@@ -13,6 +13,7 @@ mod invoice_rename_tax;
 mod linked_shipment;
 mod name_deleted_datetime;
 mod pack_variant;
+mod remove_changelog_triggers;
 mod report_views;
 mod requisition_line_add_item_name;
 mod returns;
@@ -30,6 +31,8 @@ impl Migration for V2_00_00 {
     }
 
     fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        // Remove changelog triggers (time travelling, as the code was actually introduced in 2.2.0, but we want to run it early in a patch to avoid syncing changes updated in this version invoice_line_tax for example)
+        remove_changelog_triggers::migrate(connection)?;
         add_source_site_id::migrate(connection)?;
         central_omsupply::migrate(connection)?;
         assets::migrate_assets(connection)?;

--- a/server/repository/src/migrations/v2_00_00/remove_changelog_triggers.rs
+++ b/server/repository/src/migrations/v2_00_00/remove_changelog_triggers.rs
@@ -1,0 +1,141 @@
+use crate::migrations::*;
+
+#[cfg(not(feature = "postgres"))]
+pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
+    sql!(
+        connection,
+        r#"
+        DROP TRIGGER IF EXISTS location__insert_trigger;
+        DROP TRIGGER IF EXISTS location__update_trigger;
+        DROP TRIGGER IF EXISTS location__delete_trigger;
+        DROP TRIGGER IF EXISTS stock_line_insert_trigger;
+        DROP TRIGGER IF EXISTS stock_line_update_trigger;
+        DROP TRIGGER IF EXISTS stock_line_delete_trigger;
+        DROP TRIGGER IF EXISTS stocktake_insert_trigger;
+        DROP TRIGGER IF EXISTS stocktake_update_trigger;
+        DROP TRIGGER IF EXISTS stocktake_delete_trigger;
+        DROP TRIGGER IF EXISTS stocktake_line_insert_trigger;
+        DROP TRIGGER IF EXISTS stocktake_line_update_trigger;
+        DROP TRIGGER IF EXISTS stocktake_line_delete_trigger;
+        DROP TRIGGER IF EXISTS activity_log_insert_trigger;
+        DROP TRIGGER IF EXISTS barcode_delete_trigger;
+        DROP TRIGGER IF EXISTS location_movement_insert_trigger;
+        DROP TRIGGER IF EXISTS location_movement_update_trigger;
+        DROP TRIGGER IF EXISTS location_movement_delete_trigger;
+        DROP TRIGGER IF EXISTS barcode_insert_trigger;
+        DROP TRIGGER IF EXISTS barcode_update_trigger;
+        DROP TRIGGER IF EXISTS clinician_insert_trigger;
+        DROP TRIGGER IF EXISTS clinician_update_trigger;
+        DROP TRIGGER IF EXISTS clinician_delete_trigger;
+        DROP TRIGGER IF EXISTS clinician_store_join_insert_trigger;
+        DROP TRIGGER IF EXISTS clinician_store_join_update_trigger;
+        DROP TRIGGER IF EXISTS clinician_store_join_delete_trigger;
+        DROP TRIGGER IF EXISTS document_insert_trigger;
+        DROP TRIGGER IF EXISTS document_update_trigger;
+        DROP TRIGGER IF EXISTS sensor_insert_trigger;
+        DROP TRIGGER IF EXISTS sensor_update_trigger;
+        DROP TRIGGER IF EXISTS sensor_delete_trigger;
+        DROP TRIGGER IF EXISTS temperature_breach_insert_trigger;
+        DROP TRIGGER IF EXISTS temperature_log_insert_trigger;
+        DROP TRIGGER IF EXISTS temperature_breach_config_insert_trigger;
+        DROP TRIGGER IF EXISTS temperature_breach_update_trigger;
+        DROP TRIGGER IF EXISTS temperature_log_update_trigger;
+        DROP TRIGGER IF EXISTS temperature_breach_config_update_trigger;
+        DROP TRIGGER IF EXISTS temperature_breach_delete_trigger;
+        DROP TRIGGER IF EXISTS temperature_log_delete_trigger;
+        DROP TRIGGER IF EXISTS temperature_breach_config_delete_trigger;
+        DROP TRIGGER IF EXISTS currency_insert_trigger;
+        DROP TRIGGER IF EXISTS currency_update_trigger;
+        DROP TRIGGER IF EXISTS currency_delete_trigger;
+        DROP TRIGGER IF EXISTS invoice_insert_trigger;
+        DROP TRIGGER IF EXISTS invoice_update_trigger;
+        DROP TRIGGER IF EXISTS invoice_delete_trigger;
+        DROP TRIGGER IF EXISTS invoice_line_insert_trigger;
+        DROP TRIGGER IF EXISTS invoice_line_update_trigger;
+        DROP TRIGGER IF EXISTS invoice_line_delete_trigger;
+        DROP TRIGGER IF EXISTS name_store_join_insert_trigger;
+        DROP TRIGGER IF EXISTS name_store_join_update_trigger;
+        DROP TRIGGER IF EXISTS requisition_insert_trigger;
+        DROP TRIGGER IF EXISTS requisition_update_trigger;
+        DROP TRIGGER IF EXISTS requisition_delete_trigger;
+        DROP TRIGGER IF EXISTS requisition_line_insert_trigger;
+        DROP TRIGGER IF EXISTS requisition_line_update_trigger;
+        DROP TRIGGER IF EXISTS requisition_line_delete_trigger;
+        DROP TRIGGER IF EXISTS asset_class_insert_trigger;
+        DROP TRIGGER IF EXISTS asset_class_update_trigger;
+        DROP TRIGGER IF EXISTS asset_category_insert_trigger;
+        DROP TRIGGER IF EXISTS asset_category_update_trigger;
+        DROP TRIGGER IF EXISTS asset_catalogue_type_insert_trigger;
+        DROP TRIGGER IF EXISTS asset_catalogue_type_update_trigger;
+        DROP TRIGGER IF EXISTS asset_catalogue_item_insert_trigger;
+        DROP TRIGGER IF EXISTS asset_catalogue_item_update_trigger;
+        DROP TRIGGER IF EXISTS pack_variant_insert_trigger;
+        DROP TRIGGER IF EXISTS pack_variant_update_trigger;
+    "#,
+    )?;
+    Ok(())
+}
+
+#[cfg(feature = "postgres")]
+pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
+    sql!(
+        connection,
+        r#"
+            DROP TRIGGER IF EXISTS activity_log_upsert_trigger on activity_log;
+            DROP TRIGGER IF EXISTS asset_catalogue_item_trigger on asset_catalogue_item;
+            DROP TRIGGER IF EXISTS asset_catalogue_type_trigger on asset_catalogue_type;
+            DROP TRIGGER IF EXISTS asset_category_trigger on asset_category;
+            DROP TRIGGER IF EXISTS asset_class_trigger on asset_class;
+            DROP TRIGGER IF EXISTS barcode_delete_trigger on barcode;
+            DROP TRIGGER IF EXISTS barcode_upsert_trigger on barcode;
+            DROP TRIGGER IF EXISTS clinician_trigger on clinician;
+            DROP TRIGGER IF EXISTS clinician_store_join_trigger on clinician_store_join;
+            DROP TRIGGER IF EXISTS currency_trigger on currency;
+            DROP TRIGGER IF EXISTS document_trigger on document;
+            DROP TRIGGER IF EXISTS invoice_delete_trigger on invoice;
+            DROP TRIGGER IF EXISTS invoice_upsert_trigger on invoice;
+            DROP TRIGGER IF EXISTS invoice_line_delete_trigger on invoice_line;
+            DROP TRIGGER IF EXISTS invoice_line_upsert_trigger on invoice_line;
+            DROP TRIGGER IF EXISTS location_trigger on location;
+            DROP TRIGGER IF EXISTS location_movement_trigger on location_movement;
+            DROP TRIGGER IF EXISTS name_store_join_upsert_trigger on name_store_join;
+            DROP TRIGGER IF EXISTS pack_variant_trigger on pack_variant;
+            DROP TRIGGER IF EXISTS requisition_delete_trigger on requisition;
+            DROP TRIGGER IF EXISTS requisition_upsert_trigger on requisition;
+            DROP TRIGGER IF EXISTS requisition_line_delete_trigger on requisition_line;
+            DROP TRIGGER IF EXISTS requisition_line_upsert_trigger on requisition_line;
+            DROP TRIGGER IF EXISTS sensor_trigger on sensor;
+            DROP TRIGGER IF EXISTS stock_line_trigger on stock_line;
+            DROP TRIGGER IF EXISTS stocktake_trigger on stocktake;
+            DROP TRIGGER IF EXISTS stocktake_line_trigger on stocktake_line;
+            DROP TRIGGER IF EXISTS temperature_breach_trigger on temperature_breach;
+            DROP TRIGGER IF EXISTS temperature_breach_config_trigger on temperature_breach_config;
+            DROP TRIGGER IF EXISTS temperature_log_trigger on temperature_log;
+        "#,
+    )?;
+
+    // Drop the changelog functions
+
+    sql!(
+        connection,
+        r#"
+            DROP FUNCTION IF EXISTS update_changelog;
+            DROP FUNCTION IF EXISTS upsert_invoice_changelog;
+            DROP FUNCTION IF EXISTS delete_requisition_line_changelog;
+            DROP FUNCTION IF EXISTS upsert_activity_log_changelog;
+            DROP FUNCTION IF EXISTS delete_barcode_changelog;
+            DROP FUNCTION IF EXISTS upsert_barcode_changelog;
+            DROP FUNCTION IF EXISTS update_changelog_upsert_with_sync;
+            DROP FUNCTION IF EXISTS upsert_clinician_store_join_changelog;
+            DROP FUNCTION IF EXISTS delete_invoice_changelog;
+            DROP FUNCTION IF EXISTS upsert_invoice_line_changelog;
+            DROP FUNCTION IF EXISTS delete_invoice_line_changelog;
+            DROP FUNCTION IF EXISTS upsert_name_store_join_changelog;
+            DROP FUNCTION IF EXISTS upsert_requisition_changelog;
+            DROP FUNCTION IF EXISTS delete_requisition_changelog;
+            DROP FUNCTION IF EXISTS upsert_requisition_line_changelog;
+        "#,
+    )?;
+
+    Ok(())
+}


### PR DESCRIPTION
Background. Sites that have been updated to version 1.7 were affected by a bug in SQLite that caused data corruption. 
This is most obviously seen when trying to upgrade past 1.7 as during the upgrade database triggers caused the change log to be updated for all existing invoices, this means that the system tries to re-sync records that are no longer valid.

<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7506

# 👩🏻‍💻 What does this PR do?

Technically this isn't a real fix for that database corruption errors, however I think it should allow the upgrade to continue ok. It works by removing the database triggers on the invoice_line (and other tables) this means the updates to these tables don't get changelog records and are only synced to central server when they're actually updated by users.

It's safe to remove the triggers earlier as we know they're upgrading to a version which doesn't rely on db triggers, and will also reduce the sync traffic required for the upgrade.

## 💌 Any notes for the reviewer?

Also interested to see if there's a way to fix the database corruption, might try to look at that, otherwise we'll need to schedule in some work for a process to re-sync and fix corrupted records....

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Use a database was was upgraded to 1.7 using the broken code.
- [ ] Try to update to version 2.6.4 (this PR)
- [ ] Check you can sync successfully to your 4d server.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [X] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

