### PR TITLE
7604 add doses per unit & vvm type to item variant table

### DIFF
--- a/server/graphql/item_variant/src/mutations/upsert.rs
+++ b/server/graphql/item_variant/src/mutations/upsert.rs
@@ -22,6 +22,8 @@ pub struct UpsertItemVariantInput {
     pub cold_storage_type_id: Option<String>,
     pub manufacturer_id: Option<String>,
     pub packaging_variants: Vec<PackagingVariantInput>,
+    pub doses_per_unit: Option<i32>,
+    pub vvm_type: Option<String>,
 }
 
 #[derive(InputObject)]
@@ -83,6 +85,8 @@ impl UpsertItemVariantInput {
             cold_storage_type_id,
             manufacturer_id,
             packaging_variants,
+            doses_per_unit,
+            vvm_type,
         } = self;
 
         UpsertItemVariantWithPackaging {
@@ -95,6 +99,8 @@ impl UpsertItemVariantInput {
                 .into_iter()
                 .map(|v| PackagingVariantInput::to_domain(v, id.clone()))
                 .collect(),
+            doses_per_unit,
+            vvm_type,
         }
     }
 }

--- a/server/repository/src/db_diesel/item_variant/item_variant.rs
+++ b/server/repository/src/db_diesel/item_variant/item_variant.rs
@@ -182,6 +182,8 @@ mod tests {
                 cold_storage_type_id: None,
                 manufacturer_link_id: None,
                 deleted_datetime: None,
+                doses_per_unit: 0,
+                vvm_type: None,
             })
             .unwrap();
 

--- a/server/repository/src/db_diesel/item_variant/item_variant_row.rs
+++ b/server/repository/src/db_diesel/item_variant/item_variant_row.rs
@@ -14,6 +14,8 @@ table! {
         cold_storage_type_id -> Nullable<Text>,
         manufacturer_link_id -> Nullable<Text>,
         deleted_datetime -> Nullable<Timestamp>,
+        doses_per_unit -> Integer,
+        vvm_type -> Nullable<Text>,
     }
 }
 
@@ -25,6 +27,7 @@ allow_tables_to_appear_in_same_query!(item_variant, item);
     Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq, Default, Serialize, Deserialize,
 )]
 #[diesel(table_name = item_variant)]
+#[diesel(treat_none_as_null = true)]
 pub struct ItemVariantRow {
     pub id: String,
     pub name: String,
@@ -32,6 +35,9 @@ pub struct ItemVariantRow {
     pub cold_storage_type_id: Option<String>,
     pub manufacturer_link_id: Option<String>,
     pub deleted_datetime: Option<chrono::NaiveDateTime>,
+    #[serde(default)]
+    pub doses_per_unit: i32,
+    pub vvm_type: Option<String>,
 }
 
 pub struct ItemVariantRowRepository<'a> {

--- a/server/repository/src/db_diesel/item_variant/packaging_variant.rs
+++ b/server/repository/src/db_diesel/item_variant/packaging_variant.rs
@@ -159,6 +159,8 @@ mod tests {
                 cold_storage_type_id: None,
                 manufacturer_link_id: None,
                 deleted_datetime: None,
+                doses_per_unit: 0,
+                vvm_type: None,
             })
             .unwrap();
 

--- a/server/repository/src/migrations/v2_08_00/add_doses_columns_to_item_variant.rs
+++ b/server/repository/src/migrations/v2_08_00/add_doses_columns_to_item_variant.rs
@@ -1,0 +1,21 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_doses_columns_to_item_variant"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        sql!(
+            connection,
+            r#"
+                ALTER TABLE item_variant ADD COLUMN doses_per_unit INTEGER NOT NULL DEFAULT 0;
+                ALTER TABLE item_variant ADD COLUMN vvm_type STRING;
+            "#
+        )?;
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_08_00/add_doses_columns_to_item_variant.rs
+++ b/server/repository/src/migrations/v2_08_00/add_doses_columns_to_item_variant.rs
@@ -12,7 +12,7 @@ impl MigrationFragment for Migrate {
             connection,
             r#"
                 ALTER TABLE item_variant ADD COLUMN doses_per_unit INTEGER NOT NULL DEFAULT 0;
-                ALTER TABLE item_variant ADD COLUMN vvm_type STRING;
+                ALTER TABLE item_variant ADD COLUMN vvm_type TEXT;
             "#
         )?;
 

--- a/server/repository/src/migrations/v2_08_00/mod.rs
+++ b/server/repository/src/migrations/v2_08_00/mod.rs
@@ -1,6 +1,7 @@
 use super::{version::Version, Migration, MigrationFragment};
 use crate::StorageConnection;
 
+mod add_doses_columns_to_item_variant;
 mod add_vvm_status_table;
 pub(crate) struct V2_08_00;
 
@@ -16,6 +17,7 @@ impl Migration for V2_08_00 {
     fn migrate_fragments(&self) -> Vec<Box<dyn MigrationFragment>> {
         vec![
             Box::new(add_vvm_status_table::Migrate),
+            Box::new(add_doses_columns_to_item_variant::Migrate),
         ]
     }
 }

--- a/server/repository/src/mock/item_variant.rs
+++ b/server/repository/src/mock/item_variant.rs
@@ -8,6 +8,8 @@ pub fn mock_item_a_variant_1() -> ItemVariantRow {
         cold_storage_type_id: None,
         manufacturer_link_id: None,
         deleted_datetime: None,
+        doses_per_unit: 0,
+        vvm_type: None,
     }
 }
 
@@ -19,6 +21,8 @@ pub fn mock_item_a_variant_2() -> ItemVariantRow {
         cold_storage_type_id: None,
         manufacturer_link_id: None,
         deleted_datetime: None,
+        doses_per_unit: 0,
+        vvm_type: None,
     }
 }
 
@@ -30,6 +34,8 @@ pub fn mock_item_b_variant_1() -> ItemVariantRow {
         cold_storage_type_id: None,
         manufacturer_link_id: None,
         deleted_datetime: None,
+        doses_per_unit: 0,
+        vvm_type: None,
     }
 }
 
@@ -41,6 +47,8 @@ pub fn mock_item_b_variant_2() -> ItemVariantRow {
         cold_storage_type_id: None,
         manufacturer_link_id: None,
         deleted_datetime: None,
+        doses_per_unit: 0,
+        vvm_type: None,
     }
 }
 
@@ -52,6 +60,8 @@ pub fn mock_item_c_variant_1() -> ItemVariantRow {
         cold_storage_type_id: None,
         manufacturer_link_id: None,
         deleted_datetime: None,
+        doses_per_unit: 0,
+        vvm_type: None,
     }
 }
 

--- a/server/service/src/sync/test/test_data/item_variant.rs
+++ b/server/service/src/sync/test/test_data/item_variant.rs
@@ -24,6 +24,8 @@ fn item_variant1() -> ItemVariantRow {
         cold_storage_type_id: None,
         manufacturer_link_id: None,
         deleted_datetime: None,
+        doses_per_unit: 0,
+        vvm_type: None,
     }
 }
 
@@ -34,7 +36,9 @@ const ITEM_VARIANT2: (&str, &str) = (
         "name": "Item Variant 2",
         "item_link_id": "8F252B5884B74888AAB73A0D42C09E7A",
         "cold_storage_type_id": null,
-        "manufacturer_link_id": "1FB32324AF8049248D929CFB35F255BA"
+        "manufacturer_link_id": "1FB32324AF8049248D929CFB35F255BA",
+        "doses_per_unit": 1,
+        "vvm_type": "VVM 1"
     }"#,
 );
 
@@ -46,6 +50,8 @@ fn item_variant2() -> ItemVariantRow {
         cold_storage_type_id: None, //TODO: Add cold storage type when sync is implemented
         manufacturer_link_id: Some("1FB32324AF8049248D929CFB35F255BA".to_string()), // NAME_1.0 (currently marked as manufacturer)
         deleted_datetime: None,
+        doses_per_unit: 1,
+        vvm_type: Some("VVM 1".to_string()),
     }
 }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7604

# 👩🏻‍💻 What does this PR do?
- Migrations to add `doses_per_unit` and `vvm_type` to item variants table. 
- Allow for upserting of these fields
- Make sure sync is still sync'in 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Make sure tests are passing

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

