### PR TITLE
Vaccine item_variant modal should always show doses regardless of pref

### DIFF
--- a/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantModal.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantModal.tsx
@@ -12,8 +12,6 @@ import {
   createQueryParamsStore,
   useNotification,
   NumericTextInput,
-  usePreference,
-  PreferenceKey,
 } from '@openmsupply-client/common';
 import { ItemPackagingVariantsTable } from './ItemPackagingVariantsTable';
 import {
@@ -37,8 +35,7 @@ export const ItemVariantModal = ({
   const t = useTranslation();
   const { Modal } = useDialog({ isOpen: true, onClose, disableBackdrop: true });
   const { success, error } = useNotification();
-  const { data } = usePreference(PreferenceKey.ManageVaccinesInDoses);
-  const displayVaccinesInDoses = item?.isVaccine && data?.manageVaccinesInDoses;
+  const isVaccine = item?.isVaccine;
 
   const { draft, isComplete, updateDraft, updatePackagingVariant, save } =
     useItemVariant({
@@ -89,7 +86,7 @@ export const ItemVariantModal = ({
           updateVariant={updateDraft}
           updatePackagingVariant={updatePackagingVariant}
           variant={draft}
-          displayVaccinesInDoses={displayVaccinesInDoses}
+          isVaccine={isVaccine}
         />
       </QueryParamsProvider>
     </Modal>
@@ -100,12 +97,12 @@ const ItemVariantForm = ({
   variant,
   updateVariant,
   updatePackagingVariant,
-  displayVaccinesInDoses,
+  isVaccine,
 }: {
   variant: ItemVariantFragment;
   updateVariant: (patch: Partial<ItemVariantFragment>) => void;
   updatePackagingVariant: (patch: Partial<PackagingVariantFragment>) => void;
-  displayVaccinesInDoses?: boolean;
+  isVaccine?: boolean;
 }) => {
   const t = useTranslation();
 
@@ -161,7 +158,7 @@ const ItemVariantForm = ({
             </Box>
           }
         />
-        {displayVaccinesInDoses && (
+        {isVaccine && (
           <>
             <InputWithLabelRow
               label={t('label.doses-per-unit')}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes an issue that doses can only be set on item variants if the store pref is defined for your central server.
Should be available all the time, as some stores might be using the pref even if the central store doesn't have it.

# 👩🏻‍💻 What does this PR do?

Changes the Central Server Item variant creation to always allow entering doses on vaccine items.

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Turn off the pref ManageVaccinesIn Doses for your central configuration store (Open-mSupply)
![image](https://github.com/user-attachments/assets/e4fa6136-323d-4ef9-b5d6-40eb974570f3)
- [ ] Try to create or edit an item variant, check you can still set the number of doses if the item is a vaccine


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [X] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

