### PR TITLE
7512 Prevent reasonOptions firing on scroll

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/ReduceLinesToZeroModal.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/ReduceLinesToZeroModal.tsx
@@ -31,8 +31,8 @@ export const ReduceLinesToZeroConfirmationModal = ({
 
   const onZeroQuantities = useStocktakeOld.line.zeroQuantities();
 
-  const { data } = useReasonOptions();
-  const reasonIsRequired = data?.totalCount !== 0;
+  const { data: reasonOptions, isLoading } = useReasonOptions();
+  const reasonIsRequired = reasonOptions?.totalCount !== 0;
 
   return (
     <ConfirmationModalLayout
@@ -67,6 +67,8 @@ export const ReduceLinesToZeroConfirmationModal = ({
               type={ReasonOptionNodeType.NegativeInventoryAdjustment}
               value={reason}
               onChange={reason => setReason(reason)}
+              reasonOptions={reasonOptions?.nodes ?? []}
+              isLoading={isLoading}
             />
           }
           sx={{

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -21,6 +21,7 @@ import {
   usePreference,
   PreferenceKey,
   getReasonOptionType,
+  ReasonOptionNode,
 } from '@openmsupply-client/common';
 import { DraftStocktakeLine } from './utils';
 import {
@@ -31,6 +32,7 @@ import {
   ReasonOptionRowFragment,
   ReasonOptionsSearchInput,
   useIsItemVariantsEnabled,
+  useReasonOptions,
 } from '@openmsupply-client/system';
 import {
   useStocktakeLineErrorContext,
@@ -102,6 +104,8 @@ const getCountThisLineColumn = (
 const getInventoryAdjustmentReasonInputColumn = (
   setter: DraftLineSetter,
   { getError }: UseStocktakeLineErrors,
+  reasonOptions: ReasonOptionNode[],
+  isLoading: boolean,
   initialStocktake?: boolean
 ): ColumnDescription<DraftStocktakeLine> => {
   return {
@@ -148,6 +152,8 @@ const getInventoryAdjustmentReasonInputColumn = (
             rowData.snapshotNumberOfPacks == rowData.countedNumberOfPacks
           }
           initialStocktake={initialStocktake}
+          reasonOptions={reasonOptions}
+          isLoading={isLoading}
         />
       );
     },
@@ -164,6 +170,7 @@ export const BatchTable = ({
   const theme = useTheme();
   const itemVariantsEnabled = useIsItemVariantsEnabled();
   useDisableStocktakeRows(batches);
+  const { data: reasonOptions, isLoading } = useReasonOptions();
 
   const errorsContext = useStocktakeLineErrorContext();
 
@@ -238,6 +245,8 @@ export const BatchTable = ({
       getInventoryAdjustmentReasonInputColumn(
         update,
         errorsContext,
+        reasonOptions?.nodes ?? [],
+        isLoading,
         isInitialStocktake
       )
     );

--- a/client/packages/invoices/src/Returns/modals/ReturnReasonsTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/ReturnReasonsTable.tsx
@@ -9,6 +9,7 @@ import {
   ReasonOptionRowFragment,
   ReasonOptionsSearchInput,
   INPUT_WIDTH,
+  useReasonOptions,
 } from '@openmsupply-client/system';
 import React from 'react';
 
@@ -27,16 +28,21 @@ const ReturnReasonCell = ({
   rowIndex,
   column,
   isDisabled,
-}: CellProps<ReturnWithReason>): JSX.Element => (
-  <ReasonOptionsSearchInput
-    type={ReasonOptionNodeType.ReturnReason}
-    onChange={reason => column.setter({ ...rowData, reasonOption: reason })}
-    isDisabled={isDisabled}
-    autoFocus={rowIndex === 0}
-    width={INPUT_WIDTH}
-    value={rowData.reasonOption}
-  />
-);
+}: CellProps<ReturnWithReason>): JSX.Element => {
+  const { data: reasonOptions, isLoading } = useReasonOptions();
+  return (
+    <ReasonOptionsSearchInput
+      type={ReasonOptionNodeType.ReturnReason}
+      onChange={reason => column.setter({ ...rowData, reasonOption: reason })}
+      isDisabled={isDisabled}
+      autoFocus={rowIndex === 0}
+      width={INPUT_WIDTH}
+      value={rowData.reasonOption}
+      reasonOptions={reasonOptions?.nodes ?? []}
+      isLoading={isLoading}
+    />
+  );
+};
 
 export const ReturnReasonsComponent = ({
   lines,

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -4,6 +4,7 @@ import {
   ReasonOptionsSearchInput,
   RequestFragment,
   StockItemSearchInputWithStats,
+  useReasonOptions,
 } from '@openmsupply-client/system';
 import {
   useTranslation,
@@ -66,6 +67,7 @@ export const RequestLineEdit = ({
   const unitName = currentItem?.unitName || t('label.unit');
   const defaultPackSize = currentItem?.defaultPackSize || 1;
   const disableItemSelection = disabled || isUpdateMode;
+  const { data: reasonOptions, isLoading } = useReasonOptions();
 
   const line = useMemo(
     () => lines.find(line => line.id === draft?.id),
@@ -171,6 +173,8 @@ export const RequestLineEdit = ({
                       draft?.requestedQuantity === draft?.suggestedQuantity ||
                       disabled
                     }
+                    reasonOptions={reasonOptions?.nodes ?? []}
+                    isLoading={isLoading}
                   />
                 </Typography>
               )}

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -4,6 +4,7 @@ import {
   ItemRowFragment,
   ReasonOptionsSearchInput,
   StockItemSearchInput,
+  useReasonOptions,
 } from '@openmsupply-client/system';
 import { DraftResponseLine } from './hooks';
 import {
@@ -77,6 +78,7 @@ export const ResponseLineEdit = ({
   const [theirStatsAnchorEl, setTheirStatsAnchorEl] =
     React.useState<null | HTMLElement>(null);
   const isNew = !draft;
+  const { data: reasonOptions, isLoading } = useReasonOptions();
 
   const incomingStock =
     (draft?.incomingUnits ?? 0) + (draft?.additionInUnits ?? 0);
@@ -507,6 +509,8 @@ export const ResponseLineEdit = ({
                         isFinalised
                       }
                       onBlur={save}
+                      reasonOptions={reasonOptions?.nodes ?? []}
+                      isLoading={isLoading}
                     />
                   }
                   labelWidth={'66px'}

--- a/client/packages/system/src/ReasonOption/Components/ReasonOptionsSearchInput.tsx
+++ b/client/packages/system/src/ReasonOption/Components/ReasonOptionsSearchInput.tsx
@@ -8,7 +8,6 @@ import {
   ReasonOptionNode,
   ReasonOptionNodeType,
 } from '@openmsupply-client/common';
-import { useReasonOptions } from '../api';
 
 interface ReasonOptionsSearchInputProps {
   value?: ReasonOptionNode | null;
@@ -20,6 +19,8 @@ interface ReasonOptionsSearchInputProps {
   isDisabled?: boolean;
   onBlur?: () => void;
   initialStocktake?: boolean;
+  reasonOptions: ReasonOptionNode[];
+  isLoading: boolean;
 }
 
 export const ReasonOptionsSearchInput = ({
@@ -32,8 +33,10 @@ export const ReasonOptionsSearchInput = ({
   isDisabled,
   onBlur,
   initialStocktake,
+  reasonOptions,
+  isLoading,
 }: ReasonOptionsSearchInputProps) => {
-  const { data, isLoading } = useReasonOptions();
+  // const { data, isLoading } = useReasonOptions();
 
   const reasonFilter = (reasonOption: ReasonOptionNode) => {
     if (Array.isArray(type)) {
@@ -41,7 +44,7 @@ export const ReasonOptionsSearchInput = ({
     }
     return reasonOption.type === type;
   };
-  const reasons = (data?.nodes ?? []).filter(reasonFilter);
+  const reasons = (reasonOptions ?? []).filter(reasonFilter);
 
   const isRequired = reasons.length !== 0 && !initialStocktake;
 

--- a/client/packages/system/src/ReasonOption/Components/ReasonOptionsSearchInput.tsx
+++ b/client/packages/system/src/ReasonOption/Components/ReasonOptionsSearchInput.tsx
@@ -36,8 +36,6 @@ export const ReasonOptionsSearchInput = ({
   reasonOptions,
   isLoading,
 }: ReasonOptionsSearchInputProps) => {
-  // const { data, isLoading } = useReasonOptions();
-
   const reasonFilter = (reasonOption: ReasonOptionNode) => {
     if (Array.isArray(type)) {
       return type.includes(reasonOption.type);
@@ -45,7 +43,6 @@ export const ReasonOptionsSearchInput = ({
     return reasonOption.type === type;
   };
   const reasons = (reasonOptions ?? []).filter(reasonFilter);
-
   const isRequired = reasons.length !== 0 && !initialStocktake;
 
   return (

--- a/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
+++ b/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
@@ -12,7 +12,7 @@ import {
   getReasonOptionType,
 } from '@openmsupply-client/common';
 import { StockLineRowFragment, useInventoryAdjustment } from '../../api';
-import { ReasonOptionsSearchInput } from '../../..';
+import { ReasonOptionsSearchInput, useReasonOptions } from '../../..';
 import { InventoryAdjustmentDirectionInput } from './InventoryAdjustmentDirectionSearchInput';
 import { INPUT_WIDTH, StyledInputRow } from '../StyledInputRow';
 
@@ -32,6 +32,7 @@ export const InventoryAdjustmentModal: FC<InventoryAdjustmentModalProps> = ({
   const { round } = useFormatNumber();
 
   const { draft, setDraft, create } = useInventoryAdjustment(stockLine);
+  const { data, isLoading } = useReasonOptions();
 
   const packUnit = String(stockLine.packSize);
   const saveDisabled = draft.adjustment === 0;
@@ -99,6 +100,8 @@ export const InventoryAdjustmentModal: FC<InventoryAdjustmentModalProps> = ({
                     stockLine.item.isVaccine
                   )}
                   width={INPUT_WIDTH}
+                  reasonOptions={data?.nodes ?? []}
+                  isLoading={isLoading}
                 />
               </Box>
             }

--- a/client/packages/system/src/Stock/Components/NewStockLineModal.tsx
+++ b/client/packages/system/src/Stock/Components/NewStockLineModal.tsx
@@ -17,7 +17,11 @@ import {
 } from '@openmsupply-client/common';
 import { useStockLine } from '../api';
 import { StockLineForm } from './StockLineForm';
-import { ReasonOptionsSearchInput, StockItemSearchInput } from '../..';
+import {
+  ReasonOptionsSearchInput,
+  StockItemSearchInput,
+  useReasonOptions,
+} from '../..';
 import { INPUT_WIDTH, StyledInputRow } from './StyledInputRow';
 import { AppRoute } from '@openmsupply-client/config';
 
@@ -36,6 +40,7 @@ export const NewStockLineModal: FC<NewStockLineModalProps> = ({
   const pluginEvents = usePluginEvents({
     isDirty: false,
   });
+  const { data: reasonOptions } = useReasonOptions();
 
   const { Modal } = useDialog({ isOpen, onClose });
 
@@ -153,6 +158,8 @@ export const NewStockLineModal: FC<NewStockLineModalProps> = ({
                       type={ReasonOptionNodeType.PositiveInventoryAdjustment}
                       value={draft.reasonOption}
                       onChange={reason => updatePatch({ reasonOption: reason })}
+                      reasonOptions={reasonOptions?.nodes ?? []}
+                      isLoading={isLoading}
                     />
                   </Box>
                 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Partly Fixes #7512 

# 👩🏻‍💻 What does this PR do?

- Move `useReasonOptions()` hook from `ReasonOptionsSearchInput` to parent components that are rendering `ReasonOptionsSearchInput` 
- Pass fetched data as props to `ReasonOptionsSearchInput`

<!-- Explain the changes you made -->

<!-- why are the changes needed -->
Now data is fetched only once and not every time `ReasonOptionsSearchInput` is rendered

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?
Note that fetching of item variants has not been fixed in this PR and will be fixed in another PR by @roxy-dao 

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have an item with many batches so that scroll is enabled in `StocktakeLineEditTable`
- [ ] Create a stocktake and add that item
- [ ] Click on the line and scroll 
- [ ] See that reasonOptions is not being fired on scroll

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

