### PR TITLE
Add Translation Context Split Request

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,7 @@ about: Create a report for a bug or to help us improve
 title: A brief clear title describing the bug from a user's perspective
 labels: needs triage, needs daily triage
 type: bug
-assignees: ""
+assignees: ''
 ---
 
 ## What went wrong? 😲

--- a/.github/ISSUE_TEMPLATE/translation-context-split-request.md
+++ b/.github/ISSUE_TEMPLATE/translation-context-split-request.md
@@ -1,0 +1,14 @@
+---
+name: Translation Context Split Request
+about: Some languages require different gendering, plurals depending on context
+title: Translation Text Split In `AREA HERE`
+labels: 'feature: translation'
+assignees: ''
+
+---
+
+## Translation Context Split Request
+
+<!-- Detail the text you want split including screenshots of the different areas that should have separate text -->
+
+<!-- State the different text that should be used in each context (bonus points explaining why)  -->


### PR DESCRIPTION
Adds a template for translators to use to raise requests to split up translation keys into more for different contexts, so that they may have different strings to accommodate gendering and pluralisation of things in different languages a bit better

Tangentially, we probably need a more advanced system for complicated plurals.