### PR TITLE
Update text input debounce to more moderate value

### DIFF
--- a/client/packages/common/src/ui/layout/tables/columns/types.ts
+++ b/client/packages/common/src/ui/layout/tables/columns/types.ts
@@ -18,6 +18,7 @@ export interface CellProps<T extends RecordWithId> {
   autocompleteName?: string;
   localisedText: TypedTFunction<LocaleKey>;
   localisedDate: (date: string | number | Date) => string;
+  debounceTime?: number;
 }
 
 export interface HeaderProps<T extends RecordWithId> {

--- a/client/packages/common/src/ui/layout/tables/components/Cells/TextInputCell/TextInputCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/TextInputCell/TextInputCell.tsx
@@ -18,7 +18,7 @@ export const TextInputCell = <T extends RecordWithId>({
   CellProps<T>
 > => {
   const [buffer, setBuffer] = useBufferState(column.accessor({ rowData }));
-  const updater = useDebounceCallback(column.setter, [column.setter], 500);
+  const updater = useDebounceCallback(column.setter, [column.setter], 200);
   const { maxLength } = column;
   const autoFocus = isAutoFocus || (rowIndex === 0 && columnIndex === 0);
   // This enables browser autocomplete for suggesting previously entered input

--- a/client/packages/common/src/ui/layout/tables/components/Cells/TextInputCell/TextInputCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/TextInputCell/TextInputCell.tsx
@@ -14,11 +14,16 @@ export const TextInputCell = <T extends RecordWithId>({
   autocompleteName,
   fullWidth,
   isRequired,
+  debounceTime = 500,
 }: CellProps<T> & { fullWidth?: boolean }): React.ReactElement<
   CellProps<T>
 > => {
   const [buffer, setBuffer] = useBufferState(column.accessor({ rowData }));
-  const updater = useDebounceCallback(column.setter, [column.setter], 200);
+  const updater = useDebounceCallback(
+    column.setter,
+    [column.setter],
+    debounceTime
+  );
   const { maxLength } = column;
   const autoFocus = isAutoFocus || (rowIndex === 0 && columnIndex === 0);
   // This enables browser autocomplete for suggesting previously entered input

--- a/client/packages/programs/src/VaccineCourseEditModal/VaccineCourseEditModal.tsx
+++ b/client/packages/programs/src/VaccineCourseEditModal/VaccineCourseEditModal.tsx
@@ -334,6 +334,7 @@ const VaccineCourseDoseTable = ({
         Cell: LabelCell,
         label: 'label.custom-age-label',
         accessor: ({ rowData }) => rowData.customAgeLabel ?? '',
+        cellProps: { debounceTime: 0 },
         setter: updateDose,
       },
       {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7577

Adds custom debounce prop to text input cell so can manually change.

In this case (as not connected to API calls), have set to 0.

Wondered about making it 0 for all textinputCell, but wasn't sure if somewhere it was connected to an API call which might cause some issues, so just adding a custom prop.

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [x] Navigate to vaccine courses
- [x] Open edit vaccine course modal with a number of doses
- [x] Attempt to edit many course labels in quick succession (as seen on the issue)
- [x] See that UI is more response to catch all changes.

# 📃 Documentation

- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [x] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [x] Postgres
- [x] SQLite
- [x] Frontend

