### PR TITLE
Fix french translations not refreshing

### DIFF
--- a/client/packages/common/src/intl/context/IntlContext.tsx
+++ b/client/packages/common/src/intl/context/IntlContext.tsx
@@ -45,16 +45,16 @@ export function initialiseI18n({
         ],
         backendOptions: [
           {
-            /* options for primary backend */
+            /* options for primary backend (local storage) */
             expirationTime,
-            defaultVersion: 'v0.1',
-            versions: {
-              en: languageVersion,
-            },
+            defaultVersion: languageVersion,
           },
           {
-            /* options for secondary backend */
+            /* options for secondary backend (http api request) */
             loadPath,
+            queryStringParams: {
+              v: languageVersion,
+            },
           },
         ],
       },


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7515 (hopefully)

# 👩🏻‍💻 What does this PR do?

Our translation cache was set to update when we publish a new version, but there was a catch.
It was only doing it for English. If someone had already cached their french version the update might not apply until the cache is cleared or they wait 7 days!

## 💌 Any notes for the reviewer?

I've also added the language version to they query string, which should help with caching on the backend if we want to turn that on too for remote clients (which I think might be a good idea)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Install vs 2.6.X on your APK
- [ ] Switch your language to French
- [ ] Open a prescription and check that the quanity tranlsations work correctly
![image](https://github.com/user-attachments/assets/e47c993b-c366-4419-bbff-52af223437bc)
- [ ] Now install this version
- [ ] Check that the french translations are still showing correctly, the format might have changed slightly.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [X] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

