### PR TITLE
70 the toggle 'record stock transaction for past vaccination' doesn't work when a stockline is ticked

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1992,8 +1992,5 @@
   "warning.caps-lock": "Warning: Caps lock is on",
   "warning.check-before-vaccinating": "Vaccination records from other stores may not be up to date. Ensure you have synced recently, and always confirm against the patient's physical vaccination card first.",
   "warning.field-not-parsed": "{{field}} not parsed",
-  "warning.nothing-to-supply": "Nothing left to supply!",
-  "description": {
-    "suggested-quantity": "The number of units which the system has calculated should be ordered"
-  }
+  "warning.nothing-to-supply": "Nothing left to supply!"
 }

--- a/client/packages/common/src/ui/components/inputs/Switch/Switch.tsx
+++ b/client/packages/common/src/ui/components/inputs/Switch/Switch.tsx
@@ -58,7 +58,7 @@ const getTrackBorderColor = (color?: SwitchColor) => (theme: Theme) => {
   }
 };
 
-export const Switch: React.FC<SwitchProps> = ({
+export const Switch = ({
   checked,
   color,
   defaultChecked,
@@ -70,7 +70,7 @@ export const Switch: React.FC<SwitchProps> = ({
   value,
   switchSx,
   labelSx,
-}) => {
+}: SwitchProps) => {
   const isSmall = size === 'small';
   const switchStyle = {
     width: isSmall ? '40px' : '70px',

--- a/client/packages/system/src/Vaccination/Components/SelectBatch.tsx
+++ b/client/packages/system/src/Vaccination/Components/SelectBatch.tsx
@@ -35,7 +35,7 @@ export const SelectBatch = ({
     if (data?.nodes?.length === 1 && !stockLine && isNewlyGiven) {
       setStockLine(data.nodes[0]!);
     }
-  }, [data]);
+  }, [data, isNewlyGiven, stockLine]);
 
   const columns = useColumns<StockLineFragment>(
     [
@@ -98,7 +98,7 @@ const BatchTable = ({
   data: StockLineFragment[];
   setStockLine: (stockLine: VaccinationStockLine) => void;
 }) => {
-  const t = useTranslation('dispensary');
+  const t = useTranslation();
   const { setRowStyles } = useRowStyle();
   const { setDisabledRows } = useTableStore();
 

--- a/client/packages/system/src/Vaccination/Components/SelectItemAndBatch.tsx
+++ b/client/packages/system/src/Vaccination/Components/SelectItemAndBatch.tsx
@@ -60,11 +60,9 @@ export const SelectItemAndBatch = ({
         <Switch
           label={t(transactionSwitchReason)}
           checked={draft.createTransactions}
-          onChange={(_, checked) => {
-            const nullStockLine = draft?.given && !checked;
+          onChange={() => {
             updateDraft({
               createTransactions: !draft.createTransactions,
-              stockLine: nullStockLine ? null : draft.stockLine,
             });
           }}
           labelPlacement="end"

--- a/client/packages/system/src/Vaccination/Components/SelectItemAndBatch.tsx
+++ b/client/packages/system/src/Vaccination/Components/SelectItemAndBatch.tsx
@@ -60,11 +60,13 @@ export const SelectItemAndBatch = ({
         <Switch
           label={t(transactionSwitchReason)}
           checked={draft.createTransactions}
-          onChange={() =>
+          onChange={(_, checked) => {
+            const nullStockLine = draft?.given && !checked;
             updateDraft({
               createTransactions: !draft.createTransactions,
-            })
-          }
+              stockLine: nullStockLine ? null : draft.stockLine,
+            });
+          }}
           labelPlacement="end"
           size="small"
         />

--- a/client/packages/system/src/Vaccination/api/useVaccination.ts
+++ b/client/packages/system/src/Vaccination/api/useVaccination.ts
@@ -177,6 +177,8 @@ const useInsert = ({
     if (!encounterId) return;
 
     const isOtherFacility = input.facilityId === OTHER_FACILITY;
+    const shouldUpdateStockLine =
+      input.given && !isOtherFacility && input.createTransactions;
 
     const apiResult = await api.insertVaccination({
       storeId,
@@ -195,8 +197,7 @@ const useInsert = ({
         comment: input.comment,
         notGivenReason: input.notGivenReason,
         itemId: input.itemId,
-        stockLineId:
-          input.given && !isOtherFacility ? input.stockLine?.id : undefined,
+        stockLineId: shouldUpdateStockLine ? input.stockLine?.id : undefined,
       },
     });
 

--- a/client/packages/system/src/Vaccination/api/useVaccination.ts
+++ b/client/packages/system/src/Vaccination/api/useVaccination.ts
@@ -177,7 +177,7 @@ const useInsert = ({
     if (!encounterId) return;
 
     const isOtherFacility = input.facilityId === OTHER_FACILITY;
-    const shouldUpdateStockLine =
+    const shouldCreatePrescription =
       input.given && !isOtherFacility && input.createTransactions;
 
     const apiResult = await api.insertVaccination({
@@ -197,7 +197,7 @@ const useInsert = ({
         comment: input.comment,
         notGivenReason: input.notGivenReason,
         itemId: input.itemId,
-        stockLineId: shouldUpdateStockLine ? input.stockLine?.id : undefined,
+        stockLineId: shouldCreatePrescription ? input.stockLine?.id : undefined,
       },
     });
 

--- a/server/service/src/vaccination/insert/validate.rs
+++ b/server/service/src/vaccination/insert/validate.rs
@@ -69,19 +69,17 @@ pub fn validate(
     }
 
     if let Some(facility_name_id) = &input.facility_name_id {
-        if !check_name_exists(connection, facility_name_id)?.is_some() {
+        if check_name_exists(connection, facility_name_id)?.is_none() {
             return Err(InsertVaccinationError::FacilityDoesNotExist);
         }
     }
     // If not given, reason is required
-    if !input.given {
-        if input.not_given_reason.is_none() {
-            return Err(InsertVaccinationError::ReasonNotProvided);
-        }
+    if !input.given && input.not_given_reason.is_none() {
+        return Err(InsertVaccinationError::ReasonNotProvided);
     }
 
     let stock_line = if let Some(item_id) = &input.item_id {
-        if !check_item_exists(connection, item_id)?.is_some() {
+        if check_item_exists(connection, item_id)?.is_none() {
             return Err(InsertVaccinationError::ItemDoesNotExist);
         }
 

--- a/server/service/src/vaccination/update/generate.rs
+++ b/server/service/src/vaccination/update/generate.rs
@@ -61,7 +61,7 @@ fn generate_given(
         .as_ref()
         .map(|sl| sl.stock_line_row.item_link_id.clone());
 
-    let update_transactions = update_input.update_transactions.clone().unwrap_or(false);
+    let update_transactions = update_input.update_transactions.unwrap_or(false);
 
     let vaccination = get_vaccination_with_updated_base_fields(existing_vaccination, update_input);
 

--- a/server/service/src/vaccination/update/validate.rs
+++ b/server/service/src/vaccination/update/validate.rs
@@ -67,16 +67,14 @@ pub fn validate(
     }
 
     if let Some(facility_name_id) = input.facility_name_id.clone().and_then(|u| u.value) {
-        if !check_name_exists(connection, &facility_name_id)?.is_some() {
+        if check_name_exists(connection, &facility_name_id)?.is_none() {
             return Err(UpdateVaccinationError::FacilityNameDoesNotExist);
         }
     }
 
     // If not given, reason is required
-    if input.given == Some(false) {
-        if input.not_given_reason.is_none() {
-            return Err(UpdateVaccinationError::ReasonNotProvided);
-        };
+    if input.given == Some(false) && input.not_given_reason.is_none() {
+        return Err(UpdateVaccinationError::ReasonNotProvided);
     };
 
     // If selected item is changing - validate it


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Part of [70](https://github.com/msupply-foundation/open-msupply-internal/issues/70)

# 👩🏻‍💻 What does this PR do?
There was a change to auto-select batch if there is only one, this caused the batch to be sent into the API call and the insert function only checks if there's a stock line before creating an invoice!

This PR sets the batch to 'null' if the user is choosing to not record a stock transaction.

https://github.com/user-attachments/assets/eb7c6dd5-6d82-40ff-bf40-83736d0ece9d

## 💌 Any notes for the reviewer?
Didn't do this part of the issue: 

```
- outcome of the toggle is unclear (does it put back stock, does it remove stock, does it keep stock unchanged ?
- confusing UI : all text look the same, all text has the same toggle
```

Feels like that needs UX input, but if using the same style/font/component for both recording and reverting is causing confusion, then we should think of ways to lessen that either with different colours, or whatever~

![record](https://github.com/user-attachments/assets/a852bd88-e0e6-435b-a657-48a60475e11b)
![revert](https://github.com/user-attachments/assets/30dde774-3118-498d-82cb-8bf29310b884)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a vaccination encounter for a patient
- [ ] Click on one of the dose lines
- [ ] Give the patient a vaccination in the **past**
- [ ] **Switch** toggle to say you don't want to record the stock transaction -> Save
- [ ] Check stock line -> stock line for item should **stay the same**
- [ ] Now go back and give another dose in the **encounter**, but this time you want to record the stock transaction
- [ ] Check stock line -> stock line should have decreased
- [ ] Check prescriptions -> Prescriptions should have been created

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

