### PR TITLE
Fixes postgres migration for removing `encounter_clinician_link_id_fkey` in postgres

### DIFF
--- a/server/repository/src/migrations/v2_07_00/remove_encounter_clinician_constraint.rs
+++ b/server/repository/src/migrations/v2_07_00/remove_encounter_clinician_constraint.rs
@@ -16,7 +16,7 @@ impl MigrationFragment for Migrate {
             let result = sql!(
                 connection,
                 r#"
-                    ALTER TABLE encounter CONSTRAINT encounter_clinician_link_id_fkey;
+                    ALTER TABLE encounter DROP CONSTRAINT encounter_clinician_link_id_fkey;
                 "#
             );
             if result.is_err() {

--- a/server/repository/src/migrations/v2_07_00/remove_encounter_clinician_constraint.rs
+++ b/server/repository/src/migrations/v2_07_00/remove_encounter_clinician_constraint.rs
@@ -4,7 +4,7 @@ pub(crate) struct Migrate;
 
 impl MigrationFragment for Migrate {
     fn identifier(&self) -> &'static str {
-        "remove_encounter_clinician_link_constraint"
+        "remove_encounter_clinician_link_constraint2"
     }
 
     // Patient encounters can be synced to many sites, and one of those sites may not
@@ -16,7 +16,7 @@ impl MigrationFragment for Migrate {
             let result = sql!(
                 connection,
                 r#"
-                    ALTER TABLE encounter DROP CONSTRAINT encounter_clinician_link_id_fkey;
+                    ALTER TABLE encounter DROP CONSTRAINT IF EXISTS encounter_clinician_link_id_fkey;
                 "#
             );
             if result.is_err() {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes postgres migration for removing `encounter_clinician_link_id_fkey` in postgres

# 👩🏻‍💻 What does this PR do?

Fixes SQL 
Changes the migration fragment 2

## 💌 Any notes for the reviewer?

Now it should never fail as it uses the `IF EXISTS` command. I think that's ok though

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Test upgrade from 2.7 to this branch (or 2.7.1) on postgres
- [ ] Check that `encounter_clinician_link_id_fkey` doesn't exist in the database.
- [ ] Test fresh install of 2.7, 
- [ ] Check that `encounter_clinician_link_id_fkey` doesn't exist in the database.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [X] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

