### PR TITLE
Remove ReasonOptionLoader from stocktake_line #8169

### DIFF
--- a/server/graphql/types/src/types/stocktake_line.rs
+++ b/server/graphql/types/src/types/stocktake_line.rs
@@ -162,12 +162,12 @@ impl StocktakeLineNode {
         Ok(result.map(ItemVariantNode::from_domain))
     }
 
-    pub async fn reason_option(&self, _ctx: &Context<'_>) -> Result<Option<ReasonOptionNode>> {
-        Ok(self.line.reason_option.as_ref().map(|row| {
+    pub async fn reason_option(&self, _ctx: &Context<'_>) -> Option<ReasonOptionNode> {
+        self.line.reason_option.as_ref().map(|row| {
             ReasonOptionNode::from_domain(ReasonOption {
                 reason_option_row: row.clone(),
             })
-        }))
+        })
     }
 }
 

--- a/server/graphql/types/src/types/stocktake_line.rs
+++ b/server/graphql/types/src/types/stocktake_line.rs
@@ -6,8 +6,7 @@ use service::usize_to_u32;
 
 use graphql_core::{
     loader::{
-        ItemLoader, ItemVariantByItemVariantIdLoader, LocationByIdLoader, ReasonOptionLoader,
-        StockLineByIdLoader,
+        ItemLoader, ItemVariantByItemVariantIdLoader, LocationByIdLoader, StockLineByIdLoader,
     },
     standard_graphql_error::StandardGraphqlError,
     ContextExt,
@@ -124,21 +123,12 @@ impl StocktakeLineNode {
     }
 
     #[graphql(deprecation = "Since 2.8.0. Use reason_option instead")]
-    pub async fn inventory_adjustment_reason(
-        &self,
-        ctx: &Context<'_>,
-    ) -> Result<Option<InventoryAdjustmentReasonNode>> {
-        let loader = ctx.get_loader::<DataLoader<ReasonOptionLoader>>();
-        let inventory_adjustment_reason_id = match &self.line.line.reason_option_id {
-            None => return Ok(None),
-            Some(inventory_adjustment_reason_id) => inventory_adjustment_reason_id,
-        };
-
-        let result = loader
-            .load_one(inventory_adjustment_reason_id.clone())
-            .await?;
-
-        Ok(result.map(InventoryAdjustmentReasonNode::from_domain))
+    pub async fn inventory_adjustment_reason(&self) -> Option<InventoryAdjustmentReasonNode> {
+        self.line.reason_option.as_ref().map(|row| {
+            InventoryAdjustmentReasonNode::from_domain(ReasonOption {
+                reason_option_row: row.clone(),
+            })
+        })
     }
 
     pub async fn donor_id(&self) -> Option<String> {
@@ -162,7 +152,7 @@ impl StocktakeLineNode {
         Ok(result.map(ItemVariantNode::from_domain))
     }
 
-    pub async fn reason_option(&self, _ctx: &Context<'_>) -> Option<ReasonOptionNode> {
+    pub async fn reason_option(&self) -> Option<ReasonOptionNode> {
         self.line.reason_option.as_ref().map(|row| {
             ReasonOptionNode::from_domain(ReasonOption {
                 reason_option_row: row.clone(),

--- a/server/graphql/types/src/types/stocktake_line.rs
+++ b/server/graphql/types/src/types/stocktake_line.rs
@@ -1,7 +1,7 @@
 use async_graphql::*;
 use chrono::NaiveDate;
 use dataloader::DataLoader;
-use repository::StocktakeLine;
+use repository::{ReasonOption, StocktakeLine};
 use service::usize_to_u32;
 
 use graphql_core::{
@@ -162,15 +162,12 @@ impl StocktakeLineNode {
         Ok(result.map(ItemVariantNode::from_domain))
     }
 
-    pub async fn reason_option(&self, ctx: &Context<'_>) -> Result<Option<ReasonOptionNode>> {
-        let loader = ctx.get_loader::<DataLoader<ReasonOptionLoader>>();
-        let reason_option_id = match &self.line.line.reason_option_id {
-            None => return Ok(None),
-            Some(reason_option_id) => reason_option_id,
-        };
-
-        let result = loader.load_one(reason_option_id.clone()).await?;
-        Ok(result.map(ReasonOptionNode::from_domain))
+    pub async fn reason_option(&self, _ctx: &Context<'_>) -> Result<Option<ReasonOptionNode>> {
+        Ok(self.line.reason_option.as_ref().map(|row| {
+            ReasonOptionNode::from_domain(ReasonOption {
+                reason_option_row: row.clone(),
+            })
+        }))
     }
 }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8169

# 👩🏻‍💻 What does this PR do?
StocktakeLine struct already returns Reason Options, so have refactored this to use that instead since it's better for performance and less complex.

## 💌 Any notes for the reviewer?
Probably a good idea to implement this everywhere where we are already getting the data from an sql query instead of using a loader for the reasons above + avoids N+1~

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Add a reason to a stocktake line
- [ ] Make sure the reason loads correctly

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

