### PR TITLE
Column header

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -248,7 +248,7 @@
   "error.asset-not-found": "Asset not found",
   "error.authentication-error": "The server has returned an error",
   "error.batch-is-reserved": "Batch is already reserved/issued",
-  "error.cannot-add-from-masterlist-if-not-new": "Can only add from master list on 'New' invoice",
+  "error.cannot-add-from-masterlist": "Can only add from master list when the status is 'Draft' or 'New'",
   "error.cannot-add-pack-size-of-zero": "Cannot add a variant with a pack size of zero",
   "error.cannot-add-with-no-abbreviation-and-name": "Cannot add a variant with no abbreviation and name",
   "error.cannot-backdate-prescription": "Stock is not available on specified date",

--- a/client/packages/common/src/intl/locales/es/common.json
+++ b/client/packages/common/src/intl/locales/es/common.json
@@ -249,7 +249,7 @@
   "error.asset-not-found": "Activo no encontrado",
   "error.authentication-error": "El servidor ha devuelto un error",
   "error.batch-is-reserved": "Este lote ya está reservado/enviado",
-  "error.cannot-add-from-masterlist-if-not-new": "Solo se puede agregar desde una lista maestra en factura 'Nueva'",
+  "error.cannot-add-from-masterlist": "Solo se puede agregar desde una lista maestra en factura 'Nueva'",
   "error.cannot-add-pack-size-of-zero": "No se puede agregar una variante con un tamaño de paquete de cero",
   "error.cannot-add-with-no-abbreviation-and-name": "No se puede agregar una variante sin abreviatura y nombre",
   "error.cannot-backdate-prescription": "El inventario no está disponible en la fecha especificada",

--- a/client/packages/common/src/intl/locales/fr/common.json
+++ b/client/packages/common/src/intl/locales/fr/common.json
@@ -246,7 +246,7 @@
   "error.asset-not-found": "Actif non trouvé",
   "error.authentication-error": "Le serveur a renvoyé une erreur",
   "error.batch-is-reserved": "Le lot est déjà réservé/émis",
-  "error.cannot-add-from-masterlist-if-not-new": "L'ajout d'une liste maitresse n'est possible que depuis une nouvelle livraison",
+  "error.cannot-add-from-masterlist": "L'ajout d'une liste maitresse n'est possible que depuis une nouvelle livraison",
   "error.cannot-add-pack-size-of-zero": "Impossible d'ajouter une variante avec une taille d'emballage égale à zéro",
   "error.cannot-add-with-no-abbreviation-and-name": "Impossible d'ajouter une variante sans abréviation ni nom",
   "error.cannot-backdate-prescription": "Le stock n'est pas disponible à la date spécifiée",

--- a/client/packages/common/src/intl/locales/pt/common.json
+++ b/client/packages/common/src/intl/locales/pt/common.json
@@ -247,7 +247,7 @@
   "error.asset-not-found": "Ativo não foi encontrado",
   "error.authentication-error": "O servidor retornou um erro",
   "error.batch-is-reserved": "Este lote está reservado/enviado",
-  "error.cannot-add-from-masterlist-if-not-new": "Só é possível adicionar a partir da lista principal em uma fatura 'Nova'",
+  "error.cannot-add-from-masterlist": "Só é possível adicionar a partir da lista principal em uma fatura 'Nova'",
   "error.cannot-add-pack-size-of-zero": "Não é possível adicionar uma variante com o tamanho de pacote igual a zero",
   "error.cannot-add-with-no-abbreviation-and-name": "Não é possível adicionar uma variante sem abreviação e nome",
   "error.cannot-backdate-prescription": "Stock não está disponível na data especificada",

--- a/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -99,14 +99,15 @@ export const HeaderCell = <T extends RecordWithId>({
   const child = (
     <div
       style={{
-        flexWrap: 'nowrap',
-        alignItems: 'center',
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
+        flexDirection: 'column',
       }}
     >
       <Header column={column} />
-      {infoIcon}
+      {infoIcon && (
+        <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+          {infoIcon}
+        </div>
+      )}
     </div>
   );
 

--- a/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -102,7 +102,17 @@ export const HeaderCell = <T extends RecordWithId>({
         flexDirection: 'column',
       }}
     >
-      <Header column={column} />
+      <div
+        style={{
+          display: 'block',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          maxHeight: '3em',
+          lineHeight: '1.5em',
+        }}
+      >
+        <Header column={column} />
+      </div>
       {infoIcon && (
         <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
           {infoIcon}

--- a/client/packages/invoices/src/InboundShipment/DetailView/AddButton.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/AddButton.tsx
@@ -72,7 +72,7 @@ export const AddButton = ({
       case 'add-from-master-list':
         invoice?.status === InvoiceNodeStatus.New
           ? masterListModalController.toggleOn()
-          : info(t('error.cannot-add-from-masterlist-if-not-new'))();
+          : info(t('error.cannot-add-from-masterlist'))();
         break;
       case 'add-from-internal-order':
         internalOrderModalController.toggleOn();

--- a/client/packages/purchase_orders/src/DetailView/AppBarButtons/AddFromMasterListButton.tsx
+++ b/client/packages/purchase_orders/src/DetailView/AppBarButtons/AddFromMasterListButton.tsx
@@ -15,7 +15,7 @@ export const AddFromMasterListButtonComponent = () => {
   const { storeId } = useAuthContext();
 
   return (
-    <>
+    
       <MasterListSearchModal
         open={modalController.isOn}
         onClose={modalController.toggleOff}
@@ -33,7 +33,7 @@ export const AddFromMasterListButtonComponent = () => {
         label={t('button.add-from-master-list')}
         onClick={modalController.toggleOn}
       />
-    </>
+    
   );
 };
 

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AddButton.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AddButton.tsx
@@ -8,7 +8,7 @@ import {
   PlusCircleIcon,
   RequisitionNodeStatus,
 } from '@openmsupply-client/common';
-import { AddFromMasterListButton } from './AddFromMasterListButton';
+import { AddFromMasterListModal } from './AddFromMasterListModal';
 
 interface AddButtonProps {
   status?: RequisitionNodeStatus;
@@ -78,7 +78,7 @@ export const AddButton = ({ status, onAddItem, disable }: AddButtonProps) => {
       />
 
       {masterListModalController.isOn && (
-        <AddFromMasterListButton
+        <AddFromMasterListModal
           isOn={masterListModalController.isOn}
           toggleOff={masterListModalController.toggleOff}
         />

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AddButton.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AddButton.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  useTranslation,
+  SplitButton,
+  SplitButtonOption,
+  useNotification,
+  useToggle,
+  PlusCircleIcon,
+  RequisitionNodeStatus,
+} from '@openmsupply-client/common';
+import { AddFromMasterListButton } from './AddFromMasterListButton';
+
+interface AddButtonProps {
+  status?: RequisitionNodeStatus;
+  onAddItem: (newState: boolean) => void;
+  disable: boolean /** Disable the whole control */;
+}
+
+export const AddButton = ({ status, onAddItem, disable }: AddButtonProps) => {
+  const t = useTranslation();
+  const { info } = useNotification();
+  const masterListModalController = useToggle();
+
+  const options: [SplitButtonOption<string>, SplitButtonOption<string>] =
+    useMemo(
+      () => [
+        {
+          value: 'add-item',
+          label: t('button.add-item'),
+          isDisabled: disable,
+        },
+        {
+          value: 'add-from-master-list',
+          label: t('button.add-from-master-list'),
+          isDisabled: disable,
+        },
+      ],
+      [disable]
+    );
+
+  const [selectedOption, setSelectedOption] = useState<
+    SplitButtonOption<string>
+  >(options[0]);
+
+  useEffect(() => {
+    setSelectedOption(options[0]);
+  }, [options]);
+
+  const handleOptionSelection = (option: SplitButtonOption<string>) => {
+    switch (option.value) {
+      case 'add-item':
+        onAddItem(true);
+        break;
+      case 'add-from-master-list':
+        status === RequisitionNodeStatus.Draft
+          ? masterListModalController.toggleOn()
+          : info(t('error.cannot-add-from-masterlist'))();
+        break;
+    }
+  };
+
+  const onSelectOption = (option: SplitButtonOption<string>) => {
+    setSelectedOption(option);
+    handleOptionSelection(option);
+  };
+
+  return (
+    <>
+      <SplitButton
+        color="primary"
+        options={options}
+        selectedOption={selectedOption}
+        onSelectOption={onSelectOption}
+        onClick={handleOptionSelection}
+        isDisabled={disable}
+        openFrom="bottom"
+        Icon={<PlusCircleIcon />}
+      />
+
+      {masterListModalController.isOn && (
+        <AddFromMasterListButton
+          isOn={masterListModalController.isOn}
+          toggleOff={masterListModalController.toggleOff}
+        />
+      )}
+    </>
+  );
+};

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AddFromMasterListButton.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AddFromMasterListButton.tsx
@@ -1,38 +1,29 @@
 import React from 'react';
-import {
-  ButtonWithIcon,
-  useTranslation,
-  useToggle,
-  PlusCircleIcon,
-  useAuthContext,
-} from '@openmsupply-client/common';
+import { useAuthContext } from '@openmsupply-client/common';
 import { MasterListSearchModal } from '@openmsupply-client/system';
 import { useRequest } from '../../api';
 
-export const AddFromMasterListButtonComponent = () => {
-  const t = useTranslation();
-  const isDisabled = useRequest.utils.isDisabled();
-  const isProgram = useRequest.utils.isProgram();
+export const AddFromMasterListButtonComponent = ({
+  isOn,
+  toggleOff,
+}: {
+  isOn: boolean;
+  toggleOff: () => void;
+}) => {
   const { addFromMasterList } = useRequest.utils.addFromMasterList();
-  const modalController = useToggle();
   const { storeId } = useAuthContext();
+  const filter = { isProgram: false, existsForStoreId: { equalTo: storeId } };
 
   return (
     <>
       <MasterListSearchModal
-        open={modalController.isOn}
-        onClose={modalController.toggleOff}
+        open={isOn}
+        onClose={toggleOff}
         onChange={masterList => {
-          modalController.toggleOff();
+          toggleOff();
           addFromMasterList(masterList);
         }}
-        filterBy={{ isProgram: false, existsForStoreId: { equalTo: storeId } }}
-      />
-      <ButtonWithIcon
-        disabled={isDisabled || isProgram}
-        Icon={<PlusCircleIcon />}
-        label={t('button.add-from-master-list')}
-        onClick={modalController.toggleOn}
+        filterBy={filter}
       />
     </>
   );

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AddFromMasterListModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AddFromMasterListModal.tsx
@@ -3,7 +3,7 @@ import { useAuthContext } from '@openmsupply-client/common';
 import { MasterListSearchModal } from '@openmsupply-client/system';
 import { useRequest } from '../../api';
 
-export const AddFromMasterListButtonComponent = ({
+export const AddFromMasterListModalComponent = ({
   isOn,
   toggleOff,
 }: {
@@ -15,20 +15,18 @@ export const AddFromMasterListButtonComponent = ({
   const filter = { isProgram: false, existsForStoreId: { equalTo: storeId } };
 
   return (
-    <>
-      <MasterListSearchModal
-        open={isOn}
-        onClose={toggleOff}
-        onChange={masterList => {
-          toggleOff();
-          addFromMasterList(masterList);
-        }}
-        filterBy={filter}
-      />
-    </>
+    <MasterListSearchModal
+      open={isOn}
+      onClose={toggleOff}
+      onChange={masterList => {
+        toggleOff();
+        addFromMasterList(masterList);
+      }}
+      filterBy={filter}
+    />
   );
 };
 
-export const AddFromMasterListButton = React.memo(
-  AddFromMasterListButtonComponent
+export const AddFromMasterListModal = React.memo(
+  AddFromMasterListModalComponent
 );

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
@@ -1,18 +1,15 @@
 import React, { FC } from 'react';
 import {
   AppBarButtonsPortal,
-  ButtonWithIcon,
-  PlusCircleIcon,
   Grid,
   useDetailPanel,
-  useTranslation,
   ReportContext,
   useAuthContext,
 } from '@openmsupply-client/common';
 import { ReportSelector } from '@openmsupply-client/system';
 import { useRequest } from '../../api';
 import { UseSuggestedQuantityButton } from './UseSuggestedQuantityButton';
-import { AddFromMasterListButton } from './AddFromMasterListButton';
+import { AddButton } from './AddButton';
 
 interface AppBarButtonProps {
   isDisabled: boolean;
@@ -25,7 +22,6 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   isDisabled,
   showIndicators = false,
 }) => {
-  const t = useTranslation();
   const { store } = useAuthContext();
   const isProgram = useRequest.utils.isProgram();
   const { OpenButton } = useDetailPanel();
@@ -34,14 +30,12 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   return (
     <AppBarButtonsPortal>
       <Grid container gap={1}>
-        <ButtonWithIcon
-          disabled={isDisabled || isProgram}
-          label={t('button.add-item')}
-          Icon={<PlusCircleIcon />}
-          onClick={onAddItem}
+        <AddButton
+          onAddItem={onAddItem}
+          status={data?.status}
+          disable={isDisabled || isProgram}
         />
 
-        <AddFromMasterListButton />
         <UseSuggestedQuantityButton />
 
         <ReportSelector

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/OrderInfoSection.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/OrderInfoSection.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import {
   Grid,
-  Autocomplete,
   useTranslation,
-  useConfirmationModal,
   DetailPanelSection,
   PanelRow,
   PanelLabel,
@@ -12,35 +10,13 @@ import {
 import { useRequest } from '../api';
 import { getApprovalStatusKey } from '../../utils';
 
-const months = [1, 2, 3, 4, 5, 6];
-
 export const OrderInfoSection = () => {
   const t = useTranslation();
-  const isDisabled = useRequest.utils.isDisabled();
-  const isProgram = useRequest.utils.isProgram();
-  const { minMonthsOfStock, maxMonthsOfStock, linkedRequisition, update } =
-    useRequest.document.fields([
-      'minMonthsOfStock',
-      'maxMonthsOfStock',
-      'programName',
-      'linkedRequisition',
-    ]);
+  const { linkedRequisition } = useRequest.document.fields([
+    'programName',
+    'linkedRequisition',
+  ]);
   const { usesRemoteAuthorisation } = useRequest.utils.isRemoteAuthorisation();
-
-  const getMinMOSConfirmation = useConfirmationModal({
-    title: t('heading.are-you-sure'),
-    message: t('messages.changing-min-mos'),
-  });
-
-  const getMinMOSUnassignConfirmation = useConfirmationModal({
-    title: t('heading.are-you-sure'),
-    message: t('messages.unassign-min-mos'),
-  });
-
-  const getMaxMOSConfirmation = useConfirmationModal({
-    title: t('heading.are-you-sure'),
-    message: t('messages.changing-max-mos'),
-  });
 
   return (
     <DetailPanelSection title={t('heading.order-info')}>
@@ -53,74 +29,6 @@ export const OrderInfoSection = () => {
             </PanelField>
           </PanelRow>
         )}
-        <PanelRow>
-          <PanelLabel>{t('label.min-months-of-stock')}</PanelLabel>
-          <PanelField>
-            <Autocomplete
-              disabled={isDisabled || isProgram}
-              clearIcon={null}
-              isOptionEqualToValue={(a, b) => a.value === b.value}
-              value={
-                minMonthsOfStock === 0
-                  ? { label: t('label.not-set'), value: 0 }
-                  : {
-                      label: t('label.number-months', {
-                        count: minMonthsOfStock,
-                      }),
-                      value: minMonthsOfStock,
-                    }
-              }
-              width="150px"
-              options={[
-                { label: t('label.not-set'), value: 0 },
-                ...months.map(numberOfMonths => ({
-                  label: t('label.number-months', { count: numberOfMonths }),
-                  value: numberOfMonths,
-                })),
-              ]}
-              onChange={(_, option) => {
-                if (option && option.value === 0) {
-                  getMinMOSUnassignConfirmation({
-                    onConfirm: () => update({ minMonthsOfStock: option.value }),
-                  });
-                } else {
-                  option &&
-                    getMinMOSConfirmation({
-                      onConfirm: () =>
-                        update({ minMonthsOfStock: option.value }),
-                    });
-                }
-              }}
-              getOptionDisabled={option => option.value > maxMonthsOfStock}
-            />
-          </PanelField>
-        </PanelRow>
-        <PanelRow>
-          <PanelLabel>{t('label.max-months-of-stock')}</PanelLabel>
-          <PanelField>
-            <Autocomplete
-              disabled={isDisabled || isProgram}
-              clearIcon={null}
-              isOptionEqualToValue={(a, b) => a.value === b.value}
-              value={{
-                label: t('label.number-months', { count: maxMonthsOfStock }),
-                value: maxMonthsOfStock,
-              }}
-              width="150px"
-              options={months.map(numberOfMonths => ({
-                label: t('label.number-months', { count: numberOfMonths }),
-                value: numberOfMonths,
-              }))}
-              onChange={(_, option) =>
-                option &&
-                getMaxMOSConfirmation({
-                  onConfirm: () => update({ maxMonthsOfStock: option.value }),
-                })
-              }
-              getOptionDisabled={option => option.value < minMonthsOfStock}
-            />
-          </PanelField>
-        </PanelRow>
       </Grid>
     </DetailPanelSection>
   );

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/OrderInfoSection.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/OrderInfoSection.tsx
@@ -18,6 +18,10 @@ export const OrderInfoSection = () => {
   ]);
   const { usesRemoteAuthorisation } = useRequest.utils.isRemoteAuthorisation();
 
+  if (!usesRemoteAuthorisation) {
+    return null;
+  }
+
   return (
     <DetailPanelSection title={t('heading.order-info')}>
       <Grid container gap={0.5} key="order-info">

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
@@ -167,33 +167,33 @@ export const Toolbar = () => {
               />
             }
           />
-        </Grid>
-      </Grid>
-      <Grid
-        display="flex"
-        gap={1}
-        alignItems="flex-end"
-        justifyContent="flex-end"
-      >
-        <Grid>
-          <Switch
-            label={t('label.hide-stock-over-minimum')}
-            onChange={toggle}
-            checked={on}
-            color="secondary"
-            size="small"
-            labelSx={{ margin: '5px 0' }}
-          />
-        </Grid>
-        <Grid>
-          <SearchBar
-            placeholder={t('placeholder.filter-items')}
-            value={itemFilter}
-            onChange={newValue => {
-              setItemFilter(newValue);
-            }}
-            debounceTime={0}
-          />
+          <Grid
+            display="flex"
+            gap={1}
+            alignItems="flex-end"
+            justifyContent="flex-end"
+          >
+            <Grid>
+              <Switch
+                label={t('label.hide-stock-over-minimum')}
+                onChange={toggle}
+                checked={on}
+                color="secondary"
+                size="small"
+                labelSx={{ margin: '5px 0' }}
+              />
+            </Grid>
+            <Grid>
+              <SearchBar
+                placeholder={t('placeholder.filter-items')}
+                value={itemFilter}
+                onChange={newValue => {
+                  setItemFilter(newValue);
+                }}
+                debounceTime={0}
+              />
+            </Grid>
+          </Grid>
         </Grid>
       </Grid>
     </AppBarContentPortal>

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
@@ -58,11 +58,10 @@ export const Toolbar = () => {
       sx={{
         display: 'flex',
         flex: 1,
-        marginBottom: 1,
         flexDirection: 'column',
       }}
     >
-      <Grid container gap={2} flexWrap="nowrap">
+      <Grid container flexWrap="nowrap">
         <Grid display="flex" flex={1} flexDirection="column" gap={1}>
           {otherParty && (
             <InputWithLabelRow
@@ -77,7 +76,29 @@ export const Toolbar = () => {
             />
           )}
           <InputWithLabelRow
+            label={t('label.supplier-ref')}
+            Input={
+              <Tooltip title={theirReference} placement="bottom-start">
+                <BufferedTextInput
+                  disabled={isDisabled}
+                  size="small"
+                  sx={{ width: 250 }}
+                  value={theirReference ?? null}
+                  onChange={e => update({ theirReference: e.target.value })}
+                />
+              </Tooltip>
+            }
+          />
+          {programName && (
+            <Alert severity="info" sx={{ maxWidth: 1000 }}>
+              {t('info.cannot-edit-program-requisition')}
+            </Alert>
+          )}
+        </Grid>
+        <Grid>
+          <InputWithLabelRow
             label={t('label.min-months-of-stock')}
+            labelWidth={'350px'}
             Input={
               <Autocomplete
                 disabled={isDisabled || isProgram}
@@ -93,7 +114,7 @@ export const Toolbar = () => {
                         value: minMonthsOfStock,
                       }
                 }
-                width="150px"
+                width="200px"
                 options={[
                   { label: t('label.not-set'), value: 0 },
                   ...MONTHS.map(numberOfMonths => ({
@@ -121,6 +142,7 @@ export const Toolbar = () => {
           />
           <InputWithLabelRow
             label={t('label.max-months-of-stock')}
+            labelWidth={'350px'}
             Input={
               <Autocomplete
                 disabled={isDisabled || isProgram}
@@ -130,7 +152,7 @@ export const Toolbar = () => {
                   label: t('label.number-months', { count: maxMonthsOfStock }),
                   value: maxMonthsOfStock,
                 }}
-                width="150px"
+                width="200px"
                 options={MONTHS.map(numberOfMonths => ({
                   label: t('label.number-months', { count: numberOfMonths }),
                   value: numberOfMonths,
@@ -145,27 +167,6 @@ export const Toolbar = () => {
               />
             }
           />
-          <InputWithLabelRow
-            label={t('label.supplier-ref')}
-            Input={
-              <Tooltip title={theirReference} placement="bottom-start">
-                <BufferedTextInput
-                  disabled={isDisabled}
-                  size="small"
-                  sx={{ width: 250 }}
-                  value={theirReference ?? null}
-                  onChange={e => update({ theirReference: e.target.value })}
-                />
-              </Tooltip>
-            }
-          />
-        </Grid>
-        <Grid>
-          {programName && (
-            <Alert severity="info" sx={{ marginTop: 1, maxWidth: '378px' }}>
-              {t('info.cannot-edit-program-requisition')}
-            </Alert>
-          )}
         </Grid>
       </Grid>
       <Grid
@@ -173,7 +174,6 @@ export const Toolbar = () => {
         gap={1}
         alignItems="flex-end"
         justifyContent="flex-end"
-        sx={{ marginTop: 1, flexWrap: 'wrap' }}
       >
         <Grid>
           <Switch
@@ -185,7 +185,7 @@ export const Toolbar = () => {
             labelSx={{ margin: '5px 0' }}
           />
         </Grid>
-        <Grid display="flex" gap={1} alignItems="flex-end">
+        <Grid>
           <SearchBar
             placeholder={t('placeholder.filter-items')}
             value={itemFilter}

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
@@ -29,11 +29,9 @@ export const Toolbar = () => {
     theirReference,
     update,
     otherParty,
-    programName,
   } = useRequest.document.fields([
     'theirReference',
     'otherParty',
-    'programName',
     'minMonthsOfStock',
     'maxMonthsOfStock',
   ]);
@@ -89,7 +87,7 @@ export const Toolbar = () => {
               </Tooltip>
             }
           />
-          {programName && (
+          {isProgram && (
             <Alert severity="info" sx={{ maxWidth: 1000 }}>
               {t('info.cannot-edit-program-requisition')}
             </Alert>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8048 & #8035 & #8364

# 👩🏻‍💻 What does this PR do?
- For now have moved tooltip to the bottom right of the text... moving it outside of the text doesn't work when there are a lot of columns.... (yes, it would look better being next to the text but not as a part of the text... but alas...)
- The text is forced to 2 rows of text and shows eclipses for text that will overflow... We need to stop making header names too long... My hot take is anything long should go into a description (need a better way to handle this than tooltips as well for tablets)
- Split buttons for adding from item / adding from master list
- Moved min / max MOS out of side panel
- Move things around in the toolbar to free up more real estate...
![Screenshot 2025-07-08 at 4 16 56 PM](https://github.com/user-attachments/assets/2b5fef03-46cf-49da-b536-47a205ca5e9c)
![Screenshot 2025-07-08 at 4 17 06 PM](https://github.com/user-attachments/assets/0b6a4e3d-747d-4b64-8481-5d0cf2dae68b)
![Screenshot 2025-07-08 at 4 17 16 PM](https://github.com/user-attachments/assets/b375bb7a-725e-443a-9a43-384388a82198)

## Before
![io-before-pt](https://github.com/user-attachments/assets/86d00dcb-f141-41cf-a2d8-724802dfc943)
![io-before-eng](https://github.com/user-attachments/assets/3e49c095-8cbe-49d1-a7d1-4dc9db1553e0)

## After
![pt-after](https://github.com/user-attachments/assets/bb0cac63-6a5a-428d-8aae-d61c072898dc)
![russian-after](https://github.com/user-attachments/assets/6c6f73ff-b086-4e88-af86-f185d269d963)

## 💌 Any notes for the reviewer?
Should get input from designer for this doing forth...

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

