### PR TITLE
8235 Internal order Ok & Next does not add item

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -49,6 +49,7 @@ interface RequestLineEditProps {
   isUpdateMode?: boolean;
   showExtraFields?: boolean;
   manageVaccinesInDoses?: boolean;
+  setIsEditingRequested: (isEditingRequested: boolean) => void;
 }
 
 export const RequestLineEdit = ({
@@ -65,6 +66,7 @@ export const RequestLineEdit = ({
   isUpdateMode,
   showExtraFields,
   manageVaccinesInDoses = false,
+  setIsEditingRequested,
 }: RequestLineEditProps) => {
   const t = useTranslation();
   const { plugins } = usePluginProvider();
@@ -148,6 +150,7 @@ export const RequestLineEdit = ({
             unitName={unitName}
             displayVaccinesInDoses={displayVaccinesInDoses}
             dosesPerUnit={currentItem?.doses}
+            setIsEditingRequested={setIsEditingRequested}
           />
           {showExtraFields && (
             <Typography variant="body1" fontWeight="bold">

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -89,7 +89,7 @@ export const RequestLineEditModal = ({
   const { Modal } = useDialog({ onClose: onCancel, isOpen });
 
   const onChangeItem = (item: ItemWithStatsFragment) => {
-    if (item.id !== currentItem?.id && draft?.requestedQuantity === 0) {
+    if (mode === ModalMode.Create) {
       deletePreviousLine();
     }
     setRepresentation(Representation.UNITS);
@@ -98,9 +98,6 @@ export const RequestLineEditModal = ({
 
   const onNext = async () => {
     await save();
-    if (draft?.requestedQuantity === 0) {
-      deletePreviousLine();
-    }
     if (mode === ModalMode.Update && next) setCurrentItem(next);
     else if (mode === ModalMode.Create) setCurrentItem(undefined);
     else onClose();

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -59,10 +59,14 @@ export const RequestLineEditModal = ({
     useDraftRequisitionLine(currentItem);
   const draftIdRef = useRef<string | undefined>(draft?.id);
   const { hasNext, next } = useNextRequestLine(lines, currentItem);
+  const [isEditingRequested, setIsEditingRequested] = useState(false);
 
   const useConsumptionData =
     store?.preferences?.useConsumptionAndStockFromCustomersForInternalOrders;
-  const nextDisabled = (!hasNext && mode === ModalMode.Update) || !currentItem;
+  const nextDisabled =
+    (!hasNext && mode === ModalMode.Update) ||
+    !currentItem ||
+    isEditingRequested;
 
   const deletePreviousLine = () => {
     const shouldDelete = shouldDeleteLine(mode, draft?.id, isDisabled);
@@ -127,7 +131,7 @@ export const RequestLineEditModal = ({
       okButton={
         <DialogButton
           variant="ok"
-          disabled={!currentItem}
+          disabled={!currentItem || isEditingRequested}
           onClick={async () => {
             await save();
             onClose();
@@ -154,6 +158,7 @@ export const RequestLineEditModal = ({
           isUpdateMode={mode === ModalMode.Update}
           showExtraFields={useConsumptionData && !!requisition?.program}
           manageVaccinesInDoses={manageVaccinesInDoses}
+          setIsEditingRequested={setIsEditingRequested}
         />
       )}
     </Modal>

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
@@ -34,6 +34,7 @@ interface RequestedSelectionProps {
   showExtraFields?: boolean;
   displayVaccinesInDoses?: boolean;
   dosesPerUnit?: number;
+  setIsEditingRequested: (isEditingRequested: boolean) => void;
 }
 
 export const RequestedSelection = ({
@@ -47,6 +48,7 @@ export const RequestedSelection = ({
   unitName,
   displayVaccinesInDoses = false,
   dosesPerUnit = 1,
+  setIsEditingRequested,
 }: RequestedSelectionProps) => {
   const t = useTranslation();
   const { getPlural } = useIntlUtils();
@@ -89,11 +91,13 @@ export const RequestedSelection = ({
         draft?.suggestedQuantity
       );
       update(updatedRequest);
+      setIsEditingRequested(false);
     },
     [representation, defaultPackSize, update]
   );
 
   const handleValueChange = (newValue?: number) => {
+    setIsEditingRequested(true);
     setValue(newValue ?? 0);
     debouncedUpdate(newValue);
   };
@@ -136,6 +140,7 @@ export const RequestedSelection = ({
             value={value}
             disabled={disabled}
             onChange={handleValueChange}
+            onBlur={() => setIsEditingRequested(false)}
             slotProps={{
               input: {
                 sx: {

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
@@ -54,12 +54,14 @@ export const ResponseLineEditModal = ({
   const [representation, setRepresentation] = useState<RepresentationValue>(
     Representation.UNITS
   );
+  const [isEditingSupply, setIsEditingSupply] = useState(false);
 
   const { draft, update, save, isLoading } =
     useDraftRequisitionLine(currentItem);
   const draftIdRef = useRef<string | undefined>(draft?.id);
   const { hasNext, next } = useNextResponseLine(lines, currentItem);
-  const nextDisabled = (!hasNext && mode === ModalMode.Update) || !currentItem;
+  const nextDisabled =
+    (!hasNext && mode === ModalMode.Update) || !currentItem || isEditingSupply;
 
   const deletePreviousLine = () => {
     const shouldDelete = shouldDeleteLine(mode, draft?.id, isDisabled);
@@ -167,7 +169,7 @@ export const ResponseLineEditModal = ({
       okButton={
         <DialogButton
           variant="ok"
-          disabled={!currentItem}
+          disabled={!currentItem || isEditingSupply}
           onClick={async () => {
             await save();
             onClose();
@@ -194,6 +196,7 @@ export const ResponseLineEditModal = ({
             disabled={isDisabled}
             isUpdateMode={mode === ModalMode.Update}
             manageVaccinesInDoses={manageVaccinesInDoses}
+            setIsEditingSupply={setIsEditingSupply}
           />
           {!!draft && (
             <ModalTabs

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
@@ -84,7 +84,7 @@ export const ResponseLineEditModal = ({
   const { Modal } = useDialog({ onClose: onCancel, isOpen });
 
   const onChangeItem = (item: ItemWithStatsFragment) => {
-    if (item.id !== currentItem?.id && draft?.supplyQuantity === 0) {
+    if (mode === ModalMode.Create) {
       deletePreviousLine();
     }
     setRepresentation(Representation.UNITS);
@@ -93,9 +93,6 @@ export const ResponseLineEditModal = ({
 
   const onSave = async () => {
     await save();
-    if (draft?.supplyQuantity === 0) {
-      deletePreviousLine();
-    }
     if (mode === ModalMode.Update && next) setCurrentItem(next);
     else if (mode === ModalMode.Create) setCurrentItem(undefined);
     else onClose();

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -40,6 +40,7 @@ interface ResponseLineEditProps {
   disabled: boolean;
   isUpdateMode?: boolean;
   manageVaccinesInDoses?: boolean;
+  setIsEditingSupply: (isEditingSupply: boolean) => void;
 }
 
 export const ResponseLineEdit = ({
@@ -55,6 +56,7 @@ export const ResponseLineEdit = ({
   disabled = false,
   isUpdateMode = false,
   manageVaccinesInDoses = false,
+  setIsEditingSupply,
 }: ResponseLineEditProps) => {
   const t = useTranslation();
   const { data: reasonOptions, isLoading } = useReasonOptions();
@@ -263,6 +265,7 @@ export const ResponseLineEdit = ({
             unitName={unitName}
             displayVaccinesInDoses={displayVaccinesInDoses}
             dosesPerUnit={currentItem?.doses ?? 1}
+            setIsEditingSupply={setIsEditingSupply}
           />
           {numericInput(
             'label.remaining-to-supply',

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
@@ -33,6 +33,7 @@ interface SupplySelectionProps {
   unitName: string;
   displayVaccinesInDoses?: boolean;
   dosesPerUnit: number;
+  setIsEditingSupply: (isEditingSupply: boolean) => void;
 }
 
 export const SupplySelection = ({
@@ -46,6 +47,7 @@ export const SupplySelection = ({
   unitName,
   displayVaccinesInDoses = false,
   dosesPerUnit,
+  setIsEditingSupply,
 }: SupplySelectionProps) => {
   const t = useTranslation();
   const { getPlural } = useIntlUtils();
@@ -79,6 +81,7 @@ export const SupplySelection = ({
         defaultPackSize
       );
       update(updatedSupply);
+      setIsEditingSupply(false);
     },
     [representation, defaultPackSize]
   );
@@ -88,6 +91,7 @@ export const SupplySelection = ({
   }, [draft?.id, representation]);
 
   const handleValueChange = (newValue?: number) => {
+    setIsEditingSupply(true);
     setValue(newValue ?? 0);
     debouncedUpdate(newValue);
   };
@@ -131,6 +135,7 @@ export const SupplySelection = ({
             value={value}
             disabled={disabled}
             onChange={handleValueChange}
+            onBlur={() => setIsEditingSupply(false)}
             slotProps={{
               input: {
                 sx: {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8235

# 👩🏻‍💻 What does this PR do?
Adds a bool to disable the buttons while debounce on child settles.

We really need a better way to handle disabling things if debounce hasn't settled... I'm sure this happens in a lot of places but less obvious than Internal Order / Requisitions... It's fine if you're typing slow but... if you are typing fast gg

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create Requisition/Internal Order
- [ ] Add items
- [ ] Buttons should be disabled as you type
- [ ] Clicking Ok / Ok & Next should allow you to add a new item

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

