### PR TITLE
Default to allocating in packs if there's only one packsize

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/Allocation.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/Allocation.tsx
@@ -68,17 +68,13 @@ export const Allocation = ({
       ];
 
       // if there is only one packsize, we should auto-allocate in packs for that size
-      let allocateInPacksize: AllocateInOption | undefined = undefined;
-      if (packsizes.length === 1) {
-        const packSize = packsizes[0];
-        if (packSize) {
-          // There's only one defined pack size, so set allocation to happen in packs
-          allocateInPacksize = {
-            type: AllocateInType.Packs,
-            packSize: packSize,
-          };
-        }
-      }
+      const allocateInPacksize: AllocateInOption | undefined =
+        packsizes.length === 1 && packsizes[0]
+          ? {
+              type: AllocateInType.Packs,
+              packSize: packsizes[0],
+            }
+          : undefined;
 
       initialise({
         itemData: data,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8258

# 👩🏻‍💻 What does this PR do?

When creating an outbound shipment, if there's only one existing packsize in stock, default to allocating in that packsize

## 💌 Any notes for the reviewer?

Feels like this maybe should be done in Allocation Context somewhere, however this limits this just to the Outbound shipment page.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Try allocating stock for an item with only one packsize in stock, the sysmte should default to packs of size X where X is the size of the existing stock lines
- [ ] If there's more than one packsize, it should default to units (or doses if vaccine item and `manageVaccinesInDoses` is selected
- [ ] Check I haven't broken anything else.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [X] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Allocation docs
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

