### PR TITLE
8292 add clinician mobile number

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -997,6 +997,7 @@
   "label.min": "Min",
   "label.min-interval": "Min interval (days)",
   "label.min-months-of-stock": "Reorder threshold MOS",
+  "label.mobile": "Mobile",
   "label.mode": "Mode",
   "label.model": "Model",
   "label.modified-datetime": "Modified date / time",

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -3008,6 +3008,7 @@ export type InsertClinicianInput = {
   id: Scalars['String']['input'];
   initials: Scalars['String']['input'];
   lastName: Scalars['String']['input'];
+  mobile?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type InsertContactFormInput = {

--- a/client/packages/system/src/Clinician/CreateClinicianForm.tsx
+++ b/client/packages/system/src/Clinician/CreateClinicianForm.tsx
@@ -75,6 +75,18 @@ export const CreateClinicianForm = ({
         }
       />
       <InputWithLabelRow
+        label={t('label.mobile')}
+        Input={
+          <BasicTextInput
+            sx={{ width }}
+            value={draft.mobile}
+            onChange={event => {
+              updateDraft({ mobile: event.target.value });
+            }}
+          />
+        }
+      />
+      <InputWithLabelRow
         label={t('label.gender')}
         Input={
           <GenderInput

--- a/client/packages/system/src/Clinician/CreateClinicianForm.tsx
+++ b/client/packages/system/src/Clinician/CreateClinicianForm.tsx
@@ -81,7 +81,8 @@ export const CreateClinicianForm = ({
             sx={{ width }}
             value={draft.mobile}
             onChange={event => {
-              updateDraft({ mobile: event.target.value });
+              const numericValue = event.target.value.replace(/[^0-9]/g, '');
+              updateDraft({ mobile: numericValue });
             }}
           />
         }

--- a/client/packages/system/src/Clinician/ListView/columns.ts
+++ b/client/packages/system/src/Clinician/ListView/columns.ts
@@ -26,6 +26,10 @@ export const useClinicianListColumns = () => {
       label: 'label.initials',
     },
     {
+      key: 'mobile',
+      label: 'label.mobile',
+    },
+    {
       key: 'gender',
       label: 'label.gender',
       accessor: ({ rowData }) =>

--- a/client/packages/system/src/Clinician/useCreateClinician.ts
+++ b/client/packages/system/src/Clinician/useCreateClinician.ts
@@ -10,6 +10,7 @@ export const useCreateClinician = () => {
     lastName: '',
     code: '',
     initials: '',
+    mobile: '',
   });
 
   const isValid =
@@ -33,6 +34,7 @@ export const useCreateClinician = () => {
       lastName: '',
       code: '',
       initials: '',
+      mobile: '',
     });
   };
 

--- a/server/graphql/clinician/src/mutations/insert.rs
+++ b/server/graphql/clinician/src/mutations/insert.rs
@@ -16,6 +16,7 @@ pub struct InsertClinicianInput {
     pub last_name: String,
     pub first_name: Option<String>,
     pub gender: Option<GenderType>,
+    pub mobile: Option<String>,
 }
 
 pub fn insert_clinician(
@@ -53,6 +54,7 @@ impl InsertClinicianInput {
             last_name,
             first_name,
             gender,
+            mobile,
         } = self;
 
         InsertClinician {
@@ -62,6 +64,7 @@ impl InsertClinicianInput {
             last_name,
             first_name,
             gender: gender.map(|g| g.to_domain()),
+            mobile,
         }
     }
 }

--- a/server/service/src/clinician/insert/generate.rs
+++ b/server/service/src/clinician/insert/generate.rs
@@ -26,6 +26,7 @@ pub fn generate(
         last_name,
         first_name,
         gender,
+        mobile,
     } = insert_input;
 
     let clinician = ClinicianRow {
@@ -37,12 +38,12 @@ pub fn generate(
         first_name,
         gender,
         is_active: true,
+        mobile,
 
         // Defaults for now
         address1: None,
         address2: None,
         phone: None,
-        mobile: None,
         email: None,
     };
 

--- a/server/service/src/clinician/insert/mod.rs
+++ b/server/service/src/clinician/insert/mod.rs
@@ -31,6 +31,7 @@ pub struct InsertClinician {
     pub last_name: String,
     pub first_name: Option<String>,
     pub gender: Option<GenderType>,
+    pub mobile: Option<String>,
 }
 
 pub fn insert_clinician(
@@ -53,7 +54,7 @@ pub fn insert_clinician(
                     store_row: Box::new(store_repo),
                 },
                 &input,
-                &store_id,
+                store_id,
             )?;
 
             let GenerateResult {

--- a/server/service/src/clinician/insert/validate.rs
+++ b/server/service/src/clinician/insert/validate.rs
@@ -7,8 +7,8 @@ pub struct Repositories<'a> {
     pub store_row: Box<dyn StoreRowRepositoryTrait<'a> + 'a>,
 }
 
-pub fn validate<'a>(
-    repos: Repositories<'a>,
+pub fn validate(
+    repos: Repositories<'_>,
     input: &InsertClinician,
     store_id: &str,
 ) -> Result<(), InsertClinicianError> {
@@ -28,7 +28,7 @@ pub fn validate<'a>(
         return Err(InsertClinicianError::ClinicianAlreadyExists);
     }
 
-    let store = repos.store_row.find_one_by_id(&store_id)?;
+    let store = repos.store_row.find_one_by_id(store_id)?;
 
     if store.is_none() {
         return Err(InsertClinicianError::InvalidStore);
@@ -105,7 +105,6 @@ mod test {
         let mock_repos = Repositories {
             clinician_row: Box::new(MockClinicianRowRepository {
                 find_one_by_id_result: Some(ClinicianRow::default()), // Simulate existing clinician,
-                ..Default::default()
             }),
             ..Repositories::test_defaults()
         };
@@ -129,7 +128,6 @@ mod test {
         let mock_repos = Repositories {
             store_row: Box::new(MockStoreRowRepository {
                 find_one_by_id_result: None, // Mock no matching store found,
-                ..Default::default()
             }),
             ..Repositories::test_defaults()
         };
@@ -153,7 +151,6 @@ mod test {
         let mock_repos = Repositories {
             store_row: Box::new(MockStoreRowRepository {
                 find_one_by_id_result: Some(StoreRow::default()), // Mock store found,
-                ..Default::default()
             }),
             ..Repositories::test_defaults()
         };
@@ -165,6 +162,7 @@ mod test {
             last_name: "Clinician".to_string(),
             first_name: Some("First".to_string()),
             gender: None,
+            mobile: None,
         };
         assert_eq!(validate(mock_repos, &valid_clinician, "store_id"), Ok(()));
     }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8292

# 👩🏻‍💻 What does this PR do?
Allow users to input mobile when adding a clinician and show this in the list view. Have restricted mobile to numbers only..

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [x] Postgres
- [x] SQLite
- [x] Frontend

