### PR TITLE
7606 add doses per unit & vvm type to central server UI

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1259,6 +1259,7 @@
   "label.volume-per-outer-pack": "Volume per outer pack",
   "label.volume-per-pack": "Volume per pack",
   "label.volume-per-unit": "Volume per unit (L)",
+  "label.vvm-type": "VVM Type",
   "label.ward": "Ward",
   "label.warning-message": "Warning",
   "label.warranty-end-date": "Warranty end",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -256,6 +256,7 @@
   "error.date_maxDate": "Date value is too large",
   "error.date_minDate": "Date value is too low",
   "error.dose-ages-out-of-order": "Each dose needs a higher minimum age than the previous dose",
+  "error.dose-configuration-not-allowed": "Cannot set doses for this item because it is not a vaccine.",
   "error.dose-max-lower-than-min": "Dose {{doseIndex}} must have a higher maximum age than minimum age",
   "error.duplicate-asset-number": "duplicate asset number in csv",
   "error.duplicate-item-variant-name": "Item variant with the same name already exists for this item",

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -985,11 +985,6 @@ export type CannotChangeStatusOfInvoiceOnHold = UpdateErrorInterface &
     description: Scalars['String']['output'];
   };
 
-export type DoseConfigurationNotAllowed = UpsertItemVariantErrorInterface & {
-  __typename: 'DoseConfigurationNotAllowed';
-  description: Scalars['String']['output'];
-};
-
 export type CannotDeleteInvoiceWithLines = DeleteCustomerReturnErrorInterface &
   DeleteErrorInterface &
   DeleteInboundShipmentErrorInterface &
@@ -2277,6 +2272,11 @@ export type DocumentSortInput = {
   desc?: InputMaybe<Scalars['Boolean']['input']>;
   /** Sort query result by `key` */
   key: DocumentSortFieldInput;
+};
+
+export type DoseConfigurationNotAllowed = UpsertItemVariantErrorInterface & {
+  __typename: 'DoseConfigurationNotAllowed';
+  description: Scalars['String']['output'];
 };
 
 export type EncounterConnector = {
@@ -4318,7 +4318,10 @@ export type ItemVariantNode = {
   coldStorageTypeId?: Maybe<Scalars['String']['output']>;
   dosesPerUnit: Scalars['Int']['output'];
   id: Scalars['String']['output'];
+  item?: Maybe<ItemNode>;
+  /** @deprecated From 2.8.0. Use item instead */
   itemId: Scalars['String']['output'];
+  /** @deprecated From 2.8.0. Use item instead */
   itemName: Scalars['String']['output'];
   manufacturer?: Maybe<NameNode>;
   manufacturerId?: Maybe<Scalars['String']['output']>;

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -985,6 +985,11 @@ export type CannotChangeStatusOfInvoiceOnHold = UpdateErrorInterface &
     description: Scalars['String']['output'];
   };
 
+export type DoseConfigurationNotAllowed = UpsertItemVariantErrorInterface & {
+  __typename: 'DoseConfigurationNotAllowed';
+  description: Scalars['String']['output'];
+};
+
 export type CannotDeleteInvoiceWithLines = DeleteCustomerReturnErrorInterface &
   DeleteErrorInterface &
   DeleteInboundShipmentErrorInterface &
@@ -4311,6 +4316,7 @@ export type ItemVariantNode = {
   bundlesWith: Array<BundledItemNode>;
   coldStorageType?: Maybe<ColdStorageTypeNode>;
   coldStorageTypeId?: Maybe<Scalars['String']['output']>;
+  dosesPerUnit: Scalars['Int']['output'];
   id: Scalars['String']['output'];
   itemId: Scalars['String']['output'];
   itemName: Scalars['String']['output'];
@@ -4318,6 +4324,7 @@ export type ItemVariantNode = {
   manufacturerId?: Maybe<Scalars['String']['output']>;
   name: Scalars['String']['output'];
   packagingVariants: Array<PackagingVariantNode>;
+  vvmType?: Maybe<Scalars['String']['output']>;
 };
 
 export type ItemVariantNodeManufacturerArgs = {
@@ -9587,12 +9594,14 @@ export type UpsertItemVariantErrorInterface = {
 };
 
 export type UpsertItemVariantInput = {
-  coldStorageTypeId?: InputMaybe<Scalars['String']['input']>;
+  coldStorageTypeId?: InputMaybe<NullableStringUpdate>;
+  dosesPerUnit: Scalars['Int']['input'];
   id: Scalars['String']['input'];
   itemId: Scalars['String']['input'];
-  manufacturerId?: InputMaybe<Scalars['String']['input']>;
+  manufacturerId?: InputMaybe<NullableStringUpdate>;
   name: Scalars['String']['input'];
   packagingVariants: Array<PackagingVariantInput>;
+  vvmType?: InputMaybe<NullableStringUpdate>;
 };
 
 export type UpsertLogLevelInput = {

--- a/client/packages/system/src/Item/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Item/DetailView/DetailView.tsx
@@ -104,9 +104,7 @@ export const ItemDetailView: FC = () => {
 
   isCentralServer &&
     tabs.push({
-      Component: (
-        <ItemVariantsTab itemId={data.id} itemVariants={data.variants} />
-      ),
+      Component: <ItemVariantsTab item={data} itemVariants={data.variants} />,
       value: t('label.variants'),
     });
 

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantModal.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantModal.tsx
@@ -147,7 +147,7 @@ const ItemVariantForm = ({
                 onChange={manufacturer =>
                   updateVariant({
                     manufacturer,
-                    manufacturerId: manufacturer?.id ?? '',
+                    manufacturerId: manufacturer?.id ?? null,
                   })
                 }
               />

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantModal.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantModal.tsx
@@ -154,34 +154,36 @@ const ItemVariantForm = ({
             </Box>
           }
         />
-        <InputWithLabelRow
-          label={t('label.doses-per-unit')}
-          labelWidth="200"
-          Input={
-            <NumericTextInput
-              fullWidth
-              disabled={!variant.item?.isVaccine}
-              value={variant.dosesPerUnit}
-              onChange={dosesPerUnit => {
-                updateVariant({ dosesPerUnit });
-              }}
+        {variant.item?.isVaccine && (
+          <>
+            <InputWithLabelRow
+              label={t('label.doses-per-unit')}
+              labelWidth="200"
+              Input={
+                <NumericTextInput
+                  fullWidth
+                  value={variant.dosesPerUnit}
+                  onChange={dosesPerUnit => {
+                    updateVariant({ dosesPerUnit });
+                  }}
+                />
+              }
             />
-          }
-        />
-        <InputWithLabelRow
-          label={t('label.vvm-type')}
-          labelWidth="200"
-          Input={
-            <BasicTextInput
-              disabled={!variant.item?.isVaccine}
-              value={variant.vvmType}
-              onChange={event => {
-                updateVariant({ vvmType: event.target.value });
-              }}
-              fullWidth
+            <InputWithLabelRow
+              label={t('label.vvm-type')}
+              labelWidth="200"
+              Input={
+                <BasicTextInput
+                  value={variant.vvmType}
+                  onChange={event => {
+                    updateVariant({ vvmType: event.target.value });
+                  }}
+                  fullWidth
+                />
+              }
             />
-          }
-        />
+          </>
+        )}
       </Box>
       <Box flex={1}>
         <Typography fontWeight="bold">{t('title.packaging')}</Typography>

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantModal.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantModal.tsx
@@ -14,6 +14,7 @@ import {
 } from '@openmsupply-client/common';
 import { ItemPackagingVariantsTable } from './ItemPackagingVariantsTable';
 import {
+  ItemRowFragment,
   ItemVariantFragment,
   PackagingVariantFragment,
   useItemVariant,
@@ -22,11 +23,11 @@ import { ManufacturerSearchInput } from '@openmsupply-client/system';
 import { ColdStorageTypeInput } from '../../../Components/ColdStorageTypeInput';
 
 export const ItemVariantModal = ({
-  itemId,
+  item,
   variant,
   onClose,
 }: {
-  itemId: string;
+  item: ItemRowFragment;
   variant: ItemVariantFragment | null;
   onClose: () => void;
 }) => {
@@ -36,7 +37,7 @@ export const ItemVariantModal = ({
 
   const { draft, isComplete, updateDraft, updatePackagingVariant, save } =
     useItemVariant({
-      itemId,
+      item,
       variant,
     });
 
@@ -125,12 +126,12 @@ const ItemVariantForm = ({
             <Box width="100%">
               <ColdStorageTypeInput
                 value={variant.coldStorageType ?? null}
-                onChange={coldStorageType =>
+                onChange={coldStorageType => {
                   updateVariant({
                     coldStorageType,
-                    coldStorageTypeId: coldStorageType?.id ?? '',
-                  })
-                }
+                    coldStorageTypeId: coldStorageType?.id ?? null,
+                  });
+                }}
               />
             </Box>
           }

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantModal.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantModal.tsx
@@ -11,6 +11,7 @@ import {
   QueryParamsProvider,
   createQueryParamsStore,
   useNotification,
+  NumericTextInput,
 } from '@openmsupply-client/common';
 import { ItemPackagingVariantsTable } from './ItemPackagingVariantsTable';
 import {
@@ -151,6 +152,34 @@ const ItemVariantForm = ({
                 }
               />
             </Box>
+          }
+        />
+        <InputWithLabelRow
+          label={t('label.doses-per-unit')}
+          labelWidth="200"
+          Input={
+            <NumericTextInput
+              fullWidth
+              disabled={!variant.item?.isVaccine}
+              value={variant.dosesPerUnit}
+              onChange={dosesPerUnit => {
+                updateVariant({ dosesPerUnit });
+              }}
+            />
+          }
+        />
+        <InputWithLabelRow
+          label={t('label.vvm-type')}
+          labelWidth="200"
+          Input={
+            <BasicTextInput
+              disabled={!variant.item?.isVaccine}
+              value={variant.vvmType}
+              onChange={event => {
+                updateVariant({ vvmType: event.target.value });
+              }}
+              fullWidth
+            />
           }
         />
       </Box>

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantsTab.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantsTab.tsx
@@ -7,6 +7,7 @@ import {
   FlatButton,
   InputWithLabelRow,
   NothingHere,
+  NumericTextInput,
   Typography,
 } from '@common/components';
 import {
@@ -89,7 +90,7 @@ const ItemVariant = ({
         minTemperature: variant.coldStorageType.minTemperature,
         maxTemperature: variant.coldStorageType.maxTemperature,
       })
-    : null;
+    : '';
 
   return (
     <Box maxWidth="1000px" margin="25px auto" paddingBottom={6}>
@@ -140,6 +141,28 @@ const ItemVariant = ({
             Input={
               <BasicTextInput
                 value={variant.manufacturer?.name ?? ''}
+                disabled
+                fullWidth
+              />
+            }
+          />
+          <InputWithLabelRow
+            label={t('label.doses-per-unit')}
+            labelWidth="200"
+            Input={
+              <NumericTextInput
+                value={variant.dosesPerUnit}
+                disabled
+                fullWidth
+              />
+            }
+          />
+          <InputWithLabelRow
+            label={t('label.vvm-type')}
+            labelWidth="200"
+            Input={
+              <BasicTextInput
+                value={variant.vvmType ?? ''}
                 disabled
                 fullWidth
               />

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantsTab.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantsTab.tsx
@@ -146,28 +146,32 @@ const ItemVariant = ({
               />
             }
           />
-          <InputWithLabelRow
-            label={t('label.doses-per-unit')}
-            labelWidth="200"
-            Input={
-              <NumericTextInput
-                value={variant.dosesPerUnit}
-                disabled
-                fullWidth
+          {variant.item?.isVaccine && (
+            <>
+              <InputWithLabelRow
+                label={t('label.doses-per-unit')}
+                labelWidth="200"
+                Input={
+                  <NumericTextInput
+                    value={variant.dosesPerUnit}
+                    disabled
+                    fullWidth
+                  />
+                }
               />
-            }
-          />
-          <InputWithLabelRow
-            label={t('label.vvm-type')}
-            labelWidth="200"
-            Input={
-              <BasicTextInput
-                value={variant.vvmType ?? ''}
-                disabled
-                fullWidth
+              <InputWithLabelRow
+                label={t('label.vvm-type')}
+                labelWidth="200"
+                Input={
+                  <BasicTextInput
+                    value={variant.vvmType ?? ''}
+                    disabled
+                    fullWidth
+                  />
+                }
               />
-            }
-          />
+            </>
+          )}
         </Box>
         <Box flex={1}>
           <Typography fontWeight="bold">{t('title.packaging')}</Typography>

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantsTab.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantsTab.tsx
@@ -18,15 +18,19 @@ import {
   useEditModal,
 } from '@openmsupply-client/common';
 import { ItemPackagingVariantsTable } from './ItemPackagingVariantsTable';
-import { ItemVariantFragment, useDeleteItemVariant } from '../../../api';
+import {
+  ItemRowFragment,
+  ItemVariantFragment,
+  useDeleteItemVariant,
+} from '../../../api';
 import { ItemVariantModal } from './ItemVariantModal';
 import { BundledItemVariants } from './BundledItemVariants';
 
 export const ItemVariantsTab = ({
-  itemId,
+  item,
   itemVariants,
 }: {
-  itemId: string;
+  item: ItemRowFragment;
   itemVariants: ItemVariantFragment[];
 }) => {
   const t = useTranslation();
@@ -37,7 +41,7 @@ export const ItemVariantsTab = ({
   return (
     <>
       {isOpen && (
-        <ItemVariantModal onClose={onClose} itemId={itemId} variant={entity} />
+        <ItemVariantModal onClose={onClose} item={item} variant={entity} />
       )}
       <AppBarButtonsPortal>
         <ButtonWithIcon
@@ -58,7 +62,7 @@ export const ItemVariantsTab = ({
               key={v.id}
               variant={v}
               onOpen={onOpen}
-              itemId={itemId}
+              itemId={item.id}
             />
           ))
         )}

--- a/client/packages/system/src/Item/api/hooks/useItemVariant/useItemVariant.ts
+++ b/client/packages/system/src/Item/api/hooks/useItemVariant/useItemVariant.ts
@@ -57,11 +57,8 @@ export function useItemVariant({
       item: {
         __typename: 'ItemNode',
         id: item.id,
-        code: item.code,
-        unitName: item.unitName,
         name: item.name,
         isVaccine: item.isVaccine,
-        doses: item.doses,
       },
       bundledItemVariants: [],
       bundlesWith: [],

--- a/client/packages/system/src/Item/api/hooks/useItemVariant/useItemVariant.ts
+++ b/client/packages/system/src/Item/api/hooks/useItemVariant/useItemVariant.ts
@@ -7,6 +7,7 @@ import {
   useTranslation,
 } from '@openmsupply-client/common';
 import {
+  ItemRowFragment,
   ItemVariantFragment,
   PackagingVariantFragment,
 } from '../../operations.generated';
@@ -14,15 +15,15 @@ import { useItemApi, useItemGraphQL } from '../useItemApi';
 import { ITEM_VARIANTS } from '../../keys';
 
 export function useItemVariant({
-  itemId,
+  item,
   variant,
 }: {
-  itemId: string;
+  item: ItemRowFragment;
   variant: ItemVariantFragment | null;
 }) {
   const t = useTranslation();
   const { mutateAsync } = useUpsert({
-    itemId,
+    itemId: item.id,
   });
 
   const [draft, setDraft] = useState<ItemVariantFragment>(
@@ -30,7 +31,7 @@ export function useItemVariant({
       __typename: 'ItemVariantNode',
       id: FnUtils.generateUUID(),
       name: '',
-      itemId,
+      itemId: item.id,
       manufacturerId: null,
       coldStorageTypeId: null,
       packagingVariants: [
@@ -53,6 +54,15 @@ export function useItemVariant({
           name: t('label.tertiary'),
         },
       ],
+      item: {
+        __typename: 'ItemNode',
+        id: item.id,
+        code: item.code,
+        unitName: item.unitName,
+        name: item.name,
+        isVaccine: item.isVaccine,
+        doses: item.doses,
+      },
       bundledItemVariants: [],
       bundlesWith: [],
       dosesPerUnit: 0,

--- a/client/packages/system/src/Item/api/hooks/useItemVariant/useItemVariant.ts
+++ b/client/packages/system/src/Item/api/hooks/useItemVariant/useItemVariant.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import {
   FnUtils,
   isEmpty,
+  setNullableInput,
   useMutation,
   useTranslation,
 } from '@openmsupply-client/common';
@@ -54,6 +55,8 @@ export function useItemVariant({
       ],
       bundledItemVariants: [],
       bundlesWith: [],
+      dosesPerUnit: 0,
+      vvmType: null,
     }
   );
 
@@ -87,8 +90,8 @@ const useUpsert = ({ itemId }: { itemId: string }) => {
         id: input.id,
         itemId,
         name: input.name,
-        manufacturerId: input.manufacturerId,
-        coldStorageTypeId: input.coldStorageTypeId,
+        manufacturerId: setNullableInput('manufacturerId', input),
+        coldStorageTypeId: setNullableInput('coldStorageTypeId', input),
         packagingVariants: input.packagingVariants.map(pv => ({
           id: pv.id,
           name: pv.name,
@@ -96,6 +99,8 @@ const useUpsert = ({ itemId }: { itemId: string }) => {
           packSize: pv.packSize,
           volumePerUnit: pv.volumePerUnit,
         })),
+        dosesPerUnit: input.dosesPerUnit,
+        vvmType: setNullableInput('vvmType', input),
       },
     });
     // will be empty if there's a generic error, such as permission denied
@@ -107,6 +112,9 @@ const useUpsert = ({ itemId }: { itemId: string }) => {
       if (result.__typename === 'UpsertItemVariantError') {
         if (result.error.__typename === 'UniqueValueViolation') {
           throw new Error(t('error.duplicate-item-variant-name'));
+        }
+        if (result.error.__typename === 'DoseConfigurationNotAllowed') {
+          throw new Error(t('error.dose-configuration-not-allowed'));
         }
       }
     }

--- a/client/packages/system/src/Item/api/operations.generated.ts
+++ b/client/packages/system/src/Item/api/operations.generated.ts
@@ -233,6 +233,8 @@ export type ItemVariantFragment = {
   itemId: string;
   manufacturerId?: string | null;
   coldStorageTypeId?: string | null;
+  dosesPerUnit: number;
+  vvmType?: string | null;
   manufacturer?: {
     __typename: 'NameNode';
     code: string;
@@ -385,6 +387,8 @@ export type ItemFragment = {
     itemId: string;
     manufacturerId?: string | null;
     coldStorageTypeId?: string | null;
+    dosesPerUnit: number;
+    vvmType?: string | null;
     manufacturer?: {
       __typename: 'NameNode';
       code: string;
@@ -559,6 +563,8 @@ export type ItemsWithStockLinesQuery = {
         itemId: string;
         manufacturerId?: string | null;
         coldStorageTypeId?: string | null;
+        dosesPerUnit: number;
+        vvmType?: string | null;
         manufacturer?: {
           __typename: 'NameNode';
           code: string;
@@ -846,6 +852,8 @@ export type ItemByIdQuery = {
         itemId: string;
         manufacturerId?: string | null;
         coldStorageTypeId?: string | null;
+        dosesPerUnit: number;
+        vvmType?: string | null;
         manufacturer?: {
           __typename: 'NameNode';
           code: string;
@@ -1039,6 +1047,8 @@ export type UpsertItemVariantMutation = {
             itemId: string;
             manufacturerId?: string | null;
             coldStorageTypeId?: string | null;
+            dosesPerUnit: number;
+            vvmType?: string | null;
             manufacturer?: {
               __typename: 'NameNode';
               code: string;
@@ -1110,6 +1120,10 @@ export type UpsertItemVariantMutation = {
         | {
             __typename: 'UpsertItemVariantError';
             error:
+              | {
+                  __typename: 'DoseConfigurationNotAllowed';
+                  description: string;
+                }
               | { __typename: 'DatabaseError'; description: string }
               | { __typename: 'InternalError'; description: string }
               | {
@@ -1460,6 +1474,8 @@ export const ItemVariantFragmentDoc = gql`
     bundlesWith {
       ...BundledItem
     }
+    dosesPerUnit
+    vvmType
   }
   ${NameRowFragmentDoc}
   ${ColdStorageTypeFragmentDoc}
@@ -1766,6 +1782,9 @@ export const UpsertItemVariantDocument = gql`
               ... on UniqueValueViolation {
                 description
                 field
+              }
+              ... on DoseConfigurationNotAllowed {
+                description
               }
             }
           }

--- a/client/packages/system/src/Item/api/operations.generated.ts
+++ b/client/packages/system/src/Item/api/operations.generated.ts
@@ -235,6 +235,15 @@ export type ItemVariantFragment = {
   coldStorageTypeId?: string | null;
   dosesPerUnit: number;
   vvmType?: string | null;
+  item?: {
+    __typename: 'ItemNode';
+    id: string;
+    code: string;
+    name: string;
+    unitName?: string | null;
+    isVaccine: boolean;
+    doses: number;
+  } | null;
   manufacturer?: {
     __typename: 'NameNode';
     code: string;
@@ -389,6 +398,15 @@ export type ItemFragment = {
     coldStorageTypeId?: string | null;
     dosesPerUnit: number;
     vvmType?: string | null;
+    item?: {
+      __typename: 'ItemNode';
+      id: string;
+      code: string;
+      name: string;
+      unitName?: string | null;
+      isVaccine: boolean;
+      doses: number;
+    } | null;
     manufacturer?: {
       __typename: 'NameNode';
       code: string;
@@ -565,6 +583,15 @@ export type ItemsWithStockLinesQuery = {
         coldStorageTypeId?: string | null;
         dosesPerUnit: number;
         vvmType?: string | null;
+        item?: {
+          __typename: 'ItemNode';
+          id: string;
+          code: string;
+          name: string;
+          unitName?: string | null;
+          isVaccine: boolean;
+          doses: number;
+        } | null;
         manufacturer?: {
           __typename: 'NameNode';
           code: string;
@@ -854,6 +881,15 @@ export type ItemByIdQuery = {
         coldStorageTypeId?: string | null;
         dosesPerUnit: number;
         vvmType?: string | null;
+        item?: {
+          __typename: 'ItemNode';
+          id: string;
+          code: string;
+          name: string;
+          unitName?: string | null;
+          isVaccine: boolean;
+          doses: number;
+        } | null;
         manufacturer?: {
           __typename: 'NameNode';
           code: string;
@@ -1049,6 +1085,15 @@ export type UpsertItemVariantMutation = {
             coldStorageTypeId?: string | null;
             dosesPerUnit: number;
             vvmType?: string | null;
+            item?: {
+              __typename: 'ItemNode';
+              id: string;
+              code: string;
+              name: string;
+              unitName?: string | null;
+              isVaccine: boolean;
+              doses: number;
+            } | null;
             manufacturer?: {
               __typename: 'NameNode';
               code: string;
@@ -1120,11 +1165,11 @@ export type UpsertItemVariantMutation = {
         | {
             __typename: 'UpsertItemVariantError';
             error:
+              | { __typename: 'DatabaseError'; description: string }
               | {
                   __typename: 'DoseConfigurationNotAllowed';
                   description: string;
                 }
-              | { __typename: 'DatabaseError'; description: string }
               | { __typename: 'InternalError'; description: string }
               | {
                   __typename: 'UniqueValueViolation';
@@ -1457,6 +1502,9 @@ export const ItemVariantFragmentDoc = gql`
     id
     name
     itemId
+    item {
+      ...ItemRow
+    }
     manufacturerId
     manufacturer(storeId: $storeId) {
       ...NameRow
@@ -1477,6 +1525,7 @@ export const ItemVariantFragmentDoc = gql`
     dosesPerUnit
     vvmType
   }
+  ${ItemRowFragmentDoc}
   ${NameRowFragmentDoc}
   ${ColdStorageTypeFragmentDoc}
   ${PackagingVariantFragmentDoc}

--- a/client/packages/system/src/Item/api/operations.generated.ts
+++ b/client/packages/system/src/Item/api/operations.generated.ts
@@ -238,11 +238,8 @@ export type ItemVariantFragment = {
   item?: {
     __typename: 'ItemNode';
     id: string;
-    code: string;
     name: string;
-    unitName?: string | null;
     isVaccine: boolean;
-    doses: number;
   } | null;
   manufacturer?: {
     __typename: 'NameNode';
@@ -401,11 +398,8 @@ export type ItemFragment = {
     item?: {
       __typename: 'ItemNode';
       id: string;
-      code: string;
       name: string;
-      unitName?: string | null;
       isVaccine: boolean;
-      doses: number;
     } | null;
     manufacturer?: {
       __typename: 'NameNode';
@@ -586,11 +580,8 @@ export type ItemsWithStockLinesQuery = {
         item?: {
           __typename: 'ItemNode';
           id: string;
-          code: string;
           name: string;
-          unitName?: string | null;
           isVaccine: boolean;
-          doses: number;
         } | null;
         manufacturer?: {
           __typename: 'NameNode';
@@ -884,11 +875,8 @@ export type ItemByIdQuery = {
         item?: {
           __typename: 'ItemNode';
           id: string;
-          code: string;
           name: string;
-          unitName?: string | null;
           isVaccine: boolean;
-          doses: number;
         } | null;
         manufacturer?: {
           __typename: 'NameNode';
@@ -1088,11 +1076,8 @@ export type UpsertItemVariantMutation = {
             item?: {
               __typename: 'ItemNode';
               id: string;
-              code: string;
               name: string;
-              unitName?: string | null;
               isVaccine: boolean;
-              doses: number;
             } | null;
             manufacturer?: {
               __typename: 'NameNode';
@@ -1503,7 +1488,9 @@ export const ItemVariantFragmentDoc = gql`
     name
     itemId
     item {
-      ...ItemRow
+      id
+      name
+      isVaccine
     }
     manufacturerId
     manufacturer(storeId: $storeId) {
@@ -1525,7 +1512,6 @@ export const ItemVariantFragmentDoc = gql`
     dosesPerUnit
     vvmType
   }
-  ${ItemRowFragmentDoc}
   ${NameRowFragmentDoc}
   ${ColdStorageTypeFragmentDoc}
   ${PackagingVariantFragmentDoc}

--- a/client/packages/system/src/Item/api/operations.graphql
+++ b/client/packages/system/src/Item/api/operations.graphql
@@ -164,6 +164,8 @@ fragment ItemVariant on ItemVariantNode {
   bundlesWith {
     ...BundledItem
   }
+  dosesPerUnit
+  vvmType
 }
 
 fragment Item on ItemNode {
@@ -420,6 +422,9 @@ mutation upsertItemVariant($storeId: String!, $input: UpsertItemVariantInput!) {
             ... on UniqueValueViolation {
               description
               field
+            }
+            ... on DoseConfigurationNotAllowed {
+              description
             }
           }
         }

--- a/client/packages/system/src/Item/api/operations.graphql
+++ b/client/packages/system/src/Item/api/operations.graphql
@@ -148,7 +148,9 @@ fragment ItemVariant on ItemVariantNode {
   name
   itemId
   item {
-    ...ItemRow
+    id
+    name
+    isVaccine
   }
   manufacturerId
   manufacturer(storeId: $storeId) {

--- a/client/packages/system/src/Item/api/operations.graphql
+++ b/client/packages/system/src/Item/api/operations.graphql
@@ -147,6 +147,9 @@ fragment ItemVariant on ItemVariantNode {
   id
   name
   itemId
+  item {
+    ...ItemRow
+  }
   manufacturerId
   manufacturer(storeId: $storeId) {
     ...NameRow

--- a/client/packages/system/src/Name/Components/ManufacturerSearchInput/ManufacturerSearchInput.tsx
+++ b/client/packages/system/src/Name/Components/ManufacturerSearchInput/ManufacturerSearchInput.tsx
@@ -8,7 +8,7 @@ import { useName } from '../../api';
 import {
   basicFilterOptions,
   filterByNameAndCode,
-  NameSearchInputProps,
+  NullableNameSearchInputProps,
 } from '../../utils';
 import { getNameOptionRenderer } from '../NameOptionRenderer';
 
@@ -17,7 +17,7 @@ export const ManufacturerSearchInput = ({
   width = 250,
   value,
   disabled = false,
-}: NameSearchInputProps) => {
+}: NullableNameSearchInputProps) => {
   const { data, isLoading } = useName.document.manufacturers();
   const [buffer, setBuffer] = useBufferState(value);
   const t = useTranslation();
@@ -26,14 +26,13 @@ export const ManufacturerSearchInput = ({
   return (
     <Autocomplete
       disabled={disabled}
-      clearable={false}
       value={buffer && { ...buffer, label: buffer.name }}
       filterOptionConfig={basicFilterOptions}
       filterOptions={filterByNameAndCode}
       loading={isLoading}
       onChange={(_, name) => {
         setBuffer(name);
-        name && onChange(name);
+        onChange(name);
       }}
       options={data?.nodes ?? []}
       renderOption={NameOptionRenderer}

--- a/client/packages/system/src/Name/utils.ts
+++ b/client/packages/system/src/Name/utils.ts
@@ -27,6 +27,11 @@ export interface NameSearchInputProps {
   clearable?: boolean;
 }
 
+export interface NullableNameSearchInputProps
+  extends Omit<NameSearchInputProps, 'onChange'> {
+  onChange: (name: NameRowFragment | null) => void;
+}
+
 export const basicFilterOptions = {
   stringify: (name: NameRowFragment) => `${name.code} ${name.name}`,
   limit: 100,

--- a/server/graphql/core/src/simple_generic_errors.rs
+++ b/server/graphql/core/src/simple_generic_errors.rs
@@ -311,9 +311,9 @@ impl UniqueValueViolation {
     }
 }
 
-pub struct CannotConfigureDosesForNonVaccineItem;
+pub struct DoseConfigurationNotAllowed;
 #[Object]
-impl CannotConfigureDosesForNonVaccineItem {
+impl DoseConfigurationNotAllowed {
     pub async fn description(&self) -> &str {
         "Cannot configure doses for non-vaccine item"
     }

--- a/server/graphql/core/src/simple_generic_errors.rs
+++ b/server/graphql/core/src/simple_generic_errors.rs
@@ -311,6 +311,14 @@ impl UniqueValueViolation {
     }
 }
 
+pub struct CannotConfigureDosesForNonVaccineItem;
+#[Object]
+impl CannotConfigureDosesForNonVaccineItem {
+    pub async fn description(&self) -> &str {
+        "Cannot configure doses for non-vaccine item"
+    }
+}
+
 pub struct OtherPartyNotASupplier;
 #[Object]
 impl OtherPartyNotASupplier {

--- a/server/graphql/item_variant/src/mutations/upsert.rs
+++ b/server/graphql/item_variant/src/mutations/upsert.rs
@@ -1,6 +1,10 @@
 use async_graphql::*;
 use graphql_core::{
-    simple_generic_errors::{DatabaseError, InternalError, UniqueValueKey, UniqueValueViolation},
+    generic_inputs::NullableUpdateInput,
+    simple_generic_errors::{
+        CannotConfigureDosesForNonVaccineItem, DatabaseError, InternalError, UniqueValueKey,
+        UniqueValueViolation,
+    },
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
@@ -12,6 +16,7 @@ use service::{
         item_variant::{UpsertItemVariantError as ServiceError, UpsertItemVariantWithPackaging},
         packaging_variant::{UpsertPackagingVariant, UpsertPackagingVariantError},
     },
+    NullableUpdate,
 };
 
 #[derive(InputObject)]
@@ -19,11 +24,11 @@ pub struct UpsertItemVariantInput {
     pub id: String,
     pub item_id: String,
     pub name: String,
-    pub cold_storage_type_id: Option<String>,
-    pub manufacturer_id: Option<String>,
+    pub cold_storage_type_id: Option<NullableUpdateInput<String>>,
+    pub manufacturer_id: Option<NullableUpdateInput<String>>,
     pub packaging_variants: Vec<PackagingVariantInput>,
-    pub doses_per_unit: Option<i32>,
-    pub vvm_type: Option<String>,
+    pub doses_per_unit: i32,
+    pub vvm_type: Option<NullableUpdateInput<String>>,
 }
 
 #[derive(InputObject)]
@@ -49,8 +54,9 @@ pub enum UpsertItemVariantResponse {
 #[derive(Interface)]
 #[graphql(field(name = "description", ty = "String"))]
 pub enum UpsertItemVariantErrorInterface {
-    InternalError(InternalError),
     DuplicateName(UniqueValueViolation),
+    CannotConfigureDosesForNonVaccineItem(CannotConfigureDosesForNonVaccineItem),
+    InternalError(InternalError),
     DatabaseError(DatabaseError),
 }
 
@@ -93,14 +99,20 @@ impl UpsertItemVariantInput {
             id: id.clone(),
             item_id,
             name,
-            cold_storage_type_id,
-            manufacturer_id,
+            cold_storage_type_id: cold_storage_type_id.map(|cold_storage_type_id| NullableUpdate {
+                value: cold_storage_type_id.value,
+            }),
+            manufacturer_id: manufacturer_id.map(|manufacturer_id| NullableUpdate {
+                value: manufacturer_id.value,
+            }),
             packaging_variants: packaging_variants
                 .into_iter()
                 .map(|v| PackagingVariantInput::to_domain(v, id.clone()))
                 .collect(),
             doses_per_unit,
-            vvm_type,
+            vvm_type: vvm_type.map(|vvm_type| NullableUpdate {
+                value: vvm_type.value,
+            }),
         }
     }
 }
@@ -146,6 +158,13 @@ fn map_error(error: ServiceError) -> Result<UpsertItemVariantErrorInterface> {
             return Ok(UpsertItemVariantErrorInterface::DuplicateName(
                 UniqueValueViolation(UniqueValueKey::Name),
             ))
+        }
+        ServiceError::CannotConfigureDosesForNonVaccineItem => {
+            return Ok(
+                UpsertItemVariantErrorInterface::CannotConfigureDosesForNonVaccineItem(
+                    CannotConfigureDosesForNonVaccineItem,
+                ),
+            )
         }
         // Generic errors
         ServiceError::CreatedRecordNotFound => InternalError(formatted_error),

--- a/server/graphql/item_variant/src/mutations/upsert.rs
+++ b/server/graphql/item_variant/src/mutations/upsert.rs
@@ -2,7 +2,7 @@ use async_graphql::*;
 use graphql_core::{
     generic_inputs::NullableUpdateInput,
     simple_generic_errors::{
-        CannotConfigureDosesForNonVaccineItem, DatabaseError, InternalError, UniqueValueKey,
+        DatabaseError, DoseConfigurationNotAllowed, InternalError, UniqueValueKey,
         UniqueValueViolation,
     },
     standard_graphql_error::{validate_auth, StandardGraphqlError},
@@ -55,7 +55,7 @@ pub enum UpsertItemVariantResponse {
 #[graphql(field(name = "description", ty = "String"))]
 pub enum UpsertItemVariantErrorInterface {
     DuplicateName(UniqueValueViolation),
-    CannotConfigureDosesForNonVaccineItem(CannotConfigureDosesForNonVaccineItem),
+    DoseConfigurationNotAllowed(DoseConfigurationNotAllowed),
     InternalError(InternalError),
     DatabaseError(DatabaseError),
 }
@@ -159,10 +159,10 @@ fn map_error(error: ServiceError) -> Result<UpsertItemVariantErrorInterface> {
                 UniqueValueViolation(UniqueValueKey::Name),
             ))
         }
-        ServiceError::CannotConfigureDosesForNonVaccineItem => {
+        ServiceError::DoseConfigurationNotAllowed => {
             return Ok(
-                UpsertItemVariantErrorInterface::CannotConfigureDosesForNonVaccineItem(
-                    CannotConfigureDosesForNonVaccineItem,
+                UpsertItemVariantErrorInterface::DoseConfigurationNotAllowed(
+                    DoseConfigurationNotAllowed,
                 ),
             )
         }

--- a/server/graphql/types/src/types/item_variant.rs
+++ b/server/graphql/types/src/types/item_variant.rs
@@ -30,11 +30,9 @@ impl ItemVariantNode {
         &self.item_variant.name
     }
 
-    #[graphql(deprecation = "From 2.8.0. Use item instead")]
     pub async fn item_id(&self) -> &String {
         &self.item.id
     }
-    #[graphql(deprecation = "From 2.8.0. Use item instead")]
     pub async fn item_name(&self) -> &String {
         &self.item.name
     }

--- a/server/graphql/types/src/types/item_variant.rs
+++ b/server/graphql/types/src/types/item_variant.rs
@@ -110,6 +110,14 @@ impl ItemVariantNode {
 
         Ok(BundledItemNode::from_vec(result))
     }
+
+    pub async fn doses_per_unit(&self) -> i32 {
+        self.item_variant.doses_per_unit
+    }
+
+    pub async fn vvm_type(&self) -> &Option<String> {
+        &self.item_variant.vvm_type
+    }
 }
 
 impl ItemVariantNode {

--- a/server/graphql/types/src/types/item_variant.rs
+++ b/server/graphql/types/src/types/item_variant.rs
@@ -1,9 +1,9 @@
-use super::{BundledItemNode, ColdStorageTypeNode, NameNode};
+use super::{BundledItemNode, ColdStorageTypeNode, ItemNode, NameNode};
 use async_graphql::*;
 use dataloader::DataLoader;
 use graphql_core::loader::{
     BundledItemByBundledItemVariantIdLoader, BundledItemByPrincipalItemVariantIdLoader,
-    ColdStorageTypeLoader, NameByIdLoader, NameByIdLoaderInput,
+    ColdStorageTypeLoader, ItemLoader, NameByIdLoader, NameByIdLoaderInput,
 };
 use graphql_core::{loader::PackagingVariantRowLoader, ContextExt};
 use repository::item_variant::item_variant::ItemVariant;
@@ -30,12 +30,20 @@ impl ItemVariantNode {
         &self.item_variant.name
     }
 
+    #[graphql(deprecation = "From 2.8.0. Use item instead")]
     pub async fn item_id(&self) -> &String {
         &self.item.id
     }
-
+    #[graphql(deprecation = "From 2.8.0. Use item instead")]
     pub async fn item_name(&self) -> &String {
         &self.item.name
+    }
+
+    pub async fn item(&self, ctx: &Context<'_>) -> Result<Option<ItemNode>> {
+        let loader = ctx.get_loader::<DataLoader<ItemLoader>>();
+        let result = loader.load_one(self.item.id.clone()).await?;
+
+        Ok(result.map(ItemNode::from_domain))
     }
 
     pub async fn manufacturer_id(&self) -> &Option<String> {
@@ -58,7 +66,7 @@ impl ItemVariantNode {
         let loader = ctx.get_loader::<DataLoader<ColdStorageTypeLoader>>();
         let result = loader.load_one(cold_storage_type_id.clone()).await?;
 
-        Ok(result.map(|cold_storage_type| ColdStorageTypeNode::from_domain(cold_storage_type)))
+        Ok(result.map(ColdStorageTypeNode::from_domain))
     }
 
     pub async fn manufacturer(
@@ -76,7 +84,7 @@ impl ItemVariantNode {
             .load_one(NameByIdLoaderInput::new(&store_id, manufacturer_link_id))
             .await?;
 
-        Ok(result.map(|manufacturer| NameNode::from_domain(manufacturer)))
+        Ok(result.map(NameNode::from_domain))
     }
 
     pub async fn packaging_variants(&self, ctx: &Context<'_>) -> Result<Vec<PackagingVariantNode>> {

--- a/server/service/src/item/item_variant/test/mod.rs
+++ b/server/service/src/item/item_variant/test/mod.rs
@@ -12,6 +12,7 @@ mod query {
         DeleteItemVariant, UpsertItemVariantError, UpsertItemVariantWithPackaging,
     };
     use crate::service_provider::ServiceProvider;
+    use crate::NullableUpdate;
 
     #[actix_rt::test]
     async fn create_edit_delete_item_variant() {
@@ -241,7 +242,9 @@ mod query {
                 id: test_item_a_variant_id.to_string(),
                 item_id: mock_item_a().id,
                 name: "Variant 1".to_string(),
-                cold_storage_type_id: Some(uuid()),
+                cold_storage_type_id: Some(NullableUpdate {
+                    value: Some(uuid()),
+                }),
                 ..Default::default()
             },
         );

--- a/server/service/src/item/item_variant/upsert.rs
+++ b/server/service/src/item/item_variant/upsert.rs
@@ -25,7 +25,7 @@ pub enum UpsertItemVariantError {
     CantChangeItem,
     DuplicateName,
     ColdStorageTypeDoesNotExist,
-    CannotConfigureDosesForNonVaccineItem,
+    DoseConfigurationNotAllowed,
     PackagingVariantError(UpsertPackagingVariantError),
     DatabaseError(RepositoryError),
 }
@@ -179,7 +179,7 @@ fn validate(
     }
 
     if !item.is_vaccine && input.doses_per_unit > 0 {
-        return Err(UpsertItemVariantError::CannotConfigureDosesForNonVaccineItem);
+        return Err(UpsertItemVariantError::DoseConfigurationNotAllowed);
     }
 
     Ok(())


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7606

# 👩🏻‍💻 What does this PR do?
- Adds `doses_per_unit` and `vvm_type` to the `item_variant` table and sync.
- Allows these two columns to be upserted for vaccine items
- Update item variant UI to display these two columns for editing and viewing 
- Have also updated manufacturer and cold storage type to allow these inputs to be cleared

![Screenshot 2025-05-08 at 7 46 14 AM](https://github.com/user-attachments/assets/ad9ea5b2-a64a-4c78-8b05-37d1d023c4b7)
![Screenshot 2025-05-08 at 7 46 20 AM](https://github.com/user-attachments/assets/81d72ccc-08a0-4a48-a122-3304a6888145)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] (dev) Run tests
- [ ] If you have any existing variants, can try to update the doses_per_unit or vvm_type (note these two columns can only be updated for vaccine items)
- [ ] Go to `Item` -> `Item Variant`
- [ ] Click `Add Variant`
- [ ] Add variant with doses per unit and vvm type
- [ ] Click save
- [ ] Should save and show up in the tab
- [ ] For non-vaccine items these two inputs should be disabled
- [ ] Try to empty storage type and manufacturer 
- [ ] Should empty

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

