### PR TITLE
7608 Remove confirm, strength and navigate to error when finalising

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -384,6 +384,7 @@
   "error.report-does-not-exist": "Report does not exist",
   "error.requisition-not-found": "Requisition not found",
   "error.return-not-found": "Return not found",
+  "error.rnr-has-errors": "Cannot finalise the R&R form while some lines have errors. You will be taken to the first error line",
   "error.rnr-not-found": "R&R Form not found",
   "error.scanner-not-connected": "Scanner is not connected. See the Admin > Devices section to connect a scanner.",
   "error.server-failed-to-start": "Error! The server failed to start",

--- a/client/packages/common/src/intl/locales/tet/common.json
+++ b/client/packages/common/src/intl/locales/tet/common.json
@@ -123,6 +123,7 @@
   "error.provide-reason": "Tenke justifika razaun ba lina sira ne'ebe maka iha diferensia iha kalkulasaun numeru ba pakote nian.",
   "error.provide-valid-reason": "Ajustamentu razaun la han malu ho ajustamentu diresaun",
   "error.reduced-below-zero": "Lina Stock existe iha remessas sasan sai nian. Kuantidade labele reduz kiik liu husi zero.",
+  "error.rnr-has-errors": "Cannot finalise the R&R form while some lines have errors. You will be taken to the first error line",
   "error.server-failed-to-start": "Erru! Servedor falha atu Start",
   "error.server-not-found": "Hasoru problema wainhira atu lokaliza servedor mSupply Lokal nian",
   "error.shipment-not-found": "Remessa la hetan",

--- a/client/packages/requisitions/src/RnRForms/DetailView/ContentArea.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/ContentArea.tsx
@@ -1,6 +1,7 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import {
   Box,
+  // Fade,
   GlobalStyles,
   InfoIcon,
   LocaleKey,
@@ -14,7 +15,7 @@ import {
 import { RnRFormLineFragment } from '../api/operations.generated';
 import { RnRFormLine } from './RnRFormLine';
 import { Search } from './Search';
-import { itemMatchesSearch } from '../utils';
+import { oneTime, useRnRFormContext } from '../api';
 
 interface ContentAreaProps {
   data: RnRFormLineFragment[];
@@ -56,17 +57,16 @@ export const ContentArea = ({
   const t = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<ViewportListRef>(null);
+  const { setListRef } = useRnRFormContext(
+    oneTime(({ setListRef }) => ({
+      setListRef,
+    }))
+  );
 
-  const onSearch = (search: string) => {
-    const foundIndex = data.findIndex(l => itemMatchesSearch(search, l.item));
-
-    foundIndex > -1 &&
-      listRef.current?.scrollToIndex({
-        alignToTop: false,
-        // load 2 lines below the found line
-        index: foundIndex + 2,
-      });
-  };
+  useEffect(() => {
+    // Store the ref in Zustand state
+    setListRef(listRef);
+  }, [setListRef]);
 
   return data.length === 0 ? (
     <NothingHere body={t('error.no-items')} />
@@ -134,7 +134,7 @@ export const ContentArea = ({
           },
         }}
       >
-        <Headers onSearch={onSearch} />
+        <Headers />
 
         <tbody>
           <ViewportList
@@ -162,7 +162,7 @@ export const ContentArea = ({
   );
 };
 
-const Headers = ({ onSearch }: { onSearch: (value: string) => void }) => {
+const Headers = () => {
   const t = useTranslation();
   return (
     <thead>
@@ -180,11 +180,9 @@ const Headers = ({ onSearch }: { onSearch: (value: string) => void }) => {
             }}
           >
             {t('label.name')}
-            <Search onSearch={onSearch} />
+            <Search />
           </Box>
         </th>
-
-        <HeaderCell label="label.strength" width={85} />
         <HeaderCell label="label.unit" width={80} />
         <HeaderCell label="label.ven" width={55} />
         <HeaderCell
@@ -232,7 +230,6 @@ const Headers = ({ onSearch }: { onSearch: (value: string) => void }) => {
           tooltip="description.rnr-low-stock"
         />
         <HeaderCell label="label.comment" />
-        <HeaderCell label="label.confirmed" />
         <HeaderCell
           label="label.approved-quantity"
           tooltip="description.rnr-approved-quantity"

--- a/client/packages/requisitions/src/RnRForms/DetailView/DetailView.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/DetailView.tsx
@@ -15,7 +15,7 @@ import { ActivityLogList } from '@openmsupply-client/system';
 import { Footer } from './Footer';
 import { AppBarButtons } from './AppBarButtons';
 import { ContentArea } from './ContentArea';
-import { RnRFormQuery, useRnRForm, useRnRFormContext } from '../api';
+import { oneTime, RnRFormQuery, useRnRForm, useRnRFormContext } from '../api';
 import { SidePanel } from './SidePanel';
 import { AutoSave } from './AutoSave';
 
@@ -23,7 +23,7 @@ export const RnRFormDetailView = () => {
   const { id = '' } = useParams();
   const [isInitialising, setIsInitialising] = useState(true);
 
-  const setInitial = useRnRFormContext(state => state.setInitial);
+  const setInitial = useRnRFormContext(oneTime(state => state.setInitial));
 
   const {
     query: { data, isLoading },

--- a/client/packages/requisitions/src/RnRForms/DetailView/Footer.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/Footer.tsx
@@ -47,7 +47,7 @@ export const Footer = ({ data }: { data: RnRFormQuery }) => {
     },
     message:
       errorLineIndex != -1
-        ? `You will be taken to first error line`
+        ? t('error.rnr-has-errors')
         : t('messages.confirm-finalise-rnr'),
     title: t('heading.are-you-sure'),
   });

--- a/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
@@ -34,6 +34,7 @@ export const RnRFormLine = ({
   const theme = useTheme();
   const { store } = useAuthContext();
   const { error } = useNotification();
+
   const lineState = useRnRFormContext(useCachedRnRDraftLine(lineId));
 
   // console.log('rendering', lineState?.line.id, lineId);
@@ -171,6 +172,7 @@ export const RnRFormLine = ({
         value={line.adjustedQuantityConsumed}
       />
 
+      {/* Losses/adjustments and stock out */}
       <RnRNumberCell
         value={line.losses}
         onChange={val => updateDraft({ losses: val })}

--- a/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import {
   AlertIcon,
   BasicTextInput,
-  Checkbox,
-  CircleIcon,
   DatePicker,
   Formatter,
   LowStockStatus,
@@ -13,7 +11,6 @@ import {
   Tooltip,
   useAuthContext,
   useBufferState,
-  useNotification,
   useTheme,
   VenCategoryType,
 } from '@openmsupply-client/common';
@@ -27,17 +24,12 @@ export const RnRFormLine = ({
   lineId,
 }: {
   lineId: string;
-
   periodLength: number;
   disabled: boolean;
 }) => {
   const theme = useTheme();
   const { store } = useAuthContext();
-  const { error } = useNotification();
-
   const lineState = useRnRFormContext(useCachedRnRDraftLine(lineId));
-
-  // console.log('rendering', lineState?.line.id, lineId);
 
   if (!lineState) return null;
 
@@ -141,7 +133,6 @@ export const RnRFormLine = ({
       <td className="sticky-column second-column" style={itemDetailStyle}>
         {line.item.name}
       </td>
-      <td style={readOnlyColumn}>{line.item.strength}</td>
       <td style={readOnlyColumn}>{line.item.unitName}</td>
       <td style={{ ...readOnlyColumn, textAlign: 'center' }}>{venCategory}</td>
 
@@ -278,34 +269,6 @@ export const RnRFormLine = ({
         />
       </td>
 
-      {/* Confirm the line */}
-      <td style={{ textAlign: 'center' }}>
-        {
-          <>
-            <Checkbox
-              tabIndex={-1}
-              checked={!!line.confirmed}
-              size="medium"
-              onClick={async () => {
-                if (line.finalBalance < 0) {
-                  error('Final balance should not be below 0')();
-                  return;
-                }
-                setLine({ ...line, confirmed: !line.confirmed });
-              }}
-              disabled={disabled}
-              sx={{ marginLeft: '10px' }}
-            />
-            <CircleIcon
-              sx={{
-                width: '10px',
-                visibility: line?.isDirty ? 'visible' : 'hidden',
-                color: 'secondary.main',
-              }}
-            />
-          </>
-        }
-      </td>
       {/* Readonly - populated from Response Requisition */}
       <RnRNumberCell
         backgroundColor={readOnlyBackgroundColor}

--- a/client/packages/requisitions/src/RnRForms/DetailView/Search.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/Search.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Box,
   IconButton,
@@ -8,24 +8,32 @@ import {
 } from '@openmsupply-client/common';
 import { useRnRFormContext } from '../api';
 
-export const Search = (props: { onSearch: (value: string) => void }) => {
+export const Search = () => {
   const t = useTranslation();
 
-  const { search, setSearch } = useRnRFormContext(({ search, setSearch }) => ({
-    search,
-    setSearch,
-  }));
+  const { search, scrollToIndex, resetSearch } = useRnRFormContext(
+    ({ search, scrollToIndex, resetSearch }) => ({
+      search,
+      scrollToIndex,
+      resetSearch,
+    })
+  );
 
   const [showSearch, setShowSearch] = useState(false);
-  const [input, setInput] = useState(search);
+  const [input, setInput] = useState('');
+
+  useEffect(() => {
+    return () => resetSearch();
+  }, []);
 
   const onSearch = (value: string) => {
     setInput(value);
     // Only search when 3+ characters are entered
     if (value.length > 2) {
-      setSearch(value);
-      props.onSearch(value);
-    } else setSearch('');
+      let found = search(value);
+
+      found != -1 && scrollToIndex(found);
+    } else resetSearch();
   };
 
   return (
@@ -50,7 +58,6 @@ export const Search = (props: { onSearch: (value: string) => void }) => {
             onClear={() => setShowSearch(false)}
             onSearchIconClick={() => setShowSearch(false)}
             searchIconButtonLabel={t('button.close')}
-            debounceTime={0}
             autoFocus
           />
         </Box>

--- a/client/packages/requisitions/src/RnRForms/api/hooks/useRnRForm.ts
+++ b/client/packages/requisitions/src/RnRForms/api/hooks/useRnRForm.ts
@@ -53,15 +53,6 @@ export const useRnRForm = ({ rnrFormId }: { rnrFormId: string }) => {
     debouncedUpdateRnRForm(patch);
   };
 
-  // const confirmRemainingLines = async () => {
-  //   if (!query.data) return;
-
-  //   const lines = query.data.lines
-  //     .filter(line => !line.confirmed)
-  //     .map(line => ({ ...line, confirmed: true }));
-  //   await updateLines(lines);
-  // };
-
   return {
     query,
     finalise: { finalise, isFinalising, finaliseError },

--- a/client/packages/requisitions/src/RnRForms/api/hooks/useRnRFormContext.ts
+++ b/client/packages/requisitions/src/RnRForms/api/hooks/useRnRFormContext.ts
@@ -1,32 +1,41 @@
 import React from 'react';
 import { RnRFormLineFragment } from '../operations.generated';
-import { create, RecordWithId } from '@openmsupply-client/common';
+import {
+  create,
+  RecordWithId,
+  ViewportListRef,
+} from '@openmsupply-client/common';
 import keyBy from 'lodash/keyBy';
 import mapValues from 'lodash/mapValues';
 import { itemMatchesSearch } from '../../utils';
 
 type SetLine = (line: RecordWithId & Partial<RnRFormLineFragment>) => void;
 interface RnRFormContext {
+  listRef?: React.RefObject<ViewportListRef>;
   rnrFormId: string;
-  search: string;
+  foundIds: { [id: string]: boolean };
   baseLines: { [id: string]: RnRFormLineFragment };
+  baseLineIndexes: { [id: string]: number };
   draftLines: Record<
     string,
     RecordWithId & Partial<RnRFormLineFragment> & { isDirty?: boolean }
   >;
   draftLineIteration: Record<string, number>;
   setDraftLine: SetLine;
-  setSearch: (search: string) => void;
   clearAllDirtyLines: () => void;
-  getAllDirtyLines: () => RnRFormLineFragment[];
+  getAllDirtyLines: (ignoreError?: boolean) => RnRFormLineFragment[];
   setInitial: (rnrFormId: string, _: RnRFormLineFragment[]) => void;
-  hasUnconfirmedLines: () => boolean;
-  confirmUnconfirmedLines: () => void;
+  setListRef: (_: React.RefObject<ViewportListRef>) => void;
+  scrollToIndex: (_: number) => void;
+  search: (_: string) => number;
+  resetSearch: () => void;
 }
 
 export const useRnRFormContext = create<RnRFormContext>((set, get) => ({
-  search: '',
+  listRef: undefined,
+  foundIds: {},
   baseLines: {},
+  baseLineIndexes: {},
   draftLines: {},
   draftLineIteration: {},
   rnrFormId: '',
@@ -41,12 +50,6 @@ export const useRnRFormContext = create<RnRFormContext>((set, get) => ({
         ...state.draftLineIteration,
         [line.id]: (state.draftLineIteration[line.id] ?? 0) + 1,
       },
-    }));
-  },
-  setSearch: search => {
-    set(state => ({
-      ...state,
-      search,
     }));
   },
   clearAllDirtyLines: () =>
@@ -65,15 +68,26 @@ export const useRnRFormContext = create<RnRFormContext>((set, get) => ({
     set(state => ({
       ...state,
       baseLines: keyBy(baseLines, 'id'),
+      baseLineIndexes: mapValues(
+        keyBy(
+          baseLines.map(({ id }, index) => ({ id, index })),
+          'id'
+        ),
+        ({ index }) => index
+      ),
       rnrFormId,
       draftLines: {},
       draftLineIteration: {},
     }));
   },
-  getAllDirtyLines: () => {
+  getAllDirtyLines: (ignoreError = true) => {
     const { baseLines, draftLines } = get();
     return Object.values(draftLines).flatMap(draftLine => {
-      if (!draftLine.isDirty) return [];
+      if (
+        !draftLine.isDirty ||
+        (ignoreError && (draftLine?.finalBalance || 0) < 0)
+      )
+        return [];
       const baseLine = baseLines[draftLine.id];
       if (!baseLine) return [];
 
@@ -91,29 +105,30 @@ export const useRnRFormContext = create<RnRFormContext>((set, get) => ({
       return baseLine.confirmed;
     });
   },
-  confirmUnconfirmedLines: () => {
-    const { baseLines, draftLines } = get();
-    const toBeConfirmed = Object.values(baseLines).flatMap(baseLine => {
-      const draftLine = draftLines[baseLine.id] || { id: baseLine.id };
-      const line = { ...baseLine, ...draftLine };
-      if (!line.confirmed)
-        return [{ ...draftLine, confirmed: true, isDirty: true }];
+  setListRef: listRef => set(state => ({ ...state, listRef })),
+  scrollToIndex: index =>
+    get().listRef?.current?.scrollToIndex({
+      alignToTop: false,
+      // load 2 lines below the found line
+      index: index + 2,
+    }),
+  resetSearch: () => set(state => ({ ...state, foundIds: {} })),
+  search: term => {
+    let found = Object.values(get().baseLines).filter(l =>
+      itemMatchesSearch(term, l.item)
+    );
+    let first = found[0];
+    if (!first) {
+      set(state => ({ ...state, foundIds: {} }));
+      return -1;
+    }
 
-      return [];
-    });
-
-    const toBeConfirmedById = keyBy(toBeConfirmed, 'id');
     set(state => ({
       ...state,
-      draftLines: { ...state.draftLines, ...toBeConfirmedById },
-      draftLineIteration: {
-        ...state.draftLineIteration,
-        ...mapValues(
-          toBeConfirmedById,
-          ({ id }) => (state.draftLineIteration[id] || 0) + 1
-        ),
-      },
+      foundIds: mapValues(keyBy(found, 'id'), () => true),
     }));
+
+    return get().baseLineIndexes[first.id] || -1;
   },
 }));
 
@@ -135,15 +150,23 @@ export const useRnRDraft = (id: string) => {
   };
 };
 
-// export function useShallow<S, U>(selector: (state: S) => U): (state: S) => U {
-//   const prev = React.useRef<U | undefined>(undefined);
-//   return state => {
-//     const next = selector(state);
-//     return shallow(prev.current, next)
-//       ? (prev.current as U)
-//       : (prev.current = next);
-//   };
-// }
+export function oneTime<S, U>(selector: (state: S) => U): (state: S) => U {
+  const once = React.useRef<U | undefined>(undefined);
+  return state => {
+    const next = selector(state);
+    return !!once.current ? (once.current as U) : (once.current = next);
+  };
+}
+
+export const useErrorLineIndex = (state: RnRFormContext) => {
+  const firstErrorLine = Object.values(state.draftLines).find(
+    draftLine => (draftLine?.finalBalance || 0) < 0
+  );
+
+  console.log({ firstErrorLine });
+  if (!firstErrorLine) return -1;
+  return state.baseLineIndexes[firstErrorLine.id] || -1;
+};
 
 export const useCachedRnRDraftLine = (id: string) => {
   const prevIteration = React.useRef(-1);
@@ -155,7 +178,7 @@ export const useCachedRnRDraftLine = (id: string) => {
       }
     | undefined
   >(undefined);
-
+  console.log('here');
   return (state: RnRFormContext) => {
     const previousIteration = prevIteration.current;
     prevIteration.current = state.draftLineIteration[id] ?? 0;
@@ -165,8 +188,7 @@ export const useCachedRnRDraftLine = (id: string) => {
 
     const line = { ...baseLine, ...(state.draftLines[id] || {}) };
 
-    const highlight =
-      !!state.search && itemMatchesSearch(state.search, line.item);
+    const highlight = state.foundIds[id] || false;
 
     const shouldUpdate =
       previousIteration !== (state.draftLineIteration[id] ?? 0) ||

--- a/client/packages/requisitions/src/RnRForms/api/hooks/useRnRFormContext.ts
+++ b/client/packages/requisitions/src/RnRForms/api/hooks/useRnRFormContext.ts
@@ -163,7 +163,6 @@ export const useErrorLineIndex = (state: RnRFormContext) => {
     draftLine => (draftLine?.finalBalance || 0) < 0
   );
 
-  console.log({ firstErrorLine });
   if (!firstErrorLine) return -1;
   return state.baseLineIndexes[firstErrorLine.id] || -1;
 };
@@ -178,7 +177,7 @@ export const useCachedRnRDraftLine = (id: string) => {
       }
     | undefined
   >(undefined);
-  console.log('here');
+
   return (state: RnRFormContext) => {
     const previousIteration = prevIteration.current;
     prevIteration.current = state.draftLineIteration[id] ?? 0;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7608

Carry over issue: https://github.com/msupply-foundation/open-msupply/issues/7635

# 👩🏻‍💻 What does this PR do?

* Remove confirm column
* Remove strength column
* Since confirm column is removed, error needs to be shown somehow, when finalised, there is an indication that there is an error and we navigate to that line
* Search changed slightly, for performance, and since we need to scroll to the list in other areas
* We now save only the lines that have changed and don't have error (there is a carry over for error handling, and other things in this issue)

## 💌 Any notes for the reviewer?

# 🧪 Testing

Confirm should not exist in RnR form, strength should not exist in RnR form. When there are errors you should be taken to the error when finalising.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

