### PR TITLE
7676 fix expiry date column display

### DIFF
--- a/client/packages/invoices/src/Prescriptions/LineEditView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/columns.ts
@@ -38,7 +38,7 @@ export const usePrescriptionLineEditColumns = ({
       'expiryDate',
       {
         Cell: ExpiryDateCell,
-        width: 80,
+        width: 100,
       },
     ],
     [

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -90,7 +90,7 @@ const StockListComponent: FC = () => {
       label: 'label.expiry',
       accessor: ({ rowData }) => DateUtils.getNaiveDate(rowData.expiryDate),
       Cell: ExpiryDateCell,
-      width: 110,
+      width: 120,
     },
     {
       key: 'location',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7676 

# 👩🏻‍💻 What does this PR do?
Adjust expiry date column so that values are not truncated
- Increase expiry date field width in prescription line edit form
- Increase expiry date field width in stock list view

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
`Stock List View - desktop browser`
![Screenshot 2025-05-13 at 17 12 30](https://github.com/user-attachments/assets/a7983fe4-e7bc-47c0-bbfc-5a5e5764e846)

`Prescription Line Edit - desktop browser`
![Screenshot 2025-05-13 at 17 12 20](https://github.com/user-attachments/assets/f303f34a-d5f3-480b-82eb-cd773d35b4d3)

`Stock List View - tablet portrait`
![Screenshot 2025-05-13 at 17 11 56](https://github.com/user-attachments/assets/6d0e8cdb-ed66-4c7d-a35e-6702e061284c)

`Stock List View - tablet landscape`
![Screenshot 2025-05-13 at 17 11 42](https://github.com/user-attachments/assets/2602e51b-b5e7-4fbc-b0bf-527bc2f26e96)

`Prescription Line edit - tablet landscape`
![Screenshot 2025-05-13 at 17 06 53](https://github.com/user-attachments/assets/fc6fdcb2-8c63-4e12-9f73-965e4bb63026)

`Prescription Line edit - tablet portrait`
![Screenshot 2025-05-13 at 17 06 38](https://github.com/user-attachments/assets/ad9af2db-e48b-4d95-a7db-4573b00b233f)

## 💌 Any notes for the reviewer?

I don't know if this is the most elegant solution as increasing width of the column makes it look a bit disjointed in the browser because of the extra space to the left of the expiry date values. Not sure if we need to adjust based on device type. Impact is low so not sure if worth addressing.
<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

`View Stock`
- [ ] Navigate to inventory -> View Stock
- [ ] Have different batches with a variety of expiry dates
- [ ] See that expiry date values are not truncated at different screen sizes

`Prescription`
- [ ] Navigate to Dispensary -> Prescriptions
- [ ] Create a new prescription
- [ ] Add items that have expiry dates set
- [ ] In prescription line edit view -> Observe that the expiry date values are not truncated when selecting dispensing quantity

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

