### PR TITLE
4890 dont update stock when adding lines to a Delivered inbound shipment

### DIFF
--- a/server/service/src/invoice_line/stock_in_line/insert/generate.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/generate.rs
@@ -5,13 +5,14 @@ use crate::{
         GenerateVVMStatusLogInput,
     },
     invoice_line::stock_in_line::{
-        convert_invoice_line_to_single_pack, generate_batch, StockInType, StockLineInput,
+        convert_invoice_line_to_single_pack, generate_batch, should_update_stock, StockInType,
+        StockLineInput,
     },
     store_preference::get_store_preferences,
 };
 use repository::{
     vvm_status::vvm_status_log_row::VVMStatusLogRow, BarcodeRow, InvoiceLineRow, InvoiceLineType,
-    InvoiceRow, InvoiceStatus, ItemRow, RepositoryError, StockLineRow, StorageConnection,
+    InvoiceRow, ItemRow, RepositoryError, StockLineRow, StorageConnection,
 };
 
 use super::InsertStockInLine;
@@ -163,8 +164,7 @@ fn generate_line(
 fn should_upsert_batch(stock_in_type: &StockInType, existing_invoice_row: &InvoiceRow) -> bool {
     match stock_in_type {
         StockInType::InboundShipment | StockInType::CustomerReturn => {
-            existing_invoice_row.status != InvoiceStatus::New
-                && existing_invoice_row.status != InvoiceStatus::Delivered
+            should_update_stock(&existing_invoice_row)
         }
         StockInType::InventoryAddition => true,
     }

--- a/server/service/src/invoice_line/stock_in_line/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/mod.rs
@@ -1,3 +1,5 @@
+use repository::InvoiceRow;
+use repository::InvoiceStatus;
 use repository::InvoiceType;
 
 pub mod generate;
@@ -28,5 +30,17 @@ impl StockInType {
             StockInType::InventoryAddition => InvoiceType::InventoryAddition,
             StockInType::InboundShipment => InvoiceType::InboundShipment,
         }
+    }
+}
+
+pub fn should_update_stock(invoice: &InvoiceRow) -> bool {
+    match invoice.status {
+        InvoiceStatus::New | InvoiceStatus::Delivered => false,
+        InvoiceStatus::Allocated
+        | InvoiceStatus::Picked
+        | InvoiceStatus::Shipped
+        | InvoiceStatus::Cancelled
+        | InvoiceStatus::Received
+        | InvoiceStatus::Verified => true,
     }
 }

--- a/server/service/src/invoice_line/stock_in_line/update/generate.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/generate.rs
@@ -6,7 +6,7 @@ use crate::{
     invoice_line::{
         stock_in_line::{
             convert_invoice_line_to_single_pack, generate_batch, get_existing_vvm_status_log_id,
-            StockLineInput,
+            should_update_stock, StockLineInput,
         },
         StockInType,
     },
@@ -14,7 +14,7 @@ use crate::{
 };
 use repository::{
     vvm_status::vvm_status_log_row::VVMStatusLogRow, InvoiceLine, InvoiceLineRow, InvoiceRow,
-    InvoiceStatus, ItemRow, RepositoryError, StockLineRow, StorageConnection,
+    ItemRow, RepositoryError, StockLineRow, StorageConnection,
 };
 
 use super::UpdateStockInLine;
@@ -103,18 +103,6 @@ pub fn generate(
         batch_to_delete_id,
         vvm_status_log_option,
     })
-}
-
-fn should_update_stock(invoice: &InvoiceRow) -> bool {
-    match invoice.status {
-        InvoiceStatus::New | InvoiceStatus::Delivered => false,
-        InvoiceStatus::Allocated
-        | InvoiceStatus::Picked
-        | InvoiceStatus::Shipped
-        | InvoiceStatus::Cancelled
-        | InvoiceStatus::Received
-        | InvoiceStatus::Verified => true,
-    }
 }
 
 fn get_batch_to_delete_id(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4890

# 👩🏻‍💻 What does this PR do?

Previous PR didn't update logic when editing existing lines for a delivered inbound invoice.
Now it's setup to skip stock on delivered

## 💌 Any notes for the reviewer?
I think we need a common function to map when Stock Updates and when it shouldn't so there's only one place to update in future.

Anything else we might have missed?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an inbound shipment add lines
- [ ] Check the stock isn't added
- [ ] Mark as Delivered
- [ ] Add a new line and edit an existing line
- [ ] Check not stock updates or new batches are created

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

