### PR TITLE
7749 add from master list refresh

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/utils/useAddFromMasterList.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/utils/useAddFromMasterList.ts
@@ -20,6 +20,9 @@ export const useAddFromMasterList = () => {
   const mutationState = useMutation(api.addFromMasterList, {
     onSettled: () =>
       queryClient.invalidateQueries(api.keys.detail(String(requisitionNumber))),
+    onSuccess: () => {
+      queryClient.invalidateQueries(api.keys.detail(requestId));
+    },
   });
 
   const t = useTranslation();


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7749

# 👩🏻‍💻 What does this PR do?

Fixes the issue where we have to refresh the page after clicking on `Add from Master list` button. Invalidates the keys `onSuccess`

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Replenishment -> Internal Orders
- [ ] Start a new order, or click on existing
- [ ] Click "Add from Master list", and select a list
- [ ] Click "OK" to confirm
- [ ] Items appears within the list without refreshing!

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

