### PR TITLE
null packs received updates units

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -94,8 +94,6 @@ export const QuantityTableComponent = ({
       setter: updateDraftLine,
       label: 'label.pack-size',
     }),
-    // needs to update units received and doses received when nulling
-    // is regardless of whether doses is on or off
     [
       'numberOfPacks',
       {

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -94,6 +94,8 @@ export const QuantityTableComponent = ({
       setter: updateDraftLine,
       label: 'label.pack-size',
     }),
+    // needs to update units received and doses received when nulling
+    // is regardless of whether doses is on or off
     [
       'numberOfPacks',
       {
@@ -103,7 +105,7 @@ export const QuantityTableComponent = ({
         setter: patch => {
           const { packSize, numberOfPacks } = patch;
 
-          if (!!packSize && !!numberOfPacks) {
+          if (packSize !== undefined && numberOfPacks !== undefined) {
             const packToUnits = packSize * numberOfPacks;
 
             updateDraftLine({


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7883

# 👩🏻‍💻 What does this PR do?

In inbound shipments, when `Packs received` is 0/cleared/nulled this will also update `Units received` and `Doses received` (if pref is on) to 0

Issue is specific to the `Manage in Doses pref` and vaccine items - however this bug was not specific to these and applied to all items. 

https://github.com/user-attachments/assets/b718abe9-7a60-4088-841a-bf02dd9e5537



<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?



# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->


- [ ] Have Dose Management enabled in your store and a vaccine item configured
- [ ] Go to Replenishment -> Inbound Shipments and create a new shipment
- [ ] Add the vaccine item to the shipment
- [ ] Add a value to `Packs received` -> see `Units received` and `Doses received` cell values update
- [ ] Change `Packs received` to 0 -> see `Units received` and `Doses received` cell values update to 0
- [ ] Test that adding a value to `Units received` still updates `Packs received` and `Doses received`
- [ ] Test that changing `Units received` to 0 still updates `Packs received` and `Doses received` to 0
- [ ] Also test with a non vaccine item should have the same behaviour (just no `Doses` columns)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

