### PR TITLE
7755 creating sites on OG

### DIFF
--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -48,7 +48,7 @@ use backup::*;
 use cli::{
     generate_and_install_plugin_bundle, generate_plugin_bundle, generate_report_data,
     generate_reports_recursive, generate_typescript_types, install_plugin_bundle,
-    GenerateAndInstallPluginBundle, GeneratePluginBundle, InstallPluginBundle,
+    GenerateAndInstallPluginBundle, GeneratePluginBundle, InstallPluginBundle, LoadTest,
     RefreshDatesRepository, ReportError,
 };
 
@@ -210,6 +210,8 @@ enum Action {
     },
     /// Generate TypeScript Types for backend plugins and format with Prettier
     GenerateTypeScriptTypes,
+    /// Run load test
+    LoadTest(LoadTest),
 }
 
 #[derive(Serialize, Deserialize)]
@@ -699,6 +701,28 @@ async fn main() -> anyhow::Result<()> {
         }
         Action::GenerateTypeScriptTypes => {
             generate_typescript_types()?;
+        }
+        Action::LoadTest(LoadTest {
+            url,
+            base_port,
+            output_dir,
+            test_site_name,
+            test_site_pass,
+            sites,
+            invoice_lines,
+            duration,
+        }) => {
+            let load_test = LoadTest::new(
+                url,
+                base_port,
+                output_dir,
+                test_site_name,
+                test_site_pass,
+                sites,
+                invoice_lines,
+                duration,
+            );
+            load_test.run().await?;
         }
     }
 

--- a/server/cli/src/lib.rs
+++ b/server/cli/src/lib.rs
@@ -14,3 +14,6 @@ pub use plugins::*;
 
 mod generate_typescript_types;
 pub use generate_typescript_types::*;
+
+mod load_test;
+pub use load_test::*;

--- a/server/cli/src/load_test.rs
+++ b/server/cli/src/load_test.rs
@@ -1,0 +1,131 @@
+use std::path::PathBuf;
+
+use reqwest::Client;
+use serde::Deserialize;
+const TEST_API: &str = "sync/v5/test";
+
+#[derive(clap::Args)]
+pub struct LoadTest {
+    /// Central server url including protocol (http) and port
+    #[clap(short, long)]
+    pub url: String,
+
+    /// The output directory for test results
+    #[clap(short, long)]
+    pub output_dir: PathBuf,
+
+    /// The site name of the initial test site that th cli will use to access the API
+    #[clap(long, default_value = "test_site")]
+    pub test_site_name: Option<String>,
+
+    /// The password for the test site
+    #[clap(long, default_value = "pass")]
+    pub test_site_pass: Option<String>,
+
+    /// Base port to user for the remote sites (increments by 1 for each site)
+    #[clap(short, long)]
+    pub base_port: u16,
+
+    /// The amount of sites to simulate
+    #[clap(short, long)]
+    pub sites: usize,
+
+    /// The number of lines to include in each invoice
+    #[clap(short, long)]
+    pub invoice_lines: usize,
+
+    /// Duration in seconds to run the test for
+    #[clap(short, long)]
+    pub duration: usize,
+}
+
+#[derive(Deserialize, Debug)]
+struct SyncSite {
+    #[serde(rename = "ID")]
+    id: String,
+    #[serde(rename = "site_ID")]
+    site_id: usize,
+    name: String,
+    #[serde(rename = "password")]
+    password_sha256: String,
+}
+#[derive(Deserialize, Debug)]
+struct SyncStore {
+    #[serde(rename = "ID")]
+    id: String,
+    #[serde(rename = "name_ID")]
+    name_id: String,
+}
+#[derive(Deserialize, Debug)]
+pub(crate) struct SiteNStore {
+    site: SyncSite,
+    store: SyncStore,
+}
+
+impl LoadTest {
+    pub fn new(
+        url: String,
+        base_port: u16,
+        output_dir: PathBuf,
+        test_site_name: Option<String>,
+        test_site_pass: Option<String>,
+        sites: usize,
+        invoice_lines: usize,
+        duration: usize,
+    ) -> Self {
+        Self {
+            url,
+            base_port,
+            output_dir,
+            test_site_name,
+            test_site_pass,
+            sites,
+            invoice_lines,
+            duration,
+        }
+    }
+
+    pub async fn run(&self) -> anyhow::Result<()> {
+        use util::hash::sha256;
+
+        println!("Starting load test with the following parameters:");
+        let url = format!("{}/{}", self.url, TEST_API);
+        println!("Test URL: {}", url);
+        println!("Base Port: {}", self.base_port);
+        println!("Output Directory: {}", self.output_dir.display());
+        println!("Number of Sites: {}", self.sites);
+        println!("Invoice Lines: {}", self.invoice_lines);
+        println!("Duration: {} seconds", self.duration);
+
+        let body = r#"{"visibleNameIds":[]}"#;
+        let client = Client::new();
+        let create_site_url = url + "/create_site";
+        let mut site_n_stores: Vec<SiteNStore> = Vec::new();
+        for _ in 0..self.sites {
+            let response = client
+                .post(create_site_url.to_owned())
+                .header("app-name", "load_test")
+                .header("app-version", "0")
+                .header("msupply-site-uuid", "load_test")
+                .header("sync-version", "9")
+                .header("content-length", body.len())
+                .basic_auth(
+                    self.test_site_name.as_ref().unwrap(),
+                    Some(sha256(self.test_site_pass.as_ref().unwrap().as_str())),
+                )
+                .body(body)
+                .send()
+                .await?;
+
+            if response.status().is_success() {
+                site_n_stores.push(response.json().await?);
+            } else {
+                dbg!(&response.text().await?);
+            }
+        }
+
+        dbg!(site_n_stores);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Part of #7755 

# 👩🏻‍💻 What does this PR do?

Sets up basic CLI action and creates the sites on OG

## 💌 Any notes for the reviewer?

There were utilities in integration tests, but I didn't think it was appropriate to turn on the integration tests flag to make them compile in a build. Though, I could extract them out into a common area...

I could also take this another direction and make a whole separate CLI tool, though that doesn't solve the code reuse mentioned above.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] OG central server up
- [ ] Run this CLI e.g. in `/server` run `cargo build && ./target/debug/remote_server_cli load-test -u http://localhost:8888 -b 123 -o ./dir -s 5 -i 25 -d 100`
- [ ] Sites are created in OG

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

