### PR TITLE
8225 queries for purchase order lines always return nothing

### DIFF
--- a/server/graphql/core/src/loader/purchase_order_line.rs
+++ b/server/graphql/core/src/loader/purchase_order_line.rs
@@ -26,7 +26,7 @@ impl Loader<String> for PurchaseOrderLinesByPurchaseOrderIdLoader {
             .purchase_order_line_service
             .get_purchase_order_lines(
                 &service_context,
-                "",
+                None,
                 None,
                 Some(
                     PurchaseOrderLineFilter::new()

--- a/server/graphql/purchase_order_line/src/purchase_order_line_queries.rs
+++ b/server/graphql/purchase_order_line/src/purchase_order_line_queries.rs
@@ -58,7 +58,7 @@ pub fn get_purchase_order_line(
 
     match service_provider
         .purchase_order_line_service
-        .get_purchase_order_line(&service_context, &store_id, id)
+        .get_purchase_order_line(&service_context, Some(&store_id), id)
         .map_err(StandardGraphqlError::from_repository_error)
     {
         Ok(line) => {
@@ -89,7 +89,7 @@ pub fn get_purchase_order_lines(
         .purchase_order_line_service
         .get_purchase_order_lines(
             &service_context,
-            &store_id,
+            Some(&store_id),
             page.map(PaginationOption::from),
             filter.map(|filter| filter.to_domain()),
             sort.and_then(|mut sort_list| sort_list.pop())

--- a/server/service/src/purchase_order_line/mod.rs
+++ b/server/service/src/purchase_order_line/mod.rs
@@ -12,21 +12,21 @@ pub trait PurchaseOrderLineServiceTrait: Sync + Send {
     fn get_purchase_order_line(
         &self,
         ctx: &ServiceContext,
-        store_id: &str,
+        store_id_option: Option<&str>,
         id: &str,
     ) -> Result<Option<PurchaseOrderLine>, RepositoryError> {
-        get_purchase_order_line(ctx, store_id, id)
+        get_purchase_order_line(ctx, store_id_option, id)
     }
 
     fn get_purchase_order_lines(
         &self,
         ctx: &ServiceContext,
-        store_id: &str,
+        store_id_option: Option<&str>,
         pagination: Option<PaginationOption>,
         filter: Option<PurchaseOrderLineFilter>,
         sort: Option<PurchaseOrderLineSort>,
     ) -> Result<ListResult<PurchaseOrderLine>, ListError> {
-        get_purchase_order_lines(ctx, store_id, pagination, filter, sort)
+        get_purchase_order_lines(ctx, store_id_option, pagination, filter, sort)
     }
 }
 

--- a/server/service/src/purchase_order_line/query.rs
+++ b/server/service/src/purchase_order_line/query.rs
@@ -12,7 +12,7 @@ pub const MIN_LIMIT: u32 = 1;
 
 pub fn get_purchase_order_lines(
     ctx: &ServiceContext,
-    store_id: &str,
+    store_id_option: Option<&str>,
     pagination: Option<PaginationOption>,
     filter: Option<PurchaseOrderLineFilter>,
     sort: Option<PurchaseOrderLineSort>,
@@ -21,7 +21,7 @@ pub fn get_purchase_order_lines(
     let repository = PurchaseOrderLineRepository::new(&ctx.connection);
 
     let mut filter = filter.unwrap_or_default();
-    filter.store_id = Some(store_id).map(EqualFilter::equal_to);
+    filter.store_id = store_id_option.map(EqualFilter::equal_to);
 
     Ok(ListResult {
         rows: repository.query(pagination, Some(filter.clone()), sort)?,
@@ -31,12 +31,12 @@ pub fn get_purchase_order_lines(
 
 pub fn get_purchase_order_line(
     ctx: &ServiceContext,
-    store_id: &str,
+    store_id_option: Option<&str>,
     id: &str,
 ) -> Result<Option<PurchaseOrderLine>, RepositoryError> {
     let repository = PurchaseOrderLineRepository::new(&ctx.connection);
     let mut filter = PurchaseOrderLineFilter::new().id(EqualFilter::equal_to(id));
-    filter.store_id = Some(store_id).map(EqualFilter::equal_to);
+    filter.store_id = store_id_option.map(EqualFilter::equal_to);
 
     Ok(repository.query_by_filter(filter)?.pop())
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8225 

# 👩🏻‍💻 What does this PR do?

It fixes #8225 by modifying the purchase order line loader.
There was a hardcoded empty string for store_id. The loader then filtered by store_id and as a result no purchase order line would be returned if it corresponded to a purchase order with a store_id that wasn't an empty.
This hardcoded empty string was replaced with 'None', and the store_id field was made into an optional type to allow this.

Credit to @fergie-nz for the fix and diagnosis!

And now it works!
![image](https://github.com/user-attachments/assets/a5d31d18-b918-4cde-bda5-d337925b9985)

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Add a valid line to the purchase_order table in your database.
- [ ] Add a valid line the purchase_order_line table. N.B. two values in this table need to be chosen carefully: (1) the value in the purchase_order_id column must be the same as the value in the id column of the purchase_order row you added in step 1; and (2) the value in the item_link_id column must be the same as a value in the id column of the item_link table.
- [ ] Run the server and open the GraphiQL playground.
- [ ] Make a GraphQL query for the purchase order and its lines as in the screenshot.
- [ ] Run it, and it should get the data you entered.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

