### PR TITLE
#8259 fix/ Adding a reason in stocktake not always possible until clicking on Ok

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -267,7 +267,16 @@ export const BatchTable = ({
     );
 
     return columnDefinitions;
-  }, [itemVariantsEnabled]);
+  }, [
+    update,
+    theme,
+    itemVariantsEnabled,
+    errorsContext,
+    reasonOptions,
+    isLoading,
+    isInitialStocktake,
+    displayInDoses,
+  ]);
 
   const columns = useColumns<DraftStocktakeLine>(columnDefinitions, {}, [
     columnDefinitions,

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -268,8 +268,6 @@ export const BatchTable = ({
 
     return columnDefinitions;
   }, [
-    update,
-    theme,
     itemVariantsEnabled,
     errorsContext,
     reasonOptions,

--- a/client/packages/system/src/ReasonOption/Components/ReasonOptionsSearchInput.tsx
+++ b/client/packages/system/src/ReasonOption/Components/ReasonOptionsSearchInput.tsx
@@ -53,8 +53,8 @@ export const ReasonOptionsSearchInput = ({
             }
           : null
       }
+      required={isRequired && !disabled}
       inputProps={{
-        required: isRequired && !disabled,
         ...restProps.inputProps,
       }}
       onChange={(_, reason) => {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8259

# 👩🏻‍💻 What does this PR do?
Update `useMemo` dependency array for `columnDefinitions` so that variable changes trigger update without having to click OK

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

https://github.com/user-attachments/assets/7c7208e8-e42c-4f20-a50e-0b3d12180b5c

## 💌 Any notes for the reviewer?
Not sure if all the dependencies need to be added.

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to Stocktake
- [ ] Create a stocktake
- [ ] Add an item
- [ ] Adjust stock
- [ ] Observe that reasons are enabled immediately after an adjustment number has been entered
- [ ] Observe that when both snapshot and counted are equal then reason is disabled
# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

