### PR TITLE
8201 switch store preference and properties tab

### DIFF
--- a/client/packages/system/src/Name/ListView/Stores/StoreEditModal.tsx
+++ b/client/packages/system/src/Name/ListView/Stores/StoreEditModal.tsx
@@ -12,7 +12,6 @@ import {
   TabContext,
   TabPanel,
   NamePropertyNode,
-  useIsGapsStoreOnly,
 } from '@openmsupply-client/common';
 import { useName } from '../../api';
 import { NameRenderer } from '../..';
@@ -150,10 +149,7 @@ const ModalTabs = ({
   updateProperty,
 }: ModalTabProps) => {
   const t = useTranslation();
-  const isGapsMobileStore = useIsGapsStoreOnly();
-  const [currentTab, setCurrentTab] = useState(
-    storeId && !isGapsMobileStore ? Tabs.Preferences : Tabs.Properties
-  );
+  const [currentTab, setCurrentTab] = useState(Tabs.Properties);
 
   return (
     <TabContext value={currentTab}>
@@ -162,16 +158,11 @@ const ModalTabs = ({
         centered
         onChange={(_, v) => setCurrentTab(v)}
       >
+        <Tab value={Tabs.Properties} label={t('label.properties')} />
         {storeId && (
           <Tab value={Tabs.Preferences} label={t('label.preferences')} />
         )}
-        <Tab value={Tabs.Properties} label={t('label.properties')} />
       </TabList>
-      {storeId && (
-        <TabPanel value={Tabs.Preferences}>
-          <EditStorePreferences storeId={storeId} />
-        </TabPanel>
-      )}
       <TabPanel value={Tabs.Properties}>
         <StoreProperties
           propertyConfigs={propertyConfigs}
@@ -179,6 +170,11 @@ const ModalTabs = ({
           updateProperty={updateProperty}
         />
       </TabPanel>
+      {storeId && (
+        <TabPanel value={Tabs.Preferences}>
+          <EditStorePreferences storeId={storeId} />
+        </TabPanel>
+      )}
     </TabContext>
   );
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8201

# 👩🏻‍💻 What does this PR do?

Switched properties to be the first tab selected for the Store Edit Modal

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate Settings > Configuration > Initialise gaps for your store
- [ ] Click on edit icon next to the name of your store at the footer of the screen
- [ ] Properties tab should be first

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

