### PR TITLE
5537 supplier return item search autocomplete not scrolling

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -4144,8 +4144,10 @@ export type ItemFilterInput = {
   codeOrName?: InputMaybe<StringFilterInput>;
   id?: InputMaybe<EqualFilterStringInput>;
   isActive?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Items with available stock on hand, regardless of item visibility. This filter is ignored if `is_visible_or_on_hand` is true */
+  isOnHand?: InputMaybe<Scalars['Boolean']['input']>;
   isVaccine?: InputMaybe<Scalars['Boolean']['input']>;
-  /** Items that are part of a masterlist which is visible in this store. This filter is void if `is_visible_or_on_hand` is true */
+  /** Items that are part of a masterlist which is visible in this store. This filter is ignored if `is_visible_or_on_hand` is true */
   isVisible?: InputMaybe<Scalars['Boolean']['input']>;
   /** Items that are part of a masterlist which is visible in this store OR there is available stock of that item in this store */
   isVisibleOrOnHand?: InputMaybe<Scalars['Boolean']['input']>;

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -4145,7 +4145,7 @@ export type ItemFilterInput = {
   id?: InputMaybe<EqualFilterStringInput>;
   isActive?: InputMaybe<Scalars['Boolean']['input']>;
   /** Items with available stock on hand, regardless of item visibility. This filter is ignored if `is_visible_or_on_hand` is true */
-  isOnHand?: InputMaybe<Scalars['Boolean']['input']>;
+  hasStockOnHand?: InputMaybe<Scalars['Boolean']['input']>;
   isVaccine?: InputMaybe<Scalars['Boolean']['input']>;
   /** Items that are part of a masterlist which is visible in this store. This filter is ignored if `is_visible_or_on_hand` is true */
   isVisible?: InputMaybe<Scalars['Boolean']['input']>;

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
@@ -41,7 +41,7 @@ export const StocktakeLineEditForm: FC<StocktakeLineEditProps> = ({
             disabled={disabled}
             currentItemId={item?.id}
             onChange={onChangeItem}
-            includeNonVisibleWithStockOnHand
+            filter={{ isVisibleOrOnHand: true }}
             extraFilter={
               disabled
                 ? undefined

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -171,7 +171,7 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
             disabled={disabled}
             currentItemId={item?.id}
             onChange={onChangeItem}
-            includeNonVisibleWithStockOnHand
+            filter={{ isVisibleOrOnHand: true }}
             extraFilter={
               disabled
                 ? undefined

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
@@ -287,7 +287,7 @@ export const PrescriptionLineEditForm: React.FC<
             disabled={!isNew || disabled}
             currentItemId={item?.id}
             onChange={onChangeItem}
-            includeNonVisibleWithStockOnHand
+            filter={{ isVisibleOrOnHand: true }}
             extraFilter={
               disabled
                 ? undefined

--- a/client/packages/invoices/src/Returns/modals/SupplierReturn/ItemSelector.tsx
+++ b/client/packages/invoices/src/Returns/modals/SupplierReturn/ItemSelector.tsx
@@ -40,7 +40,7 @@ export const ItemSelector: FC<ItemSelectorProps> = ({
             disabled={disabled}
             currentItemId={itemId}
             onChange={newItem => newItem && onChangeItemId(newItem.id)}
-            filter={{ isOnHand: true }}
+            filter={{ hasStockOnHand: true }}
             extraFilter={
               disabled
                 ? undefined

--- a/client/packages/invoices/src/Returns/modals/SupplierReturn/ItemSelector.tsx
+++ b/client/packages/invoices/src/Returns/modals/SupplierReturn/ItemSelector.tsx
@@ -40,13 +40,11 @@ export const ItemSelector: FC<ItemSelectorProps> = ({
             disabled={disabled}
             currentItemId={itemId}
             onChange={newItem => newItem && onChangeItemId(newItem.id)}
-            includeNonVisibleWithStockOnHand
+            filter={{ isOnHand: true }}
             extraFilter={
               disabled
                 ? undefined
-                : item =>
-                    item.availableStockOnHand !== 0 &&
-                    !existingItemIds?.some(id => id === item.id)
+                : item => !existingItemIds?.some(id => id === item.id)
             }
           />
         </Grid>

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
@@ -9,10 +9,10 @@ import {
   useDebouncedValueCallback,
   FilterOptionsState,
   RegexUtils,
+  ItemFilterInput,
 } from '@openmsupply-client/common';
 import {
   ItemStockOnHandFragment,
-  StockOnHandFilter,
   useItemById,
   useItemStockOnHandInfinite,
 } from '../../api';
@@ -30,7 +30,7 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
   width,
   autoFocus = false,
   openOnFocus,
-  includeNonVisibleWithStockOnHand = false,
+  filter: apiFilter = { isVisible: true },
   itemCategoryName,
   programId,
 }) => {
@@ -45,7 +45,7 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
     DEBOUNCE_TIMEOUT
   );
 
-  const fullFilter: StockOnHandFilter = { ...filter };
+  const fullFilter: ItemFilterInput = { ...filter, ...apiFilter };
   if (itemCategoryName) fullFilter['categoryName'] = itemCategoryName;
   // For now, we are filtering items by "master_list", as they have the same ID
   // as their equivalent program. In the future, this may change, so we can add
@@ -56,7 +56,6 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
     useItemStockOnHandInfinite({
       rowsPerPage: ROWS_PER_PAGE,
       filter: fullFilter,
-      includeNonVisibleWithStockOnHand,
     });
   // changed from useStockLines even though that is more appropriate
   // when viewing a stocktake, you may have a stocktake line which has no stock lines.

--- a/client/packages/system/src/Item/api/api.ts
+++ b/client/packages/system/src/Item/api/api.ts
@@ -81,7 +81,6 @@ export const getItemQueries = (sdk: Sdk, storeId: string) => ({
       first,
       offset,
       sortBy,
-      includeNonVisibleWithStockOnHand,
     }: ListParams<ItemRowFragment> & {
       includeNonVisibleWithStockOnHand?: boolean;
     }) => {
@@ -94,10 +93,6 @@ export const getItemQueries = (sdk: Sdk, storeId: string) => ({
         filter: {
           ...filterBy,
           type: { equalTo: ItemNodeType.Stock },
-          [includeNonVisibleWithStockOnHand
-            ? 'isVisibleOrOnHand'
-            : 'isVisible']: true,
-          isVisible: true,
           isActive: true,
         },
       });

--- a/client/packages/system/src/Item/api/api.ts
+++ b/client/packages/system/src/Item/api/api.ts
@@ -81,9 +81,7 @@ export const getItemQueries = (sdk: Sdk, storeId: string) => ({
       first,
       offset,
       sortBy,
-    }: ListParams<ItemRowFragment> & {
-      includeNonVisibleWithStockOnHand?: boolean;
-    }) => {
+    }: ListParams<ItemRowFragment>) => {
       const result = await sdk.itemStockOnHand({
         key: itemParsers.toSortField(sortBy),
         first,

--- a/client/packages/system/src/Item/api/hooks/useItemStockOnHand/useItemStockOnHand.tsx
+++ b/client/packages/system/src/Item/api/hooks/useItemStockOnHand/useItemStockOnHand.tsx
@@ -1,13 +1,8 @@
-import { useInfiniteQuery } from '@openmsupply-client/common';
+import { ItemFilterInput, useInfiniteQuery } from '@openmsupply-client/common';
 import { useItemApi } from '../useItemApi';
 
-export type StockOnHandFilter = Record<
-  string,
-  { like: string } | string | { equalTo: string }
->;
-
 type UseItemStockOnHandParams = {
-  filter: StockOnHandFilter;
+  filter?: ItemFilterInput;
   rowsPerPage: number;
   includeNonVisibleWithStockOnHand?: boolean;
 };
@@ -15,12 +10,10 @@ type UseItemStockOnHandParams = {
 export const useItemStockOnHandInfinite = ({
   rowsPerPage,
   filter,
-  includeNonVisibleWithStockOnHand,
 }: UseItemStockOnHandParams) => {
   const queryParams = {
     filterBy: filter,
     sortBy: { key: 'name', isDesc: false, direction: 'asc' as 'asc' | 'desc' },
-    includeNonVisibleWithStockOnHand,
   };
 
   const api = useItemApi();

--- a/client/packages/system/src/Item/api/hooks/useItemStockOnHand/useItemStockOnHand.tsx
+++ b/client/packages/system/src/Item/api/hooks/useItemStockOnHand/useItemStockOnHand.tsx
@@ -4,7 +4,6 @@ import { useItemApi } from '../useItemApi';
 type UseItemStockOnHandParams = {
   filter?: ItemFilterInput;
   rowsPerPage: number;
-  includeNonVisibleWithStockOnHand?: boolean;
 };
 
 export const useItemStockOnHandInfinite = ({

--- a/client/packages/system/src/Item/utils.ts
+++ b/client/packages/system/src/Item/utils.ts
@@ -5,6 +5,7 @@ import {
   ItemWithPackSizeFragment,
 } from './api';
 import { styled } from '@common/styles';
+import { ItemFilterInput } from '@common/types';
 
 export const toItemRow = (line: ItemLike): ItemRowFragment => ({
   __typename: 'ItemNode',
@@ -35,7 +36,7 @@ export interface StockItemSearchInputProps
   extends GenericStockItemSearchInputProps {
   onChange: (item: ItemStockOnHandFragment | null) => void;
   extraFilter?: (item: ItemStockOnHandFragment) => boolean;
-  includeNonVisibleWithStockOnHand?: boolean;
+  filter?: ItemFilterInput;
   itemCategoryName?: string;
   programId?: string;
 }

--- a/server/graphql/general/src/queries/item.rs
+++ b/server/graphql/general/src/queries/item.rs
@@ -49,8 +49,10 @@ pub struct ItemFilterInput {
     pub category_name: Option<String>,
     /// Items that are part of a masterlist which is visible in this store OR there is available stock of that item in this store
     pub is_visible_or_on_hand: Option<bool>,
-    /// Items that are part of a masterlist which is visible in this store. This filter is void if `is_visible_or_on_hand` is true
+    /// Items that are part of a masterlist which is visible in this store. This filter is ignored if `is_visible_or_on_hand` is true
     pub is_visible: Option<bool>,
+    /// Items with available stock on hand, regardless of item visibility. This filter is ignored if `is_visible_or_on_hand` is true
+    pub is_on_hand: Option<bool>,
     pub code_or_name: Option<StringFilterInput>,
     pub is_active: Option<bool>,
     pub is_vaccine: Option<bool>,
@@ -105,6 +107,7 @@ impl ItemFilterInput {
             code_or_name,
             is_active,
             is_vaccine,
+            is_on_hand,
             is_visible_or_on_hand,
             master_list_id,
         } = self;
@@ -120,6 +123,7 @@ impl ItemFilterInput {
             code_or_name: code_or_name.map(StringFilter::from),
             is_active,
             is_vaccine,
+            is_on_hand,
             is_visible_or_on_hand,
             master_list_id: master_list_id.map(EqualFilter::from),
         }

--- a/server/graphql/general/src/queries/item.rs
+++ b/server/graphql/general/src/queries/item.rs
@@ -52,7 +52,7 @@ pub struct ItemFilterInput {
     /// Items that are part of a masterlist which is visible in this store. This filter is ignored if `is_visible_or_on_hand` is true
     pub is_visible: Option<bool>,
     /// Items with available stock on hand, regardless of item visibility. This filter is ignored if `is_visible_or_on_hand` is true
-    pub is_on_hand: Option<bool>,
+    pub has_stock_on_hand: Option<bool>,
     pub code_or_name: Option<StringFilterInput>,
     pub is_active: Option<bool>,
     pub is_vaccine: Option<bool>,
@@ -107,7 +107,7 @@ impl ItemFilterInput {
             code_or_name,
             is_active,
             is_vaccine,
-            is_on_hand,
+            has_stock_on_hand,
             is_visible_or_on_hand,
             master_list_id,
         } = self;
@@ -123,7 +123,7 @@ impl ItemFilterInput {
             code_or_name: code_or_name.map(StringFilter::from),
             is_active,
             is_vaccine,
-            is_on_hand,
+            has_stock_on_hand,
             is_visible_or_on_hand,
             master_list_id: master_list_id.map(EqualFilter::from),
         }

--- a/server/repository/src/db_diesel/item.rs
+++ b/server/repository/src/db_diesel/item.rs
@@ -43,10 +43,12 @@ pub struct ItemFilter {
     pub r#type: Option<EqualFilter<ItemType>>,
     pub category_id: Option<String>,
     pub category_name: Option<String>,
-    /// If true it only returns ItemAndMasterList that have a name join row (void if is_visible_or_on_hand is true!)
+    /// If true it only returns ItemAndMasterList that have a name join row (ignored if is_visible_or_on_hand is true!)
     pub is_visible: Option<bool>,
-    /// If true it returns ItemAndMasterList that have a name join row, or items with stock on hand
+    /// If true it returns ItemAndMasterList that have a name join row (including items with no stock), or items with stock on hand
     pub is_visible_or_on_hand: Option<bool>,
+    /// Return items with stock on hand, including non-visible items (ignored if is_visible_or_on_hand is true!)
+    pub is_on_hand: Option<bool>,
     pub code_or_name: Option<StringFilter>,
     pub is_active: Option<bool>,
     pub is_vaccine: Option<bool>,
@@ -108,7 +110,12 @@ impl ItemFilter {
         self
     }
 
-    pub fn has_stock_on_hand(mut self, value: bool) -> Self {
+    pub fn is_on_hand(mut self, value: bool) -> Self {
+        self.is_on_hand = Some(value);
+        self
+    }
+
+    pub fn visible_or_on_hand(mut self, value: bool) -> Self {
         self.is_visible_or_on_hand = Some(value);
         self
     }
@@ -216,6 +223,7 @@ fn create_filtered_query(store_id: String, filter: Option<ItemFilter>) -> BoxedI
             code_or_name,
             is_active,
             is_vaccine,
+            is_on_hand,
             is_visible_or_on_hand,
             master_list_id,
         } = f;
@@ -276,8 +284,7 @@ fn create_filtered_query(store_id: String, filter: Option<ItemFilter>) -> BoxedI
                     .eq(master_list_name_join::name_link_id)
                     .and(store::id.eq(store_id.clone()))),
             )
-            .filter(store::id.eq(store_id.clone()))
-            .into_boxed();
+            .filter(store::id.eq(store_id.clone()));
 
         let item_ids_with_stock_on_hand = item_link::table
             .select(item_link::item_id)
@@ -287,21 +294,42 @@ fn create_filtered_query(store_id: String, filter: Option<ItemFilter>) -> BoxedI
                     .gt(0.0)
                     .and(stock_on_hand::store_id.eq(store_id.clone())),
             )
-            .group_by(item_link::item_id)
-            .into_boxed();
+            .group_by(item_link::item_id);
+
+        query = match (is_visible_or_on_hand, is_on_hand) {
+            // visible items AND non-visible items with stock on hand
+            (Some(true), _) => query.filter(
+                item::id
+                    .eq_any(visible_item_ids.clone().into_boxed())
+                    .or(item::id.eq_any(item_ids_with_stock_on_hand.clone().into_boxed())),
+            ),
+            // Not handling Some(false) of is_visible_or_on_hand here - no use case for returning non-visible items
+            // Items with stock on hand
+            (_, Some(true)) => {
+                query.filter(item::id.eq_any(item_ids_with_stock_on_hand.clone().into_boxed()))
+            }
+
+            // Items with no stock on hand
+            (_, Some(false)) => {
+                query.filter(item::id.ne_all(item_ids_with_stock_on_hand.clone().into_boxed()))
+            }
+
+            // no stock_on_hand filters
+            (_, _) => query,
+        };
 
         query = match (is_visible_or_on_hand, is_visible) {
             // visible items AND non-visible items with stock on hand
             (Some(true), _) => query.filter(
                 item::id
-                    .eq_any(visible_item_ids)
-                    .or(item::id.eq_any(item_ids_with_stock_on_hand)),
+                    .eq_any(visible_item_ids.into_boxed())
+                    .or(item::id.eq_any(item_ids_with_stock_on_hand.into_boxed())),
             ),
             // visible items
-            (_, Some(true)) => query.filter(item::id.eq_any(visible_item_ids)),
+            (_, Some(true)) => query.filter(item::id.eq_any(visible_item_ids.into_boxed())),
 
             // invisible items
-            (_, Some(false)) => query.filter(item::id.ne_all(visible_item_ids)),
+            (_, Some(false)) => query.filter(item::id.ne_all(visible_item_ids.into_boxed())),
 
             // no visibility filters
             (_, _) => query,
@@ -736,7 +764,7 @@ mod tests {
         let results = ItemRepository::new(&storage_connection)
             .query(
                 Pagination::new(),
-                Some(ItemFilter::new().is_visible(true).has_stock_on_hand(true)),
+                Some(ItemFilter::new().is_visible(true).visible_or_on_hand(true)),
                 None,
                 Some("name1_store".to_string()),
             )
@@ -755,7 +783,7 @@ mod tests {
         let results = ItemRepository::new(&storage_connection)
             .query(
                 Pagination::new(),
-                Some(ItemFilter::new().has_stock_on_hand(true)),
+                Some(ItemFilter::new().visible_or_on_hand(true)),
                 None,
                 Some("some other store".to_string()),
             )

--- a/server/repository/src/db_diesel/item.rs
+++ b/server/repository/src/db_diesel/item.rs
@@ -48,7 +48,7 @@ pub struct ItemFilter {
     /// If true it returns ItemAndMasterList that have a name join row (including items with no stock), or items with stock on hand
     pub is_visible_or_on_hand: Option<bool>,
     /// Return items with stock on hand, including non-visible items (ignored if is_visible_or_on_hand is true!)
-    pub is_on_hand: Option<bool>,
+    pub has_stock_on_hand: Option<bool>,
     pub code_or_name: Option<StringFilter>,
     pub is_active: Option<bool>,
     pub is_vaccine: Option<bool>,
@@ -110,8 +110,8 @@ impl ItemFilter {
         self
     }
 
-    pub fn is_on_hand(mut self, value: bool) -> Self {
-        self.is_on_hand = Some(value);
+    pub fn has_stock_on_hand(mut self, value: bool) -> Self {
+        self.has_stock_on_hand = Some(value);
         self
     }
 
@@ -223,7 +223,7 @@ fn create_filtered_query(store_id: String, filter: Option<ItemFilter>) -> BoxedI
             code_or_name,
             is_active,
             is_vaccine,
-            is_on_hand,
+            has_stock_on_hand,
             is_visible_or_on_hand,
             master_list_id,
         } = f;
@@ -296,7 +296,7 @@ fn create_filtered_query(store_id: String, filter: Option<ItemFilter>) -> BoxedI
             )
             .group_by(item_link::item_id);
 
-        query = match (is_visible_or_on_hand, is_on_hand) {
+        query = match (is_visible_or_on_hand, has_stock_on_hand) {
             // visible items AND non-visible items with stock on hand
             (Some(true), _) => query.filter(
                 item::id


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes reopened #5537

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Adds an `has_stock_on_hand` filter to item search, so we only get the relevant results from backend. Can then remove the problematic frontend filter, which doesn't map well to paginated autocomplete.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Took me a while to track down the issue, we thought it was a problem with autocomplete, but it was actually the relationship with item query. We were querying all visible items (paginated) and then filter on frontend for items with stock.

Issue was happening in the case of:

- There are lots of items visible to your store (let's say 5000)
- You only have stock on hand for a few of them (say 200 items)
- Supplier return modal gets items in pages of 100 items
- Of that initial set of 100 visible items, on average, only 4 would have stock on hand
- Front end filters those results, so only 4 items in the autocomplete
- Because 4 items fit in the view, no need for a scroll bar
- No scroll = no action to trigger the call to get next page of items 😱 

The less noticeable version was when you had in stock enough of the items starting with 'A' (i.e. at the start of the list) to have the scroll bar/trigger pagination, but then would only add 2ish items per scroll, because most weren't visible, which seemed super weird.

Also, querying several thousand items only to show a few is not very efficient! Backend query should return only relevant results, not rely on frontend filtering.

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

hit me up if you need db file

- [ ] Have loads of items visible to your store
- [ ] Only have stock for some of them
- [ ] Create a Supplier Return, and click Add Item
- [ ] Autocomplete should be scrollable, with about 100 items per scroll-to-bottom

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

