### PR TITLE
7755 load test measure and report

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -44,3 +44,6 @@ report_builder/config.yaml
 
 # fridge tag imports
 sensor_*.txt
+
+# Load test artifacts
+load_test/

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2019,6 +2019,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_yml",
  "server",
  "service",
  "shellexpand",
@@ -4658,7 +4659,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -5378,6 +5379,16 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
 ]
 
 [[package]]
@@ -7664,6 +7675,21 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yml"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyml",
+ "memchr",
+ "ryu",
+ "serde",
+ "version_check",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -3,10 +3,7 @@ strip = true
 
 [workspace.dependencies]
 # dependencies used in graphql crates:
-actix-web = { version = "4.9.0", default-features = false, features = [
-  "macros",
-  "rustls",
-] }
+actix-web = { version = "4.9.0", default-features = false, features = ["macros", "rustls"] }
 actix-multipart = "0.7.2"
 anymap = "0.12.1"
 async-graphql = { version = "7.0.13", features = ["dataloader", "chrono"] }
@@ -35,7 +32,7 @@ sha2 = "0.10.8"
 simple-log = { version = "2.0.2" }
 strum = { version = "0.26.3", features = ["derive"] }
 thiserror = "1.0.30"
-tokio = { version = "1.42.0", features = ["macros"] }
+tokio = { version = "1.42.0", features = ["macros", "process"] }
 # dev dependencies used in graphql crates:
 actix-rt = "2.10.0"
 assert-json-diff = "2.0.2"
@@ -44,8 +41,8 @@ rand = "0.8.5"
 anyhow = "1.0.95"
 actix-files = "0.6.6"
 log-panics = { version = "2.1.0", features = ["with-backtrace"] }
-base64 =  "0.22.1"
-ts-rs =  { version = "10.1", features = ["chrono-impl", "serde-json-impl"] }
+base64 = "0.22.1"
+ts-rs = { version = "10.1", features = ["chrono-impl", "serde-json-impl"] }
 
 # TODO: Remove. async_graphql is using 1.0 but SET_COOKIE was being imported from wrong version.
 http2 = { package = "http", version = "1.0.0" }
@@ -95,5 +92,5 @@ members = [
   "graphql/types",
   "graphql/vaccine_course",
   "cli",
-  "windows"
+  "windows",
 ]

--- a/server/cli/Cargo.toml
+++ b/server/cli/Cargo.toml
@@ -56,3 +56,4 @@ actix-rt = { workspace = true }
 default = ["sqlite"]
 sqlite = ["server/sqlite"]
 postgres = ["server/postgres"]
+integration_test = []

--- a/server/cli/Cargo.toml
+++ b/server/cli/Cargo.toml
@@ -22,7 +22,7 @@ util = { path = "../util" }
 service = { path = "../service" }
 server = { path = "../server" }
 graphql = { path = "../graphql" }
-report_builder = {path = "../report_builder"}
+report_builder = { path = "../report_builder" }
 
 
 anyhow = { workspace = true }
@@ -47,6 +47,7 @@ async-trait = "0.1.8"
 machine-uid = { version = "0.5.1" }
 copy_dir = "0.1.3"
 shellexpand = "3.1.0"
+serde_yml = "0.0.12"
 
 [dev-dependencies]
 actix-rt = { workspace = true }

--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -709,7 +709,7 @@ async fn main() -> anyhow::Result<()> {
             test_site_name,
             test_site_pass,
             sites,
-            invoice_lines,
+            lines,
             duration,
         }) => {
             let load_test = LoadTest::new(
@@ -719,7 +719,7 @@ async fn main() -> anyhow::Result<()> {
                 test_site_name,
                 test_site_pass,
                 sites,
-                invoice_lines,
+                lines,
                 duration,
             );
             load_test.run().await?;

--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -45,10 +45,12 @@ use util::inline_init;
 mod backup;
 use backup::*;
 
+#[cfg(feature = "integration_test")]
+use cli::LoadTest;
 use cli::{
     generate_and_install_plugin_bundle, generate_plugin_bundle, generate_report_data,
     generate_reports_recursive, generate_typescript_types, install_plugin_bundle,
-    GenerateAndInstallPluginBundle, GeneratePluginBundle, InstallPluginBundle, LoadTest,
+    GenerateAndInstallPluginBundle, GeneratePluginBundle, InstallPluginBundle,
     RefreshDatesRepository, ReportError,
 };
 
@@ -211,6 +213,7 @@ enum Action {
     /// Generate TypeScript Types for backend plugins and format with Prettier
     GenerateTypeScriptTypes,
     /// Run load test
+    #[cfg(feature = "integration_test")]
     LoadTest(LoadTest),
 }
 
@@ -702,6 +705,7 @@ async fn main() -> anyhow::Result<()> {
         Action::GenerateTypeScriptTypes => {
             generate_typescript_types()?;
         }
+        #[cfg(feature = "integration_test")]
         Action::LoadTest(LoadTest {
             url,
             base_port,

--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -709,7 +709,8 @@ async fn main() -> anyhow::Result<()> {
         }
         #[cfg(feature = "integration_test")]
         Action::LoadTest(LoadTest {
-            url,
+            msupply_central_url,
+            oms_central_url,
             base_port,
             output_dir,
             test_site_name,
@@ -719,7 +720,8 @@ async fn main() -> anyhow::Result<()> {
             duration,
         }) => {
             let load_test = LoadTest::new(
-                url,
+                msupply_central_url,
+                oms_central_url,
                 base_port,
                 output_dir,
                 test_site_name,

--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -22,7 +22,7 @@ use service::{
     login::{LoginInput, LoginService},
     plugin::validation::sign_plugin,
     service_provider::{ServiceContext, ServiceProvider},
-    settings::{Level, Settings},
+    settings::Settings,
     standard_reports::{ReportData, ReportsData, StandardReports},
     sync::{
         file_sync_driver::FileSyncDriver, settings::SyncSettings, sync_status::logger::SyncLogger,

--- a/server/cli/src/lib.rs
+++ b/server/cli/src/lib.rs
@@ -15,5 +15,7 @@ pub use plugins::*;
 mod generate_typescript_types;
 pub use generate_typescript_types::*;
 
+#[cfg(feature = "integration_test")]
 mod load_test;
+#[cfg(feature = "integration_test")]
 pub use load_test::*;

--- a/server/cli/src/load_test.rs
+++ b/server/cli/src/load_test.rs
@@ -1,7 +1,7 @@
-use std::{io::Write, path::PathBuf};
+use std::{path::PathBuf, time::Duration};
 
 use repository::database_settings::DatabaseSettings;
-use reqwest::Client;
+use reqwest::{Client, Error};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use serde_yml;
@@ -9,8 +9,47 @@ use service::{
     settings::{DiscoveryMode, ServerSettings, Settings},
     sync::settings::{BatchSize, SyncSettings},
 };
+use tokio::{process::Child, time::sleep};
 use util::uuid::uuid;
 const TEST_API: &str = "sync/v5/test";
+
+const SYNC_INFO_QUERY: &str = r#"
+query SyncInfo {
+  latestSyncStatus { isSyncing }
+}
+"#;
+
+const MANUAL_SYNC_QUERY: &str = r#"
+mutation ManualSync {
+  manualSync
+}
+"#;
+
+const STOCK_TAKE_MUTATION: &str = r#"
+mutation InsertStockTake($storeId: String!, $input: InsertStocktakeInput!) {
+  insertStocktake(storeId: $storeId, input: $input) {
+    ... on StocktakeNode {
+      id
+    }
+  }
+}
+"#;
+
+const STOCK_TAKE_LINE_MUTATION: &str = r#"
+mutation InsertStockTakeLine ($storeId: String!, $input: InsertStocktakeLineInput!) {
+  insertStocktakeLine (storeId: $storeId, input: $input) {
+    __typename
+    ... on StocktakeLineNode {
+      id
+    }
+    ... on InsertStocktakeLineError{
+      error {
+        description
+      }
+    }
+  }
+}
+"#;
 
 #[derive(clap::Args)]
 pub struct LoadTest {
@@ -47,7 +86,7 @@ pub struct LoadTest {
     pub duration: usize,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 struct SyncSite {
     #[serde(rename = "site_ID")]
     site_id: usize,
@@ -55,17 +94,42 @@ struct SyncSite {
     #[serde(rename = "password")]
     password_sha256: String,
 }
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 struct SyncStore {
     #[serde(rename = "ID")]
     id: String,
     #[serde(rename = "name_ID")]
     name_id: String,
 }
-#[derive(Deserialize, Debug)]
-pub(crate) struct SiteNStore {
+#[derive(Deserialize, Debug, Clone)]
+struct SiteNStore {
     site: SyncSite,
     store: SyncStore,
+}
+
+#[derive(Deserialize, Clone)]
+struct TestSite {
+    site: SyncSite,
+    store: SyncStore,
+    settings: Settings,
+    next_store: SyncStore,
+    config_file_path: PathBuf,
+}
+
+#[derive(Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct SyncInfo {
+    data: LatestSyncStatus,
+}
+#[derive(Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct LatestSyncStatus {
+    latest_sync_status: SyncStatus,
+}
+#[derive(Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct SyncStatus {
+    is_syncing: bool,
 }
 
 impl LoadTest {
@@ -92,9 +156,7 @@ impl LoadTest {
     }
 
     pub async fn run(&self) -> anyhow::Result<()> {
-        use std::process::Command;
-        use std::time::Duration;
-        use tokio::time::sleep;
+        use tokio::process::Command;
         use util::hash::sha256;
 
         println!("Starting load test with the following parameters:");
@@ -106,6 +168,7 @@ impl LoadTest {
         println!("Invoice Lines: {}", self.invoice_lines);
         println!("Duration: {} seconds", self.duration);
 
+        std::fs::remove_dir_all(&self.output_dir).ok();
         // Creating the sites on OG central
         let body = r#"{"visibleNameIds":[]}"#;
         let client = Client::new();
@@ -135,19 +198,71 @@ impl LoadTest {
             }
         }
 
-        // Creating name store joins between each site's store and the next
-        let mut name_store_joins: Vec<Value> = Vec::new();
-
-        for i in 0..site_n_stores.len() {
+        let mut test_sites: Vec<TestSite> = Vec::new();
+        for (i, site_n_store) in site_n_stores.iter().enumerate() {
             let next = if i >= site_n_stores.len() - 1 {
                 0
             } else {
                 i + 1
             };
+
+            let port = self.base_port + (i * 2) as u16;
+            let database_path = self.output_dir.display();
+            let settings = Settings {
+                server: ServerSettings {
+                    port,
+                    danger_allow_http: true,
+                    debug_no_access_control: true, // Allow us to use GQL on the remote sites without auth
+                    discovery: DiscoveryMode::Disabled,
+                    cors_origins: vec![],
+                    base_dir: Some(database_path.to_string()),
+                    machine_uid: Some("1337_test".to_owned()),
+                },
+                database: DatabaseSettings {
+                    username: "postgres".to_owned(),
+                    password: "password".to_owned(),
+                    port: 5432,
+                    host: "localhost".to_owned(),
+                    database_name: format!("site_{}", site_n_store.site.site_id),
+                    database_path: Some(database_path.to_string()),
+                    init_sql: None,
+                },
+                sync: Some(SyncSettings {
+                    url: self.url.clone(),
+                    username: site_n_store.site.name.clone(),
+                    password_sha256: site_n_store.site.password_sha256.clone(),
+                    interval_seconds: 600,
+                    batch_size: BatchSize {
+                        remote_pull: 512,
+                        remote_push: 512,
+                        central_pull: 512,
+                    },
+                }),
+                logging: None,
+                backup: None,
+                mail: None,
+            };
+
+            let full_site = TestSite {
+                site: site_n_store.site.clone(),
+                store: site_n_store.store.clone(),
+                settings,
+                next_store: site_n_stores[next].store.clone(),
+                config_file_path: self
+                    .output_dir
+                    .join(format!("site_{}_config.yaml", site_n_store.site.site_id)),
+            };
+
+            test_sites.push(full_site);
+        }
+
+        // Creating name store joins between each site's store and the next
+        let mut name_store_joins: Vec<Value> = Vec::new();
+        for test_site in &test_sites {
             let name_store_join1 = json!({
                 "ID": &uuid(),
-                "name_ID": site_n_stores[next].store.name_id,
-                "store_ID": site_n_stores[i].store.id,
+                "name_ID": test_site.next_store.name_id,
+                "store_ID": test_site.store.id,
                 "om_name_is_customer": true,
                 "om_name_is_supplier": true,
             });
@@ -155,15 +270,22 @@ impl LoadTest {
 
             let name_store_join2 = json!({
                 "ID": &uuid(),
-                "name_ID": site_n_stores[i].store.name_id,
-                "store_ID": site_n_stores[next].store.id,
+                "name_ID": test_site.store.name_id,
+                "store_ID": test_site.next_store.id,
                 "om_name_is_customer": true,
                 "om_name_is_supplier": true,
             });
             name_store_joins.push(name_store_join2);
         }
-
-        let body = json!({"name_store_join": name_store_joins}).to_string();
+        let item_id = uuid();
+        let item = json!( [{
+            "ID": item_id,
+            "type_of": "general",
+            "code": "test_item_code",
+            "item_name": "test_item",
+            "default_pack_size": 12,
+        }]);
+        let body = json!({"name_store_join": name_store_joins, "item": item}).to_string();
         let response = client
             .post(url.clone() + "/upsert")
             .header("app-name", "load_test")
@@ -218,93 +340,194 @@ impl LoadTest {
         let base_config_path = self.output_dir.join("base.yaml");
         std::fs::write(base_config_path, serde_yml::to_string(&base_config)?)?;
 
-        for (i, site_n_store) in site_n_stores.iter().enumerate() {
-            let port = self.base_port + (i * 2) as u16;
-            let config_file_path = self.output_dir.join(format!(
-                "site_{}_config.yaml",
-                site_n_store.site.site_id + 1
-            ));
-            let database_path = self.output_dir.display();
-
-            let config = Settings {
-                server: ServerSettings {
-                    port,
-                    danger_allow_http: true,
-                    debug_no_access_control: true, // Allow us to use GQL on the remote sites without auth
-                    discovery: DiscoveryMode::Disabled,
-                    cors_origins: vec![],
-                    base_dir: Some(database_path.to_string()),
-                    machine_uid: Some("1337_test".to_owned()),
-                },
-                database: DatabaseSettings {
-                    username: "postgres".to_owned(),
-                    password: "password".to_owned(),
-                    port: 5432,
-                    host: "localhost".to_owned(),
-                    database_name: format!("site_{}", site_n_store.site.site_id),
-                    database_path: Some(database_path.to_string()),
-                    init_sql: None,
-                },
-                sync: Some(SyncSettings {
-                    url: self.url.clone(),
-                    username: site_n_store.site.name.clone(),
-                    password_sha256: site_n_store.site.password_sha256.clone(),
-                    interval_seconds: 600,
-                    batch_size: BatchSize {
-                        remote_pull: 512,
-                        remote_push: 512,
-                        central_pull: 512,
-                    },
-                }),
-                logging: None,
-                backup: None,
-                mail: None,
-            };
-
-            std::fs::write(&config_file_path, serde_yml::to_string(&config)?)?;
-            println!("Created config file {:?}", config_file_path);
+        for test_site in &test_sites {
+            std::fs::write(
+                &test_site.config_file_path.clone(),
+                serde_yml::to_string(&test_site.settings.clone())?,
+            )?;
         }
 
         // Start each remote OMS instance
         println!("Starting remote OMS instances...");
-        let mut child_processes = Vec::new();
+        let mut handles = Vec::new();
+        let duration = self.duration as u64;
+        let num_lines = self.invoice_lines;
 
-        let output = Command::new("pwd").output()?;
-        std::io::stdout().write_all(&output.stdout)?;
+        for test_site in test_sites {
+            let dir = self.output_dir.clone();
+            let item_id_copy = item_id.clone();
+            let handle = tokio::spawn(async move {
+                let log = std::fs::File::create(
+                    dir.join(format!("site_{}_output.log", test_site.site.site_id)),
+                )
+                .unwrap();
+                let mut child = match Command::new("cargo") // TODO: be better to run prod binary instead
+                    .arg("run")
+                    .arg("--")
+                    .arg("--config-path")
+                    .arg(&test_site.config_file_path)
+                    .stdout(log.try_clone().unwrap())
+                    .stderr(log)
+                    .kill_on_drop(true)
+                    .spawn()
+                {
+                    Ok(child) => child,
+                    Err(e) => {
+                        println!("Failed to spawn process: {}", e);
+                        return;
+                    }
+                };
+                sleep(Duration::from_secs(20)).await; // Let db get created, migrated and initialisation started
+                let client = Client::new();
+                let remote_url = format!("http://localhost:{}", test_site.settings.server.port);
+                let graphql_url = format!("{}/{}", remote_url, "graphql");
 
-        for site_n_store in site_n_stores.iter() {
-            let config_file_path = self
-                .output_dir
-                .join(format!("site_{}_config.yaml", site_n_store.site.site_id));
+                if wait_for_sync(&client, &graphql_url).await.is_err() {
+                    kill(&mut child).await;
+                    return;
+                }
 
-            let child = Command::new("cargo")
-                .arg("run")
-                .arg("--")
-                .arg("--config-path")
-                .arg(&config_file_path)
-                .spawn()?;
+                let start = std::time::Instant::now();
+                loop {
+                    let stock_take_id = uuid();
+                    let stock_take_gql = json!({
+                        "operationName": "InsertStockTake",
+                        "query": STOCK_TAKE_MUTATION,
+                        "variables": {"storeId": test_site.store.id, "input": {"id": stock_take_id}}
+                    });
+                    match client
+                        .post(&graphql_url)
+                        .header(
+                            "Authorization",
+                            "is disabled :) but still need a token to pretend",
+                        )
+                        .body(stock_take_gql.to_string())
+                        .send()
+                        .await
+                    {
+                        Ok(response) => response,
+                        Err(e) => {
+                            println!("Failed to make stocktake request: {}", e);
+                            kill(&mut child).await;
+                            return;
+                        }
+                    };
 
-            child_processes.push(child);
+                    for i in 0..num_lines {
+                        let line_gql = json!({
+                            "operationName": "InsertStockTakeLine",
+                            "query": STOCK_TAKE_LINE_MUTATION,
+                            "variables": {"storeId": test_site.store.id, "input": {"id": uuid(), "stocktakeId": stock_take_id, "itemId": item_id_copy, "countedNumberOfPacks": i, "packSize": i, "batch": "abc-123" } }
+                        });
+                        match client
+                            .post(&graphql_url)
+                            .header(
+                                "Authorization",
+                                "is disabled :) but still need a token to pretend",
+                            )
+                            .body(line_gql.to_string())
+                            .send()
+                            .await
+                        {
+                            Ok(response) => response,
+                            Err(e) => {
+                                println!("Failed to make stocktake line request: {}", e);
+                                kill(&mut child).await;
+                                return;
+                            }
+                        };
+                    }
 
-            // Give a little time for the instance to start before launching the next one
-            sleep(Duration::from_millis(200)).await
+                    let sync_gql = json!({
+                        "operationName": "manualSync",
+                        "query": MANUAL_SYNC_QUERY,
+                    });
+                    match client
+                        .post(&graphql_url)
+                        .header(
+                            "Authorization",
+                            "is disabled :) but still need a token to pretend",
+                        )
+                        .body(sync_gql.to_string())
+                        .send()
+                        .await
+                    {
+                        Ok(response) => response,
+                        Err(e) => {
+                            println!("Failed to make stocktake request: {}", e);
+                            kill(&mut child).await;
+                            return;
+                        }
+                    };
+
+                    if wait_for_sync(&client, &graphql_url).await.is_err() {
+                        kill(&mut child).await;
+                        return;
+                    }
+
+                    if start.elapsed().as_secs() >= duration {
+                        kill(&mut child).await;
+                        break;
+                    }
+                }
+            });
+            handles.push(handle)
         }
 
-        // Run for the specified duration
-        println!("Running test for {} seconds", self.duration);
-        sleep(Duration::from_secs(self.duration as u64)).await;
-
-        // Terminate all child processes
-        for mut child in child_processes {
-            match child.kill() {
-                Ok(_) => println!("Process terminated successfully"),
-                Err(_) => println!("Failed to kill process {:?}", child),
+        for handle in handles {
+            if let Err(e) = handle.await {
+                println!("Error joining task: {}", e);
             }
         }
 
-        std::fs::remove_dir_all(&self.output_dir)?;
-
         println!("end");
         Ok(())
+    }
+}
+
+async fn kill(child: &mut Child) {
+    match child.kill().await {
+        Ok(_) => println!("Child terminated successfully"),
+        Err(e) => println!("Failed to kill child: {}", e),
+    }
+}
+
+async fn wait_for_sync(client: &Client, graphql_url: &String) -> Result<(), Error> {
+    loop {
+        sleep(Duration::from_secs(1)).await;
+        let sync_gql = json!({
+            "operationName": "SyncInfo",
+            "query": SYNC_INFO_QUERY,
+        });
+        let response = match client
+            .post(graphql_url)
+            .header(
+                "Authorization",
+                "is disabled :) but still need a token to pretend",
+            )
+            .body(sync_gql.to_string())
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(e) => {
+                println!("SyncInfo request failed: {}", e);
+                return Err(e);
+            }
+        };
+
+        if response.status().is_success() {
+            match response.json::<SyncInfo>().await {
+                Ok(sync_info) => {
+                    if !sync_info.data.latest_sync_status.is_syncing {
+                        return Ok(());
+                    }
+                }
+                Err(e) => println!("Error parsing SyncInfo: {}", e),
+            };
+        } else {
+            dbg!(&response);
+            dbg!(&response.text().await.unwrap());
+        }
     }
 }

--- a/server/cli/src/load_test.rs
+++ b/server/cli/src/load_test.rs
@@ -9,6 +9,7 @@ use service::{
     sync::settings::{BatchSize, SyncSettings},
 };
 use std::{
+    collections::HashMap,
     io::Write,
     path::PathBuf,
     time::{Duration, Instant},
@@ -647,8 +648,7 @@ impl LoadTest {
             // Group metrics by 5-second intervals
             let mut grouped_metrics: Vec<(u64, usize, usize)> = Vec::new();
             // Create a map to group metrics by 5-second intervals
-            let mut interval_map: std::collections::HashMap<u64, (usize, usize)> =
-                std::collections::HashMap::new();
+            let mut interval_map: HashMap<u64, (usize, usize)> = HashMap::new();
 
             // Determine the first start time as the reference point
             let first_start = results

--- a/server/cli/src/load_test.rs
+++ b/server/cli/src/load_test.rs
@@ -1,4 +1,5 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use log::{error, info};
 use repository::database_settings::DatabaseSettings;
 use reqwest::{Client, Error, Response};
 use serde::{Deserialize, Serialize};
@@ -18,77 +19,9 @@ use tokio::{process::Child, task::JoinHandle, time::sleep};
 use util::uuid::uuid;
 const TEST_API: &str = "sync/v5/test";
 
-const SYNC_INFO_QUERY: &str = r#"
-query SyncInfo {
-  latestSyncStatus {
-    isSyncing
-    push {
-      done
-    }
-    pushV6 {
-      done
-    }
-    pullV6 {
-      done
-    }
-    pullRemote {
-      done
-    }
-    pullCentral {
-      done
-    }
-  }
-}
-"#;
-
 const MANUAL_SYNC_QUERY: &str = r#"
 mutation ManualSync {
   manualSync
-}
-"#;
-
-const INSERT_REQUISITION_MUTATION: &str = r#"
-mutation InsertRequestRequisition($storeId: String!, $input: InsertRequestRequisitionInput!) {
-  insertRequestRequisition(storeId:$storeId, input: $input){
-    ... on RequisitionNode {
-      id
-    }
-    ... on InsertRequestRequisitionError {
-      error {
-        description
-      }
-    }
-  }
-}
-"#;
-
-const BATCH_REQUISITION_LINES_MUTATION: &str = r#"
-mutation BatchRequestRequisitionLineInsert ($storeId: String!, $input: BatchRequestRequisitionInput!) {
-  batchRequestRequisition(storeId:$storeId, input:$input){
-    ... on BatchRequestRequisitionResponse {
-      insertRequestRequisitionLines  {
-        id
-      }
-      updateRequestRequisitionLines{
-        id
-      }
-    }
-  }
-}
-"#;
-
-const UPDATE_REQUISITION_MUTATION: &str = r#"
-mutation UpdateRequestRequisition ($storeId: String!, $input: UpdateRequestRequisitionInput!) {
-  updateRequestRequisition(storeId: $storeId, input: $input) {
-    ... on RequisitionNode {
-    	id
-    }
-    ... on UpdateRequestRequisitionError {
-      error {
-        description
-      }
-    }
-  }
 }
 "#;
 
@@ -205,6 +138,40 @@ impl Metric {
             pulled: 0,
         }
     }
+
+    fn update_sync_metrics(&mut self, site_info: &SyncInfo) {
+        self.pushed = site_info
+            .data
+            .latest_sync_status
+            .push_v6
+            .as_ref()
+            .map_or(0, |s| s.done.unwrap_or(0))
+            + site_info
+                .data
+                .latest_sync_status
+                .push
+                .as_ref()
+                .map_or(0, |s| s.done.unwrap_or(0));
+
+        self.pulled = site_info
+            .data
+            .latest_sync_status
+            .pull_v6
+            .as_ref()
+            .map_or(0, |s| s.done.unwrap_or(0))
+            + site_info
+                .data
+                .latest_sync_status
+                .pull_remote
+                .as_ref()
+                .map_or(0, |s| s.done.unwrap_or(0))
+            + site_info
+                .data
+                .latest_sync_status
+                .pull_central
+                .as_ref()
+                .map_or(0, |s| s.done.unwrap_or(0));
+    }
 }
 
 impl LoadTest {
@@ -243,45 +210,264 @@ impl LoadTest {
         println!("Invoice Lines: {}", self.lines);
         println!("Duration: {} seconds", self.duration);
 
-        std::fs::remove_dir_all(&self.output_dir).ok();
+        std::fs::remove_dir_all(&self.output_dir)?;
+
         // Creating the sites on OG central
         let client = Client::new();
         let test_site_name = self.test_site_name.as_ref().unwrap();
         let test_site_pass = Some(sha256(self.test_site_pass.as_ref().unwrap()));
-        let mut site_n_stores: Vec<SiteNStore> = Vec::new();
         let num_sites = if self.sites > 1 { self.sites } else { 2 };
-        let mut last_store_name_id: Option<String> = None;
-        for _ in 0..num_sites {
-            let body = if last_store_name_id.is_some() {
-                json!({"visibleNameIds": [last_store_name_id]})
-            } else {
-                json!({"visibleNameIds": []})
-            }
-            .to_string();
+        let site_n_stores =
+            create_sites(&url, &client, test_site_name, &test_site_pass, num_sites).await?;
 
-            let response = client
-                .post(url.clone() + "/create_site")
-                .header("app-name", "load_test")
-                .header("app-version", "0")
-                .header("msupply-site-uuid", "load_test")
-                .header("sync-version", "9")
-                .header("content-length", body.len())
-                .basic_auth(test_site_name, test_site_pass.to_owned())
-                .body(body)
-                .send()
-                .await?;
+        let test_sites = self.create_test_sites(site_n_stores);
 
-            if response.status().is_success() {
-                let site_n_store: SiteNStore = response.json().await?;
-                last_store_name_id = Some(site_n_store.store.name_id.clone());
-                site_n_stores.push(site_n_store);
-            } else {
-                dbg!(&response);
-                dbg!(&response.text().await?);
-                return Ok(());
+        let item_ids = self
+            .create_items(url, client, test_site_name, test_site_pass)
+            .await?;
+
+        self.create_configs(&test_sites)?;
+
+        // Start each remote OMS instance
+        println!("Starting remote OMS instances...");
+        let mut handles = Vec::new();
+        let duration = self.duration as u64;
+        let num_lines = self.lines;
+
+        for test_site in test_sites {
+            let dir = self.output_dir.clone();
+            let item_ids_copy = item_ids.clone();
+            let handle: JoinHandle<anyhow::Result<Vec<Metric>>> = tokio::spawn(async move {
+                let log = std::fs::File::create(
+                    dir.join(format!("site_{}_output.log", test_site.site.site_id)),
+                )?;
+
+                let mut child = Command::new("./target/debug/remote_server") // TODO: be better to run prod binary instead
+                    .arg("--config-path")
+                    .arg(&test_site.config_file_path)
+                    .stdout(log.try_clone().unwrap())
+                    .stderr(log)
+                    .env("RUST_LOG", "none")
+                    .kill_on_drop(true)
+                    .spawn()?;
+
+                sleep(Duration::from_secs(10)).await; // Let db get created, migrated and initialisation started
+
+                info!(
+                    "Site {} started, waiting for initial sync to complete",
+                    test_site.site.site_id
+                );
+                if let Err(e) = test_site.wait_for_sync().await {
+                    kill(&mut child).await;
+                    return Err(e);
+                }
+
+                info!("Beginning load test for site: {}", test_site.site.site_id);
+
+                let start = std::time::Instant::now();
+                let mut metrics = Vec::new();
+                loop {
+                    let mut metric = Metric::new(test_site.site.site_id);
+                    if let Err(e) =
+                        create_and_send_requisition(&test_site, num_lines, &item_ids_copy).await
+                    {
+                        kill(&mut child).await;
+                        return Err(e);
+                    };
+
+                    let sync_gql = json!({
+                        "operationName": "ManualSync",
+                        "query": MANUAL_SYNC_QUERY,
+                    });
+                    match test_site.do_post(&sync_gql).await {
+                        Ok(response) => response,
+                        Err(e) => {
+                            println!("manualSync request failed: {}", e);
+                            kill(&mut child).await;
+                            return Err(e.into());
+                        }
+                    };
+
+                    let site_info = match test_site.wait_for_sync().await {
+                        Ok(site_info) => site_info,
+                        Err(e) => {
+                            kill(&mut child).await;
+                            return Err(e.into());
+                        }
+                    };
+
+                    metric.end_time = std::time::Instant::now();
+                    metric.update_sync_metrics(&site_info);
+                    println!(
+                        "Site {}: Pushed: {}, Pulled: {}, Duration: {:?}",
+                        test_site.site.site_id,
+                        metric.pushed,
+                        metric.pulled,
+                        metric.end_time.duration_since(metric.start_time)
+                    );
+
+                    metrics.push(metric);
+
+                    if start.elapsed().as_secs() >= duration {
+                        kill(&mut child).await;
+                        break;
+                    }
+                }
+                Ok(metrics)
+            });
+            handles.push(handle)
+        }
+
+        let mut results: Vec<Metric> = Vec::new();
+        for handle in handles {
+            match handle.await {
+                Ok(metric) => results.append(&mut metric?),
+                Err(e) => println!("Error joining task: {}", e),
             }
         }
 
+        // Aggregate the results into groups of 5 seconds
+        println!("\nProcessing results...");
+
+        self.write_results(results);
+
+        println!("end");
+        Ok(())
+    }
+
+    fn write_results(&self, results: Vec<Metric>) {
+        // Group metrics by 5-second intervals
+        if !results.is_empty() {
+            // open a file to write the results
+            // The first line of the file should be csv headers "time, records pushed, records pulled"
+            let output_file = self.output_dir.join("load_test_results.txt");
+            let mut file =
+                std::fs::File::create(output_file).expect("Failed to create output file");
+            writeln!(file, "time, records pushed, records pulled")
+                .expect("Failed to write to output file");
+
+            // Group metrics by 5-second intervals
+            let mut grouped_metrics: Vec<(u64, usize, usize)> = Vec::new();
+            // Create a map to group metrics by 5-second intervals
+            let mut interval_map: HashMap<u64, (usize, usize)> = HashMap::new();
+
+            // Determine the first start time as the reference point
+            let first_start = results
+                .iter()
+                .map(|m| m.start_time)
+                .min()
+                .unwrap_or(Instant::now());
+
+            // Group metrics by their start time intervals
+            for metric in &results {
+                let seconds_since_start = metric.start_time.duration_since(first_start).as_secs();
+                let interval = seconds_since_start / 5;
+
+                let entry = interval_map.entry(interval).or_insert((0, 0));
+                entry.0 += metric.pushed;
+                entry.1 += metric.pulled;
+            }
+
+            // Convert the map to a sorted vector
+            let mut keys: Vec<_> = interval_map.keys().collect();
+            keys.sort();
+
+            for key in keys {
+                if let Some(&(pushed, pulled)) = interval_map.get(key) {
+                    grouped_metrics.push((*key, pushed, pulled));
+                }
+            }
+            for (interval, pushed, pulled) in grouped_metrics {
+                writeln!(file, "{}, {}, {}", (interval + 1) * 5, pushed, pulled)
+                    .expect("Failed to write to output file");
+            }
+        } else {
+            println!("No results collected during the test.");
+        }
+    }
+
+    fn create_configs(&self, test_sites: &Vec<TestSite>) -> Result<(), anyhow::Error> {
+        if !self.output_dir.exists() {
+            std::fs::create_dir_all(&self.output_dir)?;
+        }
+        let base_config = Settings {
+            server: ServerSettings {
+                port: 8000,
+                danger_allow_http: true,
+                debug_no_access_control: true,
+                discovery: DiscoveryMode::Disabled,
+                cors_origins: vec![
+                    "http://localhost:3003".to_string(),
+                    "https://demo-open.msupply.org".to_string(),
+                    "http://localhost:8000".to_string(),
+                ],
+                base_dir: Some("app_data".to_string()),
+                machine_uid: None,
+            },
+            database: DatabaseSettings {
+                username: "postgres".to_owned(),
+                password: "password".to_owned(),
+                port: 5432,
+                host: "localhost".to_owned(),
+                database_name: "omsupply-database".to_string(),
+                database_path: None,
+                init_sql: None,
+            },
+            logging: None,
+            backup: None,
+            mail: None,
+            sync: None,
+        };
+        let base_config_path = self.output_dir.join("base.yaml");
+        std::fs::write(base_config_path, serde_yml::to_string(&base_config)?)?;
+        Ok(for test_site in test_sites {
+            std::fs::write(
+                &test_site.config_file_path.clone(),
+                serde_yml::to_string(&test_site.settings.clone())?,
+            )?;
+        })
+    }
+
+    async fn create_items(
+        &self,
+        url: String,
+        client: Client,
+        test_site_name: &String,
+        test_site_pass: Option<String>,
+    ) -> Result<Vec<String>, anyhow::Error> {
+        let item_ids: Vec<String> = (0..self.lines).map(|_| uuid()).collect();
+        let items: Vec<Value> = item_ids
+            .iter()
+            .map(|id| {
+                json!({
+                    "ID": id,
+                    "type_of": "general",
+                    "code": "test_item_code",
+                    "item_name": "test_item",
+                    "default_pack_size": 12,
+                })
+            })
+            .collect();
+        let body = json!({"item": items}).to_string();
+        let response = client
+            .post(url.clone() + "/upsert")
+            .header("app-name", "load_test")
+            .header("app-version", "0")
+            .header("msupply-site-uuid", "load_test")
+            .header("sync-version", "9")
+            .header("content-length", body.len())
+            .basic_auth(test_site_name, test_site_pass.to_owned())
+            .body(body)
+            .send()
+            .await?;
+        if !response.status().is_success() {
+            let message = response.text().await?;
+            return Err(anyhow!("Failed to create items: {}", message));
+        }
+        Ok(item_ids)
+    }
+
+    fn create_test_sites(&self, site_n_stores: Vec<SiteNStore>) -> Vec<TestSite> {
         let mut test_sites: Vec<TestSite> = Vec::new();
         for (i, site_n_store) in site_n_stores.iter().enumerate() {
             let next = if i >= site_n_stores.len() - 1 {
@@ -341,23 +527,29 @@ impl LoadTest {
 
             test_sites.push(full_site);
         }
+        test_sites
+    }
+}
 
-        let item_ids: Vec<String> = (0..self.lines).map(|_| uuid()).collect();
-        let items: Vec<Value> = item_ids
-            .iter()
-            .map(|id| {
-                json!({
-                    "ID": id,
-                    "type_of": "general",
-                    "code": "test_item_code",
-                    "item_name": "test_item",
-                    "default_pack_size": 12,
-                })
-            })
-            .collect();
-        let body = json!({"item": items}).to_string();
+async fn create_sites(
+    url: &String,
+    client: &Client,
+    test_site_name: &String,
+    test_site_pass: &Option<String>,
+    num_sites: usize,
+) -> Result<Vec<SiteNStore>, anyhow::Error> {
+    let mut last_store_name_id: Option<String> = None;
+    let mut site_n_stores: Vec<SiteNStore> = Vec::new();
+    for _ in 0..num_sites {
+        let body = if last_store_name_id.is_some() {
+            json!({"visibleNameIds": [last_store_name_id]})
+        } else {
+            json!({"visibleNameIds": []})
+        }
+        .to_string();
+
         let response = client
-            .post(url.clone() + "/upsert")
+            .post(url.clone() + "/create_site")
             .header("app-name", "load_test")
             .header("app-version", "0")
             .header("msupply-site-uuid", "load_test")
@@ -368,331 +560,16 @@ impl LoadTest {
             .send()
             .await?;
 
-        if !response.status().is_success() {
-            dbg!(&response);
-            dbg!(&response.text().await?);
-            return Ok(());
-        }
-
-        // Creating config files for each remote site
-        if !self.output_dir.exists() {
-            std::fs::create_dir_all(&self.output_dir)?;
-        }
-
-        let base_config = Settings {
-            server: ServerSettings {
-                port: 8000,
-                danger_allow_http: true,
-                debug_no_access_control: true,
-                discovery: DiscoveryMode::Disabled,
-                cors_origins: vec![
-                    "http://localhost:3003".to_string(),
-                    "https://demo-open.msupply.org".to_string(),
-                    "http://localhost:8000".to_string(),
-                ],
-                base_dir: Some("app_data".to_string()),
-                machine_uid: None,
-            },
-            database: DatabaseSettings {
-                username: "postgres".to_owned(),
-                password: "password".to_owned(),
-                port: 5432,
-                host: "localhost".to_owned(),
-                database_name: "omsupply-database".to_string(),
-                database_path: None,
-                init_sql: None,
-            },
-            logging: None,
-            backup: None,
-            mail: None,
-            sync: None,
-        };
-        let base_config_path = self.output_dir.join("base.yaml");
-        std::fs::write(base_config_path, serde_yml::to_string(&base_config)?)?;
-
-        for test_site in &test_sites {
-            std::fs::write(
-                &test_site.config_file_path.clone(),
-                serde_yml::to_string(&test_site.settings.clone())?,
-            )?;
-        }
-
-        // Start each remote OMS instance
-        println!("Starting remote OMS instances...");
-        let mut handles = Vec::new();
-        let duration = self.duration as u64;
-        let num_lines = self.lines;
-
-        for test_site in test_sites {
-            let dir = self.output_dir.clone();
-            let item_ids_copy = item_ids.clone();
-            let handle: JoinHandle<anyhow::Result<Vec<Metric>>> = tokio::spawn(async move {
-                let log = std::fs::File::create(
-                    dir.join(format!("site_{}_output.log", test_site.site.site_id)),
-                )?;
-
-                let mut child = Command::new("cargo") // TODO: be better to run prod binary instead
-                    .arg("run")
-                    .arg("--")
-                    .arg("--config-path")
-                    .arg(&test_site.config_file_path)
-                    .stdout(log.try_clone().unwrap())
-                    .stderr(log)
-                    .env("RUST_LOG", "none")
-                    .kill_on_drop(true)
-                    .spawn()?;
-
-                sleep(Duration::from_secs(10)).await; // Let db get created, migrated and initialisation started
-
-                info!(
-                    "Site {} started, waiting for initial sync to complete",
-                    test_site.site.site_id
-                );
-                if let Err(e) = test_site.wait_for_sync().await {
-                    kill(&mut child).await;
-                    return Err(e);
-                }
-
-                info!("Beginning load test for site: {}", test_site.site.site_id);
-
-                let start = std::time::Instant::now();
-                let mut metrics = Vec::new();
-                loop {
-                    let mut metric = Metric::new(test_site.site.site_id);
-                    let requisition_id = uuid();
-                    let requisition_gql = json!({
-                        "operationName": "InsertRequestRequisition",
-                        "query": INSERT_REQUISITION_MUTATION,
-                        "variables": {
-                            "storeId": test_site.store.id,
-                            "input": {
-                                "id": requisition_id,
-                                "otherPartyId": test_site.next_store.name_id,
-                                "maxMonthsOfStock": 3,
-                                "minMonthsOfStock": 1
-                            }
-                        }
-                    });
-                    match test_site.do_post(&requisition_gql).await {
-                        Ok(response) => response,
-                        Err(e) => {
-                            println!("insertRequestRequisition request failed: {}", e);
-                            kill(&mut child).await;
-                            return Err(e.into());
-                        }
-                    };
-                    let mut line_inserts: Vec<Value> = Vec::new();
-                    let mut line_updates: Vec<Value> = Vec::new();
-
-                    for i in 0..num_lines {
-                        let line_id = uuid();
-                        line_inserts.push(json!({
-                            "id": line_id,
-                            "itemId": item_ids_copy[i%num_lines],
-                            "requisitionId": requisition_id
-                        }));
-
-                        line_updates.push(json!({
-                            "id": line_id,
-                            "requestedQuantity": i+1,
-                            "comment": "Please send me the stocks"
-                        }))
-                    }
-
-                    let line_gql = json!({
-                        "operationName": "BatchRequestRequisitionLineInsert",
-                        "query": BATCH_REQUISITION_LINES_MUTATION,
-                        "variables": {
-                            "storeId": test_site.store.id,
-                            "input": {
-                                "insertRequestRequisitionLines": line_inserts
-                            }
-                        }
-                    });
-
-                    match test_site.do_post(&line_gql).await {
-                        Ok(response) => response,
-                        Err(e) => {
-                            println!("insertRequestRequisitionLine request failed: {}", e);
-                            kill(&mut child).await;
-                            return Err(e.into());
-                        }
-                    };
-
-                    let line_gql = json!({
-                        "operationName": "BatchRequestRequisitionLineInsert",
-                        "query": BATCH_REQUISITION_LINES_MUTATION,
-                        "variables": {
-                            "storeId": test_site.store.id,
-                            "input": {
-                                "updateRequestRequisitionLines": line_updates
-                            }
-                        }
-                    });
-                    match test_site.do_post(&line_gql).await {
-                        Ok(response) => response,
-                        Err(e) => {
-                            println!("insertRequestRequisitionLine request failed: {}", e);
-                            kill(&mut child).await;
-                            return Err(e.into());
-                        }
-                    };
-
-                    let requisition_gql = json!({
-                        "operationName": "UpdateRequestRequisition",
-                        "query": UPDATE_REQUISITION_MUTATION,
-                        "variables": {
-                            "storeId": test_site.store.id,
-                            "input": {
-                                "id": requisition_id,
-                                "status": "SENT"
-                            }
-                        }
-                    });
-                    match test_site.do_post(&requisition_gql).await {
-                        Ok(response) => response,
-                        Err(e) => {
-                            println!("insertRequestRequisition request failed: {}", e);
-                            kill(&mut child).await;
-                            return Err(e.into());
-                        }
-                    };
-
-                    let sync_gql = json!({
-                        "operationName": "ManualSync",
-                        "query": MANUAL_SYNC_QUERY,
-                    });
-                    match test_site.do_post(&sync_gql).await {
-                        Ok(response) => response,
-                        Err(e) => {
-                            println!("manualSync request failed: {}", e);
-                            kill(&mut child).await;
-                            return Err(e.into());
-                        }
-                    };
-
-                    let site_info = match test_site.wait_for_sync().await {
-                        Ok(site_info) => site_info,
-                        Err(e) => {
-                            kill(&mut child).await;
-                            return Err(e.into());
-                        }
-                    };
-
-                    metric.end_time = std::time::Instant::now();
-                    metric.pushed = site_info
-                        .data
-                        .latest_sync_status
-                        .push_v6
-                        .as_ref()
-                        .map_or(0, |s| s.done.unwrap_or(0))
-                        + site_info
-                            .data
-                            .latest_sync_status
-                            .push
-                            .as_ref()
-                            .map_or(0, |s| s.done.unwrap_or(0));
-                    metric.pulled = site_info
-                        .data
-                        .latest_sync_status
-                        .pull_v6
-                        .as_ref()
-                        .map_or(0, |s| s.done.unwrap_or(0))
-                        + site_info
-                            .data
-                            .latest_sync_status
-                            .pull_remote
-                            .as_ref()
-                            .map_or(0, |s| s.done.unwrap_or(0))
-                        + site_info
-                            .data
-                            .latest_sync_status
-                            .pull_central
-                            .as_ref()
-                            .map_or(0, |s| s.done.unwrap_or(0));
-                    println!(
-                        "Site {}: Pushed: {}, Pulled: {}, Duration: {:?}",
-                        test_site.site.site_id,
-                        metric.pushed,
-                        metric.pulled,
-                        metric.end_time.duration_since(metric.start_time)
-                    );
-
-                    metrics.push(metric);
-
-                    if start.elapsed().as_secs() >= duration {
-                        kill(&mut child).await;
-                        break;
-                    }
-                }
-                Ok(metrics)
-            });
-            handles.push(handle)
-        }
-
-        let mut results: Vec<Metric> = Vec::new();
-        for handle in handles {
-            match handle.await {
-                Ok(metric) => results.append(&mut metric?),
-                Err(e) => println!("Error joining task: {}", e),
-            }
-        }
-
-        // Aggregate the results into groups of 5 seconds
-        println!("\nProcessing results...");
-
-        // Group metrics by 5-second intervals
-        if !results.is_empty() {
-            // open a file to write the results
-            // The first line of the file should be csv headers "time, records pushed, records pulled"
-            let output_file = self.output_dir.join("load_test_results.txt");
-            let mut file =
-                std::fs::File::create(output_file).expect("Failed to create output file");
-            writeln!(file, "time, records pushed, records pulled")
-                .expect("Failed to write to output file");
-
-            // Group metrics by 5-second intervals
-            let mut grouped_metrics: Vec<(u64, usize, usize)> = Vec::new();
-            // Create a map to group metrics by 5-second intervals
-            let mut interval_map: HashMap<u64, (usize, usize)> = HashMap::new();
-
-            // Determine the first start time as the reference point
-            let first_start = results
-                .iter()
-                .map(|m| m.start_time)
-                .min()
-                .unwrap_or(Instant::now());
-
-            // Group metrics by their start time intervals
-            for metric in &results {
-                let seconds_since_start = metric.start_time.duration_since(first_start).as_secs();
-                let interval = seconds_since_start / 5;
-
-                let entry = interval_map.entry(interval).or_insert((0, 0));
-                entry.0 += metric.pushed;
-                entry.1 += metric.pulled;
-            }
-
-            // Convert the map to a sorted vector
-            let mut keys: Vec<_> = interval_map.keys().collect();
-            keys.sort();
-
-            for key in keys {
-                if let Some(&(pushed, pulled)) = interval_map.get(key) {
-                    grouped_metrics.push((*key, pushed, pulled));
-                }
-            }
-            for (interval, pushed, pulled) in grouped_metrics {
-                writeln!(file, "{}, {}, {}", (interval + 1) * 5, pushed, pulled)
-                    .expect("Failed to write to output file");
-            }
+        if response.status().is_success() {
+            let site_n_store: SiteNStore = response.json().await?;
+            last_store_name_id = Some(site_n_store.store.name_id.clone());
+            site_n_stores.push(site_n_store);
         } else {
-            println!("No results collected during the test.");
+            let message = response.text().await?;
+            return Err(anyhow!("Failed to create site: {}", message));
         }
-
-        println!("end");
-        Ok(())
     }
+    Ok(site_n_stores)
 }
 
 async fn kill(child: &mut Child) {
@@ -700,6 +577,154 @@ async fn kill(child: &mut Child) {
         Ok(_) => println!("Child terminated successfully"),
         Err(e) => println!("Failed to kill child: {}", e),
     }
+}
+
+async fn create_and_send_requisition(
+    test_site: &TestSite,
+    num_lines: usize,
+    item_ids: &Vec<String>,
+) -> anyhow::Result<()> {
+    const INSERT_REQUISITION_MUTATION: &str = r#"
+mutation InsertRequestRequisition($storeId: String!, $input: InsertRequestRequisitionInput!) {
+  insertRequestRequisition(storeId:$storeId, input: $input){
+    ... on RequisitionNode {
+      id
+    }
+    ... on InsertRequestRequisitionError {
+      error {
+        description
+      }
+    }
+  }
+}
+"#;
+
+    const BATCH_REQUISITION_LINES_MUTATION: &str = r#"
+mutation BatchRequestRequisitionLineInsert ($storeId: String!, $input: BatchRequestRequisitionInput!) {
+  batchRequestRequisition(storeId:$storeId, input:$input){
+    ... on BatchRequestRequisitionResponse {
+      insertRequestRequisitionLines  {
+        id
+      }
+      updateRequestRequisitionLines{
+        id
+      }
+    }
+  }
+}
+"#;
+
+    const UPDATE_REQUISITION_MUTATION: &str = r#"
+mutation UpdateRequestRequisition ($storeId: String!, $input: UpdateRequestRequisitionInput!) {
+  updateRequestRequisition(storeId: $storeId, input: $input) {
+    ... on RequisitionNode {
+    	id
+    }
+    ... on UpdateRequestRequisitionError {
+      error {
+        description
+      }
+    }
+  }
+}
+"#;
+
+    let requisition_id = uuid();
+    let requisition_gql = json!({
+        "operationName": "InsertRequestRequisition",
+        "query": INSERT_REQUISITION_MUTATION,
+        "variables": {
+            "storeId": test_site.store.id,
+            "input": {
+                "id": requisition_id,
+                "otherPartyId": test_site.next_store.name_id,
+                "maxMonthsOfStock": 3,
+                "minMonthsOfStock": 1
+            }
+        }
+    });
+    match test_site.do_post(&requisition_gql).await {
+        Ok(response) => response,
+        Err(e) => {
+            println!("insertRequestRequisition request failed: {}", e);
+            return Err(e.into());
+        }
+    };
+    let mut line_inserts: Vec<Value> = Vec::new();
+    let mut line_updates: Vec<Value> = Vec::new();
+
+    for i in 0..num_lines {
+        let line_id = uuid();
+        line_inserts.push(json!({
+            "id": line_id,
+            "itemId": item_ids[i%num_lines],
+            "requisitionId": requisition_id
+        }));
+
+        line_updates.push(json!({
+            "id": line_id,
+            "requestedQuantity": i+1,
+            "comment": "Please send me the stocks"
+        }))
+    }
+
+    let line_gql = json!({
+        "operationName": "BatchRequestRequisitionLineInsert",
+        "query": BATCH_REQUISITION_LINES_MUTATION,
+        "variables": {
+            "storeId": test_site.store.id,
+            "input": {
+                "insertRequestRequisitionLines": line_inserts
+            }
+        }
+    });
+
+    match test_site.do_post(&line_gql).await {
+        Ok(response) => response,
+        Err(e) => {
+            println!("insertRequestRequisitionLine request failed: {}", e);
+            return Err(e.into());
+        }
+    };
+
+    let line_gql = json!({
+        "operationName": "BatchRequestRequisitionLineInsert",
+        "query": BATCH_REQUISITION_LINES_MUTATION,
+        "variables": {
+            "storeId": test_site.store.id,
+            "input": {
+                "updateRequestRequisitionLines": line_updates
+            }
+        }
+    });
+    match test_site.do_post(&line_gql).await {
+        Ok(response) => response,
+        Err(e) => {
+            println!("insertRequestRequisitionLine request failed: {}", e);
+            return Err(e.into());
+        }
+    };
+
+    let requisition_gql = json!({
+        "operationName": "UpdateRequestRequisition",
+        "query": UPDATE_REQUISITION_MUTATION,
+        "variables": {
+            "storeId": test_site.store.id,
+            "input": {
+                "id": requisition_id,
+                "status": "SENT"
+            }
+        }
+    });
+    match test_site.do_post(&requisition_gql).await {
+        Ok(response) => response,
+        Err(e) => {
+            println!("insertRequestRequisition request failed: {}", e);
+            return Err(e.into());
+        }
+    };
+
+    Ok(())
 }
 
 impl TestSite {
@@ -717,6 +742,28 @@ impl TestSite {
     }
 
     async fn wait_for_sync(&self) -> Result<SyncInfo> {
+        const SYNC_INFO_QUERY: &str = r#"
+query SyncInfo {
+  latestSyncStatus {
+    isSyncing
+    push {
+      done
+    }
+    pushV6 {
+      done
+    }
+    pullV6 {
+      done
+    }
+    pullRemote {
+      done
+    }
+    pullCentral {
+      done
+    }
+  }
+}
+"#;
         loop {
             sleep(Duration::from_millis(500)).await;
             let sync_gql = json!({

--- a/server/cli/src/load_test.rs
+++ b/server/cli/src/load_test.rs
@@ -634,28 +634,6 @@ impl LoadTest {
         // Aggregate the results into groups of 5 seconds
         println!("\nProcessing results...");
 
-        // Calculate memory usage of results vector
-        let size_of_metric = std::mem::size_of::<Metric>();
-        let capacity = results.capacity();
-        let len = results.len();
-        let allocated_bytes = capacity * size_of_metric;
-        let used_bytes = len * size_of_metric;
-
-        println!("\nMemory Statistics for Results Vector:");
-        println!("Size of single Metric: {} bytes", size_of_metric);
-        println!("Number of metrics: {}", len);
-        println!("Vector capacity: {}", capacity);
-        println!(
-            "Memory allocated: {} bytes ({:.2} KB)",
-            allocated_bytes,
-            allocated_bytes as f64 / 1024.0
-        );
-        println!(
-            "Memory used: {} bytes ({:.2} KB)",
-            used_bytes,
-            used_bytes as f64 / 1024.0
-        );
-
         // Group metrics by 5-second intervals
         if !results.is_empty() {
             // open a file to write the results

--- a/server/repository/src/database_settings.rs
+++ b/server/repository/src/database_settings.rs
@@ -2,6 +2,7 @@ use crate::db_diesel::{DBBackendConnection, StorageConnectionManager};
 use diesel::connection::SimpleConnection;
 use diesel::r2d2::{ConnectionManager, Pool};
 use log::info;
+use serde::{Deserialize, Serialize};
 
 // Timeout for waiting for the SQLite lock (https://www.sqlite.org/c3ref/busy_timeout.html).
 // A locked DB results in the "SQLite database is locked" error.
@@ -11,7 +12,7 @@ const SQLITE_LOCKWAIT_MS: u32 = 30 * 1000;
 #[cfg(all(not(feature = "postgres"), not(feature = "memory")))]
 const SQLITE_WAL_PRAGMA: &str = "PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;";
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct DatabaseSettings {
     pub username: String,
     pub password: String,

--- a/server/service/src/settings.rs
+++ b/server/service/src/settings.rs
@@ -1,10 +1,11 @@
 use std::fmt::{Display, Formatter, Result};
 
 use repository::database_settings::DatabaseSettings;
+use serde::{Deserialize, Serialize};
 
 use crate::sync::settings::SyncSettings;
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct Settings {
     pub server: ServerSettings,
     pub database: DatabaseSettings,
@@ -14,7 +15,7 @@ pub struct Settings {
     pub mail: Option<MailSettings>,
 }
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct ServerSettings {
     pub port: u16,
     /// Allow to run the server in http mode
@@ -45,7 +46,7 @@ impl ServerSettings {
 }
 
 /// See backup cli for more details
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct BackupSettings {
     // Root folder for backup
     pub backup_dir: String,
@@ -60,14 +61,14 @@ pub fn is_develop() -> bool {
     cfg!(debug_assertions)
 }
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub enum LogMode {
     All,
     Console,
     File,
 }
 
-#[derive(serde::Deserialize, Clone, Default)]
+#[derive(Deserialize, Serialize, Clone, Default)]
 pub enum DiscoveryMode {
     #[default]
     Auto,
@@ -75,7 +76,7 @@ pub enum DiscoveryMode {
     Disabled,
 }
 
-#[derive(serde::Deserialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub enum Level {
     Error,
     Warn,
@@ -97,7 +98,7 @@ impl Display for Level {
     }
 }
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct LoggingSettings {
     /// Console (default) | File
     pub mode: LogMode,
@@ -129,25 +130,25 @@ impl LoggingSettings {
     }
 }
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct DisplaySettingNode {
     pub value: String,
     pub hash: String,
 }
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct DisplaySettingsNode {
     pub custom_logo: Option<DisplaySettingNode>,
     pub custom_theme: Option<DisplaySettingNode>,
 }
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct DisplaySettingsInput {
     pub custom_logo: Option<String>,
     pub custom_theme: Option<String>,
 }
 
-#[derive(serde::Deserialize, Clone, serde::Serialize)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct LabelPrinterSettingNode {
     pub address: String,
     pub label_height: i32,
@@ -155,7 +156,7 @@ pub struct LabelPrinterSettingNode {
     pub port: u16,
 }
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct MailSettings {
     pub port: u16,
     pub host: String,

--- a/server/service/src/sync/settings.rs
+++ b/server/service/src/sync/settings.rs
@@ -1,10 +1,10 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 // See README.md for description of when this API version needs to be updated
 pub(crate) static SYNC_V5_VERSION: u32 = 9; // bumped for v2.8
 pub(crate) static SYNC_V6_VERSION: u32 = 4;
 
-#[derive(Deserialize, Clone, Debug, PartialEq, Default)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Default)]
 pub struct SyncSettings {
     pub url: String,
     pub username: String,
@@ -16,7 +16,7 @@ pub struct SyncSettings {
     pub batch_size: BatchSize,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct BatchSize {
     pub remote_pull: u32,
     pub remote_push: u32,


### PR DESCRIPTION
Fixes #7755

# 👩🏻‍💻 What does this PR do?

- Now under integration_test feature flag
- Creates a base config yaml file
- Creates yaml config files for each simulated remote site 
- Spins up tokio processes for each of the remote sites, each of which run an OMS remote site via command line
- Each tokio process makes API requests to it's server creating a requisition, lines, finalising, syncing and waiting, recording some metrics, until duration is achieved.
- Measurements aggregated into 5s intervals are thrown into a csv output file

## 💌 Any notes for the reviewer?

I ended up using requisitions as they had the least amount of FK constraints to please and for sync API testing it's probably much the same as invoices.

I think the way it is now the last measurements of each process can be a bit iffy and it can run a little over the duration set, as it waits for sync before checking the duration.

I've been lazy on the OMS server start up and just wait 10 seconds. In theory this could be too short, and the process will fail to continue. I think this could be done by watching stdout to see when GQL starts, or might be possible to just poll the GQL endpoint until it's published, ignoring the errors. Either way done naively might just get stuck I think.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] OG and OMS central servers. Preferably a fresh datafile when actually benching howeer for just testing the PR it doesn't matter (OG http port running on 8888 or change in the command below)
- [ ] OG needs an extra site called `load_test` with password `pass` with some store on it. Alternatively you can use CLI parameters to use any site you want to specify. This site is purely to auth in order to use the integration testing API.
- [ ] On OG make sure to run the method `syncV5API_test_enable` or the CLI will fail
- [ ] Try out the help commands to see what the CLI action parameters are
- [ ] in `./server/` of the repo run `cargo build --features integration_test && ./target/debug/remote_server_cli load-test -u http://localhost:8888 -s 20 -d 60` 
- [ ] Creates many items
- [ ] Creates 20 sites and stores
- [ ] Runs the test for 60 seconds
- [ ] Creates a base.yaml file
- [ ] Creates 3 files for each site: an sqlite file (+ wal, shm files), a config file, an output.log file
- [ ] Creates a final load_test_result.txt
- [ ] The sites have all created internal orders (requisitions) to another site, and received requisitions from another site. By default these each have 25 lines in each

Note on apple silicon interpreted 4D: If you focus the mSupply app/window it seems to run much faster, presumably in foreground processes on performance cores rather than efficiency cores

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

