### PR TITLE
7590 Translate GAPS Store properties into French

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -68,6 +68,7 @@
   "button.import-properties": "Import Properties",
   "button.initial-stocktake": "initial stocktake",
   "button.initialise": "Initialise",
+  "button.re-initialise": "Re-initialise",
   "button.language": "Language",
   "button.link-contact-to-patient": "Link to Patient",
   "button.login": "Log in",
@@ -2079,5 +2080,6 @@
   "warning.caps-lock": "Warning: Caps lock is on",
   "warning.check-before-vaccinating": "Vaccination records from other stores may not be up to date. Ensure you have synced recently, and always confirm against the patient's physical vaccination card first.",
   "warning.field-not-parsed": "{{field}} not parsed",
-  "warning.nothing-to-supply": "Nothing left to supply!"
+  "warning.nothing-to-supply": "Nothing left to supply!",
+  "tooltip.re-initialise-in-language": "Re-initialise using {{language}} language"
 }

--- a/client/packages/common/src/intl/locales/fr/common.json
+++ b/client/packages/common/src/intl/locales/fr/common.json
@@ -1983,5 +1983,6 @@
   "warning.caps-lock": "Avertissement: Verrouillage majuscule activé",
   "warning.check-before-vaccinating": "La carte de vaccination éléctronique provenant d'autres sites de vaccination peuvent ne pas être à jour ! Assurez-vous d'avoir effectué une synchronisation récente et vérifiez toujours la validité de la carte de vaccination papier du patient.",
   "warning.field-not-parsed": "{{field}} non analysé",
-  "warning.nothing-to-supply": "La quantité demandée à été fournie !"
+  "warning.nothing-to-supply": "La quantité demandée à été fournie !",
+  "tooltip.re-initialise-in-language": "Réinitialiser en utilisant la langue {{language}}"
 }

--- a/client/packages/host/src/Admin/ConfigurationSettings.tsx
+++ b/client/packages/host/src/Admin/ConfigurationSettings.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 
-import { BaseButton, useTranslation } from '@openmsupply-client/common';
+import {
+  BaseButton,
+  useIntlUtils,
+  useTranslation,
+} from '@openmsupply-client/common';
 import { useName } from '@openmsupply-client/system';
 
 import { Setting } from './Setting';
@@ -13,7 +17,7 @@ import {
 
 export const ConfigurationSettings = () => {
   const t = useTranslation();
-
+  const { currentLanguage } = useIntlUtils();
   const { mutateAsync, isLoading } = useConfigureNameProperties();
   const { isLoading: dataLoading } = useName.document.properties();
   const { gapsConfigured, populationConfigured } =
@@ -30,9 +34,14 @@ export const ConfigurationSettings = () => {
         component={
           <BaseButton
             onClick={handleClick('gaps')}
-            disabled={dataLoading || isLoading || gapsConfigured}
+            disabled={dataLoading || isLoading}
+            title={t('tooltip.re-initialise-in-language', {
+              language: currentLanguage,
+            })}
           >
-            {gapsConfigured ? t('label.initialised') : t('button.initialise')}
+            {gapsConfigured
+              ? t('button.re-initialise')
+              : t('button.initialise')}
           </BaseButton>
         }
       />
@@ -43,10 +52,13 @@ export const ConfigurationSettings = () => {
         component={
           <BaseButton
             onClick={handleClick('population')}
-            disabled={dataLoading || isLoading || populationConfigured}
+            disabled={dataLoading || isLoading}
+            title={t('tooltip.re-initialise-in-language', {
+              language: currentLanguage,
+            })}
           >
             {populationConfigured
-              ? t('label.initialised')
+              ? t('button.re-initialise')
               : t('button.initialise')}
           </BaseButton>
         }

--- a/client/packages/host/src/api/hooks/settings/namePropertyData.ts
+++ b/client/packages/host/src/api/hooks/settings/namePropertyData.ts
@@ -29,6 +29,8 @@ export type LocalisedNamePropertyConfig = Partial<
 };
 
 // English keys are fall-backs, all other languages should implement the same keys
+// NOTE: If we need to add a third language or are doing refactoring here, we should probaly use the usual t() style translation function
+// Perhaps with a different .json file to so these translations are easy to find and not accidentally removed...
 type TranslationKey = keyof typeof frTranslations;
 
 const enTranslations = {

--- a/client/packages/host/src/api/hooks/settings/namePropertyData.ts
+++ b/client/packages/host/src/api/hooks/settings/namePropertyData.ts
@@ -28,6 +28,71 @@ export type LocalisedNamePropertyConfig = Partial<
   en: ConfigureNamePropertyInput[];
 };
 
+const enTranslations: Record<string, string> | null = {
+  POPULATION_SERVED_KEY: 'Population Served',
+  LATITUDE_KEY: 'Latitude',
+  LONGITUDE_KEY: 'Longitude',
+  SUPPLY_LEVEL_KEY: 'Supply Level',
+  FACILITY_TYPE_KEY: 'Facility Type',
+  OWNERSHIP_TYPE_KEY: 'Ownership Type',
+  BUFFER_STOCK_KEY: 'Stock Safety Buffer (months)',
+  SUPPLY_INTERVAL_KEY: 'Supply Interval (Months between deliveries)',
+  PACKAGING_LEVEL_KEY: 'Packaging Level',
+  ELECTRICITY_AVAILABILITY_KEY: 'Electricity Availability',
+  SOLAR_AVAILABILITY_KEY: 'Solar Availability',
+  GAS_AVAILABILITY_KEY: 'Gas Availability',
+  KEROSENE_AVAILABILITY_KEY: 'Kerosene Availability',
+  PENTA_3_KEY: 'Penta-3 Coverage',
+  ZERO_DOSE_KEY: 'Zero Dose Coverage',
+};
+
+// French Translations
+const frTranslations: Record<string, string> | null = {
+  POPULATION_SERVED_KEY: 'Population Desservie',
+  LATITUDE_KEY: 'Latitude',
+  LONGITUDE_KEY: 'Longitude',
+  SUPPLY_LEVEL_KEY: "Niveau d'approvisionnement",
+  FACILITY_TYPE_KEY: "Type d'etablissement",
+  OWNERSHIP_TYPE_KEY: 'Type de propriété',
+  BUFFER_STOCK_KEY: 'Marge de sécurité des stocks (mois)',
+  SUPPLY_INTERVAL_KEY:
+    "Intervalle d'approvisionnement (Mois entre les livraisons)",
+  PACKAGING_LEVEL_KEY: 'Niveau de conditionnement',
+  ELECTRICITY_AVAILABILITY_KEY: 'Disponibilité de l’électricité',
+  SOLAR_AVAILABILITY_KEY: 'Disponibilité de l’énergie solaire',
+  GAS_AVAILABILITY_KEY: 'Disponibilité du gaz',
+  KEROSENE_AVAILABILITY_KEY: 'Disponibilité du kérosène',
+  PENTA_3_KEY: 'Couverture Penta-3',
+  ZERO_DOSE_KEY: 'Couverture Zéro Dose',
+  // Allowed values translations
+  Primary: 'Niveau national',
+  'Sub-National': 'Niveau régional',
+  'Lowest Distribution': 'Niveau district',
+  'Service Point': 'Point de service',
+  'National Vaccine Store': 'Dépôt national de vaccins',
+  'Regional Vaccine Store': 'Dépôt régional de vaccins',
+  'Referral Hospital': 'Hôpital Général de référence',
+  'Municipal Warehouse': 'Entrepôt municipal',
+  'Maternal Clinic': 'Clinique de maternité',
+  Government: 'Gouvernement',
+  NGO: 'ONG',
+  Private: 'Privé',
+  'Faith-based': 'Confessionnel',
+  'Primary (1)': 'Primaire (1)',
+  'Secondary (2)': 'Secondaire (2)',
+  'Tertiary (3)': 'Tertiaire (3)',
+  '> 16 hours': '> 16 heures',
+  '8-16 hours': '8-16 heures',
+  '< 8 hours': '< 8 heures',
+  'No availability': 'Aucun(e) disponibilité',
+  Unknown: 'Inconnu(e)',
+  Available: 'Disponible',
+  Irregular: 'Irrégulier',
+  High: 'Élevé(e)',
+  Medium: 'Moyen(ne)',
+  Low: 'Faible',
+};
+
 const populationServed: ConfigureNamePropertyInput = {
   id: '7716cecc-7d62-4f1b-93fa-a55a275079b4',
   propertyId: POPULATION_SERVED_KEY,
@@ -38,13 +103,26 @@ const populationServed: ConfigureNamePropertyInput = {
   remoteEditable: true,
 };
 
-export const gapsNameProperties: LocalisedNamePropertyConfig = {
-  en: [
+function translateAllowedValues(
+  allowedValues: string | null,
+  translations: Record<string, string> | null
+): string | null {
+  if (!allowedValues || !translations) return allowedValues;
+
+  return allowedValues
+    .split(',')
+    .map(value => translations[value.trim()] || value.trim())
+    .join(',');
+}
+
+function getGapsPropertiesForLanguage(language: string) {
+  const translations = language === 'fr' ? frTranslations : enTranslations;
+  return [
     {
       id: '0ed01a18-c9ac-4b51-bb56-d5fea4f15feb',
       propertyId: LATITUDE_KEY,
       key: LATITUDE_KEY,
-      name: 'Latitude',
+      name: translations?.[LATITUDE_KEY] ?? 'Latitude',
       valueType: PropertyNodeValueType.Float,
       allowedValues: null,
       remoteEditable: false,
@@ -53,7 +131,7 @@ export const gapsNameProperties: LocalisedNamePropertyConfig = {
       id: '9d595b3e-2eca-4b1a-983e-77aa34b14e62',
       propertyId: LONGITUDE_KEY,
       key: LONGITUDE_KEY,
-      name: 'Longitude',
+      name: translations?.[LONGITUDE_KEY] ?? 'Longitude',
       valueType: PropertyNodeValueType.Float,
       allowedValues: null,
       remoteEditable: false,
@@ -62,35 +140,43 @@ export const gapsNameProperties: LocalisedNamePropertyConfig = {
       id: '3285c231-ffc2-485b-9a86-5ccafed9a5c5',
       propertyId: SUPPLY_LEVEL_KEY,
       key: SUPPLY_LEVEL_KEY,
-      name: 'Supply Level',
+      name: translations?.[SUPPLY_LEVEL_KEY] ?? 'Supply Level',
       valueType: PropertyNodeValueType.String,
-      allowedValues: 'Primary,Sub-National,Lowest Distribution,Service Point',
+      allowedValues: translateAllowedValues(
+        'Primary,Sub-National,Lowest Distribution,Service Point',
+        translations
+      ),
       remoteEditable: false,
     },
     {
       id: '0e6fa1d3-4762-4b19-a832-1fe8a391e75b',
       propertyId: FACILITY_TYPE_KEY,
       key: FACILITY_TYPE_KEY,
-      name: 'Facility Type',
+      name: translations?.[FACILITY_TYPE_KEY] ?? 'Facility Type',
       valueType: PropertyNodeValueType.String,
-      allowedValues:
+      allowedValues: translateAllowedValues(
         'National Vaccine Store,Regional Vaccine Store,Referral Hospital,Municipal Warehouse,Maternal Clinic',
+        translations
+      ),
       remoteEditable: false,
     },
     {
       id: '098d1c23-1257-451a-a449-500ab3907337',
       propertyId: OWNERSHIP_TYPE_KEY,
       key: OWNERSHIP_TYPE_KEY,
-      name: 'Ownership Type',
+      name: translations?.[OWNERSHIP_TYPE_KEY] ?? 'Ownership Type',
       valueType: PropertyNodeValueType.String,
-      allowedValues: 'Government,NGO,Private,Faith-based',
+      allowedValues: translateAllowedValues(
+        'Government,NGO,Private,Faith-based',
+        translations
+      ),
       remoteEditable: false,
     },
     {
       id: '4396d231-ffc2-485b-9a86-5ccafed0b6d6',
       propertyId: BUFFER_STOCK_KEY,
       key: BUFFER_STOCK_KEY,
-      name: 'Stock Safety Buffer (months)',
+      name: translations?.[BUFFER_STOCK_KEY] ?? 'Stock Safety Buffer (months)',
       valueType: PropertyNodeValueType.Integer,
       allowedValues: null,
       remoteEditable: false,
@@ -99,7 +185,9 @@ export const gapsNameProperties: LocalisedNamePropertyConfig = {
       id: 'd4d252eb-40c6-491c-bd2a-65c74534b966',
       propertyId: SUPPLY_INTERVAL_KEY,
       key: SUPPLY_INTERVAL_KEY,
-      name: 'Supply Interval (Months between deliveries)',
+      name:
+        translations?.[SUPPLY_INTERVAL_KEY] ??
+        'Supply Interval (Months between deliveries)',
       valueType: PropertyNodeValueType.Integer,
       allowedValues: null,
       remoteEditable: false,
@@ -108,67 +196,99 @@ export const gapsNameProperties: LocalisedNamePropertyConfig = {
       id: 'c5e363fc-40c9-4m1c-b29a-76d74534b077',
       propertyId: PACKAGING_LEVEL_KEY,
       key: PACKAGING_LEVEL_KEY,
-      name: 'Packaging Level',
+      name: translations?.[PACKAGING_LEVEL_KEY] ?? 'Packaging Level',
       valueType: PropertyNodeValueType.String,
-      allowedValues: 'Primary (1),Secondary (2),Tertiary (3)',
+      allowedValues: translateAllowedValues(
+        'Primary (1),Secondary (2),Tertiary (3)',
+        translations
+      ),
       remoteEditable: true,
     },
-    populationServed,
+    {
+      ...populationServed,
+      name: translations?.[POPULATION_SERVED_KEY] ?? 'Population Served',
+    },
     {
       id: 'd700e86a-28c9-40a9-830c-f8a9793c63a0',
       propertyId: ELECTRICITY_AVAILABILITY_KEY,
       key: ELECTRICITY_AVAILABILITY_KEY,
-      name: 'Electricity Availability',
+      name:
+        translations?.[ELECTRICITY_AVAILABILITY_KEY] ??
+        'Electricity Availability',
       valueType: PropertyNodeValueType.String,
-      allowedValues: '> 16 hours,8-16 hours,< 8 hours,No availability,Unknown',
+      allowedValues: translateAllowedValues(
+        '> 16 hours,8-16 hours,< 8 hours,No availability,Unknown',
+        translations
+      ),
       remoteEditable: true,
     },
     {
       id: 'cbb104cd-c5f7-4c7a-af5e-ef4ad1b428e0',
       propertyId: SOLAR_AVAILABILITY_KEY,
       key: SOLAR_AVAILABILITY_KEY,
-      name: 'Solar Availability',
+      name: translations?.[SOLAR_AVAILABILITY_KEY] ?? 'Solar Availability',
       valueType: PropertyNodeValueType.String,
-      allowedValues: '> 16 hours,8-16 hours,< 8 hours,No availability,Unknown',
+      allowedValues: translateAllowedValues(
+        '> 16 hours,8-16 hours,< 8 hours,No availability,Unknown',
+        translations
+      ),
       remoteEditable: true,
     },
     {
       id: '633f4741-91ad-46a6-b302-8d1979eb3be4',
       propertyId: GAS_AVAILABILITY_KEY,
       key: GAS_AVAILABILITY_KEY,
-      name: 'Gas Availability',
+      name: translations?.[GAS_AVAILABILITY_KEY] ?? 'Gas Availability',
       valueType: PropertyNodeValueType.String,
-      allowedValues: 'No availability,Available,Irregular,Unknown',
+      allowedValues: translateAllowedValues(
+        'No availability,Available,Irregular,Unknown',
+        translations
+      ),
       remoteEditable: true,
     },
     {
       id: 'a4338ad6-b6eb-46f0-bd8a-217f2820978d',
       propertyId: KEROSENE_AVAILABILITY_KEY,
       key: KEROSENE_AVAILABILITY_KEY,
-      name: 'Kerosene Availability',
+      name:
+        translations?.[KEROSENE_AVAILABILITY_KEY] ?? 'Kerosene Availability',
       valueType: PropertyNodeValueType.String,
-      allowedValues: 'No availability,Available,Irregular,Unknown',
+      allowedValues: translateAllowedValues(
+        'No availability,Available,Irregular,Unknown',
+        translations
+      ),
       remoteEditable: true,
     },
     {
       id: '86cb041d-96d3-40f1-874e-4189f4796790',
       propertyId: PENTA_3_KEY,
       key: PENTA_3_KEY,
-      name: 'Penta-3 Coverage',
+      name: translations?.[PENTA_3_KEY] ?? 'Penta-3 Coverage',
       valueType: PropertyNodeValueType.String,
-      allowedValues: 'High,Medium,Low,Unknown',
+      allowedValues: translateAllowedValues(
+        'High,Medium,Low,Unknown',
+        translations
+      ),
       remoteEditable: true,
     },
     {
       id: '9cc3ac59-061e-4e3f-af13-d2b6d9a52dea',
       propertyId: ZERO_DOSE_KEY,
       key: ZERO_DOSE_KEY,
-      name: 'Zero Dose Coverage',
+      name: translations?.[ZERO_DOSE_KEY] ?? 'Zero Dose Coverage',
       valueType: PropertyNodeValueType.String,
-      allowedValues: 'High,Medium,Low,Unknown',
+      allowedValues: translateAllowedValues(
+        'High,Medium,Low,Unknown',
+        translations
+      ),
       remoteEditable: true,
     },
-  ],
+  ];
+}
+
+export const gapsNameProperties: LocalisedNamePropertyConfig = {
+  en: getGapsPropertiesForLanguage('en'),
+  fr: getGapsPropertiesForLanguage('fr'),
 };
 
 export const populationNameProperties: LocalisedNamePropertyConfig = {

--- a/client/packages/host/src/api/hooks/settings/namePropertyData.ts
+++ b/client/packages/host/src/api/hooks/settings/namePropertyData.ts
@@ -28,7 +28,10 @@ export type LocalisedNamePropertyConfig = Partial<
   en: ConfigureNamePropertyInput[];
 };
 
-const enTranslations: Record<string, string> = {
+// English keys are fall-backs, all other languages should implement the same keys
+type TranslationKey = keyof typeof frTranslations;
+
+const enTranslations = {
   POPULATION_SERVED_KEY: 'Population Served',
   LATITUDE_KEY: 'Latitude',
   LONGITUDE_KEY: 'Longitude',
@@ -47,7 +50,7 @@ const enTranslations: Record<string, string> = {
 };
 
 // French Translations
-const frTranslations: Record<string, string> = {
+const frTranslations = {
   POPULATION_SERVED_KEY: 'Population Desservie',
   LATITUDE_KEY: 'Latitude',
   LONGITUDE_KEY: 'Longitude',
@@ -99,7 +102,7 @@ function getPopulationServedForLanguage(language: string) {
     id: '7716cecc-7d62-4f1b-93fa-a55a275079b4',
     propertyId: POPULATION_SERVED_KEY,
     key: POPULATION_SERVED_KEY,
-    name: translations['POPULATION_SERVED_KEY'] ?? 'Population Served',
+    name: translations['POPULATION_SERVED_KEY'],
     valueType: PropertyNodeValueType.Float,
     allowedValues: null,
     remoteEditable: true,
@@ -107,25 +110,27 @@ function getPopulationServedForLanguage(language: string) {
 }
 
 function translateAllowedValues(
-  allowedValues: string | null,
-  translations: Record<string, string> | null
-): string | null {
-  if (!allowedValues || !translations) return allowedValues;
-
+  allowedValues: TranslationKey[],
+  translations: Record<TranslationKey, string> | typeof enTranslations
+): string {
   return allowedValues
-    .split(',')
-    .map(value => translations[value.trim()] || value.trim())
+    .map(
+      // If translation not found, use the key (should be english fallback value)
+      value => translations[value as keyof typeof translations] || value.trim()
+    )
     .join(',');
 }
 
-function getGapsPropertiesForLanguage(language: string) {
+function getGapsPropertiesForLanguage(
+  language: string
+): ConfigureNamePropertyInput[] {
   const translations = language === 'fr' ? frTranslations : enTranslations;
   return [
     {
       id: '0ed01a18-c9ac-4b51-bb56-d5fea4f15feb',
       propertyId: LATITUDE_KEY,
       key: LATITUDE_KEY,
-      name: translations['LATITUDE_KEY'] ?? 'Latitude',
+      name: translations['LATITUDE_KEY'],
       valueType: PropertyNodeValueType.Float,
       allowedValues: null,
       remoteEditable: false,
@@ -134,7 +139,7 @@ function getGapsPropertiesForLanguage(language: string) {
       id: '9d595b3e-2eca-4b1a-983e-77aa34b14e62',
       propertyId: LONGITUDE_KEY,
       key: LONGITUDE_KEY,
-      name: translations['LONGITUDE_KEY'] ?? 'Longitude',
+      name: translations['LONGITUDE_KEY'],
       valueType: PropertyNodeValueType.Float,
       allowedValues: null,
       remoteEditable: false,
@@ -143,10 +148,10 @@ function getGapsPropertiesForLanguage(language: string) {
       id: '3285c231-ffc2-485b-9a86-5ccafed9a5c5',
       propertyId: SUPPLY_LEVEL_KEY,
       key: SUPPLY_LEVEL_KEY,
-      name: translations['SUPPLY_LEVEL_KEY'] ?? 'Supply Level',
+      name: translations['SUPPLY_LEVEL_KEY'],
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
-        'Primary,Sub-National,Lowest Distribution,Service Point',
+        ['Primary', 'Sub-National', 'Lowest Distribution', 'Service Point'],
         translations
       ),
       remoteEditable: false,
@@ -155,10 +160,16 @@ function getGapsPropertiesForLanguage(language: string) {
       id: '0e6fa1d3-4762-4b19-a832-1fe8a391e75b',
       propertyId: FACILITY_TYPE_KEY,
       key: FACILITY_TYPE_KEY,
-      name: translations['FACILITY_TYPE_KEY'] ?? 'Facility Type',
+      name: translations['FACILITY_TYPE_KEY'],
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
-        'National Vaccine Store,Regional Vaccine Store,Referral Hospital,Municipal Warehouse,Maternal Clinic',
+        [
+          'National Vaccine Store',
+          'Regional Vaccine Store',
+          'Referral Hospital',
+          'Municipal Warehouse',
+          'Maternal Clinic',
+        ],
         translations
       ),
       remoteEditable: false,
@@ -167,10 +178,10 @@ function getGapsPropertiesForLanguage(language: string) {
       id: '098d1c23-1257-451a-a449-500ab3907337',
       propertyId: OWNERSHIP_TYPE_KEY,
       key: OWNERSHIP_TYPE_KEY,
-      name: translations['OWNERSHIP_TYPE_KEY'] ?? 'Ownership Type',
+      name: translations['OWNERSHIP_TYPE_KEY'],
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
-        'Government,NGO,Private,Faith-based',
+        ['Government', 'NGO', 'Private', 'Faith-based'],
         translations
       ),
       remoteEditable: false,
@@ -179,7 +190,7 @@ function getGapsPropertiesForLanguage(language: string) {
       id: '4396d231-ffc2-485b-9a86-5ccafed0b6d6',
       propertyId: BUFFER_STOCK_KEY,
       key: BUFFER_STOCK_KEY,
-      name: translations['BUFFER_STOCK_KEY'] ?? 'Stock Safety Buffer (months)',
+      name: translations['BUFFER_STOCK_KEY'],
       valueType: PropertyNodeValueType.Integer,
       allowedValues: null,
       remoteEditable: false,
@@ -188,9 +199,7 @@ function getGapsPropertiesForLanguage(language: string) {
       id: 'd4d252eb-40c6-491c-bd2a-65c74534b966',
       propertyId: SUPPLY_INTERVAL_KEY,
       key: SUPPLY_INTERVAL_KEY,
-      name:
-        translations['SUPPLY_INTERVAL_KEY'] ??
-        'Supply Interval (Months between deliveries)',
+      name: translations['SUPPLY_INTERVAL_KEY'],
       valueType: PropertyNodeValueType.Integer,
       allowedValues: null,
       remoteEditable: false,
@@ -199,10 +208,10 @@ function getGapsPropertiesForLanguage(language: string) {
       id: 'c5e363fc-40c9-4m1c-b29a-76d74534b077',
       propertyId: PACKAGING_LEVEL_KEY,
       key: PACKAGING_LEVEL_KEY,
-      name: translations['PACKAGING_LEVEL_KEY'] ?? 'Packaging Level',
+      name: translations['PACKAGING_LEVEL_KEY'],
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
-        'Primary (1),Secondary (2),Tertiary (3)',
+        ['Primary (1)', 'Secondary (2)', 'Tertiary (3)'],
         translations
       ),
       remoteEditable: true,
@@ -212,12 +221,10 @@ function getGapsPropertiesForLanguage(language: string) {
       id: 'd700e86a-28c9-40a9-830c-f8a9793c63a0',
       propertyId: ELECTRICITY_AVAILABILITY_KEY,
       key: ELECTRICITY_AVAILABILITY_KEY,
-      name:
-        translations['ELECTRICITY_AVAILABILITY_KEY'] ??
-        'Electricity Availability',
+      name: translations['ELECTRICITY_AVAILABILITY_KEY'],
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
-        '> 16 hours,8-16 hours,< 8 hours,No availability,Unknown',
+        ['> 16 hours', '8-16 hours', '< 8 hours', 'No availability', 'Unknown'],
         translations
       ),
       remoteEditable: true,
@@ -226,10 +233,10 @@ function getGapsPropertiesForLanguage(language: string) {
       id: 'cbb104cd-c5f7-4c7a-af5e-ef4ad1b428e0',
       propertyId: SOLAR_AVAILABILITY_KEY,
       key: SOLAR_AVAILABILITY_KEY,
-      name: translations['SOLAR_AVAILABILITY_KEY'] ?? 'Solar Availability',
+      name: translations['SOLAR_AVAILABILITY_KEY'],
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
-        '> 16 hours,8-16 hours,< 8 hours,No availability,Unknown',
+        ['> 16 hours', '8-16 hours', '< 8 hours', 'No availability', 'Unknown'],
         translations
       ),
       remoteEditable: true,
@@ -238,10 +245,10 @@ function getGapsPropertiesForLanguage(language: string) {
       id: '633f4741-91ad-46a6-b302-8d1979eb3be4',
       propertyId: GAS_AVAILABILITY_KEY,
       key: GAS_AVAILABILITY_KEY,
-      name: translations['GAS_AVAILABILITY_KEY'] ?? 'Gas Availability',
+      name: translations['GAS_AVAILABILITY_KEY'],
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
-        'No availability,Available,Irregular,Unknown',
+        ['No availability', 'Available', 'Irregular', 'Unknown'],
         translations
       ),
       remoteEditable: true,
@@ -250,11 +257,10 @@ function getGapsPropertiesForLanguage(language: string) {
       id: 'a4338ad6-b6eb-46f0-bd8a-217f2820978d',
       propertyId: KEROSENE_AVAILABILITY_KEY,
       key: KEROSENE_AVAILABILITY_KEY,
-      name:
-        translations['KEROSENE_AVAILABILITY_KEY'] ?? 'Kerosene Availability',
+      name: translations['KEROSENE_AVAILABILITY_KEY'],
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
-        'No availability,Available,Irregular,Unknown',
+        ['No availability', 'Available', 'Irregular', 'Unknown'],
         translations
       ),
       remoteEditable: true,
@@ -263,10 +269,10 @@ function getGapsPropertiesForLanguage(language: string) {
       id: '86cb041d-96d3-40f1-874e-4189f4796790',
       propertyId: PENTA_3_KEY,
       key: PENTA_3_KEY,
-      name: translations['PENTA_3_KEY'] ?? 'Penta-3 Coverage',
+      name: translations['PENTA_3_KEY'],
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
-        'High,Medium,Low,Unknown',
+        ['High', 'Medium', 'Low', 'Unknown'],
         translations
       ),
       remoteEditable: true,
@@ -275,10 +281,10 @@ function getGapsPropertiesForLanguage(language: string) {
       id: '9cc3ac59-061e-4e3f-af13-d2b6d9a52dea',
       propertyId: ZERO_DOSE_KEY,
       key: ZERO_DOSE_KEY,
-      name: translations['ZERO_DOSE_KEY'] ?? 'Zero Dose Coverage',
+      name: translations['ZERO_DOSE_KEY'],
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
-        'High,Medium,Low,Unknown',
+        ['High', 'Medium', 'Low', 'Unknown'],
         translations
       ),
       remoteEditable: true,

--- a/client/packages/host/src/api/hooks/settings/namePropertyData.ts
+++ b/client/packages/host/src/api/hooks/settings/namePropertyData.ts
@@ -28,7 +28,7 @@ export type LocalisedNamePropertyConfig = Partial<
   en: ConfigureNamePropertyInput[];
 };
 
-const enTranslations: Record<string, string> | null = {
+const enTranslations: Record<string, string> = {
   POPULATION_SERVED_KEY: 'Population Served',
   LATITUDE_KEY: 'Latitude',
   LONGITUDE_KEY: 'Longitude',
@@ -47,7 +47,7 @@ const enTranslations: Record<string, string> | null = {
 };
 
 // French Translations
-const frTranslations: Record<string, string> | null = {
+const frTranslations: Record<string, string> = {
   POPULATION_SERVED_KEY: 'Population Desservie',
   LATITUDE_KEY: 'Latitude',
   LONGITUDE_KEY: 'Longitude',
@@ -93,15 +93,18 @@ const frTranslations: Record<string, string> | null = {
   Low: 'Faible',
 };
 
-const populationServed: ConfigureNamePropertyInput = {
-  id: '7716cecc-7d62-4f1b-93fa-a55a275079b4',
-  propertyId: POPULATION_SERVED_KEY,
-  key: POPULATION_SERVED_KEY,
-  name: 'Population Served',
-  valueType: PropertyNodeValueType.Float,
-  allowedValues: null,
-  remoteEditable: true,
-};
+function getPopulationServedForLanguage(language: string) {
+  const translations = language === 'fr' ? frTranslations : enTranslations;
+  return {
+    id: '7716cecc-7d62-4f1b-93fa-a55a275079b4',
+    propertyId: POPULATION_SERVED_KEY,
+    key: POPULATION_SERVED_KEY,
+    name: translations['POPULATION_SERVED_KEY'] ?? 'Population Served',
+    valueType: PropertyNodeValueType.Float,
+    allowedValues: null,
+    remoteEditable: true,
+  };
+}
 
 function translateAllowedValues(
   allowedValues: string | null,
@@ -122,7 +125,7 @@ function getGapsPropertiesForLanguage(language: string) {
       id: '0ed01a18-c9ac-4b51-bb56-d5fea4f15feb',
       propertyId: LATITUDE_KEY,
       key: LATITUDE_KEY,
-      name: translations?.[LATITUDE_KEY] ?? 'Latitude',
+      name: translations['LATITUDE_KEY'] ?? 'Latitude',
       valueType: PropertyNodeValueType.Float,
       allowedValues: null,
       remoteEditable: false,
@@ -131,7 +134,7 @@ function getGapsPropertiesForLanguage(language: string) {
       id: '9d595b3e-2eca-4b1a-983e-77aa34b14e62',
       propertyId: LONGITUDE_KEY,
       key: LONGITUDE_KEY,
-      name: translations?.[LONGITUDE_KEY] ?? 'Longitude',
+      name: translations['LONGITUDE_KEY'] ?? 'Longitude',
       valueType: PropertyNodeValueType.Float,
       allowedValues: null,
       remoteEditable: false,
@@ -140,7 +143,7 @@ function getGapsPropertiesForLanguage(language: string) {
       id: '3285c231-ffc2-485b-9a86-5ccafed9a5c5',
       propertyId: SUPPLY_LEVEL_KEY,
       key: SUPPLY_LEVEL_KEY,
-      name: translations?.[SUPPLY_LEVEL_KEY] ?? 'Supply Level',
+      name: translations['SUPPLY_LEVEL_KEY'] ?? 'Supply Level',
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
         'Primary,Sub-National,Lowest Distribution,Service Point',
@@ -152,7 +155,7 @@ function getGapsPropertiesForLanguage(language: string) {
       id: '0e6fa1d3-4762-4b19-a832-1fe8a391e75b',
       propertyId: FACILITY_TYPE_KEY,
       key: FACILITY_TYPE_KEY,
-      name: translations?.[FACILITY_TYPE_KEY] ?? 'Facility Type',
+      name: translations['FACILITY_TYPE_KEY'] ?? 'Facility Type',
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
         'National Vaccine Store,Regional Vaccine Store,Referral Hospital,Municipal Warehouse,Maternal Clinic',
@@ -164,7 +167,7 @@ function getGapsPropertiesForLanguage(language: string) {
       id: '098d1c23-1257-451a-a449-500ab3907337',
       propertyId: OWNERSHIP_TYPE_KEY,
       key: OWNERSHIP_TYPE_KEY,
-      name: translations?.[OWNERSHIP_TYPE_KEY] ?? 'Ownership Type',
+      name: translations['OWNERSHIP_TYPE_KEY'] ?? 'Ownership Type',
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
         'Government,NGO,Private,Faith-based',
@@ -176,7 +179,7 @@ function getGapsPropertiesForLanguage(language: string) {
       id: '4396d231-ffc2-485b-9a86-5ccafed0b6d6',
       propertyId: BUFFER_STOCK_KEY,
       key: BUFFER_STOCK_KEY,
-      name: translations?.[BUFFER_STOCK_KEY] ?? 'Stock Safety Buffer (months)',
+      name: translations['BUFFER_STOCK_KEY'] ?? 'Stock Safety Buffer (months)',
       valueType: PropertyNodeValueType.Integer,
       allowedValues: null,
       remoteEditable: false,
@@ -186,7 +189,7 @@ function getGapsPropertiesForLanguage(language: string) {
       propertyId: SUPPLY_INTERVAL_KEY,
       key: SUPPLY_INTERVAL_KEY,
       name:
-        translations?.[SUPPLY_INTERVAL_KEY] ??
+        translations['SUPPLY_INTERVAL_KEY'] ??
         'Supply Interval (Months between deliveries)',
       valueType: PropertyNodeValueType.Integer,
       allowedValues: null,
@@ -196,7 +199,7 @@ function getGapsPropertiesForLanguage(language: string) {
       id: 'c5e363fc-40c9-4m1c-b29a-76d74534b077',
       propertyId: PACKAGING_LEVEL_KEY,
       key: PACKAGING_LEVEL_KEY,
-      name: translations?.[PACKAGING_LEVEL_KEY] ?? 'Packaging Level',
+      name: translations['PACKAGING_LEVEL_KEY'] ?? 'Packaging Level',
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
         'Primary (1),Secondary (2),Tertiary (3)',
@@ -204,16 +207,13 @@ function getGapsPropertiesForLanguage(language: string) {
       ),
       remoteEditable: true,
     },
-    {
-      ...populationServed,
-      name: translations?.[POPULATION_SERVED_KEY] ?? 'Population Served',
-    },
+    getPopulationServedForLanguage(language),
     {
       id: 'd700e86a-28c9-40a9-830c-f8a9793c63a0',
       propertyId: ELECTRICITY_AVAILABILITY_KEY,
       key: ELECTRICITY_AVAILABILITY_KEY,
       name:
-        translations?.[ELECTRICITY_AVAILABILITY_KEY] ??
+        translations['ELECTRICITY_AVAILABILITY_KEY'] ??
         'Electricity Availability',
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
@@ -226,7 +226,7 @@ function getGapsPropertiesForLanguage(language: string) {
       id: 'cbb104cd-c5f7-4c7a-af5e-ef4ad1b428e0',
       propertyId: SOLAR_AVAILABILITY_KEY,
       key: SOLAR_AVAILABILITY_KEY,
-      name: translations?.[SOLAR_AVAILABILITY_KEY] ?? 'Solar Availability',
+      name: translations['SOLAR_AVAILABILITY_KEY'] ?? 'Solar Availability',
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
         '> 16 hours,8-16 hours,< 8 hours,No availability,Unknown',
@@ -238,7 +238,7 @@ function getGapsPropertiesForLanguage(language: string) {
       id: '633f4741-91ad-46a6-b302-8d1979eb3be4',
       propertyId: GAS_AVAILABILITY_KEY,
       key: GAS_AVAILABILITY_KEY,
-      name: translations?.[GAS_AVAILABILITY_KEY] ?? 'Gas Availability',
+      name: translations['GAS_AVAILABILITY_KEY'] ?? 'Gas Availability',
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
         'No availability,Available,Irregular,Unknown',
@@ -251,7 +251,7 @@ function getGapsPropertiesForLanguage(language: string) {
       propertyId: KEROSENE_AVAILABILITY_KEY,
       key: KEROSENE_AVAILABILITY_KEY,
       name:
-        translations?.[KEROSENE_AVAILABILITY_KEY] ?? 'Kerosene Availability',
+        translations['KEROSENE_AVAILABILITY_KEY'] ?? 'Kerosene Availability',
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
         'No availability,Available,Irregular,Unknown',
@@ -263,7 +263,7 @@ function getGapsPropertiesForLanguage(language: string) {
       id: '86cb041d-96d3-40f1-874e-4189f4796790',
       propertyId: PENTA_3_KEY,
       key: PENTA_3_KEY,
-      name: translations?.[PENTA_3_KEY] ?? 'Penta-3 Coverage',
+      name: translations['PENTA_3_KEY'] ?? 'Penta-3 Coverage',
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
         'High,Medium,Low,Unknown',
@@ -275,7 +275,7 @@ function getGapsPropertiesForLanguage(language: string) {
       id: '9cc3ac59-061e-4e3f-af13-d2b6d9a52dea',
       propertyId: ZERO_DOSE_KEY,
       key: ZERO_DOSE_KEY,
-      name: translations?.[ZERO_DOSE_KEY] ?? 'Zero Dose Coverage',
+      name: translations['ZERO_DOSE_KEY'] ?? 'Zero Dose Coverage',
       valueType: PropertyNodeValueType.String,
       allowedValues: translateAllowedValues(
         'High,Medium,Low,Unknown',
@@ -292,5 +292,6 @@ export const gapsNameProperties: LocalisedNamePropertyConfig = {
 };
 
 export const populationNameProperties: LocalisedNamePropertyConfig = {
-  en: [populationServed],
+  en: [getPopulationServedForLanguage('en')],
+  fr: [getPopulationServedForLanguage('fr')],
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7590

# 👩🏻‍💻 What does this PR do?

Gaps store properties can now be initalised and re-initialised.
The language selected is based on your currently selected language.
Note: re-initialising might not work correctly depending on what changes have been done, it will upsert the records so won't remove anything existing.It also won't remap any previously entered values if you change languages


![image](https://github.com/user-attachments/assets/3e883d21-1396-4fe8-bd4a-b631ee7b67dc)
![image](https://github.com/user-attachments/assets/3ad75dcd-ad08-4778-ad18-c53d841543be)


## 💌 Any notes for the reviewer?



# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Try initialising properties in english and french
- [ ] Check french translations are correct based on this document
https://docs.google.com/document/d/1fWmzx57uwq4vopfWMhYA-PYKHgQqsfpAjgiBX-lNUNU/edit?tab=t.0

# 📃 Documentation

- [X] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

