### PR TITLE
7915 vvm status field showing incorrectly stock detail view

### DIFF
--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -56,7 +56,8 @@ export const StockLineForm = ({
 
   const { data: preferences } = usePreference(
     PreferenceKey.AllowTrackingOfStockByDonor,
-    PreferenceKey.ManageVaccinesInDoses
+    PreferenceKey.ManageVaccinesInDoses,
+    PreferenceKey.ManageVvmStatusForStock
   );
 
   const { isConnected, isEnabled, isScanning, startScan } =
@@ -293,7 +294,7 @@ export const StockLineForm = ({
             text={String(supplierName)}
             textProps={{ textAlign: 'end' }}
           />
-          {draft?.item?.isVaccine && (
+          {draft?.item?.isVaccine && preferences?.manageVvmStatusForStock && (
             <StyledInputRow
               label={t('label.vvm-status')}
               Input={

--- a/client/packages/system/src/Stock/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Stock/DetailView/DetailView.tsx
@@ -16,6 +16,8 @@ import {
   usePluginEvents,
   useConfirmOnLeaving,
   useSimplifiedTabletUI,
+  usePreference,
+  PreferenceKey,
 } from '@openmsupply-client/common';
 import { ActivityLogList } from '@openmsupply-client/system';
 import { AppBarButtons } from './AppBarButtons';
@@ -96,6 +98,9 @@ export const StockLineDetailView: React.FC = () => {
   );
 
   const isVaccine = draft?.item?.isVaccine ?? false;
+  const { data: preferences } = usePreference(
+    PreferenceKey.ManageVvmStatusForStock
+  );
 
   const tabs = [
     {
@@ -109,7 +114,7 @@ export const StockLineDetailView: React.FC = () => {
       ),
       value: t('label.details'),
     },
-    ...(isVaccine
+    ...(isVaccine && preferences?.manageVvmStatusForStock
       ? [
           {
             Component: <StatusHistory draft={draft} isLoading={isLoading} />,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7915 

# 👩🏻‍💻 What does this PR do?
- renders VVM status field based on pref in stocklineForm
- renders Status history tab based on pref

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
`Vaccine with VVM pref OFF`
![Screenshot 2025-05-29 at 17 01 36](https://github.com/user-attachments/assets/84b6f145-5dc3-49d6-91cd-c68d46de2a74)

`Vaccine with VVM pref ON`
![Screenshot 2025-05-29 at 17 02 14](https://github.com/user-attachments/assets/45c2c894-50f4-4b4c-8cbf-11f0e82437c4)

## 💌 Any notes for the reviewer?

The issue had also mentioned that the VVM status column was persisting in Outbound Line edit when the pref was OFF. I wasn't able to replicate that. Behaves as expected. 

`Pref ON`
![Screenshot 2025-05-29 at 17 03 48](https://github.com/user-attachments/assets/19ce23ba-26e8-4b15-9ca0-de2323ba33dc)

`Pref OFF`
![Screenshot 2025-05-29 at 17 04 08](https://github.com/user-attachments/assets/20ed9ee6-3cd4-4108-9823-27ecd02f3309)

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to 'Inventory > View stock'
- [ ] Click on a Vaccine item
- [ ] See that the VVM status field and the Status History tab are showing when `Manage VVM status for stock` store pref is ON
- [ ] See that the VVM status field and the Status History tab are NOT showing when `Manage VVM status for stock` store pref is OFF

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

