### PR TITLE
7755 write site configs to files

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2019,6 +2019,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_yml",
  "server",
  "service",
  "shellexpand",
@@ -4658,7 +4659,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -5378,6 +5379,16 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
 ]
 
 [[package]]
@@ -7664,6 +7675,21 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yml"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyml",
+ "memchr",
+ "ryu",
+ "serde",
+ "version_check",
 ]
 
 [[package]]

--- a/server/cli/Cargo.toml
+++ b/server/cli/Cargo.toml
@@ -22,7 +22,7 @@ util = { path = "../util" }
 service = { path = "../service" }
 server = { path = "../server" }
 graphql = { path = "../graphql" }
-report_builder = {path = "../report_builder"}
+report_builder = { path = "../report_builder" }
 
 
 anyhow = { workspace = true }
@@ -47,6 +47,7 @@ async-trait = "0.1.8"
 machine-uid = { version = "0.5.1" }
 copy_dir = "0.1.3"
 shellexpand = "3.1.0"
+serde_yml = "0.0.12"
 
 [dev-dependencies]
 actix-rt = { workspace = true }

--- a/server/repository/src/database_settings.rs
+++ b/server/repository/src/database_settings.rs
@@ -2,6 +2,7 @@ use crate::db_diesel::{DBBackendConnection, StorageConnectionManager};
 use diesel::connection::SimpleConnection;
 use diesel::r2d2::{ConnectionManager, Pool};
 use log::info;
+use serde::{Deserialize, Serialize};
 
 // Timeout for waiting for the SQLite lock (https://www.sqlite.org/c3ref/busy_timeout.html).
 // A locked DB results in the "SQLite database is locked" error.
@@ -11,7 +12,7 @@ const SQLITE_LOCKWAIT_MS: u32 = 30 * 1000;
 #[cfg(all(not(feature = "postgres"), not(feature = "memory")))]
 const SQLITE_WAL_PRAGMA: &str = "PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;";
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct DatabaseSettings {
     pub username: String,
     pub password: String,

--- a/server/service/src/settings.rs
+++ b/server/service/src/settings.rs
@@ -1,10 +1,11 @@
 use std::fmt::{Display, Formatter, Result};
 
 use repository::database_settings::DatabaseSettings;
+use serde::{Deserialize, Serialize};
 
 use crate::sync::settings::SyncSettings;
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct Settings {
     pub server: ServerSettings,
     pub database: DatabaseSettings,
@@ -14,7 +15,7 @@ pub struct Settings {
     pub mail: Option<MailSettings>,
 }
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct ServerSettings {
     pub port: u16,
     /// Allow to run the server in http mode
@@ -45,7 +46,7 @@ impl ServerSettings {
 }
 
 /// See backup cli for more details
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct BackupSettings {
     // Root folder for backup
     pub backup_dir: String,
@@ -60,14 +61,14 @@ pub fn is_develop() -> bool {
     cfg!(debug_assertions)
 }
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub enum LogMode {
     All,
     Console,
     File,
 }
 
-#[derive(serde::Deserialize, Clone, Default)]
+#[derive(Deserialize, Serialize, Clone, Default)]
 pub enum DiscoveryMode {
     #[default]
     Auto,
@@ -75,7 +76,7 @@ pub enum DiscoveryMode {
     Disabled,
 }
 
-#[derive(serde::Deserialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub enum Level {
     Error,
     Warn,
@@ -97,7 +98,7 @@ impl Display for Level {
     }
 }
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct LoggingSettings {
     /// Console (default) | File
     pub mode: LogMode,
@@ -129,25 +130,25 @@ impl LoggingSettings {
     }
 }
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct DisplaySettingNode {
     pub value: String,
     pub hash: String,
 }
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct DisplaySettingsNode {
     pub custom_logo: Option<DisplaySettingNode>,
     pub custom_theme: Option<DisplaySettingNode>,
 }
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct DisplaySettingsInput {
     pub custom_logo: Option<String>,
     pub custom_theme: Option<String>,
 }
 
-#[derive(serde::Deserialize, Clone, serde::Serialize)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct LabelPrinterSettingNode {
     pub address: String,
     pub label_height: i32,
@@ -155,7 +156,7 @@ pub struct LabelPrinterSettingNode {
     pub port: u16,
 }
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct MailSettings {
     pub port: u16,
     pub host: String,

--- a/server/service/src/sync/settings.rs
+++ b/server/service/src/sync/settings.rs
@@ -1,10 +1,10 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 // See README.md for description of when this API version needs to be updated
 pub(crate) static SYNC_V5_VERSION: u32 = 9; // bumped for v2.8
 pub(crate) static SYNC_V6_VERSION: u32 = 4;
 
-#[derive(Deserialize, Clone, Debug, PartialEq, Default)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Default)]
 pub struct SyncSettings {
     pub url: String,
     pub username: String,
@@ -16,7 +16,7 @@ pub struct SyncSettings {
     pub batch_size: BatchSize,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct BatchSize {
     pub remote_pull: u32,
     pub remote_push: u32,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7755 

# 👩🏻‍💻 What does this PR do?

For each site create the config file for starting OMS instances from CLI. There are probably some details in the settings that ain't quite right, I plan to iron it out when actually using these configs and seeing what blows up.

## 💌 Any notes for the reviewer?

from `.../open-msupply/server/` run `cargo build && ./target/debug/remote_server_cli load-test -u http://localhost:8888 -s 5 -i 25 -d 100` (substitute your 4D server in `-u`)

Had to sprinkle `Serialize` derive around Settings structs so that `serde_yml` would work. I was pretty liberal with it, may have got an extra struct but it can't hurt much.

Note, there is a similar crate `serde-yml`, but the author (same guy who made serde, serde-json, anyhow...) stopped maintaining it and marked it as deprecated. `serde_yml` is a fork of `serde-yml` that is maintained. 

# 🧪 Testing

Dev tested 

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

