### PR TITLE
Max/min datetime handled in datetime picker

### DIFF
--- a/client/packages/common/src/ui/components/inputs/DateTimePickers/TimePickerInput/TimePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DateTimePickers/TimePickerInput/TimePickerInput.tsx
@@ -49,7 +49,7 @@ export const TimePickerInput = ({
         textField: {
           disabled: !!disabled,
           error: isInvalid(internalValue),
-          sx: getTextFieldSx(theme, !!props.label),
+          sx: getTextFieldSx(theme, !!props.label, false),
         },
       }}
       {...props}

--- a/client/packages/programs/src/JsonForms/common/components/DateTime.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/DateTime.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { rankWith, ControlProps, isDateTimeControl } from '@jsonforms/core';
-import { withJsonFormsControlProps } from '@jsonforms/react';
+import { useJsonForms, withJsonFormsControlProps } from '@jsonforms/react';
 import {
   DetailInputWithLabelRow,
   DateUtils,
   DateTimePickerInput,
   LocaleKey,
   useTranslation,
+  extractProperty,
 } from '@openmsupply-client/common';
 import { DefaultFormRowSx, FORM_LABEL_WIDTH } from '../styleConstants';
 import { z } from 'zod';
@@ -33,6 +34,7 @@ export const datetimeTester = rankWith(5, isDateTimeControl);
 
 const UIComponent = (props: ControlProps) => {
   const t = useTranslation();
+  const { core } = useJsonForms();
   const [error, setError] = React.useState<string | undefined>(undefined);
   const { data, handleChange, label, path, uischema } = props;
   const { errors: zErrors, options } = useZodOptionsValidation(
@@ -50,8 +52,13 @@ const UIComponent = (props: ControlProps) => {
   }
 
   const dateOnly = options?.dateOnly ?? false;
-
   const inputFormat = !dateOnly ? 'P p' : 'P';
+  const max = options?.max
+    ? extractProperty(core?.data, options.max.split('/').pop() ?? '')
+    : undefined;
+  const min = options?.min
+    ? extractProperty(core?.data, options.min.split('/').pop() ?? '')
+    : undefined;
 
   const onChange = (e: Date | null) => {
     if (!e) handleChange(path, undefined);
@@ -85,8 +92,8 @@ const UIComponent = (props: ControlProps) => {
           actions: ['clear', 'accept'] as PickersActionBarAction[],
         }
       : {}),
-    minDate: DateUtils.getDateOrNull(options?.min) ?? undefined,
-    maxDate: DateUtils.getDateOrNull(options?.max) ?? undefined,
+    minDate: DateUtils.getDateOrNull(min) ?? undefined,
+    maxDate: DateUtils.getDateOrNull(max) ?? undefined,
   };
 
   return (

--- a/client/packages/programs/src/JsonForms/common/components/DateTime.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/DateTime.tsx
@@ -22,6 +22,7 @@ const Options = z
     monthOnly: z.boolean().optional(),
     dateAsEndOfDay: z.boolean().optional(),
     disableFuture: z.boolean().optional(),
+    // Max and min are paths to the data object
     max: z.string().optional(),
     min: z.string().optional(),
   })


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Part of https://github.com/msupply-foundation/open-msupply-reports/issues/218

# 👩🏻‍💻 What does this PR do?
handles max / min properly in DateTime JSON component

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

