### PR TITLE
7390 Simplified UI Inbound Detail

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/AppBarButtons.tsx
@@ -20,9 +20,13 @@ import { AddButton } from './AddButton';
 
 interface AppBarButtonProps {
   onAddItem: (newState: boolean) => void;
+  simplifiedTabletView?: boolean;
 }
 
-export const AppBarButtonsComponent = ({ onAddItem }: AppBarButtonProps) => {
+export const AppBarButtonsComponent = ({
+  onAddItem,
+  simplifiedTabletView,
+}: AppBarButtonProps) => {
   const t = useTranslation();
   const { store } = useAuthContext();
   const isDisabled = useInbound.utils.isDisabled();
@@ -72,7 +76,7 @@ export const AppBarButtonsComponent = ({ onAddItem }: AppBarButtonProps) => {
           isPrinting={isPrinting}
           buttonLabel={t('button.print')}
         />
-        {OpenButton}
+        {!simplifiedTabletView && OpenButton}
       </Grid>
     </AppBarButtonsPortal>
   );

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -165,6 +165,7 @@ export const useInboundShipmentColumns = ({
             { path: ['location', 'code'], default: '' },
           ]),
         width: 150,
+        defaultHideOnMobile: true,
       },
     ],
 
@@ -181,6 +182,7 @@ export const useInboundShipmentColumns = ({
             { path: ['lines', 'item', 'unitName'] },
             { path: ['item', 'unitName'], default: '' },
           ]),
+        defaultHideOnMobile: true,
       },
     ],
     [
@@ -196,6 +198,7 @@ export const useInboundShipmentColumns = ({
             { path: ['lines', 'packSize'] },
             { path: ['packSize'], default: '' },
           ]),
+        defaultHideOnMobile: true,
       },
     ],
   ];
@@ -245,6 +248,7 @@ export const useInboundShipmentColumns = ({
             return getUnitQuantity(rowData);
           }
         },
+        defaultHideOnMobile: true,
       },
     ]
   );
@@ -269,6 +273,7 @@ export const useInboundShipmentColumns = ({
         }
       },
       sortable: false,
+      defaultHideOnMobile: true,
     },
     {
       label: 'label.total',
@@ -278,6 +283,7 @@ export const useInboundShipmentColumns = ({
       Cell: CurrencyCell,
       accessor: ({ rowData }) => calculateRowTotalCost(rowData),
       getSortValue: rowData => calculateRowTotalCost(rowData),
+      defaultHideOnMobile: true,
     }
   );
 

--- a/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -16,6 +16,7 @@ import {
   useBreadcrumbs,
   usePreference,
   PreferenceKey,
+  useSimplifiedTabletUI,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import {
@@ -61,6 +62,7 @@ const DetailViewInner = () => {
   );
   const { data: vvmStatuses } = useVvmStatusesEnabled();
   const hasItemVariantsEnabled = useIsItemVariantsEnabled();
+  const simplifiedTabletView = useSimplifiedTabletUI();
 
   const onRowClick = React.useCallback(
     (line: InboundItem | InboundLineFragment) => {
@@ -127,9 +129,12 @@ const DetailViewInner = () => {
       {data ? (
         <>
           <InboundShipmentLineErrorProvider>
-            <AppBarButtons onAddItem={() => onOpen()} />
+            <AppBarButtons
+              onAddItem={() => onOpen()}
+              simplifiedTabletView={simplifiedTabletView}
+            />
 
-            <Toolbar />
+            <Toolbar simplifiedTabletView={simplifiedTabletView} />
 
             <DetailTabs tabs={tabs} />
 

--- a/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React from 'react';
 import {
   AppBarContentPortal,
   Box,
@@ -35,7 +35,13 @@ const InboundInfoPanel = ({
   return <Alert severity="info">{loadMessage(shipment)}</Alert>;
 };
 
-export const Toolbar: FC = () => {
+interface ToolbarProps {
+  simplifiedTabletView?: boolean;
+}
+
+export const Toolbar = ({ simplifiedTabletView }: ToolbarProps) => {
+  const t = useTranslation();
+
   const isDisabled = useInbound.utils.isDisabled();
   const { data } = useInbound.lines.items();
   const { data: shipment } = useInbound.document.get();
@@ -45,7 +51,6 @@ export const Toolbar: FC = () => {
     'theirReference',
   ]);
   const { isGrouped, toggleIsGrouped } = useInbound.lines.rows();
-  const t = useTranslation();
 
   const isTransfer = !!shipment?.linkedShipment?.id;
   if (!data) return null;
@@ -107,22 +112,24 @@ export const Toolbar: FC = () => {
             <InboundInfoPanel shipment={shipment} />
           </Box>
         </Grid>
-        <Grid
-          display="flex"
-          gap={1}
-          justifyContent="flex-end"
-          alignItems="center"
-        >
-          <Box sx={{ marginRight: 2 }}>
-            <Switch
-              label={t('label.group-by-item')}
-              onChange={toggleIsGrouped}
-              checked={isGrouped}
-              size="small"
-              color="secondary"
-            />
-          </Box>
-        </Grid>
+        {!simplifiedTabletView && (
+          <Grid
+            display="flex"
+            gap={1}
+            justifyContent="flex-end"
+            alignItems="center"
+          >
+            <Box sx={{ marginRight: 2 }}>
+              <Switch
+                label={t('label.group-by-item')}
+                onChange={toggleIsGrouped}
+                checked={isGrouped}
+                size="small"
+                color="secondary"
+              />
+            </Box>
+          </Grid>
+        )}
       </Grid>
     </AppBarContentPortal>
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7390 (partially)

Second issue to follow with remaining change: Status button -> Verify button

This is MVP for 2.8 release (columns) plus the changes in the App Bar as they had already been completed

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Used simplified UI in Inbound Shipments -> Detail View

If on, the following columns are hidden:

Location
Unit
Pack Size
Unit quantity
Cost per Unit
Total

In the App Bar, the "More" button and "Group by" toggle are hidden
![Screenshot 2025-05-23 at 12 52 53 PM](https://github.com/user-attachments/assets/24865f87-da7b-4fd6-9237-1b0381dc1e63)

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

In order to get the 'simplified' view, these three conditions need to be in effect:

viewport width < 1025 px

store pref "Use Simplified mobile UI" is on

(old) store pref "pack_to_one" is true

- [ ] Go to Inbound Shipments -> Select a shipment -> be on the Detail View
- [ ]  If the above conditions are met, the columns "Location", "Unit", "Pack Size", "Unit quantity", "Cost per Unit" and "Total" will be hidden
- [ ]  In the app bar, the "More" button and "Group" toggle will be hidden
- [ ]  Increase the viewport to over 1025 and refresh the page -> see the columns are showing and the filter selection is present

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

