### PR TITLE
7894 update stock line campaign id when inbound shipment updates

### DIFF
--- a/server/service/src/invoice_line/stock_in_line/update/generate.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/generate.rs
@@ -71,7 +71,7 @@ pub fn generate(
                     on_hold: false,
                     barcode_id: None,
                     overwrite_stock_levels: true,
-                    campaign_id: None,
+                    campaign_id: update_line.campaign_id.clone(),
                 },
             )?;
             update_line.stock_line_id = Some(new_batch.id.clone());


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7894 

# 👩🏻‍💻 What does this PR do?

When updating the campaign on an Inbound Shipment Item, Stock Line's campaign doesn't update.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Add/update a campaign Id for an item within an Inbound Shipment
- [ ] Navigate Inventory -> View Stock -> Find the stock line that relates to your item
- [ ] Campaign is the same as Inbound Shipment!

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

