### PR TITLE
7628 Set Item Variant on Stocktake

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -20,12 +20,14 @@ import {
   NumberCell,
   getReasonOptionType,
   ReasonOptionNode,
+  usePreference,
+  PreferenceKey,
 } from '@openmsupply-client/common';
 import { DraftStocktakeLine } from './utils';
 import {
   getDonorColumn,
   getLocationInputColumn,
-  ItemVariantInputCellOld,
+  ItemVariantInputCell,
   PackSizeEntryCell,
   ReasonOptionRowFragment,
   ReasonOptionsSearchInput,
@@ -168,10 +170,14 @@ export const BatchTable = ({
   const t = useTranslation();
   const theme = useTheme();
   const itemVariantsEnabled = useIsItemVariantsEnabled();
+  const { data: preferences } = usePreference(
+    PreferenceKey.ManageVaccinesInDoses
+  );
   useDisableStocktakeRows(batches);
   const { data: reasonOptions, isLoading } = useReasonOptions();
-
   const errorsContext = useStocktakeLineErrorContext();
+
+  const displayInDoses = !!preferences?.manageVaccinesInDoses;
 
   const columnDefinitions = useMemo(() => {
     const columnDefinitions: ColumnDescription<DraftStocktakeLine>[] = [
@@ -191,7 +197,13 @@ export const BatchTable = ({
         label: 'label.item-variant',
         width: 170,
         Cell: props => (
-          <ItemVariantInputCellOld {...props} itemId={props.rowData.item.id} />
+          <ItemVariantInputCell
+            displayInDoses={
+              (displayInDoses && props.rowData.item.isVaccine) ?? false
+            }
+            {...props}
+            itemId={props.rowData.item.id}
+          />
         ),
         setter: patch => update({ ...patch }),
       });


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7628 


# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Replace the Item Variant dropdown with the new popover Item Variant component. 
Use the `manageVaccinesInDoses` pref to render the doses column in the popover if the pref is on

If there are variants and the item is a vaccine (manageVaccinesInDoses is on):
<img width="1271" alt="Screenshot 2025-05-27 at 1 06 31 PM" src="https://github.com/user-attachments/assets/393ba034-2f5a-4f15-8277-0fe205d42c6c" />

If there are variants and the item is not a vaccine:
<img width="1271" alt="Screenshot 2025-05-27 at 1 07 29 PM" src="https://github.com/user-attachments/assets/af6c1b91-e6b1-436e-a648-210b8c2c2525" />

If there are no variants:
<img width="1271" alt="Screenshot 2025-05-27 at 1 06 19 PM" src="https://github.com/user-attachments/assets/6530dbba-01ba-4646-a81e-5c8edb64ccaf" />


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have some vaccine and non vaccine items with variants configured
- [ ] Have manageVaccinesInDoses store pref on (OMS)
- [ ] Create a new stocktake -> add these items to the stocktake
- [ ] Vaccine item with variants: Click on the edit icon to choose a variant -> see the popover open
- [ ] See the configured variants and the Doses column -> select a variant -> Ok
- [ ] Non vaccine item with variants: Click on the edit icon to choose a variant -> see the popover open
- [ ] See the configured variants - no Doses column -> select a variant -> Ok
- [ ] Add another item that has no variants to the stocktake
- [ ] See the `Nothing here` message in the popover
- [ ] Turn off the manageVaccinesInDoses store pref
- [ ] Go back to the stocktake -> vaccine item
- [ ] See the Item variant is saved on the stocktake
- [ ] See the `Doses` column does not show when editing the variant

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

