### PR TITLE
#8085 Fix error when going back after changing customer

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
@@ -62,7 +62,8 @@ export const Toolbar: FC = () => {
                         RouteBuilder.create(AppRoute.Distribution)
                           .addPart(AppRoute.OutboundShipment)
                           .addPart(newId)
-                          .build()
+                          .build(),
+                        { replace: true }
                       );
                     }}
                   />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fix #8085

# 👩🏻‍💻 What does this PR do?

The error was caused by the "back" button attempting to go to the old invoice URL, which no longer exists. This fix prevents that by "replacing" the url in the history when navigating after changing customer. However, if you go "back" from the line edit modal now, you'll be taken to the list view, which is not ideal, but it's consistent with how it works in a normal detail view (when not changing customer).

It doesn't really make sense to go "back" from a modal like this, as the URL hasn't actually changed. I think, ultimately, it would be good to add a url parameter to the url when opening modals (e.g. `?editItem=<id>`), so that you *can* go "back", but that's a much larger change and needs further discussion/planning.

## 💌 Any notes for the reviewer?

The behaviour now should be exactly the same as it is when you haven't changed the customer at all.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] In an Outbound shipment, change the customer, noting the re-direct to a new invoice URL
- [ ] Open a line
- [ ] Click "Back" -- you should be taken to the Outbound shipments list
- [ ] Confirm this behaviour is the same when *not* changing the customer 


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

