### PR TITLE
7363 RnR From demo related, search by starts with make adjustment numeric input

### DIFF
--- a/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
@@ -175,7 +175,7 @@ export const RnRFormLine = ({
         value={line.adjustments}
         onChange={val => updateDraft({ adjustments: val })}
         textColor={textColor}
-        allowNegative
+        // allowNegative
         disabled={disabled}
       />
       <RnRNumberCell
@@ -251,10 +251,14 @@ export const RnRFormLine = ({
           sx={{ width: '200px', color: textColor }}
           slotProps={{
             input: {
+              tabIndex: -1,
               sx: {
                 backgroundColor: theme.palette.background.default,
                 '& .MuiInput-input': { color: textColor },
               },
+            },
+            htmlInput: {
+              tabIndex: -1,
             },
           }}
           onKeyDown={e => {

--- a/client/packages/requisitions/src/RnRForms/DetailView/Search.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/Search.tsx
@@ -29,7 +29,7 @@ export const Search = () => {
   const onSearch = (value: string) => {
     setInput(value);
     // Only search when 3+ characters are entered
-    if (value.length > 2) {
+    if (value.length > 0) {
       let found = search(value);
 
       found != -1 && scrollToIndex(found);

--- a/client/packages/requisitions/src/RnRForms/api/hooks/useRnRFormContext.ts
+++ b/client/packages/requisitions/src/RnRForms/api/hooks/useRnRFormContext.ts
@@ -125,7 +125,7 @@ export const useRnRFormContext = create<RnRFormContext>((set, get) => ({
         return false;
       }
     });
-    let first = found[0];
+    const first = found[0];
     if (!first) {
       set(state => ({ ...state, foundIds: {} }));
       return -1;

--- a/client/packages/requisitions/src/RnRForms/api/hooks/useRnRFormContext.ts
+++ b/client/packages/requisitions/src/RnRForms/api/hooks/useRnRFormContext.ts
@@ -114,9 +114,17 @@ export const useRnRFormContext = create<RnRFormContext>((set, get) => ({
     }),
   resetSearch: () => set(state => ({ ...state, foundIds: {} })),
   search: term => {
-    let found = Object.values(get().baseLines).filter(l =>
-      itemMatchesSearch(term, l.item)
-    );
+    let numberOfMatches = 0;
+    let found = Object.values(get().baseLines).filter(l => {
+      if (numberOfMatches > 10) return false;
+
+      if (itemMatchesSearch(term, l.item)) {
+        numberOfMatches++;
+        return true;
+      } else {
+        return false;
+      }
+    });
     let first = found[0];
     if (!first) {
       set(state => ({ ...state, foundIds: {} }));

--- a/client/packages/requisitions/src/RnRForms/utils.ts
+++ b/client/packages/requisitions/src/RnRForms/utils.ts
@@ -29,7 +29,7 @@ export const itemMatchesSearch = (
   // Use lowerCase to make the search case-insensitive
   const lowerCaseSearch = search.toLowerCase();
   return (
-    item.name.toLowerCase().includes(lowerCaseSearch) ||
-    item.code.toLowerCase().includes(lowerCaseSearch)
+    item.name.toLowerCase().startsWith(lowerCaseSearch) ||
+    item.code.toLowerCase().startsWith(lowerCaseSearch)
   );
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7636 

# 👩🏻‍💻 What does this PR do?

* Do starts with for search (restrict to max 10 found lines for highlighting)
* Make adjustments numeric inputs  (see issue)

## 💌 Any notes for the reviewer?

# 🧪 Testing

RnR form search should be by 'starts with' of item code or name, adjustments input is numeric, resulting with easy skip/edit lines

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

