### PR TITLE
8211 Create Clinician From Within Search

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useCallback } from 'react';
+import React, { PropsWithChildren } from 'react';
 import {
   Autocomplete as MuiAutocomplete,
   AutocompleteRenderInputParams,
@@ -102,24 +102,17 @@ export function Autocomplete<T>({
   const openOverrides = useOpenStateWithKeyboard(restOfAutocompleteProps);
 
   const isCreateOption = (option: unknown): option is AddOption => {
-    return (
-      typeof option === 'object' &&
-      option !== null &&
-      '_isAddOption' in option &&
-      (option as any)._isAddOption === true
-    );
+    return option === createOption;
   };
 
-  const filter = useCallback(
-    (options: T[], state: FilterOptionsState<T>) => {
-      const filterType =
-        filterOptions ?? createFilterOptions(filterOptionConfig);
-      let filtered = filterType(options, state);
-      filtered = filtered.filter(option => !isCreateOption(option));
+  const filterType = filterOptions ?? createFilterOptions(filterOptionConfig);
+  const filter = (options: T[], state: FilterOptionsState<T>) => {
+    const filtered = filterType(options, state);
+    if (createOption && !filtered.some(option => isCreateOption(option))) {
       return [...filtered, createOption as T];
-    },
-    [filterOptions, filterOptionConfig, isCreateOption]
-  );
+    }
+    return filtered;
+  };
 
   const defaultRenderInput = (props: AutocompleteRenderInputParams) => (
     <BasicTextInput

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
@@ -188,11 +188,15 @@ export function Autocomplete<T>({
     ? [...options, createOption as T]
     : options;
 
-  const customRenderOption = (props: any, option: any, state: any) => {
+  const customRenderOption = (
+    props: React.HTMLAttributes<HTMLLIElement>,
+    option: T,
+    state: AutocompleteRenderOptionState
+  ) => {
     if (isCreateOption(option)) {
       return (
         <li {...props} key={option.id}>
-          {createOptionRenderer(option as AddOption)}
+          {createOptionRenderer(option)}
         </li>
       );
     }

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
@@ -233,7 +233,7 @@ export function Autocomplete<T>({
       }
       onChange={(_event, option, reason, details) => {
         if (isClickableOption(option) && clickableOption?.onClick) {
-          clickableOption?.onClick();
+          clickableOption.onClick();
           return;
         }
         if (onChange) onChange(_event, option, reason, details);

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
@@ -109,16 +109,18 @@ export function Autocomplete<T>({
     );
   };
 
-  const filter = useMemo(() => {
-    const filterType = filterOptions ?? createFilterOptions(filterOptionConfig);
-    return (options: T[], state: FilterOptionsState<T>) => {
+  const filter = useCallback(
+    (options: T[], state: FilterOptionsState<T>) => {
+      const filterType =
+        filterOptions ?? createFilterOptions(filterOptionConfig);
       const filtered = filterType(options, state);
       const addOptions = options.filter(
         option => isCreateOption(option) && !filtered.includes(option)
       );
       return [...filtered, ...addOptions];
-    };
-  }, [filterOptions, filterOptionConfig]);
+    },
+    [filterOptions, filterOptionConfig, isCreateOption]
+  );
 
   const defaultRenderInput = (props: AutocompleteRenderInputParams) => (
     <BasicTextInput

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useMemo } from 'react';
+import React, { PropsWithChildren, useCallback } from 'react';
 import {
   Autocomplete as MuiAutocomplete,
   AutocompleteRenderInputParams,
@@ -12,6 +12,7 @@ import {
   Box,
   Typography,
   FilterOptionsState,
+  AutocompleteRenderOptionState,
 } from '@mui/material';
 import {
   AutocompleteOption,
@@ -113,11 +114,9 @@ export function Autocomplete<T>({
     (options: T[], state: FilterOptionsState<T>) => {
       const filterType =
         filterOptions ?? createFilterOptions(filterOptionConfig);
-      const filtered = filterType(options, state);
-      const addOptions = options.filter(
-        option => isCreateOption(option) && !filtered.includes(option)
-      );
-      return [...filtered, ...addOptions];
+      let filtered = filterType(options, state);
+      filtered = filtered.filter(option => !isCreateOption(option));
+      return [...filtered, createOption as T];
     },
     [filterOptions, filterOptionConfig, isCreateOption]
   );
@@ -194,11 +193,7 @@ export function Autocomplete<T>({
     state: AutocompleteRenderOptionState
   ) => {
     if (isCreateOption(option)) {
-      return (
-        <li {...props} key={option.id}>
-          {createOptionRenderer(option)}
-        </li>
-      );
+      return <li {...props}>{createOptionRenderer(option)}</li>;
     }
 
     if (renderOption) {
@@ -206,9 +201,7 @@ export function Autocomplete<T>({
     }
 
     return (
-      <li {...props} key={option.id}>
-        {(getOptionLabel || defaultGetOptionLabel)(option)}
-      </li>
+      <li {...props}>{(getOptionLabel || defaultGetOptionLabel)(option)}</li>
     );
   };
 

--- a/client/packages/system/src/Clinician/ClinicianSearchInput.tsx
+++ b/client/packages/system/src/Clinician/ClinicianSearchInput.tsx
@@ -48,8 +48,7 @@ export const ClinicianSearchInput = ({
 
   const clinicians: ClinicianFragment[] = data?.nodes ?? [];
 
-  const [modalOpen, setModalOpen] = useState(false);
-  const [sliderOpen, setSliderOpen] = useState(false);
+  const [editorOpen, setEditorOpen] = useState(false);
 
   const addClinicianOption = {
     id: 'add',
@@ -59,7 +58,7 @@ export const ClinicianSearchInput = ({
 
   const handleAddClick = () => {
     onChange(null);
-    mountSlidePanel ? setSliderOpen(true) : setModalOpen(true);
+    setEditorOpen(true);
   };
 
   const asOption = (clinician: Clinician): ClinicianAutocompleteOption => ({
@@ -69,8 +68,7 @@ export const ClinicianSearchInput = ({
   });
 
   const handleClinicianClose = async (clinicianId?: string) => {
-    setSliderOpen(false);
-    setModalOpen(false);
+    setEditorOpen(false);
 
     if (clinicianId) {
       const refreshedList = await refetch();
@@ -138,7 +136,7 @@ export const ClinicianSearchInput = ({
             draft={draft}
             updateDraft={updateDraft}
             width={500}
-            open={sliderOpen}
+            open={editorOpen}
             onClose={handleClinicianClose}
             confirmAndSave={confirmAndSave}
             isSaving={isSaving}
@@ -149,7 +147,7 @@ export const ClinicianSearchInput = ({
             draft={draft}
             updateDraft={updateDraft}
             onClose={handleClinicianClose}
-            open={modalOpen}
+            open={editorOpen}
             confirmAndSave={confirmAndSave}
             isSaving={isSaving}
             isValid={isValid}

--- a/client/packages/system/src/Clinician/ClinicianSearchInput.tsx
+++ b/client/packages/system/src/Clinician/ClinicianSearchInput.tsx
@@ -48,7 +48,6 @@ export const ClinicianSearchInput = ({
 
   const clinicians: ClinicianFragment[] = data?.nodes ?? [];
 
-  const [open, setPopoverOpen] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [sliderOpen, setSliderOpen] = useState(false);
 
@@ -59,7 +58,6 @@ export const ClinicianSearchInput = ({
   };
 
   const handleAddClick = () => {
-    setPopoverOpen(false);
     onChange(null);
     mountSlidePanel ? setSliderOpen(true) : setModalOpen(true);
   };
@@ -112,9 +110,6 @@ export const ClinicianSearchInput = ({
   return (
     <Box width={`${width}px`} display={'flex'} alignItems="center">
       <Autocomplete
-        open={open}
-        onOpen={() => setPopoverOpen(true)}
-        onClose={() => setPopoverOpen(false)}
         value={clinicianValue ? asOption(clinicianValue) : null}
         isOptionEqualToValue={(option, value) =>
           option.value.id === value.value?.id

--- a/client/packages/system/src/Clinician/ClinicianSearchInput.tsx
+++ b/client/packages/system/src/Clinician/ClinicianSearchInput.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import {
   Autocomplete,
   Box,
-  IconButton,
   PlusCircleIcon,
   Typography,
   useConfirmationModal,
@@ -161,9 +160,11 @@ export const ClinicianSearchInput = ({
         isOptionEqualToValue={(option, value) =>
           option.id !== 'add' && option.value.id === value.value?.id
         }
+        getOptionLabel={option => (option.id === 'add' ? '' : option.label)}
         onChange={(_, option) => {
           if (option && option.id == 'add') {
             setPopoverOpen(false);
+            onChange(null);
             mountSlidePanel ? setSliderOpen(true) : setModalOpen(true);
             return;
           }
@@ -185,44 +186,29 @@ export const ClinicianSearchInput = ({
         disabled={disabled}
         fullWidth={fullWidth}
       />
-      {allowCreate && (
-        <Box
-          sx={{
-            overflow: 'hidden',
-          }}
-        >
-          <IconButton
-            icon={<PlusCircleIcon />}
-            label={t('button.add-new-clinician')}
-            color="secondary"
-            onClick={() =>
-              mountSlidePanel ? setSliderOpen(true) : setModalOpen(true)
-            }
+      {allowCreate &&
+        (mountSlidePanel ? (
+          <CreateClinicianSlider
+            draft={draft}
+            updateDraft={updateDraft}
+            width={500}
+            open={sliderOpen}
+            onClose={handleClinicianClose}
+            confirmAndSave={confirmAndSave}
+            isSaving={isSaving}
+            isValid={isValid}
           />
-          {mountSlidePanel ? (
-            <CreateClinicianSlider
-              draft={draft}
-              updateDraft={updateDraft}
-              width={500}
-              open={sliderOpen}
-              onClose={handleClinicianClose}
-              confirmAndSave={confirmAndSave}
-              isSaving={isSaving}
-              isValid={isValid}
-            />
-          ) : (
-            <CreateClinicianModal
-              draft={draft}
-              updateDraft={updateDraft}
-              onClose={handleClinicianClose}
-              open={modalOpen}
-              confirmAndSave={confirmAndSave}
-              isSaving={isSaving}
-              isValid={isValid}
-            />
-          )}
-        </Box>
-      )}
+        ) : (
+          <CreateClinicianModal
+            draft={draft}
+            updateDraft={updateDraft}
+            onClose={handleClinicianClose}
+            open={modalOpen}
+            confirmAndSave={confirmAndSave}
+            isSaving={isSaving}
+            isValid={isValid}
+          />
+        ))}
     </Box>
   );
 };

--- a/client/packages/system/src/Clinician/ClinicianSearchInput.tsx
+++ b/client/packages/system/src/Clinician/ClinicianSearchInput.tsx
@@ -50,13 +50,7 @@ export const ClinicianSearchInput = ({
 
   const [editorOpen, setEditorOpen] = useState(false);
 
-  const addClinicianOption = {
-    id: 'add',
-    label: t('label.create-clinician'),
-    _isAddOption: true,
-  };
-
-  const handleAddClick = () => {
+  const handleCreateClick = () => {
     onChange(null);
     setEditorOpen(true);
   };
@@ -127,8 +121,14 @@ export const ClinicianSearchInput = ({
         textSx={{ backgroundColor: theme.palette.background.drawer }}
         disabled={disabled}
         fullWidth={fullWidth}
-        onCreateOptionClick={handleAddClick}
-        createOption={allowCreate ? addClinicianOption : undefined}
+        clickableOption={
+          allowCreate
+            ? {
+                label: t('label.create-clinician'),
+                onClick: handleCreateClick,
+              }
+            : undefined
+        }
       />
       {allowCreate &&
         (mountSlidePanel ? (

--- a/client/packages/system/src/Clinician/ClinicianSearchInput.tsx
+++ b/client/packages/system/src/Clinician/ClinicianSearchInput.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import {
   Autocomplete,
   Box,
-  PlusCircleIcon,
   Typography,
   useConfirmationModal,
   useIntlUtils,
@@ -56,11 +55,13 @@ export const ClinicianSearchInput = ({
   const addClinicianOption = {
     id: 'add',
     label: t('label.create-clinician'),
-    value: {
-      id: 'add',
-      firstName: '',
-      lastName: '',
-    },
+    _isAddOption: true,
+  };
+
+  const handleAddClick = () => {
+    setPopoverOpen(false);
+    onChange(null);
+    mountSlidePanel ? setSliderOpen(true) : setModalOpen(true);
   };
 
   const asOption = (clinician: Clinician): ClinicianAutocompleteOption => ({
@@ -68,25 +69,6 @@ export const ClinicianSearchInput = ({
     value: clinician,
     id: clinician.id,
   });
-
-  const options = clinicians.map(
-    (clinician): ClinicianAutocompleteOption => asOption(clinician)
-  );
-  const optionsWithAdd = allowCreate
-    ? [...options, addClinicianOption]
-    : options;
-
-  const filterOptions = (
-    options: ClinicianAutocompleteOption[],
-    value: { inputValue: string }
-  ) => {
-    return options.filter(
-      option =>
-        // Always include the 'add' option
-        option.id === 'add' ||
-        option.label.toLowerCase().includes(value.inputValue.toLowerCase())
-    );
-  };
 
   const handleClinicianClose = async (clinicianId?: string) => {
     setSliderOpen(false);
@@ -127,29 +109,6 @@ export const ClinicianSearchInput = ({
     }
   };
 
-  const CreateOption = (option: ClinicianAutocompleteOption) => (
-    <Box
-      display="flex"
-      justifyContent="space-between"
-      alignItems="center"
-      gap={1}
-      height={25}
-      width="100%"
-    >
-      <Typography
-        overflow="hidden"
-        fontWeight="bold"
-        textOverflow="ellipsis"
-        sx={{
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {option.label}
-      </Typography>
-      <PlusCircleIcon color="secondary" />
-    </Box>
-  );
-
   return (
     <Box width={`${width}px`} display={'flex'} alignItems="center">
       <Autocomplete
@@ -158,33 +117,25 @@ export const ClinicianSearchInput = ({
         onClose={() => setPopoverOpen(false)}
         value={clinicianValue ? asOption(clinicianValue) : null}
         isOptionEqualToValue={(option, value) =>
-          option.id !== 'add' && option.value.id === value.value?.id
+          option.value.id === value.value?.id
         }
-        getOptionLabel={option => (option.id === 'add' ? '' : option.label)}
         onChange={(_, option) => {
-          if (option && option.id == 'add') {
-            setPopoverOpen(false);
-            onChange(null);
-            mountSlidePanel ? setSliderOpen(true) : setModalOpen(true);
-            return;
-          }
           onChange(option);
         }}
-        options={optionsWithAdd}
-        filterOptions={filterOptions}
+        options={clinicians.map(
+          (clinician): ClinicianAutocompleteOption => asOption(clinician)
+        )}
         sx={{ width: '100%' }}
         renderOption={(props, option) => (
           <li {...props} key={option.id}>
-            {option.id === 'add' ? (
-              <CreateOption {...option} />
-            ) : (
-              <Typography>{option.label}</Typography>
-            )}
+            <Typography>{option.label}</Typography>
           </li>
         )}
         textSx={{ backgroundColor: theme.palette.background.drawer }}
         disabled={disabled}
         fullWidth={fullWidth}
+        onCreateOptionClick={handleAddClick}
+        createOption={allowCreate ? addClinicianOption : undefined}
       />
       {allowCreate &&
         (mountSlidePanel ? (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8211

# 👩🏻‍💻 What does this PR do?

Can create a clinician from within the clinicians search input
Is always visible - regardless of filtering

![Screenshot 2025-06-25 at 9 47 31 AM](https://github.com/user-attachments/assets/b2c00c26-bb96-43d4-89ca-a54cfdefabe3)
![Screenshot 2025-06-25 at 9 47 41 AM](https://github.com/user-attachments/assets/d74b0e7e-4c01-4a28-9b19-c155ca65cbd4)


I first created this as a specific component, and then pulled out the logic to the common autocomplete - can see in commit history.

To add this functionality to another search component, the following will be needed:
- define the CreateOption object with an id, label, and _isAddOption flag
- define a handler for what needs to happen when this option is selected (open modal)
- pass both of these to the Autocomplete component
- conditions can be set eg createOption only to be passed through if there are no results from filtering
- popover open/closed state may need to be managed here as well

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->
Changes to a common component - it should be set up so as to not interfere with any existing functionality

Both createOption and onCreateOptionClick need to be provided to the autocomplete in order for this to work properly. Omitting createOption - it doesn't render.
Omitting onCreateOptionClick - it selects the createOption as value.

Is there a way to ensure that both are provided? I considered adding the handler as a required key of the createOption object


<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

Have some clinicians already visible

- [ ] Go to Prescriptions -> New Prescription -> click on the clinicians search area
- [ ] See list of existing clinicians, and a `Create Clinician` button at the bottom of the list
- [ ] Search in the clinicians, see this button always visible regardless of search results
- [ ] Click on `Create Clinician` -> See the side modal open where you can create a clinician
- [ ] Enter clinician details -> OK -> new clinician name will populate
- [ ] Repeat in Prescriptions -> open an existing prescription -> search in clinicians. Should be the same, except selecting `Create Clinician` will open a modal

As this is a change on a common component, check other autocompletes throughout the app and that they work as expected

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [x] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [x] Postgres
- [x] SQLite
- [x] Frontend

