### PR TITLE
use getNaiveDate to render dates

### DIFF
--- a/client/packages/system/src/Manage/Campaigns/ListView/CampaignEditModal.tsx
+++ b/client/packages/system/src/Manage/Campaigns/ListView/CampaignEditModal.tsx
@@ -75,7 +75,7 @@ export const CampaignEditModal: FC<CampaignEditModalProps> = ({
             Input={
               <DateTimePickerInput
                 sx={{ width: 250 }}
-                value={DateUtils.getDateOrNull(startDate)}
+                value={DateUtils.getNaiveDate(startDate)}
                 onChange={startDate => updateDraft({ startDate })}
               />
             }
@@ -86,7 +86,7 @@ export const CampaignEditModal: FC<CampaignEditModalProps> = ({
             Input={
               <DateTimePickerInput
                 sx={{ width: 250 }}
-                value={DateUtils.getDateOrNull(endDate)}
+                value={DateUtils.getNaiveDate(endDate)}
                 onChange={endDate => updateDraft({ endDate })}
               />
             }

--- a/client/packages/system/src/Manage/Campaigns/ListView/ListView.tsx
+++ b/client/packages/system/src/Manage/Campaigns/ListView/ListView.tsx
@@ -14,6 +14,7 @@ import {
   useTableStore,
   useDeleteConfirmation,
   useNotification,
+  DateUtils,
 } from '@openmsupply-client/common';
 import { Footer } from './Footer';
 import { CampaignEditModal } from './CampaignEditModal';
@@ -103,6 +104,7 @@ const CampaignsComponent = () => {
         width: 150,
         format: ColumnFormat.Date,
         sortable: false,
+        accessor: ({ rowData }) => DateUtils.getNaiveDate(rowData.startDate),
       },
       {
         key: 'endDate',
@@ -110,6 +112,7 @@ const CampaignsComponent = () => {
         width: 150,
         format: ColumnFormat.Date,
         sortable: false,
+        accessor: ({ rowData }) => DateUtils.getNaiveDate(rowData.endDate),
       },
     ],
     {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7983 

# 👩🏻‍💻 What does this PR do?

Fix date display issue by using `getNaiveDate` for campaign start/end dates. 

Using `getNaiveDate` solved the issue because it creates dates at midnight in the user's local timezone instead of midnight in universal time, preventing the date from shifting to the previous day when displayed.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

**_Would be beneficial to test it outside this fix, so either an older RC or a different branch (if you're a dev)_**

**Requirements (Assuming you're in NZ)**
- [ ] Open Chrome DevTools (F12)
- [ ] Go to Settings (⚙️) → More tools → Sensors
- [ ] Set Location to San Francisco
- [ ] Refresh the application

**OMS**
- [ ] Navigate Manage -> Campaigns
- [ ] Click on `Add New Campaign`
- [ ] Choose a valid Start Date and End Date
- [ ] Click Ok
- [ ] The dates should reflect what was selected and not one day behind.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

