### PR TITLE
7605 Add fallback to handle undefined value - fix crash on backspace NewStocklineModal

### DIFF
--- a/client/packages/common/src/intl/utils/DateUtils.test.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.test.ts
@@ -15,38 +15,43 @@ describe('useFormatDateTime', () => {
 });
 
 describe('getDisplayAge', () => {
+  jest.useFakeTimers().setSystemTime(new Date('2025-10-01'));
   const hookResult = renderHookWithProvider(() => useFormatDateTime());
   const { getDisplayAge } = hookResult.result.current;
-  const today = new Date();
 
   it('returns age in years when patient is over 1 year or 1 year old', () => {
-    const dob = DateUtils.addYears(today, -9);
+    const dob = new Date('2016-02-01');
     const result = getDisplayAge(dob);
     expect(result).toBe('9');
   });
 
   it('returns age in months and days when patient is less than 1 year old', () => {
-    const threeMonthsAgo = DateUtils.addMonths(today, -3);
-    const dob = DateUtils.addDays(threeMonthsAgo, -2);
+    const dob1 = new Date('2025-09-01');
+    expect(getDisplayAge(dob1)).toBe('1 month, 0 days');
 
-    const dayOffset =
-      DateUtils.getDaysInMonth(today) - DateUtils.getDaysInMonth(dob);
+    const dob3 = new Date('2024-10-02');
+    expect(getDisplayAge(dob3)).toBe('11 months, 29 days');
 
-    const result = getDisplayAge(dob);
-    expect(result).toBe(
-      `3 months, ${2 + (dayOffset > 0 ? dayOffset : 0)} days`
-    );
+    const dob4 = new Date('2025-04-01');
+    expect(getDisplayAge(dob4)).toBe('6 months, 0 days');
   });
 
   it('returns age in days when patient is less than 1 month old', () => {
-    const dob = DateUtils.addDays(today, -10);
+    const dob = new Date('2025-09-21');
     const result = getDisplayAge(dob);
     expect(result).toBe('10 days');
+
+    const dob2 = new Date('2025-09-30');
+    expect(getDisplayAge(dob2)).toBe('1 day');
   });
 
   it('returns an empty string if dob is not defined', () => {
     const dob = null;
     const result = getDisplayAge(dob);
     expect(result).toBe('');
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
   });
 });

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -119,6 +119,22 @@ export const StockLineForm: FC<StockLineFormProps> = ({
               />
             }
           />
+          {!isInModal && (
+            <StyledInputRow
+              label={t('label.available-packs')}
+              Input={
+                <NumericTextInput
+                  autoFocus
+                  disabled={!packEditable}
+                  width={160}
+                  value={parseFloat(draft.availableNumberOfPacks.toFixed(2))}
+                  onChange={availableNumberOfPacks =>
+                    onUpdate({ availableNumberOfPacks })
+                  }
+                />
+              }
+            />
+          )}
           <StyledInputRow
             label={t('label.cost-price')}
             Input={

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -108,7 +108,11 @@ export const StockLineForm: FC<StockLineFormProps> = ({
                 autoFocus
                 disabled={!packEditable}
                 width={160}
-                value={parseFloat(draft.totalNumberOfPacks.toFixed(2))}
+                value={
+                  draft.totalNumberOfPacks
+                    ? parseFloat(draft.totalNumberOfPacks.toFixed(2))
+                    : 0
+                }
                 onChange={totalNumberOfPacks =>
                   onUpdate({ totalNumberOfPacks })
                 }

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -120,20 +120,6 @@ export const StockLineForm: FC<StockLineFormProps> = ({
             }
           />
           <StyledInputRow
-            label={t('label.available-packs')}
-            Input={
-              <NumericTextInput
-                autoFocus
-                disabled={!packEditable}
-                width={160}
-                value={parseFloat(draft.availableNumberOfPacks.toFixed(2))}
-                onChange={availableNumberOfPacks =>
-                  onUpdate({ availableNumberOfPacks })
-                }
-              />
-            }
-          />
-          <StyledInputRow
             label={t('label.cost-price')}
             Input={
               <CurrencyInput

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -119,7 +119,7 @@ export const StockLineForm: FC<StockLineFormProps> = ({
               />
             }
           />
-          {!isInModal && (
+          {!packEditable && (
             <StyledInputRow
               label={t('label.available-packs')}
               Input={


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7605 fixes #7540

# 👩🏻‍💻 What does this PR do?

- Add fallback value for totalNumberOfPacks so that undefined value does not throw error
- Remove available packs input field

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

EDIT - after requested changes
Available packs field still available on stock detail view but not in new stockline modal

![Screenshot 2025-05-07 at 09 25 40](https://github.com/user-attachments/assets/63f3f855-b3a0-46a6-8e93-7b49c7cf327b)

![Screenshot 2025-05-07 at 09 25 25](https://github.com/user-attachments/assets/33a8cd5a-17b1-4134-b8e1-a4b81e5dfa3d)

## 💌 Any notes for the reviewer?

~~I haven't applied the fix to the available packs field -> it seems redundant to add code that will only get removed later. We should also remove the available packs field as requested here #7540 but not sure if that needs to go into 2.7.1. I don't see why not~~

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Inventory -> View Stock -> New Stock
- [ ] Choose an item that has 0 stock
- [ ] Autofocus on Pack Qty
- [ ] Enter an amount in Pack Qty
- [ ] Remove amount completely by backspacing 
- [ ] See that app does not crash

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

