### PR TITLE
7663 show years for display age utils

### DIFF
--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -267,7 +267,7 @@ export const useFormatDateTime = () => {
     const { months, days } = DateUtils.ageInMonthsAndDays(dob ?? '');
 
     if (patientAge >= 1) {
-      return String(patientAge);
+      return `${t('label.age-years', {count: patientAge})}`;
     } else
       return `${months > 0 ? t('label.age-months-and', { count: months }) : ''}${t('label.age-days', { count: days })}`;
   };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7663 

# 👩🏻‍💻 What does this PR do?
Shows 'years' to age with label as opposed to just number.
Previously would only append 'month' or 'weeks' clarifier when age was less than 1.


<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Implements this change throughout the codebase where we use this function for consistency (not just in vaccine card.

Notably also makes this change in Patient Summary - but I think makes sense to have this here also.


<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to encounters and select an encounter
- [ ] See patient age shows with 'years' text (not just 'months' when the patient is less than 1 year)

# 📃 Documentation

- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

