### PR TITLE
Fix GraphiQL playground

### DIFF
--- a/server/graphql/playground.html
+++ b/server/graphql/playground.html
@@ -36,6 +36,46 @@
   <script>
     // Login plugin for GraphiQL
     function LoginContent() {
+      const [isSubmitting, setIsSubmitting] = React.useState(false);
+
+      function handleSubmit(event) {
+        event.preventDefault();
+
+        if (isSubmitting) return;
+
+        setIsSubmitting(true);
+
+        const formData = new FormData(event.target);
+        const username = formData.get('username');
+        const password = formData.get('password');
+
+        fetch('/graphql', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            query: `query Login {
+  authToken(password: "${password}", username: "${username}") {
+    ... on AuthToken {
+      __typename
+      token
+    }
+  }
+}`,
+          }),
+        })
+          .then((res) => res.json())
+          .then((res) => {
+            const token = res.data.authToken.token;
+            localStorage.setItem('token', token);
+            window.location.reload();
+          })
+          .finally(() => {
+            setIsSubmitting(false);
+          });
+      }
+
       return React.createElement(
         'div',
         {
@@ -48,47 +88,43 @@
           },
         },
         React.createElement('h1', null, 'Login'),
-        React.createElement('input', {
-          type: 'text',
-          id: 'username',
-          placeholder: 'Username',
-        }),
-        React.createElement('input', {
-          type: 'password',
-          id: 'password',
-          placeholder: 'Password',
-        }),
         React.createElement(
-          'button',
+          'form',
           {
-            onClick: () => {
-              const username = document.getElementById('username').value;
-              const password = document.getElementById('password').value;
-              fetch('/graphql', {
-                method: 'POST',
-                headers: {
-                  'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                  query: `query Login {
-    authToken(password: "${password}", username: "${username}") {
-        ... on AuthToken {
-            __typename
-            token
-        }
-    }
-}`,
-                }),
-              })
-                .then((res) => res.json())
-                .then((res) => {
-                  const token = res.data.authToken.token;
-                  localStorage.setItem('token', token);
-                  window.location.reload();
-                });
-            },
+            onSubmit: handleSubmit,
+            style: { display: 'flex', flexDirection: 'column', alignItems: 'center' },
           },
-          'Login'
+          React.createElement('input', {
+            type: 'text',
+            id: 'username',
+            name: 'username',
+            placeholder: 'Username',
+            autoFocus: true,
+          }),
+          React.createElement('input', {
+            type: 'password',
+            name: 'password',
+            id: 'password',
+            placeholder: 'Password',
+          }),
+          React.createElement(
+            'div',
+            null,
+            React.createElement(
+              'button',
+              {
+                type: 'submit',
+                disabled: isSubmitting,
+                style: {
+                  width: 'auto',
+                  padding: '0.5rem 1rem',
+                  cursor: isSubmitting ? 'not-allowed' : 'pointer',
+                  opacity: isSubmitting ? 0.6 : 1,
+                },
+              },
+              isSubmitting ? 'Logging in...' : 'Login'
+            )
+          )
         )
       );
     }

--- a/server/graphql/playground.html
+++ b/server/graphql/playground.html
@@ -1,74 +1,76 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <title>GraphiQL Playground</title>
-    <style>
-      body {
-        height: 100%;
-        margin: 0;
-        width: 100%;
-        overflow: hidden;
-      }
 
-      #graphiql {
-        height: 100vh;
-      }
-      input {
-        margin-bottom: 10px;
-      }
-    </style>
+<head>
+  <title>GraphiQL Playground</title>
+  <style>
+    body {
+      height: 100%;
+      margin: 0;
+      width: 100%;
+      overflow: hidden;
+    }
 
-    <link rel="stylesheet" href="https://unpkg.com/graphiql@3.0.6/graphiql.min.css" />
-    <link rel="stylesheet" href="https://unpkg.com/@graphiql/plugin-explorer/dist/style.css" />
-  </head>
+    #graphiql {
+      height: 100vh;
+    }
 
-  <body>
-    <div id="graphiql">Loading...</div>
+    input {
+      margin-bottom: 10px;
+    }
+  </style>
 
-    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+  <link rel="stylesheet" href="https://unpkg.com/@graphiql/plugin-explorer/dist/style.css" />
+</head>
 
-    <script src="https://unpkg.com/graphiql/graphiql.min.js"></script>
-    <script src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js"></script>
+<body>
+  <div id="graphiql">Loading...</div>
 
-    <script>
-      // Login plugin for GraphiQL
-      function LoginContent() {
-        return React.createElement(
-          'div',
-          {
-            style: {
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              justifyContent: 'center',
-              height: '100%',
-            },
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+
+  <script src="https://unpkg.com/graphiql/graphiql.min.js"></script>
+  <script src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js"></script>
+
+  <script>
+    // Login plugin for GraphiQL
+    function LoginContent() {
+      return React.createElement(
+        'div',
+        {
+          style: {
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            height: '100%',
           },
-          React.createElement('h1', null, 'Login'),
-          React.createElement('input', {
-            type: 'text',
-            id: 'username',
-            placeholder: 'Username',
-          }),
-          React.createElement('input', {
-            type: 'password',
-            id: 'password',
-            placeholder: 'Password',
-          }),
-          React.createElement(
-            'button',
-            {
-              onClick: () => {
-                const username = document.getElementById('username').value;
-                const password = document.getElementById('password').value;
-                fetch('/graphql', {
-                  method: 'POST',
-                  headers: {
-                    'Content-Type': 'application/json',
-                  },
-                  body: JSON.stringify({
-                    query: `query Login {
+        },
+        React.createElement('h1', null, 'Login'),
+        React.createElement('input', {
+          type: 'text',
+          id: 'username',
+          placeholder: 'Username',
+        }),
+        React.createElement('input', {
+          type: 'password',
+          id: 'password',
+          placeholder: 'Password',
+        }),
+        React.createElement(
+          'button',
+          {
+            onClick: () => {
+              const username = document.getElementById('username').value;
+              const password = document.getElementById('password').value;
+              fetch('/graphql', {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                  query: `query Login {
     authToken(password: "${password}", username: "${username}") {
         ... on AuthToken {
             __typename
@@ -76,70 +78,70 @@
         }
     }
 }`,
-                  }),
-                })
-                  .then((res) => res.json())
-                  .then((res) => {
-                    const token = res.data.authToken.token;
-                    localStorage.setItem('token', token);
-                    window.location.reload();
-                  });
-              },
+                }),
+              })
+                .then((res) => res.json())
+                .then((res) => {
+                  const token = res.data.authToken.token;
+                  localStorage.setItem('token', token);
+                  window.location.reload();
+                });
             },
-            'Login'
-          )
-        );
-      }
-
-      function LoginImage() {
-        // FeatherIcons login icon
-        return React.createElement(
-          'svg',
-          {
-            width: 24,
-            height: 24,
-            viewBox: '0 0 24 24',
-            fill: 'none',
-            xmlns: 'http://www.w3.org/2000/svg',
           },
-          React.createElement('path', {
-            d: 'M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4',
-            stroke: 'currentColor',
-            strokeWidth: '2',
-            strokeLinecap: 'round',
-            strokeLinejoin: 'round',
-          }),
-          React.createElement('polyline', {
-            points: '10 17 15 12 10 7',
-            stroke: 'currentColor',
-            strokeWidth: '2',
-            strokeLinecap: 'round',
-            strokeLinejoin: 'round',
-          }),
-          React.createElement('line', {
-            x1: '15',
-            y1: '12',
-            x2: '3',
-            y2: '12',
-            stroke: 'currentColor',
-            strokeWidth: '2',
-            strokeLinecap: 'round',
-            strokeLinejoin: 'round',
-          })
-        );
-      }
-    </script>
+          'Login'
+        )
+      );
+    }
 
-    <script>
-      // Always connect to the current app's local graphql endpoint
-      // Pass the token from local storage as the Authorization header if it exists
-      const authHeader = 'Bearer ' + localStorage.getItem('token');
-      var fetcher = GraphiQL.createFetcher({
-        url: '/graphql',
-        headers: { Authorization: authHeader },
-      });
+    function LoginImage() {
+      // FeatherIcons login icon
+      return React.createElement(
+        'svg',
+        {
+          width: 24,
+          height: 24,
+          viewBox: '0 0 24 24',
+          fill: 'none',
+          xmlns: 'http://www.w3.org/2000/svg',
+        },
+        React.createElement('path', {
+          d: 'M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4',
+          stroke: 'currentColor',
+          strokeWidth: '2',
+          strokeLinecap: 'round',
+          strokeLinejoin: 'round',
+        }),
+        React.createElement('polyline', {
+          points: '10 17 15 12 10 7',
+          stroke: 'currentColor',
+          strokeWidth: '2',
+          strokeLinecap: 'round',
+          strokeLinejoin: 'round',
+        }),
+        React.createElement('line', {
+          x1: '15',
+          y1: '12',
+          x2: '3',
+          y2: '12',
+          stroke: 'currentColor',
+          strokeWidth: '2',
+          strokeLinecap: 'round',
+          strokeLinejoin: 'round',
+        })
+      );
+    }
+  </script>
 
-      var defaultQuery = `
+  <script>
+    // Always connect to the current app's local graphql endpoint
+    // Pass the token from local storage as the Authorization header if it exists
+    const authHeader = 'Bearer ' + localStorage.getItem('token');
+    var fetcher = GraphiQL.createFetcher({
+      url: '/graphql',
+      headers: { Authorization: authHeader },
+    });
+
+    var defaultQuery = `
 query MyQuery {
   me {
     ... on UserAccountNode {
@@ -148,24 +150,25 @@ query MyQuery {
   }
 }
 `;
-      var explorerPlugin = GraphiQLPluginExplorer.explorerPlugin();
-      const loginPlugin = {
-        title: 'Login',
-        icon: LoginImage,
-        content: LoginContent,
-      };
+    var explorerPlugin = GraphiQLPluginExplorer.explorerPlugin();
+    const loginPlugin = {
+      title: 'Login',
+      icon: LoginImage,
+      content: LoginContent,
+    };
 
-      function GraphiQLWithPlugins() {
-        return React.createElement(GraphiQL, {
-          fetcher: fetcher,
-          defaultEditorToolsVisibility: true,
-          plugins: [explorerPlugin, loginPlugin],
-          defaultQuery: defaultQuery,
-        });
-      }
+    function GraphiQLWithPlugins() {
+      return React.createElement(GraphiQL, {
+        fetcher: fetcher,
+        defaultEditorToolsVisibility: true,
+        plugins: [explorerPlugin, loginPlugin],
+        defaultQuery: defaultQuery,
+      });
+    }
 
-      const root = ReactDOM.createRoot(document.getElementById('graphiql'));
-      root.render(React.createElement(GraphiQLWithPlugins));
-    </script>
-  </body>
+    const root = ReactDOM.createRoot(document.getElementById('graphiql'));
+    root.render(React.createElement(GraphiQLWithPlugins));
+  </script>
+</body>
+
 </html>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fix for the recently broken GraphQL playground, which we access on `http://localhost:8000/graphql`

# 👩🏻‍💻 What does this PR do?

Problem was that the version of the graphiql package wasn't being specified in the script tag, but the style sheet tag specified version (3.0.6). And so when the library was updated to V4 a few days ago, we now get a mismatch between the script JS and the styles. 

I've removed the version specifier completely -- I think it should be fine to always fetch the latest stable version. Is there any reason not to?

ALSO...

I've fixed something that's been annoying me for a while -- I've wrapped the Login form in proper `<form>` tags, so that we can now submit using the "Enter" key, using default form behaviour.

## 💌 Any notes for the reviewer?

Some auto-formatting changes in here. I suggest reviewing with the "Hide whitespace changes" enabled for a cleaner view of the actual changes.

I've targeted the 2.7.x branch, as that's going to be merged into develop sooner than the other way round. Can do a quick fix to develop as well if anyone's itching for it (but maybe just merge 2.7 into develop sooner rather than later @jmbrunskill ?)

# 🧪 Testing

- [ ] Check it looks correct
- [ ] Check the login works correctly (with Enter key, as well as button click)
- [ ] Confirm queries still work as normal


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

