### PR TITLE
7982 campaign name support case sensitive

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1624,6 +1624,7 @@
   "messages.error-no-file-selected": "No file selected",
   "messages.error-not-valid-email": "Please enter a valid email address",
   "messages.error-printing-report": "Unable to print report",
+  "messages.error-campaign-name-already-exists": "A campaign with same name already exists 🥺",
   "messages.error-saving-campaign": "Error saving campaign 🥺",
   "messages.error-saving-insurances": "Error saving insurances 🥺",
   "messages.error-saving-prescription": "Error saving prescription 🥺",

--- a/client/packages/system/src/Manage/Campaigns/ListView/ListView.tsx
+++ b/client/packages/system/src/Manage/Campaigns/ListView/ListView.tsx
@@ -53,12 +53,24 @@ const CampaignsComponent = () => {
 
   const save = async () => {
     const result = await upsert();
-    if (result?.__typename === 'CampaignNode')
+    if (result?.__typename === 'CampaignNode') {
       success(t('messages.campaign-saved'))();
-    else if ('error' in result)
+      return;
+    }
+
+    if ('error' in result) {
+      if (
+        '__typename' in result.error &&
+        result.error.__typename === 'UniqueValueViolation'
+      ) {
+        error(t('messages.error-campaign-name-already-exists'))();
+        return;
+      }
+
       error(
-        `${t('messages.error-saving-campaign')} — ${result?.error?.description ?? ''}`
+        `${t('messages.error-saving-campaign')} — ${result.error.description ?? ''}`
       )();
+    }
   };
 
   const confirmAndDelete = useDeleteConfirmation({

--- a/server/service/src/campaign/upsert.rs
+++ b/server/service/src/campaign/upsert.rs
@@ -76,7 +76,7 @@ fn validate(
     // Check for duplicate name
     let campaigns_with_duplicate_name = CampaignRepository::new(connection).query_by_filter(
         CampaignFilter::new()
-            .name(StringFilter::equal_to(input.name.trim()))
+            .name(StringFilter::like(&input.name))
             .id(EqualFilter::not_equal_to(&input.id)),
     )?;
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7982 

# 👩🏻‍💻 What does this PR do?

Prevents the user from creating a campaign with a name that already exists, whether by adding a new campaign or editing an existing one.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] On omSupply Central server, go to 'Manage > Campaigns'
- [ ] Click on 'Add New Campaign'
- [ ] Name your campaign identical to an existing one except for the **_case_** of one letter.
- [ ] Click Ok
- [ ] Error should indicate that you can't create or edit because campaign name already exist
  - [ ] Error message: `A campaign with same name already exists 🥺` 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

