### PR TITLE
7531 Fix postgres tests

### DIFF
--- a/server/repository/src/migrations/v2_00_00/remove_changelog_triggers.rs
+++ b/server/repository/src/migrations/v2_00_00/remove_changelog_triggers.rs
@@ -114,28 +114,5 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
         "#,
     )?;
 
-    // Drop the changelog functions
-
-    sql!(
-        connection,
-        r#"
-            DROP FUNCTION IF EXISTS update_changelog;
-            DROP FUNCTION IF EXISTS upsert_invoice_changelog;
-            DROP FUNCTION IF EXISTS delete_requisition_line_changelog;
-            DROP FUNCTION IF EXISTS upsert_activity_log_changelog;
-            DROP FUNCTION IF EXISTS delete_barcode_changelog;
-            DROP FUNCTION IF EXISTS upsert_barcode_changelog;
-            DROP FUNCTION IF EXISTS update_changelog_upsert_with_sync;
-            DROP FUNCTION IF EXISTS upsert_clinician_store_join_changelog;
-            DROP FUNCTION IF EXISTS delete_invoice_changelog;
-            DROP FUNCTION IF EXISTS upsert_invoice_line_changelog;
-            DROP FUNCTION IF EXISTS delete_invoice_line_changelog;
-            DROP FUNCTION IF EXISTS upsert_name_store_join_changelog;
-            DROP FUNCTION IF EXISTS upsert_requisition_changelog;
-            DROP FUNCTION IF EXISTS delete_requisition_changelog;
-            DROP FUNCTION IF EXISTS upsert_requisition_line_changelog;
-        "#,
-    )?;
-
     Ok(())
 }

--- a/server/service/src/sync/translations/special/name_merge.rs
+++ b/server/service/src/sync/translations/special/name_merge.rs
@@ -244,7 +244,7 @@ mod tests {
         // This prevents names (nameK in this case) showing twice in lists after a merge.
         // What's more, a store shouldn't become visible to itself! e.g. if storeA above is actually nameK.
         let (_, connection, _, _) = setup_all(
-            "test_name_merge_message_translation_removes_duplicate_name_store_joins",
+            "test_name_merge_message_translation_removes_duplicate_namesj",
             MockDataInserts::none()
                 .units()
                 .names()


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7531

# 👩🏻‍💻 What does this PR do?

There was conflict when trying to remove a postgres function. I resolved conflict by removing a trigger that relies on it, and then had other migration problem because removed postgres functions were used elsewhere, so just removed the removal (triggers are still removed though, and function is removed in future migration, as those were just copied to earlier migration to fix a separate issue)

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

