### PR TITLE
#7081 Add comment to inboundLineEdit

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -3182,6 +3182,7 @@ export type InsertInboundShipmentLineInput = {
   itemId: Scalars['String']['input'];
   itemVariantId?: InputMaybe<Scalars['String']['input']>;
   location?: InputMaybe<NullableStringUpdate>;
+  note?: InputMaybe<Scalars['String']['input']>;
   numberOfPacks: Scalars['Float']['input'];
   packSize: Scalars['Float']['input'];
   sellPricePerPack: Scalars['Float']['input'];
@@ -8381,16 +8382,15 @@ export type StocktakeLineNode = {
 };
 
 export enum StocktakeLineSortFieldInput {
-  /** Stocktake line batch */
   Batch = 'batch',
-  /** Stocktake line expiry date */
+  CountedNumberOfPacks = 'countedNumberOfPacks',
   ExpiryDate = 'expiryDate',
   ItemCode = 'itemCode',
   ItemName = 'itemName',
-  /** Stocktake line item stock location code */
   LocationCode = 'locationCode',
-  /** Stocktake line pack size */
   PackSize = 'packSize',
+  ReasonOption = 'reasonOption',
+  SnapshotNumberOfPacks = 'snapshotNumberOfPacks',
 }
 
 export type StocktakeLineSortInput = {
@@ -9087,6 +9087,7 @@ export type UpdateInboundShipmentLineInput = {
   itemId?: InputMaybe<Scalars['String']['input']>;
   itemVariantId?: InputMaybe<NullableStringUpdate>;
   location?: InputMaybe<NullableStringUpdate>;
+  note?: InputMaybe<Scalars['String']['input']>;
   numberOfPacks?: InputMaybe<Scalars['Float']['input']>;
   packSize?: InputMaybe<Scalars['Float']['input']>;
   sellPricePerPack?: InputMaybe<Scalars['Float']['input']>;

--- a/client/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
+++ b/client/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
@@ -49,7 +49,8 @@ export type ColumnKey =
   | 'availableNumberOfPacks'
   | 'numberOfPacksToReturn'
   | 'numberOfPacksReturned'
-  | 'availableStockOnHand';
+  | 'availableStockOnHand'
+  | 'note';
 
 export const getColumnLookupWithOverrides = <T extends RecordWithId>(
   columnKey: ColumnKey,
@@ -308,6 +309,11 @@ const getColumnLookup = <T extends RecordWithId>(): Record<
     label: 'label.reason',
     key: 'returnReason',
     width: 200,
+  },
+  note: {
+    label: 'label.comment',
+    key: 'note',
+    width: 250,
   },
 });
 

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -21,6 +21,7 @@ import {
   getDosesPerUnitColumn,
   useFormatNumber,
   NumUtils,
+  TextInputCell,
 } from '@openmsupply-client/common';
 import { DraftInboundLine } from '../../../../types';
 import {
@@ -340,7 +341,15 @@ export const LocationTableComponent = ({
         accessor: ({ rowData }) => rowData.batch || '',
       },
     ],
-    [getLocationInputColumn(), { setter: updateDraftLine, width: 550 }],
+    [getLocationInputColumn(), { setter: updateDraftLine, width: 530 }],
+    [
+      'note',
+      {
+        Cell: TextInputCell,
+        setter: patch => updateDraftLine({ ...patch }),
+        accessor: ({ rowData }) => rowData.note || '',
+      },
+    ],
   ];
 
   if (preferences?.allowTrackingOfStockByDonor) {

--- a/client/packages/invoices/src/InboundShipment/api/api.ts
+++ b/client/packages/invoices/src/InboundShipment/api/api.ts
@@ -121,6 +121,7 @@ const inboundParsers = {
       vvmStatusId: 'vvmStatusId' in line ? line.vvmStatusId : undefined,
       donorId: line.donor?.id,
       campaignId: line.campaign?.id,
+      note: line.note,
     };
   },
   toInsertLineFromInternalOrder: (line: {
@@ -152,6 +153,7 @@ const inboundParsers = {
     campaignId: setNullableInput('campaignId', {
       campaignId: line.campaign?.id ?? null,
     }),
+    note: line.note ?? '',
   }),
   toDeleteLine: (line: { id: string }): DeleteInboundShipmentLineInput => {
     return { id: line.id };

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
@@ -33,6 +33,7 @@ pub struct InsertInput {
     pub vvm_status_id: Option<String>,
     pub donor_id: Option<String>,
     pub campaign_id: Option<String>,
+    pub note: Option<String>,
 }
 
 #[derive(SimpleObject)]
@@ -94,6 +95,7 @@ impl InsertInput {
             donor_id,
             vvm_status_id,
             campaign_id,
+            note,
         } = self;
 
         ServiceInput {
@@ -116,7 +118,7 @@ impl InsertInput {
             vvm_status_id,
             donor_id,
             // Default
-            note: None,
+            note,
             stock_line_id: None,
             barcode: None,
             stock_on_hold: false,

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
@@ -36,6 +36,7 @@ pub struct UpdateInput {
     pub vvm_status_id: Option<String>,
     pub donor_id: Option<NullableUpdateInput<String>>,
     pub campaign_id: Option<NullableUpdateInput<String>>,
+    pub note: Option<String>,
 }
 
 #[derive(SimpleObject)]
@@ -105,6 +106,7 @@ impl UpdateInput {
             vvm_status_id,
             donor_id,
             campaign_id,
+            note,
         } = self;
 
         ServiceInput {
@@ -129,7 +131,7 @@ impl UpdateInput {
             r#type: StockInType::InboundShipment,
             vvm_status_id,
             // Default
-            note: None,
+            note,
             donor_id: donor_id.map(|donor_id| NullableUpdate {
                 value: donor_id.value,
             }),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7081

# 👩🏻‍💻 What does this PR do?

- Add a text input comment field to `Other` tab in `InboundLineEdit``
- Create a new column key `note`

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->
![Screenshot 2025-06-17 at 12 18 22](https://github.com/user-attachments/assets/72c7907f-e26c-46a9-bca9-70d23e2e7417)
<img width="771" alt="Screenshot 2025-06-17 at 12 18 44" src="https://github.com/user-attachments/assets/45fe3cdd-c01f-4221-a76a-1b8bbee4b33a" />

`With donor pref on`
![Screenshot 2025-06-17 at 12 21 59](https://github.com/user-attachments/assets/7200165d-631a-4209-a0a2-e343d8c0380b)

## 💌 Any notes for the reviewer?
I've left the label on the column as comment as per issue but can update to note if needed. 

With the donor pref on, the ends of the location and donor input fields gets cut off.

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to Replenishment -> Inbound Shipment
- [ ] Create or open an invoice
- [ ] Add an item or click on an existing line 
- [ ] Navigate to other tab
- [ ] Enter a comment -> Observe that comment doesn't disappear
- [ ] Click ok
- [ ] Open the same line again and see that the comment persists
- [ ] In DB see that 'note' column has updated with the comment you entered

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

