### PR TITLE
8142 stock line import issue

### DIFF
--- a/server/service/src/sync/test/test_data/invoice_line.rs
+++ b/server/service/src/sync/test/test_data/invoice_line.rs
@@ -66,7 +66,7 @@ const TRANS_LINE_1: (&str, &str) = (
         "volume_per_pack": 0,
         "om_item_variant_id": "",
         "donor_id": "donor_a",
-        "oms_fields": null
+        "oms_fields": ""
         }
     "#,
 );

--- a/server/service/src/sync/test/test_data/stock_line.rs
+++ b/server/service/src/sync/test/test_data/stock_line.rs
@@ -49,7 +49,7 @@ const ITEM_LINE_1: (&str, &str) = (
       "volume_per_pack": 0,
       "vvm_status_id": "",
       "weight_per_pack": 0,
-      "oms_fields": null
+      "oms_fields": ""
     }"#,
 );
 fn item_line_1_pull_record() -> TestSyncIncomingRecord {

--- a/server/service/src/sync/test/test_data/stock_line.rs
+++ b/server/service/src/sync/test/test_data/stock_line.rs
@@ -148,6 +148,7 @@ const ITEM_LINE_2: (&str, &str) = (
       "volume_per_pack": 0,
       "vvm_status_id": "",
       "weight_per_pack": 0,
+      "om_item_variant_id": "",
       "oms_fields": null
   }"#,
 );

--- a/server/service/src/sync/translations/invoice_line.rs
+++ b/server/service/src/sync/translations/invoice_line.rs
@@ -1,5 +1,8 @@
 use crate::sync::{
-    sync_serde::{date_option_to_isostring, empty_str_as_option_string, zero_date_as_option},
+    sync_serde::{
+        date_option_to_isostring, empty_str_as_option, empty_str_as_option_string,
+        zero_date_as_option,
+    },
     translations::{
         currency::CurrencyTranslation, invoice::InvoiceTranslation, item::ItemTranslation,
         item_variant::ItemVariantTranslation, location::LocationTranslation,
@@ -104,6 +107,7 @@ pub struct LegacyTransLineRow {
     #[serde(rename = "vaccine_vial_monitor_status_ID")]
     pub vvm_status_id: Option<String>,
     #[serde(default)]
+    #[serde(deserialize_with = "empty_str_as_option")]
     pub oms_fields: Option<TransLineRowOmsFields>,
 }
 

--- a/server/service/src/sync/translations/stock_line.rs
+++ b/server/service/src/sync/translations/stock_line.rs
@@ -53,6 +53,7 @@ pub struct LegacyStockLineRow {
     #[serde(deserialize_with = "empty_str_as_option_string", rename = "barcodeID")]
     pub barcode_id: Option<String>,
     #[serde(rename = "om_item_variant_id")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     #[serde(default)]
     pub item_variant_id: Option<String>,
     #[serde(default)]

--- a/server/service/src/sync/translations/stock_line.rs
+++ b/server/service/src/sync/translations/stock_line.rs
@@ -1,5 +1,8 @@
 use crate::sync::{
-    sync_serde::{date_option_to_isostring, empty_str_as_option_string, zero_date_as_option},
+    sync_serde::{
+        date_option_to_isostring, empty_str_as_option, empty_str_as_option_string,
+        zero_date_as_option,
+    },
     translations::{
         barcode::BarcodeTranslation, campaign::CampaignTranslation, item::ItemTranslation,
         item_variant::ItemVariantTranslation, location::LocationTranslation, name::NameTranslation,
@@ -62,6 +65,7 @@ pub struct LegacyStockLineRow {
     #[serde(deserialize_with = "empty_str_as_option_string")]
     pub vvm_status_id: Option<String>,
     #[serde(default)]
+    #[serde(deserialize_with = "empty_str_as_option")]
     pub oms_fields: Option<StockLineRowOmsFields>,
 }
 // Needs to be added to all_translators()


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8142 (for 2.8.1)

# 👩🏻‍💻 What does this PR do?

Same as https://github.com/msupply-foundation/open-msupply/pull/8150
but add empty string support for oms_fields too

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] update mSupply to latest version
- [ ] Sync invoice lines and stockline updates from a non OMS system (mobile perhaps?)
- [ ] Migrate store to OMS store
- [ ] Check all lines and stocklines are there.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

