### PR TITLE
8278 Fix load test hang

### DIFF
--- a/server/cli/src/load_test.rs
+++ b/server/cli/src/load_test.rs
@@ -337,8 +337,10 @@ impl LoadTest {
             all_metrics
         });
 
-        // Wait for either all tasks to complete or timeout
-        let timeout_duration = Duration::from_secs(duration + 30); // Extra 30 seconds for cleanup
+        // Wait for either all tasks to complete or timeout. We delay by a significant amount here as the child processes don't start their timers based
+        // on duration until after they've initialised, where this timer will start essentially immediately, before the children have initialised.
+        // The more sites/children spawned, the longer we should expect initialisation to take.
+        let timeout_duration = Duration::from_secs(duration + (60 * 2 * num_sites as u64));
 
         let handles_for_timeout = handles.iter().map(|h| h.abort_handle()).collect::<Vec<_>>();
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8278 

# 👩🏻‍💻 What does this PR do?

- Use channels to return metrics throughout test
- Parent process kills children after duration of test if they haven't terminated themselves
- include the child site_id in kill log message

## 💌 Any notes for the reviewer?

I copiloted 90% of this

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] OMS and OG central
- [ ] a site called `test_site` with at least 1 store on it
- [ ] add an infinite loop to the code to ensure that the child processes are stuck
- [ ] `cargo build --features integration_test && ./target/debug/remote_server_cli load-test --msupply-central-url http://localhost:8888 --oms-central-url http://localhost:8000 -s 10 -d 10`

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

