### PR TITLE
8137 Move HTTP logs to debug level, add graphql logs

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "f9e772b3bcafe335042b5db010ab7c09013dad6eac4915c91d8d50902769f331"
 dependencies = [
  "actix-utils",
  "actix-web",
- "derive_more",
+ "derive_more 0.99.18",
  "futures-util",
  "log",
  "once_cell",
@@ -172,7 +172,7 @@ dependencies = [
  "actix-web",
  "bitflags 2.9.1",
  "bytes",
- "derive_more",
+ "derive_more 0.99.18",
  "futures-core",
  "http-range",
  "log",
@@ -185,24 +185,24 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.9.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48f96fc3003717aeb9856ca3d02a8c7de502667ad76eeacd830b48d2e91fac4"
+checksum = "44dfe5c9e0004c623edc65391dfd51daa201e7e30ebd9c9bedf873048ec32bc2"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-tls",
  "actix-utils",
- "ahash",
  "base64 0.22.1",
  "bitflags 2.9.1",
  "brotli",
  "bytes",
  "bytestring",
- "derive_more",
+ "derive_more 2.0.1",
  "encoding_rs",
  "flate2",
+ "foldhash",
  "futures-core",
  "h2",
  "http 0.2.12",
@@ -214,7 +214,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.9.1",
  "sha1",
  "smallvec",
  "tokio",
@@ -242,7 +242,7 @@ dependencies = [
  "actix-multipart-derive",
  "actix-utils",
  "actix-web",
- "derive_more",
+ "derive_more 0.99.18",
  "futures-core",
  "futures-util",
  "httparse",
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca2549781d8dd6d75c40cf6b6051260a2cc2f3c62343d761a969a0640646894"
+checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -358,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.9.0"
+version = "4.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9180d76e5cc7ccbc4d60a506f2c727730b154010262df5b910eb17dbe4b8cb38"
+checksum = "a597b77b5c6d6a1e1097fddde329a83665e25c5437c696a3a9a4aa514a614dea"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -372,13 +372,13 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "actix-web-codegen",
- "ahash",
  "bytes",
  "bytestring",
  "cfg-if",
  "cookie",
- "derive_more",
+ "derive_more 2.0.1",
  "encoding_rs",
+ "foldhash",
  "futures-core",
  "futures-util",
  "impl-more",
@@ -396,6 +396,7 @@ dependencies = [
  "smallvec",
  "socket2 0.5.9",
  "time",
+ "tracing",
  "url",
 ]
 
@@ -1620,9 +1621,9 @@ checksum = "3eeab4423108c5d7c744f4d234de88d18d636100093ae04caf4825134b9c3a32"
 
 [[package]]
 name = "brotli"
-version = "6.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1631,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -2450,6 +2451,27 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -4810,16 +4832,6 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
@@ -5047,7 +5059,7 @@ dependencies = [
  "email_address",
  "fancy-regex",
  "fraction",
- "idna 1.0.3",
+ "idna",
  "itoa",
  "num-cmp",
  "once_cell",
@@ -5159,7 +5171,7 @@ dependencies = [
  "email_address",
  "fastrand 2.1.1",
  "httpdate",
- "idna 1.0.3",
+ "idna",
  "mime",
  "nom",
  "percent-encoding",
@@ -7301,7 +7313,7 @@ checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
- "derive_more",
+ "derive_more 0.99.18",
  "fxhash",
  "log",
  "new_debug_unreachable",
@@ -8593,25 +8605,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -8678,12 +8675,12 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna",
  "percent-encoding",
 ]
 

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -3628,6 +3628,8 @@ dependencies = [
  "graphql_types",
  "graphql_vaccine_course",
  "graphql_vvm",
+ "log",
+ "rand 0.8.5",
  "repository",
  "serde",
  "serde_json",

--- a/server/graphql/Cargo.toml
+++ b/server/graphql/Cargo.toml
@@ -43,14 +43,16 @@ graphql_plugin = { path = "plugin" }
 graphql_contact_form = { path = "contact_form" }
 graphql_preference = { path = "preference" }
 graphql_vvm = { path = "vvm" }
-graphql_purchase_order =  { path = "purchase_order" }
-graphql_purchase_order_line =  { path = "purchase_order_line" }
+graphql_purchase_order = { path = "purchase_order" }
+graphql_purchase_order_line = { path = "purchase_order_line" }
 
 actix-web = { workspace = true }
 async-graphql = { workspace = true }
 async-graphql-actix-web = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
+rand = { workspace = true }
+log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/server/graphql/lib.rs
+++ b/server/graphql/lib.rs
@@ -3,6 +3,9 @@
 #[cfg(test)]
 mod tests;
 
+mod logger;
+use logger::{GraphQLRequestLogger, QueryLogInfo};
+
 use std::sync::Mutex;
 
 use actix_web::web::{self, Data};
@@ -322,6 +325,7 @@ impl GraphqlSchema {
                 .data(auth.clone())
                 .data(settings.clone())
                 .data(validated_plugins.clone())
+                .extension(GraphQLRequestLogger)
                 .finish();
         // Self requester does not need loggers
 
@@ -335,7 +339,8 @@ impl GraphqlSchema {
                 .data(settings.clone())
                 .data(validated_plugins.clone())
                 // Add self requester to operational
-                .data(Data::new(SelfRequestImpl::new_boxed(self_requester_schema)));
+                .data(Data::new(SelfRequestImpl::new_boxed(self_requester_schema)))
+                .extension(GraphQLRequestLogger);
 
         // Initialisation schema should ony need service_provider
         let initialisation_builder = InitialisationSchema::build(
@@ -343,7 +348,8 @@ impl GraphqlSchema {
             InitialisationMutations,
             EmptySubscription,
         )
-        .data(service_provider.clone());
+        .data(service_provider.clone())
+        .extension(GraphQLRequestLogger);
 
         GraphqlSchema {
             operational: operational_builder.finish(),
@@ -357,7 +363,9 @@ impl GraphqlSchema {
     }
 
     async fn execute(&self, http_req: HttpRequest, req: GraphQLRequest) -> Response {
-        let req = req.into_inner();
+        let mut req = req.into_inner();
+        req = req.data(QueryLogInfo::new());
+
         if *self.is_operational.read().await {
             // auth_data is only available in schema in operational mode
             let user_data = auth_data_from_request(&http_req);

--- a/server/graphql/logger.rs
+++ b/server/graphql/logger.rs
@@ -1,0 +1,161 @@
+use async_graphql::{
+    extensions::{
+        Extension, ExtensionContext, ExtensionFactory, NextExecute, NextParseQuery, NextValidation,
+    },
+    parser::types::{ExecutableDocument, Selection},
+    Response, ServerError, ServerResult, ValidationResult, Variables,
+};
+use chrono::{DateTime, Utc};
+use rand::Rng;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+pub struct GraphQLRequestLogger;
+
+impl ExtensionFactory for GraphQLRequestLogger {
+    fn create(&self) -> Arc<dyn Extension> {
+        Arc::new(LoggerExtension {})
+    }
+}
+
+struct LoggerExtension {}
+
+#[derive(Debug, Default)]
+pub struct QueryLogInfo {
+    inner: Arc<Mutex<QueryInfoInner>>,
+}
+impl QueryLogInfo {
+    pub fn new() -> QueryLogInfo {
+        let mut rng = rand::thread_rng();
+        QueryLogInfo {
+            inner: Arc::new(Mutex::new(QueryInfoInner {
+                id: rng.gen_range(100_000_000..=999_999_999),
+                start_time: Utc::now(),
+            })),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct QueryInfoInner {
+    id: u64,
+    start_time: DateTime<Utc>,
+}
+
+#[async_trait::async_trait]
+impl Extension for LoggerExtension {
+    // Log any invalid queries received
+    async fn validation(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        next: NextValidation<'_>,
+    ) -> Result<ValidationResult, Vec<ServerError>> {
+        let res = next.run(ctx).await;
+
+        match res {
+            Ok(_) => res,
+            Err(ref errors) => match ctx.data_opt::<QueryLogInfo>() {
+                Some(info) => {
+                    let info = info.inner.lock().await;
+                    for e in errors {
+                        log::info!(
+                            target: "gql_logger",
+                            "[QueryID: {}] Received invalid query: {}",
+                            info.id,
+                            e.message
+                        )
+                    }
+                    res
+                }
+                None => res,
+            },
+        }
+    }
+
+    // Log the received request
+    async fn parse_query(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        query: &str,
+        variables: &Variables,
+        next: NextParseQuery<'_>,
+    ) -> ServerResult<ExecutableDocument> {
+        let document = next.run(ctx, query, variables).await?;
+        if let Some(info) = ctx.data_opt::<QueryLogInfo>() {
+            let info = info.inner.lock().await;
+
+            let mut variables = variables.clone();
+            if let Some(password) = variables.get_mut("password") {
+                *password = "****".into(); // Mask password variable if present
+            }
+
+            for (_, operation) in document.operations.iter() {
+                let roots_queried = operation
+                    .node
+                    .selection_set
+                    .node
+                    .items
+                    .iter()
+                    .filter_map(|i| {
+                        if let Selection::Field(field) = &i.node {
+                            Some(field.node.name.node.as_str())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                log::info!(
+                    target: "gql_logger",
+                    "[QueryID: {}] {}: {} {}",
+                    info.id,
+                    operation.node.ty,        // mutation or query
+                    roots_queried.join(", "), // e.g. `updateStockLine`, or `locations`
+                    if variables.is_empty() {
+                       "".to_string()
+                    } else {
+                        format!(" - variables: {:?}", serde_json::to_value(&variables).unwrap_or_else(|_| serde_json::Value::Null))
+                    }
+                );
+            }
+
+            log::trace!(target: "gql_logger", "[QueryID: {}] Full request: {}", info.id, ctx.stringify_execute_doc(&document, &variables));
+        }
+        Ok(document)
+    }
+
+    // Log the response
+    async fn execute(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        operation_name: Option<&str>,
+        next: NextExecute<'_>,
+    ) -> Response {
+        let resp = next.run(ctx, operation_name).await;
+        if let Some(info) = ctx.data_opt::<QueryLogInfo>() {
+            let info = info.inner.lock().await;
+            let query_id = info.id;
+
+            // Log errors to the info level
+            if resp.is_err() {
+                for err in &resp.errors {
+                    log::info!(
+                        target: "gql_logger",
+                        "[QueryID: {query_id}] [Error] {}", err.message,
+                    );
+                }
+            }
+            let query_start_time = info.start_time;
+            let duration = Utc::now() - query_start_time;
+
+            // Log successful responses to the debug level
+            log::debug!(target: "gql_logger",
+                        "[QueryID: {query_id}] Response: {} Duration: {}ms",
+                        resp.data,
+                        duration.num_milliseconds()
+            );
+        }
+
+        resp
+    }
+}

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -25,7 +25,7 @@ util = { path = "../util" }
 machine-uid = { version = "0.5.1", optional = true }
 
 actix-cors = "0.7.0"
-actix-web = { version = "4.7.0", features = ["rustls-0_23"] }
+actix-web = { version = "4.11.0", features = ["rustls-0_23"] }
 actix-files.workspace = true
 anyhow.workspace = true
 config = "0.15.4"

--- a/server/server/src/middleware/mod.rs
+++ b/server/server/src/middleware/mod.rs
@@ -9,8 +9,9 @@ pub fn compress() -> actix_web::middleware::Compress {
 
 pub fn logger() -> actix_web::middleware::Logger {
     actix_web::middleware::Logger::new(r#""%r" FROM: "%{Referer}i" STATUS: %s"#)
-        .log_level(Level::Debug)
+        .log_level(Level::Info)
         .log_target("request_log")
+        .exclude("/graphql")
 }
 
 pub(crate) fn central_server_only() -> central_server_only::CentralServerOnly {

--- a/server/server/src/middleware/mod.rs
+++ b/server/server/src/middleware/mod.rs
@@ -1,12 +1,16 @@
-pub mod content_length_limit;
+use log::Level;
+
 mod central_server_only;
+pub mod content_length_limit;
 
 pub fn compress() -> actix_web::middleware::Compress {
     actix_web::middleware::Compress::default()
 }
 
 pub fn logger() -> actix_web::middleware::Logger {
-    actix_web::middleware::Logger::default()
+    actix_web::middleware::Logger::new(r#""%r" FROM: "%{Referer}i" STATUS: %s"#)
+        .log_level(Level::Debug)
+        .log_target("request_log")
 }
 
 pub(crate) fn central_server_only() -> central_server_only::CentralServerOnly {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Another part of #8137 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Was raised in discussion, that the HTTP logs are noisy, and not particularly helpful.

Moves them to `DEBUG` log level, and strips some of the user agent etc. noise from the format:

![Screenshot 2025-07-09 at 4 57 34 PM](https://github.com/user-attachments/assets/a955c749-755d-4581-bd7e-d3ee81ef737a)


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

Our request logs are especially unhelpful, because the majority of our requests are graphql, so always to `/graphql`, and even when graphql returns an error, its still HTTP 200 status. We don't have access to the request/response body in the logger, just the headers, so this is about all the info we can show...

So logging the requests at all only really adds value for the REST requests we have. Maybe its helpful to see that requests are being received/responded to?

I'm wondering about something [like this](https://docs.rs/actix-web/latest/actix_web/middleware/struct.Logger.html#method.custom_response_replace) - and we leave as info level, but only log non-graphql requests?

I think with #7243 - we'd get more value by logging in each query/mutation, the name of the query/mutation (+ maybe params? Just not login 😁), and then the result before returning.

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Restart server - with default Info log level
- [ ] Do some things in the UI, no HTTP logs
- [ ] Restart server - with Debug log level
- [ ] Do some things in the UI, see the request logs, but they're simpler than before 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

