### PR TITLE
Hide doses if 0 units

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
@@ -156,7 +156,7 @@ export const RequestedSelection = ({
               },
             }}
           />
-          {displayVaccinesInDoses && (
+          {displayVaccinesInDoses && !!value && (
             <Typography
               variant="caption"
               color="text.secondary"

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ContentLayout.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ContentLayout.tsx
@@ -162,7 +162,7 @@ export const NumInputRow = ({
           alignItems: { xs: 'flex-start', md: 'center' },
         }}
       />
-      {displayVaccinesInDoses && !!valueInDoses && (
+      {displayVaccinesInDoses && !!valueInUnitsOrPacks && (
         <Typography
           variant="caption"
           color="text.secondary"

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
@@ -152,7 +152,7 @@ export const SupplySelection = ({
               },
             }}
           />
-          {displayVaccinesInDoses && (
+          {displayVaccinesInDoses && !!value && (
             <Typography
               variant="caption"
               color="text.secondary"

--- a/client/packages/requisitions/src/common/ModalContentLayout.tsx
+++ b/client/packages/requisitions/src/common/ModalContentLayout.tsx
@@ -178,7 +178,7 @@ export const ValueInfoRow = ({
       value={displayValue}
       packagingDisplay={treatAsNull ? '' : endAdornment}
       sx={sx}
-      displayVaccinesInDoses={displayVaccinesInDoses}
+      displayVaccinesInDoses={displayVaccinesInDoses && !!valueInUnitsOrPacks}
       doses={round(valueInDoses, 2)}
       dosesLabel={t('label.doses')}
     />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8052

# 👩🏻‍💻 What does this PR do?
Hide doses for 0 units to save on real estate
![Screenshot 2025-06-09 at 4 11 52 PM](https://github.com/user-attachments/assets/9dcc4fa1-a8a8-475e-8c46-fb5617161025)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Fields with 0 { presentation } should not show how much value is in units

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

