### PR TITLE
8069 Save program ID on outbound shipments created from program requisitions

### DIFF
--- a/server/service/src/requisition/response_requisition/create_requisition_shipment/generate.rs
+++ b/server/service/src/requisition/response_requisition/create_requisition_shipment/generate.rs
@@ -39,6 +39,7 @@ pub fn generate(
         created_datetime: Utc::now().naive_utc(),
         requisition_id: Some(requisition_row.id),
         their_reference: requisition_row.their_reference,
+        program_id: requisition_row.program_id,
 
         // Default
         currency_id: Some(currency.currency_row.id),
@@ -59,7 +60,6 @@ pub fn generate(
         original_shipment_id: None,
         backdated_datetime: None,
         diagnosis_id: None,
-        program_id: None,
         name_insurance_join_id: None,
         insurance_discount_amount: None,
         insurance_discount_percentage: None,

--- a/server/service/src/requisition/response_requisition/create_requisition_shipment/test.rs
+++ b/server/service/src/requisition/response_requisition/create_requisition_shipment/test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test_update {
-    use repository::mock::{mock_store_a, mock_store_b};
+    use repository::mock::{mock_new_response_program_requisition, mock_store_a, mock_store_b};
     use repository::EqualFilter;
     use repository::{
         mock::{
@@ -185,5 +185,22 @@ mod test_update {
         assert_eq!(invoice_lines.len(), 1);
 
         assert_eq!(invoice_lines[0].invoice_line_row.number_of_packs, 50.0);
+
+        // Program requisitions map program ID onto resulting outbound shipment
+        let created_outbound = service
+            .create_requisition_shipment(
+                &context,
+                CreateRequisitionShipment {
+                    response_requisition_id: mock_new_response_program_requisition().requisition.id,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(
+            created_outbound.invoice_row.program_id,
+            mock_new_response_program_requisition()
+                .requisition
+                .program_id
+        );
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8069

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Saves program ID on outbound shipments created from program requisitions
<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create program requisition
- [ ] Have some quantity to supply
- [ ] Click Create Shipment
- [ ] Check the invoice record in the DB - should have program_id field populated
- [ ] OR upload this custom report and view program name in report

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

