### PR TITLE
7530 save prescription even when line items issued quantity zero

### DIFF
--- a/server/service/src/invoice/prescription/update/mod.rs
+++ b/server/service/src/invoice/prescription/update/mod.rs
@@ -76,7 +76,6 @@ pub fn update_prescription(
             } = generate(invoice, patch.clone(), connection)?;
 
             InvoiceRowRepository::new(connection).upsert_one(&update_invoice)?;
-            let invoice_line_repo = InvoiceLineRowRepository::new(connection);
 
             if let Some(stock_lines) = batches_to_update {
                 let repository = StockLineRowRepository::new(connection);

--- a/server/service/src/invoice/prescription/update/mod.rs
+++ b/server/service/src/invoice/prescription/update/mod.rs
@@ -73,7 +73,6 @@ pub fn update_prescription(
             let GenerateResult {
                 batches_to_update,
                 update_invoice,
-                lines_to_trim,
             } = generate(invoice, patch.clone(), connection)?;
 
             InvoiceRowRepository::new(connection).upsert_one(&update_invoice)?;
@@ -86,11 +85,11 @@ pub fn update_prescription(
                 }
             }
 
-            if let Some(lines) = lines_to_trim {
-                for line in lines {
-                    invoice_line_repo.delete(&line.id)?;
-                }
-            }
+            // if let Some(lines) = lines_to_trim {
+            //     for line in lines {
+            //         invoice_line_repo.delete(&line.id)?;
+            //     }
+            // }
 
             if status_changed {
                 activity_log_entry(

--- a/server/service/src/invoice/prescription/update/mod.rs
+++ b/server/service/src/invoice/prescription/update/mod.rs
@@ -85,12 +85,6 @@ pub fn update_prescription(
                 }
             }
 
-            // if let Some(lines) = lines_to_trim {
-            //     for line in lines {
-            //         invoice_line_repo.delete(&line.id)?;
-            //     }
-            // }
-
             if status_changed {
                 activity_log_entry(
                     ctx,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7530 

# 👩🏻‍💻 What does this PR do?

Allow saving prescriptions with line items that have zero issued quantity. Previously, `update_prescription` removed any line items with a `number_of_packs` of zero. This change removes that logic to permit saving such prescriptions.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

There's a bit of a gap of what I know about prescriptions. From what I conducted it is safe to remove the logic that prunes line items with zero issued quantity. Please let me know otherwise.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to `Dispensary` -> `Prescription` -> Select a prescription
- [ ] Add or Edit an item
- [ ] Assign value to prescribed quantity > 0 and remove value in issued quantity
- [ ] Save item
- [ ] Navigate back to the detail view of prescription
- [ ] Click on confirm button
- [ ] Should not prune or remove line items with zero issued quantity

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

