### PR TITLE
8232 sync vaccine course dose and item

### DIFF
--- a/server/repository/src/migrations/v2_09_00/mod.rs
+++ b/server/repository/src/migrations/v2_09_00/mod.rs
@@ -5,6 +5,7 @@ mod add_mutate_clinician_permission;
 mod add_store_id_to_clinician;
 mod extend_name_table_fields;
 mod process_clinician_store_join_deletes;
+mod resync_existing_vaccine_course_dose_and_item;
 
 pub(crate) struct V2_09_00;
 
@@ -23,6 +24,7 @@ impl Migration for V2_09_00 {
             Box::new(add_mutate_clinician_permission::Migrate),
             Box::new(add_store_id_to_clinician::Migrate),
             Box::new(extend_name_table_fields::Migrate),
+            Box::new(resync_existing_vaccine_course_dose_and_item::Migrate),
         ]
     }
 }

--- a/server/repository/src/migrations/v2_09_00/resync_existing_vaccine_course_dose_and_item.rs
+++ b/server/repository/src/migrations/v2_09_00/resync_existing_vaccine_course_dose_and_item.rs
@@ -1,0 +1,23 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "resync_existing_vaccine_course_dose_and_item"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        sql!(
+            connection,
+            r#"
+                INSERT INTO changelog (table_name, record_id, row_action)
+                SELECT 'vaccine_course_dose', id, 'UPSERT' FROM vaccine_course_dose; 
+                INSERT INTO changelog (table_name, record_id, row_action)
+                SELECT 'vaccine_course_item', id, 'UPSERT' FROM vaccine_course_item;
+            "#
+        )?;
+
+        Ok(())
+    }
+}

--- a/server/service/src/sync/translations/mod.rs
+++ b/server/service/src/sync/translations/mod.rs
@@ -78,6 +78,7 @@ pub(crate) mod utils;
 pub(crate) mod vaccination;
 pub(crate) mod vaccine_course;
 pub(crate) mod vaccine_course_dose;
+pub(crate) mod vaccine_course_dose_legacy;
 pub(crate) mod vaccine_course_item;
 pub(crate) mod vvm_status;
 pub(crate) mod vvm_status_log;
@@ -173,6 +174,7 @@ pub(crate) fn all_translators() -> SyncTranslators {
         // Vaccine course
         vaccine_course::boxed(),
         vaccine_course_dose::boxed(),
+        vaccine_course_dose_legacy::boxed(),
         vaccine_course_item::boxed(),
         demographic::boxed(),
         // Vaccination

--- a/server/service/src/sync/translations/mod.rs
+++ b/server/service/src/sync/translations/mod.rs
@@ -80,6 +80,7 @@ pub(crate) mod vaccine_course;
 pub(crate) mod vaccine_course_dose;
 pub(crate) mod vaccine_course_dose_legacy;
 pub(crate) mod vaccine_course_item;
+pub(crate) mod vaccine_course_item_legacy;
 pub(crate) mod vvm_status;
 pub(crate) mod vvm_status_log;
 pub(crate) mod warning;
@@ -176,6 +177,7 @@ pub(crate) fn all_translators() -> SyncTranslators {
         vaccine_course_dose::boxed(),
         vaccine_course_dose_legacy::boxed(),
         vaccine_course_item::boxed(),
+        vaccine_course_item_legacy::boxed(),
         demographic::boxed(),
         // Vaccination
         vaccination::boxed(),

--- a/server/service/src/sync/translations/vaccine_course_dose.rs
+++ b/server/service/src/sync/translations/vaccine_course_dose.rs
@@ -52,9 +52,9 @@ impl SyncTranslation for VaccineCourseDoseTranslation {
                 self.change_log_type().as_ref() == Some(&row.table_name)
             }
             ToSyncRecordTranslationType::PushToOmSupplyCentral => {
-                // Skip translation when pushing to Central Server
-                // Vaccine courses should only be created on remote sites, not on Central
-                // (Central may have changelog records from data migrations, but we ignore them)
+                // We shouldn't ever create Vaccine Course dose rows in the central server,
+                // so we don't translate this, even when changelog records might exist
+                // This can happen due to migrations that recreate change log rows
                 false
             }
             _ => false,

--- a/server/service/src/sync/translations/vaccine_course_dose.rs
+++ b/server/service/src/sync/translations/vaccine_course_dose.rs
@@ -51,6 +51,12 @@ impl SyncTranslation for VaccineCourseDoseTranslation {
             ToSyncRecordTranslationType::PullFromOmSupplyCentral => {
                 self.change_log_type().as_ref() == Some(&row.table_name)
             }
+            ToSyncRecordTranslationType::PushToOmSupplyCentral => {
+                // Skip translation when pushing to Central Server
+                // Vaccine courses should only be created on remote sites, not on Central
+                // (Central may have changelog records from data migrations, but we ignore them)
+                false
+            }
             _ => false,
         }
     }

--- a/server/service/src/sync/translations/vaccine_course_dose_legacy.rs
+++ b/server/service/src/sync/translations/vaccine_course_dose_legacy.rs
@@ -1,0 +1,187 @@
+use serde::Serialize;
+
+use crate::sync::CentralServerConfig;
+
+use super::{PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
+use repository::{
+    vaccine_course::vaccine_course_dose_row::VaccineCourseDoseRowRepository, ChangelogRow,
+    ChangelogTableName, StorageConnection,
+};
+
+/*
+    This translator is only used to push VaccineCourseDose rows to the legacy mSupply server.
+    It should run from the Central Server
+*/
+
+#[allow(non_snake_case)]
+#[derive(Serialize)]
+pub struct LegacyVaccineCourseDoseRow {
+    pub ID: String,
+    pub vaccine_course_ID: String,
+    pub label: String,
+    pub min_interval_days: i32,
+    pub min_age: f64,
+    pub max_age: f64,
+    pub deleted_datetime: Option<String>,
+    pub custom_age_label: Option<String>,
+}
+
+const LEGACY_VACCINE_COURSE_DOSE_TABLE_NAME: &str = "om_vaccine_course_dose";
+
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(VaccineCourseDoseLegacyTranslation)
+}
+
+pub(crate) struct VaccineCourseDoseLegacyTranslation;
+
+impl SyncTranslation for VaccineCourseDoseLegacyTranslation {
+    fn table_name(&self) -> &'static str {
+        "vaccine_course_dose"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![] // No pull, as this is just a push to Legacy mSupply
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::VaccineCourseDose)
+    }
+
+    fn should_translate_to_sync_record(
+        &self,
+        row: &ChangelogRow,
+        r#type: &ToSyncRecordTranslationType,
+    ) -> bool {
+        match r#type {
+            ToSyncRecordTranslationType::PushToLegacyCentral => {
+                self.change_log_type().as_ref() == Some(&row.table_name)
+                    && CentralServerConfig::is_central_server()
+            }
+            _ => false,
+        }
+    }
+
+    fn try_translate_to_upsert_sync_record(
+        &self,
+        connection: &StorageConnection,
+        changelog: &ChangelogRow,
+    ) -> Result<PushTranslateResult, anyhow::Error> {
+        let row = VaccineCourseDoseRowRepository::new(connection)
+            .find_one_by_id(&changelog.record_id)?
+            .ok_or(anyhow::Error::msg(format!(
+                "VaccineCourseDose row ({}) not found",
+                changelog.record_id
+            )))?;
+
+        let legacy_row = LegacyVaccineCourseDoseRow {
+            ID: row.id.clone(),
+            vaccine_course_ID: row.vaccine_course_id.clone(),
+            label: row.label,
+            min_interval_days: row.min_interval_days,
+            min_age: row.min_age,
+            max_age: row.max_age,
+            deleted_datetime: row.deleted_datetime.map(|dt| dt.and_utc().to_rfc3339()),
+            custom_age_label: row.custom_age_label,
+        };
+
+        let json_record = serde_json::to_value(legacy_row)?;
+
+        Ok(PushTranslateResult::upsert(
+            changelog,
+            LEGACY_VACCINE_COURSE_DOSE_TABLE_NAME,
+            json_record,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::sync::test_util_set_is_central_server;
+
+    use super::*;
+    use repository::{
+        mock::MockDataInserts, test_db::setup_all,
+        vaccine_course::vaccine_course_dose_row::VaccineCourseDoseRow, ChangelogRepository,
+    };
+
+    #[actix_rt::test]
+    async fn test_vaccine_course_legacy_translation() {
+        let translator = VaccineCourseDoseLegacyTranslation;
+
+        let (_, connection, _, _) = setup_all(
+            "test_vaccine_course_legacy_translation",
+            MockDataInserts::none()
+                .vaccine_courses()
+                .full_master_list()
+                .programs()
+                .items()
+                .names(),
+        )
+        .await;
+
+        // Get the current cursor value
+        let cursor = ChangelogRepository::new(&connection)
+            .latest_cursor()
+            .unwrap();
+
+        // Create a new VaccineCourseDoseRow (this will get a changelog entry created automatically)
+        let vaccine_course_dose_row = VaccineCourseDoseRow {
+            id: "test_vaccine_course_dose_id".to_string(),
+            vaccine_course_id: "vaccine_course_a".to_string(),
+            label: "test dose label".to_string(),
+            min_age: 12.0,
+            max_age: 13.0,
+            custom_age_label: Some("Test label".to_string()),
+            min_interval_days: 20,
+            deleted_datetime: None,
+        };
+
+        let _insert_cursor = VaccineCourseDoseRowRepository::new(&connection)
+            .upsert_one(&vaccine_course_dose_row)
+            .unwrap();
+
+        let changelog_row = ChangelogRepository::new(&connection)
+            .changelogs(cursor, 100, None)
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        // Shouldn't translate if not a central server
+        test_util_set_is_central_server(false);
+        assert_eq!(
+            translator.should_translate_to_sync_record(
+                &changelog_row,
+                &ToSyncRecordTranslationType::PushToLegacyCentral
+            ),
+            false
+        );
+
+        // Should translate if a central server
+        test_util_set_is_central_server(true);
+        assert!(translator.should_translate_to_sync_record(
+            &changelog_row,
+            &ToSyncRecordTranslationType::PushToLegacyCentral
+        ));
+
+        let translation_result = translator
+            .try_translate_to_upsert_sync_record(&connection, &changelog_row)
+            .unwrap();
+
+        match translation_result {
+            PushTranslateResult::PushRecord(upsert_result) => {
+                assert_eq!(
+                    upsert_result[0].record.record_id,
+                    "test_vaccine_course_dose_id"
+                );
+                assert_eq!(
+                    upsert_result[0].record.table_name,
+                    LEGACY_VACCINE_COURSE_DOSE_TABLE_NAME
+                );
+            }
+            _ => panic!("Expected Upsert result"),
+        }
+    }
+}

--- a/server/service/src/sync/translations/vaccine_course_item.rs
+++ b/server/service/src/sync/translations/vaccine_course_item.rs
@@ -54,6 +54,12 @@ impl SyncTranslation for VaccineCourseItemTranslation {
             ToSyncRecordTranslationType::PullFromOmSupplyCentral => {
                 self.change_log_type().as_ref() == Some(&row.table_name)
             }
+            ToSyncRecordTranslationType::PushToOmSupplyCentral => {
+                // We shouldn't ever create Vaccine Course item rows in the central server,
+                // so we don't translate this, even when changelog records might exist
+                // This can happen due to migrations that recreate change log rows
+                false
+            }
             _ => false,
         }
     }

--- a/server/service/src/sync/translations/vaccine_course_item_legacy.rs
+++ b/server/service/src/sync/translations/vaccine_course_item_legacy.rs
@@ -1,0 +1,175 @@
+use serde::Serialize;
+
+use crate::sync::CentralServerConfig;
+
+use super::{PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
+use repository::{
+    vaccine_course::vaccine_course_item_row::VaccineCourseItemRowRepository, ChangelogRow,
+    ChangelogTableName, StorageConnection,
+};
+
+/*
+    This translator is only used to push VaccineCourseItem rows to the legacy mSupply server.
+    It should run from the Central Server
+*/
+
+#[allow(non_snake_case)]
+#[derive(Serialize)]
+pub struct LegacyVaccineCourseItemRow {
+    pub ID: String,
+    pub vaccine_course_ID: String,
+    pub item_ID: String,
+    pub deleted_datetime: Option<String>,
+}
+
+const LEGACY_VACCINE_COURSE_ITEM_TABLE_NAME: &str = "om_vaccine_course_item";
+
+// Needs to be added to all_translators()
+#[deny(dead_code)]
+pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
+    Box::new(VaccineCourseItemLegacyTranslation)
+}
+
+pub(crate) struct VaccineCourseItemLegacyTranslation;
+
+impl SyncTranslation for VaccineCourseItemLegacyTranslation {
+    fn table_name(&self) -> &'static str {
+        "vaccine_course_item"
+    }
+
+    fn pull_dependencies(&self) -> Vec<&'static str> {
+        vec![] // No pull, as this is just a push to Legacy mSupply
+    }
+
+    fn change_log_type(&self) -> Option<ChangelogTableName> {
+        Some(ChangelogTableName::VaccineCourseItem)
+    }
+
+    fn should_translate_to_sync_record(
+        &self,
+        row: &ChangelogRow,
+        r#type: &ToSyncRecordTranslationType,
+    ) -> bool {
+        match r#type {
+            ToSyncRecordTranslationType::PushToLegacyCentral => {
+                self.change_log_type().as_ref() == Some(&row.table_name)
+                    && CentralServerConfig::is_central_server()
+            }
+            _ => false,
+        }
+    }
+
+    fn try_translate_to_upsert_sync_record(
+        &self,
+        connection: &StorageConnection,
+        changelog: &ChangelogRow,
+    ) -> Result<PushTranslateResult, anyhow::Error> {
+        let row = VaccineCourseItemRowRepository::new(connection)
+            .find_one_by_id(&changelog.record_id)?
+            .ok_or(anyhow::Error::msg(format!(
+                "VaccineCourseItem row ({}) not found",
+                changelog.record_id
+            )))?;
+
+        let legacy_row = LegacyVaccineCourseItemRow {
+            ID: row.id.clone(),
+            vaccine_course_ID: row.vaccine_course_id.clone(),
+            item_ID: row.item_link_id.clone(),
+            deleted_datetime: row.deleted_datetime.map(|dt| dt.and_utc().to_rfc3339()),
+        };
+
+        let json_record = serde_json::to_value(legacy_row)?;
+
+        Ok(PushTranslateResult::upsert(
+            changelog,
+            LEGACY_VACCINE_COURSE_ITEM_TABLE_NAME,
+            json_record,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::sync::test_util_set_is_central_server;
+
+    use super::*;
+    use repository::{
+        mock::MockDataInserts, test_db::setup_all,
+        vaccine_course::vaccine_course_item_row::VaccineCourseItemRow, ChangelogRepository,
+    };
+
+    #[actix_rt::test]
+    async fn test_vaccine_course_legacy_translation() {
+        let translator = VaccineCourseItemLegacyTranslation;
+
+        let (_, connection, _, _) = setup_all(
+            "test_vaccine_course_legacy_translation",
+            MockDataInserts::none()
+                .vaccine_courses()
+                .programs()
+                .full_master_list()
+                .items()
+                .names(),
+        )
+        .await;
+
+        // Get the current cursor value
+        let cursor = ChangelogRepository::new(&connection)
+            .latest_cursor()
+            .unwrap();
+
+        // Create a new VaccineCourseItemRow (this will get a changelog entry created automatically)
+        let vaccine_course_item_row = VaccineCourseItemRow {
+            id: "test_vaccine_course_item_id".to_string(),
+            vaccine_course_id: "vaccine_course_a".to_string(),
+            item_link_id: "item_a".to_string(),
+            deleted_datetime: None,
+        };
+
+        let _insert_cursor = VaccineCourseItemRowRepository::new(&connection)
+            .upsert_one(&vaccine_course_item_row)
+            .unwrap();
+
+        let changelog_row = ChangelogRepository::new(&connection)
+            .changelogs(cursor, 100, None)
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        // Shouldn't translate if not a central server
+        test_util_set_is_central_server(false);
+        assert_eq!(
+            translator.should_translate_to_sync_record(
+                &changelog_row,
+                &ToSyncRecordTranslationType::PushToLegacyCentral
+            ),
+            false
+        );
+
+        // Should translate if a central server
+        test_util_set_is_central_server(true);
+        assert!(translator.should_translate_to_sync_record(
+            &changelog_row,
+            &ToSyncRecordTranslationType::PushToLegacyCentral
+        ));
+
+        let translation_result = translator
+            .try_translate_to_upsert_sync_record(&connection, &changelog_row)
+            .unwrap();
+
+        match translation_result {
+            PushTranslateResult::PushRecord(upsert_result) => {
+                assert_eq!(
+                    upsert_result[0].record.record_id,
+                    "test_vaccine_course_item_id"
+                );
+                assert_eq!(
+                    upsert_result[0].record.table_name,
+                    LEGACY_VACCINE_COURSE_ITEM_TABLE_NAME
+                );
+            }
+            _ => panic!("Expected Upsert result"),
+        }
+    }
+}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8232 and #8233 

# 👩🏻‍💻 What does this PR do?

Created a dedicated translator which syncs vaccine_course_dose and vaccine_course_item data to legacy mSupply from OMS Central.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a vaccine_course with doses and item on OMS Central
- [ ] Sync OMS Central
- [ ] Navigate to Legacy mSupply
- [ ] Open record_browser and confirm that the value in OMS Central reflects in the list

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

