### PR TITLE
Always show tabs in view stock

### DIFF
--- a/client/packages/system/src/Stock/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Stock/DetailView/DetailView.tsx
@@ -161,20 +161,7 @@ export const StockLineDetailView: React.FC = () => {
         openAdjust={openInventoryAdjustmentModal}
       />
       <TableProvider createStore={createTableStore}>
-        {simplifiedTabletView ? (
-          <>
-            <StockLineForm
-              loading={isLoading}
-              draft={draft}
-              onUpdate={updatePatch}
-              pluginEvents={pluginEvents}
-            />
-          </>
-        ) : (
-          <>
-            <DetailTabs tabs={tabs} />
-          </>
-        )}
+        <DetailTabs tabs={tabs} />
         {(tab === t('label.details') || !tab || simplifiedTabletView) && (
           <Footer {...footerProps} />
         )}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8391 

# 👩🏻‍💻 What does this PR do?

Allows users to enter vvm statuses when Simplified UI is ON by showing all the tabs (including status history)

A small screen view now looks like this...
![image](https://github.com/user-attachments/assets/2ad61979-9ca5-4fdb-91ee-a2c0f35768c3)


## 💌 Any notes for the reviewer?

A better solution might be to have a Add vvm status button in the main view stock panel?

Could also hide log and ledger with simplified UI but without saving the space I feel like we might as well keep them accessible?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Turn on simplified UI (pack size to 1, store pref for simplified UI on in OMS Central)
- [ ] Use a small screensize/window
- [ ] Make sure you can enter a vvm status from the view stock page.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [X] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [X] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

