### PR TITLE
7934 Allow requisitions with missing order types to be confirmed

### DIFF
--- a/server/service/src/requisition/common.rs
+++ b/server/service/src/requisition/common.rs
@@ -80,8 +80,13 @@ pub fn check_emergency_order_within_max_items_limit(
         .collect::<Vec<String>>();
 
     let order_type = ProgramRequisitionOrderTypeRowRepository::new(connection)
-        .find_one_by_setting_and_name(&program_settings_ids, order_type)?
-        .ok_or(OrderTypeNotFoundError::OrderTypeNotFound)?;
+        .find_one_by_setting_and_name(&program_settings_ids, order_type)?;
+    //    .ok_or(OrderTypeNotFoundError::OrderTypeNotFound)?;
+    let order_type = match order_type {
+        Some(order_type) => order_type,
+        None => return Ok((true, 0)),
+        // If no order type is found, we assume it's ok to proceed, better than blocking the confirmation unnecessarily
+    };
 
     if !order_type.is_emergency {
         return Ok((true, 0));


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7934

# 👩🏻‍💻 What does this PR do?

If we can't match the name of the order_type received in a requistion to the requisition_order_types table name.
We assume it's not a limited emergency order and allow it to continue processing

I think we might be miss interpreting the mSupply logic though, see comments on issue.

I see this as a potential stop gap measure until a better solution is implemented...

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

See issue for testing steps but probably best to use the datafile from Alain to confirm the issue is resolved.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

