### PR TITLE
7343 dose management display doses in internal order & requisition

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -764,6 +764,7 @@
   "label.date-range": "Date Range",
   "label.date-time": "Date time",
   "label.day": "day",
+  "label.days": "days",
   "label.days-out-of-stock": "Days out of stock",
   "label.ddd": "Defined Daily Dose",
   "label.deceased": "Deceased",

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/ContentArea.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/ContentArea.tsx
@@ -13,6 +13,7 @@ import { isRequestLinePlaceholderRow } from '../../utils';
 interface ContentAreaProps {
   onAddItem: () => void;
   onRowClick: null | ((line: RequestLineFragment) => void);
+  manageVaccinesInDoses: boolean;
 }
 
 const useHighlightPlaceholderRows = (
@@ -33,9 +34,15 @@ const useHighlightPlaceholderRows = (
   }, [rows, setRowStyles]);
 };
 
-export const ContentArea = ({ onAddItem, onRowClick }: ContentAreaProps) => {
+export const ContentArea = ({
+  onAddItem,
+  onRowClick,
+  manageVaccinesInDoses,
+}: ContentAreaProps) => {
   const t = useTranslation();
-  const { lines, columns, itemFilter } = useRequest.line.list();
+  const { lines, columns, itemFilter } = useRequest.line.list(
+    manageVaccinesInDoses
+  );
   const { on } = useHideOverStocked();
   const { plugins } = usePluginProvider();
   const isDisabled = useRequest.utils.isDisabled();

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/DetailView.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/DetailView.tsx
@@ -12,6 +12,8 @@ import {
   useAuthContext,
   useBreadcrumbs,
   useEditModal,
+  PreferenceKey,
+  usePreference,
 } from '@openmsupply-client/common';
 import { ActivityLogList } from '@openmsupply-client/system';
 import { RequestLineFragment, useRequest } from '../api';
@@ -31,6 +33,8 @@ export const DetailView = () => {
   const navigate = useNavigate();
   const { setCustomBreadcrumbs } = useBreadcrumbs();
   const { store } = useAuthContext();
+  const { data: { manageVaccinesInDoses } = { manageVaccinesInDoses: false } } =
+    usePreference(PreferenceKey.ManageVaccinesInDoses);
   const {
     onOpen,
     onClose,
@@ -143,6 +147,7 @@ export const DetailView = () => {
             onClose={onClose}
             mode={mode}
             store={store}
+            manageVaccinesInDoses={manageVaccinesInDoses}
           />
         )}
       </TableProvider>

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/DetailView.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/DetailView.tsx
@@ -91,7 +91,13 @@ export const DetailView = () => {
 
   const tabs = [
     {
-      Component: <ContentArea onRowClick={onRowClick} onAddItem={onAddItem} />,
+      Component: (
+        <ContentArea
+          onRowClick={onRowClick}
+          onAddItem={onAddItem}
+          manageVaccinesInDoses={manageVaccinesInDoses}
+        />
+      ),
       value: 'Details',
     },
     {

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ModalContentPanels.ts
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ModalContentPanels.ts
@@ -66,6 +66,7 @@ export const getExtraMiddlePanels = (
     {
       label: t('label.days-out-of-stock'),
       value: draft?.daysOutOfStock,
+      endAdornmentOverride: t('label.days'),
     },
   ];
 };

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ModalContentPanels.ts
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ModalContentPanels.ts
@@ -41,7 +41,11 @@ export const getExtraMiddlePanels = (
     {
       label: t('label.suggested'),
       value: draft?.suggestedQuantity,
-      sx: { background: theme => theme.palette.background.group },
+      sx: {
+        background: theme => theme.palette.background.group,
+        pt: 0.5,
+        pb: 0.5,
+      },
     },
     {
       label: t('label.incoming-stock'),

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -71,6 +71,7 @@ export const RequestLineEdit = ({
   const { width } = useWindowDimensions();
   const unitName = currentItem?.unitName || t('label.unit');
   const defaultPackSize = currentItem?.defaultPackSize || 1;
+  const showContent = !!draft && !!currentItem;
   const displayVaccinesInDoses =
     manageVaccinesInDoses && currentItem?.isVaccine;
   const disableItemSelection = disabled || isUpdateMode;
@@ -115,13 +116,13 @@ export const RequestLineEdit = ({
   ]);
 
   const getMiddlePanelContent = () => {
-    if (!draft) return null;
+    if (!showContent) return null;
 
     return renderValueInfoRows(getExtraMiddlePanels(t, draft));
   };
 
   const getRightPanelContent = () => {
-    if (!draft) return null;
+    if (!showContent) return null;
 
     return (
       <>
@@ -227,7 +228,7 @@ export const RequestLineEdit = ({
           </>
         }
         Left={
-          draft ? (
+          showContent ? (
             <>
               {currentItem?.unitName && (
                 <InfoRow label={t('label.unit')} value={unitName} />
@@ -260,7 +261,7 @@ export const RequestLineEdit = ({
           ))}
       </Box>
 
-      {!!draft && (
+      {showContent && (
         <Box
           display="flex"
           flexDirection="column"

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -64,7 +64,7 @@ export const RequestLineEdit = ({
   disabled,
   isUpdateMode,
   showExtraFields,
-  manageVaccinesInDoses,
+  manageVaccinesInDoses = false,
 }: RequestLineEditProps) => {
   const t = useTranslation();
   const { plugins } = usePluginProvider();
@@ -100,11 +100,19 @@ export const RequestLineEdit = ({
             representation={representation}
             unitName={unitName}
             sx={sx}
+            displayVaccinesInDoses={displayVaccinesInDoses}
+            dosesPerUnit={currentItem?.doses}
           />
         ))}
       </>
     );
-  }, [defaultPackSize, representation, unitName]);
+  }, [
+    defaultPackSize,
+    representation,
+    unitName,
+    displayVaccinesInDoses,
+    currentItem?.doses,
+  ]);
 
   const getMiddlePanelContent = () => {
     if (!draft) return null;
@@ -122,8 +130,7 @@ export const RequestLineEdit = ({
             background: theme => theme.palette.background.group,
             padding: '0px 8px',
             borderRadius: 2,
-            pb: 2,
-            pt: 0.5,
+            pb: 1,
           }}
         >
           {!showExtraFields && renderValueInfoRows(getSuggestedRow(t, draft))}
@@ -136,7 +143,8 @@ export const RequestLineEdit = ({
             representation={representation}
             setRepresentation={setRepresentation}
             unitName={unitName}
-            showExtraFields={showExtraFields}
+            displayVaccinesInDoses={displayVaccinesInDoses}
+            dosesPerUnit={currentItem?.doses}
           />
           {showExtraFields && (
             <Typography variant="body1" fontWeight="bold">
@@ -146,7 +154,7 @@ export const RequestLineEdit = ({
                 onChange={value => {
                   update({ reason: value });
                 }}
-                width={360}
+                fullWidth
                 type={ReasonOptionNodeType.RequisitionLineVariance}
                 disabled={disableReasons}
                 reasonOptions={reasonOptions?.nodes ?? []}
@@ -165,7 +173,7 @@ export const RequestLineEdit = ({
               />
             </Typography>
           )}
-          <Typography variant="body1" fontWeight="bold" paddingBottom={0}>
+          <Typography variant="body1" fontWeight="bold" pb={0.5}>
             {t('heading.comment')}:
           </Typography>
           <BufferedTextArea

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -261,33 +261,52 @@ export const RequestLineEdit = ({
           ))}
       </Box>
 
-      {showContent && (
-        <Box
-          display="flex"
-          flexDirection="column"
-          justifySelf="center"
-          width={900}
-        >
-          <StockDistribution
-            availableStockOnHand={draft?.itemStats?.availableStockOnHand}
-            averageMonthlyConsumption={
-              draft?.itemStats?.averageMonthlyConsumption
-            }
-            suggestedQuantity={draft?.suggestedQuantity}
-          />
+      {line && (
+        <Box padding={'2px 16px 0 16px'}>
+          {plugins.requestRequisitionLine?.editViewInfo?.map((Info, index) => (
+            <Info key={index} line={line} requisition={requisition} />
+          ))}
         </Box>
       )}
 
-      {line && (
-        <Box>
-          <Box padding={'2px 16px 0 16px'}>
-            {plugins.requestRequisitionLine?.editViewInfo?.map(
-              (Info, index) => (
-                <Info key={index} line={line} requisition={requisition} />
-              )
-            )}
+      {showContent && line && (
+        <Box
+          sx={{
+            width: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+          }}
+        >
+          <Box
+            sx={{
+              width: '100%',
+              maxWidth: 900,
+              mx: 'auto',
+              p: '8px 16px',
+            }}
+          >
+            <StockDistribution
+              availableStockOnHand={line.itemStats?.availableStockOnHand}
+              averageMonthlyConsumption={
+                line.itemStats?.averageMonthlyConsumption
+              }
+              suggestedQuantity={line.suggestedQuantity}
+            />
           </Box>
-          <Box display="flex" sx={{ padding: 2 }} justifyContent="center">
+          <Box
+            display="flex"
+            justifyContent="center"
+            gap={2}
+            sx={{
+              padding: 2,
+              flexDirection: {
+                xs: 'column',
+                md: 'row',
+              },
+              alignItems: 'center',
+            }}
+          >
             <ConsumptionHistory id={line.id} />
             <StockEvolution id={line.id} />
           </Box>

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -49,6 +49,7 @@ interface RequestLineEditProps {
   isUpdateMode?: boolean;
   showExtraFields?: boolean;
   manageVaccinesInDoses?: boolean;
+  setIsDirty?: (isDirty: boolean) => void;
 }
 
 export const RequestLineEdit = ({
@@ -65,6 +66,7 @@ export const RequestLineEdit = ({
   isUpdateMode,
   showExtraFields,
   manageVaccinesInDoses = false,
+  setIsDirty = () => {},
 }: RequestLineEditProps) => {
   const t = useTranslation();
   const { plugins } = usePluginProvider();
@@ -146,6 +148,7 @@ export const RequestLineEdit = ({
             unitName={unitName}
             displayVaccinesInDoses={displayVaccinesInDoses}
             dosesPerUnit={currentItem?.doses}
+            setIsDirty={setIsDirty}
           />
           {showExtraFields && (
             <Typography variant="body1" fontWeight="bold">

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -48,6 +48,7 @@ interface RequestLineEditProps {
   disabled?: boolean;
   isUpdateMode?: boolean;
   showExtraFields?: boolean;
+  manageVaccinesInDoses?: boolean;
 }
 
 export const RequestLineEdit = ({
@@ -63,12 +64,15 @@ export const RequestLineEdit = ({
   disabled,
   isUpdateMode,
   showExtraFields,
+  manageVaccinesInDoses,
 }: RequestLineEditProps) => {
   const t = useTranslation();
   const { plugins } = usePluginProvider();
   const { width } = useWindowDimensions();
   const unitName = currentItem?.unitName || t('label.unit');
   const defaultPackSize = currentItem?.defaultPackSize || 1;
+  const displayVaccinesInDoses =
+    manageVaccinesInDoses && currentItem?.isVaccine;
   const disableItemSelection = disabled || isUpdateMode;
   const disableReasons =
     draft?.requestedQuantity === draft?.suggestedQuantity || disabled;
@@ -226,6 +230,12 @@ export const RequestLineEdit = ({
                   value={String(currentItem?.defaultPackSize)}
                 />
               )}
+              {displayVaccinesInDoses && currentItem?.doses ? (
+                <InfoRow
+                  label={t('label.doses-per-unit')}
+                  value={String(currentItem?.doses)}
+                />
+              ) : null}
               {renderValueInfoRows(getLeftPanel(t, draft, showExtraFields))}
             </>
           ) : null

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -49,7 +49,6 @@ interface RequestLineEditProps {
   isUpdateMode?: boolean;
   showExtraFields?: boolean;
   manageVaccinesInDoses?: boolean;
-  setIsDirty?: (isDirty: boolean) => void;
 }
 
 export const RequestLineEdit = ({
@@ -66,7 +65,6 @@ export const RequestLineEdit = ({
   isUpdateMode,
   showExtraFields,
   manageVaccinesInDoses = false,
-  setIsDirty = () => {},
 }: RequestLineEditProps) => {
   const t = useTranslation();
   const { plugins } = usePluginProvider();
@@ -148,7 +146,6 @@ export const RequestLineEdit = ({
             unitName={unitName}
             displayVaccinesInDoses={displayVaccinesInDoses}
             dosesPerUnit={currentItem?.doses}
-            setIsDirty={setIsDirty}
           />
           {showExtraFields && (
             <Typography variant="body1" fontWeight="bold">

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -83,7 +83,9 @@ export const RequestLineEditModal = ({
   };
 
   const onChangeItem = (item: ItemWithStatsFragment) => {
-    deletePreviousLine();
+    if (item.id !== currentItem?.id) {
+      deletePreviousLine();
+    }
     setRepresentation(Representation.UNITS);
     setCurrentItem(item);
   };
@@ -104,7 +106,7 @@ export const RequestLineEditModal = ({
     if (!!draft?.isCreated) {
       save();
     }
-  }, [draft]);
+  }, [draft?.isCreated]);
 
   return (
     <Modal

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -20,6 +20,7 @@ interface RequestLineEditModalProps {
   itemId: string | null;
   isOpen: boolean;
   onClose: () => void;
+  manageVaccinesInDoses?: boolean;
 }
 
 export const RequestLineEditModal = ({
@@ -29,6 +30,7 @@ export const RequestLineEditModal = ({
   itemId,
   isOpen,
   onClose,
+  manageVaccinesInDoses = false,
 }: RequestLineEditModalProps) => {
   const { Modal } = useDialog({ onClose, isOpen });
   const deleteLine = useRequest.line.deleteLine();
@@ -137,6 +139,7 @@ export const RequestLineEditModal = ({
         disabled={isDisabled}
         isUpdateMode={mode === ModalMode.Update}
         showExtraFields={useConsumptionData && isProgram}
+        manageVaccinesInDoses={manageVaccinesInDoses}
       />
     </Modal>
   );

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -10,7 +10,11 @@ import { RequestFragment, useRequest } from '../../api';
 import { useDraftRequisitionLine, useNextRequestLine } from './hooks';
 import { isRequestDisabled } from '../../../utils';
 import { RequestLineEdit } from './RequestLineEdit';
-import { Representation, RepresentationValue } from '../../../common';
+import {
+  Representation,
+  RepresentationValue,
+  shouldDeleteLine,
+} from '../../../common';
 
 import { ItemWithStatsFragment } from '@openmsupply-client/system';
 
@@ -62,15 +66,9 @@ export const RequestLineEditModal = ({
   const isProgram = !!requisition?.program;
   const nextDisabled = (!hasNext && mode === ModalMode.Update) || !currentItem;
 
-  const shouldDeleteLine = () => {
-    if (mode === ModalMode.Create && !draft?.requestedQuantity) return true;
-    if (!draft?.id || isDisabled) return false;
-    if (mode === ModalMode.Update) return false;
-    return false;
-  };
-
   const deletePreviousLine = () => {
-    if (draft?.id && shouldDeleteLine()) {
+    const shouldDelete = shouldDeleteLine(mode, draft?.id, isDisabled);
+    if (draft?.id && shouldDelete) {
       deleteLine(draft.id);
     }
   };

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   BasicSpinner,
   DialogButton,
@@ -58,6 +58,7 @@ export const RequestLineEditModal = ({
 
   const { draft, save, update, isLoading } =
     useDraftRequisitionLine(currentItem);
+  const draftIdRef = useRef<string | undefined>(draft?.id);
   const { hasNext, next } = useNextRequestLine(lines, currentItem);
 
   const useConsumptionData =
@@ -71,9 +72,13 @@ export const RequestLineEditModal = ({
     }
   };
 
+  useEffect(() => {
+    draftIdRef.current = draft?.id;
+  }, [draft?.id]);
+
   const onCancel = () => {
     if (mode === ModalMode.Create) {
-      deleteLine(draft?.id || '');
+      deleteLine(draftIdRef.current || '');
     }
     onClose();
   };

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
+  BasicSpinner,
   DialogButton,
   ModalMode,
   useDialog,
@@ -51,7 +52,8 @@ export const RequestLineEditModal = ({
     Representation.UNITS
   );
 
-  const { draft, save, update } = useDraftRequisitionLine(currentItem);
+  const { draft, save, update, isDirty, setIsDirty, isLoading } =
+    useDraftRequisitionLine(currentItem);
   const { hasNext, next } = useNextRequestLine(lines, currentItem);
 
   const isPacksEnabled = !!currentItem?.defaultPackSize;
@@ -111,7 +113,7 @@ export const RequestLineEditModal = ({
       cancelButton={<DialogButton variant="cancel" onClick={onCancel} />}
       nextButton={
         <DialogButton
-          disabled={nextDisabled}
+          disabled={nextDisabled || isDirty}
           variant="next-and-ok"
           onClick={onNext}
         />
@@ -119,7 +121,7 @@ export const RequestLineEditModal = ({
       okButton={
         <DialogButton
           variant="ok"
-          disabled={!currentItem}
+          disabled={!currentItem || isDirty}
           onClick={async () => {
             await save();
             onClose();
@@ -129,21 +131,26 @@ export const RequestLineEditModal = ({
       height={800}
       width={1200}
     >
-      <RequestLineEdit
-        requisition={requisition}
-        lines={lines}
-        currentItem={currentItem}
-        onChangeItem={onChangeItem}
-        draft={draft}
-        update={update}
-        isPacksEnabled={isPacksEnabled}
-        representation={representation}
-        setRepresentation={setRepresentation}
-        disabled={isDisabled}
-        isUpdateMode={mode === ModalMode.Update}
-        showExtraFields={useConsumptionData && isProgram}
-        manageVaccinesInDoses={manageVaccinesInDoses}
-      />
+      {isLoading ? (
+        <BasicSpinner />
+      ) : (
+        <RequestLineEdit
+          requisition={requisition}
+          lines={lines}
+          currentItem={currentItem}
+          onChangeItem={onChangeItem}
+          draft={draft}
+          update={update}
+          isPacksEnabled={isPacksEnabled}
+          representation={representation}
+          setRepresentation={setRepresentation}
+          disabled={isDisabled}
+          isUpdateMode={mode === ModalMode.Update}
+          showExtraFields={useConsumptionData && isProgram}
+          manageVaccinesInDoses={manageVaccinesInDoses}
+          setIsDirty={setIsDirty}
+        />
+      )}
     </Modal>
   );
 };

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -59,6 +59,7 @@ export const RequestLineEditModal = ({
   const { draft, save, update, isDirty, setIsDirty, isLoading } =
     useDraftRequisitionLine(currentItem);
   const { hasNext, next } = useNextRequestLine(lines, currentItem);
+  const shouldDelete = shouldDeleteLine(mode, draft?.id, isDisabled);
 
   const isPacksEnabled = !!currentItem?.defaultPackSize;
   const useConsumptionData =
@@ -67,7 +68,6 @@ export const RequestLineEditModal = ({
   const nextDisabled = (!hasNext && mode === ModalMode.Update) || !currentItem;
 
   const deletePreviousLine = () => {
-    const shouldDelete = shouldDeleteLine(mode, draft?.id, isDisabled);
     if (draft?.id && shouldDelete) {
       deleteLine(draft.id);
     }
@@ -123,6 +123,9 @@ export const RequestLineEditModal = ({
           variant="ok"
           disabled={!currentItem || isDirty}
           onClick={async () => {
+            if (draft?.requestedQuantity === 0) {
+              deletePreviousLine();
+            }
             await save();
             onClose();
           }}

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -62,10 +62,10 @@ export const RequestLineEditModal = ({
 
   const useConsumptionData =
     store?.preferences?.useConsumptionAndStockFromCustomersForInternalOrders;
-  const shouldDelete = shouldDeleteLine(mode, draft?.id, isDisabled);
   const nextDisabled = (!hasNext && mode === ModalMode.Update) || !currentItem;
 
   const deletePreviousLine = () => {
+    const shouldDelete = shouldDeleteLine(mode, draft?.id, isDisabled);
     if (draft?.id && shouldDelete) {
       deleteLine(draft.id);
     }
@@ -121,9 +121,6 @@ export const RequestLineEditModal = ({
           variant="ok"
           disabled={!currentItem || isDirty}
           onClick={async () => {
-            if (draft?.requestedQuantity === 0) {
-              deletePreviousLine();
-            }
             await save();
             onClose();
           }}

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -56,7 +56,7 @@ export const RequestLineEditModal = ({
     Representation.UNITS
   );
 
-  const { draft, save, update, isDirty, setIsDirty, isLoading } =
+  const { draft, save, update, isLoading } =
     useDraftRequisitionLine(currentItem);
   const { hasNext, next } = useNextRequestLine(lines, currentItem);
 
@@ -111,7 +111,7 @@ export const RequestLineEditModal = ({
       cancelButton={<DialogButton variant="cancel" onClick={onCancel} />}
       nextButton={
         <DialogButton
-          disabled={nextDisabled || isDirty}
+          disabled={nextDisabled}
           variant="next-and-ok"
           onClick={onNext}
         />
@@ -119,7 +119,7 @@ export const RequestLineEditModal = ({
       okButton={
         <DialogButton
           variant="ok"
-          disabled={!currentItem || isDirty}
+          disabled={!currentItem}
           onClick={async () => {
             await save();
             onClose();
@@ -146,7 +146,6 @@ export const RequestLineEditModal = ({
           isUpdateMode={mode === ModalMode.Update}
           showExtraFields={useConsumptionData && !!requisition?.program}
           manageVaccinesInDoses={manageVaccinesInDoses}
-          setIsDirty={setIsDirty}
         />
       )}
     </Modal>

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -84,7 +84,7 @@ export const RequestLineEditModal = ({
   };
 
   const onChangeItem = (item: ItemWithStatsFragment) => {
-    if (item.id !== currentItem?.id) {
+    if (item.id !== currentItem?.id && draft?.requestedQuantity === 0) {
       deletePreviousLine();
     }
     setRepresentation(Representation.UNITS);
@@ -93,7 +93,9 @@ export const RequestLineEditModal = ({
 
   const onNext = async () => {
     await save();
-    deletePreviousLine();
+    if (draft?.requestedQuantity === 0) {
+      deletePreviousLine();
+    }
     if (mode === ModalMode.Update && next) setCurrentItem(next);
     else if (mode === ModalMode.Create) setCurrentItem(undefined);
     else onClose();

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -86,6 +86,7 @@ export const RequestLineEditModal = ({
     if (mode === ModalMode.Update && next) setCurrentItem(next);
     else if (mode === ModalMode.Create) setCurrentItem(undefined);
     else onClose();
+    return true;
   };
 
   // When currentItem changes, draft is reset in `useDraftRequisitionLine`

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -59,12 +59,10 @@ export const RequestLineEditModal = ({
   const { draft, save, update, isDirty, setIsDirty, isLoading } =
     useDraftRequisitionLine(currentItem);
   const { hasNext, next } = useNextRequestLine(lines, currentItem);
-  const shouldDelete = shouldDeleteLine(mode, draft?.id, isDisabled);
 
-  const isPacksEnabled = !!currentItem?.defaultPackSize;
   const useConsumptionData =
     store?.preferences?.useConsumptionAndStockFromCustomersForInternalOrders;
-  const isProgram = !!requisition?.program;
+  const shouldDelete = shouldDeleteLine(mode, draft?.id, isDisabled);
   const nextDisabled = (!hasNext && mode === ModalMode.Update) || !currentItem;
 
   const deletePreviousLine = () => {
@@ -144,12 +142,12 @@ export const RequestLineEditModal = ({
           onChangeItem={onChangeItem}
           draft={draft}
           update={update}
-          isPacksEnabled={isPacksEnabled}
+          isPacksEnabled={!!currentItem?.defaultPackSize}
           representation={representation}
           setRepresentation={setRepresentation}
           disabled={isDisabled}
           isUpdateMode={mode === ModalMode.Update}
-          showExtraFields={useConsumptionData && isProgram}
+          showExtraFields={useConsumptionData && !!requisition?.program}
           manageVaccinesInDoses={manageVaccinesInDoses}
           setIsDirty={setIsDirty}
         />

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -21,7 +21,7 @@ interface RequestLineEditModalProps {
   itemId: string | null;
   isOpen: boolean;
   onClose: () => void;
-  manageVaccinesInDoses?: boolean;
+  manageVaccinesInDoses: boolean;
 }
 
 export const RequestLineEditModal = ({
@@ -31,7 +31,7 @@ export const RequestLineEditModal = ({
   itemId,
   isOpen,
   onClose,
-  manageVaccinesInDoses = false,
+  manageVaccinesInDoses,
 }: RequestLineEditModalProps) => {
   const { Modal } = useDialog({ onClose, isOpen });
   const deleteLine = useRequest.line.deleteLine();

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
@@ -149,7 +149,7 @@ export const RequestedSelection = ({
               variant="caption"
               color="text.secondary"
               pt={0.3}
-              pr={1}
+              pr={1.5}
               sx={{ textAlign: 'right' }}
             >
               {valueInDoses} {t('label.doses').toLowerCase()}

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   Box,
   NumericTextInput,
@@ -60,6 +60,10 @@ export const RequestedSelection = ({
     [representation, draft?.requestedQuantity, defaultPackSize]
   );
   const [value, setValue] = useState(currentValue);
+
+  useEffect(() => {
+    setValue(currentValue);
+  }, [currentValue, representation]);
 
   const options = useMemo((): Option[] => {
     const unitPlural = getPlural(unitName, currentValue);

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
@@ -156,7 +156,7 @@ export const RequestedSelection = ({
               },
             }}
           />
-          {displayVaccinesInDoses && valueInDoses !== undefined && (
+          {displayVaccinesInDoses && (
             <Typography
               variant="caption"
               color="text.secondary"

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
@@ -33,7 +33,6 @@ interface RequestedSelectionProps {
   showExtraFields?: boolean;
   displayVaccinesInDoses?: boolean;
   dosesPerUnit?: number;
-  setIsDirty?: (isDirty: boolean) => void;
 }
 
 export const RequestedSelection = ({
@@ -47,7 +46,6 @@ export const RequestedSelection = ({
   unitName,
   displayVaccinesInDoses = false,
   dosesPerUnit = 1,
-  setIsDirty = () => {},
 }: RequestedSelectionProps) => {
   const t = useTranslation();
   const { getPlural } = useIntlUtils();
@@ -89,14 +87,11 @@ export const RequestedSelection = ({
         draft?.suggestedQuantity
       );
       update(updatedRequest);
-      setIsDirty(false);
     },
     [representation, defaultPackSize, update]
   );
 
   const handleValueChange = (newValue?: number) => {
-    const valueChanged = newValue !== currentValue;
-    setIsDirty(valueChanged);
     setValue(newValue ?? 0);
     debouncedUpdate(newValue);
   };

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
@@ -69,7 +69,7 @@ export const RequestedSelection = ({
 
   const options = useMemo((): Option[] => {
     const displayValue = value === 1 ? 1 : 2;
-    const unitPlural = getPlural(unitName, displayValue);
+    const unitPlural = getPlural(unitName.toLowerCase(), displayValue);
     const packPlural = getPlural(t('label.pack'), displayValue).toLowerCase();
 
     if (!isPacksEnabled)

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
@@ -10,7 +10,11 @@ import {
 } from '@openmsupply-client/common';
 import { getCurrentValue, getUpdatedRequest } from './utils';
 import { DraftRequestLine } from '../hooks';
-import { Representation, RepresentationValue } from '../../../../common';
+import {
+  calculateValueInDoses,
+  Representation,
+  RepresentationValue,
+} from '../../../../common';
 
 interface Option {
   label: string;
@@ -27,6 +31,8 @@ interface RequestedSelectionProps {
   setRepresentation: (rep: RepresentationValue) => void;
   unitName: string;
   showExtraFields?: boolean;
+  displayVaccinesInDoses?: boolean;
+  dosesPerUnit?: number;
 }
 
 export const RequestedSelection = ({
@@ -38,11 +44,11 @@ export const RequestedSelection = ({
   representation,
   setRepresentation,
   unitName,
-  showExtraFields,
+  displayVaccinesInDoses = false,
+  dosesPerUnit = 1,
 }: RequestedSelectionProps) => {
   const t = useTranslation();
   const { getPlural } = useIntlUtils();
-  const width = showExtraFields ? 170 : 250;
 
   const currentValue = useMemo(
     (): number =>
@@ -85,74 +91,95 @@ export const RequestedSelection = ({
     debouncedUpdate(value);
   };
 
+  const valueInDoses = useMemo(() => {
+    if (!displayVaccinesInDoses) return undefined;
+    return calculateValueInDoses(
+      representation,
+      defaultPackSize || 1,
+      dosesPerUnit,
+      value
+    );
+  }, [displayVaccinesInDoses, defaultPackSize, dosesPerUnit, value]);
+
   return (
     <Box
       sx={{
         display: 'flex',
         flexDirection: 'column',
-        mb: 1,
       }}
     >
-      <Typography variant="body1" fontWeight="bold" p={0.5}>
+      <Typography variant="body1" fontWeight="bold" pt={0.5} pb={0.5}>
         {t('label.requested')}:
       </Typography>
-      <Box gap={1} display="flex" flexDirection="row">
-        <NumericTextInput
-          autoFocus
-          width={width}
-          min={0}
-          value={value}
-          disabled={disabled}
-          onChange={handleValueChange}
-          slotProps={{
-            input: {
-              sx: {
-                background: theme =>
+      <Box display="flex" flexDirection="row" gap={1}>
+        <Box display="flex" flexDirection="column" flex={1}>
+          <NumericTextInput
+            autoFocus
+            fullWidth
+            min={0}
+            value={value}
+            disabled={disabled}
+            onChange={handleValueChange}
+            slotProps={{
+              input: {
+                sx: {
+                  background: theme =>
+                    disabled
+                      ? theme.palette.background.toolbar
+                      : theme.palette.background.white,
+                },
+              },
+            }}
+            sx={{
+              '& .MuiInputBase-input': {
+                p: '3px 4px',
+                backgroundColor: theme =>
                   disabled
                     ? theme.palette.background.toolbar
                     : theme.palette.background.white,
               },
-            },
-          }}
-          sx={{
-            boxShadow: theme => (!disabled ? theme.shadows[2] : 'none'),
-            '& .MuiInputBase-input': {
-              p: '3px 4px',
-              backgroundColor: theme =>
-                disabled
-                  ? theme.palette.background.toolbar
-                  : theme.palette.background.white,
-            },
-          }}
-        />
-        <Select
-          fullWidth
-          clearable={false}
-          options={options}
-          value={representation}
-          onChange={e => {
-            setRepresentation(
-              (e.target.value as RepresentationValue) ?? Representation.UNITS
-            );
-          }}
-          sx={{
-            boxShadow: theme => (!disabled ? theme.shadows[2] : 'none'),
-            '& .MuiInputBase-input': {
-              p: '3px 4px',
-              backgroundColor: theme => theme.palette.background.white,
-            },
-          }}
-          slotProps={{
-            input: {
-              disableUnderline: true,
-              sx: {
+            }}
+          />
+          {displayVaccinesInDoses && valueInDoses !== undefined && (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              pt={0.3}
+              pr={1}
+              sx={{ textAlign: 'right' }}
+            >
+              {valueInDoses} {t('label.doses').toLowerCase()}
+            </Typography>
+          )}
+        </Box>
+        <Box flex={1}>
+          <Select
+            fullWidth
+            clearable={false}
+            options={options}
+            value={representation}
+            onChange={e => {
+              setRepresentation(
+                (e.target.value as RepresentationValue) ?? Representation.UNITS
+              );
+            }}
+            sx={{
+              '& .MuiInputBase-input': {
+                p: '3px 4px',
                 backgroundColor: theme => theme.palette.background.white,
-                borderRadius: 2,
-                p: 0.5,
               },
-            },
-          }}
-        />
+            }}
+            slotProps={{
+              input: {
+                disableUnderline: true,
+                sx: {
+                  backgroundColor: theme => theme.palette.background.white,
+                  borderRadius: 2,
+                },
+              },
+            }}
+          />
+        </Box>
       </Box>
     </Box>
   );

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
@@ -94,9 +94,12 @@ export const useDraftRequisitionLine = (
 };
 
 export const useNextRequestLine = (
+  lines?: RequestLineFragment[],
   currentItem?: ItemWithStatsFragment | null
 ) => {
-  const { lines } = useRequest.line.list();
+  if (!lines || !currentItem) {
+    return { hasNext: false, next: null };
+  }
 
   const nextState: {
     hasNext: boolean;

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
@@ -68,7 +68,6 @@ export const useDraftRequisitionLine = (
   const { mutateAsync: saveMutation, isLoading } = useRequest.line.save();
 
   const [draft, setDraft] = useState<DraftRequestLine | null>(null);
-  const [isDirty, setIsDirty] = useState(false);
 
   useEffect(() => {
     if (lines && item && data) {
@@ -80,10 +79,8 @@ export const useDraftRequisitionLine = (
       } else {
         setDraft(createDraftFromItem(item, data));
       }
-      setIsDirty(false);
     } else {
       setDraft(null);
-      setIsDirty(false);
     }
   }, [lines, item, data]);
 
@@ -96,7 +93,6 @@ export const useDraftRequisitionLine = (
   const save = async () => {
     if (draft) {
       const result = await saveMutation(draft);
-      setIsDirty(false);
       return result;
     }
     return null;
@@ -107,8 +103,6 @@ export const useDraftRequisitionLine = (
     isLoading,
     save,
     update,
-    isDirty,
-    setIsDirty,
   };
 };
 

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
@@ -80,8 +80,10 @@ export const useDraftRequisitionLine = (
       } else {
         setDraft(createDraftFromItem(item, data));
       }
+      setIsDirty(false);
     } else {
       setDraft(null);
+      setIsDirty(false);
     }
   }, [lines, item, data]);
 
@@ -92,12 +94,13 @@ export const useDraftRequisitionLine = (
   };
 
   const save = async () => {
-    if (draft && !isDirty) {
+    if (draft) {
       const result = await saveMutation(draft);
 
       if (draft.isCreated) {
-        setDraft(prev => (prev ? { ...prev, isCreated: false } : null));
+        setDraft(line => (line ? { ...line, isCreated: false } : null));
       }
+      setIsDirty(false);
       return result;
     }
     return null;

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { FnUtils, QuantityUtils } from '@openmsupply-client/common';
 import {
   useRequest,
@@ -84,19 +84,17 @@ export const useDraftRequisitionLine = (
     }
   }, [lines, item, data]);
 
-  const update = (patch: Partial<DraftRequestLine>) => {
-    if (draft) {
-      setDraft({ ...draft, ...patch });
-    }
-  };
+  const update = useCallback((patch: Partial<DraftRequestLine>) => {
+    setDraft(current => (current ? { ...current, ...patch } : null));
+  }, []);
 
-  const save = async () => {
+  const save = useCallback(async () => {
     if (draft) {
       const result = await saveMutation(draft);
       return result;
     }
     return null;
-  };
+  }, [draft, saveMutation]);
 
   return {
     draft,

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
@@ -96,10 +96,6 @@ export const useDraftRequisitionLine = (
   const save = async () => {
     if (draft) {
       const result = await saveMutation(draft);
-
-      if (draft.isCreated) {
-        setDraft(line => (line ? { ...line, isCreated: false } : null));
-      }
       setIsDirty(false);
       return result;
     }

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
@@ -10,12 +10,13 @@ import {
   useAuthContext,
   getLinesFromRow,
   usePluginProvider,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { useRequest } from '../api';
 import { PackQuantityCell } from '@openmsupply-client/system';
 import { useRequestRequisitionLineErrorContext } from '../context';
 
-export const useRequestColumns = () => {
+export const useRequestColumns = (manageVaccinesInDoses: boolean = false) => {
   const { maxMonthsOfStock, programName } = useRequest.document.fields([
     'maxMonthsOfStock',
     'programName',
@@ -57,6 +58,21 @@ export const useRequestColumns = () => {
       sortable: false,
       defaultHideOnMobile: true,
     },
+  ];
+
+  if (manageVaccinesInDoses) {
+    columnDefinitions.push({
+      key: 'dosesPerUnit',
+      label: 'label.doses-per-unit',
+      width: 100,
+      align: ColumnAlign.Right,
+      sortable: false,
+      accessor: ({ rowData }) =>
+        rowData.item?.isVaccine ? rowData.item.doses : UNDEFINED_STRING_VALUE,
+    });
+  }
+
+  columnDefinitions.push(
     {
       key: 'defaultPackSize',
       label: 'label.dps',
@@ -93,8 +109,8 @@ export const useRequestColumns = () => {
       width: 150,
       Cell: PackQuantityCell,
       accessor: ({ rowData }) => rowData.itemStats.availableMonthsOfStockOnHand,
-    },
-  ];
+    }
+  );
 
   columnDefinitions.push(
     {

--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/line/useRequestLines.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/line/useRequestLines.ts
@@ -4,10 +4,12 @@ import { useRequestColumns } from '../../../DetailView/columns';
 import { useHideOverStocked } from '../index';
 import { useRequestFields } from '../document/useRequestFields';
 
-export const useRequestLines = () => {
+export const useRequestLines = (manageVaccinesInDoses: boolean = false) => {
   const { on } = useHideOverStocked();
   const { itemFilter, setItemFilter, matchItem } = useItemUtils();
-  const { columns, onChangeSortBy, sortBy } = useRequestColumns();
+  const { columns, onChangeSortBy, sortBy } = useRequestColumns(
+    manageVaccinesInDoses
+  );
   const { lines, minMonthsOfStock, maxMonthsOfStock } = useRequestFields([
     'lines',
     'minMonthsOfStock',

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ContentArea.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ContentArea.tsx
@@ -1,16 +1,37 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
+  AppSxProp,
   DataTable,
   NothingHere,
+  useRowStyle,
   useTranslation,
 } from '@openmsupply-client/common';
 import { useResponse, ResponseLineFragment } from '../api';
+import { isResponseLinePlaceholderRow } from '../../utils';
 
 interface ContentAreaProps {
   onAddItem: () => void;
   onRowClick: null | ((line: ResponseLineFragment) => void);
   disableAddLine: boolean;
 }
+
+const useHighlightPlaceholderRows = (
+  rows: ResponseLineFragment[] | undefined
+) => {
+  const { setRowStyles } = useRowStyle();
+
+  useEffect(() => {
+    if (!rows) return;
+
+    const placeholders = rows
+      .filter(isResponseLinePlaceholderRow)
+      .map(row => row.id);
+    const style: AppSxProp = {
+      color: theme => theme.palette.secondary.light,
+    };
+    setRowStyles(placeholders, style);
+  }, [rows, setRowStyles]);
+};
 
 export const ContentArea = ({
   onRowClick,
@@ -19,6 +40,7 @@ export const ContentArea = ({
 }: ContentAreaProps) => {
   const t = useTranslation();
   const { columns, lines } = useResponse.line.list();
+  useHighlightPlaceholderRows(lines);
 
   return (
     <DataTable

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ContentArea.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ContentArea.tsx
@@ -13,6 +13,7 @@ interface ContentAreaProps {
   onAddItem: () => void;
   onRowClick: null | ((line: ResponseLineFragment) => void);
   disableAddLine: boolean;
+  manageVaccinesInDoses?: boolean;
 }
 
 const useHighlightPlaceholderRows = (
@@ -37,9 +38,10 @@ export const ContentArea = ({
   onRowClick,
   onAddItem,
   disableAddLine,
+  manageVaccinesInDoses = false,
 }: ContentAreaProps) => {
   const t = useTranslation();
-  const { columns, lines } = useResponse.line.list();
+  const { columns, lines } = useResponse.line.list(manageVaccinesInDoses);
   useHighlightPlaceholderRows(lines);
 
   return (

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/DetailView.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/DetailView.tsx
@@ -105,6 +105,7 @@ export const DetailView = () => {
           disableAddLine={
             isDisabled || !!data?.linkedRequisition || !!data?.programName
           }
+          manageVaccinesInDoses={manageVaccinesInDoses}
         />
       ),
       value: 'Details',

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/DetailView.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/DetailView.tsx
@@ -13,6 +13,8 @@ import {
   useBreadcrumbs,
   useEditModal,
   useAuthContext,
+  usePreference,
+  PreferenceKey,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { ActivityLogList } from '@openmsupply-client/system';
@@ -33,6 +35,8 @@ export const DetailView = () => {
   const navigate = useNavigate();
   const { setCustomBreadcrumbs } = useBreadcrumbs();
   const { store } = useAuthContext();
+  const { data: { manageVaccinesInDoses } = { manageVaccinesInDoses: false } } =
+    usePreference(PreferenceKey.ManageVaccinesInDoses);
   const {
     onOpen,
     onClose,
@@ -152,6 +156,7 @@ export const DetailView = () => {
             mode={mode}
             isOpen={isOpen}
             onClose={onClose}
+            manageVaccinesInDoses={manageVaccinesInDoses}
           />
         )}
       </TableProvider>

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ContentLayout.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ContentLayout.tsx
@@ -10,12 +10,14 @@ import {
   NumericTextInput,
   TypedTFunction,
   LocaleKey,
+  Typography,
 } from '@openmsupply-client/common';
 import {
   useEndAdornment,
   useValueInUnitsOrPacks,
   Representation,
   RepresentationValue,
+  calculateValueInDoses,
 } from '../../../common';
 
 export interface NumInputRowProps {
@@ -29,6 +31,8 @@ export interface NumInputRowProps {
   endAdornmentOverride?: string;
   sx?: SxProps<Theme>;
   showExtraFields?: boolean;
+  displayVaccinesInDoses?: boolean;
+  dosesPerUnit: number;
 }
 
 export const NumInputRow = ({
@@ -42,6 +46,8 @@ export const NumInputRow = ({
   endAdornmentOverride,
   sx,
   showExtraFields = false,
+  displayVaccinesInDoses = false,
+  dosesPerUnit,
 }: NumInputRowProps) => {
   const t = useTranslation();
   const { getPlural } = useIntlUtils();
@@ -70,6 +76,25 @@ export const NumInputRow = ({
       onChange(newValue);
     }
   };
+
+  const valueInDoses = React.useMemo(
+    () =>
+      displayVaccinesInDoses
+        ? calculateValueInDoses(
+            representation,
+            defaultPackSize,
+            dosesPerUnit,
+            valueInUnitsOrPacks
+          )
+        : undefined,
+    [
+      displayVaccinesInDoses,
+      representation,
+      defaultPackSize,
+      dosesPerUnit,
+      valueInUnitsOrPacks,
+    ]
+  );
 
   return (
     <Box
@@ -130,6 +155,15 @@ export const NumInputRow = ({
           alignItems: { xs: 'flex-start', md: 'center' },
         }}
       />
+      {displayVaccinesInDoses && !!valueInDoses && (
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ display: 'flex', justifyContent: 'flex-end', pt: 0.3, pr: 1.3 }}
+        >
+          {valueInDoses} {t('label.doses').toLowerCase()}
+        </Typography>
+      )}
     </Box>
   );
 };
@@ -150,6 +184,8 @@ export const createNumericInput =
       unitName: string;
       disabled: boolean;
       showExtraFields?: boolean;
+      displayVaccinesInDoses?: boolean;
+      dosesPerUnit: number;
     }
   ) =>
   (
@@ -166,16 +202,18 @@ export const createNumericInput =
 
     return (
       <NumInputRow
-        label={t(label)}
-        value={value ?? 0}
-        onChange={onChange}
-        disabled={disabledOverride ?? commonProps.disabled}
         defaultPackSize={commonProps.defaultPackSize}
         representation={commonProps.representation}
         unitName={commonProps.unitName}
+        showExtraFields={commonProps.showExtraFields}
+        displayVaccinesInDoses={commonProps.displayVaccinesInDoses}
+        disabled={disabledOverride ?? commonProps.disabled}
+        label={t(label)}
+        value={value ?? 0}
+        onChange={onChange}
         endAdornmentOverride={endAdornmentOverride}
         sx={sx}
-        showExtraFields={commonProps.showExtraFields}
+        dosesPerUnit={commonProps.dosesPerUnit}
       />
     );
   };

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ContentLayout.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ContentLayout.tsx
@@ -28,6 +28,7 @@ export interface NumInputRowProps {
   unitName: string;
   endAdornmentOverride?: string;
   sx?: SxProps<Theme>;
+  showExtraFields?: boolean;
 }
 
 export const NumInputRow = ({
@@ -40,6 +41,7 @@ export const NumInputRow = ({
   unitName,
   endAdornmentOverride,
   sx,
+  showExtraFields = false,
 }: NumInputRowProps) => {
   const t = useTranslation();
   const { getPlural } = useIntlUtils();
@@ -70,10 +72,18 @@ export const NumInputRow = ({
   };
 
   return (
-    <Box sx={{ marginBottom: 1, px: 1, flex: 1, ...sx }}>
+    <Box
+      sx={{
+        marginBottom: 1,
+        px: 1,
+        flex: 1,
+        ...sx,
+      }}
+    >
       <InputWithLabelRow
         Input={
           <NumericTextInput
+            fullWidth
             sx={{
               '& .MuiInputBase-input': {
                 backgroundColor: theme =>
@@ -94,7 +104,6 @@ export const NumInputRow = ({
               },
             }}
             min={0}
-            width={170}
             value={roundedValue}
             onChange={handleChange}
             disabled={disabled}
@@ -103,8 +112,22 @@ export const NumInputRow = ({
           />
         }
         label={label}
+        labelProps={{
+          sx: {
+            width: {
+              xs: '100%',
+              md: showExtraFields ? '400px' : '600px',
+              lg: showExtraFields ? '370px' : '550px',
+            },
+          },
+        }}
         sx={{
           justifyContent: 'space-between',
+          flexDirection: {
+            xs: 'column',
+            md: 'row',
+          },
+          alignItems: { xs: 'flex-start', md: 'center' },
         }}
       />
     </Box>
@@ -126,6 +149,7 @@ export const createNumericInput =
       representation: RepresentationValue;
       unitName: string;
       disabled: boolean;
+      showExtraFields?: boolean;
     }
   ) =>
   (
@@ -151,6 +175,7 @@ export const createNumericInput =
         unitName={commonProps.unitName}
         endAdornmentOverride={endAdornmentOverride}
         sx={sx}
+        showExtraFields={commonProps.showExtraFields}
       />
     );
   };

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ContentLayout.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ContentLayout.tsx
@@ -11,6 +11,7 @@ import {
   TypedTFunction,
   LocaleKey,
   Typography,
+  useMediaQuery,
 } from '@openmsupply-client/common';
 import {
   useEndAdornment,
@@ -51,6 +52,7 @@ export const NumInputRow = ({
 }: NumInputRowProps) => {
   const t = useTranslation();
   const { getPlural } = useIntlUtils();
+  const isVerticalScreen = useMediaQuery('(max-width:800px)');
 
   const valueInUnitsOrPacks = useValueInUnitsOrPacks(
     representation,
@@ -149,7 +151,7 @@ export const NumInputRow = ({
         sx={{
           justifyContent: 'space-between',
           flexDirection: {
-            xs: 'column',
+            xs: isVerticalScreen ? 'column' : 'row',
             md: 'row',
           },
           alignItems: { xs: 'flex-start', md: 'center' },

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   BasicSpinner,
   DialogButton,
@@ -38,7 +38,6 @@ export const ResponseLineEditModal = ({
   onClose,
   manageVaccinesInDoses,
 }: ResponseLineEditModalProps) => {
-  const { Modal } = useDialog({ onClose, isOpen });
   const deleteLine = useResponse.line.deleteLine();
   const isDisabled = useResponse.utils.isDisabled();
 
@@ -58,6 +57,7 @@ export const ResponseLineEditModal = ({
 
   const { draft, update, save, isLoading } =
     useDraftRequisitionLine(currentItem);
+  const draftIdRef = useRef<string | undefined>(draft?.id);
   const { hasNext, next } = useNextResponseLine(lines, currentItem);
   const nextDisabled = (!hasNext && mode === ModalMode.Update) || !currentItem;
 
@@ -68,12 +68,18 @@ export const ResponseLineEditModal = ({
     }
   };
 
+  useEffect(() => {
+    draftIdRef.current = draft?.id;
+  }, [draft?.id]);
+
   const onCancel = () => {
     if (mode === ModalMode.Create) {
-      deleteLine(draft?.id || '');
+      deleteLine(draftIdRef.current || '');
     }
     onClose();
   };
+
+  const { Modal } = useDialog({ onClose: onCancel, isOpen });
 
   const onChangeItem = (item: ItemWithStatsFragment) => {
     if (item.id !== currentItem?.id) {

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
@@ -59,8 +59,8 @@ export const ResponseLineEditModal = ({
   const { draft, update, save, isDirty, setIsDirty, isLoading } =
     useDraftRequisitionLine(currentItem);
   const { hasNext, next } = useNextResponseLine(currentItem);
-  const shouldDelete = shouldDeleteLine(mode, draft?.id, isDisabled);
 
+  const shouldDelete = shouldDeleteLine(mode, draft?.id, isDisabled);
   const nextDisabled = (!hasNext && mode === ModalMode.Update) || !currentItem;
 
   const deletePreviousLine = () => {

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
@@ -59,11 +59,10 @@ export const ResponseLineEditModal = ({
   const { draft, update, save, isDirty, setIsDirty, isLoading } =
     useDraftRequisitionLine(currentItem);
   const { hasNext, next } = useNextResponseLine(lines, currentItem);
-
-  const shouldDelete = shouldDeleteLine(mode, draft?.id, isDisabled);
   const nextDisabled = (!hasNext && mode === ModalMode.Update) || !currentItem;
 
   const deletePreviousLine = () => {
+    const shouldDelete = shouldDeleteLine(mode, draft?.id, isDisabled);
     if (draft?.id && shouldDelete) {
       deleteLine(draft.id);
     }
@@ -162,9 +161,6 @@ export const ResponseLineEditModal = ({
           variant="ok"
           disabled={!currentItem || isDirty}
           onClick={async () => {
-            if (draft?.requestedQuantity === 0) {
-              deletePreviousLine();
-            }
             await save();
             onClose();
           }}

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
@@ -59,11 +59,11 @@ export const ResponseLineEditModal = ({
   const { draft, update, save, isDirty, setIsDirty, isLoading } =
     useDraftRequisitionLine(currentItem);
   const { hasNext, next } = useNextResponseLine(currentItem);
+  const shouldDelete = shouldDeleteLine(mode, draft?.id, isDisabled);
 
   const nextDisabled = (!hasNext && mode === ModalMode.Update) || !currentItem;
 
   const deletePreviousLine = () => {
-    const shouldDelete = shouldDeleteLine(mode, draft?.id, isDisabled);
     if (draft?.id && shouldDelete) {
       deleteLine(draft.id);
     }
@@ -162,6 +162,9 @@ export const ResponseLineEditModal = ({
           variant="ok"
           disabled={!currentItem || isDirty}
           onClick={async () => {
+            if (draft?.requestedQuantity === 0) {
+              deletePreviousLine();
+            }
             await save();
             onClose();
           }}

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
@@ -11,7 +11,11 @@ import { ItemWithStatsFragment } from '@openmsupply-client/system';
 import { ResponseFragment, useResponse } from '../../api';
 import { ResponseLineEdit } from './ResponseLineEdit';
 import { useDraftRequisitionLine, useNextResponseLine } from './hooks';
-import { Representation, RepresentationValue } from '../../../common';
+import {
+  Representation,
+  RepresentationValue,
+  shouldDeleteLine,
+} from '../../../common';
 import { ResponseStoreStats } from '../ResponseStats/ResponseStoreStats';
 import { RequestStoreStats } from '../ResponseStats/RequestStoreStats';
 
@@ -58,15 +62,9 @@ export const ResponseLineEditModal = ({
 
   const nextDisabled = (!hasNext && mode === ModalMode.Update) || !currentItem;
 
-  const shouldDeleteLine = () => {
-    if (mode === ModalMode.Create && !!draft?.isCreated) return true;
-    if (!draft?.id || isDisabled) return false;
-    if (mode === ModalMode.Update) return false;
-    return false;
-  };
-
   const deletePreviousLine = () => {
-    if (draft?.id && shouldDeleteLine()) {
+    const shouldDelete = shouldDeleteLine(mode, draft?.id, isDisabled);
+    if (draft?.id && shouldDelete) {
       deleteLine(draft.id);
     }
   };

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
@@ -80,6 +80,7 @@ export const ResponseLineEditModal = ({
     if (mode === ModalMode.Update && next) setCurrentItem(next);
     else if (mode === ModalMode.Create) setCurrentItem(undefined);
     else onClose();
+    return true;
   };
 
   useEffect(() => {

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
@@ -56,7 +56,7 @@ export const ResponseLineEditModal = ({
     Representation.UNITS
   );
 
-  const { draft, update, save, isDirty, setIsDirty, isLoading } =
+  const { draft, update, save, isLoading } =
     useDraftRequisitionLine(currentItem);
   const { hasNext, next } = useNextResponseLine(lines, currentItem);
   const nextDisabled = (!hasNext && mode === ModalMode.Update) || !currentItem;
@@ -151,7 +151,7 @@ export const ResponseLineEditModal = ({
       cancelButton={<DialogButton variant="cancel" onClick={onCancel} />}
       nextButton={
         <DialogButton
-          disabled={nextDisabled || isDirty}
+          disabled={nextDisabled}
           variant="next-and-ok"
           onClick={onSave}
         />
@@ -159,7 +159,7 @@ export const ResponseLineEditModal = ({
       okButton={
         <DialogButton
           variant="ok"
-          disabled={!currentItem || isDirty}
+          disabled={!currentItem}
           onClick={async () => {
             await save();
             onClose();
@@ -185,7 +185,6 @@ export const ResponseLineEditModal = ({
             setRepresentation={setRepresentation}
             disabled={isDisabled}
             isUpdateMode={mode === ModalMode.Update}
-            setIsDirty={setIsDirty}
             manageVaccinesInDoses={manageVaccinesInDoses}
           />
           {!!draft && (

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
@@ -73,7 +73,7 @@ export const ResponseLineEditModal = ({
   }, [draft?.id]);
 
   const onCancel = () => {
-    if (mode === ModalMode.Create) {
+    if (mode === ModalMode.Create && draft?.id) {
       deleteLine(draftIdRef.current || '');
     }
     onClose();
@@ -82,7 +82,7 @@ export const ResponseLineEditModal = ({
   const { Modal } = useDialog({ onClose: onCancel, isOpen });
 
   const onChangeItem = (item: ItemWithStatsFragment) => {
-    if (item.id !== currentItem?.id) {
+    if (item.id !== currentItem?.id && draft?.supplyQuantity === 0) {
       deletePreviousLine();
     }
     setRepresentation(Representation.UNITS);
@@ -91,7 +91,9 @@ export const ResponseLineEditModal = ({
 
   const onSave = async () => {
     await save();
-    deletePreviousLine();
+    if (draft?.supplyQuantity === 0) {
+      deletePreviousLine();
+    }
     if (mode === ModalMode.Update && next) setCurrentItem(next);
     else if (mode === ModalMode.Create) setCurrentItem(undefined);
     else onClose();

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
@@ -22,6 +22,7 @@ interface ResponseLineEditModalProps {
   mode: ModalMode | null;
   isOpen: boolean;
   onClose: () => void;
+  manageVaccinesInDoses: boolean;
 }
 
 export const ResponseLineEditModal = ({
@@ -31,6 +32,7 @@ export const ResponseLineEditModal = ({
   mode,
   isOpen,
   onClose,
+  manageVaccinesInDoses,
 }: ResponseLineEditModalProps) => {
   const { Modal } = useDialog({ onClose, isOpen });
   const deleteLine = useResponse.line.deleteLine();
@@ -184,6 +186,7 @@ export const ResponseLineEditModal = ({
             disabled={isDisabled}
             isUpdateMode={mode === ModalMode.Update}
             setIsDirty={setIsDirty}
+            manageVaccinesInDoses={manageVaccinesInDoses}
           />
           {!!draft && (
             <ModalTabs

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
@@ -79,7 +79,9 @@ export const ResponseLineEditModal = ({
   };
 
   const onChangeItem = (item: ItemWithStatsFragment) => {
-    deletePreviousLine();
+    if (item.id !== currentItem?.id) {
+      deletePreviousLine();
+    }
     setRepresentation(Representation.UNITS);
     setCurrentItem(item);
   };
@@ -95,12 +97,13 @@ export const ResponseLineEditModal = ({
 
   // Effect triggered when the selected item changes:
   // 1. The draft is reset by the useDraftRequisitionLine hook
-  // 2. For newly created lines, we immediately save to enable requisition chart data
+  // 2. For newly created lines, we immediately save to enable requisition chart
+  //    data
   useEffect(() => {
     if (!!draft?.isCreated) {
       save();
     }
-  }, [draft]);
+  }, [draft?.isCreated]);
 
   const { data } = useResponse.line.stats(!draft?.isCreated, draft?.id);
 

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
@@ -83,8 +83,10 @@ export const ResponseLineEditModal = ({
     return true;
   };
 
+  // Effect triggered when the selected item changes:
+  // 1. The draft is reset by the useDraftRequisitionLine hook
+  // 2. For newly created lines, we immediately save to enable requisition chart data
   useEffect(() => {
-    // Inserts new requisition line if it doesn't exist
     if (!!draft?.isCreated) {
       save();
     } else {

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
@@ -58,7 +58,7 @@ export const ResponseLineEditModal = ({
 
   const { draft, update, save, isDirty, setIsDirty, isLoading } =
     useDraftRequisitionLine(currentItem);
-  const { hasNext, next } = useNextResponseLine(currentItem);
+  const { hasNext, next } = useNextResponseLine(lines, currentItem);
 
   const shouldDelete = shouldDeleteLine(mode, draft?.id, isDisabled);
   const nextDisabled = (!hasNext && mode === ModalMode.Update) || !currentItem;

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
@@ -182,7 +182,6 @@ export const ResponseLineEditModal = ({
               display: 'flex',
               justifyContent: 'center',
               background: theme => theme.palette.background.toolbar,
-              pt: 1,
             }}
           />
         )}

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -80,6 +80,7 @@ export const ResponseLineEdit = ({
     representation,
     unitName,
     disabled: isDisabled,
+    showExtraFields,
   });
 
   const getLeftPanelContent = () => {
@@ -166,7 +167,7 @@ export const ResponseLineEdit = ({
               variant="body1"
               fontWeight="bold"
               sx={{ pl: 1, pb: 0.5 }}
-              width={370}
+              width={'calc(100% - 10px)'}
             >
               {t('label.reason')}:
               <ReasonOptionsSearchInput
@@ -218,6 +219,7 @@ export const ResponseLineEdit = ({
           sx={{
             background: theme => theme.palette.background.group,
             borderRadius: 2,
+            p: 1,
             pb: 0.5,
           }}
         >
@@ -225,8 +227,8 @@ export const ResponseLineEdit = ({
             numericInput('label.approved', draft?.approvedQuantity, {
               disabledOverride: true,
               sx: {
-                pt: 1,
-                pl: 0,
+                px: 0,
+                mb: 0,
               },
             })}
           <SupplySelection
@@ -238,17 +240,22 @@ export const ResponseLineEdit = ({
             representation={representation}
             setRepresentation={setRepresentation}
             unitName={unitName}
-            showExtraFields={showExtraFields}
           />
           {numericInput(
             'label.remaining-to-supply',
             draft?.remainingQuantityToSupply,
             {
               disabledOverride: true,
+              sx: {
+                px: 0,
+              },
             }
           )}
           {numericInput('label.already-issued', draft?.alreadyIssued, {
             disabledOverride: true,
+            sx: {
+              px: 0,
+            },
           })}
         </Box>
         {!!requisition.linkedRequisition || showExtraFields ? (
@@ -268,7 +275,7 @@ export const ResponseLineEdit = ({
             })}
           </>
         ) : null}
-        <Typography variant="body1" fontWeight="bold" p={0.5}>
+        <Typography variant="body1" fontWeight="bold" p={1}>
           {t('heading.comment')}:
         </Typography>
         <BufferedTextArea

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -38,7 +38,6 @@ interface ResponseLineEditProps {
   setRepresentation: (type: RepresentationValue) => void;
   disabled: boolean;
   isUpdateMode?: boolean;
-  setIsDirty?: (isDirty: boolean) => void;
   manageVaccinesInDoses?: boolean;
 }
 
@@ -54,7 +53,6 @@ export const ResponseLineEdit = ({
   setRepresentation,
   disabled = false,
   isUpdateMode = false,
-  setIsDirty = () => {},
   manageVaccinesInDoses = false,
 }: ResponseLineEditProps) => {
   const t = useTranslation();
@@ -259,7 +257,6 @@ export const ResponseLineEdit = ({
             representation={representation}
             setRepresentation={setRepresentation}
             unitName={unitName}
-            setIsDirty={setIsDirty}
             displayVaccinesInDoses={displayVaccinesInDoses}
             dosesPerUnit={currentItem?.doses ?? 1}
           />

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -128,6 +128,7 @@ export const ResponseLineEdit = ({
             })}
             {numericInput('label.days-out-of-stock', draft?.daysOutOfStock, {
               onChange: value => update({ daysOutOfStock: value }),
+              endAdornmentOverride: t('label.days'),
             })}
           </>
         )}

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -38,7 +38,7 @@ interface ResponseLineEditProps {
   setRepresentation: (type: RepresentationValue) => void;
   disabled: boolean;
   isUpdateMode?: boolean;
-  showExtraFields?: boolean;
+  setIsDirty?: (isDirty: boolean) => void;
 }
 
 export const ResponseLineEdit = ({
@@ -53,6 +53,7 @@ export const ResponseLineEdit = ({
   setRepresentation,
   disabled = false,
   isUpdateMode = false,
+  setIsDirty = () => {},
 }: ResponseLineEditProps) => {
   const t = useTranslation();
   const { data: reasonOptions, isLoading } = useReasonOptions();
@@ -240,6 +241,7 @@ export const ResponseLineEdit = ({
             representation={representation}
             setRepresentation={setRepresentation}
             unitName={unitName}
+            setIsDirty={setIsDirty}
           />
           {numericInput(
             'label.remaining-to-supply',

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -86,6 +86,8 @@ export const ResponseLineEdit = ({
     unitName,
     disabled: isDisabled,
     showExtraFields,
+    displayVaccinesInDoses,
+    dosesPerUnit: currentItem?.doses ?? 1,
   });
 
   const getLeftPanelContent = () => {
@@ -258,6 +260,8 @@ export const ResponseLineEdit = ({
             setRepresentation={setRepresentation}
             unitName={unitName}
             setIsDirty={setIsDirty}
+            displayVaccinesInDoses={displayVaccinesInDoses}
+            dosesPerUnit={currentItem?.doses ?? 1}
           />
           {numericInput(
             'label.remaining-to-supply',

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -39,6 +39,7 @@ interface ResponseLineEditProps {
   disabled: boolean;
   isUpdateMode?: boolean;
   setIsDirty?: (isDirty: boolean) => void;
+  manageVaccinesInDoses?: boolean;
 }
 
 export const ResponseLineEdit = ({
@@ -54,13 +55,16 @@ export const ResponseLineEdit = ({
   disabled = false,
   isUpdateMode = false,
   setIsDirty = () => {},
+  manageVaccinesInDoses = false,
 }: ResponseLineEditProps) => {
   const t = useTranslation();
   const { data: reasonOptions, isLoading } = useReasonOptions();
   const hasApproval =
     requisition.approvalStatus === RequisitionNodeApprovalStatus.Approved;
   const isPacksEnabled = !!currentItem?.defaultPackSize;
-
+  const showContent = !!draft && !!currentItem;
+  const displayVaccinesInDoses =
+    manageVaccinesInDoses && currentItem?.isVaccine;
   const showExtraFields =
     store?.preferences?.extraFieldsInRequisition && !!requisition.program;
   const isDisabled = disabled || !!requisition.linkedRequisition;
@@ -85,7 +89,7 @@ export const ResponseLineEdit = ({
   });
 
   const getLeftPanelContent = () => {
-    if (!draft) return null;
+    if (!showContent) return null;
 
     return (
       <>
@@ -95,6 +99,12 @@ export const ResponseLineEdit = ({
             value={String(currentItem?.defaultPackSize)}
           />
         )}
+        {displayVaccinesInDoses && currentItem?.doses ? (
+          <InfoRow
+            label={t('label.doses-per-unit')}
+            value={String(currentItem?.doses)}
+          />
+        ) : null}
         {showExtraFields && (
           <>
             {numericInput(
@@ -126,7 +136,7 @@ export const ResponseLineEdit = ({
   };
 
   const getMiddlePanelContent = () => {
-    if (!draft) return null;
+    if (!showContent) return null;
 
     return (
       <>
@@ -136,6 +146,12 @@ export const ResponseLineEdit = ({
             value={String(currentItem?.defaultPackSize)}
           />
         )}
+        {displayVaccinesInDoses && currentItem?.doses && !showExtraFields ? (
+          <InfoRow
+            label={t('label.doses-per-unit')}
+            value={String(currentItem?.doses)}
+          />
+        ) : null}
         <Box
           sx={{
             background: theme => theme.palette.background.group,
@@ -212,7 +228,7 @@ export const ResponseLineEdit = ({
   };
 
   const getRightPanelContent = () => {
-    if (!draft) return null;
+    if (!showContent) return null;
 
     return (
       <>

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
@@ -9,7 +9,11 @@ import {
   useTranslation,
 } from '@openmsupply-client/common';
 import { getCurrentValue, getUpdatedSupply } from './utils';
-import { Representation, RepresentationValue } from '../../../../common';
+import {
+  calculateValueInDoses,
+  Representation,
+  RepresentationValue,
+} from '../../../../common';
 import { DraftResponseLine } from '../hooks';
 
 interface Option {
@@ -27,6 +31,8 @@ interface SupplySelectionProps {
   setRepresentation: (rep: RepresentationValue) => void;
   unitName: string;
   setIsDirty?: (isDirty: boolean) => void;
+  displayVaccinesInDoses?: boolean;
+  dosesPerUnit: number;
 }
 
 export const SupplySelection = ({
@@ -39,6 +45,8 @@ export const SupplySelection = ({
   setRepresentation,
   unitName,
   setIsDirty = () => {},
+  displayVaccinesInDoses = false,
+  dosesPerUnit,
 }: SupplySelectionProps) => {
   const t = useTranslation();
   const { getPlural } = useIntlUtils();
@@ -87,6 +95,22 @@ export const SupplySelection = ({
     debouncedUpdate(newValue);
   };
 
+  const valueInDoses = useMemo(() => {
+    if (!displayVaccinesInDoses) return undefined;
+    return calculateValueInDoses(
+      representation,
+      defaultPackSize || 1,
+      dosesPerUnit,
+      value
+    );
+  }, [
+    displayVaccinesInDoses,
+    representation,
+    defaultPackSize,
+    dosesPerUnit,
+    value,
+  ]);
+
   return (
     <Box
       sx={{
@@ -128,6 +152,17 @@ export const SupplySelection = ({
               },
             }}
           />
+          {displayVaccinesInDoses && (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              pt={0.3}
+              pr={1.2}
+              sx={{ textAlign: 'right' }}
+            >
+              {valueInDoses} {t('label.doses').toLowerCase()}
+            </Typography>
+          )}
         </Box>
         <Box flex={1}>
           <Select

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
@@ -26,7 +26,6 @@ interface SupplySelectionProps {
   representation: RepresentationValue;
   setRepresentation: (rep: RepresentationValue) => void;
   unitName: string;
-  showExtraFields?: boolean;
 }
 
 export const SupplySelection = ({
@@ -38,11 +37,9 @@ export const SupplySelection = ({
   representation,
   setRepresentation,
   unitName,
-  showExtraFields = false,
 }: SupplySelectionProps) => {
   const t = useTranslation();
   const { getPlural } = useIntlUtils();
-  const width = showExtraFields ? 170 : 250;
 
   const currentValue = useMemo(
     (): number =>
@@ -89,70 +86,72 @@ export const SupplySelection = ({
       sx={{
         display: 'flex',
         flexDirection: 'column',
-        p: 1,
-        mb: 1,
+        pb: 1,
       }}
     >
-      <Typography variant="body1" fontWeight="bold" p={0.5}>
+      <Typography variant="body1" fontWeight="bold" pt={0.5} pb={0.5}>
         {t('label.supply')}:
       </Typography>
-      <Box gap={1} display="flex" flexDirection="row">
-        <NumericTextInput
-          autoFocus
-          width={width}
-          min={0}
-          value={value}
-          disabled={disabled}
-          onChange={handleValueChange}
-          slotProps={{
-            input: {
-              sx: {
-                background: theme =>
+      <Box display="flex" flexDirection="row" gap={1}>
+        <Box display="flex" flexDirection="column" flex={1}>
+          <NumericTextInput
+            autoFocus
+            fullWidth
+            min={0}
+            value={value}
+            disabled={disabled}
+            onChange={handleValueChange}
+            slotProps={{
+              input: {
+                sx: {
+                  boxShadow: theme => (!disabled ? theme.shadows[2] : 'none'),
+                  background: theme =>
+                    disabled
+                      ? theme.palette.background.toolbar
+                      : theme.palette.background.white,
+                },
+              },
+            }}
+            sx={{
+              '& .MuiInputBase-input': {
+                p: '3px 4px',
+                backgroundColor: theme =>
                   disabled
                     ? theme.palette.background.toolbar
                     : theme.palette.background.white,
               },
-            },
-          }}
-          sx={{
-            boxShadow: theme => (!disabled ? theme.shadows[2] : 'none'),
-            '& .MuiInputBase-input': {
-              p: '3px 4px',
-              backgroundColor: theme =>
-                disabled
-                  ? theme.palette.background.toolbar
-                  : theme.palette.background.white,
-            },
-          }}
-        />
-        <Select
-          fullWidth
-          clearable={false}
-          options={options}
-          value={representation}
-          onChange={e => {
-            setRepresentation(
-              (e.target.value as RepresentationValue) ?? Representation.UNITS
-            );
-          }}
-          sx={{
-            boxShadow: theme => (!disabled ? theme.shadows[2] : 'none'),
-            '& .MuiInputBase-input': {
-              p: '3px 4px',
-              backgroundColor: theme => theme.palette.background.white,
-            },
-          }}
-          slotProps={{
-            input: {
-              disableUnderline: true,
-              sx: {
+            }}
+          />
+        </Box>
+        <Box flex={1}>
+          <Select
+            fullWidth
+            clearable={false}
+            options={options}
+            value={representation}
+            onChange={e => {
+              setRepresentation(
+                (e.target.value as RepresentationValue) ?? Representation.UNITS
+              );
+            }}
+            sx={{
+              boxShadow: theme => (!disabled ? theme.shadows[2] : 'none'),
+              '& .MuiInputBase-input': {
+                p: '3px 4px',
                 backgroundColor: theme => theme.palette.background.white,
-                borderRadius: 2,
-                p: 0.5,
               },
-            },
-          }}
-        />
+            }}
+            slotProps={{
+              input: {
+                disableUnderline: true,
+                sx: {
+                  backgroundColor: theme => theme.palette.background.white,
+                  borderRadius: 2,
+                },
+              },
+            }}
+          />
+        </Box>
       </Box>
     </Box>
   );

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
@@ -60,7 +60,7 @@ export const SupplySelection = ({
 
   const options = useMemo((): Option[] => {
     const displayValue = value === 1 ? 1 : 2;
-    const unitPlural = getPlural(unitName, displayValue);
+    const unitPlural = getPlural(unitName.toLowerCase(), displayValue);
     const packPlural = getPlural(t('label.pack'), displayValue).toLowerCase();
 
     if (!isPacksEnabled)

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   Box,
   NumericTextInput,
@@ -74,6 +74,10 @@ export const SupplySelection = ({
     },
     [representation, defaultPackSize, update]
   );
+
+  useEffect(() => {
+    setValue(currentValue);
+  }, [currentValue, representation]);
 
   const handleValueChange = (value?: number) => {
     setValue(value ?? 0);

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
@@ -30,7 +30,6 @@ interface SupplySelectionProps {
   representation: RepresentationValue;
   setRepresentation: (rep: RepresentationValue) => void;
   unitName: string;
-  setIsDirty?: (isDirty: boolean) => void;
   displayVaccinesInDoses?: boolean;
   dosesPerUnit: number;
 }
@@ -44,7 +43,6 @@ export const SupplySelection = ({
   representation,
   setRepresentation,
   unitName,
-  setIsDirty = () => {},
   displayVaccinesInDoses = false,
   dosesPerUnit,
 }: SupplySelectionProps) => {
@@ -79,7 +77,6 @@ export const SupplySelection = ({
         defaultPackSize
       );
       update(updatedSupply);
-      setIsDirty(false);
     },
     [representation, defaultPackSize]
   );
@@ -89,8 +86,6 @@ export const SupplySelection = ({
   }, [draft?.id, representation]);
 
   const handleValueChange = (newValue?: number) => {
-    const valueChanged = newValue !== currentValue;
-    setIsDirty(valueChanged);
     setValue(newValue ?? 0);
     debouncedUpdate(newValue);
   };

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
@@ -26,6 +26,7 @@ interface SupplySelectionProps {
   representation: RepresentationValue;
   setRepresentation: (rep: RepresentationValue) => void;
   unitName: string;
+  setIsDirty?: (isDirty: boolean) => void;
 }
 
 export const SupplySelection = ({
@@ -37,6 +38,7 @@ export const SupplySelection = ({
   representation,
   setRepresentation,
   unitName,
+  setIsDirty = () => {},
 }: SupplySelectionProps) => {
   const t = useTranslation();
   const { getPlural } = useIntlUtils();
@@ -49,8 +51,9 @@ export const SupplySelection = ({
   const [value, setValue] = useState(currentValue);
 
   const options = useMemo((): Option[] => {
-    const unitPlural = getPlural(unitName, currentValue);
-    const packPlural = getPlural(t('label.pack'), currentValue).toLowerCase();
+    const displayValue = value === 1 ? 1 : 2;
+    const unitPlural = getPlural(unitName, displayValue);
+    const packPlural = getPlural(t('label.pack'), displayValue).toLowerCase();
 
     if (!isPacksEnabled)
       return [{ label: unitName, value: Representation.UNITS }];
@@ -68,17 +71,20 @@ export const SupplySelection = ({
         defaultPackSize
       );
       update(updatedSupply);
+      setIsDirty(false);
     },
-    [representation, defaultPackSize, update]
+    [representation, defaultPackSize]
   );
 
   useEffect(() => {
     setValue(currentValue);
-  }, [currentValue, representation]);
+  }, [draft?.id, representation]);
 
-  const handleValueChange = (value?: number) => {
-    setValue(value ?? 0);
-    debouncedUpdate(value);
+  const handleValueChange = (newValue?: number) => {
+    const valueChanged = newValue !== currentValue;
+    setIsDirty(valueChanged);
+    setValue(newValue ?? 0);
+    debouncedUpdate(newValue);
   };
 
   return (

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/hooks.tsx
@@ -80,7 +80,7 @@ export const useDraftRequisitionLine = (
     }
   }, [lines, item, data]);
 
-  const update = (patch: Partial<DraftResponseLine>) => {
+  const update = (patch?: Partial<DraftResponseLine>) => {
     if (draft) {
       setDraft({ ...draft, ...patch });
     }
@@ -89,10 +89,6 @@ export const useDraftRequisitionLine = (
   const save = async () => {
     if (draft) {
       const result = await saveMutation(draft);
-
-      if (draft.isCreated) {
-        setDraft(line => (line ? { ...line, isCreated: false } : null));
-      }
       setIsDirty(false);
       return result;
     }

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/hooks.tsx
@@ -61,7 +61,6 @@ export const useDraftRequisitionLine = (
   const { mutateAsync: saveMutation, isLoading } = useResponse.line.save();
 
   const [draft, setDraft] = useState<DraftResponseLine | null>(null);
-  const [isDirty, setIsDirty] = useState(false);
 
   useEffect(() => {
     if (lines && item && data) {
@@ -73,10 +72,8 @@ export const useDraftRequisitionLine = (
       } else {
         setDraft(createDraftFromItem(item, data));
       }
-      setIsDirty(false);
     } else {
       setDraft(null);
-      setIsDirty(false);
     }
   }, [lines, item, data]);
 
@@ -89,13 +86,12 @@ export const useDraftRequisitionLine = (
   const save = async () => {
     if (draft) {
       const result = await saveMutation(draft);
-      setIsDirty(false);
       return result;
     }
     return null;
   };
 
-  return { draft, isLoading, save, update, isDirty, setIsDirty };
+  return { draft, isLoading, save, update };
 };
 
 export const useNextResponseLine = (

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/hooks.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useResponse, ResponseLineFragment, ResponseFragment } from '../../api';
 import { ItemWithStatsFragment } from '@openmsupply-client/system';
 import { FnUtils } from '@common/utils';
@@ -77,19 +77,17 @@ export const useDraftRequisitionLine = (
     }
   }, [lines, item, data]);
 
-  const update = (patch: Partial<DraftResponseLine>) => {
-    if (draft) {
-      setDraft({ ...draft, ...patch });
-    }
-  };
+  const update = useCallback((patch: Partial<DraftResponseLine>) => {
+    setDraft(current => (current ? { ...current, ...patch } : null));
+  }, []);
 
-  const save = async () => {
+  const save = useCallback(async () => {
     if (draft) {
       const result = await saveMutation(draft);
       return result;
     }
     return null;
-  };
+  }, [draft, saveMutation]);
 
   return { draft, isLoading, save, update };
 };

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/hooks.tsx
@@ -80,7 +80,7 @@ export const useDraftRequisitionLine = (
     }
   }, [lines, item, data]);
 
-  const update = (patch?: Partial<DraftResponseLine>) => {
+  const update = (patch: Partial<DraftResponseLine>) => {
     if (draft) {
       setDraft({ ...draft, ...patch });
     }

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/hooks.tsx
@@ -58,9 +58,10 @@ export const useDraftRequisitionLine = (
 ) => {
   const { lines } = useResponse.line.list();
   const { data } = useResponse.document.get();
-  const { mutateAsync: save, isLoading } = useResponse.line.save();
+  const { mutateAsync: saveMutation, isLoading } = useResponse.line.save();
 
   const [draft, setDraft] = useState<DraftResponseLine | null>(null);
+  const [isDirty, setIsDirty] = useState(false);
 
   useEffect(() => {
     if (lines && item && data) {
@@ -72,8 +73,10 @@ export const useDraftRequisitionLine = (
       } else {
         setDraft(createDraftFromItem(item, data));
       }
+      setIsDirty(false);
     } else {
       setDraft(null);
+      setIsDirty(false);
     }
   }, [lines, item, data]);
 
@@ -83,7 +86,20 @@ export const useDraftRequisitionLine = (
     }
   };
 
-  return { draft, isLoading, save: () => draft && save(draft), update };
+  const save = async () => {
+    if (draft) {
+      const result = await saveMutation(draft);
+
+      if (draft.isCreated) {
+        setDraft(line => (line ? { ...line, isCreated: false } : null));
+      }
+      setIsDirty(false);
+      return result;
+    }
+    return null;
+  };
+
+  return { draft, isLoading, save, update, isDirty, setIsDirty };
 };
 
 export const useNextResponseLine = (

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/hooks.tsx
@@ -99,10 +99,12 @@ export const useDraftRequisitionLine = (
 };
 
 export const useNextResponseLine = (
+  lines: ResponseLineFragment[],
   currentItem?: ItemWithStatsFragment | null
 ) => {
-  const { lines } = useResponse.line.list();
-
+  if (!lines || !currentItem) {
+    return { hasNext: false, next: null };
+  }
   const nextState: {
     hasNext: boolean;
     next: ItemWithStatsFragment | null;

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseStats/RequestStoreStats.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseStats/RequestStoreStats.tsx
@@ -105,7 +105,7 @@ const CalculationError = ({
   const message = `${t('error.unable-to-calculate')}${detail}`;
 
   return (
-    <Box display="flex" padding={2} gap={1}>
+    <Box display="flex" padding={2} gap={1} justifyContent="center">
       <AlertIcon color="primary" fontSize="small" />
       <Typography variant="body1" fontSize={12} sx={{ color: 'error.main' }}>
         {message}
@@ -165,11 +165,10 @@ export const RequestStoreStats = ({
   return (
     <Box
       sx={{
-        width: 800,
-        margin: '0 auto',
-        display: 'flex',
-        flexDirection: 'column',
-        pt: 2,
+        width: '100%',
+        maxWidth: 800,
+        mx: 'auto',
+        p: '16px 16px',
       }}
     >
       <Typography variant="body1" fontWeight={700} fontSize={12}>

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseStats/ResponseStoreStats.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseStats/ResponseStoreStats.tsx
@@ -73,11 +73,10 @@ export const ResponseStoreStats = ({
   return (
     <Box
       sx={{
-        width: 800,
-        margin: '0 auto',
-        display: 'flex',
-        flexDirection: 'column',
-        pt: 2,
+        width: '100%',
+        maxWidth: 800,
+        mx: 'auto',
+        p: '16px 16px',
       }}
     >
       <Box
@@ -87,7 +86,11 @@ export const ResponseStoreStats = ({
         }}
       >
         {formattedSoh === 0 && formattedIncoming === 0 && formattedSoo === 0 ? (
-          <Typography fontSize={14} style={{ textAlign: 'center' }}>
+          <Typography
+            fontSize={14}
+            style={{ textAlign: 'center' }}
+            justifyContent="center"
+          >
             ⓘ
             <span style={{ fontStyle: 'italic', paddingLeft: 4 }}>
               {t('messages.requisition-no-stock')}

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
@@ -9,12 +9,13 @@ import {
   TooltipTextCell,
   useAuthContext,
   getLinesFromRow,
+  UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { ResponseLineFragment, useResponse } from './../api';
 import { PackQuantityCell } from '@openmsupply-client/system';
 import { useResponseRequisitionLineErrorContext } from '../context';
 
-export const useResponseColumns = () => {
+export const useResponseColumns = (manageVaccinesInDoses: boolean = false) => {
   const { getError } = useResponseRequisitionLineErrorContext();
 
   const {
@@ -62,17 +63,30 @@ export const useResponseColumns = () => {
       },
       width: 130,
     },
-    [
-      'availableStockOnHand',
-      {
-        label: 'label.our-soh',
-        description: 'description.our-soh',
-        sortable: false,
-        Cell: PackQuantityCell,
-        accessor: ({ rowData }) => rowData.itemStats.stockOnHand,
-      },
-    ],
   ];
+
+  if (manageVaccinesInDoses) {
+    columnDefinitions.push({
+      key: 'dosesPerUnit',
+      label: 'label.doses-per-unit',
+      width: 100,
+      align: ColumnAlign.Right,
+      sortable: false,
+      accessor: ({ rowData }) =>
+        rowData.item?.isVaccine ? rowData.item.doses : UNDEFINED_STRING_VALUE,
+    });
+  }
+
+  columnDefinitions.push([
+    'availableStockOnHand',
+    {
+      label: 'label.our-soh',
+      description: 'description.our-soh',
+      sortable: false,
+      Cell: PackQuantityCell,
+      accessor: ({ rowData }) => rowData.itemStats.stockOnHand,
+    },
+  ]);
 
   if (!programName) {
     columnDefinitions.push({

--- a/client/packages/requisitions/src/ResponseRequisition/api/hooks/line/useResponseLines.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/api/hooks/line/useResponseLines.ts
@@ -18,9 +18,13 @@ interface UseResponseLinesController
   onChangeSortBy: any;
 }
 
-export const useResponseLines = (): UseResponseLinesController => {
+export const useResponseLines = (
+  manageVaccinesInDoses: boolean = false
+): UseResponseLinesController => {
   const { lines } = useResponseFields('lines');
-  const { columns, onChangeSortBy, sortBy } = useResponseColumns();
+  const { columns, onChangeSortBy, sortBy } = useResponseColumns(
+    manageVaccinesInDoses
+  );
   const { itemFilter, setItemFilter, matchItem } = useItemUtils();
 
   const sorted = useMemo(() => {

--- a/client/packages/requisitions/src/common/ModalContentLayout.tsx
+++ b/client/packages/requisitions/src/common/ModalContentLayout.tsx
@@ -12,6 +12,7 @@ import {
   useEndAdornment,
   useValueInUnitsOrPacks,
   RepresentationValue,
+  calculateValueInDoses,
 } from './utils';
 
 interface LayoutProps {
@@ -55,6 +56,9 @@ interface InfoRowProps {
   value?: number | string;
   packagingDisplay?: string;
   sx?: SxProps<Theme>;
+  displayVaccinesInDoses?: boolean;
+  doses?: number;
+  dosesLabel?: string;
 }
 
 export const InfoRow = ({
@@ -62,6 +66,9 @@ export const InfoRow = ({
   value,
   packagingDisplay,
   sx,
+  displayVaccinesInDoses = false,
+  doses,
+  dosesLabel,
 }: InfoRowProps) => {
   return (
     <Grid
@@ -72,15 +79,20 @@ export const InfoRow = ({
       borderRadius={2}
       sx={sx}
     >
-      <Grid size={6}>
+      <Grid size={8}>
         <Typography variant="body1" fontWeight={700}>
           {label}:
         </Typography>
       </Grid>
-      <Grid size={6} textAlign="right">
+      <Grid size={4} textAlign="right">
         <Typography variant="body1">
           {value} {packagingDisplay}
         </Typography>
+        {displayVaccinesInDoses && (
+          <Typography variant="caption" color="text.secondary">
+            {doses ? `(${doses} ${dosesLabel?.toLowerCase()})` : ''}
+          </Typography>
+        )}
       </Grid>
     </Grid>
   );
@@ -92,6 +104,8 @@ interface ValueInfoRowProps extends Omit<InfoRowProps, 'value'> {
   defaultPackSize: number;
   unitName: string;
   endAdornmentOverride?: string;
+  displayVaccinesInDoses?: boolean;
+  dosesPerUnit?: number;
 }
 
 export type ValueInfo = {
@@ -99,6 +113,8 @@ export type ValueInfo = {
   endAdornmentOverride?: string;
   value?: number | null;
   sx?: SxProps<Theme>;
+  displayVaccinesInDoses?: boolean;
+  dosesPerUnit?: number;
 };
 
 export const ValueInfoRow = ({
@@ -109,6 +125,8 @@ export const ValueInfoRow = ({
   unitName,
   sx,
   endAdornmentOverride,
+  displayVaccinesInDoses = false,
+  dosesPerUnit = 1,
 }: ValueInfoRowProps) => {
   const t = useTranslation();
   const { getPlural } = useIntlUtils();
@@ -117,6 +135,24 @@ export const ValueInfoRow = ({
     representation,
     defaultPackSize,
     value
+  );
+  const valueInDoses = React.useMemo(
+    () =>
+      displayVaccinesInDoses
+        ? calculateValueInDoses(
+            representation,
+            defaultPackSize,
+            dosesPerUnit,
+            valueInUnitsOrPacks
+          )
+        : undefined,
+    [
+      displayVaccinesInDoses,
+      representation,
+      defaultPackSize,
+      dosesPerUnit,
+      valueInUnitsOrPacks,
+    ]
   );
 
   const endAdornment = useEndAdornment(
@@ -134,6 +170,9 @@ export const ValueInfoRow = ({
       value={round(valueInUnitsOrPacks, 2)}
       packagingDisplay={endAdornment}
       sx={sx}
+      displayVaccinesInDoses={displayVaccinesInDoses}
+      doses={valueInDoses}
+      dosesLabel={t('label.doses')}
     />
   );
 };

--- a/client/packages/requisitions/src/common/utils.test.ts
+++ b/client/packages/requisitions/src/common/utils.test.ts
@@ -1,4 +1,8 @@
-import { calculateValueInUnitsOrPacks, Representation } from './utils';
+import {
+  calculateValueInDoses,
+  calculateValueInUnitsOrPacks,
+  Representation,
+} from './utils';
 
 describe('calculateValueInUnitsOrPacks', () => {
   it('returns value as is when package type is UNITS', () => {
@@ -20,5 +24,48 @@ describe('calculateValueInUnitsOrPacks', () => {
       value
     );
     expect(result).toBe(value / defaultPackSize);
+  });
+});
+
+describe('calculateValueInDoses', () => {
+  it('should return 0 when value is null or undefined', () => {
+    expect(calculateValueInDoses(Representation.UNITS, 10, 5, null)).toBe(0);
+    expect(calculateValueInDoses(Representation.PACKS, 10, 5, undefined)).toBe(
+      0
+    );
+  });
+
+  describe('when representation is UNITS', () => {
+    it('should multiply value by dosesPerUnit', () => {
+      // 10 units × 5 doses per unit = 50 doses
+      expect(calculateValueInDoses(Representation.UNITS, 10, 5, 10)).toBe(50);
+
+      // 1 unit × 1 dose per unit = 1 dose
+      expect(calculateValueInDoses(Representation.UNITS, 10, 1, 1)).toBe(1);
+
+      // 100 units × 2 doses per unit = 200 doses
+      expect(calculateValueInDoses(Representation.UNITS, 10, 2, 100)).toBe(200);
+    });
+  });
+
+  describe('when representation is PACKS', () => {
+    it('should multiply value by defaultPackSize and dosesPerUnit', () => {
+      // 5 packs × 10 units per pack × 2 doses per unit = 100 doses
+      expect(calculateValueInDoses(Representation.PACKS, 10, 2, 5)).toBe(100);
+
+      // 1 pack × 20 units per pack × 5 doses per unit = 100 doses
+      expect(calculateValueInDoses(Representation.PACKS, 20, 5, 1)).toBe(100);
+
+      // 2 packs × 5 units per pack × 10 doses per unit = 100 doses
+      expect(calculateValueInDoses(Representation.PACKS, 5, 10, 2)).toBe(100);
+    });
+  });
+
+  it('should handle fractional values', () => {
+    // 0.5 packs × 10 units per pack × 2 doses per unit = 10 doses
+    expect(calculateValueInDoses(Representation.PACKS, 10, 2, 0.5)).toBe(10);
+
+    // 2.5 units × 2 doses per unit = 5 doses
+    expect(calculateValueInDoses(Representation.UNITS, 10, 2, 2.5)).toBe(5);
   });
 });

--- a/client/packages/requisitions/src/common/utils.test.ts
+++ b/client/packages/requisitions/src/common/utils.test.ts
@@ -68,4 +68,16 @@ describe('calculateValueInDoses', () => {
     // 2.5 units × 2 doses per unit = 5 doses
     expect(calculateValueInDoses(Representation.UNITS, 10, 2, 2.5)).toBe(5);
   });
+
+  it('should round to two decimal places', () => {
+    // 3.333 packs × 10 units per pack × 2 doses per unit = 66.66 doses
+    expect(
+      calculateValueInDoses(Representation.PACKS, 10, 2, 3.333)
+    ).toBeCloseTo(66.66, 2);
+
+    // 1.111 units × 2 doses per unit = 2.22 doses
+    expect(
+      calculateValueInDoses(Representation.UNITS, 10, 2, 1.111)
+    ).toBeCloseTo(2.22, 2);
+  });
 });

--- a/client/packages/requisitions/src/common/utils.ts
+++ b/client/packages/requisitions/src/common/utils.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { LocaleKey, TypedTFunction } from '@common/intl';
 import { NumUtils } from '@common/utils';
+import { ModalMode } from '@common/hooks';
 
 export const Representation = {
   PACKS: 'packs',
@@ -67,3 +68,13 @@ export const useEndAdornment = (
       valueInUnitsOrPacks,
     ]
   );
+
+export const shouldDeleteLine = (
+  mode: ModalMode | null,
+  draftId?: string,
+  isDisabled?: boolean
+): boolean => {
+  if (mode === ModalMode.Create) return true;
+  if (!draftId || isDisabled || mode === ModalMode.Update) return false;
+  return false;
+};

--- a/client/packages/requisitions/src/common/utils.ts
+++ b/client/packages/requisitions/src/common/utils.ts
@@ -30,6 +30,19 @@ export const useValueInUnitsOrPacks = (
     [representation, defaultPackSize, value]
   );
 
+export const calculateValueInDoses = (
+  representation: RepresentationValue,
+  defaultPackSize: number,
+  dosesPerUnit: number,
+  value?: number | null
+): number => {
+  if (!value) return 0;
+  if (representation === Representation.PACKS) {
+    return value * defaultPackSize * dosesPerUnit;
+  }
+  return value * dosesPerUnit;
+};
+
 export const useEndAdornment = (
   t: TypedTFunction<LocaleKey>,
   getPlural: (word: string, value: number) => string,

--- a/client/packages/requisitions/src/common/utils.ts
+++ b/client/packages/requisitions/src/common/utils.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { LocaleKey, TypedTFunction } from '@common/intl';
+import { NumUtils } from '@common/utils';
 
 export const Representation = {
   PACKS: 'packs',
@@ -38,9 +39,9 @@ export const calculateValueInDoses = (
 ): number => {
   if (!value) return 0;
   if (representation === Representation.PACKS) {
-    return value * defaultPackSize * dosesPerUnit;
+    return NumUtils.round(value * defaultPackSize * dosesPerUnit, 2);
   }
-  return value * dosesPerUnit;
+  return NumUtils.round(value * dosesPerUnit, 2);
 };
 
 export const useEndAdornment = (

--- a/client/packages/requisitions/src/utils.ts
+++ b/client/packages/requisitions/src/utils.ts
@@ -8,7 +8,10 @@ import {
   RequisitionNodeApprovalStatus,
   noOtherVariants,
 } from '@openmsupply-client/common';
-import { ResponseRowFragment } from './ResponseRequisition/api';
+import {
+  ResponseLineFragment,
+  ResponseRowFragment,
+} from './ResponseRequisition/api';
 import { RequestLineFragment } from './RequestRequisition/api';
 
 export const requestStatuses = [
@@ -128,6 +131,10 @@ export const responsesToCsv = (
 export const isRequestLinePlaceholderRow = (
   row: RequestLineFragment
 ): boolean => row.requestedQuantity === 0;
+
+export const isResponseLinePlaceholderRow = (
+  row: ResponseLineFragment
+): boolean => row.supplyQuantity === 0;
 
 export const getApprovalStatusKey = (
   approvalStatus?: RequisitionNodeApprovalStatus

--- a/server/service/src/sync/test/test_data/store_preference.rs
+++ b/server/service/src/sync/test/test_data/store_preference.rs
@@ -67,8 +67,7 @@ const STORE_PREFERENCE_1: (&str, &str) = (
         "boxPercentageSpace": 0,
         "omSupplyUsesProgramModule": true,
         "stocktakeFrequency": 1.34,
-        "keepRequisitionLinesWithZeroQuantity": true,
-        "canLinkRequisitionToSupplierInvoice": false
+        "keepRequisitionLinesWithZeroQuantity": true
     }
 }"#,
 );
@@ -105,7 +104,7 @@ const STORE_PREFERENCE_2: (&str, &str) = (
         "default_item_packsize_to_one": false,
         "shouldAuthoriseResponseRequisition": false,
         "includeRequisitionsInSuppliersRemoteAuthorisationProcesses": true,
-        "canLinkRequisitionToSupplierInvoice": false,
+        "canLinkRequisitionToSupplierInvoice": true,
         "responseRequisitionAutoFillSupplyQuantity": false,
         "useExtraFieldsForRequisitions": true,
         "CommentFieldToBeShownOnSupplierInvoiceLines": false,
@@ -135,8 +134,7 @@ const STORE_PREFERENCE_2: (&str, &str) = (
         "boxPrefix": "",
         "boxPercentageSpace": 0,
         "stocktakeFrequency": 1,
-        "keepRequisitionLinesWithZeroQuantity": false,
-        "canLinkRequisitionToSupplierInvoice": true
+        "keepRequisitionLinesWithZeroQuantity": false
     }
 }"#,
 );

--- a/server/service/src/sync/test/test_data/store_preference.rs
+++ b/server/service/src/sync/test/test_data/store_preference.rs
@@ -68,7 +68,7 @@ const STORE_PREFERENCE_1: (&str, &str) = (
         "omSupplyUsesProgramModule": true,
         "stocktakeFrequency": 1.34,
         "keepRequisitionLinesWithZeroQuantity": true,
-        "canLinkRequistionToSupplierInvoice": false
+        "canLinkRequisitionToSupplierInvoice": false
     }
 }"#,
 );
@@ -136,7 +136,7 @@ const STORE_PREFERENCE_2: (&str, &str) = (
         "boxPercentageSpace": 0,
         "stocktakeFrequency": 1,
         "keepRequisitionLinesWithZeroQuantity": false,
-        "canLinkRequistionToSupplierInvoice": true
+        "canLinkRequisitionToSupplierInvoice": true
     }
 }"#,
 );

--- a/server/service/src/sync/translations/store_preference.rs
+++ b/server/service/src/sync/translations/store_preference.rs
@@ -72,7 +72,7 @@ pub struct LegacyPrefData {
     #[serde(rename = "useConsumptionAndStockFromCustomersForInternalOrders")]
     pub use_consumption_and_stock_from_customers_for_internal_orders: bool,
     #[serde(default)]
-    #[serde(rename = "canLinkRequistionToSupplierInvoice")]
+    #[serde(rename = "canLinkRequisitionToSupplierInvoice")]
     pub manually_link_internal_order_to_inbound_shipment: bool,
     #[serde(default)]
     #[serde(rename = "editPrescribedQuantityOnPrescription")]


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7343

# 👩🏻‍💻 What does this PR do?
Sorry... the PR got bloated again ;-; pls forgive 🙇🏻‍♀️ 

- Lots of stylin' changes to try get components to align with each other and to get components to change dynamically with size... Note 1 below tho...
- Add loading spinner to Requisition and Internal Order modals
- Show placeholder lines in Requisition
- Added `doses per unit` row for Internal Order and Requisitions which will only show up if the user has the `Manage vaccines in doses` pref on and the item is a vaccine item
- Display helper text underneath components to display the value in doses based on the `item.doses` value
- Fix bug with newly created lines not correctly setting `isCreated` because it's still using the previous draft...
- Internal Order requested value should update depending on the packs / units representation
- Move item information plugin before charts since clients using it will care about that more than the charts
- Fixes autofocus not refocusing on supply / requested when changing items
- Hide content of model if there is no item selected
- Disable Ok and Ok & Next buttons if supply / requested quantity value hasn't fully settled... a bit buggy atm... 

### Internal Order
https://github.com/user-attachments/assets/242faa9d-e61d-4ad0-9ce6-210e2fc28f2b

### Requisition
https://github.com/user-attachments/assets/990f4bf7-6fc2-4488-8fe3-af0082234fc3

<img width="1197" alt="Screenshot 2025-06-04 at 1 16 29 PM" src="https://github.com/user-attachments/assets/e39cbf70-07da-4bfd-9b3f-320298d25980" />

## 💌 Any notes for the reviewer?
1. Noticed that all modals kinda sometimes resize correctly when tablet is turned but sometimes it doesn't. Will create an issue for this...
2. Item information plugin should not show up for non-program orders without preference. Will create an issue for this too...
3. Had a funky bug with plugins where Outbound / Prescription line edit content disappeared after selecting item... not sure if this is one off or not...
4. Requisition add from master list? Will create an issue.
5. One item left in the issue that isn't done `Update item_stats to show accurate doses`... leaving until Item Variants discussions take place and we learn the fate of that
6. Should graphs be hidden in tablets? @mark-prins They're nice, but just thinking about real estate on a small screen...
7. Ok & Next? Should it be [deleting placeholder](https://github.com/msupply-foundation/open-msupply/pull/8008#discussion_r2125540111) lines? It did in the old modal....
8. The overlap of the full screen modal closing icon overlapping with components is kinda 🤕 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have item that is vaccine 
- [ ] Create Internal Order / Requisition
- [ ] Should have a spinner while swapping / selecting item
- [ ] Placeholder lines in Requisition should show in blue
- [ ] Supply / Requested should always be in focus when swapping / adding items
- [ ] Content shouldn't display underneath item selector if no item has been selected
- [ ] Add vaccine item (would be good if you have some stats with that too)
- [ ] Should see doses in places where applicable (e.g. number is not 0)
- [ ] For non-vaccine items, doses shouldn't show up at all
- [ ] Should be able to swap items either through: 
   - [ ] Clicking in the item selection at the top (only for new items)
   - [ ] Clicking `Ok & Next`
- [ ] Ok should let you save placeholder lines (for now, 数7 decision)
- [ ] Ok & Next deletes previous line (old modal behaviour, again 数7 decision)
- [ ] Also note any other buggy things in notes above

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

