### PR TITLE
#7752 Display nothing here message when no log entries to display 

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1696,7 +1696,7 @@
   "messages.no-lines": "Cannot change the status because there are no lines or because there are only placeholder lines",
   "messages.no-lines-selected": "No lines selected",
   "messages.no-locations": "No locations available",
-  "messages.no-log-entries": "No log entries available",
+  "messages.no-log-entries": "There are no log entries to display.",
   "messages.no-master-lists": "No master lists available",
   "messages.no-matching-patients": "No matching patients",
   "messages.no-matching-patients-for-contact-trace": "No matching patients",

--- a/client/packages/system/src/ActivityLog/Components/ListView.tsx
+++ b/client/packages/system/src/ActivityLog/Components/ListView.tsx
@@ -7,6 +7,7 @@ import {
   Formatter,
   TableProvider,
   createTableStore,
+  NothingHere,
 } from '@openmsupply-client/common';
 import { useFormatDateTime } from '@common/intl';
 
@@ -64,7 +65,7 @@ export const ActivityLogList: FC<{ recordId: string }> = ({ recordId }) => {
         data={data?.nodes}
         isLoading={isLoading}
         isError={isError}
-        noDataMessage={t('messages.no-log-entries')}
+        noDataElement={<NothingHere body={t('messages.no-log-entries')} />}
         overflowX="auto"
       />
     </TableProvider>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7752

# 👩🏻‍💻 What does this PR do?
Display nothing here message when no log entries to display
<!-- Explain the changes you made -->

<!-- why are the changes needed -->
Changes needed for consistency.

<!-- Add a screenshot if there are UI changes  -->
![Screenshot 2025-06-06 at 15 24 42](https://github.com/user-attachments/assets/b44339ae-ba39-406a-83ff-8951d49f9927)

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Inventory -> View Stock
- [ ] Find a batch with no log entries
- [ ] See that Nothing here icon appears with the correct message


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

