### PR TITLE
7511 Fix unable to save stocktake line for an item

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -4248,6 +4248,7 @@ export type MasterListNode = {
   __typename: 'MasterListNode';
   code: Scalars['String']['output'];
   description: Scalars['String']['output'];
+  discountPercentage: Scalars['Float']['output'];
   id: Scalars['String']['output'];
   linesCount?: Maybe<Scalars['Int']['output']>;
   name: Scalars['String']['output'];
@@ -7709,6 +7710,7 @@ export type StocktakeLineConnector = {
 export type StocktakeLineFilterInput = {
   id?: InputMaybe<EqualFilterStringInput>;
   itemCodeOrName?: InputMaybe<StringFilterInput>;
+  itemId?: InputMaybe<EqualFilterStringInput>;
   locationId?: InputMaybe<EqualFilterStringInput>;
   stocktakeId?: InputMaybe<EqualFilterStringInput>;
 };

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/hooks/useDraftStocktakeLines.ts
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/hooks/useDraftStocktakeLines.ts
@@ -8,7 +8,7 @@ export const useDraftStocktakeLines = (
 ): [DraftStocktakeLine[], Dispatch<SetStateAction<DraftStocktakeLine[]>>] => {
   const { id } = useStocktake.document.fields('id');
   const { data: stockLines } = useStockLines(item?.id || '');
-  const { lines } = useStocktake.line.rows();
+  const { lines } = useStocktake.line.rows(item?.code);
   const [draftLines, setDraftLines] = useState<DraftStocktakeLine[]>([]);
 
   useEffect(() => {
@@ -24,6 +24,7 @@ export const useDraftStocktakeLines = (
         id,
         stocktakeLines ?? []
       );
+
       setDraftLines(fromStockLines.concat(fromStocktakeLines));
     }
   }, [stockLines, lines, item, id]);

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/hooks/useDraftStocktakeLines.ts
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/hooks/useDraftStocktakeLines.ts
@@ -8,7 +8,7 @@ export const useDraftStocktakeLines = (
 ): [DraftStocktakeLine[], Dispatch<SetStateAction<DraftStocktakeLine[]>>] => {
   const { id } = useStocktake.document.fields('id');
   const { data: stockLines } = useStockLines(item?.id || '');
-  const { lines } = useStocktake.line.rows(item?.code);
+  const { lines } = useStocktake.line.rows(item?.id);
   const [draftLines, setDraftLines] = useState<DraftStocktakeLine[]>([]);
 
   useEffect(() => {

--- a/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeLines.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeLines.ts
@@ -2,11 +2,23 @@ import { useQuery, useUrlQueryParams } from '@openmsupply-client/common';
 import { useStocktakeApi } from '../utils/useStocktakeApi';
 import { useStocktakeNumber } from '../document/useStocktake';
 
-export const useStocktakeLines = (id: string) => {
+export const useStocktakeLines = (id: string, itemCode?: string) => {
   const { queryParams } = useUrlQueryParams({
     initialSort: { key: 'itemName', dir: 'asc' },
     filters: [{ key: 'itemCodeOrName' }],
   });
+
+  if (itemCode) {
+    queryParams.filterBy = {
+      ...queryParams.filterBy,
+      itemCodeOrName: { equalTo: itemCode },
+    };
+    // We use itemCode when we want to get all the lines for a specific item
+    // Get 1000 lines back, assuming that there's never more than 1000 lines for a single item
+    queryParams.first = 1000;
+    queryParams.offset = 0;
+  }
+
   const api = useStocktakeApi();
   const stocktakeNumber = useStocktakeNumber();
 

--- a/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeLines.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeLines.ts
@@ -2,16 +2,16 @@ import { useQuery, useUrlQueryParams } from '@openmsupply-client/common';
 import { useStocktakeApi } from '../utils/useStocktakeApi';
 import { useStocktakeNumber } from '../document/useStocktake';
 
-export const useStocktakeLines = (id: string, itemCode?: string) => {
+export const useStocktakeLines = (id: string, itemId?: string) => {
   const { queryParams } = useUrlQueryParams({
     initialSort: { key: 'itemName', dir: 'asc' },
     filters: [{ key: 'itemCodeOrName' }],
   });
 
-  if (itemCode) {
+  if (itemId) {
     queryParams.filterBy = {
       ...queryParams.filterBy,
-      itemCodeOrName: { equalTo: itemCode },
+      itemId: { equalTo: itemId },
     };
     // We use itemCode when we want to get all the lines for a specific item
     // Get 1000 lines back, assuming that there's never more than 1000 lines for a single item

--- a/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
@@ -15,9 +15,12 @@ const getStocktakeItems = (lines: StocktakeLineFragment[]) =>
     } as StocktakeSummaryItem;
   });
 
-export const useStocktakeRows = () => {
+export const useStocktakeRows = (itemCode?: string) => {
   const { data: stocktake } = useStocktake.document.get();
-  const { data: lineData, isLoading } = useStocktakeLines(stocktake?.id ?? '');
+  const { data: lineData, isLoading } = useStocktakeLines(
+    stocktake?.id ?? '',
+    itemCode
+  );
   const lines = lineData?.nodes;
   const items = useMemo(() => getStocktakeItems(lines ?? []), [lines]);
   const totalLineCount = lineData?.totalCount ?? 0;

--- a/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
@@ -15,11 +15,11 @@ const getStocktakeItems = (lines: StocktakeLineFragment[]) =>
     } as StocktakeSummaryItem;
   });
 
-export const useStocktakeRows = (itemCode?: string) => {
+export const useStocktakeRows = (itemId?: string) => {
   const { data: stocktake } = useStocktake.document.get();
   const { data: lineData, isLoading } = useStocktakeLines(
     stocktake?.id ?? '',
-    itemCode
+    itemId
   );
   const lines = lineData?.nodes;
   const items = useMemo(() => getStocktakeItems(lines ?? []), [lines]);

--- a/server/graphql/stocktake_line/src/stocktake_line_queries.rs
+++ b/server/graphql/stocktake_line/src/stocktake_line_queries.rs
@@ -18,6 +18,7 @@ pub struct StocktakeLineFilterInput {
     pub stocktake_id: Option<EqualFilterStringInput>,
     pub location_id: Option<EqualFilterStringInput>,
     pub item_code_or_name: Option<StringFilterInput>,
+    pub item_id: Option<EqualFilterStringInput>,
 }
 
 impl From<StocktakeLineFilterInput> for StocktakeLineFilter {
@@ -27,6 +28,7 @@ impl From<StocktakeLineFilterInput> for StocktakeLineFilter {
             stocktake_id: f.stocktake_id.map(EqualFilter::from),
             location_id: f.location_id.map(EqualFilter::from),
             item_code_or_name: f.item_code_or_name.map(StringFilterInput::into),
+            item_id: f.item_id.map(EqualFilter::from),
         }
     }
 }

--- a/server/repository/src/db_diesel/stocktake_line.rs
+++ b/server/repository/src/db_diesel/stocktake_line.rs
@@ -23,6 +23,7 @@ pub struct StocktakeLineFilter {
     pub stocktake_id: Option<EqualFilter<String>>,
     pub location_id: Option<EqualFilter<String>>,
     pub item_code_or_name: Option<StringFilter>,
+    pub item_id: Option<EqualFilter<String>>,
 }
 
 impl StocktakeLineFilter {
@@ -42,6 +43,11 @@ impl StocktakeLineFilter {
 
     pub fn location_id(mut self, filter: EqualFilter<String>) -> Self {
         self.location_id = Some(filter);
+        self
+    }
+
+    pub fn item_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.item_id = Some(filter);
         self
     }
 }
@@ -174,6 +180,7 @@ fn create_filtered_query(filter: Option<StocktakeLineFilter>) -> BoxedStocktakeL
         apply_equal_filter!(query, f.id, stocktake_line::id);
         apply_equal_filter!(query, f.stocktake_id, stocktake_line::stocktake_id);
         apply_equal_filter!(query, f.location_id, stocktake_line::location_id);
+        apply_equal_filter!(query, f.item_id, item::id);
     }
 
     query


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7511 

# 👩🏻‍💻 What does this PR do?

The problem was that if some of the stock_lines for the item you are editing are on a separate page in the API response, the UI doesn't know that the stock line has been created and there for 

## 💌 Any notes for the reviewer?

This fix feels a bit messy, I feel like an upsert from the backend might be a nice solution but it's a big change.
A slightly nicer solution would be to add an item_id filter to stocktake lines rather than relying on the existing itemNameOrCode filter.

Didn't do either of those right now to keep the fix small.

# 🧪 Testing

See testing steps in issue to re-create...

- [ ] Try editing stocktake lines where the lines for item item span across the pages of the stock take.
- [ ] Try adding new lines
- [ ] Try editing existing lines
- [ ] Basically try to find if there's a scenario where this fix doesn't work!

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [X] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

