### PR TITLE
#8116 Sync clinician mutate permission to OMS

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -1301,7 +1301,6 @@ export type ColdStorageTypeConnector = {
 
 export type ColdStorageTypeFilterInput = {
   id?: InputMaybe<EqualFilterStringInput>;
-  minTemperature?: InputMaybe<EqualFilterBigFloatingNumberInput>;
   name?: InputMaybe<EqualFilterStringInput>;
 };
 
@@ -10032,6 +10031,7 @@ export enum UserPermission {
   ItemNamesCodesAndUnitsMutate = 'ITEM_NAMES_CODES_AND_UNITS_MUTATE',
   LocationMutate = 'LOCATION_MUTATE',
   LogQuery = 'LOG_QUERY',
+  MutateClinician = 'MUTATE_CLINICIAN',
   NamePropertiesMutate = 'NAME_PROPERTIES_MUTATE',
   OutboundShipmentMutate = 'OUTBOUND_SHIPMENT_MUTATE',
   OutboundShipmentQuery = 'OUTBOUND_SHIPMENT_QUERY',

--- a/server/graphql/types/src/types/permissions.rs
+++ b/server/graphql/types/src/types/permissions.rs
@@ -60,6 +60,7 @@ pub enum UserPermission {
     NamePropertiesMutate,
     EditCentralData,
     ViewAndEditVvmStatus,
+    MutateClinician,
 }
 
 #[Object]
@@ -152,6 +153,7 @@ impl UserPermission {
             PermissionType::NamePropertiesMutate => UserPermission::NamePropertiesMutate,
             PermissionType::EditCentralData => UserPermission::EditCentralData,
             PermissionType::ViewAndEditVvmStatus => UserPermission::ViewAndEditVvmStatus,
+            PermissionType::MutateClinician => UserPermission::MutateClinician,
         }
     }
 
@@ -206,6 +208,7 @@ impl UserPermission {
             UserPermission::NamePropertiesMutate => PermissionType::NamePropertiesMutate,
             UserPermission::EditCentralData => PermissionType::EditCentralData,
             UserPermission::ViewAndEditVvmStatus => PermissionType::ViewAndEditVvmStatus,
+            UserPermission::MutateClinician => PermissionType::MutateClinician,
         }
     }
 }

--- a/server/repository/src/db_diesel/user_permission_row.rs
+++ b/server/repository/src/db_diesel/user_permission_row.rs
@@ -16,13 +16,15 @@ table! {
     }
 }
 
-#[derive(DbEnum, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(DbEnum, Debug, Clone, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(test, derive(strum::EnumIter))]
 #[DbValueStyle = "SCREAMING_SNAKE_CASE"]
 pub enum PermissionType {
     ServerAdmin,
 
     /// User has access to the store this permission is associated with.
     /// This acts like a master switch to enable/disable all user's permissions associated with a store.
+    #[default]
     StoreAccess,
     // location,
     LocationMutate,
@@ -90,7 +92,7 @@ pub enum PermissionType {
     MutateClinician,
 }
 
-#[derive(Clone, Queryable, Insertable, Debug, PartialEq, Eq, AsChangeset)]
+#[derive(Clone, Queryable, Insertable, Debug, PartialEq, Eq, AsChangeset, Default)]
 #[diesel(treat_none_as_null = true)]
 #[diesel(table_name = user_permission)]
 pub struct UserPermissionRow {
@@ -171,5 +173,40 @@ impl Upsert for UserPermissionRow {
             UserPermissionRowRepository::new(con).find_one_by_id(&self.id),
             Ok(Some(self.clone()))
         )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        mock::MockDataInserts, test_db::setup_all, PermissionType, UserPermissionRow,
+        UserPermissionRowRepository,
+    };
+    use strum::IntoEnumIterator;
+
+    #[actix_rt::test]
+    async fn user_permission_row_type_enum() {
+        let (_, connection, _, _) = setup_all(
+            "user_permission_row_type_enum",
+            MockDataInserts::none().stores(),
+        )
+        .await;
+
+        let repo = UserPermissionRowRepository::new(&connection);
+        // Try upsert all variants of PermissionType, confirm that diesel enums match postgres
+        for permission in PermissionType::iter() {
+            let row_id = format!("{:?}", permission);
+
+            let result = repo.upsert_one(&UserPermissionRow {
+                id: row_id.clone(),
+                permission: permission.clone(),
+                store_id: Some("store_a".to_string()),
+                ..Default::default()
+            });
+            assert_eq!(result, Ok(()), "\n \n HINT: Failed to insert permission for type {:?}. Have you created a migration to add this type to the postgres database enum? \n", row_id);
+
+            let found = repo.find_one_by_id(&row_id).unwrap().unwrap();
+            assert_eq!(found.permission, permission);
+        }
     }
 }

--- a/server/repository/src/db_diesel/user_permission_row.rs
+++ b/server/repository/src/db_diesel/user_permission_row.rs
@@ -86,6 +86,8 @@ pub enum PermissionType {
     // Central Server
     EditCentralData,
     ViewAndEditVvmStatus,
+    // clinician
+    MutateClinician,
 }
 
 #[derive(Clone, Queryable, Insertable, Debug, PartialEq, Eq, AsChangeset)]

--- a/server/repository/src/migrations/v2_09_00/add_mutate_clinician_permission.rs
+++ b/server/repository/src/migrations/v2_09_00/add_mutate_clinician_permission.rs
@@ -1,0 +1,22 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_mutate_clinician_permission"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        if cfg!(feature = "postgres") {
+            sql!(
+                connection,
+                r#"
+                    ALTER TYPE permission_type ADD VALUE 'MUTATE_CLINICIAN';
+                "#
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_09_00/mod.rs
+++ b/server/repository/src/migrations/v2_09_00/mod.rs
@@ -1,6 +1,7 @@
 use super::{version::Version, Migration, MigrationFragment};
 use crate::StorageConnection;
 
+mod add_mutate_clinician_permission;
 mod process_clinician_store_join_deletes;
 
 pub(crate) struct V2_09_00;
@@ -15,7 +16,10 @@ impl Migration for V2_09_00 {
     }
 
     fn migrate_fragments(&self) -> Vec<Box<dyn MigrationFragment>> {
-        vec![Box::new(process_clinician_store_join_deletes::Migrate)]
+        vec![
+            Box::new(process_clinician_store_join_deletes::Migrate),
+            Box::new(add_mutate_clinician_permission::Migrate),
+        ]
     }
 }
 

--- a/server/service/src/auth.rs
+++ b/server/service/src/auth.rs
@@ -96,6 +96,7 @@ pub enum Resource {
     ServerAdmin,
     // clinician
     QueryClinician,
+    MutateClinician,
 
     // document
     QueryDocument,
@@ -460,6 +461,14 @@ fn all_permissions() -> HashMap<Resource, PermissionDSL> {
     );
 
     map.insert(Resource::QueryClinician, PermissionDSL::HasStoreAccess);
+
+    map.insert(
+        Resource::MutateClinician,
+        PermissionDSL::And(vec![
+            PermissionDSL::HasStoreAccess,
+            PermissionDSL::HasPermission(PermissionType::MutateClinician),
+        ]),
+    );
 
     // TODO add permissions from central
     map.insert(

--- a/server/service/src/login.rs
+++ b/server/service/src/login.rs
@@ -514,6 +514,9 @@ fn permissions_to_domain(permissions: Vec<Permissions>) -> HashSet<PermissionTyp
             Permissions::ViewAndEditVaccineVialMonitorStatus => {
                 output.insert(PermissionType::ViewAndEditVvmStatus);
             }
+            Permissions::AddEditPrescribers => {
+                output.insert(PermissionType::MutateClinician);
+            }
             _ => continue,
         }
     }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8116

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
Maps OG permission `AddEditPrescribers` to OMS permission `MutateClinician`

Not used as of yet, but shows in the schema under `UserPermission`, and appears in the graphql `permissions` object when logging in or syncing

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have Add / Edit Prescribers user permission turned on in OG
- [ ] Log in to OMS - check the permissions object in graphql responses -> see the permission MutateClinician
- [ ] Turn off the Add / Edit Prescribers user permission in OG -> sync
- [ ] Log in to OMS - check the permissions object in graphql responses -> MutateClinician will not be included

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

