### PR TITLE
Remove filter that masterList exists on store

### DIFF
--- a/client/packages/system/src/Stock/api/hooks/useStockList.ts
+++ b/client/packages/system/src/Stock/api/hooks/useStockList.ts
@@ -37,10 +37,6 @@ export const useStockList = (queryParams: StockListParams) => {
     const filter = {
       ...filterBy,
       hasPacksInStore: true,
-      masterList: {
-        existsForStoreId: { equalTo: storeId },
-        ...filterBy?.masterList,
-      },
     };
     const query = await stockApi.stockLines({
       storeId,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7705

# 👩🏻‍💻 What does this PR do?""

Show stock regardless of if masterList exists on store.


<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Note - this query is only used on the stock ListView component - so restrictions on adding stock on a masterList not visible on the store remain

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Add stock to a store where master list exists on store
- [ ] Remove masterlist from store
- [ ] See stock remains visible

# 📃 Documentation

- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

