### PR TITLE
7992 Add population percentage to demographic table

### DIFF
--- a/server/repository/src/db_diesel/demographic_row.rs
+++ b/server/repository/src/db_diesel/demographic_row.rs
@@ -12,6 +12,7 @@ table! {
     demographic(id) {
         id -> Text,
         name -> Text,
+        population_percentage -> Double
     }
 }
 
@@ -22,6 +23,7 @@ table! {
 pub struct DemographicRow {
     pub id: String,
     pub name: String,
+    pub population_percentage: f64,
 }
 
 pub struct DemographicRowRepository<'a> {

--- a/server/repository/src/migrations/v2_08_00/add_population_percentage_to_demographic.rs
+++ b/server/repository/src/migrations/v2_08_00/add_population_percentage_to_demographic.rs
@@ -11,17 +11,32 @@ impl MigrationFragment for Migrate {
         sql!(
             connection,
             r#"
-                ALTER TABLE demographic ADD COLUMN population_percentage {DOUBLE} NOT NULL DEFAULT 0;
+                ALTER TABLE demographic ADD COLUMN population_percentage {DOUBLE} NOT NULL DEFAULT 0;  
+            "#,
+        )?;
 
+        // Populate the new column with the existing values from demographic_indicator if they exist
+        // They should only exist for the central server, so this will only affect the central server
+        sql!(
+            connection,
+            r#"
                 UPDATE demographic SET population_percentage = (
                     SELECT population_percentage FROM demographic_indicator
                     WHERE demographic_id = demographic.id
                 ) WHERE id in (
                     SELECT demographic_id FROM demographic_indicator
-                    WHERE population_percentage IS NOT NULL
                 );
             "#,
         )?;
+
+        // Create changelog entries for all the existing demographic records, so they'll be synced with their new population_percentage
+        // We limit it to records that have a corresponding demographic_indicator, so this actually only affects the central server, otherwise we sync 0 records to central!
+        sql!(
+                connection,
+                "INSERT INTO changelog (table_name, record_id, row_action) SELECT 'demographic', id, 'UPSERT' FROM demographic WHERE id in (
+                    SELECT demographic_id FROM demographic_indicator
+                );"
+            )?;
 
         Ok(())
     }

--- a/server/repository/src/migrations/v2_08_00/add_population_percentage_to_demographic.rs
+++ b/server/repository/src/migrations/v2_08_00/add_population_percentage_to_demographic.rs
@@ -31,8 +31,11 @@ impl MigrationFragment for Migrate {
             "#,
         )?;
 
-        // Create changelog entries for all the existing demographic records, so they'll be synced with their new population_percentage
-        // We limit it to records that have a corresponding demographic_indicator, so this actually only affects the central server, otherwise we might accidentally sync 0 records to central!
+        // Create changelog entries for all the existing demographic records, so
+        // they'll be synced with their new population_percentage.
+        // We limit it to records that have a corresponding
+        // demographic_indicator, so this actually only affects the central
+        // server, otherwise we might accidentally sync 0 records to central!
         sql!(
                 connection,
                 "INSERT INTO changelog (table_name, record_id, row_action) SELECT 'demographic', id, 'UPSERT' FROM demographic WHERE id in (
@@ -40,9 +43,13 @@ impl MigrationFragment for Migrate {
                 );"
             )?;
 
-        // If we've update and synced the records on central, the remote site might not have had that column yet.
-        // So we need to re-integrate the records on the remote site on upgrade, this should be safe as only the remote site should have data in the sync_buffer.
-        // Would be nice to limit this so Central server doesn't run this code at all but it doesn't know it's central till first sync.
+        // If we've update and synced the records on central, the remote site
+        // might not have had that column yet.
+        // So we need to re-integrate the records on the remote site on upgrade,
+        // this should be safe as only the remote site should have data in the
+        // sync_buffer.
+        // Would be nice to limit this so Central server doesn't run this code
+        // at all but it doesn't know it's central till first sync.
         sql!(
             connection,
             r#"

--- a/server/repository/src/migrations/v2_08_00/add_population_percentage_to_demographic.rs
+++ b/server/repository/src/migrations/v2_08_00/add_population_percentage_to_demographic.rs
@@ -30,13 +30,24 @@ impl MigrationFragment for Migrate {
         )?;
 
         // Create changelog entries for all the existing demographic records, so they'll be synced with their new population_percentage
-        // We limit it to records that have a corresponding demographic_indicator, so this actually only affects the central server, otherwise we sync 0 records to central!
+        // We limit it to records that have a corresponding demographic_indicator, so this actually only affects the central server, otherwise we might accidentally sync 0 records to central!
         sql!(
                 connection,
                 "INSERT INTO changelog (table_name, record_id, row_action) SELECT 'demographic', id, 'UPSERT' FROM demographic WHERE id in (
                     SELECT demographic_id FROM demographic_indicator
                 );"
             )?;
+
+        // If we've update and synced the records on central, the remote site might not have had that column yet.
+        // So we need to re-integrate the records on the remote site on upgrade, this should be safe as only the remote site should have data in the sync_buffer.
+        // Would be nice to limit this so Central server doesn't run this code at all but it doesn't know it's central till first sync.
+        sql!(
+            connection,
+            r#"
+                UPDATE sync_buffer SET integration_datetime = NULL 
+                    WHERE table_name = 'demographic';
+            "#
+        )?;
 
         Ok(())
     }

--- a/server/repository/src/migrations/v2_08_00/add_population_percentage_to_demographic.rs
+++ b/server/repository/src/migrations/v2_08_00/add_population_percentage_to_demographic.rs
@@ -16,6 +16,9 @@ impl MigrationFragment for Migrate {
                 UPDATE demographic SET population_percentage = (
                     SELECT population_percentage FROM demographic_indicator
                     WHERE demographic_id = demographic.id
+                ) WHERE id in (
+                    SELECT demographic_id FROM demographic_indicator
+                    WHERE population_percentage IS NOT NULL
                 );
             "#,
         )?;

--- a/server/repository/src/migrations/v2_08_00/add_population_percentage_to_demographic.rs
+++ b/server/repository/src/migrations/v2_08_00/add_population_percentage_to_demographic.rs
@@ -15,8 +15,10 @@ impl MigrationFragment for Migrate {
             "#,
         )?;
 
-        // Populate the new column with the existing values from demographic_indicator if they exist
-        // They should only exist for the central server, so this will only affect the central server
+        // Populate the new column with the existing values from
+        // demographic_indicator if they exist.
+        // They should only exist for the central server, so this will only
+        // affect the central server
         sql!(
             connection,
             r#"

--- a/server/repository/src/migrations/v2_08_00/add_population_percentage_to_demographic.rs
+++ b/server/repository/src/migrations/v2_08_00/add_population_percentage_to_demographic.rs
@@ -1,0 +1,25 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_population_percentage_to_demographic"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        sql!(
+            connection,
+            r#"
+                ALTER TABLE demographic ADD COLUMN population_percentage {DOUBLE} NOT NULL DEFAULT 0;
+
+                UPDATE demographic SET population_percentage = (
+                    SELECT population_percentage FROM demographic_indicator
+                    WHERE demographic_id = demographic.id
+                );
+            "#,
+        )?;
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_08_00/mod.rs
+++ b/server/repository/src/migrations/v2_08_00/mod.rs
@@ -13,6 +13,7 @@ mod add_doses_columns_to_item_variant;
 mod add_initial_stocktake_field;
 mod add_item_variant_enums_to_activity_log;
 mod add_open_vial_wastage_to_reason_option_type;
+mod add_population_percentage_to_demographic;
 mod add_view_and_edit_vvm_status_permission;
 mod add_vvm_status_id_to_invoice_line;
 mod add_vvm_status_id_to_stock_line;
@@ -59,6 +60,7 @@ impl Migration for V2_08_00 {
             Box::new(reintegrate_options_sync_buffer_records::Migrate),
             Box::new(donor_id_to_donor_link_id::Migrate),
             Box::new(add_campaign_id_to_invoice_line_row::Migrate),
+            Box::new(add_population_percentage_to_demographic::Migrate),
         ]
     }
 }

--- a/server/repository/src/migrations/views/mod.rs
+++ b/server/repository/src/migrations/views/mod.rs
@@ -463,9 +463,9 @@ CREATE VIEW vaccination_course AS
       item.unit_id AS unit_id,
       unit.name AS unit,
       unit."index" AS unit_index,
-      di.demographic_id AS demographic_id,
-      di.name AS demographic_name,
-      di.population_percentage AS population_percentage,
+      d.id AS demographic_id,
+      d.name AS demographic_name,
+      d.population_percentage AS population_percentage,
       p.id AS program_id,
       p.name AS program_name
     FROM
@@ -475,9 +475,7 @@ CREATE VIEW vaccination_course AS
       JOIN item_link il ON vci.item_link_id = il.id
       JOIN item ON item.id = il.item_id
       LEFT JOIN unit ON item.unit_id = unit.id
-      -- This assumes that there is only one demographic indicator for each 
-      -- "demographic_id", which could potentially change in the future
-      LEFT JOIN demographic_indicator di ON di.demographic_id = vc.demographic_id
+      LEFT JOIN demographic d ON d.id = vc.demographic_id
       JOIN PROGRAM p ON p.id = vc.program_id
     WHERE
       vc.deleted_datetime IS NULL

--- a/server/repository/src/mock/demographic.rs
+++ b/server/repository/src/mock/demographic.rs
@@ -4,6 +4,7 @@ pub fn mock_demographic_a() -> DemographicRow {
     DemographicRow {
         id: "demographic_1".to_owned(),
         name: "demographic_1".to_owned(),
+        population_percentage: 25.0,
     }
 }
 

--- a/server/service/src/demographic/insert_demographic_indicator.rs
+++ b/server/service/src/demographic/insert_demographic_indicator.rs
@@ -54,6 +54,7 @@ pub fn insert_demographic_indicator(
                     let new_demographic = DemographicRow {
                         id: uuid(),
                         name: demographic_name.clone(),
+                        population_percentage: input.population_percentage.unwrap_or_default(),
                     };
                     new_demographic.upsert(connection)?;
                     // TODO add activity log entry

--- a/server/service/src/demographic/update_demographic_indicator.rs
+++ b/server/service/src/demographic/update_demographic_indicator.rs
@@ -2,8 +2,8 @@ use crate::{
     activity_log::activity_log_entry, service_provider::ServiceContext, SingleRecordError,
 };
 use repository::{
-    ActivityLogType, DemographicIndicatorRow, DemographicIndicatorRowRepository, RepositoryError,
-    StorageConnection,
+    ActivityLogType, DemographicIndicatorRow, DemographicIndicatorRowRepository, DemographicRow,
+    DemographicRowRepository, RepositoryError, StorageConnection,
 };
 
 use super::{
@@ -46,6 +46,15 @@ pub fn update_demographic_indicator(
                 generate(input.clone(), demographic_indicator_row.clone());
             DemographicIndicatorRowRepository::new(connection)
                 .upsert_one(&updated_demographic_indicator_row)?;
+
+            // Also update corresponding demographic record
+            DemographicRowRepository::new(connection).upsert_one(&DemographicRow {
+                id: updated_demographic_indicator_row.demographic_id.clone(),
+                name: updated_demographic_indicator_row.name.clone(),
+                population_percentage: updated_demographic_indicator_row
+                    .population_percentage
+                    .clone(),
+            })?;
 
             activity_log_entry(
                 ctx,

--- a/server/service/src/sync/test/test_data/demographic.rs
+++ b/server/service/src/sync/test/test_data/demographic.rs
@@ -9,7 +9,8 @@ const DEMOGRAPHIC1: (&str, &str) = (
     "test_demographic",
     r#"{
         "id":  "test_demographic",
-        "name": "test demographic"
+        "name": "test demographic",
+        "population_percentage": 10
     }"#,
 );
 
@@ -17,6 +18,7 @@ fn demographic1() -> DemographicRow {
     DemographicRow {
         id: DEMOGRAPHIC1.0.to_string(),
         name: "test demographic".to_string(),
+        population_percentage: 10.0,
     }
 }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7992

# 👩🏻‍💻 What does this PR do?

- Migration to add "population_percentage" to "demographic" table
- Funcionality to automatically update that field whenever a "demographic_indicator" is added/edited
- Change "vaccination_course" view to use percentage from this field rather the demographic_indicator

# 🧪 Testing

Not much for QA to test here, other than confirming that the forecasting plugin works on a non-central system

Devs, check database is modified as expected

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

