### PR TITLE
8299 distributed quantity field gets automatically replaced by minimum pack size before the user finishes typing

### DIFF
--- a/client/packages/invoices/src/StockOut/Components/AutoAllocateIssueField.tsx
+++ b/client/packages/invoices/src/StockOut/Components/AutoAllocateIssueField.tsx
@@ -27,29 +27,18 @@ export const AutoAllocateField = ({
     allocatedQuantity: getAllocatedQuantity(state),
     allocateIn: state.allocateIn,
   }));
-
-  // Using buffer state with the allocated quantity, so gets pre-populated with existing
-  // quantity, and updated when the user edits the individual lines
   const [issueQuantity, setIssueQuantity] = useBufferState(allocatedQuantity);
 
-  // using a debounced value for the allocation. In the scenario where
-  // you have only pack sizes > 1 available, and try to type a quantity which starts with 1
-  // e.g. 10, 12, 100.. then the allocation rounds the 1 up immediately to the available
-  // pack size which stops you entering the required quantity.
-  // See https://github.com/msupply-foundation/open-msupply/issues/2727
-  // and https://github.com/msupply-foundation/open-msupply/issues/3532
   const debouncedAllocate = useDebounceCallback(
     quantity => {
       const allocated = autoAllocate(quantity, format, t, allowPartialPacks);
       setIssueQuantity(allocated);
     },
     [],
-    500
+    1000
   );
 
   const handleIssueQuantityChange = (quantity: number | undefined) => {
-    // this method is also called onBlur... check that there actually has been a change
-    // in quantity (to prevent triggering auto allocation if only focus has moved)
     if (quantity === issueQuantity) return;
 
     // Set immediate value to the input


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8299 

# 👩🏻‍💻 What does this PR do?

Updates debounce time from 500 to 1000 (1 sec) after a user types. 

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

Took the time to think about how long our users actually take to type something. 1 second seems after a user type seems to be enough, but some might be new to typing and can be slower with typing. 

Anyways thought could start off with bumping debounce to 1 sec and wait for any user to mention anything about it

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Outbound shipment → New shipment
- [ ] Select a Client and a Master list (preferably with vaccine items)
- [ ] Select an item that has a defined pack size (e.g., 20 doses per pack)
- [ ] In the quantity field, try to enter a number that is higher than the pack size, but whose initial digits are smaller than the pack size. Example: Try to enter 1000 when the pack size is 20
- [ ] Should be able to enter values without the system overriding it straight away
- [ ] System should override value 1 second after typing

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

