### PR TITLE
7721 inform user that batch is on hold when making inventory adjustment

### DIFF
--- a/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
+++ b/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
@@ -10,6 +10,7 @@ import {
   useDialog,
   useFormatNumber,
   getReasonOptionType,
+  Checkbox,
 } from '@openmsupply-client/common';
 import { StockLineRowFragment, useInventoryAdjustment } from '../../api';
 import { ReasonOptionsSearchInput, useReasonOptions } from '../../..';
@@ -35,7 +36,7 @@ export const InventoryAdjustmentModal = ({
   const { data, isLoading } = useReasonOptions();
 
   const packUnit = String(stockLine.packSize);
-  const saveDisabled = draft.adjustment === 0;
+  const saveDisabled = draft.adjustment === 0 || stockLine.onHold;
   const isInventoryReduction =
     draft.adjustmentType === AdjustmentTypeInput.Reduction;
 
@@ -106,6 +107,10 @@ export const InventoryAdjustmentModal = ({
                 />
               </Box>
             }
+          />
+          <StyledInputRow
+            label={t('label.on-hold')}
+            Input={<Checkbox checked={stockLine.onHold} disabled />}
           />
         </Box>
         <Box


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7721 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

If stock line is on hold, disabled the Ok button from being click for InventoryAdjustment. Also added a new field `On Hold` to help indicate to the user that a stock line is on hold

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to View Stock -> Select a Stock that is on hold -> Click on `Adjust` button
- [ ] Try increasing or decreasing the value
- [ ] It shouldn't let the user press Ok or save the adjustment

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

