### PR TITLE
7843 In Store Preferences clicking the Cancel button doesn't prevent your change to be saved

### DIFF
--- a/client/packages/system/src/Name/ListView/Stores/StoreEditModal.tsx
+++ b/client/packages/system/src/Name/ListView/Stores/StoreEditModal.tsx
@@ -37,21 +37,18 @@ export const StoreEditModal = ({
   setNextStore,
 }: StoreEditModalProps) => {
   const t = useTranslation();
+  const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
 
   const { data: properties, isLoading: propertiesLoading } =
     useName.document.properties();
-
   const { data, isLoading } = useName.document.get(nameId);
-
   const { mutateAsync } = useName.document.updateProperties(nameId);
-
-  const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
+  const nextId = useName.utils.nextStoreId(nameId);
 
   const { draftProperties, setDraftProperties } = useDraftStoreProperties(
     data?.properties
   );
-
-  const nextId = useName.utils.nextStoreId(nameId);
+  const [currentTab, setCurrentTab] = useState(Tabs.Properties);
 
   const save = async () => {
     mutateAsync({
@@ -65,7 +62,11 @@ export const StoreEditModal = ({
   return !!data ? (
     <Modal
       title=""
-      cancelButton={<DialogButton variant="cancel" onClick={onClose} />}
+      cancelButton={
+        currentTab !== Tabs.Preferences ? (
+          <DialogButton variant="cancel" onClick={onClose} />
+        ) : undefined
+      }
       okButton={
         <DialogButton
           variant="ok"
@@ -123,6 +124,8 @@ export const StoreEditModal = ({
             updateProperty={patch =>
               setDraftProperties({ ...draftProperties, ...patch })
             }
+            currentTab={currentTab}
+            setCurrentTab={setCurrentTab}
           />
         </Box>
       </DetailContainer>
@@ -140,6 +143,8 @@ interface ModalTabProps {
   propertyConfigs: NamePropertyNode[];
   draftProperties: DraftProperties;
   updateProperty: (update: DraftProperties) => void;
+  currentTab: Tabs;
+  setCurrentTab: (tab: Tabs) => void;
 }
 
 const ModalTabs = ({
@@ -147,9 +152,10 @@ const ModalTabs = ({
   propertyConfigs,
   draftProperties,
   updateProperty,
+  currentTab,
+  setCurrentTab,
 }: ModalTabProps) => {
   const t = useTranslation();
-  const [currentTab, setCurrentTab] = useState(Tabs.Properties);
 
   return (
     <TabContext value={currentTab}>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7843

# 👩🏻‍💻 What does this PR do?
Don't show cancel button if the user is in the preference tab

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Manage -> Stores
- [ ] Click on a store
- [ ] Go to the preference tab
- [ ] Shouldn't see the cancel button

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Screenshots of the preference tab?
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

