### PR TITLE
6238 Pack qty to show [multiple] in prescriptions

### DIFF
--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -16,7 +16,6 @@ import {
   usePreference,
   PreferenceKey,
   getDosesPerUnitColumn,
-  NumberCell,
   BasicCell,
 } from '@openmsupply-client/common';
 import { StockOutLineFragment } from '../../StockOut';

--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -9,7 +9,6 @@ import {
   ArrayUtils,
   useTranslation,
   useColumnUtils,
-  NumberCell,
   CurrencyCell,
   ColumnDescription,
   NumUtils,
@@ -275,46 +274,22 @@ export const usePrescriptionColumn = ({
   }
 
   columns.push(
-    [
-      'numberOfPacks',
-      {
-        Cell: NumberCell,
-        getSortValue: row => {
-          if ('lines' in row) {
-            const { lines } = row;
-            const packSize = ArrayUtils.ifTheSameElseDefault(
-              lines,
-              'packSize',
-              ''
-            );
-            if (packSize) {
-              return lines.reduce((acc, value) => acc + value.numberOfPacks, 0);
-            } else {
-              return '';
-            }
-          } else {
-            return row.numberOfPacks;
-          }
-        },
-        accessor: ({ rowData }) => {
-          if ('lines' in rowData) {
-            const { lines } = rowData;
-            const packSize = ArrayUtils.ifTheSameElseDefault(
-              lines,
-              'packSize',
-              ''
-            );
-            if (packSize) {
-              return lines.reduce((acc, value) => acc + value.numberOfPacks, 0);
-            } else {
-              return '';
-            }
-          } else {
-            return rowData.numberOfPacks;
-          }
-        },
-      },
-    ],
+    {
+      label: 'label.pack-quantity',
+      description: 'description.pack-quantity',
+      key: 'numberOfPacks',
+      align: ColumnAlign.Right,
+      getSortValue: row =>
+        getColumnPropertyAsString(row, [
+          { path: ['lines', 'numberOfPacks'] },
+          { path: ['numberOfPacks'], default: '' },
+        ]),
+      accessor: ({ rowData }) =>
+        getColumnProperty(rowData, [
+          { path: ['lines', 'numberOfPacks'] },
+          { path: ['numberOfPacks'] },
+        ]),
+    },
     {
       label: 'label.unit-price',
       key: 'sellPricePerUnit',

--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -16,6 +16,8 @@ import {
   usePreference,
   PreferenceKey,
   getDosesPerUnitColumn,
+  NumberCell,
+  BasicCell,
 } from '@openmsupply-client/common';
 import { StockOutLineFragment } from '../../StockOut';
 import { StockOutItem } from '../../types';
@@ -274,22 +276,46 @@ export const usePrescriptionColumn = ({
   }
 
   columns.push(
-    {
-      label: 'label.pack-quantity',
-      description: 'description.pack-quantity',
-      key: 'numberOfPacks',
-      align: ColumnAlign.Right,
-      getSortValue: row =>
-        getColumnPropertyAsString(row, [
-          { path: ['lines', 'numberOfPacks'] },
-          { path: ['numberOfPacks'], default: '' },
-        ]),
-      accessor: ({ rowData }) =>
-        getColumnProperty(rowData, [
-          { path: ['lines', 'numberOfPacks'] },
-          { path: ['numberOfPacks'] },
-        ]),
-    },
+    [
+      'numberOfPacks',
+      {
+        Cell: BasicCell,
+        getSortValue: row => {
+          if ('lines' in row) {
+            const { lines } = row;
+            const packSize = ArrayUtils.ifTheSameElseDefault(
+              lines,
+              'packSize',
+              ''
+            );
+            if (packSize) {
+              return lines.reduce((acc, value) => acc + value.numberOfPacks, 0);
+            } else {
+              return '';
+            }
+          } else {
+            return row.numberOfPacks;
+          }
+        },
+        accessor: ({ rowData }) => {
+          if ('lines' in rowData) {
+            const { lines } = rowData;
+            const packSize = ArrayUtils.ifTheSameElseDefault(
+              lines,
+              'packSize',
+              ''
+            );
+            if (packSize) {
+              return lines.reduce((acc, value) => acc + value.numberOfPacks, 0);
+            } else {
+              return t('multiple');
+            }
+          } else {
+            return rowData.numberOfPacks;
+          }
+        },
+      },
+    ],
     {
       label: 'label.unit-price',
       key: 'sellPricePerUnit',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6238 

# 👩🏻‍💻 What does this PR do?

- Refactor implementation of 'Pack Qty' column -> No longer uses ColumnDefinitionSetBuilder
  - This allows for string `[multiple]` to display in the 'Pack Qty' column when issuing from multiple batches

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

![Screenshot 2025-05-13 at 13 00 36](https://github.com/user-attachments/assets/ddff106e-0d2b-4a8a-9e3e-6da6d5c00b0f)

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have an item with multiple batches
- [ ] Go to Dispensary -> Prescriptions and create a new prescription
- [ ] Issue from multiple batches and save
- [ ] Close Prescription line edit view and go back to detail view
- [ ] See that for the line you have just issue that 'Pack Qty' has value `[multiple]`

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

