### PR TITLE
8280 prescriptions cant input correct amount of units

### DIFF
--- a/client/packages/invoices/src/Prescriptions/LineEditView/columns.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/columns.tsx
@@ -150,7 +150,7 @@ export const usePrescriptionLineEditColumns = ({
 const UnitQuantityCell = (props: CellProps<DraftStockOutLineFragment>) => (
   <NumberInputCell
     {...props}
-    max={props.rowData.availablePacks}
+    max={props.rowData.availablePacks * props.rowData.packSize}
     decimalLimit={2}
     min={0}
     slotProps={{ htmlInput: { sx: { backgroundColor: 'white' } } }}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8280 

# 👩🏻‍💻 What does this PR do?

Updated the max calculation for `NumberInputCell` to use `availablePacks` * `packSize`.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to prescription
- [ ] Have a pack size of > 1 for an item
- [ ] Try to issue all units
- [ ] Should let you issue all of the units

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend