### PR TITLE
7899 error when saving new stock without a campaign specified

### DIFF
--- a/client/packages/system/src/Stock/api/hooks/useStockLine.ts
+++ b/client/packages/system/src/Stock/api/hooks/useStockLine.ts
@@ -35,16 +35,8 @@ const defaultDraftStockLine: DraftStockLine = {
     __typename: 'VvmstatusLogConnector',
     nodes: [],
   },
-  vvmStatus: {
-    __typename: 'VvmstatusNode',
-    id: '',
-    description: '',
-  },
-  campaign: {
-    __typename: 'CampaignNode',
-    id: '',
-    name: '',
-  },
+  vvmStatus: null,
+  campaign: null,
 };
 
 export function useStockLine(id?: string) {
@@ -131,6 +123,7 @@ const useCreate = () => {
     donor,
     campaign,
   }: DraftStockLine) => {
+    console.log('new stockline -> campaign ', campaign);
     return await stockApi.insertStockLine({
       storeId,
       input: {

--- a/client/packages/system/src/Stock/api/hooks/useStockLine.ts
+++ b/client/packages/system/src/Stock/api/hooks/useStockLine.ts
@@ -123,7 +123,6 @@ const useCreate = () => {
     donor,
     campaign,
   }: DraftStockLine) => {
-    console.log('new stockline -> campaign ', campaign);
     return await stockApi.insertStockLine({
       storeId,
       input: {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7899

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Try to add stock from the add stock screen without selecting a campaign

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

