### PR TITLE
Add translation number formatting in RnR form

### DIFF
--- a/client/packages/common/src/intl/locales/tet/common.json
+++ b/client/packages/common/src/intl/locales/tet/common.json
@@ -345,7 +345,7 @@
   "label.requested": "Kuantidade husu",
   "label.requisition": "Requizisaun",
   "label.rnr-adjustments": "Ajustamentu",
-  "label.rnr-consumed": "Kuantitade konsumu / distribuída",
+  "label.rnr-consumed": "Distribution",
   "label.rnr-final-balance": "Balansu Ikus",
   "label.rnr-initial-balance": "Balansu Inisiu",
   "label.rnr-maximum-quantity": "Kuantidade maximu",

--- a/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
@@ -11,6 +11,7 @@ import {
   Tooltip,
   useAuthContext,
   useBufferState,
+  useFormatNumber,
   useTheme,
   VenCategoryType,
 } from '@openmsupply-client/common';
@@ -309,6 +310,7 @@ const RnRNumberCell = ({
   max?: number;
   allowNegative?: boolean;
 }) => {
+  const { format } = useFormatNumber();
   const [buffer, setBuffer] = useBufferState<number | undefined>(
     NumUtils.round(value)
   );
@@ -317,7 +319,7 @@ const RnRNumberCell = ({
 
   return (
     <td style={{ backgroundColor }}>
-      <Tooltip title={value === buffer ? '' : value}>
+      <Tooltip title={value === buffer ? '' : format(value)}>
         {disabled || !onChange ? (
           <p
             style={{
@@ -326,7 +328,7 @@ const RnRNumberCell = ({
               color: textColor,
             }}
           >
-            {buffer}
+            {format(buffer)}
           </p>
         ) : (
           <NumericTextInput

--- a/server/graphql/general/src/lib.rs
+++ b/server/graphql/general/src/lib.rs
@@ -609,7 +609,11 @@ impl InitialisationMutations {
         initialise_site(ctx, input).await
     }
 
-    pub async fn manual_sync(&self, ctx: &Context<'_>) -> Result<String> {
+    pub async fn manual_sync(
+        &self,
+        ctx: &Context<'_>,
+        _fetch_patient_id: Option<String>,
+    ) -> Result<String> {
         manual_sync(ctx, false, None)
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7739 
Fixes: #7748 

# 👩🏻‍💻 What does this PR do?

Add translation and RnR form number formatting

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

Check tetum translation for RnR form consumption is 'Distribution'

Numbers are formatted with correct thousands separator, even for non editable columns in RnR form (try Tetum, comma, French, space, Portugese, dot), you can set up quickly [with this data file: ](https://drive.google.com/drive/u/1/folders/1N-haFv9ixg-z3crQViMDP4BW8ukF4rWq)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

