### PR TITLE
8052 requisitions full screen modal x not behaving like cancel

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -14,6 +14,7 @@ import {
   usePluginProvider,
   Typography,
   BufferedTextArea,
+  useFormatNumber,
 } from '@openmsupply-client/common';
 import { DraftRequestLine } from './hooks';
 import { RequestLineFragment } from '../../api';
@@ -67,8 +68,10 @@ export const RequestLineEdit = ({
 }: RequestLineEditProps) => {
   const t = useTranslation();
   const { plugins } = usePluginProvider();
+  const { round } = useFormatNumber();
   const unitName = currentItem?.unitName || t('label.unit');
   const defaultPackSize = currentItem?.defaultPackSize || 1;
+
   const showContent = !!draft && !!currentItem;
   const displayVaccinesInDoses =
     manageVaccinesInDoses && currentItem?.isVaccine;
@@ -235,13 +238,13 @@ export const RequestLineEdit = ({
               {isPacksEnabled && (
                 <InfoRow
                   label={t('label.default-pack-size')}
-                  value={String(currentItem?.defaultPackSize)}
+                  value={round(currentItem?.defaultPackSize)}
                 />
               )}
               {displayVaccinesInDoses && currentItem?.doses ? (
                 <InfoRow
                   label={t('label.doses-per-unit')}
-                  value={String(currentItem?.doses)}
+                  value={round(currentItem?.doses)}
                 />
               ) : null}
               {renderValueInfoRows(getLeftPanel(t, draft, showExtraFields))}

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -37,7 +37,6 @@ export const RequestLineEditModal = ({
   onClose,
   manageVaccinesInDoses,
 }: RequestLineEditModalProps) => {
-  const { Modal } = useDialog({ onClose, isOpen });
   const deleteLine = useRequest.line.deleteLine();
   const isDisabled = isRequestDisabled(requisition);
 
@@ -82,6 +81,8 @@ export const RequestLineEditModal = ({
     }
     onClose();
   };
+
+  const { Modal } = useDialog({ onClose: onCancel, isOpen });
 
   const onChangeItem = (item: ItemWithStatsFragment) => {
     if (item.id !== currentItem?.id && draft?.requestedQuantity === 0) {

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
@@ -5,6 +5,7 @@ import {
   Select,
   Typography,
   useDebounceCallback,
+  useFormatNumber,
   useIntlUtils,
   useTranslation,
 } from '@openmsupply-client/common';
@@ -49,6 +50,7 @@ export const RequestedSelection = ({
 }: RequestedSelectionProps) => {
   const t = useTranslation();
   const { getPlural } = useIntlUtils();
+  const { round } = useFormatNumber();
 
   const currentValue = useMemo(
     (): number =>
@@ -98,11 +100,14 @@ export const RequestedSelection = ({
 
   const valueInDoses = useMemo(() => {
     if (!displayVaccinesInDoses) return undefined;
-    return calculateValueInDoses(
-      representation,
-      defaultPackSize || 1,
-      dosesPerUnit,
-      value
+    return round(
+      calculateValueInDoses(
+        representation,
+        defaultPackSize || 1,
+        dosesPerUnit,
+        value
+      ),
+      2
     );
   }, [
     displayVaccinesInDoses,

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ContentLayout.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ContentLayout.tsx
@@ -12,6 +12,7 @@ import {
   LocaleKey,
   Typography,
   useMediaQuery,
+  useFormatNumber,
 } from '@openmsupply-client/common';
 import {
   useEndAdornment,
@@ -52,6 +53,7 @@ export const NumInputRow = ({
 }: NumInputRowProps) => {
   const t = useTranslation();
   const { getPlural } = useIntlUtils();
+  const { round } = useFormatNumber();
   const isVerticalScreen = useMediaQuery('(max-width:800px)');
 
   const valueInUnitsOrPacks = useValueInUnitsOrPacks(
@@ -82,11 +84,14 @@ export const NumInputRow = ({
   const valueInDoses = React.useMemo(
     () =>
       displayVaccinesInDoses
-        ? calculateValueInDoses(
-            representation,
-            defaultPackSize,
-            dosesPerUnit,
-            valueInUnitsOrPacks
+        ? round(
+            calculateValueInDoses(
+              representation,
+              defaultPackSize,
+              dosesPerUnit,
+              valueInUnitsOrPacks
+            ),
+            2
           )
         : undefined,
     [

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
@@ -73,7 +73,7 @@ export const ResponseLineEditModal = ({
   }, [draft?.id]);
 
   const onCancel = () => {
-    if (mode === ModalMode.Create && draft?.id) {
+    if (mode === ModalMode.Create) {
       deleteLine(draftIdRef.current || '');
     }
     onClose();

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -8,6 +8,7 @@ import {
   RequisitionNodeApprovalStatus,
   Typography,
   UserStoreNodeFragment,
+  useFormatNumber,
 } from '@openmsupply-client/common';
 import {
   ItemWithStatsFragment,
@@ -57,6 +58,8 @@ export const ResponseLineEdit = ({
 }: ResponseLineEditProps) => {
   const t = useTranslation();
   const { data: reasonOptions, isLoading } = useReasonOptions();
+  const { round } = useFormatNumber();
+
   const hasApproval =
     requisition.approvalStatus === RequisitionNodeApprovalStatus.Approved;
   const isPacksEnabled = !!currentItem?.defaultPackSize;
@@ -96,13 +99,13 @@ export const ResponseLineEdit = ({
         {isPacksEnabled && (
           <InfoRow
             label={t('label.default-pack-size')}
-            value={String(currentItem?.defaultPackSize)}
+            value={round(currentItem?.defaultPackSize)}
           />
         )}
         {displayVaccinesInDoses && currentItem?.doses ? (
           <InfoRow
             label={t('label.doses-per-unit')}
-            value={String(currentItem?.doses)}
+            value={round(currentItem?.doses)}
           />
         ) : null}
         {showExtraFields && (
@@ -144,13 +147,13 @@ export const ResponseLineEdit = ({
         {isPacksEnabled && !showExtraFields && (
           <InfoRow
             label={t('label.default-pack-size')}
-            value={String(currentItem?.defaultPackSize)}
+            value={round(currentItem?.defaultPackSize)}
           />
         )}
         {displayVaccinesInDoses && currentItem?.doses && !showExtraFields ? (
           <InfoRow
             label={t('label.doses-per-unit')}
-            value={String(currentItem?.doses)}
+            value={round(currentItem?.doses)}
           />
         ) : null}
         <Box

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
@@ -5,6 +5,7 @@ import {
   Select,
   Typography,
   useDebounceCallback,
+  useFormatNumber,
   useIntlUtils,
   useTranslation,
 } from '@openmsupply-client/common';
@@ -48,6 +49,7 @@ export const SupplySelection = ({
 }: SupplySelectionProps) => {
   const t = useTranslation();
   const { getPlural } = useIntlUtils();
+  const { round } = useFormatNumber();
 
   const currentValue = useMemo(
     (): number =>
@@ -92,11 +94,14 @@ export const SupplySelection = ({
 
   const valueInDoses = useMemo(() => {
     if (!displayVaccinesInDoses) return undefined;
-    return calculateValueInDoses(
-      representation,
-      defaultPackSize || 1,
-      dosesPerUnit,
-      value
+    return round(
+      calculateValueInDoses(
+        representation,
+        defaultPackSize || 1,
+        dosesPerUnit,
+        value
+      ),
+      2
     );
   }, [
     displayVaccinesInDoses,

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseStats/ResponseStoreStats.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseStats/ResponseStoreStats.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useIntlUtils, useTranslation } from '@common/intl';
+import { useFormatNumber, useIntlUtils, useTranslation } from '@common/intl';
 import { Box, Typography, NewValueBar } from '@openmsupply-client/common';
 import { RepresentationValue, useValueInUnitsOrPacks } from '../../../common';
 import { calculatePercentage, stats } from './utils';
@@ -27,10 +27,11 @@ export const ResponseStoreStats = ({
 }: ResponseStoreStatsProps) => {
   const t = useTranslation();
   const { getPlural } = useIntlUtils();
+  const { round } = useFormatNumber();
 
   const unit = unitName || t('label.unit');
 
-  const statsDisplay = stats(t, getPlural, unit, representation);
+  const statsDisplay = stats(t, getPlural, round, unit, representation);
 
   const formattedSoh = useValueInUnitsOrPacks(
     representation,

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseStats/utils.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseStats/utils.tsx
@@ -10,6 +10,7 @@ import { RepresentationValue, useEndAdornment } from '../../../common';
 type StatsInfoProps = {
   t: TypedTFunction<LocaleKey>;
   getPlural: (word: string, value: number) => string;
+  round: (value?: number, dp?: number) => string;
   unit: string;
   representation: RepresentationValue;
   label: LocaleKey;
@@ -20,6 +21,7 @@ type StatsInfoProps = {
 const StatsInfoValue = ({
   t,
   getPlural,
+  round,
   unit,
   representation,
   label,
@@ -47,7 +49,7 @@ const StatsInfoValue = ({
         alignItems: 'center',
       }}
     >
-      {value}
+      {round(value, 2)}
       &nbsp;
       {useEndAdornment(t, getPlural, unit, representation, value)}
     </Typography>
@@ -58,6 +60,7 @@ export const stats =
   (
     t: TypedTFunction<LocaleKey>,
     getPlural: (word: string, value: number) => string,
+    round: (value?: number, dp?: number) => string,
     unit: string,
     representation: RepresentationValue
   ) =>
@@ -72,6 +75,7 @@ export const stats =
       <StatsInfoValue
         t={t}
         getPlural={getPlural}
+        round={round}
         unit={unit}
         representation={representation}
         label={label}

--- a/client/packages/requisitions/src/common/ModalContentLayout.tsx
+++ b/client/packages/requisitions/src/common/ModalContentLayout.tsx
@@ -57,7 +57,7 @@ interface InfoRowProps {
   packagingDisplay?: string;
   sx?: SxProps<Theme>;
   displayVaccinesInDoses?: boolean;
-  doses?: number;
+  doses?: number | string;
   dosesLabel?: string;
 }
 
@@ -179,7 +179,7 @@ export const ValueInfoRow = ({
       packagingDisplay={treatAsNull ? '' : endAdornment}
       sx={sx}
       displayVaccinesInDoses={displayVaccinesInDoses}
-      doses={valueInDoses}
+      doses={round(valueInDoses, 2)}
       dosesLabel={t('label.doses')}
     />
   );

--- a/client/packages/requisitions/src/common/utils.ts
+++ b/client/packages/requisitions/src/common/utils.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import { LocaleKey, TypedTFunction } from '@common/intl';
-import { NumUtils } from '@common/utils';
 import { ModalMode } from '@common/hooks';
 
 export const Representation = {
@@ -40,9 +39,9 @@ export const calculateValueInDoses = (
 ): number => {
   if (!value) return 0;
   if (representation === Representation.PACKS) {
-    return NumUtils.round(value * defaultPackSize * dosesPerUnit, 2);
+    return value * defaultPackSize * dosesPerUnit;
   }
-  return NumUtils.round(value * dosesPerUnit, 2);
+  return value * dosesPerUnit;
 };
 
 export const useEndAdornment = (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8052

# 👩🏻‍💻 What does this PR do?
- Full screen modal `X` button to cancel functions like the cancel button
- Dose number formatting for readability

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a small screen (tablet).
- [ ] Add requisition or internal order line
- [ ] Click `x`
- [ ] Line shouldn't have been added
- [ ] Large dose numbers should be formatted (e.g. 1,000 instead of 1000)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

