### PR TITLE
#7388 Store pref for simplifed mobile UI

### DIFF
--- a/client/packages/common/src/hooks/index.ts
+++ b/client/packages/common/src/hooks/index.ts
@@ -31,3 +31,4 @@ export * from './useUserPreferencePagination';
 export * from './useStringFilter';
 export * from './useIsGapsStoreOnly';
 export * from './useKeyboardShortcut';
+export * from './useSimplifiedTabletUI';

--- a/client/packages/common/src/hooks/useSimplifiedTabletUI/index.ts
+++ b/client/packages/common/src/hooks/useSimplifiedTabletUI/index.ts
@@ -1,0 +1,1 @@
+export * from './useSimplifiedTabletUI';

--- a/client/packages/common/src/hooks/useSimplifiedTabletUI/useSimplifiedTabletUI.ts
+++ b/client/packages/common/src/hooks/useSimplifiedTabletUI/useSimplifiedTabletUI.ts
@@ -1,0 +1,32 @@
+/**
+ * This hook determines whether or not the UI should be displayed with the
+ * "simplified" options when on a mobile device.
+ *
+ * Use the value returned from this hook whenever a UI element is conditional on
+ * the "simplified" mobile view.
+ *
+ * Three criteria must be true:
+ * - The store pref "Use Simplified Mobile UI" is enabled
+ * - The (old) preference "Pack size to 1" is enabled
+ * - The device screen size is "tablet" size or smaller
+ */
+
+import { useAppTheme, useMediaQuery, Breakpoints } from '@common/styles';
+import { useAuthContext, usePreference } from '../../authentication';
+import { PreferenceKey } from '@common/types';
+
+export const useSimplifiedTabletUI = () => {
+  const theme = useAppTheme();
+  const isMediumScreen = useMediaQuery(theme.breakpoints.down(Breakpoints.lg));
+
+  const { data } = usePreference(PreferenceKey.UseSimplifiedMobileUi);
+
+  const { store } = useAuthContext();
+
+  // Defaulting these values to `true` -- if the value hasn't loaded yet, it's
+  // better that the UI shows too simplified than too crowded
+  const packToOne = store?.preferences?.packToOne ?? true;
+  const useSimplifiedMobileUi = data?.useSimplifiedMobileUi ?? true;
+
+  return isMediumScreen && useSimplifiedMobileUi && packToOne;
+};

--- a/client/packages/common/src/hooks/useSimplifiedTabletUI/useSimplifiedTabletUI.ts
+++ b/client/packages/common/src/hooks/useSimplifiedTabletUI/useSimplifiedTabletUI.ts
@@ -9,6 +9,10 @@
  * - The store pref "Use Simplified Mobile UI" is enabled
  * - The (old) preference "Pack size to 1" is enabled
  * - The device screen size is "tablet" size or smaller
+ *
+ * We may wish to modify this so that the "pack size to 1" preference is only
+ * required where it would be relevant. In which case, we would make
+ * "requirePackToOne" a parameter to this hook.
  */
 
 import { useAppTheme, useMediaQuery, Breakpoints } from '@common/styles';

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1801,6 +1801,7 @@
   "preference.manageVvmStatusForStock": "Manage VVM status for stock",
   "preference.showContactTracing": "Show Contact Tracing",
   "preference.sortByVvmStatusThenExpiry": "Sort available batches by VVM status then expiry",
+  "preference.useSimplifiedMobileUi": "Use simplified mobile UI",
   "prescription": "Prescriptions",
   "prescriptions": "Prescriptions",
   "programs": "Programs",

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -6004,7 +6004,7 @@ export enum PreferenceKey {
   ManageVvmStatusForStock = 'manageVvmStatusForStock',
   ShowContactTracing = 'showContactTracing',
   SortByVvmStatusThenExpiry = 'sortByVvmStatusThenExpiry',
-  UseSimplifiedMobileUi = 'useSimplifiedMobileUI',
+  UseSimplifiedMobileUi = 'useSimplifiedMobileUi',
 }
 
 export type PreferenceMutations = {

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -133,6 +133,13 @@ export enum ActivityLogNodeType {
   InvoiceStatusPicked = 'INVOICE_STATUS_PICKED',
   InvoiceStatusShipped = 'INVOICE_STATUS_SHIPPED',
   InvoiceStatusVerified = 'INVOICE_STATUS_VERIFIED',
+  ItemVariantCreated = 'ITEM_VARIANT_CREATED',
+  ItemVariantDeleted = 'ITEM_VARIANT_DELETED',
+  ItemVariantUpdatedName = 'ITEM_VARIANT_UPDATED_NAME',
+  ItemVariantUpdateColdStorageType = 'ITEM_VARIANT_UPDATE_COLD_STORAGE_TYPE',
+  ItemVariantUpdateDosePerUnit = 'ITEM_VARIANT_UPDATE_DOSE_PER_UNIT',
+  ItemVariantUpdateManufacturer = 'ITEM_VARIANT_UPDATE_MANUFACTURER',
+  ItemVariantUpdateVvmType = 'ITEM_VARIANT_UPDATE_VVM_TYPE',
   PrescriptionCreated = 'PRESCRIPTION_CREATED',
   PrescriptionDeleted = 'PRESCRIPTION_DELETED',
   PrescriptionStatusCancelled = 'PRESCRIPTION_STATUS_CANCELLED',
@@ -5997,6 +6004,7 @@ export enum PreferenceKey {
   ManageVvmStatusForStock = 'manageVvmStatusForStock',
   ShowContactTracing = 'showContactTracing',
   SortByVvmStatusThenExpiry = 'sortByVvmStatusThenExpiry',
+  UseSimplifiedMobileUi = 'useSimplifiedMobileUI',
 }
 
 export type PreferenceMutations = {
@@ -6027,6 +6035,7 @@ export type PreferencesNode = {
   manageVvmStatusForStock: Scalars['Boolean']['output'];
   showContactTracing: Scalars['Boolean']['output'];
   sortByVvmStatusThenExpiry: Scalars['Boolean']['output'];
+  useSimplifiedMobileUi: Scalars['Boolean']['output'];
 };
 
 export type PricingNode = {
@@ -9753,6 +9762,7 @@ export type UpsertPreferencesInput = {
   manageVvmStatusForStock?: InputMaybe<Array<BoolStorePrefInput>>;
   showContactTracing?: InputMaybe<Scalars['Boolean']['input']>;
   sortByVvmStatusThenExpiry?: InputMaybe<Array<BoolStorePrefInput>>;
+  useSimplifiedMobileUi?: InputMaybe<Array<BoolStorePrefInput>>;
 };
 
 export type UpsertVaccineCourseDoseInput = {

--- a/client/packages/common/src/ui/layout/tables/hooks/useColumnDisplayState.ts
+++ b/client/packages/common/src/ui/layout/tables/hooks/useColumnDisplayState.ts
@@ -1,5 +1,8 @@
 import { useState } from 'react';
-import { useLocalStorage } from '@openmsupply-client/common';
+import {
+  useLocalStorage,
+  useSimplifiedTabletUI,
+} from '@openmsupply-client/common';
 import { Column } from '../columns';
 import { RecordWithId } from '@common/types';
 
@@ -10,6 +13,10 @@ export const useColumnDisplayState = <T extends RecordWithId>(
   const [hiddenColsStorage, setHiddenColsStorage] =
     useLocalStorage('/columns/hidden');
   const hiddenColKeys = hiddenColsStorage?.[tableId] ?? [];
+
+  // TO-DO Implement for column display...
+  const simplifiedTabletView = useSimplifiedTabletUI();
+  console.log('Mobile UI?', simplifiedTabletView);
 
   const [columnDisplayState, setColumnDisplayState] = useState<
     Record<string, boolean>

--- a/client/packages/common/src/ui/layout/tables/hooks/useColumnDisplayState.ts
+++ b/client/packages/common/src/ui/layout/tables/hooks/useColumnDisplayState.ts
@@ -16,6 +16,7 @@ export const useColumnDisplayState = <T extends RecordWithId>(
 
   // TO-DO Implement for column display...
   const simplifiedTabletView = useSimplifiedTabletUI();
+  // eslint-disable-next-line
   console.log('Mobile UI?', simplifiedTabletView);
 
   const [columnDisplayState, setColumnDisplayState] = useState<

--- a/server/graphql/preference/src/upsert.rs
+++ b/server/graphql/preference/src/upsert.rs
@@ -20,6 +20,7 @@ pub struct UpsertPreferencesInput {
     pub display_vaccines_in_doses: Option<Vec<BoolStorePrefInput>>,
     pub manage_vvm_status_for_stock: Option<Vec<BoolStorePrefInput>>,
     pub sort_by_vvm_status_then_expiry: Option<Vec<BoolStorePrefInput>>,
+    pub use_simplified_mobile_ui: Option<Vec<BoolStorePrefInput>>,
 }
 
 pub fn upsert_preferences(
@@ -55,6 +56,7 @@ impl UpsertPreferencesInput {
             display_vaccines_in_doses,
             manage_vvm_status_for_stock,
             sort_by_vvm_status_then_expiry,
+            use_simplified_mobile_ui,
         } = self;
 
         UpsertPreferences {
@@ -70,6 +72,9 @@ impl UpsertPreferencesInput {
                 .as_ref()
                 .map(|i| i.iter().map(|i| i.to_domain()).collect()),
             sort_by_vvm_status_then_expiry: sort_by_vvm_status_then_expiry
+                .as_ref()
+                .map(|i| i.iter().map(|i| i.to_domain()).collect()),
+            use_simplified_mobile_ui: use_simplified_mobile_ui
                 .as_ref()
                 .map(|i| i.iter().map(|i| i.to_domain()).collect()),
         }

--- a/server/graphql/types/src/types/preferences.rs
+++ b/server/graphql/types/src/types/preferences.rs
@@ -38,6 +38,10 @@ impl PreferencesNode {
     pub async fn sort_by_vvm_status_then_expiry(&self) -> Result<bool> {
         self.load_preference(&self.preferences.sort_by_vvm_status_then_expiry)
     }
+
+    pub async fn use_simplified_mobile_ui(&self) -> Result<bool> {
+        self.load_preference(&self.preferences.use_simplified_mobile_ui)
+    }
 }
 
 impl PreferencesNode {
@@ -92,6 +96,7 @@ pub enum PreferenceKey {
     DisplayVaccinesInDoses,
     ManageVvmStatusForStock,
     SortByVvmStatusThenExpiry,
+    UseSimplifiedMobileUI,
 }
 
 impl PreferenceKey {
@@ -107,6 +112,7 @@ impl PreferenceKey {
             PrefKey::DisplayVaccinesInDoses => PreferenceKey::DisplayVaccinesInDoses,
             PrefKey::ManageVvmStatusForStock => PreferenceKey::ManageVvmStatusForStock,
             PrefKey::SortByVvmStatusThenExpiry => PreferenceKey::SortByVvmStatusThenExpiry,
+            PrefKey::UseSimplifiedMobileUI => PreferenceKey::UseSimplifiedMobileUI,
         }
     }
 }

--- a/server/graphql/types/src/types/preferences.rs
+++ b/server/graphql/types/src/types/preferences.rs
@@ -96,7 +96,7 @@ pub enum PreferenceKey {
     DisplayVaccinesInDoses,
     ManageVvmStatusForStock,
     SortByVvmStatusThenExpiry,
-    UseSimplifiedMobileUI,
+    UseSimplifiedMobileUi,
 }
 
 impl PreferenceKey {
@@ -112,7 +112,7 @@ impl PreferenceKey {
             PrefKey::DisplayVaccinesInDoses => PreferenceKey::DisplayVaccinesInDoses,
             PrefKey::ManageVvmStatusForStock => PreferenceKey::ManageVvmStatusForStock,
             PrefKey::SortByVvmStatusThenExpiry => PreferenceKey::SortByVvmStatusThenExpiry,
-            PrefKey::UseSimplifiedMobileUI => PreferenceKey::UseSimplifiedMobileUI,
+            PrefKey::UseSimplifiedMobileUi => PreferenceKey::UseSimplifiedMobileUi,
         }
     }
 }

--- a/server/service/src/preference/mod.rs
+++ b/server/service/src/preference/mod.rs
@@ -33,6 +33,7 @@ pub trait PreferenceServiceTrait: Sync + Send {
             display_vaccines_in_doses,
             manage_vvm_status_for_stock,
             sort_by_vvm_status_then_expiry,
+            use_simplified_mobile_ui,
         } = self.get_preference_provider();
 
         let input = AppendIfTypeInputs {
@@ -51,6 +52,7 @@ pub trait PreferenceServiceTrait: Sync + Send {
         append_if_type(display_vaccines_in_doses, &mut prefs, &input)?;
         append_if_type(manage_vvm_status_for_stock, &mut prefs, &input)?;
         append_if_type(sort_by_vvm_status_then_expiry, &mut prefs, &input)?;
+        append_if_type(use_simplified_mobile_ui, &mut prefs, &input)?;
 
         Ok(prefs)
     }

--- a/server/service/src/preference/preferences/mod.rs
+++ b/server/service/src/preference/preferences/mod.rs
@@ -22,7 +22,7 @@ pub struct PreferenceProvider {
     pub display_vaccines_in_doses: DisplayVaccinesInDoses,
     pub manage_vvm_status_for_stock: ManageVvmStatusForStock,
     pub sort_by_vvm_status_then_expiry: SortByVvmStatusThenExpiry,
-    pub use_simplified_mobile_ui: UseSimplifiedMobileUI,
+    pub use_simplified_mobile_ui: UseSimplifiedMobileUi,
 }
 
 pub fn get_preference_provider() -> PreferenceProvider {
@@ -35,6 +35,6 @@ pub fn get_preference_provider() -> PreferenceProvider {
         display_vaccines_in_doses: DisplayVaccinesInDoses,
         manage_vvm_status_for_stock: ManageVvmStatusForStock,
         sort_by_vvm_status_then_expiry: SortByVvmStatusThenExpiry,
-        use_simplified_mobile_ui: UseSimplifiedMobileUI,
+        use_simplified_mobile_ui: UseSimplifiedMobileUi,
     }
 }

--- a/server/service/src/preference/preferences/mod.rs
+++ b/server/service/src/preference/preferences/mod.rs
@@ -10,6 +10,8 @@ pub mod manage_vvm_status_for_stock;
 pub use manage_vvm_status_for_stock::*;
 pub mod allow_tracking_of_stock_by_donor;
 pub use allow_tracking_of_stock_by_donor::*;
+pub mod use_simplified_mobile_ui;
+pub use use_simplified_mobile_ui::*;
 
 pub struct PreferenceProvider {
     // Global preferences
@@ -20,6 +22,7 @@ pub struct PreferenceProvider {
     pub display_vaccines_in_doses: DisplayVaccinesInDoses,
     pub manage_vvm_status_for_stock: ManageVvmStatusForStock,
     pub sort_by_vvm_status_then_expiry: SortByVvmStatusThenExpiry,
+    pub use_simplified_mobile_ui: UseSimplifiedMobileUI,
 }
 
 pub fn get_preference_provider() -> PreferenceProvider {
@@ -32,5 +35,6 @@ pub fn get_preference_provider() -> PreferenceProvider {
         display_vaccines_in_doses: DisplayVaccinesInDoses,
         manage_vvm_status_for_stock: ManageVvmStatusForStock,
         sort_by_vvm_status_then_expiry: SortByVvmStatusThenExpiry,
+        use_simplified_mobile_ui: UseSimplifiedMobileUI,
     }
 }

--- a/server/service/src/preference/preferences/use_simplified_mobile_ui.rs
+++ b/server/service/src/preference/preferences/use_simplified_mobile_ui.rs
@@ -1,12 +1,12 @@
 use crate::preference::{PrefKey, Preference, PreferenceType, PreferenceValueType};
 
-pub struct UseSimplifiedMobileUI;
+pub struct UseSimplifiedMobileUi;
 
-impl Preference for UseSimplifiedMobileUI {
+impl Preference for UseSimplifiedMobileUi {
     type Value = bool;
 
     fn key(&self) -> PrefKey {
-        PrefKey::UseSimplifiedMobileUI
+        PrefKey::UseSimplifiedMobileUi
     }
 
     fn preference_type(&self) -> PreferenceType {
@@ -15,5 +15,9 @@ impl Preference for UseSimplifiedMobileUI {
 
     fn value_type(&self) -> PreferenceValueType {
         PreferenceValueType::Boolean
+    }
+
+    fn default_value(&self) -> Self::Value {
+        true
     }
 }

--- a/server/service/src/preference/preferences/use_simplified_mobile_ui.rs
+++ b/server/service/src/preference/preferences/use_simplified_mobile_ui.rs
@@ -1,0 +1,19 @@
+use crate::preference::{PrefKey, Preference, PreferenceType, PreferenceValueType};
+
+pub struct UseSimplifiedMobileUI;
+
+impl Preference for UseSimplifiedMobileUI {
+    type Value = bool;
+
+    fn key(&self) -> PrefKey {
+        PrefKey::UseSimplifiedMobileUI
+    }
+
+    fn preference_type(&self) -> PreferenceType {
+        PreferenceType::Store
+    }
+
+    fn value_type(&self) -> PreferenceValueType {
+        PreferenceValueType::Boolean
+    }
+}

--- a/server/service/src/preference/types.rs
+++ b/server/service/src/preference/types.rs
@@ -20,7 +20,7 @@ pub enum PrefKey {
     DisplayPopulationBasedForecasting,
     ManageVvmStatusForStock,
     SortByVvmStatusThenExpiry,
-    UseSimplifiedMobileUI,
+    UseSimplifiedMobileUi,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/server/service/src/preference/types.rs
+++ b/server/service/src/preference/types.rs
@@ -20,6 +20,7 @@ pub enum PrefKey {
     DisplayPopulationBasedForecasting,
     ManageVvmStatusForStock,
     SortByVvmStatusThenExpiry,
+    UseSimplifiedMobileUI,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/server/service/src/preference/upsert.rs
+++ b/server/service/src/preference/upsert.rs
@@ -20,6 +20,7 @@ pub struct UpsertPreferences {
     pub display_vaccines_in_doses: Option<Vec<StorePrefUpdate<bool>>>,
     pub manage_vvm_status_for_stock: Option<Vec<StorePrefUpdate<bool>>>,
     pub sort_by_vvm_status_then_expiry: Option<Vec<StorePrefUpdate<bool>>>,
+    pub use_simplified_mobile_ui: Option<Vec<StorePrefUpdate<bool>>>,
 }
 
 pub fn upsert_preferences(
@@ -33,6 +34,7 @@ pub fn upsert_preferences(
         display_vaccines_in_doses: display_vaccines_in_doses_input,
         manage_vvm_status_for_stock: manage_vvm_status_for_stock_input,
         sort_by_vvm_status_then_expiry: sort_by_vvm_status_then_expiry_input,
+        use_simplified_mobile_ui: use_simplified_mobile_ui_input,
     }: UpsertPreferences,
 ) -> Result<(), UpsertPreferenceError> {
     let PreferenceProvider {
@@ -44,6 +46,7 @@ pub fn upsert_preferences(
         display_vaccines_in_doses,
         manage_vvm_status_for_stock,
         sort_by_vvm_status_then_expiry,
+        use_simplified_mobile_ui,
     }: PreferenceProvider = get_preference_provider();
 
     ctx.connection
@@ -61,7 +64,7 @@ pub fn upsert_preferences(
                 show_contact_tracing.upsert(connection, input, None)?;
             }
 
-            // Store peferences, input could be array of store IDs and values - iterate and insert...
+            // Store preferences, input could be array of store IDs and values - iterate and insert...
             if let Some(input) = display_vaccines_in_doses_input {
                 for update in input.into_iter() {
                     display_vaccines_in_doses.upsert(
@@ -85,6 +88,16 @@ pub fn upsert_preferences(
             if let Some(input) = sort_by_vvm_status_then_expiry_input {
                 for update in input.into_iter() {
                     sort_by_vvm_status_then_expiry.upsert(
+                        connection,
+                        update.value,
+                        Some(update.store_id),
+                    )?;
+                }
+            }
+
+            if let Some(input) = use_simplified_mobile_ui_input {
+                for update in input.into_iter() {
+                    use_simplified_mobile_ui.upsert(
                         connection,
                         update.value,
                         Some(update.store_id),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7388.

Implemented with front-end hook as suggested [in this comment](https://github.com/msupply-foundation/open-msupply/issues/7388#issuecomment-2889279437).

All checks for whether to display UI with "simplifed" view should use this hook.

# 👩🏻‍💻 What does this PR do?

- Implemented `useSimplifiedMobileUi` preference on server
- Add "useSimplifiedTabletUI` hook on front-end which uses this preference plus two other conditions (see code)

## 💌 Any notes for the reviewer?

Haven't actually implemented this anywhere yet, but it will be used in #7397 which will be available soo.

For now, I've just added a `console.log()` to display the value on any Table.

See additional comments in code review

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Can display and edit the preference "Use Simplified Mobile UI" in Facilities -> Store -> Preferences
- [ ] Correct value for front-end hook is displayed in `console.log()` in front-end tables (will be replaced)

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

