### PR TITLE
Fix broken View migrations (Postgres)

### DIFF
--- a/server/repository/src/migrations/views/mod.rs
+++ b/server/repository/src/migrations/views/mod.rs
@@ -4,11 +4,14 @@ pub(crate) fn drop_views(connection: &StorageConnection) -> anyhow::Result<()> {
     log::info!("Dropping database views...");
     sql!(
         connection,
+        // Drop order is important here, as some views depend on others. Please
+        // check when adding new views.
         r#"
       DROP VIEW IF EXISTS invoice_stats;
       DROP VIEW IF EXISTS consumption;
       DROP VIEW IF EXISTS replenishment;
       DROP VIEW IF EXISTS adjustments;
+      DROP VIEW IF EXISTS item_ledger;
       DROP VIEW IF EXISTS stock_movement;
       DROP VIEW IF EXISTS outbound_shipment_stock_movement;
       DROP VIEW IF EXISTS inbound_shipment_stock_movement;
@@ -29,7 +32,6 @@ pub(crate) fn drop_views(connection: &StorageConnection) -> anyhow::Result<()> {
       DROP VIEW IF EXISTS store_items;
       DROP VIEW IF EXISTS vaccination_card;
       DROP VIEW IF EXISTS vaccination_course;
-      DROP VIEW IF EXISTS item_ledger;
     "#
     )?;
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Quick fix for the View migration error when using Postgres.

Problem was the new `item_ledger` view depends on the `invoice_line_stock_movement` view, so needs to be dropped *before* that one in the migration script.

# 👩🏻‍💻 What does this PR do?

Re-orded view dropping, added comment

# Testing

- [ ] Launch server using Postgres, confirm it launches without view migrations error

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

