### PR TITLE
8315 input cell loses focus for datatable

### DIFF
--- a/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -71,66 +71,8 @@ const DataRowComponent = <T extends RecordWithId>({
 
   useEffect(() => {
     if (isFocused) onRowClick();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [keyboardActivated]);
-
-  interface ColumnContentProps<T extends RecordWithId> {
-    column: Column<T>;
-    columnIndex: number;
-    isError: boolean | undefined;
-  }
-
-  const ColumnContent = ({
-    column,
-    columnIndex,
-    isError,
-  }: ColumnContentProps<T>) => (
-    <column.Cell
-      isDisabled={isDisabled || column.getIsDisabled?.(rowData)}
-      rowData={rowData}
-      columns={columns}
-      isError={isError}
-      column={column}
-      rowKey={rowKey}
-      columnIndex={columnIndex}
-      rowIndex={rowIndex}
-      autocompleteName={column.autocompleteProvider?.(rowData)}
-      localisedText={localisedText}
-      localisedDate={localisedDate}
-      dense={dense}
-      rowLinkBuilder={rowLinkBuilder}
-      {...column.cellProps}
-    />
-  );
-
-  const ContentWrapper = ({
-    children,
-    column,
-  }: {
-    children: React.ReactNode;
-    column: Column<T>;
-  }) => {
-    return (
-      <Box
-        component={rowLinkBuilder && !column.customLinkRendering ? Link : Box}
-        to={
-          rowLinkBuilder && !column.customLinkRendering
-            ? rowLinkBuilder(rowData)
-            : ''
-        }
-        sx={{
-          display: 'flex',
-          width: '100%',
-          height: '40px',
-          textDecoration: 'none',
-          alignItems: 'center',
-          justifyContent: `${column.align}`,
-          color: 'inherit',
-        }}
-      >
-        {children}
-      </Box>
-    );
-  };
 
   return (
     <>
@@ -196,11 +138,24 @@ const DataRowComponent = <T extends RecordWithId>({
                       : {}),
                   }}
                 >
-                  <ContentWrapper column={column}>
+                  <ContentWrapper
+                    column={column}
+                    rowData={rowData}
+                    rowLinkBuilder={rowLinkBuilder}
+                  >
                     <ColumnContent
                       column={column}
                       columnIndex={columnIndex}
                       isError={isError}
+                      isDisabled={isDisabled}
+                      rowData={rowData}
+                      rowKey={rowKey}
+                      rowIndex={rowIndex}
+                      localisedDate={localisedDate}
+                      localisedText={localisedText}
+                      dense={dense}
+                      columns={columns}
+                      {...column.cellProps}
                     />
                   </ContentWrapper>
                 </TableCell>
@@ -221,3 +176,86 @@ const DataRowComponent = <T extends RecordWithId>({
 };
 
 export const DataRow = React.memo(DataRowComponent) as typeof DataRowComponent;
+
+interface ColumnContentProps<T extends RecordWithId> {
+  columns: Column<T>[];
+  column: Column<T>;
+  columnIndex: number;
+  isError: boolean | undefined;
+  isDisabled?: boolean;
+  rowData: T;
+  rowKey: string;
+  dense?: boolean;
+  rowIndex: number;
+  localisedText: TypedTFunction<LocaleKey>;
+  localisedDate: (date: string | number | Date) => string;
+  rowLinkBuilder?: (rowData: T) => string;
+}
+
+const ColumnContent = <T extends RecordWithId>({
+  columns,
+  column,
+  columnIndex,
+  isError,
+  isDisabled,
+  rowData,
+  rowKey,
+  rowIndex,
+  rowLinkBuilder,
+  localisedDate,
+  localisedText,
+  dense,
+}: ColumnContentProps<T>) => (
+  <column.Cell
+    isDisabled={isDisabled || column.getIsDisabled?.(rowData)}
+    rowData={rowData}
+    columns={columns}
+    isError={isError}
+    column={column}
+    rowKey={rowKey}
+    columnIndex={columnIndex}
+    rowIndex={rowIndex}
+    autocompleteName={column.autocompleteProvider?.(rowData)}
+    localisedText={localisedText}
+    localisedDate={localisedDate}
+    dense={dense}
+    rowLinkBuilder={rowLinkBuilder}
+    {...column.cellProps}
+  />
+);
+
+interface ContentWrapperProps<T extends RecordWithId> {
+  children: React.ReactNode;
+  column: Column<T>;
+  rowData: T;
+  rowLinkBuilder?: (rowData: T) => string;
+}
+
+const ContentWrapper = <T extends RecordWithId>({
+  children,
+  column,
+  rowData,
+  rowLinkBuilder,
+}: ContentWrapperProps<T>) => {
+  return (
+    <Box
+      component={rowLinkBuilder && !column.customLinkRendering ? Link : Box}
+      to={
+        rowLinkBuilder && !column.customLinkRendering
+          ? rowLinkBuilder(rowData)
+          : ''
+      }
+      sx={{
+        display: 'flex',
+        width: '100%',
+        height: '40px',
+        textDecoration: 'none',
+        alignItems: 'center',
+        justifyContent: `${column.align}`,
+        color: 'inherit',
+      }}
+    >
+      {children}
+    </Box>
+  );
+};


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8315 

# 👩🏻‍💻 What does this PR do?

Previously, `ColumnContent` and `ContentWrapper` were defined inside `DataRowComponent`, causing them to be recreated on every render. Because variables like `isDisabled` and others from the parent scope change, this led to new component identities and unnecessary rerenders. Moving these components outside ensures stable references and better rendering performance

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to any page that uses DataTable and have an input (e.g. Prescriptions Edit Page, Stocktake Edit page, Inbound Shipment Edit page, etc)
- [ ] Add value to the Input cell, (if there's more than one - add to all of them)
- [ ] Input shouldn't lose focus!

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

