### PR TITLE
7951 update stock line donor on stock take insert or update

### DIFF
--- a/server/service/src/stocktake_line/insert/mod.rs
+++ b/server/service/src/stocktake_line/insert/mod.rs
@@ -307,9 +307,33 @@ mod stocktake_line_test {
 
     #[actix_rt::test]
     async fn insert_stocktake_line_with_donor_id() {
-        let (_, _, connection_manager, _) = setup_all(
+        fn mock_stock_line_for_donor_test() -> StockLineRow {
+            StockLineRow {
+                id: String::from("mock_stock_line_for_donor_test"),
+                item_link_id: String::from("item_a"),
+                location_id: None,
+                store_id: String::from("store_a"),
+                batch: Some(String::from("item_a_batch_b")),
+                available_number_of_packs: 20.0,
+                pack_size: 1.0,
+                cost_price_per_pack: 0.0,
+                sell_price_per_pack: 0.0,
+                total_number_of_packs: 30.0,
+                expiry_date: None,
+                on_hold: false,
+                note: None,
+                supplier_link_id: Some(String::from("name_store_b")),
+                ..Default::default()
+            }
+        }
+
+        let (_, _, connection_manager, _) = setup_all_with_data(
             "insert_stocktake_line_with_donor_id",
             MockDataInserts::all(),
+            MockData {
+                stock_lines: vec![mock_stock_line_for_donor_test()],
+                ..Default::default()
+            },
         )
         .await;
 
@@ -322,7 +346,7 @@ mod stocktake_line_test {
         // success with donor_id
         let stocktake_a = mock_stocktake_a();
         let donor_id = mock_donor_a().id;
-        let stock_line = mock_new_stock_line_for_stocktake_a();
+        let stock_line = mock_stock_line_for_donor_test();
         service
             .insert_stocktake_line(
                 &context,

--- a/server/service/src/stocktake_line/update/mod.rs
+++ b/server/service/src/stocktake_line/update/mod.rs
@@ -84,7 +84,7 @@ mod stocktake_line_test {
             mock_stock_line_b, mock_stocktake_line_a, mock_stocktake_line_finalised, mock_store_a,
             MockData, MockDataInserts,
         },
-        test_db::{setup_all, setup_all_with_data},
+        test_db::setup_all_with_data,
         EqualFilter, InvoiceLineRow, InvoiceRow, InvoiceStatus, InvoiceType, ReasonOptionRow,
         ReasonOptionRowRepository, ReasonOptionType, StockLineFilter, StockLineRepository,
         StockLineRowRepository, StocktakeLineRow,
@@ -428,21 +428,6 @@ mod stocktake_line_test {
                 r.comment = Some("Some comment".to_string());
             })
         );
-    }
-
-    #[actix_rt::test]
-    async fn update_stocktake_line_with_donor_id() {
-        let (_, _, connection_manager, _) = setup_all(
-            "insert_stocktake_line_with_donor_id",
-            MockDataInserts::all(),
-        )
-        .await;
-
-        let service_provider = ServiceProvider::new(connection_manager);
-        let context = service_provider
-            .context(mock_store_a().id, "".to_string())
-            .unwrap();
-        let service = service_provider.stocktake_line_service;
 
         // success with donor_id update
         let stocktake_line_a = mock_stocktake_line_a();


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7951 

# 👩🏻‍💻 What does this PR do?

It should update Stock lines donor when Stocktakes lines donor gets added or updated

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to 'Inventory > stocktake'
- [ ] Click on 'Create a new stocktake'
- [ ] On a stockline add or edit a donor in the Other tab
- [ ] Finalise your stocktake
- [ ] In inventory > View stock and find your line
- [ ] Verify that the donor has been changed as well

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

