### PR TITLE
Override tet with en in Intl.NumberFormat

### DIFF
--- a/client/packages/coldchain/src/common/utils.ts
+++ b/client/packages/coldchain/src/common/utils.ts
@@ -1,4 +1,4 @@
-import { useIntlUtils } from '@common/intl';
+import { intlNumberFormat, useIntlUtils } from '@common/intl';
 import { TemperatureBreachNodeType } from '@common/types';
 import { NumUtils } from '@common/utils';
 
@@ -13,7 +13,7 @@ export const parseBreachType = (
 
 export const useFormatTemperature = () => {
   const { currentLanguage: language } = useIntlUtils();
-  const numberFormat = new Intl.NumberFormat(language, {
+  const numberFormat = intlNumberFormat(language, {
     style: 'unit',
     unit: 'celsius',
     unitDisplay: 'short',

--- a/client/packages/common/src/intl/currency/currency.ts
+++ b/client/packages/common/src/intl/currency/currency.ts
@@ -1,6 +1,7 @@
 import currency from 'currency.js';
 import { useAuthContext } from '../../authentication';
 import { MAX_FRACTION_DIGITS, useIntlUtils } from '../utils';
+import { intlNumberFormat } from '@openmsupply-client/common';
 
 const trimCents = (centsString: string) => {
   const number = Number(`.${centsString}`);
@@ -10,7 +11,7 @@ const trimCents = (centsString: string) => {
     return '00';
   }
 
-  const trimmed = new Intl.NumberFormat('en', {
+  const trimmed = intlNumberFormat('en', {
     maximumFractionDigits: MAX_FRACTION_DIGITS,
   }).format(number);
   // Trimmed is some number with just one decimal place.
@@ -78,7 +79,7 @@ export const format: currency.Format = (
 // this should be the source of truth.
 const getSeparatorAndDecimal = (locale: string) => {
   // Some locales (at least `es`) don't include a group separator for 4 digits (1000), only for 5 (10000)
-  const parts = new Intl.NumberFormat(locale).formatToParts(10000.1);
+  const parts = intlNumberFormat(locale).formatToParts(10000.1);
   const separator = parts.find(({ type }) => type === 'group')?.value ?? ',';
   const decimal = parts.find(({ type }) => type === 'decimal')?.value ?? '.';
   return { separator, decimal };

--- a/client/packages/common/src/intl/number/IntlNumber.ts
+++ b/client/packages/common/src/intl/number/IntlNumber.ts
@@ -2,6 +2,18 @@ import { RegexUtils } from '../../utils/regex';
 import { useCurrency } from '../currency';
 import { MAX_FRACTION_DIGITS, SupportedLocales, useIntlUtils } from '../utils';
 
+const localeNumberOverrides: { [locale: string]: /* Override */ string } = {
+  tet: 'en-US',
+};
+
+// This method needs to be used instead of Intl.NumberFormat directly
+export const intlNumberFormat = (
+  locale: string,
+  params?: Intl.NumberFormatOptions
+) => {
+  return new Intl.NumberFormat(localeNumberOverrides[locale] ?? locale, params);
+};
+
 export const useFormatNumber = () => {
   const { currentLanguage } = useIntlUtils();
   const {
@@ -15,13 +27,13 @@ export const useFormatNumber = () => {
     ) => {
       if (value === undefined || value === null) return '';
       const locale = options?.locale ?? currentLanguage;
-      return new Intl.NumberFormat(locale, {
+      return intlNumberFormat(locale, {
         maximumFractionDigits: MAX_FRACTION_DIGITS,
         ...options,
       }).format(value);
     },
     round: (value?: number, dp?: number): string => {
-      const intl = new Intl.NumberFormat(currentLanguage, {
+      const intl = intlNumberFormat(currentLanguage, {
         // not strictly necessary perhaps - but if you specify a minimumFractionDigits
         // outside of the range 0,20 then an error is thrown
         maximumFractionDigits: Math.max(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7735

# 👩🏻‍💻 What does this PR do?

* Creates `intlNumberFormat` method that replaces Intl.NumberFormat
* Adds tet override for number format to match english

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

From related issues:

I haven't been able to set my regional setting (this is not timezone setting), but if you are able to then set to Indonesia, you will see in ledger and other places that thousand's are separated by a dot. Similar example has been tested on Indonesia regional setting.

Need to also quickly check that number display still works correctly, try a french language

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

