### PR TITLE
8407 exf78   civ   fiche d'inventaire des ppi   a master list filter is missing

### DIFF
--- a/server/graphql/invoice_line/src/invoice_line_queries.rs
+++ b/server/graphql/invoice_line/src/invoice_line_queries.rs
@@ -46,6 +46,7 @@ pub struct InvoiceLineFilterInput {
     #[graphql(deprecation = "Since 2.8.0. Use reason_option")]
     pub inventory_adjustment_reason: Option<EqualFilterStringInput>,
     pub verified_datetime: Option<DatetimeFilterInput>,
+    pub program_id: Option<EqualFilterStringInput>,
 }
 
 impl From<InvoiceLineFilterInput> for InvoiceLineFilter {
@@ -73,6 +74,7 @@ impl From<InvoiceLineFilterInput> for InvoiceLineFilter {
                 .reason_option
                 .map(EqualFilter::from)
                 .or(f.inventory_adjustment_reason.map(EqualFilter::from)),
+            program_id: f.program_id.map(EqualFilter::from),
             picked_datetime: None,
             delivered_datetime: None,
             has_prescribed_quantity: None,

--- a/server/repository/src/db_diesel/invoice_line.rs
+++ b/server/repository/src/db_diesel/invoice_line.rs
@@ -91,6 +91,7 @@ pub struct InvoiceLineFilter {
     pub reason_option: Option<EqualFilter<String>>,
     pub has_prescribed_quantity: Option<bool>,
     pub has_note: Option<bool>,
+    pub program_id: Option<EqualFilter<String>>,
 }
 
 impl InvoiceLineFilter {
@@ -180,6 +181,11 @@ impl InvoiceLineFilter {
 
     pub fn has_note(mut self, filter: bool) -> Self {
         self.has_note = Some(filter);
+        self
+    }
+
+    pub fn program_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.program_id = Some(filter);
         self
     }
 }
@@ -321,6 +327,7 @@ fn create_filtered_query(filter: Option<InvoiceLineFilter>) -> BoxedInvoiceLineQ
             reason_option,
             has_prescribed_quantity,
             has_note,
+            program_id,
         } = f;
 
         apply_equal_filter!(query, id, invoice_line::id);
@@ -359,6 +366,8 @@ fn create_filtered_query(filter: Option<InvoiceLineFilter>) -> BoxedInvoiceLineQ
                 query = query.filter(invoice_line::note.is_null());
             }
         }
+
+        apply_equal_filter!(query, program_id, invoice::program_id);
     }
 
     query

--- a/server/service/src/processors/transfer/invoice/create_inbound_invoice.rs
+++ b/server/service/src/processors/transfer/invoice/create_inbound_invoice.rs
@@ -230,6 +230,7 @@ fn generate_inbound_invoice(
         currency_rate: outbound_invoice_row.currency_rate,
         expected_delivery_date: outbound_invoice_row.expected_delivery_date,
         original_shipment_id,
+        program_id: outbound_invoice_row.program_id.clone(),
         // Default
         colour: None,
         user_id: None,
@@ -242,7 +243,6 @@ fn generate_inbound_invoice(
         clinician_link_id: None,
         backdated_datetime: None,
         diagnosis_id: None,
-        program_id: None,
         name_insurance_join_id: None,
         insurance_discount_amount: None,
         insurance_discount_percentage: None,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8407

# 👩🏻‍💻 What does this PR do?
Need https://github.com/msupply-foundation/open-msupply-reports/pull/231. Allow filtering of program id on invoice lines & transferring the outbound shipment's program id to inbound shipments

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create manual requisition from a program
- [ ] Generate Outbound Shipments from requisition
- [ ] Change status to shipped
- [ ] Switch stores, to view the corresponding inbound shipment
- [ ] Go to `{YOUR_SERVER_URL}/graphql` and expect to see the id of your created inbound shipment, when you query API with the following:

```gql
query {
  invoiceLines(storeId: "your-store-id", filter: { programId: { equalTo: "your-program-id" }}) {
    ... on InvoiceLineConnector {
      nodes {
        invoiceId
      }
    }
  }
}
```


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

