### PR TITLE
8426 set donor id on newly created stock lines

### DIFF
--- a/server/repository/src/mock/test_stocktake.rs
+++ b/server/repository/src/mock/test_stocktake.rs
@@ -3,7 +3,7 @@ use util::inline_init;
 
 use crate::{StockLineRow, StocktakeLineRow, StocktakeRow, StocktakeStatus};
 
-use super::{mock_item_a, mock_stock_line_a, mock_stock_line_b, MockData};
+use super::{mock_donor_a, mock_item_a, mock_stock_line_a, mock_stock_line_b, MockData};
 
 pub fn mock_stocktake_without_lines() -> StocktakeRow {
     inline_init(|r: &mut StocktakeRow| {
@@ -261,6 +261,7 @@ pub fn mock_stocktake_line_new_stock_line() -> StocktakeLineRow {
         r.cost_price_per_pack = Some(11.0);
         r.sell_price_per_pack = Some(12.0);
         r.note = Some("note".to_string());
+        r.donor_link_id = Some(mock_donor_a().id);
     })
 }
 

--- a/server/service/src/stocktake/update/generate.rs
+++ b/server/service/src/stocktake/update/generate.rs
@@ -330,12 +330,12 @@ fn generate_new_stock_line(
         item_id,
         note: row.note,
         item_variant_id: stocktake_line.line.item_variant_id.clone(),
+        donor_id: stocktake_line.line.donor_link_id.clone(),
         // Default
         stock_on_hold: false,
         barcode: None,
         total_before_tax: None,
         tax_percentage: None,
-        donor_id: None,
         vvm_status_id: None,
         campaign_id: None,
     });

--- a/server/service/src/stocktake/update/mod.rs
+++ b/server/service/src/stocktake/update/mod.rs
@@ -598,6 +598,7 @@ mod test {
             stock_line.supplier_link_id.unwrap(),
             INVENTORY_ADJUSTMENT_NAME_CODE.to_string()
         );
+        assert_eq!(stock_line.donor_link_id, stocktake_line.donor_link_id);
 
         // assert stocktake_line has been updated
         let updated_stocktake_line = StocktakeLineRowRepository::new(&context.connection)


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8426

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Sets donor id on new stock lines when finalising stocktake

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Enable donor tracking store pref
- [ ] Create stocktake
- [ ] For a given item, and a new batch
- [ ] Add some stock and set a donor
- [ ] Finalise the stocktake
- [ ] View newly created stock line in View Stock - selected donor is set

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

