### PR TITLE
8403 donor not visible

### DIFF
--- a/server/service/src/invoice_line/stock_in_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/mod.rs
@@ -134,10 +134,9 @@ mod test {
         barcode::{BarcodeFilter, BarcodeRepository},
         mock::{
             mock_customer_return_a, mock_customer_return_a_invoice_line_a, mock_inbound_shipment_a,
-            mock_inbound_shipment_c, mock_inbound_shipment_e, mock_item_a, mock_name_b,
-            mock_name_customer_a, mock_name_store_b, mock_outbound_shipment_e, mock_store_a,
-            mock_store_b, mock_user_account_a, mock_vaccine_item_a, mock_vvm_status_a, MockData,
-            MockDataInserts,
+            mock_inbound_shipment_c, mock_inbound_shipment_e, mock_item_a, mock_name_customer_a,
+            mock_name_store_b, mock_outbound_shipment_e, mock_store_a, mock_store_b,
+            mock_user_account_a, mock_vaccine_item_a, mock_vvm_status_a, MockData, MockDataInserts,
         },
         test_db::{setup_all, setup_all_with_data},
         vvm_status::{
@@ -361,24 +360,6 @@ mod test {
                 },
             ),
             Err(ServiceError::DonorDoesNotExist)
-        );
-
-        // DonorNotVisible
-        assert_eq!(
-            insert_stock_in_line(
-                &context,
-                InsertStockInLine {
-                    id: "new invoice line id".to_string(),
-                    pack_size: 1.0,
-                    number_of_packs: 1.0,
-                    item_id: mock_item_a().id,
-                    invoice_id: mock_inbound_shipment_c().id,
-                    r#type: StockInType::InboundShipment,
-                    donor_id: Some(mock_name_b().id), // Not visible in store_a
-                    ..Default::default()
-                },
-            ),
-            Err(ServiceError::DonorNotVisible)
         );
 
         // DonorIsNotADonor


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8403

# 👩🏻‍💻 What does this PR do?

Allows newly added stocklines to go inserted with invisible donors.
Very edge case situation but is affecting a client with migrations so was considered worth fixing for this usecase.

## 💌 Any notes for the reviewer?

I'll raise a follow up issue to what should happen when donors are made invisible.

I haven't changed the `update.rs` logic in the same way. The justification for now is that its a nullable update, so it should only be set if they change the donor and then they should only see valid donors? But maybe I should change it as well to be consistent?

# 🧪 Testing

See bug issue for testing steps

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [X] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

