### PR TITLE
Vacuum sqlite database on shutdown on shutdown and after migration

### DIFF
--- a/server/android/src/android.rs
+++ b/server/android/src/android.rs
@@ -57,6 +57,7 @@ pub mod android {
                 database_path: None,
                 // See https://github.com/openmsupply/remote-server/issues/1076
                 init_sql: Some(format!("PRAGMA temp_store_directory = '{}';", cache_dir)),
+                sqlite_vacuum: Default::default(),
             },
             // sync settings need to be configured at runtime
             sync: None,

--- a/server/configuration/example.yaml
+++ b/server/configuration/example.yaml
@@ -29,6 +29,10 @@
 #   username: "postgres"
 #   password: "password"
 #   database_name: "omsupply-database"
+#   sqlite_vacuum:
+#     # on_startup: true
+#     # after_migration: true
+#     # on_shutdown: false
 # logging:
 ##   one of: All | Console | File
 #   mode: Console

--- a/server/repository/src/database_settings.rs
+++ b/server/repository/src/database_settings.rs
@@ -229,6 +229,7 @@ mod database_setting_test {
             database_name: "".to_string(),
             init_sql,
             database_path: None,
+            // These vacuums should only happen in server lib.rs, does not effect tests
             sqlite_vacuum: Default::default(),
         }
     }

--- a/server/repository/src/database_settings.rs
+++ b/server/repository/src/database_settings.rs
@@ -21,6 +21,32 @@ pub struct DatabaseSettings {
     pub database_path: Option<String>,
     /// SQL run once at startup. For example, to run pragma statements
     pub init_sql: Option<String>,
+    #[serde(default)]
+    pub sqlite_vacuum: SqliteVacuum,
+}
+
+#[derive(serde::Deserialize, Clone)]
+pub struct SqliteVacuum {
+    #[serde(default = "default_as_true")]
+    pub on_startup: bool,
+    #[serde(default = "default_as_true")]
+    pub after_migration: bool,
+    #[serde(default = "default_as_true")]
+    pub on_shutdown: bool,
+}
+
+fn default_as_true() -> bool {
+    true
+}
+
+impl Default for SqliteVacuum {
+    fn default() -> Self {
+        Self {
+            on_startup: true,
+            after_migration: true,
+            on_shutdown: false,
+        }
+    }
 }
 
 // feature postgres
@@ -203,6 +229,7 @@ mod database_setting_test {
             database_name: "".to_string(),
             init_sql,
             database_path: None,
+            sqlite_vacuum: Default::default(),
         }
     }
 

--- a/server/repository/src/database_settings.rs
+++ b/server/repository/src/database_settings.rs
@@ -31,7 +31,7 @@ pub struct SqliteVacuum {
     pub on_startup: bool,
     #[serde(default = "default_as_true")]
     pub after_migration: bool,
-    #[serde(default = "default_as_true")]
+    #[serde(default)]
     pub on_shutdown: bool,
 }
 

--- a/server/repository/src/db_diesel/storage_connection.rs
+++ b/server/repository/src/db_diesel/storage_connection.rs
@@ -234,7 +234,14 @@ impl StorageConnectionManager {
         }
 
         info!("{message} vacuum...");
-        self.execute("VACUUM").expect("Failed to vacuum");
+        match self.execute("VACUUM") {
+            Ok(_) => {
+                info!("VACUUM completed");
+            }
+            Err(e) => {
+                error!("VACUUM failed: {e}");
+            }
+        }
     }
 }
 

--- a/server/repository/src/migrations/mod.rs
+++ b/server/repository/src/migrations/mod.rs
@@ -162,7 +162,7 @@ pub fn migrate(
     // From v2.3 we drop all views and re-create them
     let min_version_for_dropping_views = v2_03_00::V2_03_00.version();
     let mut drop_view_has_run = false;
-    let mut migration_has_ran = false;
+    let mut migration_has_run = false;
 
     for migration in migrations {
         let migration_version = migration.version();
@@ -200,7 +200,7 @@ pub fn migrate(
                     version: migration_version.clone(),
                 })?;
             set_database_version(connection, &migration_version)?;
-            migration_has_ran = true;
+            migration_has_run = true;
         }
 
         // Run fragment migrations (can run on current version)
@@ -220,7 +220,7 @@ pub fn migrate(
 
                 migration_fragment_log_repo.insert(&migration, &fragment)?;
             }
-            migration_has_ran = true;
+            migration_has_run = true;
         }
     }
 
@@ -232,7 +232,7 @@ pub fn migrate(
     }
 
     set_database_version(connection, &to_version)?;
-    Ok((to_version, migration_has_ran))
+    Ok((to_version, migration_has_run))
 }
 
 fn get_database_version(connection: &StorageConnection) -> Version {

--- a/server/repository/src/test_db/postgres.rs
+++ b/server/repository/src/test_db/postgres.rs
@@ -24,6 +24,7 @@ pub fn get_test_db_settings(db_name: &str) -> DatabaseSettings {
         database_name: db_name.to_string(),
         init_sql: None,
         database_path: None,
+        sqlite_vacuum: Default::default(),
     }
 }
 

--- a/server/repository/src/test_db/sqlite.rs
+++ b/server/repository/src/test_db/sqlite.rs
@@ -35,6 +35,7 @@ fn get_test_db_settings_etc(db_name: &str, is_template: bool) -> DatabaseSetting
         },
         init_sql: None,
         database_path: None,
+        // These vacuums should only happen in server lib.rs, does not effect tests
         sqlite_vacuum: Default::default(),
     }
 }

--- a/server/repository/src/test_db/sqlite.rs
+++ b/server/repository/src/test_db/sqlite.rs
@@ -35,6 +35,7 @@ fn get_test_db_settings_etc(db_name: &str, is_template: bool) -> DatabaseSetting
         },
         init_sql: None,
         database_path: None,
+        sqlite_vacuum: Default::default(),
     }
 }
 

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -90,7 +90,7 @@ pub async fn start_server(
         connection_manager.execute(init_sql).unwrap();
     }
 
-    // ON STARTUP VACUUM]
+    // ON STARTUP VACUUM
     let sqlite_vacuum = &settings.database.sqlite_vacuum;
     connection_manager.sqlite_vacuum(SqliteVacuumAction::OnStartup, sqlite_vacuum);
 
@@ -105,7 +105,9 @@ pub async fn start_server(
     StandardReports::load_reports(&connection_manager.connection().unwrap(), false).unwrap();
 
     // AFTER MIGRATION VACUUM
-    connection_manager.sqlite_vacuum(SqliteVacuumAction::AfterMigration, sqlite_vacuum);
+    if (migration_has_ran) {
+        connection_manager.sqlite_vacuum(SqliteVacuumAction::AfterMigration, sqlite_vacuum);
+    }
 
     // INITIALISE CONTEXT
     info!("Initialising server context..");

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -96,7 +96,7 @@ pub async fn start_server(
 
     // MIGRATION
     info!("Run DB migrations...");
-    let (version, migration_has_ran) = migrate(&connection_manager.connection().unwrap(), None)
+    let (version, migration_has_run) = migrate(&connection_manager.connection().unwrap(), None)
         .context("Failed to run DB migrations")
         .unwrap();
     info!("Run DB migrations...done");
@@ -105,7 +105,7 @@ pub async fn start_server(
     StandardReports::load_reports(&connection_manager.connection().unwrap(), false).unwrap();
 
     // AFTER MIGRATION VACUUM
-    if (migration_has_ran) {
+    if migration_has_run {
         connection_manager.sqlite_vacuum(SqliteVacuumAction::AfterMigration, sqlite_vacuum);
     }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7682 
Fixes: #610 

# 👩🏻‍💻 What does this PR do?

Add sqlite database vacuuming on startup on shutdown and after migration.

Defaults to vacuuming on startup and after migration only, can manually set vacuum after shutdown

## 💌 Any notes for the reviewer?

Should there be a vacuum after large initialisation ?

# 🧪 Testing

Try a large initialisation, then re-start the app, make sure this doesn't take too long

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

