### PR TITLE
7873 add report upload modal

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -35,6 +35,8 @@
   "button.add-program": "Add Program",
   "button.add-status-entry": "Add Status Entry",
   "button.adjust": "Adjust",
+  "messsages.reports-installed-successfully": "Added reports successuflly",
+  "error.unable-to-install-reports": "Unable to install reports",
   "button.allocate": "Allocate",
   "button.allocate-lines": "Allocate placeholder lines",
   "button.back": "Back",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -126,6 +126,7 @@
   "button.try-again": "Try again",
   "button.unlink-patient": "Unlink Patient",
   "button.update-status": "Update Status",
+  "title.upload-reports": "Upload Reports",
   "button.upload-assets": "Import",
   "button.view": "View",
   "button.view-all-breaches": "View all breaches",

--- a/client/packages/config/src/config.ts
+++ b/client/packages/config/src/config.ts
@@ -39,6 +39,7 @@ export const Environment = {
   PRINT_LABEL_TEST: `${apiHost}/print/label-test`,
   PRINT_LABEL_PRESCRIPTION: `${apiHost}/print/label-prescription`,
   ANDROID_DATA_FILES_PATH: `static_files/sync_files`,
+  REPORT_UPLOAD_URL: `${apiHost}/upload`, 
 
   // -- Feature Flags --
   // To add a new feature flag:

--- a/client/packages/system/src/Manage/Reports/ListView/AppBarButtons.tsx
+++ b/client/packages/system/src/Manage/Reports/ListView/AppBarButtons.tsx
@@ -7,7 +7,7 @@ import {
   PlusCircleIcon,
 } from '@openmsupply-client/common';
 
-export const AppBarButtonsComponent = () => {
+export const AppBarButtonsComponent = ({ onOpen }: { onOpen: () => void }) => {
   const t = useTranslation();
 
   return (
@@ -16,9 +16,7 @@ export const AppBarButtonsComponent = () => {
         <ButtonWithIcon
           Icon={<PlusCircleIcon />}
           label={t('button.install-reports')}
-          onClick={() => {
-            // TODO add modal with upsert report
-          }}
+          onClick={onOpen}
         />
       </Grid>
     </AppBarButtonsPortal>

--- a/client/packages/system/src/Manage/Reports/ListView/ListView.tsx
+++ b/client/packages/system/src/Manage/Reports/ListView/ListView.tsx
@@ -8,10 +8,12 @@ import {
   useUrlQueryParams,
   useTranslation,
   TooltipTextCell,
+  useEditModal,
 } from '@openmsupply-client/common';
 import { AppBarButtons } from './AppBarButtons';
 import { useAllReportVersionsList } from '../hooks/useAllReportVersionsList';
 import { ReportRowFragment } from 'packages/system/src/Report';
+import { ReportUploadModal } from './ReportUploadModal';
 
 const ReportsComponent = () => {
   const t = useTranslation();
@@ -29,6 +31,8 @@ const ReportsComponent = () => {
   });
 
   const pagination = { page, first, offset };
+
+  const { isOpen, onClose, onOpen } = useEditModal();
 
   const columns = useColumns<ReportRowFragment>(
     [
@@ -74,7 +78,8 @@ const ReportsComponent = () => {
 
   return (
     <>
-      <AppBarButtons />
+      <AppBarButtons onOpen={onOpen} />
+      {isOpen && <ReportUploadModal isOpen={isOpen} onClose={onClose} />}
       <DataTable
         id="report-list"
         pagination={{ ...pagination, total: data?.totalCount ?? 0 }}

--- a/client/packages/system/src/Manage/Reports/ListView/ReportUploadModal.tsx
+++ b/client/packages/system/src/Manage/Reports/ListView/ReportUploadModal.tsx
@@ -1,0 +1,117 @@
+import { DialogButton, Typography, UploadFile } from '@common/components';
+import { useDialog, useNotification } from '@common/hooks';
+import { useTranslation } from '@common/intl';
+import { Box, DetailContainer, FnUtils } from 'packages/common/src';
+import React, { useState } from 'react';
+import { FileList } from '../../../../../coldchain/src/Equipment/Components';
+import { Environment } from 'packages/config/src';
+
+interface ReportUploadModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const ReportUploadModal = ({
+  isOpen,
+  onClose,
+}: ReportUploadModalProps) => {
+  const t = useTranslation();
+  const [draft, setDraft] = useState<{ id?: string; files?: File[] }>({});
+  const { error, success } = useNotification();
+  const [errorMessage, setErrorMessage] = useState<string>(() => '');
+
+  const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
+
+  const removeFile = (name: string) => {
+    setDraft({ files: draft.files?.filter(file => file.name !== name) });
+  };
+
+  const onUpload = (files: File[]) => {
+    files.forEach(file => {
+      if (!file.name.endsWith('json')) {
+        setErrorMessage(t('messages.invalid-file'));
+      }
+    });
+
+    if (errorMessage != '') {
+      setDraft({ files });
+      setErrorMessage('');
+    }
+  };
+
+  const onOk = async () => {
+    const uploadPromise = () => {
+      if (!draft.files?.length)
+        return new Promise(resolve => resolve('no files'));
+
+      // create new json file id
+      const id = FnUtils.generateUUID();
+      const url = `${Environment.SYNC_FILES_URL}/report-data/${id}`;
+      const formData = new FormData();
+      draft.files?.forEach(file => {
+        formData.append('files', file);
+      });
+
+      return fetch(url, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+        },
+        credentials: 'include',
+        body: formData,
+      });
+    };
+
+    uploadPromise()
+      .then(id => {
+        // TODO add install uploaded plugin end point here
+        throw error;
+      })
+      .then(() => {
+        success(t('messages.log-saved-successfully'))();
+        onClose();
+      })
+      .catch(e => error(`${t('error.unable-to-save-log')}: ${e.message}`)());
+  };
+
+  return (
+    <Modal
+      title={t('title.upload-reports')}
+      cancelButton={
+        <DialogButton
+          variant="cancel"
+          onClick={() => {
+            onClose();
+          }}
+        />
+      }
+      okButton={<DialogButton variant="ok" onClick={onOk} />}
+    >
+      <DetailContainer>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'row',
+            marginTop: 2,
+            padding: 0,
+            alignItems: 'center',
+            height: '100%',
+            width: '100%',
+            justifyContent: 'center',
+          }}
+        >
+          <UploadFile onUpload={onUpload} files={draft.files} />
+        </Box>
+        <Box sx={{ display: 'flex', width: '300px' }}>
+          <FileList
+            assetId={'report-data'}
+            files={draft.files}
+            padding={0.5}
+            removeFile={removeFile}
+          />
+        </Box>
+        <Typography>{errorMessage}</Typography>
+      </DetailContainer>
+    </Modal>
+  );
+};

--- a/client/packages/system/src/Manage/Reports/ListView/ReportUploadModal.tsx
+++ b/client/packages/system/src/Manage/Reports/ListView/ReportUploadModal.tsx
@@ -1,7 +1,7 @@
-import { DialogButton, Typography, UploadFile } from '@common/components';
+import { DialogButton, UploadFile } from '@common/components';
 import { useDialog, useNotification } from '@common/hooks';
 import { useTranslation } from '@common/intl';
-import { Box, DetailContainer, FnUtils } from 'packages/common/src';
+import { Box, DetailContainer } from 'packages/common/src';
 import React, { useState } from 'react';
 import { FileList } from '../../../../../coldchain/src/Equipment/Components';
 import { Environment } from 'packages/config/src';
@@ -38,8 +38,7 @@ export const ReportUploadModal = ({
       return new Promise(resolve => resolve('no files'));
 
     // create new json file id
-    const id = FnUtils.generateUUID();
-    const url = `${Environment.SYNC_FILES_URL}/report-data/${id}`;
+    const url = `${Environment.REPORT_UPLOAD_URL}`;
     try {
       if (draft.files) {
         for (const file of draft.files) {

--- a/client/packages/system/src/Manage/Reports/ListView/ReportUploadModal.tsx
+++ b/client/packages/system/src/Manage/Reports/ListView/ReportUploadModal.tsx
@@ -18,7 +18,6 @@ export const ReportUploadModal = ({
   const t = useTranslation();
   const [draft, setDraft] = useState<{ id?: string; files?: File[] }>({});
   const { error, success } = useNotification();
-  const [errorMessage, setErrorMessage] = useState<string>(() => '');
 
   const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
 
@@ -27,51 +26,46 @@ export const ReportUploadModal = ({
   };
 
   const onUpload = (files: File[]) => {
-    files.forEach(file => {
-      if (!file.name.endsWith('json')) {
-        setErrorMessage(t('messages.invalid-file'));
-      }
-    });
-
-    if (errorMessage != '') {
+    if (files.filter(f => !f.name.endsWith('json')).length > 0) {
+      error('error.report-invalid-file')();
+    } else {
       setDraft({ files });
-      setErrorMessage('');
     }
   };
 
   const onOk = async () => {
-    const uploadPromise = () => {
-      if (!draft.files?.length)
-        return new Promise(resolve => resolve('no files'));
+    if (!draft.files?.length)
+      return new Promise(resolve => resolve('no files'));
 
-      // create new json file id
-      const id = FnUtils.generateUUID();
-      const url = `${Environment.SYNC_FILES_URL}/report-data/${id}`;
-      const formData = new FormData();
-      draft.files?.forEach(file => {
-        formData.append('files', file);
-      });
-
-      return fetch(url, {
-        method: 'POST',
-        headers: {
-          Accept: 'application/json',
-        },
-        credentials: 'include',
-        body: formData,
-      });
-    };
-
-    uploadPromise()
-      .then(id => {
-        // TODO add install uploaded plugin end point here
-        throw error;
-      })
-      .then(() => {
-        success(t('messages.log-saved-successfully'))();
-        onClose();
-      })
-      .catch(e => error(`${t('error.unable-to-save-log')}: ${e.message}`)());
+    // create new json file id
+    const id = FnUtils.generateUUID();
+    const url = `${Environment.SYNC_FILES_URL}/report-data/${id}`;
+    try {
+      if (draft.files) {
+        for (const file of draft.files) {
+          const formData = new FormData();
+          formData.append('files', file);
+          const fileId = await fetch(url, {
+            method: 'POST',
+            headers: {
+              Accept: 'application/json',
+            },
+            credentials: 'include',
+            body: formData,
+          });
+          if (!fileId) {
+            throw error;
+          }
+          console.log('fileId', fileId.json());
+          // TODO do something with fileId
+        }
+      }
+      success(t('messsages.reports-installed-successfully'))();
+      onClose();
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      error(`${t('error.unable-to-install-reports')}: ${message}`)();
+    }
   };
 
   return (
@@ -110,7 +104,6 @@ export const ReportUploadModal = ({
             removeFile={removeFile}
           />
         </Box>
-        <Typography>{errorMessage}</Typography>
       </DetailContainer>
     </Modal>
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7873

# 👩🏻‍💻 What does this PR do?

Adds report upload modal for report files.
Adds dropzone to put uploaded files into temporary storage
Plugs in to (to be created in #7874)  end point

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Won't actually upsert reports - but will log file id of temporary storage

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to manage -> reports list view when on central server and logged in as server admin
- [ ] Click upload reports modal
- [ ] Add a report json file to the drag and drop and click OK
- [ ] Nothing will happen - but console should log temporary file id which we can use later in #7874 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole



# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

