### PR TITLE
7996 change prescribed quan between doses and units

### DIFF
--- a/client/packages/common/src/ui/components/loading/BasicSpinner/BasicSpinner.tsx
+++ b/client/packages/common/src/ui/components/loading/BasicSpinner/BasicSpinner.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { CSSProperties } from 'react';
 import { CircularProgress, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
@@ -7,6 +7,7 @@ import { LocaleKey, useTranslation } from '@common/intl';
 interface BasicSpinnerProps {
   inline?: boolean;
   messageKey?: LocaleKey;
+  style?: CSSProperties;
 }
 
 const Container = styled(Box)({
@@ -26,13 +27,14 @@ const StyledText = styled(Typography)(({ theme }) => ({
   },
 }));
 
-export const BasicSpinner: FC<BasicSpinnerProps> = ({
+export const BasicSpinner = ({
   messageKey = 'loading',
   inline = false,
-}) => {
+  style = {},
+}: BasicSpinnerProps) => {
   const t = useTranslation();
   return (
-    <Container style={inline ? {} : { position: 'fixed' }}>
+    <Container style={inline ? style : { position: 'fixed', ...style }}>
       <CircularProgress />
       <StyledText>{t(messageKey)}</StyledText>
     </Container>

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
@@ -191,7 +191,10 @@ export const OutboundLineEditTable = ({
     );
 
   let extraColumnOffset = 0;
-  if (prefs?.manageVvmStatusForStock || prefs?.sortByVvmStatusThenExpiry) {
+  if (
+    item?.isVaccine &&
+    (prefs?.manageVvmStatusForStock || prefs?.sortByVvmStatusThenExpiry)
+  ) {
     extraColumnOffset += 1;
   }
   if (prefs?.allowTrackingOfStockByDonor) {

--- a/client/packages/invoices/src/Prescriptions/LineEditView/AutoAllocatePrescribedQuantityField.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/AutoAllocatePrescribedQuantityField.tsx
@@ -7,7 +7,7 @@ import {
   InputLabel,
 } from '@openmsupply-client/common';
 
-import { useAllocationContext } from '../../StockOut';
+import { AllocateInType, useAllocationContext } from '../../StockOut';
 
 export const AutoAllocatePrescribedQuantityField = () => {
   const t = useTranslation();
@@ -16,9 +16,10 @@ export const AutoAllocatePrescribedQuantityField = () => {
   const { autoAllocate, prescribedQuantity, setPrescribedQuantity } =
     useAllocationContext(state => ({
       autoAllocate: state.autoAllocate,
-      alerts: state.alerts,
-      prescribedQuantity: state.prescribedQuantity,
-      allocateIn: state.allocateIn,
+      prescribedQuantity:
+        state.allocateIn.type === AllocateInType.Doses
+          ? (state.prescribedUnits ?? 0) * (state.item?.doses ?? 1)
+          : state.prescribedUnits,
       setPrescribedQuantity: state.setPrescribedQuantity,
     }));
 

--- a/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
@@ -29,7 +29,7 @@ export const PrescriptionLineEditView = () => {
   const isDirty = useRef(false);
   const navigate = useNavigate();
 
-  const { data: prefs } = usePreference(
+  const { data: prefs, isLoading: isLoadingPrefs } = usePreference(
     PreferenceKey.ManageVaccinesInDoses,
     PreferenceKey.SortByVvmStatusThenExpiry
   );
@@ -151,7 +151,7 @@ export const PrescriptionLineEditView = () => {
     }
   };
 
-  if (isLoading || !itemId) return <BasicSpinner />;
+  if (isLoading || !itemId || isLoadingPrefs) return <BasicSpinner />;
   if (!data) return <NothingHere />;
 
   const itemIdList = items.map(item => item.id);

--- a/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
@@ -38,7 +38,7 @@ export const PrescriptionLineEditView = () => {
     isDirty: allocationIsDirty,
     draftLines,
     item,
-    prescribedQuantity,
+    prescribedUnits,
     note,
     allocatedQuantity,
     setIsDirty: setAllocationIsDirty,
@@ -128,7 +128,7 @@ export const PrescriptionLineEditView = () => {
       await savePrescriptionItemLineData({
         itemId: contextItemId,
         lines: draftLines,
-        prescribedQuantity: prescribedQuantity,
+        prescribedUnits,
         note,
       });
 
@@ -211,7 +211,7 @@ export const PrescriptionLineEditView = () => {
         disabled={
           !item?.id ||
           !allocationIsDirty ||
-          (allocatedQuantity === 0 && prescribedQuantity === 0)
+          (allocatedQuantity === 0 && prescribedUnits === 0)
         }
         handleSave={onSave}
         handleCancel={() =>

--- a/client/packages/invoices/src/Prescriptions/LineEditView/NavBar.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/NavBar.tsx
@@ -20,12 +20,12 @@ interface NavBarProps {
   scrollIntoView: () => void;
 }
 
-export const NavBar: React.FC<NavBarProps> = ({
+export const NavBar = ({
   items,
   currentItem,
   setItem,
   scrollIntoView,
-}) => {
+}: NavBarProps) => {
   const t = useTranslation();
   const currentIndex = items.findIndex(item => item === currentItem);
   const hasPrevious = currentIndex > 0;

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEdit.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEdit.tsx
@@ -116,7 +116,7 @@ export const PrescriptionLineEdit = ({
       </AccordionPanelSection>
 
       {isFetching ? (
-        <BasicSpinner />
+        <BasicSpinner inline style={{ flexGrow: 1 }} />
       ) : item ? (
         <PrescriptionLineEditForm disabled={isDisabled} isNew={isNew} />
       ) : null}

--- a/client/packages/invoices/src/Prescriptions/api/hooks/useSavePrescriptionItemLineData.ts
+++ b/client/packages/invoices/src/Prescriptions/api/hooks/useSavePrescriptionItemLineData.ts
@@ -10,12 +10,12 @@ export const useSavePrescriptionItemLineData = (invoiceId: string) => {
     async ({
       itemId,
       lines,
-      prescribedQuantity,
+      prescribedUnits,
       note,
     }: {
       itemId: string;
       lines: DraftStockOutLineFragment[];
-      prescribedQuantity: number | null;
+      prescribedUnits: number | null;
       note: string | null;
     }) => {
       return await prescriptionApi.savePrescriptionItemLines({
@@ -29,7 +29,7 @@ export const useSavePrescriptionItemLineData = (invoiceId: string) => {
             stockLineId: line.stockLineId,
           })),
           prescribedQuantity:
-            (prescribedQuantity ?? 0) > 0 ? prescribedQuantity : null,
+            (prescribedUnits ?? 0) > 0 ? prescribedUnits : null,
           note,
         },
       });

--- a/client/packages/invoices/src/StockOut/useAllocationContext.ts
+++ b/client/packages/invoices/src/StockOut/useAllocationContext.ts
@@ -58,7 +58,7 @@ interface AllocationContext {
   allocateIn: AllocateInOption;
   item: DraftItem | null;
   placeholderUnits: number | null;
-  prescribedQuantity: number | null;
+  prescribedUnits: number | null;
   note: string | null;
 
   initialise: (params: {
@@ -72,7 +72,7 @@ interface AllocationContext {
   }) => void;
 
   setAlerts: (alerts: StockOutAlert[]) => void;
-  setPrescribedQuantity: (quantity: number | null) => void;
+  setPrescribedQuantity: (quantity: number) => void;
   setNote: (note: string | null) => void;
   setAllocateIn: (
     allocateIn: AllocateInOption,
@@ -109,7 +109,7 @@ export const useAllocationContext = create<AllocationContext>((set, get) => ({
   draftLines: [],
   nonAllocatableLines: [],
   placeholderUnits: null,
-  prescribedQuantity: null,
+  prescribedUnits: null,
   alerts: [],
   allocateIn: { type: AllocateInType.Units },
   note: null,
@@ -149,9 +149,7 @@ export const useAllocationContext = create<AllocationContext>((set, get) => ({
       nonAllocatableLines: ignoreNonAllocatableLines ? [] : nonAllocatableLines,
 
       placeholderUnits: allowPlaceholder ? (placeholderUnits ?? 0) : null,
-      prescribedQuantity: allowPrescribedQuantity
-        ? (prescribedUnits ?? 0)
-        : null,
+      prescribedUnits: allowPrescribedQuantity ? (prescribedUnits ?? 0) : null,
       alerts: [],
     });
   },
@@ -168,7 +166,7 @@ export const useAllocationContext = create<AllocationContext>((set, get) => ({
       availablePackSizes: [],
       alerts: [],
       note: null,
-      prescribedQuantity: null,
+      prescribedUnits: null,
     })),
 
   setAllocateIn: (allocateIn, format, t) => {
@@ -216,12 +214,15 @@ export const useAllocationContext = create<AllocationContext>((set, get) => ({
       isDirty: true,
     })),
 
-  setPrescribedQuantity: (quantity: number | null) =>
+  setPrescribedQuantity: (quantity: number) => {
+    const { allocateIn, item } = get();
+
     set(state => ({
       ...state,
-      prescribedQuantity: quantity,
+      prescribedUnits: normaliseToUnits(quantity, allocateIn, item?.doses || 1),
       isDirty: true,
-    })),
+    }));
+  },
 
   autoAllocate: (quantity, format, t, allowPartialPacks = false) => {
     const {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7996

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Set prescribed quan in doses:
![Screenshot 2025-06-04 at 3 45 00 PM](https://github.com/user-attachments/assets/d122bdad-ccc0-43ba-91b6-d5908f89f6b0)

Switch to units - quantity adjusts accordingly:
![Screenshot 2025-06-04 at 3 45 04 PM](https://github.com/user-attachments/assets/cfc87d6e-fa9b-4e7b-ac74-6e210770843d)


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

Note that if you have item variants, when you switch to unit view, prescribed and issued may vary (as issued just adds up actual allocated units, prescribed changes dose to unit quantity based on default doses per unit).

I'm comfortable calling this an edge case, I think pretty low likelihood, and values are correct (so not really a bug anyway). Especially if variants may be changed. Just wanted to capture
![Screenshot 2025-06-04 at 3 48 38 PM](https://github.com/user-attachments/assets/31c1e659-544d-4b27-9d33-825719aeaa5b)

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have doses store pref (OMS) and prescribed quantity pref (OG) enabled for your store
- [ ] Add a vaccine item to your prescription
- [ ] Add some number of doses to prescribed quantity - correct amount get issued
- [ ] Switch to unit view - values are adjusted correctly
- [ ] Entering prescribed quan as units allocated quantities correctly
- [ ] Save and refresh - dose count for prescribed quantity is correct

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

