### PR TITLE
7689 add vvm status to stock line

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -3056,6 +3056,7 @@ export type InsertInboundShipmentLineInput = {
   sellPricePerPack: Scalars['Float']['input'];
   taxPercentage?: InputMaybe<Scalars['Float']['input']>;
   totalBeforeTax?: InputMaybe<Scalars['Float']['input']>;
+  vvmStatusId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type InsertInboundShipmentLineResponse =
@@ -3555,6 +3556,7 @@ export type InsertStockLineInput = {
   onHold: Scalars['Boolean']['input'];
   packSize: Scalars['Float']['input'];
   sellPricePerPack: Scalars['Float']['input'];
+  vvmStatusId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type InsertStockLineLineResponse = InsertStockLineError | StockLineNode;
@@ -4319,9 +4321,7 @@ export type ItemVariantNode = {
   dosesPerUnit: Scalars['Int']['output'];
   id: Scalars['String']['output'];
   item?: Maybe<ItemNode>;
-  /** @deprecated From 2.8.0. Use item instead */
   itemId: Scalars['String']['output'];
-  /** @deprecated From 2.8.0. Use item instead */
   itemName: Scalars['String']['output'];
   manufacturer?: Maybe<NameNode>;
   manufacturerId?: Maybe<Scalars['String']['output']>;
@@ -7971,6 +7971,7 @@ export type StockLineNode = {
   storeId: Scalars['String']['output'];
   supplierName?: Maybe<Scalars['String']['output']>;
   totalNumberOfPacks: Scalars['Float']['output'];
+  vvmStatus?: Maybe<VvmstatusNode>;
 };
 
 export type StockLineReducedBelowZero =
@@ -9374,6 +9375,7 @@ export type UpdateStockLineInput = {
   location?: InputMaybe<NullableStringUpdate>;
   onHold?: InputMaybe<Scalars['Boolean']['input']>;
   sellPricePerPack?: InputMaybe<Scalars['Float']['input']>;
+  vvmStatusId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type UpdateStockLineLineResponse = StockLineNode | UpdateStockLineError;

--- a/server/graphql/core/src/loader/loader_registry.rs
+++ b/server/graphql/core/src/loader/loader_registry.rs
@@ -493,6 +493,12 @@ pub async fn get_loaders(
         },
         async_std::task::spawn,
     ));
+    loaders.insert(DataLoader::new(
+        VVMStatusLoader {
+            connection_manager: connection_manager.clone(),
+        },
+        async_std::task::spawn,
+    ));
 
     loaders
 }

--- a/server/graphql/core/src/loader/mod.rs
+++ b/server/graphql/core/src/loader/mod.rs
@@ -54,6 +54,7 @@ mod vaccine_course;
 mod vaccine_course_by_program;
 mod vaccine_course_dose_by_vaccine_course;
 mod vaccine_course_item_by_vaccine_course;
+mod vvm_status;
 mod warning;
 
 use std::{collections::HashSet, hash::Hasher};
@@ -114,6 +115,7 @@ pub use vaccine_course::*;
 pub use vaccine_course_by_program::*;
 pub use vaccine_course_dose_by_vaccine_course::*;
 pub use vaccine_course_item_by_vaccine_course::*;
+pub use vvm_status::*;
 pub use warning::*;
 
 #[derive(Debug, Clone)]

--- a/server/graphql/core/src/loader/vvm_status.rs
+++ b/server/graphql/core/src/loader/vvm_status.rs
@@ -1,0 +1,27 @@
+use repository::vvm_status_row::{VVMStatusRow, VVMStatusRowRepository};
+use repository::{RepositoryError, StorageConnectionManager};
+
+use async_graphql::dataloader::*;
+use async_graphql::*;
+use std::collections::HashMap;
+
+pub struct VVMStatusLoader {
+    pub connection_manager: StorageConnectionManager,
+}
+
+impl Loader<String> for VVMStatusLoader {
+    type Value = VVMStatusRow;
+    type Error = RepositoryError;
+
+    async fn load(&self, ids: &[String]) -> Result<HashMap<String, Self::Value>, Self::Error> {
+        let connection = self.connection_manager.connection()?;
+        let repo = VVMStatusRowRepository::new(&connection);
+
+        let result = repo.find_many_by_ids(ids)?;
+
+        Ok(result
+            .into_iter()
+            .map(|vvm_status| (vvm_status.id.clone(), vvm_status))
+            .collect())
+    }
+}

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
@@ -30,6 +30,7 @@ pub struct InsertInput {
     pub total_before_tax: Option<f64>,
     pub tax_percentage: Option<f64>,
     pub item_variant_id: Option<String>,
+    pub vvm_status_id: Option<String>,
 }
 
 #[derive(SimpleObject)]
@@ -88,6 +89,7 @@ impl InsertInput {
             total_before_tax,
             tax_percentage,
             item_variant_id,
+            vvm_status_id: _, // Ignoring until the ability to record vvm status is added by https://github.com/msupply-foundation/open-msupply/issues/7366
         } = self;
 
         ServiceInput {
@@ -112,6 +114,7 @@ impl InsertInput {
             stock_line_id: None,
             barcode: None,
             stock_on_hold: false,
+            vvm_status_id: None, // Setting to none until the ability to record vvm status is added by https://github.com/msupply-foundation/open-msupply/issues/7366
         }
     }
 }

--- a/server/graphql/stock_line/src/mutations/insert.rs
+++ b/server/graphql/stock_line/src/mutations/insert.rs
@@ -30,6 +30,7 @@ pub struct InsertInput {
     /// Empty barcode will unlink barcode from StockLine
     pub barcode: Option<String>,
     pub item_variant_id: Option<String>,
+    pub vvm_status_id: Option<String>,
 }
 
 #[derive(SimpleObject)]
@@ -97,6 +98,7 @@ impl InsertInput {
             pack_size,
             inventory_adjustment_reason_id,
             item_variant_id,
+            vvm_status_id,
         } = self;
 
         AddNewStockLine {
@@ -115,6 +117,7 @@ impl InsertInput {
             pack_size,
             inventory_adjustment_reason_id,
             item_variant_id,
+            vvm_status_id,
         }
     }
 }

--- a/server/graphql/stock_line/src/mutations/update.rs
+++ b/server/graphql/stock_line/src/mutations/update.rs
@@ -27,6 +27,7 @@ pub struct UpdateInput {
     /// Empty barcode will unlink barcode from StockLine
     pub barcode: Option<String>,
     pub item_variant_id: Option<NullableUpdateInput<String>>,
+    pub vvm_status_id: Option<String>,
 }
 
 #[derive(Interface)]
@@ -93,6 +94,7 @@ impl UpdateInput {
             on_hold,
             barcode,
             item_variant_id,
+            vvm_status_id,
         } = self;
 
         ServiceInput {
@@ -109,6 +111,7 @@ impl UpdateInput {
             item_variant_id: item_variant_id.map(|item_variant_id| NullableUpdate {
                 value: item_variant_id.value,
             }),
+            vvm_status_id,
         }
     }
 }

--- a/server/graphql/types/src/types/mod.rs
+++ b/server/graphql/types/src/types/mod.rs
@@ -139,6 +139,9 @@ pub use self::insurance_provider::*;
 pub mod warning;
 pub use self::warning::*;
 
+pub mod vvm_status;
+pub use self::vvm_status::*;
+
 use async_graphql::*;
 pub struct DeleteResponse(pub String);
 #[Object]

--- a/server/graphql/types/src/types/stock_line.rs
+++ b/server/graphql/types/src/types/stock_line.rs
@@ -1,13 +1,14 @@
-use super::{ItemNode, LocationNode};
+use super::{ItemNode, LocationNode, VVMStatusNode};
 use async_graphql::dataloader::DataLoader;
 use async_graphql::*;
 use chrono::NaiveDate;
 use graphql_core::{
-    loader::{ItemLoader, LocationByIdLoader},
+    loader::{ItemLoader, LocationByIdLoader, VVMStatusLoader},
     simple_generic_errors::NodeError,
     standard_graphql_error::StandardGraphqlError,
     ContextExt,
 };
+
 use repository::{ItemRow, StockLine, StockLineRow};
 use service::{
     service_provider::ServiceContext, stock_line::query::get_stock_line, usize_to_u32, ListResult,
@@ -104,6 +105,19 @@ impl StockLineNode {
 
     pub async fn barcode(&self) -> Option<&str> {
         self.stock_line.barcode()
+    }
+
+    pub async fn vvm_status(&self, ctx: &Context<'_>) -> Result<Option<VVMStatusNode>> {
+        let loader = ctx.get_loader::<DataLoader<VVMStatusLoader>>();
+        let type_id = match self.row().vvm_status_id.clone() {
+            Some(type_id) => type_id,
+            None => return Ok(None),
+        };
+
+        Ok(loader
+            .load_one(type_id)
+            .await?
+            .map(VVMStatusNode::from_domain))
     }
 }
 

--- a/server/graphql/types/src/types/vvm_status.rs
+++ b/server/graphql/types/src/types/vvm_status.rs
@@ -53,9 +53,7 @@ pub struct VVMStatusConnector {
 }
 
 impl VVMStatusConnector {
-    pub fn from_domain(
-        vvm_statuses: Vec<VVMStatusRow>,
-    ) -> VVMStatusConnector {
+    pub fn from_domain(vvm_statuses: Vec<VVMStatusRow>) -> VVMStatusConnector {
         VVMStatusConnector {
             nodes: vvm_statuses
                 .into_iter()

--- a/server/graphql/vvm/src/lib.rs
+++ b/server/graphql/vvm/src/lib.rs
@@ -1,9 +1,8 @@
-pub mod types;
 pub mod queries;
 
 use async_graphql::*;
+use graphql_types::types::VVMStatusesResponse;
 use queries::vvm_status::active_vvm_statuses;
-use types::vvm_status::VVMStatusesResponse;
 
 #[derive(Default, Clone)]
 pub struct VVMQueries;

--- a/server/graphql/vvm/src/queries/vvm_status.rs
+++ b/server/graphql/vvm/src/queries/vvm_status.rs
@@ -3,14 +3,10 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
+use graphql_types::types::vvm_status::{VVMStatusConnector, VVMStatusesResponse};
 use service::auth::{Resource, ResourceAccessRequest};
-use crate::types::vvm_status::{VVMStatusesResponse, VVMStatusConnector};
 
-
-pub fn active_vvm_statuses(
-    ctx: &Context<'_>,
-    store_id: String,
-) -> Result<VVMStatusesResponse> {
+pub fn active_vvm_statuses(ctx: &Context<'_>, store_id: String) -> Result<VVMStatusesResponse> {
     let user = validate_auth(
         ctx,
         &ResourceAccessRequest {

--- a/server/graphql/vvm/src/types/mod.rs
+++ b/server/graphql/vvm/src/types/mod.rs
@@ -1,1 +1,0 @@
-pub mod vvm_status;

--- a/server/repository/src/db_diesel/stock_line.rs
+++ b/server/repository/src/db_diesel/stock_line.rs
@@ -1,7 +1,8 @@
 use super::{
     barcode_row::barcode, item_link_row::item_link, item_row::item, location_row::location,
-    name_link_row::name_link, name_row::name, stock_line_row::stock_line, DBType, LocationRow,
-    MasterListFilter, MasterListLineFilter, StockLineRow, StorageConnection,
+    name_link_row::name_link, name_row::name, stock_line_row::stock_line,
+    DBType, LocationRow, MasterListFilter, MasterListLineFilter,
+    StockLineRow, StorageConnection,
 };
 
 use crate::{

--- a/server/repository/src/db_diesel/stock_line_row.rs
+++ b/server/repository/src/db_diesel/stock_line_row.rs
@@ -1,6 +1,6 @@
 use super::{
     item_link_row::item_link, location_row::location, name_link_row::name_link, store_row::store,
-    StorageConnection,
+    vvm_status_row::vvm_status, StorageConnection,
 };
 
 use crate::{db_diesel::barcode_row::barcode, repository_error::RepositoryError, Delete, Upsert};
@@ -28,6 +28,7 @@ table! {
         supplier_link_id -> Nullable<Text>,
         barcode_id -> Nullable<Text>,
         item_variant_id -> Nullable<Text>,
+        vvm_status_id -> Nullable<Text>,
     }
 }
 
@@ -36,6 +37,7 @@ joinable!(stock_line -> store (store_id));
 joinable!(stock_line -> location (location_id));
 joinable!(stock_line -> name_link (supplier_link_id));
 joinable!(stock_line -> barcode (barcode_id));
+joinable!(stock_line -> vvm_status (vvm_status_id));
 allow_tables_to_appear_in_same_query!(stock_line, item_link);
 allow_tables_to_appear_in_same_query!(stock_line, name_link);
 
@@ -59,6 +61,7 @@ pub struct StockLineRow {
     pub supplier_link_id: Option<String>,
     pub barcode_id: Option<String>,
     pub item_variant_id: Option<String>,
+    pub vvm_status_id: Option<String>,
 }
 
 pub struct StockLineRowRepository<'a> {

--- a/server/repository/src/db_diesel/vvm_status_row.rs
+++ b/server/repository/src/db_diesel/vvm_status_row.rs
@@ -75,6 +75,13 @@ impl<'a> VVMStatusRowRepository<'a> {
         Ok(result)
     }
 
+    pub fn find_many_by_ids(&self, ids: &[String]) -> Result<Vec<VVMStatusRow>, RepositoryError> {
+        vvm_status::table
+            .filter(vvm_status::id.eq_any(ids))
+            .load::<VVMStatusRow>(self.connection.lock().connection())
+            .map_err(RepositoryError::from)
+    }
+
     pub fn delete(&self, vvm_status_id: &str) -> Result<(), RepositoryError> {
         diesel::delete(vvm_status.filter(id.eq(vvm_status_id)))
             .execute(self.connection.lock().connection())?;

--- a/server/repository/src/migrations/v2_08_00/add_vvm_status_id_to_stock_line.rs
+++ b/server/repository/src/migrations/v2_08_00/add_vvm_status_id_to_stock_line.rs
@@ -1,0 +1,20 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_vvm_status_id_to_stock_line"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        sql!(
+            connection,
+            r#"
+                ALTER TABLE stock_line ADD COLUMN vvm_status_id TEXT REFERENCES vvm_status(id);
+            "#,
+        )?;
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_08_00/mod.rs
+++ b/server/repository/src/migrations/v2_08_00/mod.rs
@@ -2,6 +2,7 @@ use super::{version::Version, Migration, MigrationFragment};
 use crate::StorageConnection;
 
 mod add_doses_columns_to_item_variant;
+mod add_vvm_status_id_to_stock_line;
 mod add_vvm_status_table;
 pub(crate) struct V2_08_00;
 
@@ -18,20 +19,21 @@ impl Migration for V2_08_00 {
         vec![
             Box::new(add_vvm_status_table::Migrate),
             Box::new(add_doses_columns_to_item_variant::Migrate),
+            Box::new(add_vvm_status_id_to_stock_line::Migrate),
         ]
     }
 }
 
 #[cfg(test)]
 mod test {
+    // use crate::{migrations::sql, StorageConnection};
 
     #[actix_rt::test]
     async fn migration_2_08_00() {
-        use v2_07_00::V2_07_00;
-        use v2_08_00::V2_08_00;
-
         use crate::migrations::*;
         use crate::test_db::*;
+        use v2_07_00::V2_07_00;
+        use v2_08_00::V2_08_00;
 
         let previous_version = V2_07_00.version();
         let version = V2_08_00.version();
@@ -43,8 +45,112 @@ mod test {
         })
         .await;
 
+        // insert_2_7_0_stock_lines(&connection, "some_store_id").unwrap();
+
         // Run this migration
         migrate(&connection, Some(version.clone())).unwrap();
         assert_eq!(get_database_version(&connection), version);
     }
+
+    // TODO: write test
+    // // Insert stock lines to ensure migration to add vvm_status_id to stock_line works
+    // fn insert_2_7_0_stock_lines(
+    //     connection: &StorageConnection,
+    //     store_id: &str,
+    // ) -> anyhow::Result<()> {
+    //     let vvm_status_id = "status_1".to_string();
+    //     let stock_line_id = "stock_line_id".to_string();
+    //     let course_id = "course_id".to_string();
+    //     let dose_id = "dose_id".to_string();
+
+    //     sql!(
+    //         connection,
+    //         r#"
+    //         INSERT INTO vvm_status (
+    //             	id,
+    //                 description,
+    //                 code,
+    //                 level,
+    //                 is_active,
+    //                 unusable
+    //         ) VALUES (
+    //             '{vvm_status_id}',
+    //             'status 1',
+    //             'status 1',
+    //             '1',
+    //             true,
+    //             false
+    //         );
+
+    //         INSERT INTO stock_line (
+    //             id TEXT NOT NULL,
+    //             store_id TEXT NOT NULL,
+    //             cost_price_per_pack REAL NOT NULL,
+    //             sell_price_per_pack REAL NOT NULL,
+    //             available_number_of_packs REAL NOT NULL,
+    //             total_number_of_packs REAL NOT NULL,
+    //             on_hold BOOLEAN NOT NULL,
+    //             pack_size REAL DEFAULT (0) NOT NULL,
+    //         ) VALUES (
+    //             '{stock_line_id}',
+    //             'program 1',
+    //             '{context_id}',
+    //             TRUE
+    //         );
+
+    //         INSERT INTO vaccine_course (
+    //             id,
+    //             name,
+    //             program_id
+    //         ) VALUES (
+    //             '{course_id}',
+    //             'course 1',
+    //             '{program_id}'
+    //         );
+
+    //         INSERT INTO vaccine_course_dose (
+    //             id,
+    //             vaccine_course_id,
+    //             label
+    //         ) VALUES (
+    //             '{dose_id}',
+    //             '{course_id}',
+    //             'dose 1'
+    //         );
+
+    //         INSERT INTO vaccination (
+    //             id,
+    //             store_id,
+    //             program_enrolment_id,
+    //             encounter_id,
+    //             user_id,
+    //             vaccine_course_dose_id,
+    //             created_datetime,
+    //             vaccination_date,
+    //             given
+    //         ) VALUES (
+    //             '2.6.2-given',
+    //             '{store_id}',
+    //             'program_enrolment_1',
+    //             'encounter_1',
+    //             'user_1',
+    //             '{dose_id}',
+    //             '2025-01-01 00:00:00',
+    //             '2025-01-01',
+    //             TRUE
+    //         ), (
+    //             '2.6.2-not-given',
+    //             '{store_id}',
+    //             'program_enrolment_1',
+    //             'encounter_1',
+    //             'user_1',
+    //             '{dose_id}',
+    //             '2025-01-01 00:00:00',
+    //             NULL,
+    //             FALSE
+    // );
+    //     "#,
+    //     )?;
+    //     Ok(())
+    // }
 }

--- a/server/service/src/invoice/customer_return/insert/generate.rs
+++ b/server/service/src/invoice/customer_return/insert/generate.rs
@@ -124,6 +124,7 @@ pub fn generate(
                 stock_line_id,
                 barcode: None,
                 stock_on_hold: false,
+                vvm_status_id: None, // Setting to none until the ability to record vvm status is added by https://github.com/msupply-foundation/open-msupply/issues/7366
             },
         )
         .collect();

--- a/server/service/src/invoice/customer_return/update_lines/generate.rs
+++ b/server/service/src/invoice/customer_return/update_lines/generate.rs
@@ -72,6 +72,7 @@ pub fn generate(
                 barcode: None,
                 stock_line_id: None,
                 stock_on_hold: false,
+                vvm_status_id: None, // Setting to none until the ability to record vvm status is added by https://github.com/msupply-foundation/open-msupply/issues/7366
             },
         )
         .collect();

--- a/server/service/src/invoice/inbound_shipment/update/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/update/generate.rs
@@ -351,6 +351,7 @@ pub fn generate_lines_and_stock_lines(
                 supplier_link_id: Some(supplier_id.to_string()),
                 barcode_id: None,
                 item_variant_id,
+                vvm_status_id: None,
             };
             result.push(LineAndStockLine { line, stock_line });
         }

--- a/server/service/src/invoice/inventory_adjustment/add_new_stock_line/generate.rs
+++ b/server/service/src/invoice/inventory_adjustment/add_new_stock_line/generate.rs
@@ -37,6 +37,7 @@ pub fn generate(
         expiry_date,
         barcode,
         item_variant_id,
+        vvm_status_id,
     }: AddNewStockLine,
 ) -> Result<GenerateResult, RepositoryError> {
     let current_datetime = Utc::now().naive_utc();
@@ -108,6 +109,7 @@ pub fn generate(
         tax_percentage: None,
         barcode,
         item_variant_id,
+        vvm_status_id,
     };
 
     let update_inventory_adjustment_reason = UpdateInventoryAdjustmentReason {

--- a/server/service/src/invoice/inventory_adjustment/add_new_stock_line/insert.rs
+++ b/server/service/src/invoice/inventory_adjustment/add_new_stock_line/insert.rs
@@ -28,6 +28,7 @@ pub struct AddNewStockLine {
     pub inventory_adjustment_reason_id: Option<String>,
     pub barcode: Option<String>,
     pub item_variant_id: Option<String>,
+    pub vvm_status_id: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/server/service/src/invoice/inventory_adjustment/adjust_existing_stock/generate.rs
+++ b/server/service/src/invoice/inventory_adjustment/adjust_existing_stock/generate.rs
@@ -134,6 +134,7 @@ pub fn generate(
             barcode: None,
             total_before_tax: None,
             tax_percentage: None,
+            vvm_status_id: None,
         }),
         AdjustmentType::Reduction => InsertStockInOrOutLine::StockOut(InsertStockOutLine {
             r#type: StockOutType::InventoryReduction,

--- a/server/service/src/invoice_line/stock_in_line/generate.rs
+++ b/server/service/src/invoice_line/stock_in_line/generate.rs
@@ -107,6 +107,7 @@ pub fn generate_batch(
         on_hold,
         barcode_id,
         item_variant_id,
+        vvm_status_id: None, // Setting to none until the ability to record vvm status is added by https://github.com/msupply-foundation/open-msupply/issues/7366
     };
 
     Ok(stock_line_row)

--- a/server/service/src/invoice_line/stock_in_line/insert/generate.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/generate.rs
@@ -90,6 +90,7 @@ fn generate_line(
         stock_on_hold: _,
         tax_percentage: _,
         r#type: _,
+        vvm_status_id: _, // Ignoring until the ability to record vvm status is added by https://github.com/msupply-foundation/open-msupply/issues/7366
     }: InsertStockInLine,
     ItemRow {
         name: item_name,

--- a/server/service/src/invoice_line/stock_in_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/mod.rs
@@ -43,6 +43,7 @@ pub struct InsertStockInLine {
     pub barcode: Option<String>,
     pub stock_on_hold: bool,
     pub item_variant_id: Option<String>,
+    pub vvm_status_id: Option<String>,
 }
 
 type OutError = InsertStockInLineError;

--- a/server/service/src/stock_line/update.rs
+++ b/server/service/src/stock_line/update.rs
@@ -29,6 +29,7 @@ pub struct UpdateStockLine {
     pub batch: Option<String>,
     pub barcode: Option<String>,
     pub item_variant_id: Option<NullableUpdate<String>>,
+    pub vvm_status_id: Option<String>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -133,6 +134,7 @@ fn generate(
         on_hold,
         barcode,
         item_variant_id,
+        vvm_status_id,
     }: UpdateStockLine,
 ) -> Result<GenerateResult, UpdateStockLineError> {
     let mut existing = existing_line.stock_line_row;
@@ -183,6 +185,7 @@ fn generate(
     existing.item_variant_id = item_variant_id
         .map(|v| v.value)
         .unwrap_or(existing.item_variant_id);
+    existing.vvm_status_id = vvm_status_id.or(existing.vvm_status_id);
 
     Ok(GenerateResult {
         new_stock_line: existing,

--- a/server/service/src/stocktake/insert/generate.rs
+++ b/server/service/src/stocktake/insert/generate.rs
@@ -167,6 +167,7 @@ pub fn generate_lines_from_master_list(
                     available_number_of_packs: _,
                     barcode_id: _,
                     item_variant_id,
+                    vvm_status_id: _,
                 } = line.stock_line_row;
 
                 result.push(StocktakeLineRow {
@@ -229,6 +230,7 @@ pub fn generate_lines_from_location(
                 available_number_of_packs: _,
                 barcode_id: _,
                 item_variant_id,
+                vvm_status_id: _,
             } = line.stock_line_row;
 
             StocktakeLineRow {
@@ -287,6 +289,7 @@ pub fn generate_lines_with_stock(
                 available_number_of_packs: _,
                 barcode_id: _,
                 item_variant_id,
+                vvm_status_id: _,
             } = line.stock_line_row;
 
             StocktakeLineRow {
@@ -346,6 +349,7 @@ pub fn generate_lines_expiring_before(
                 available_number_of_packs: _,
                 barcode_id: _,
                 item_variant_id,
+                vvm_status_id: _,
             } = line.stock_line_row;
 
             StocktakeLineRow {

--- a/server/service/src/stocktake/update/generate.rs
+++ b/server/service/src/stocktake/update/generate.rs
@@ -161,6 +161,7 @@ fn generate_stock_in_out_or_update(
             // Default
             total_before_tax: None,
             tax_percentage: None,
+            vvm_status_id: None, // Setting to none until the ability to record vvm status is added by https://github.com/msupply-foundation/open-msupply/issues/7366
         })
     } else {
         StockChange::StockOut(InsertStockOutLine {
@@ -333,6 +334,7 @@ fn generate_new_stock_line(
         total_before_tax: None,
         tax_percentage: None,
         item_variant_id: stocktake_line.line.item_variant_id.clone(),
+        vvm_status_id: None, // Setting to none until the ability to record vvm status is added by https://github.com/msupply-foundation/open-msupply/issues/7366
     });
 
     // If new stock line has a location, create location movement

--- a/server/service/src/sync/test/test_data/stock_line.rs
+++ b/server/service/src/sync/test/test_data/stock_line.rs
@@ -72,6 +72,7 @@ fn item_line_1_pull_record() -> TestSyncIncomingRecord {
             supplier_link_id: Some("name_store_b".to_string()),
             barcode_id: None,
             item_variant_id: None,
+            vvm_status_id: None,
         },
     )
 }
@@ -96,6 +97,7 @@ fn item_line_1_push_record() -> TestSyncOutgoingRecord {
             supplier_id: Some("name_store_b".to_string()),
             barcode_id: None,
             item_variant_id: None,
+            vvm_status: None,
         }),
     }
 }
@@ -164,6 +166,7 @@ fn item_line_2_pull_record() -> TestSyncIncomingRecord {
             supplier_link_id: None,
             barcode_id: None,
             item_variant_id: None,
+            vvm_status_id: None,
         },
     )
 }
@@ -188,6 +191,7 @@ fn item_line_2_push_record() -> TestSyncOutgoingRecord {
             supplier_id: None,
             barcode_id: None,
             item_variant_id: None,
+            vvm_status: None,
         }),
     }
 }

--- a/server/service/src/sync/translations/stock_line.rs
+++ b/server/service/src/sync/translations/stock_line.rs
@@ -46,6 +46,8 @@ pub struct LegacyStockLineRow {
     #[serde(rename = "om_item_variant_id")]
     #[serde(default)]
     pub item_variant_id: Option<String>,
+    #[serde(deserialize_with = "empty_str_as_option_string")]
+    pub vvm_status: Option<String>,
 }
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -96,6 +98,7 @@ impl SyncTranslation for StockLineTranslation {
             supplier_id,
             barcode_id,
             item_variant_id,
+            vvm_status,
         } = serde_json::from_str::<LegacyStockLineRow>(&sync_record.data)?;
 
         let barcode_id = clear_invalid_barcode_id(connection, barcode_id)?;
@@ -117,6 +120,7 @@ impl SyncTranslation for StockLineTranslation {
             supplier_link_id: supplier_id,
             barcode_id,
             item_variant_id,
+            vvm_status_id: vvm_status,
         };
 
         Ok(PullTranslateResult::upsert(result))
@@ -156,6 +160,7 @@ impl SyncTranslation for StockLineTranslation {
                     supplier_link_id: _,
                     barcode_id,
                     item_variant_id,
+                    vvm_status_id,
                 },
             item_row,
             supplier_name_row,
@@ -179,6 +184,7 @@ impl SyncTranslation for StockLineTranslation {
             supplier_id: supplier_name_row.map(|supplier| supplier.id),
             barcode_id,
             item_variant_id,
+            vvm_status: vvm_status_id,
         };
 
         Ok(PushTranslateResult::upsert(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7689 

# 👩🏻‍💻 What does this PR do?

- Adds a migration to add the column to stock_line wit ha foreign key constraint.
- Corresponding updates in the service and repo layer
- Adding a loader for vvm_status in the stock line node in the graphql layer
- Refactoring the graphql types of vvm_status for the loader.

## 💌 Any notes for the reviewer?

There are many merge conflicts! At the same time as I was making a loader, someone else was! There are some other potentially fundamental conflicts as well, so it may take a little while to work through them.

# 🧪 Testing

- Go to the GraphiQL playground and check that the VvmStatusNode is reachable through the StockLineNode.

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

