### PR TITLE
Fix rebuilding views so it doesn't run on test cases

### DIFF
--- a/server/repository/src/migrations/mod.rs
+++ b/server/repository/src/migrations/mod.rs
@@ -229,7 +229,8 @@ pub fn migrate(
     let last_version_in_migration_vec = migrations.last().unwrap().version();
 
     // Recreate views only if we've migrated to the latest version
-    // If we do migrations to a early version for a test case, views won't be available
+    // Creating Views on an earlier version migration test might fail due to more recent views referencing schema elements that didn't previously exist
+    // Note: When Migration tests run, views won't be available
     if final_database_version >= last_version_in_migration_vec && drop_view_has_run {
         rebuild_views(connection).map_err(MigrationError::DatabaseViewsError)?;
     } else {

--- a/server/repository/src/migrations/mod.rs
+++ b/server/repository/src/migrations/mod.rs
@@ -165,7 +165,7 @@ pub fn migrate(
     let min_version_for_dropping_views = v2_03_00::V2_03_00.version();
     let mut drop_view_has_run = false;
 
-    for migration in migrations {
+    for migration in &migrations {
         let migration_version = migration.version();
 
         if migration_version > to_version {
@@ -191,7 +191,7 @@ pub fn migrate(
 
         // TODO transaction ?
 
-        // Run one time migrations
+        // Run one time migrations only if we're on the last version, if we're in a test case checking an old creating migrations might fail
         if migration_version > database_version {
             log::info!("Running one time database migration {}", migration_version);
             migration
@@ -225,9 +225,19 @@ pub fn migrate(
 
     let final_database_version = get_database_version(connection);
 
-    // Recreate views
-    if final_database_version >= min_version_for_dropping_views {
+    // Unwrap is safe here, because we know that the migration vec is not empty
+    let last_version_in_migration_vec = migrations.last().unwrap().version();
+
+    // Recreate views only if we've migrated to the latest version
+    // If we do migrations to a early version for a test case, views won't be available
+    if final_database_version >= last_version_in_migration_vec && drop_view_has_run {
         rebuild_views(connection).map_err(MigrationError::DatabaseViewsError)?;
+    } else {
+        log::warn!(
+            "Not recreating views, database version is {}, last version in migration vec is {}",
+            final_database_version,
+            last_version_in_migration_vec
+        );
     }
 
     set_database_version(connection, &to_version)?;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #

# 👩🏻‍💻 What does this PR do?

This is modelled off @noel-yeldos fix for views in his PR https://github.com/msupply-foundation/open-msupply/pull/7654/commits/2299f44b3516206b9d146b6950bf173916be3924

Since this is needed for https://github.com/msupply-foundation/open-msupply/pull/7718 I've split this out into it's own PR.

I've tested with 7718 and postgres and the tests all pass, so I think it's good.

I've added a check for if the views have been droped before re-creating.
If we haven't dropped any, we shouldn't need to recreate, and there's a warning message now too if the don't run view logic triggers we'll have something to trace back on.

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Test that the views are only re-created for latest migration
- [ ] Check all test cases pass

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [X] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

