### PR TITLE
#6167 Reorder cold storage types to appear in desc order

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -282,6 +282,7 @@ export type AllocateOutboundShipmentUnallocatedLineNode = {
   issuedExpiringSoonStockLines: StockLineConnector;
   skippedExpiredStockLines: StockLineConnector;
   skippedOnHoldStockLines: StockLineConnector;
+  skippedUnusableVvmStatusLines: StockLineConnector;
   updates: InvoiceLineConnector;
 };
 

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -1301,6 +1301,7 @@ export type ColdStorageTypeConnector = {
 
 export type ColdStorageTypeFilterInput = {
   id?: InputMaybe<EqualFilterStringInput>;
+  minTemperature?: InputMaybe<EqualFilterBigFloatingNumberInput>;
   name?: InputMaybe<EqualFilterStringInput>;
 };
 
@@ -1314,6 +1315,7 @@ export type ColdStorageTypeNode = {
 
 export enum ColdStorageTypeSortFieldInput {
   Id = 'id',
+  MinTemperature = 'minTemperature',
   Name = 'name',
 }
 

--- a/client/packages/system/src/Item/api/operations.generated.ts
+++ b/client/packages/system/src/Item/api/operations.generated.ts
@@ -1945,7 +1945,7 @@ export const DeleteItemVariantDocument = gql`
 `;
 export const ColdStorageTypesDocument = gql`
   query coldStorageTypes($storeId: String!) {
-    coldStorageTypes(storeId: $storeId) {
+    coldStorageTypes(storeId: $storeId, sort: { key: id, desc: true }) {
       ... on ColdStorageTypeConnector {
         nodes {
           ...ColdStorageType

--- a/client/packages/system/src/Item/api/operations.generated.ts
+++ b/client/packages/system/src/Item/api/operations.generated.ts
@@ -1945,7 +1945,10 @@ export const DeleteItemVariantDocument = gql`
 `;
 export const ColdStorageTypesDocument = gql`
   query coldStorageTypes($storeId: String!) {
-    coldStorageTypes(storeId: $storeId, sort: { key: id, desc: true }) {
+    coldStorageTypes(
+      storeId: $storeId
+      sort: { key: minTemperature, desc: true }
+    ) {
       ... on ColdStorageTypeConnector {
         nodes {
           ...ColdStorageType

--- a/client/packages/system/src/Item/api/operations.graphql
+++ b/client/packages/system/src/Item/api/operations.graphql
@@ -455,7 +455,7 @@ mutation deleteItemVariant($storeId: String!, $input: DeleteItemVariantInput!) {
 }
 
 query coldStorageTypes($storeId: String!) {
-  coldStorageTypes(storeId: $storeId) {
+  coldStorageTypes(storeId: $storeId, sort: { key: id, desc: true }) {
     ... on ColdStorageTypeConnector {
       nodes {
         ...ColdStorageType

--- a/client/packages/system/src/Item/api/operations.graphql
+++ b/client/packages/system/src/Item/api/operations.graphql
@@ -455,7 +455,10 @@ mutation deleteItemVariant($storeId: String!, $input: DeleteItemVariantInput!) {
 }
 
 query coldStorageTypes($storeId: String!) {
-  coldStorageTypes(storeId: $storeId, sort: { key: id, desc: true }) {
+  coldStorageTypes(
+    storeId: $storeId
+    sort: { key: minTemperature, desc: true }
+  ) {
     ... on ColdStorageTypeConnector {
       nodes {
         ...ColdStorageType

--- a/server/graphql/general/src/queries/cold_storage_type.rs
+++ b/server/graphql/general/src/queries/cold_storage_type.rs
@@ -38,7 +38,6 @@ pub struct ColdStorageTypeSortInput {
 pub struct ColdStorageTypeFilterInput {
     pub id: Option<EqualFilterStringInput>,
     pub name: Option<EqualFilterStringInput>,
-    pub min_temperature: Option<EqualFilterBigFloatingNumberInput>,
 }
 
 #[derive(SimpleObject)]
@@ -85,16 +84,11 @@ pub fn cold_storage_types(
 
 impl ColdStorageTypeFilterInput {
     pub fn to_domain(self) -> ColdStorageTypeFilter {
-        let ColdStorageTypeFilterInput {
-            id,
-            name,
-            min_temperature,
-        } = self;
+        let ColdStorageTypeFilterInput { id, name } = self;
 
         ColdStorageTypeFilter {
             id: id.map(EqualFilter::from),
             name: name.map(EqualFilter::from),
-            min_temperature: min_temperature.map(EqualFilter::from),
         }
     }
 }

--- a/server/graphql/general/src/queries/cold_storage_type.rs
+++ b/server/graphql/general/src/queries/cold_storage_type.rs
@@ -1,6 +1,6 @@
 use async_graphql::*;
 use graphql_core::{
-    generic_filters::{EqualFilterBigFloatingNumberInput, EqualFilterStringInput},
+    generic_filters::EqualFilterStringInput,
     pagination::PaginationInput,
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,

--- a/server/graphql/general/src/queries/cold_storage_type.rs
+++ b/server/graphql/general/src/queries/cold_storage_type.rs
@@ -1,6 +1,6 @@
 use async_graphql::*;
 use graphql_core::{
-    generic_filters::EqualFilterStringInput,
+    generic_filters::{EqualFilterBigFloatingNumberInput, EqualFilterStringInput},
     pagination::PaginationInput,
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
@@ -22,6 +22,7 @@ use service::{
 pub enum ColdStorageTypeSortFieldInput {
     Id,
     Name,
+    MinTemperature,
 }
 
 #[derive(InputObject)]
@@ -37,6 +38,7 @@ pub struct ColdStorageTypeSortInput {
 pub struct ColdStorageTypeFilterInput {
     pub id: Option<EqualFilterStringInput>,
     pub name: Option<EqualFilterStringInput>,
+    pub min_temperature: Option<EqualFilterBigFloatingNumberInput>,
 }
 
 #[derive(SimpleObject)]
@@ -83,11 +85,16 @@ pub fn cold_storage_types(
 
 impl ColdStorageTypeFilterInput {
     pub fn to_domain(self) -> ColdStorageTypeFilter {
-        let ColdStorageTypeFilterInput { id, name } = self;
+        let ColdStorageTypeFilterInput {
+            id,
+            name,
+            min_temperature,
+        } = self;
 
         ColdStorageTypeFilter {
             id: id.map(EqualFilter::from),
             name: name.map(EqualFilter::from),
+            min_temperature: min_temperature.map(EqualFilter::from),
         }
     }
 }
@@ -99,6 +106,7 @@ impl ColdStorageTypeSortInput {
         let key = match self.key {
             from::Name => to::Name,
             from::Id => to::Id,
+            from::MinTemperature => to::MinTemperature,
         };
 
         ColdStorageTypeSort {

--- a/server/repository/src/db_diesel/cold_storage_type.rs
+++ b/server/repository/src/db_diesel/cold_storage_type.rs
@@ -20,12 +20,14 @@ pub struct ColdStorageType {
 pub struct ColdStorageTypeFilter {
     pub id: Option<EqualFilter<String>>,
     pub name: Option<EqualFilter<String>>,
+    pub min_temperature: Option<EqualFilter<f64>>,
 }
 
 #[derive(PartialEq, Debug)]
 pub enum ColdStorageTypeSortField {
     Id,
     Name,
+    MinTemperature,
 }
 
 pub type ColdStorageTypeSort = Sort<ColdStorageTypeSortField>;
@@ -68,6 +70,9 @@ impl<'a> ColdStorageTypeRepository<'a> {
                 ColdStorageTypeSortField::Name => {
                     apply_sort!(query, sort, cold_storage_type::name)
                 }
+                ColdStorageTypeSortField::MinTemperature => {
+                    apply_sort!(query, sort, cold_storage_type::min_temperature)
+                }
             }
         } else {
             query = query.order(cold_storage_type::name.desc())
@@ -98,10 +103,15 @@ impl<'a> ColdStorageTypeRepository<'a> {
             .and(cold_storage_type::max_temperature.eq(0.0))));
 
         if let Some(f) = filter {
-            let ColdStorageTypeFilter { id, name } = f;
+            let ColdStorageTypeFilter {
+                id,
+                name,
+                min_temperature,
+            } = f;
 
             apply_equal_filter!(query, id, cold_storage_type::id);
             apply_equal_filter!(query, name, cold_storage_type::name);
+            apply_equal_filter!(query, min_temperature, cold_storage_type::min_temperature)
         }
 
         query

--- a/server/repository/src/db_diesel/cold_storage_type.rs
+++ b/server/repository/src/db_diesel/cold_storage_type.rs
@@ -20,7 +20,6 @@ pub struct ColdStorageType {
 pub struct ColdStorageTypeFilter {
     pub id: Option<EqualFilter<String>>,
     pub name: Option<EqualFilter<String>>,
-    pub min_temperature: Option<EqualFilter<f64>>,
 }
 
 #[derive(PartialEq, Debug)]
@@ -103,15 +102,10 @@ impl<'a> ColdStorageTypeRepository<'a> {
             .and(cold_storage_type::max_temperature.eq(0.0))));
 
         if let Some(f) = filter {
-            let ColdStorageTypeFilter {
-                id,
-                name,
-                min_temperature,
-            } = f;
+            let ColdStorageTypeFilter { id, name } = f;
 
             apply_equal_filter!(query, id, cold_storage_type::id);
             apply_equal_filter!(query, name, cold_storage_type::name);
-            apply_equal_filter!(query, min_temperature, cold_storage_type::min_temperature)
         }
 
         query


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6167

# 👩🏻‍💻 What does this PR do?
Reorder cold storage types to appear in desc order (based on minimum temperature)

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
![Screenshot 2025-06-06 at 16 41 16](https://github.com/user-attachments/assets/9a8ca7e4-46de-4f1f-a2e8-aa4948245528)

## 💌 Any notes for the reviewer?
The issue had only specified item variant cold storage type selector but I've made api return the list in descending so it will appear that way in all places that cold storage type selector is used. Seems like that's ok to me but happy to be told otherwise. 
<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

Ensure you have cold storage location types set up in OG - Item -> show location types:
  - your store will need to be on OG server to be able to edit location types
  - I just moved a random store to OG server -> logged in as that store to og -> added the types -> and then moved store back to OMS server
- [ ] Navigate to Catalogue -> Item
- [ ] Go to item variant tab and create a variant
- [ ] Open cold storage type dropdown and see that types are ordered in descending order (i.e higher temperatures will appear first as per screenshot above)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

