### PR TITLE
7569 FIx JSON Form telephone field

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/Text.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Text.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { ControlProps, rankWith, schemaTypeIs } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import {
@@ -75,12 +75,30 @@ const usePatternValidation = (
   value?: string
 ): string | undefined => {
   const { customError, setCustomError } = useJSONFormsCustomError(path, 'Text');
+  const lastValidatedValue = useRef<{ pattern?: string; value?: string }>({});
 
   useEffect(() => {
+    // Skip validation if pattern or value hasn't actually changed
+    const patternString = pattern?.toString();
+    if (
+      lastValidatedValue.current.pattern === patternString &&
+      lastValidatedValue.current.value === value
+    ) {
+      return;
+    }
+
+    // Update last validated values
+    lastValidatedValue.current = {
+      pattern: patternString,
+      value,
+    };
+
+    // Process validation
     if (!pattern || !value) {
       setCustomError(undefined);
       return;
     }
+
     const result = pattern.exec(value);
     if (result == null) {
       setCustomError('Invalid format');
@@ -88,6 +106,7 @@ const usePatternValidation = (
       setCustomError(undefined);
     }
   }, [pattern, setCustomError, value]);
+
   return customError;
 };
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7569

# 👩🏻‍💻 What does this PR do?

This was actually a worse problem than what was described in the issue -- there was an infinite re-render going on due to the customErrors triggering a useEffect that in turn updated customErrors (I think).

I've mitigated this as much as I can for now, but I think this whole JSON Forms area needs a significant re-factor as there's all kinds of anti-patterns going on in it (such as returning un-memoized JSX from a hook, which causes a re-mount of child components on re-render). I think we could make this a lot more robust and less bug-prone with a few days cleanup.

## 💌 Any notes for the reviewer?

I'm still not 100% sure I've totally fixed the issue, as I can still re-create the occasional bit of weirdness around the `isDirty` state update and the error messaging, but not sure if that's just my hot reloading, as it seems to go away when I do a full refresh. I can't consistently recreate any problems such that I can describe the steps though 🤷‍♂️. So keep an eye out :) 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

You'll want to check the following states as you change the telephone field:

- the "Save" button -- should be enabled if changes have been made, and they are valid
- the "Error message" in the telephone field -- should only appear when the pattern is not matched (but not when it's empty)

With that in mind, check that you can do the following things:
- [ ] Can enter a valid phone number into a patient that doesn't currently have one
- [ ] You get an error and can't save if the entered text is invalid
- [ ] WIth a patient that does already have a phone number, check that you can backspace on the number to get the error state, but if you keep backspacing to nothing it should become valid and save-able
- [ ] Can "clear" a phone number (by selecting and deleting) and save the change
- [ ] Make sure all your changes (above) are saved correctly (i.e. persist after a refresh)

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

