### PR TITLE
7692 add vvm status permission from legacy m supply

### DIFF
--- a/server/graphql/types/src/types/permissions.rs
+++ b/server/graphql/types/src/types/permissions.rs
@@ -59,6 +59,7 @@ pub enum UserPermission {
     AssetCatalogueItemMutate,
     NamePropertiesMutate,
     EditCentralData,
+    ViewAndEditVvmStatus,
 }
 
 #[Object]
@@ -150,6 +151,7 @@ impl UserPermission {
             PermissionType::AssetCatalogueItemMutate => UserPermission::AssetCatalogueItemMutate,
             PermissionType::NamePropertiesMutate => UserPermission::NamePropertiesMutate,
             PermissionType::EditCentralData => UserPermission::EditCentralData,
+            PermissionType::ViewAndEditVvmStatus => UserPermission::ViewAndEditVvmStatus,
         }
     }
 
@@ -203,6 +205,7 @@ impl UserPermission {
             UserPermission::AssetCatalogueItemMutate => PermissionType::AssetCatalogueItemMutate,
             UserPermission::NamePropertiesMutate => PermissionType::NamePropertiesMutate,
             UserPermission::EditCentralData => PermissionType::EditCentralData,
+            UserPermission::ViewAndEditVvmStatus => PermissionType::ViewAndEditVvmStatus,
         }
     }
 }

--- a/server/graphql/vvm/src/queries/vvm_status.rs
+++ b/server/graphql/vvm/src/queries/vvm_status.rs
@@ -1,20 +1,16 @@
+use crate::types::vvm_status::{VVMStatusConnector, VVMStatusesResponse};
 use async_graphql::{Context, Result};
 use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
 use service::auth::{Resource, ResourceAccessRequest};
-use crate::types::vvm_status::{VVMStatusesResponse, VVMStatusConnector};
 
-
-pub fn active_vvm_statuses(
-    ctx: &Context<'_>,
-    store_id: String,
-) -> Result<VVMStatusesResponse> {
+pub fn active_vvm_statuses(ctx: &Context<'_>, store_id: String) -> Result<VVMStatusesResponse> {
     let user = validate_auth(
         ctx,
         &ResourceAccessRequest {
-            resource: Resource::QueryPatient,
+            resource: Resource::QueryAndMutateVvmStatus,
             store_id: Some(store_id.clone()),
         },
     )?;

--- a/server/graphql/vvm/src/queries/vvm_status_log.rs
+++ b/server/graphql/vvm/src/queries/vvm_status_log.rs
@@ -12,12 +12,10 @@ pub fn get_vvm_status_log_by_stock_line(
     store_id: String,
     stock_line_id: &str,
 ) -> Result<VVMStatusLogResponse> {
-    // TODO: Change this to proper VVM-specific permission
-    // Add "View and edit vaccine vial monitor status" user permission from OG
     let user = validate_auth(
         ctx,
         &ResourceAccessRequest {
-            resource: Resource::QueryPatient,
+            resource: Resource::QueryAndMutateVvmStatus,
             store_id: Some(store_id.clone()),
         },
     )?;

--- a/server/repository/src/db_diesel/user_permission_row.rs
+++ b/server/repository/src/db_diesel/user_permission_row.rs
@@ -85,6 +85,7 @@ pub enum PermissionType {
     NamePropertiesMutate,
     // Central Server
     EditCentralData,
+    ViewAndEditVvmStatus,
 }
 
 #[derive(Clone, Queryable, Insertable, Debug, PartialEq, Eq, AsChangeset)]

--- a/server/repository/src/migrations/v2_08_00/add_view_and_edit_vvm_status_permission.rs
+++ b/server/repository/src/migrations/v2_08_00/add_view_and_edit_vvm_status_permission.rs
@@ -1,0 +1,22 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_view_and_edit_vvm_status_permission"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        if cfg!(feature = "postgres") {
+            sql!(
+                connection,
+                r#"
+                    ALTER TYPE permission_type ADD VALUE 'VIEW_AND_EDIT_VVM_STATUS';
+                "#
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_08_00/mod.rs
+++ b/server/repository/src/migrations/v2_08_00/mod.rs
@@ -3,6 +3,7 @@ use crate::StorageConnection;
 
 mod add_doses_columns_to_item_variant;
 mod add_initial_stocktake_field;
+mod add_view_and_edit_vvm_status_permission;
 mod add_vvm_status_log_change_log_table_name;
 mod add_vvm_status_log_table;
 mod add_vvm_status_table;
@@ -25,6 +26,7 @@ impl Migration for V2_08_00 {
             Box::new(add_doses_columns_to_item_variant::Migrate),
             Box::new(add_vvm_status_log_change_log_table_name::Migrate),
             Box::new(add_initial_stocktake_field::Migrate),
+            Box::new(add_view_and_edit_vvm_status_permission::Migrate),
         ]
     }
 }

--- a/server/service/src/auth.rs
+++ b/server/service/src/auth.rs
@@ -143,6 +143,7 @@ pub enum Resource {
     PluginGraphql,
     // Preferences
     MutatePreferences,
+    QueryAndMutateVvmStatus,
 }
 
 fn all_permissions() -> HashMap<Resource, PermissionDSL> {
@@ -640,6 +641,16 @@ fn all_permissions() -> HashMap<Resource, PermissionDSL> {
         Resource::PluginGraphql,
         PermissionDSL::Any(vec![PermissionDSL::HasStoreAccess]),
     );
+
+    // vvm status
+    map.insert(
+        Resource::QueryAndMutateVvmStatus,
+        PermissionDSL::Any(vec![
+            PermissionDSL::HasStoreAccess,
+            PermissionDSL::HasPermission(PermissionType::ViewAndEditVvmStatus),
+        ]),
+    );
+
     map
 }
 

--- a/server/service/src/login.rs
+++ b/server/service/src/login.rs
@@ -511,6 +511,9 @@ fn permissions_to_domain(permissions: Vec<Permissions>) -> HashSet<PermissionTyp
             Permissions::EditCentralData => {
                 output.insert(PermissionType::EditCentralData);
             }
+            Permissions::ViewAndEditVaccineVialMonitorStatus => {
+                output.insert(PermissionType::ViewAndEditVvmStatus);
+            }
             _ => continue,
         }
     }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7692

# 👩🏻‍💻 What does this PR do?
- Migration to view and edit VVM status permission
- Fix vvm related queries to use this permission

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Login
- [ ] Check DB -> user_permisson
- [ ] ViewAndEditVVMStatus perm should be there if it's turned on in OG

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

