### PR TITLE
Remove (level) after vvm status description

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.tsx
@@ -130,7 +130,7 @@ export const useOutboundLineEditColumns = ({
       accessor: ({ rowData }) => {
         if (!rowData.vvmStatus) return '';
         // TODO: Show unusable VVM status somehow?
-        return `${rowData.vvmStatus?.description} (${rowData.vvmStatus?.level})`;
+        return `${rowData.vvmStatus?.description}`;
       },
       width: 85,
       Cell: TooltipTextCell,

--- a/client/packages/invoices/src/Prescriptions/LineEditView/columns.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/columns.tsx
@@ -75,7 +75,7 @@ export const usePrescriptionLineEditColumns = ({
       accessor: ({ rowData }) => {
         if (!rowData.vvmStatus) return '';
         // TODO: Show unusable VVM status somehow?
-        return `${rowData.vvmStatus?.description} (${rowData.vvmStatus?.level})`;
+        return `${rowData.vvmStatus?.description}`;
       },
       width: 85,
     });


### PR DESCRIPTION
Fixes #8206 

# 👩🏻‍💻 What does this PR do?

Removes the (level #) that appeared after the vmm status description when allocating stock to a prescription.
This was done to make the display less confusing for users, as discussed in Issue #8206 👍 

It used to look like this:

![image](https://github.com/user-attachments/assets/773881b4-6aeb-4299-9461-f9383af79081)

Now it looks like this:

![image](https://github.com/user-attachments/assets/2ad1ec68-9e73-45d2-9f0b-6ab6f3672375)


<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Nice day :D
<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Add a vaccine to your stock, and add a vvm status to each vaccine.
- [ ] In OMS, turn on these store preferences:

![image](https://github.com/user-attachments/assets/7977f4f2-6e2e-4920-9143-2f4772b42890)

- [ ] Go to prescriptions > add new prescription > add item > add the vaccine you added in step 1.
- [ ] Check that only the vvm status' description is displayed in the 'vvm status' column, not the description and then (in brackets) the level number, as it was before this PR.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: We might need to update screenshots of the presciption issuing page if any include a vvm status column with vvm status descriptions showing the level number in brackets afterwards.

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

