### PR TITLE
89 internal: negative R&R balances

### DIFF
--- a/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
+++ b/client/packages/requisitions/src/RnRForms/DetailView/RnRFormLine.tsx
@@ -16,7 +16,7 @@ import {
   VenCategoryType,
 } from '@openmsupply-client/common';
 import { RnRFormLineFragment } from '../api/operations.generated';
-import { getLowStockStatus, getAmc } from './helpers';
+import { getLowStockStatus, getAmc, isLineError } from './helpers';
 import { useCachedRnRDraftLine, useRnRFormContext } from '../api';
 
 export const RnRFormLine = ({
@@ -117,14 +117,14 @@ export const RnRFormLine = ({
     padding: '5px',
     color: textColor,
   };
+
   const itemDetailStyle = {
     ...readOnlyColumn,
-    backgroundColor:
-      line.finalBalance < 0
-        ? errorColour
-        : highlight
-          ? highlightColour
-          : readOnlyBackgroundColor,
+    backgroundColor: isLineError(line)
+      ? errorColour
+      : highlight
+        ? highlightColour
+        : readOnlyBackgroundColor,
   };
 
   return (
@@ -145,6 +145,7 @@ export const RnRFormLine = ({
 
       {/* Enterable consumption data */}
       <RnRNumberCell
+        backgroundColor={line.initialBalance < 0 ? errorColour : undefined}
         value={line.initialBalance}
         onChange={val => updateDraft({ initialBalance: val })}
         textColor={textColor}

--- a/client/packages/requisitions/src/RnRForms/DetailView/helpers.test.ts
+++ b/client/packages/requisitions/src/RnRForms/DetailView/helpers.test.ts
@@ -1,5 +1,5 @@
 import { LowStockStatus } from '@common/types';
-import { getLowStockStatus, getAmc } from './helpers';
+import { getLowStockStatus, getAmc, isLineError } from './helpers';
 
 describe('getAmc', () => {
   it('should return the average monthly consumption', () => {
@@ -43,5 +43,27 @@ describe('getLowStockStatus', () => {
     const result = getLowStockStatus(finalBalance, maximumQuantity);
 
     expect(result).toBe(LowStockStatus.Ok);
+  });
+});
+
+describe('isLineError', () => {
+  it('returns true if initial balance is less than 0', () => {
+    const line = { initialBalance: -1, finalBalance: 10 };
+    expect(isLineError(line)).toBe(true);
+  });
+
+  it('returns true if final balance is less than 0', () => {
+    const line = { initialBalance: 10, finalBalance: -1 };
+    expect(isLineError(line)).toBe(true);
+  });
+
+  it('returns false if both balances are non-negative', () => {
+    const line = { initialBalance: 10, finalBalance: 20 };
+    expect(isLineError(line)).toBe(false);
+  });
+
+  it('returns false when balances are undefined', () => {
+    const line = { initialBalance: undefined, finalBalance: undefined };
+    expect(isLineError(line)).toBe(false);
   });
 });

--- a/client/packages/requisitions/src/RnRForms/DetailView/helpers.ts
+++ b/client/packages/requisitions/src/RnRForms/DetailView/helpers.ts
@@ -1,4 +1,5 @@
 import { LowStockStatus } from '@common/types';
+import { RnRFormLineFragment } from '../api';
 
 export const getAmc = (
   previousMonthlyConsumptionValues: string,
@@ -35,4 +36,8 @@ export const getLowStockStatus = (
   }
 
   return LowStockStatus.Ok;
+};
+
+export const isLineError = (line: Partial<RnRFormLineFragment>): boolean => {
+  return (line.initialBalance ?? 0) < 0 || (line.finalBalance ?? 0) < 0;
 };

--- a/client/packages/requisitions/src/RnRForms/api/hooks/useRnRFormContext.ts
+++ b/client/packages/requisitions/src/RnRForms/api/hooks/useRnRFormContext.ts
@@ -8,6 +8,7 @@ import {
 import keyBy from 'lodash/keyBy';
 import mapValues from 'lodash/mapValues';
 import { itemMatchesSearch } from '../../utils';
+import { isLineError } from '../../DetailView/helpers';
 
 type SetLine = (line: RecordWithId & Partial<RnRFormLineFragment>) => void;
 interface RnRFormContext {
@@ -83,10 +84,7 @@ export const useRnRFormContext = create<RnRFormContext>((set, get) => ({
   getAllDirtyLines: (ignoreError = true) => {
     const { baseLines, draftLines } = get();
     return Object.values(draftLines).flatMap(draftLine => {
-      if (
-        !draftLine.isDirty ||
-        (ignoreError && (draftLine?.finalBalance || 0) < 0)
-      )
+      if (!draftLine.isDirty || (ignoreError && isLineError(draftLine)))
         return [];
       const baseLine = baseLines[draftLine.id];
       if (!baseLine) return [];
@@ -167,9 +165,15 @@ export function oneTime<S, U>(selector: (state: S) => U): (state: S) => U {
 }
 
 export const useErrorLineIndex = (state: RnRFormContext) => {
-  const firstErrorLine = Object.values(state.draftLines).find(
-    draftLine => (draftLine?.finalBalance || 0) < 0
-  );
+  const firstErrorLine = Object.values(state.baseLines).find(line => {
+    const draftLine = state.draftLines[line.id];
+
+    return draftLine
+      ? // If there is draft line, that's the latest state, check if that has an error
+        isLineError(draftLine)
+      : // otherwise check the base line wasn't in error state to start with
+        isLineError(line);
+  });
 
   if (!firstErrorLine) return -1;
   return state.baseLineIndexes[firstErrorLine.id] || -1;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "2.7.07",
+  "version": "2.7.08",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -4126,6 +4126,7 @@ dependencies = [
  "chrono",
  "graphql_core",
  "graphql_types",
+ "log",
  "repository",
  "serde",
  "serde_json",

--- a/server/graphql/programs/Cargo.toml
+++ b/server/graphql/programs/Cargo.toml
@@ -20,6 +20,7 @@ async-graphql = { workspace = true }
 async-graphql-actix-web = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
+log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/server/graphql/programs/src/mutations/rnr_form/finalise.rs
+++ b/server/graphql/programs/src/mutations/rnr_form/finalise.rs
@@ -59,10 +59,12 @@ pub fn finalise_rnr_form(
 fn map_error(error: ServiceError) -> Result<FinaliseRnRFormResponse> {
     use StandardGraphqlError::*;
     let formatted_error = format!("{:#?}", error);
+    log::error!("Error finalising RnR form: {}", formatted_error);
 
     let graphql_error = match error {
         ServiceError::RnRFormDoesNotExist
         | ServiceError::RnRFormDoesNotBelongToStore
+        | ServiceError::ContainsNegativeLines
         | ServiceError::RnRFormAlreadyFinalised => BadUserInput(formatted_error),
 
         ServiceError::InternalError(_)

--- a/server/graphql/programs/src/mutations/rnr_form/update.rs
+++ b/server/graphql/programs/src/mutations/rnr_form/update.rs
@@ -85,6 +85,7 @@ pub fn update_rnr_form(
 fn map_error(error: ServiceError) -> Result<UpdateRnRFormResponse> {
     use StandardGraphqlError::*;
     let formatted_error = format!("{:#?}", error);
+    log::error!("Error updating RnR form: {}", formatted_error);
 
     let graphql_error = match error {
         ServiceError::RnRFormDoesNotExist

--- a/server/service/src/rnr_form/finalise.rs
+++ b/server/service/src/rnr_form/finalise.rs
@@ -25,6 +25,7 @@ pub enum FinaliseRnRFormError {
     RnRFormDoesNotExist,
     RnRFormDoesNotBelongToStore,
     RnRFormAlreadyFinalised,
+    ContainsNegativeLines,
     FinalisedRnRFormDoesNotExist,
 }
 
@@ -93,6 +94,15 @@ fn validate(
     if rnr_form.rnr_form_row.status == RnRFormStatus::Finalised {
         return Err(FinaliseRnRFormError::RnRFormAlreadyFinalised);
     };
+
+    let lines = RnRFormLineRepository::new(connection)
+        .query_by_filter(RnRFormLineFilter::new().rnr_form_id(EqualFilter::equal_to(&input.id)))?;
+
+    if lines.iter().any(|line| {
+        line.rnr_form_line_row.initial_balance < 0.0 || line.rnr_form_line_row.final_balance < 0.0
+    }) {
+        return Err(FinaliseRnRFormError::ContainsNegativeLines);
+    }
 
     Ok(rnr_form)
 }

--- a/server/service/src/rnr_form/tests/finalise.rs
+++ b/server/service/src/rnr_form/tests/finalise.rs
@@ -1,12 +1,12 @@
 #[cfg(test)]
 mod finalise {
-    use repository::mock::{mock_rnr_form_a, mock_rnr_form_b, mock_store_a};
+    use repository::mock::{mock_item_c, mock_rnr_form_a, mock_rnr_form_b, mock_store_a, MockData};
     use repository::mock::{mock_store_b, MockDataInserts};
-    use repository::test_db::setup_all;
+    use repository::test_db::{setup_all, setup_all_with_data};
     use repository::{
         EqualFilter, RequisitionFilter, RequisitionLineFilter, RequisitionLineRepository,
-        RequisitionRepository, RequisitionStatus, RnRFormLineRowRepository, RnRFormRowRepository,
-        RnRFormStatus,
+        RequisitionRepository, RequisitionStatus, RnRFormLineRow, RnRFormLineRowRepository,
+        RnRFormRowRepository, RnRFormStatus,
     };
 
     use crate::rnr_form::finalise::{FinaliseRnRForm, FinaliseRnRFormError};
@@ -14,8 +14,24 @@ mod finalise {
 
     #[actix_rt::test]
     async fn finalise_rnr_form_errors() {
-        let (_, _, connection_manager, _) =
-            setup_all("finalise_rnr_form_errors", MockDataInserts::all()).await;
+        fn negative_rnr_form_line() -> RnRFormLineRow {
+            RnRFormLineRow {
+                id: "negative_line".to_string(),
+                rnr_form_id: mock_rnr_form_b().id,
+                item_link_id: mock_item_c().id,
+                final_balance: -5.0,
+                ..Default::default()
+            }
+        }
+        let (_, _, connection_manager, _) = setup_all_with_data(
+            "finalise_rnr_form_errors",
+            MockDataInserts::all(),
+            MockData {
+                rnr_form_lines: vec![negative_rnr_form_line()],
+                ..Default::default()
+            },
+        )
+        .await;
 
         let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
@@ -58,6 +74,18 @@ mod finalise {
                 }
             ),
             Err(FinaliseRnRFormError::RnRFormAlreadyFinalised)
+        );
+
+        // ContainsNegativeLines
+        assert_eq!(
+            service.finalise_rnr_form(
+                &context,
+                &store_id,
+                FinaliseRnRForm {
+                    id: mock_rnr_form_b().id,
+                }
+            ),
+            Err(FinaliseRnRFormError::ContainsNegativeLines)
         );
     }
 

--- a/server/service/src/rnr_form/tests/update.rs
+++ b/server/service/src/rnr_form/tests/update.rs
@@ -155,6 +155,31 @@ mod update {
             })
         );
 
+        // InitialBalanceCannotBeNegative
+        assert_eq!(
+            service.update_rnr_form(
+                &context,
+                &store_id,
+                UpdateRnRForm {
+                    id: mock_rnr_form_b().id,
+                    lines: vec![UpdateRnRFormLine {
+                        id: mock_rnr_form_b_line_a().id,
+                        initial_balance: -5.0,
+                        quantity_consumed: Some(0.0),
+                        quantity_received: Some(7.0),
+                        adjustments: Some(0.0),
+                        final_balance: 2.0,
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }
+            ),
+            Err(UpdateRnRFormError::LineError {
+                line_id: mock_rnr_form_b_line_a().id,
+                error: UpdateRnRFormLineError::InitialBalanceCannotBeNegative
+            })
+        );
+
         // FinalBalanceCannotBeNegative
         assert_eq!(
             service.update_rnr_form(

--- a/server/service/src/rnr_form/update.rs
+++ b/server/service/src/rnr_form/update.rs
@@ -57,6 +57,7 @@ pub enum UpdateRnRFormLineError {
     LineDoesNotExist,
     LineDoesNotBelongToRnRForm,
     ValuesDoNotBalance,
+    InitialBalanceCannotBeNegative,
     FinalBalanceCannotBeNegative,
     StockOutDurationExceedsPeriod,
     CannotRequestNegativeQuantity,
@@ -165,6 +166,13 @@ fn validate(
                 return Err(UpdateRnRFormError::LineError {
                     line_id: line.id.clone(),
                     error: UpdateRnRFormLineError::ValuesDoNotBalance,
+                });
+            }
+
+            if initial_balance < 0.0 {
+                return Err(UpdateRnRFormError::LineError {
+                    line_id: line.id.clone(),
+                    error: UpdateRnRFormLineError::InitialBalanceCannotBeNegative,
                 });
             }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes https://github.com/msupply-foundation/open-msupply-internal/issues/89

# 👩🏻‍💻 What does this PR do?

- Prevents finalisation of R&R form when initial or final balance is negative
- Fix frontend error mapping - was only checking draft/touched lines, but should validate all lines

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a draft R&R form with some negative initial and/or final balances
  - [ ] Either use datafile from issue, or manually edit DB to emulate a few lines like this
- [ ] Negative initial balance - the item name and the initial balance cell is highlighted
- [ ] Negative final balance - the item name and the final balance cell is highlighted
- [ ] Don't make any edits - try to finalise
  - [ ] See cannot finalise due to errors popup
  - [ ] Clicking OK takes you to the first negative line
- [ ] After fixing all lines, you can save

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

