### PR TITLE
Change tooltip of numbercell so that the tooltip is  formatted the sa…

### DIFF
--- a/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberCell.tsx
@@ -27,7 +27,13 @@ export const NumberCell = <T extends RecordWithId>({
         padding: '4px 8px',
       }}
     >
-      <Tooltip title={value?.toString()}>
+      <Tooltip
+        title={
+          !!NumUtils.hasMoreThanTwoDp(value ?? 0)
+            ? `${displayValue}...`
+            : displayValue
+        }
+      >
         <Typography
           style={{
             overflow: 'hidden',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6941 

# 👩🏻‍💻 What does this PR do?

Changes the tooltip of NumberCell.tsx (**WHICH IS A COMMON COMPONENT**) so that the tooltip is rounded the same as the value in the cell.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

This changes a common component: NumberCell.tsx.

# 🧪 Testing

- [ ] Create an item that has total number of units and available number of units = something with more than 2 d.p
- [ ] Create a stocktake with that item in it.
- [ ] Once you've created the stocktake, exit the stocktake view and then go back in, click on the stocktake, and try to edit the item.
- [ ] Check that when you hover over the value in the column 'Snapshot Packs', you get a rounded value in the tooltip.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

