### PR TITLE
Use Default packsize for new lines in stocktake if not entered

### DIFF
--- a/client/packages/inventory/src/Stocktake/api/api.ts
+++ b/client/packages/inventory/src/Stocktake/api/api.ts
@@ -60,7 +60,7 @@ const stocktakeParser = {
     toUpdate: (line: DraftStocktakeLine): UpdateStocktakeLineInput => ({
       location: setNullableInput('id', line.location),
       batch: line.batch ?? '',
-      packSize: line.packSize ?? 1,
+      packSize: line.packSize ?? line.item.defaultPackSize,
       costPricePerPack: line.costPricePerPack,
       countedNumberOfPacks: line.countedNumberOfPacks,
       sellPricePerPack: line.sellPricePerPack,
@@ -76,7 +76,7 @@ const stocktakeParser = {
     toInsert: (line: DraftStocktakeLine): InsertStocktakeLineInput => ({
       location: setNullableInput('id', line.location),
       batch: line.batch ?? '',
-      packSize: line.packSize ?? 1,
+      packSize: line.packSize ?? line.item.defaultPackSize,
       costPricePerPack: line.costPricePerPack,
       countedNumberOfPacks: line.countedNumberOfPacks,
       id: line.id,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8260

# 👩🏻‍💻 What does this PR do?

It assumes the item's default packsize when creating new lines, if the user hasn't entered a packsize

## 💌 Any notes for the reviewer?

A nicer fix might be to actually update the packsize as seen in the frontend when the counted packs is updated?
Just in case there's some additional logic added for packsizes in future?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Make sure you have an item which has a default packsize bigger than 1 set as part of a master list
- [ ] Make sure the item doesn't have any existing stock transactions
- [ ] (Good idea to create a new masterlist and new items for this test?)
- [ ] Add a stock take from this masterlist
- [ ] Create a new batch for the item and see that the default packsize is displayed
- [ ] Save the batch line, check that the default packsize is still selected (hasn't reset to 1)
- [ ] Test other variations eg. items with no default packsize?

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [X] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

