### PR TITLE
7868 add running balance total for ledger queries

### DIFF
--- a/server/repository/src/db_diesel/invoice_row.rs
+++ b/server/repository/src/db_diesel/invoice_row.rs
@@ -64,7 +64,7 @@ joinable!(invoice -> clinician_link (clinician_link_id));
 allow_tables_to_appear_in_same_query!(invoice, item_link);
 allow_tables_to_appear_in_same_query!(invoice, name_link);
 
-#[derive(DbEnum, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(DbEnum, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, PartialOrd, Ord)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[DbValueStyle = "SCREAMING_SNAKE_CASE"]
 pub enum InvoiceType {

--- a/server/repository/src/db_diesel/ledger.rs
+++ b/server/repository/src/db_diesel/ledger.rs
@@ -153,7 +153,10 @@ impl<'a> LedgerRepository<'a> {
             }
         }
 
-        let final_query = query;
+        // Apply final sort ordering based on quantity,this means the negative quantities will be first, then the positive ones, so if two operations happen at the same time, the negative one will be first
+        // This makes sense for nulled or cancelled transactions, where we want to see the negative quantity first.
+        // Ideally it should be the actual order of the transactions, but this is at least consistent
+        let final_query = query.order_by(ledger::quantity.asc());
 
         // Debug diesel query
         // println!(

--- a/server/repository/src/db_diesel/ledger.rs
+++ b/server/repository/src/db_diesel/ledger.rs
@@ -33,7 +33,7 @@ table! {
     }
 }
 
-#[derive(Clone, Queryable, Debug, PartialEq)]
+#[derive(Clone, Queryable, Debug, PartialEq, Default)]
 pub struct LedgerRow {
     pub id: String,
     pub stock_line_id: Option<String>,

--- a/server/repository/src/db_diesel/ledger.rs
+++ b/server/repository/src/db_diesel/ledger.rs
@@ -153,10 +153,7 @@ impl<'a> LedgerRepository<'a> {
             }
         }
 
-        // Apply final sort ordering based on quantity,this means the negative quantities will be first, then the positive ones, so if two operations happen at the same time, the negative one will be first
-        // This makes sense for nulled or cancelled transactions, where we want to see the negative quantity first.
-        // Ideally it should be the actual order of the transactions, but this is at least consistent
-        let final_query = query.order_by(ledger::quantity.asc());
+        let final_query = query;
 
         // Debug diesel query
         // println!(

--- a/server/service/src/ledger.rs
+++ b/server/service/src/ledger.rs
@@ -52,6 +52,19 @@ pub fn get_item_ledger(
             desc: Some(false),
         }),
     )?;
+
+    let item_ledgers = calculate_ledger_balance(rows, all_ledger_items);
+
+    Ok(ListResult {
+        count: i64_to_u32(repository.count(Some(filter))?),
+        rows: item_ledgers,
+    })
+}
+
+fn calculate_ledger_balance(
+    rows: Vec<LedgerRow>,
+    all_ledger_items: Vec<LedgerRow>,
+) -> Vec<ItemLedger> {
     let mut item_ledgers = vec![];
 
     for row in rows {
@@ -72,9 +85,5 @@ pub fn get_item_ledger(
 
         item_ledgers.push(ledger);
     }
-
-    Ok(ListResult {
-        count: i64_to_u32(repository.count(Some(filter))?),
-        rows: item_ledgers,
-    })
+    item_ledgers
 }

--- a/server/service/src/ledger.rs
+++ b/server/service/src/ledger.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use repository::{
-    ledger::{LedgerFilter, LedgerRepository, LedgerRow, LedgerSort, LedgerSortField},
+    ledger::{self, LedgerFilter, LedgerRepository, LedgerRow, LedgerSort, LedgerSortField},
     EqualFilter, Pagination, PaginationOption, StorageConnection, StorageConnectionManager,
 };
 
@@ -13,6 +13,11 @@ use super::{ListError, ListResult};
 pub struct ItemLedger {
     pub ledger: LedgerRow,
     pub balance: f64,
+}
+
+pub struct ItemLedgerWithCursor {
+    pub item_ledger: ItemLedger,
+    pub cursor: i32,
 }
 
 pub fn get_ledger(
@@ -45,7 +50,6 @@ pub fn get_item_ledger(
         .unwrap_or_default()
         .store_id(EqualFilter::equal_to(store_id));
 
-    let rows = repository.query(pagination, Some(filter.clone()), sort)?;
     let all_ledger_items = repository.query(
         Pagination::all(),
         Some(filter.clone()),
@@ -55,7 +59,7 @@ pub fn get_item_ledger(
         }),
     )?;
 
-    let item_ledgers = calculate_ledger_balance(rows, all_ledger_items);
+    let item_ledgers = calculate_ledger_balance(pagination, sort, all_ledger_items);
 
     Ok(ListResult {
         count: i64_to_u32(repository.count(Some(filter))?),
@@ -64,95 +68,103 @@ pub fn get_item_ledger(
 }
 
 fn calculate_ledger_balance(
-    rows: Vec<LedgerRow>,
+    pagination: Pagination,
+    sort: Option<LedgerSort>,
     all_ledger_items: Vec<LedgerRow>,
 ) -> Vec<ItemLedger> {
-    let mut item_ledgers = vec![];
     // TODO fix in refactor. Hashmap because currently we can still query for multiple items.
     // See in issue #7905
     let mut running_balance = HashMap::<String, f64>::new();
-    // balance for each ledger item. Save these separately to preserve the queried order of rows
-    let mut ledger_balance = HashMap::<String, f64>::new();
+    // balance for each ledger item. Save these separately to preserve the queried order of rows.
+    let mut ledger_balance = HashMap::<String, (f64, i32)>::new();
+    // Also have a second integer cursor to keep track of order of operations so that ledgers of same datetime are not out of order with how balance is calculated.
+    let mut cursor = 0;
 
-    for ledger in all_ledger_items {
+    for ledger in all_ledger_items.clone() {
         // we want to iterate through all ledger items to calculate the balance
         let previous_balance = running_balance.get(&ledger.item_id).cloned().unwrap_or(0.0);
         running_balance.insert(ledger.item_id.clone(), previous_balance + ledger.quantity);
 
-        // only add the queried rows to the item_ledgers to return
-        if rows.iter().any(|row| row.id == ledger.id) {
-            ledger_balance.insert(ledger.id.clone(), running_balance[&ledger.item_id]);
+        ledger_balance.insert(
+            ledger.id.clone(),
+            (running_balance[&ledger.item_id], cursor),
+        );
+        cursor += 1;
+    }
+
+    // manual paginate
+    let mut item_ledgers_trimmed: Vec<LedgerRow> = all_ledger_items
+        .into_iter()
+        .skip(pagination.offset as usize)
+        .take(pagination.limit as usize)
+        .collect();
+
+    // manual sort
+    if let Some(sort) = sort {
+        match sort.key {
+            LedgerSortField::Id => {
+                item_ledgers_trimmed.sort_by_key(|l| l.id.clone());
+            }
+            LedgerSortField::Datetime => {
+                // first sort by cursor to preserve the order of operations when displaying ledger lines of same datetime
+                item_ledgers_trimmed.sort_by_key(|l| ledger_balance[&l.id].1);
+                item_ledgers_trimmed.sort_by_key(|l| l.datetime);
+            }
+            LedgerSortField::Name => {
+                item_ledgers_trimmed.sort_by_key(|l| l.name.clone());
+            }
+            LedgerSortField::InvoiceType => {
+                item_ledgers_trimmed.sort_by(|a, b| {
+                    a.invoice_type
+                        .partial_cmp(&b.invoice_type)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+            }
+            LedgerSortField::StockLineId => {
+                item_ledgers_trimmed.sort_by_key(|l| l.stock_line_id.clone());
+            }
+            LedgerSortField::Quantity => {
+                item_ledgers_trimmed.sort_by(|a, b| {
+                    a.quantity
+                        .partial_cmp(&b.quantity)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+            }
+            LedgerSortField::ItemId => {
+                item_ledgers_trimmed.sort_by_key(|l| l.item_id.clone());
+            }
+        }
+
+        if sort.desc.unwrap_or(false) {
+            item_ledgers_trimmed.reverse();
         }
     }
 
-    for row in rows {
-        item_ledgers.push(ItemLedger {
-            ledger: row.clone(),
-            balance: ledger_balance.get(&row.id).cloned().unwrap_or(0.0),
-        });
-    }
-
-    item_ledgers
+    // map trimmed ledger items with balance
+    item_ledgers_trimmed
+        .into_iter()
+        .map(|ledger| ItemLedger {
+            ledger: ledger.clone(),
+            balance: ledger_balance
+                .get(&ledger.id)
+                .cloned()
+                .unwrap_or((0.0, 0))
+                .0,
+        })
+        .collect()
 }
 
 // Add tests for calculate_ledger_balance function
-// Note test does not simulate case where multiple items are queried.
 #[cfg(test)]
 mod tests {
 
     use super::*;
     use chrono::NaiveDateTime;
-    use repository::ledger::LedgerRow;
+    use repository::{ledger::LedgerRow, InvoiceType};
 
     #[actix_rt::test]
     async fn test_calculate_ledger_balance() {
-        // ledger rows can be called in any order. In this case simulating descending order by datetime
-        let ledger_rows = vec![
-            LedgerRow {
-                id: "4".to_string(),
-                item_id: "item1".to_string(),
-                quantity: -1176.0,
-                datetime: NaiveDateTime::parse_from_str(
-                    "2025-05-19T02:57:15.920256",
-                    "%Y-%m-%dT%H:%M:%S%.f",
-                )
-                .unwrap(),
-                ..Default::default()
-            },
-            LedgerRow {
-                id: "3".to_string(),
-                item_id: "item1".to_string(),
-                quantity: -1200.0,
-                datetime: NaiveDateTime::parse_from_str(
-                    "2025-02-05T04:43:02.213892",
-                    "%Y-%m-%dT%H:%M:%S%.f",
-                )
-                .unwrap(),
-                ..Default::default()
-            },
-            LedgerRow {
-                id: "2".to_string(),
-                item_id: "item1".to_string(),
-                quantity: 1200.0,
-                datetime: NaiveDateTime::parse_from_str(
-                    "2025-02-05T04:43:02.213892",
-                    "%Y-%m-%dT%H:%M:%S%.f",
-                )
-                .unwrap(),
-                ..Default::default()
-            },
-            LedgerRow {
-                id: "1".to_string(),
-                item_id: "item1".to_string(),
-                quantity: 2400.0,
-                datetime: NaiveDateTime::parse_from_str(
-                    "2025-02-03T22:16:26.986939",
-                    "%Y-%m-%dT%H:%M:%S%.f",
-                )
-                .unwrap(),
-                ..Default::default()
-            },
-        ];
+        // ledger rows are called in
 
         let all_ledger_items = vec![
             LedgerRow {
@@ -164,6 +176,7 @@ mod tests {
                     "%Y-%m-%dT%H:%M:%S%.f",
                 )
                 .unwrap(),
+                invoice_type: InvoiceType::InboundShipment,
                 ..Default::default()
             },
             LedgerRow {
@@ -175,6 +188,7 @@ mod tests {
                     "%Y-%m-%dT%H:%M:%S%.f",
                 )
                 .unwrap(),
+                invoice_type: InvoiceType::OutboundShipment,
                 ..Default::default()
             },
             LedgerRow {
@@ -186,6 +200,7 @@ mod tests {
                     "%Y-%m-%dT%H:%M:%S%.f",
                 )
                 .unwrap(),
+                invoice_type: InvoiceType::OutboundShipment,
                 ..Default::default()
             },
             LedgerRow {
@@ -197,72 +212,54 @@ mod tests {
                     "%Y-%m-%dT%H:%M:%S%.f",
                 )
                 .unwrap(),
+                invoice_type: InvoiceType::InboundShipment,
                 ..Default::default()
             },
         ];
-
-        let result = calculate_ledger_balance(ledger_rows, all_ledger_items);
+        let pagination = get_default_pagination_unlimited(None);
+        let result = calculate_ledger_balance(pagination, None, all_ledger_items.clone());
 
         assert_eq!(result.len(), 4);
 
-        // check that balances are calculated correctly by line rather than summing when multiple ledgers
-        // occur at the same time
+        // check that balances are calculated correctly by line rather than summing when multiple ledgers occur at the same time
         // in this case the middle two ledgers are a repack, and occur at the same time
+
+        assert_eq!(result[0].balance, 2400.0);
+        assert_eq!(result[1].balance, 3600.0);
+        assert_eq!(result[2].balance, 2400.0);
+        assert_eq!(result[3].balance, 1224.0);
+
+        // check ledger order is coherent with descending datetime sort
+        let pagination = get_default_pagination_unlimited(None);
+
+        let sort = LedgerSort {
+            key: LedgerSortField::Datetime,
+            desc: Some(true),
+        };
+        let result = calculate_ledger_balance(pagination, Some(sort), all_ledger_items.clone());
+
         assert_eq!(result[0].balance, 1224.0);
         assert_eq!(result[1].balance, 2400.0);
         assert_eq!(result[2].balance, 3600.0);
         assert_eq!(result[3].balance, 2400.0);
+
+        // assert manual sorting works as expected
+        let pagination = get_default_pagination_unlimited(None);
+        let sort = LedgerSort {
+            key: LedgerSortField::InvoiceType,
+            desc: Some(false),
+        };
+        let result = calculate_ledger_balance(pagination, Some(sort), all_ledger_items);
+
+        assert_eq!(result[0].balance, 3600.0);
+        assert_eq!(result[1].balance, 2400.0);
+        assert_eq!(result[2].balance, 2400.0);
+        assert_eq!(result[3].balance, 1224.0);
     }
 
     #[actix_rt::test]
     async fn test_calculate_ledger_balance_with_multiple_items() {
         // ledger rows can be called in any order. In this case simulating descending order by datetime
-        let ledger_rows = vec![
-            LedgerRow {
-                id: "4".to_string(),
-                item_id: "item1".to_string(),
-                quantity: -1176.0,
-                datetime: NaiveDateTime::parse_from_str(
-                    "2025-05-19T02:57:15.920256",
-                    "%Y-%m-%dT%H:%M:%S%.f",
-                )
-                .unwrap(),
-                ..Default::default()
-            },
-            LedgerRow {
-                id: "3".to_string(),
-                item_id: "item2".to_string(),
-                quantity: -1200.0,
-                datetime: NaiveDateTime::parse_from_str(
-                    "2025-02-05T04:43:02.213892",
-                    "%Y-%m-%dT%H:%M:%S%.f",
-                )
-                .unwrap(),
-                ..Default::default()
-            },
-            LedgerRow {
-                id: "2".to_string(),
-                item_id: "item2".to_string(),
-                quantity: 1200.0,
-                datetime: NaiveDateTime::parse_from_str(
-                    "2025-02-05T04:43:02.213892",
-                    "%Y-%m-%dT%H:%M:%S%.f",
-                )
-                .unwrap(),
-                ..Default::default()
-            },
-            LedgerRow {
-                id: "1".to_string(),
-                item_id: "item1".to_string(),
-                quantity: 2400.0,
-                datetime: NaiveDateTime::parse_from_str(
-                    "2025-02-03T22:16:26.986939",
-                    "%Y-%m-%dT%H:%M:%S%.f",
-                )
-                .unwrap(),
-                ..Default::default()
-            },
-        ];
 
         let all_ledger_items = vec![
             LedgerRow {
@@ -310,10 +307,12 @@ mod tests {
                 ..Default::default()
             },
         ];
-
-        let result = calculate_ledger_balance(ledger_rows, all_ledger_items);
-
-        println!("{:?}", result);
+        let sort = LedgerSort {
+            key: LedgerSortField::Datetime,
+            desc: Some(true),
+        };
+        let pagination = get_default_pagination_unlimited(None);
+        let result = calculate_ledger_balance(pagination, Some(sort), all_ledger_items);
 
         assert_eq!(result.len(), 4);
 

--- a/server/service/src/ledger.rs
+++ b/server/service/src/ledger.rs
@@ -91,14 +91,14 @@ fn calculate_ledger_balance(
         item_ledgers.push(new_ledger);
     }
 
-    // manual sort
+    // TODO Fix or remove manual sort. Sorting by anything other than the existing datetime sort gets balance out of order
     if let Some(sort) = sort {
         match sort.key {
             LedgerSortField::Id => {
                 item_ledgers.sort_by_key(|l| l.ledger.id.clone());
             }
             LedgerSortField::Datetime => {
-                item_ledgers.sort_by_key(|l| l.ledger.datetime);
+                // Don't need to re-sort it, as it's already in datetime order and re-sorting risks getting rows out of order
             }
             LedgerSortField::Name => {
                 item_ledgers.sort_by_key(|l| l.ledger.name.clone());


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7868 

# 👩🏻‍💻 What does this PR do?

Refactors item_ledger to prevent double counting of ledger items in cases where they occur at the same datetime.
Preserve multiple id query logic without mapping to keep functionality for reports which use this query
Add tests to ensure logic is stable

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Note that the ledger balance is always calculated based on dateTime, which leads to strange displaying results if we sort by datetime in the front end in a reverse order from how we calculate the balance.

You can see this when you change the datetime order from ascending to descending in the item ledger tab of items.
Some ways the ledgers are out of order.

Unsure quite how to handle this, but I am thinking this is still better than the alternative of prematurely summing of total values.

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to Items and then ledger tab 
- [ ] See that balance is calculated for each line where more than one line exists for the same datetime.
- [ ] Also should double check the stockouts report [here](https://github.com/msupply-foundation/open-msupply-reports/blob/8b5414fc9ee03de983f1f20da1812b90723c059f/clients/Ivory-Coast/stockouts/latest/src/query.graphql#L2) is still working without regression

# 📃 Documentation

- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

