### PR TITLE
8295 - New Patient button in Patient Search

### DIFF
--- a/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
@@ -171,7 +171,7 @@ export const Toolbar = () => {
                   await update({ id, patientId });
                 }}
                 setEditPatientModalOpen={setEditPatientModalOpen}
-                // allowCreate
+                allowCreate
                 setCreatePatientModalOpen={openPatientModal}
               />
             }

--- a/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Toolbar.tsx
@@ -8,9 +8,6 @@ import {
   Formatter,
   DateUtils,
   useConfirmationModal,
-  DefaultAutocompleteItemOption,
-  Box,
-  Typography,
   useCallbackWithPermission,
   UserPermission,
 } from '@openmsupply-client/common';
@@ -174,40 +171,8 @@ export const Toolbar = () => {
                   await update({ id, patientId });
                 }}
                 setEditPatientModalOpen={setEditPatientModalOpen}
-                NoOptionsRenderer={props => (
-                  <DefaultAutocompleteItemOption
-                    {...props}
-                    key="no-options-renderer"
-                  >
-                    <Box
-                      display="flex"
-                      justifyContent="space-between"
-                      alignItems="flex-end"
-                      gap={1}
-                      height={25}
-                      width="100%"
-                    >
-                      <Typography
-                        overflow="hidden"
-                        fontWeight="bold"
-                        textOverflow="ellipsis"
-                        sx={{
-                          whiteSpace: 'nowrap',
-                        }}
-                      >
-                        {t('messages.no-matching-patients')}
-                      </Typography>
-                      <Typography
-                        onClick={() => {
-                          openPatientModal();
-                        }}
-                        color="secondary"
-                      >
-                        {t('button.create-new-patient')}
-                      </Typography>
-                    </Box>
-                  </DefaultAutocompleteItemOption>
-                )}
+                // allowCreate
+                setCreatePatientModalOpen={openPatientModal}
               />
             }
           />

--- a/client/packages/invoices/src/Prescriptions/ListView/NewPrescriptionModal.tsx
+++ b/client/packages/invoices/src/Prescriptions/ListView/NewPrescriptionModal.tsx
@@ -4,7 +4,6 @@ import {
   Box,
   DateTimePickerInput,
   DateUtils,
-  DefaultAutocompleteItemOption,
   DialogButton,
   FnUtils,
   Formatter,
@@ -12,7 +11,6 @@ import {
   LoadingButton,
   SaveIcon,
   Stack,
-  Typography,
   useDialog,
   useNavigate,
   useNotification,
@@ -126,41 +124,8 @@ export const NewPrescriptionModal: FC<NewPrescriptionModalProps> = ({
                   setPatient(result);
                 }}
                 width={350}
-                NoOptionsRenderer={props => (
-                  <DefaultAutocompleteItemOption
-                    {...props}
-                    key="no-options-renderer"
-                  >
-                    <Box
-                      display="flex"
-                      justifyContent="space-between"
-                      alignItems="flex-end"
-                      gap={1}
-                      height={25}
-                      width="100%"
-                    >
-                      <Typography
-                        overflow="hidden"
-                        fontWeight="bold"
-                        textOverflow="ellipsis"
-                        sx={{
-                          whiteSpace: 'nowrap',
-                        }}
-                      >
-                        {t('messages.no-matching-patients')}
-                      </Typography>
-                      <Typography
-                        onClick={() => {
-                          openPatientModal();
-                          handleClose();
-                        }}
-                        color="secondary"
-                      >
-                        {t('button.create-new-patient')}
-                      </Typography>
-                    </Box>
-                  </DefaultAutocompleteItemOption>
-                )}
+                allowCreate
+                setCreatePatientModalOpen={openPatientModal}
               />
             }
           />

--- a/client/packages/system/src/Patient/Components/PatientSearchInput/PatientSearchInput.tsx
+++ b/client/packages/system/src/Patient/Components/PatientSearchInput/PatientSearchInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Autocomplete,
   Box,
@@ -11,22 +11,24 @@ import { getPatientOptionRenderer } from '../PatientOptionRenderer';
 import { useSearchPatient } from '../utils';
 
 interface PatientSearchInputProps extends NameSearchInputProps {
+  setCreatePatientModalOpen?: (open: boolean) => void;
   setEditPatientModalOpen?: (open: boolean) => void;
+  allowCreate?: boolean;
+  allowEdit?: boolean;
 }
 
-export const PatientSearchInput: FC<
-  PatientSearchInputProps & { allowEdit?: boolean }
-> = ({
+export const PatientSearchInput = ({
   autoFocus,
   onChange,
   width = 250,
   value,
   disabled = false,
   sx,
-  NoOptionsRenderer,
+  setCreatePatientModalOpen,
   setEditPatientModalOpen,
+  allowCreate = false,
   allowEdit = false,
-}) => {
+}: PatientSearchInputProps) => {
   const t = useTranslation();
   const PatientOptionRenderer = getPatientOptionRenderer();
   const { isLoading, patients, search } = useSearchPatient();
@@ -40,21 +42,10 @@ export const PatientSearchInput: FC<
     }
   }, [value]);
 
-  const noResults =
-    NoOptionsRenderer && patients.length === 0 && input !== '' && !isLoading;
+  const showCreate =
+    allowCreate && patients.length === 0 && input !== '' && !isLoading;
 
-  const options = noResults
-    ? // This is a bit of hack to allow us to render a component inside the
-      // Autocomplete when there are no options/results. Normally, only "text"
-      // can be defined for "No Options", so we create this "dummy" option to
-      // prevent the "No Options" behaviour, and then we specify a custom
-      // renderer which (should) have a static component (e.g. a "Create new
-      // patient" link) The type of this dummy value doesn't matter as it's
-      // values never get rendered/referenced.
-      // If a "NoOptionsRenderer" isn't specified, the component will behave as
-      // normal (i.e. show the "noOptionsText" when no results are found)
-      ([{ name: 'Dummy', value: '_' }] as unknown as SearchInputPatient[])
-    : patients;
+  const options = patients as SearchInputPatient[];
 
   return (
     <Box width={`${width}px`} display={'flex'} alignItems="center">
@@ -70,7 +61,7 @@ export const PatientSearchInput: FC<
             setInput(name.name);
           }
         }}
-        renderOption={noResults ? NoOptionsRenderer : PatientOptionRenderer}
+        renderOption={PatientOptionRenderer}
         getOptionLabel={(option: SearchInputPatient) => option.name}
         isOptionEqualToValue={(option, value) => option.name === value.name}
         popperMinWidth={width}
@@ -93,6 +84,14 @@ export const PatientSearchInput: FC<
           input.length > 0
             ? t('messages.no-matching-patients')
             : t('messages.type-to-search')
+        }
+        clickableOption={
+          showCreate && setCreatePatientModalOpen
+            ? {
+                label: t('label.new-patient'),
+                onClick: () => setCreatePatientModalOpen(true),
+              }
+            : undefined
         }
       />
       {allowEdit && value && (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8295

# 👩🏻‍💻 What does this PR do?

Use the new Autocomplete prop to render a button to make a new patient where patients are searched - currently in the `New Prescription` modal and prescription detail view. This is controlled in each place by the allowCreate prop

The whole button is now clickable and no longer can select the 'Dummy' patient

With allowCreate on and search results:
![Screenshot 2025-06-27 at 11 54 54 AM](https://github.com/user-attachments/assets/60367486-8753-43c7-833f-233f6a59d5dd)

With allowCreate on and no search results:
![Screenshot 2025-06-27 at 11 55 02 AM](https://github.com/user-attachments/assets/0fcada39-3bd7-4126-b946-1a3be1ef06ec)

With allowCreate off will look like this (for reference only, is not implemented currently)
![Screenshot 2025-06-27 at 11 53 47 AM](https://github.com/user-attachments/assets/fea3aeff-095b-4ebf-805e-242cc71df58f)

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to dispensary -> prescriptions -> `New Prescription'
- [ ] Search for a patient, see no `New Patient` option until there are no existing patient results 
- [ ] Selecting the `New Patient` button opens a modal to create a new patient
- [ ] Go to dispensary -> prescriptions -> open an existing prescription
- [ ] Search for a patient, see no `New Patient` option until there are no existing patient results 
- [ ] Selecting the `New Patient` button opens a modal to create a new patient

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

