### PR TITLE
8137 Add debug logs for label printing

### DIFF
--- a/client/packages/common/src/ui/components/buttons/FlatButton/FlatButton.tsx
+++ b/client/packages/common/src/ui/components/buttons/FlatButton/FlatButton.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { Button as MuiButton, styled, SxProps, Theme } from '@mui/material';
+import {
+  CircularProgress,
+  Button as MuiButton,
+  styled,
+  SxProps,
+  Theme,
+} from '@mui/material';
 import { Property } from 'csstype';
 import { useIntlUtils } from '@common/intl';
 import { useAppTheme, useMediaQuery } from '@common/styles';
@@ -14,6 +20,7 @@ interface ButtonProps {
   name?: string;
   shouldShrink?: boolean;
   shrinkThreshold?: 'sm' | 'md' | 'lg' | 'xl';
+  loading?: boolean;
 }
 
 const StyledButton = styled(MuiButton, {
@@ -50,6 +57,7 @@ export const FlatButton: React.FC<ButtonProps> = ({
   disabled = false,
   shouldShrink = false,
   shrinkThreshold = 'md',
+  loading = false,
 }) => {
   const { isRtl } = useIntlUtils();
   const theme = useAppTheme();
@@ -66,16 +74,18 @@ export const FlatButton: React.FC<ButtonProps> = ({
 
   return (
     <StyledButton
-      disabled={disabled}
       shrink={shrink}
       onClick={onClick}
       endIcon={endIcon}
-      startIcon={regularIcon}
       variant="text"
       color={color}
       isRtl={isRtl}
       sx={sx}
       name={name}
+      disabled={loading || disabled}
+      startIcon={
+        loading ? <CircularProgress size={20} sx={{ color }} /> : regularIcon
+      }
     >
       {centredIcon}
       {text}

--- a/client/packages/common/src/ui/components/footer/ActionsFooter.tsx
+++ b/client/packages/common/src/ui/components/footer/ActionsFooter.tsx
@@ -13,6 +13,7 @@ export interface Action {
   icon: ReactNode;
   onClick: () => void;
   disabled?: boolean;
+  loading?: boolean;
   shouldShrink?: boolean;
 }
 
@@ -50,17 +51,20 @@ export const ActionsFooter: FC<ActionsFooterProps> = ({
         >
           {selectedRowCount} {t('label.selected')}
         </Typography>
-        {actions.map(({ label, icon, onClick, disabled, shouldShrink }) => (
-          <FlatButton
-            key={label}
-            startIcon={icon}
-            label={label}
-            disabled={disabled}
-            onClick={onClick}
-            // Flatbutton doesn't shrink by default but we want it to in actions footer
-            shouldShrink={shouldShrink ?? true}
-          />
-        ))}
+        {actions.map(
+          ({ label, icon, onClick, disabled, shouldShrink, loading }) => (
+            <FlatButton
+              key={label}
+              startIcon={icon}
+              label={label}
+              disabled={disabled}
+              loading={loading}
+              onClick={onClick}
+              // Flatbutton doesn't shrink by default but we want it to in actions footer
+              shouldShrink={shouldShrink ?? true}
+            />
+          )
+        )}
       </Stack>
       <FlatButton
         startIcon={<MinusCircleIcon />}

--- a/client/packages/invoices/src/Prescriptions/DetailView/Footer/Footer.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Footer/Footer.tsx
@@ -118,7 +118,8 @@ export const FooterComponent: FC = () => {
       label: t('button.print-prescription-label'),
       icon: <PrinterIcon />,
       onClick: handlePrintLabels,
-      disabled: isDisabled || isPrintingLabels,
+      disabled: isDisabled,
+      loading: isPrintingLabels,
     },
   ];
 

--- a/server/service/src/print/jetdirect.rs
+++ b/server/service/src/print/jetdirect.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use std::{io::Write, net::SocketAddr};
 use telnet::{Event, Telnet};
 
-const PRINTER_COMMAND_TIMEOUT: Duration = Duration::new(1, 0);
+const PRINTER_COMMAND_TIMEOUT: Duration = Duration::new(1, 500);
 const PRINTER_CONNECTION_TIMEOUT: Duration = Duration::new(5, 0);
 
 // Note: this file is mostly taken from https://github.com/fearful-symmetry/zebrasend/blob/main/src/cmd/jetdirect.rs
@@ -35,7 +35,7 @@ impl Jetdirect {
         mode: Mode,
         timeout: Duration,
     ) -> Result<String> {
-        log::debug!("Sending jetdirect command: {}", payload);
+        log::debug!("Sending jetdirect command");
         handle.write(payload.as_bytes())?;
         log::debug!("Command sent, awaiting response...");
 

--- a/server/service/src/print/jetdirect.rs
+++ b/server/service/src/print/jetdirect.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use std::{io::Write, net::SocketAddr};
 use telnet::{Event, Telnet};
 
-const PRINTER_COMMAND_TIMEOUT: Duration = Duration::new(1, 500);
+const PRINTER_COMMAND_TIMEOUT: Duration = Duration::new(2, 500);
 const PRINTER_CONNECTION_TIMEOUT: Duration = Duration::new(5, 0);
 
 // Note: this file is mostly taken from https://github.com/fearful-symmetry/zebrasend/blob/main/src/cmd/jetdirect.rs
@@ -77,6 +77,7 @@ impl Jetdirect {
         log::debug!("Connecting to jetdirect printer at {}", socket);
         let mut telnet = Telnet::connect_timeout(&socket, 512, PRINTER_CONNECTION_TIMEOUT)?;
         log::debug!("Connected to printer");
+
         self.send_command(data, &mut telnet, mode, PRINTER_COMMAND_TIMEOUT)
     }
 }

--- a/server/service/src/print/jetdirect.rs
+++ b/server/service/src/print/jetdirect.rs
@@ -74,6 +74,7 @@ impl Jetdirect {
     pub fn send_string(&self, data: String, mode: Mode) -> Result<String> {
         let ip_addr = IpAddr::from_str(&self.addr)?;
         let socket = SocketAddr::new(ip_addr, self.port);
+
         log::debug!("Connecting to jetdirect printer at {}", socket);
         let mut telnet = Telnet::connect_timeout(&socket, 512, PRINTER_CONNECTION_TIMEOUT)?;
         log::debug!("Connected to printer");


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8137

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Extends label printer command timeout - give printer more time to execute the command before we close the connection. My initial testing, this seems to result in the printer more reliably remaining connected.

Adds a loading state to the printing action, now that the action takes a bit longer:


![Screenshot 2025-07-09 at 1 00 13 PM](https://github.com/user-attachments/assets/632772e5-51fe-4ee3-8874-108629cc36ab)


Adds logs around label printing - failures are intermittent, at least show a bit more context in the logs.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

First print after restarting the printer always works. Second print returns a success response, but no print, 3rd print request fails to connect. This failure to connect now shows in the logs.

With extending the command timeout, this seems to happen less frequently, though I am still getting it sometimes 🤷‍♀️ 

No other differences were found, e.g. command payload between successful and failing requests is identical.

If you have any other bright ideas, please share.

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Start OMS server with log level `Debug`
- [ ] Go to prescription detail view
- [ ] Select some lines
- [ ] Click `Print labels`
- [ ] See the loading button while the print executes
- [ ] View server logs, see logs of the print steps
- [ ] Hopefully you can successfully print labels subsequent times?

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

