### PR TITLE
Fix plugin type error

### DIFF
--- a/client/packages/plugins/api/index.ts
+++ b/client/packages/plugins/api/index.ts
@@ -1,3 +1,2 @@
 export * from './hooks';
 export * from './operations.generated';
-export { StockLineRowFragment } from './operations.generated';


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7374 

# 👩🏻‍💻 What does this PR do?

Very tiny omission that should have gone into https://github.com/msupply-foundation/open-msupply/pull/7798 -- didn't notice the type error until trying to compile the plugin builder.

## 💌 Any notes for the reviewer?

Have confirmed that the "install-plugin-bundle" and "generate-and-install-plugin-bundle" now work with front-end plugin bundles.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

