### PR TITLE
8005 generate program enrolment button to single use

### DIFF
--- a/client/packages/programs/src/JsonForms/components/IdGenerator.tsx
+++ b/client/packages/programs/src/JsonForms/components/IdGenerator.tsx
@@ -302,17 +302,16 @@ const useUniqueProgramPatientCodeValidation = () => {
 };
 
 const UIComponent = (props: ControlProps) => {
-  const { label, errors, path, data, visible, handleChange, uischema } = props;
-  const config: JsonFormsConfig = props.config;
   const t = useTranslation();
+  const config: JsonFormsConfig = props.config;
+
+  const { label, errors, path, data, visible, handleChange, uischema } = props;
   const { core } = useJsonForms();
   const { mutateAsync: mutateGenerateId } = useMutation(
     async (input: GenerateIdInput): Promise<string> => generateId(input)
   );
   const { mutateAsync: allocateNumber } = useDocument.utils.allocateNumber();
-  const validateUniqueProgramEnrolmentId =
-    useUniqueProgramEnrolmentIdValidation();
-  const validateUniquePatientCode = useUniqueProgramPatientCodeValidation();
+
   const { customError, setCustomError } = useJSONFormsCustomError(
     path,
     'UIGenerator'
@@ -322,11 +321,6 @@ const UIComponent = (props: ControlProps) => {
     GeneratorOptions,
     uischema.options
   );
-
-  const savedDataField = extractProperty(config.initialData ?? {}, path);
-  const requireConfirmation = !options?.confirmRegenerate
-    ? false
-    : !!savedDataField;
 
   const validationError = useMemo(() => {
     if (!options || !core?.data) {
@@ -350,6 +344,11 @@ const UIComponent = (props: ControlProps) => {
   );
 
   const { text, onChange } = useDebouncedTextInput(data, manualUpdate);
+  const requireConfirmation = !options?.confirmRegenerate ? false : !!text;
+
+  const validateUniqueProgramEnrolmentId =
+    useUniqueProgramEnrolmentIdValidation();
+  const validateUniquePatientCode = useUniqueProgramPatientCodeValidation();
 
   const validateId = async (
     options: GeneratorOptions,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8005 

# 👩🏻‍💻 What does this PR do?

Shows a modal if the user clicks on generate button again on patient program modal.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

Document registry have to be configured (if you don't have it configured please follow: https://github.com/msupply-foundation/open-msupply/issues/4642)
- [ ] Navigate to Dispensary -> Patient -> Select a patient -> Click on Add Program
- [ ] Click on generate button by `Enrolment Id`
- [ ] Should set an ID
- [ ] Click on generate button again
- [ ] Shows a modal confirming if you would like to generate a new ID

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

