### PR TITLE
8280 Prescription: Can't input correct amount of units & input losing focus

### DIFF
--- a/client/packages/invoices/src/Prescriptions/LineEditView/columns.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/columns.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
   CellProps,
   ColumnAlign,
@@ -6,8 +6,9 @@ import {
   ExpiryDateCell,
   Formatter,
   NumberCell,
-  NumberInputCell,
+  NumericTextInput,
   PreferenceKey,
+  useBufferState,
   useColumns,
   useIntlUtils,
   usePreference,
@@ -147,12 +148,31 @@ export const usePrescriptionLineEditColumns = ({
   return useColumns(columnDefinitions, {}, [allocate]);
 };
 
-const UnitQuantityCell = (props: CellProps<DraftStockOutLineFragment>) => (
-  <NumberInputCell
-    {...props}
-    max={props.rowData.availablePacks}
-    decimalLimit={2}
-    min={0}
-    slotProps={{ htmlInput: { sx: { backgroundColor: 'white' } } }}
-  />
-);
+const UnitQuantityCell = (props: CellProps<DraftStockOutLineFragment>) => {
+  const { rowData, column } = props;
+  const [buffer, setBuffer] = useBufferState(column.accessor({ rowData }));
+
+  const handleChange = (num: number | undefined) => {
+    setBuffer(num ?? 0);
+  };
+
+  const handleBlur = useCallback(() => {
+    const resetValue = column.setter({ ...rowData, [column.key]: buffer });
+    if (resetValue !== undefined) setBuffer(resetValue);
+  }, [buffer, column, rowData, setBuffer]);
+
+  return (
+    <NumericTextInput
+      value={buffer as number | undefined}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      min={0}
+      max={rowData.availablePacks * rowData.packSize}
+      decimalLimit={2}
+      slotProps={{
+        input: { sx: { '& .MuiInput-input': { textAlign: 'right' } } },
+        htmlInput: { sx: { backgroundColor: 'white' } },
+      }}
+    />
+  );
+};

--- a/client/packages/invoices/src/Prescriptions/LineEditView/columns.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/columns.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import {
   CellProps,
   ColumnAlign,
@@ -6,9 +6,8 @@ import {
   ExpiryDateCell,
   Formatter,
   NumberCell,
-  NumericTextInput,
+  NumberInputCell,
   PreferenceKey,
-  useBufferState,
   useColumns,
   useIntlUtils,
   usePreference,
@@ -148,31 +147,13 @@ export const usePrescriptionLineEditColumns = ({
   return useColumns(columnDefinitions, {}, [allocate]);
 };
 
-const UnitQuantityCell = (props: CellProps<DraftStockOutLineFragment>) => {
-  const { rowData, column } = props;
-  const [buffer, setBuffer] = useBufferState(column.accessor({ rowData }));
-
-  const handleChange = (num: number | undefined) => {
-    setBuffer(num ?? 0);
-  };
-
-  const handleBlur = useCallback(() => {
-    const resetValue = column.setter({ ...rowData, [column.key]: buffer });
-    if (resetValue !== undefined) setBuffer(resetValue);
-  }, [buffer, column, rowData, setBuffer]);
-
-  return (
-    <NumericTextInput
-      value={buffer as number | undefined}
-      onChange={handleChange}
-      onBlur={handleBlur}
-      min={0}
-      max={rowData.availablePacks * rowData.packSize}
-      decimalLimit={2}
-      slotProps={{
-        input: { sx: { '& .MuiInput-input': { textAlign: 'right' } } },
-        htmlInput: { sx: { backgroundColor: 'white' } },
-      }}
-    />
-  );
-};
+const UnitQuantityCell = (props: CellProps<DraftStockOutLineFragment>) => (
+  <NumberInputCell
+    {...props}
+    max={props.rowData.availablePacks * props.rowData.packSize}
+    decimalLimit={2}
+    min={0}
+    debounce={1000}
+    slotProps={{ htmlInput: { sx: { backgroundColor: 'white' } } }}
+  />
+);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8280 

# 👩🏻‍💻 What does this PR do?

Updated the max calculation for `NumericTextInput` to use `availablePacks` * `packSize`.

Chose not to use `NumberInputCell`—it has some built-in calculations that trigger right when the value changes. We could debounce the update for longer, but even then we’d run into the same issue: it loses focus and causes the UI to jump around.

Instead, saving now happens on blur. It gives a much smoother UI experience. The only trade-off is that the `Save` button won’t appear clickable until the user clicks out of the input.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to prescription
- [ ] Have a pack size of > 1 for an item
- [ ] Try to issue all units
- [ ] Should let you issue all of the units
- [ ] Click out of the input
- [ ] Save button is now clickable

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

