### PR TITLE
7084 Program input background colour consistency

### DIFF
--- a/client/packages/system/src/Program/ProgramSearchInput.tsx
+++ b/client/packages/system/src/Program/ProgramSearchInput.tsx
@@ -1,4 +1,4 @@
-import { Autocomplete, useTheme } from '@openmsupply-client/common';
+import { Autocomplete } from '@openmsupply-client/common';
 import { ProgramFragment } from '@openmsupply-client/programs';
 import React from 'react';
 import { FC } from 'react';
@@ -20,8 +20,6 @@ export const ProgramSearchInput: FC<ProgramSearchInputProps> = ({
   fullWidth = true,
   disabled,
 }) => {
-  const theme = useTheme();
-
   return (
     <Autocomplete
       value={
@@ -44,7 +42,6 @@ export const ProgramSearchInput: FC<ProgramSearchInputProps> = ({
       }))}
       fullWidth={fullWidth}
       sx={{ minWidth: width }}
-      textSx={{ backgroundColor: theme.palette.background.white }}
       disabled={disabled}
     />
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7084 

# 👩🏻‍💻 What does this PR do?


Update the Program Input to use the default background colour instead of white
This component is used in Prescriptions - `New Prescription Modal` and `Detail View - Toolbar` - default background is needed in both of these places

There is another ProgramSearchInput used elsewhere which didn't need any colour changes

Checked through the codebase and don't see other cases where a white background is being used but not needed

Other mentioned ones in PR - clinicians and reasons - are already fixed

![Screenshot 2025-07-07 at 9 16 20 AM](https://github.com/user-attachments/assets/e35453af-4a19-44ec-9b30-0d9ebbbd8d7a)

![Screenshot 2025-07-07 at 9 16 11 AM](https://github.com/user-attachments/assets/cdc913a8-fcd6-411b-82bc-ea2600f07f48)


<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Dispensary -> Prescriptions -> New Prescription -> see grey background on the Program Input
- [ ] Go to Dispensary -> Prescriptions -> open a prescription -> see grey background on the Program Input

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

