### PR TITLE
Fix GraphQL playground (Again!)

### DIFF
--- a/server/graphql/playground.html
+++ b/server/graphql/playground.html
@@ -20,7 +20,7 @@
     }
   </style>
 
-  <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+  <link rel="stylesheet" href="https://unpkg.com/graphiql@4.0.2/graphiql.min.css" />
   <link rel="stylesheet" href="https://unpkg.com/@graphiql/plugin-explorer/dist/style.css" />
 </head>
 
@@ -30,7 +30,7 @@
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
 
-  <script src="https://unpkg.com/graphiql/graphiql.min.js"></script>
+  <script src="https://unpkg.com/graphiql@4.0.2/graphiql.min.js"></script>
   <script src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js"></script>
 
   <script>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Lol, I said when I [fixed this last week](https://github.com/msupply-foundation/open-msupply/pull/7618):

> I've removed the version specifier completely -- I think it should be fine to always fetch the latest stable version. Is there any reason not to?

Well, they proved me wrong and went and broke it again with v4.0.3 -- now the Explorer panel doesn't scroll!

So I've just fixed the version to 4.0.2 for now -- I guess we should test each version before upgrading rather than assuming new releases are solid.