### PR TITLE
Add no_equal_to_or_null filter option & use in central server sync

### DIFF
--- a/server/graphql/core/src/generic_filters.rs
+++ b/server/graphql/core/src/generic_filters.rs
@@ -60,6 +60,7 @@ where
             not_equal_to,
             equal_any_or_null,
             not_equal_all: None,
+            not_equal_to_or_null: None,
             is_null: None,
         }
     }

--- a/server/graphql/core/src/lib.rs
+++ b/server/graphql/core/src/lib.rs
@@ -144,6 +144,7 @@ macro_rules! map_filter {
             equal_any: $from
                 .equal_any
                 .map(|inputs| inputs.into_iter().map($f).collect()),
+            not_equal_to_or_null: None,
             equal_any_or_null: None,
             not_equal_all: None,
             is_null: None,

--- a/server/graphql/general/src/queries/inventory_adjustment_reason.rs
+++ b/server/graphql/general/src/queries/inventory_adjustment_reason.rs
@@ -121,6 +121,7 @@ fn map_inventory_adjustment_reason_filter(
                             }),
                             equal_any_or_null: None,
                             not_equal_all: None,
+                            not_equal_to_or_null: None,
                             is_null: None,
                         }
                     }),

--- a/server/graphql/general/src/queries/return_reason.rs
+++ b/server/graphql/general/src/queries/return_reason.rs
@@ -74,6 +74,7 @@ fn map_return_reason_filter(filter: Option<ReturnReasonFilterInput>) -> ReasonOp
         r#type: Some(EqualFilter {
             equal_to: Some(ReasonOptionType::ReturnReason),
             not_equal_to: None,
+            not_equal_to_or_null: None,
             equal_any: None,
             equal_any_or_null: None,
             not_equal_all: None,

--- a/server/repository/src/db_diesel/activity_log.rs
+++ b/server/repository/src/db_diesel/activity_log.rs
@@ -147,6 +147,7 @@ impl ActivityLogType {
         EqualFilter {
             equal_to: Some(self.clone()),
             not_equal_to: None,
+            not_equal_to_or_null: None,
             equal_any: None,
             not_equal_all: None,
             equal_any_or_null: None,

--- a/server/repository/src/db_diesel/document_registry.rs
+++ b/server/repository/src/db_diesel/document_registry.rs
@@ -203,6 +203,7 @@ impl DocumentRegistryCategory {
         EqualFilter {
             equal_to: Some(self.clone()),
             not_equal_to: None,
+            not_equal_to_or_null: None,
             equal_any: None,
             not_equal_all: None,
             equal_any_or_null: None,

--- a/server/repository/src/db_diesel/filter_sort_pagination.rs
+++ b/server/repository/src/db_diesel/filter_sort_pagination.rs
@@ -74,6 +74,8 @@ where
     #[ts(optional)]
     pub equal_to: Option<T>,
     #[ts(optional)]
+    pub not_equal_to_or_null: Option<T>,
+    #[ts(optional)]
     pub not_equal_to: Option<T>,
     #[ts(optional)]
     pub equal_any: Option<Vec<T>>,
@@ -90,6 +92,7 @@ impl<T> Default for EqualFilter<T> {
         Self {
             equal_to: Default::default(),
             not_equal_to: Default::default(),
+            not_equal_to_or_null: Default::default(),
             equal_any: Default::default(),
             equal_any_or_null: Default::default(),
             not_equal_all: Default::default(),
@@ -107,6 +110,7 @@ impl<F> EqualFilter<F> {
             equal_to,
             equal_any,
             not_equal_to,
+            not_equal_to_or_null,
             equal_any_or_null,
             not_equal_all,
             is_null,
@@ -116,6 +120,7 @@ impl<F> EqualFilter<F> {
             equal_to: equal_to.map(T::from),
             equal_any: equal_any.map(|r| r.into_iter().map(T::from).collect()),
             not_equal_to: not_equal_to.map(T::from),
+            not_equal_to_or_null: not_equal_to_or_null.map(T::from),
             equal_any_or_null: equal_any_or_null.map(|r| r.into_iter().map(T::from).collect()),
             not_equal_all: not_equal_all.map(|r| r.into_iter().map(T::from).collect()),
             is_null,
@@ -152,6 +157,13 @@ impl EqualFilter<i32> {
     pub fn not_equal_to_i32(value: i32) -> Self {
         Self {
             not_equal_to: Some(value),
+            ..Default::default()
+        }
+    }
+
+    pub fn not_equal_to_or_null_i32(value: i32) -> Self {
+        Self {
+            not_equal_to_or_null: Some(value),
             ..Default::default()
         }
     }

--- a/server/repository/src/db_diesel/name_row.rs
+++ b/server/repository/src/db_diesel/name_row.rs
@@ -108,6 +108,7 @@ impl GenderType {
         EqualFilter {
             equal_to: Some(self.clone()),
             not_equal_to: None,
+            not_equal_to_or_null: None,
             equal_any: None,
             not_equal_all: None,
             equal_any_or_null: None,

--- a/server/repository/src/diesel_macros.rs
+++ b/server/repository/src/diesel_macros.rs
@@ -26,6 +26,10 @@ macro_rules! apply_equal_filter {
                 $query = $query.filter($dsl_field.ne(value));
             }
 
+            if let Some(value) = equal_filter.not_equal_to_or_null {
+                $query = $query.filter($dsl_field.ne(value).or($dsl_field.is_null()));
+            }
+
             if let Some(value) = equal_filter.equal_any {
                 $query = $query.filter($dsl_field.eq_any(value));
             }

--- a/server/service/src/programs/patient/search.rs
+++ b/server/service/src/programs/patient/search.rs
@@ -70,6 +70,7 @@ pub fn patient_search(
         filter = filter.gender(EqualFilter {
             equal_to: Some(gender),
             not_equal_to: None,
+            not_equal_to_or_null: None,
             equal_any: None,
             not_equal_all: None,
             equal_any_or_null: None,

--- a/server/service/src/sync/mod.rs
+++ b/server/service/src/sync/mod.rs
@@ -64,7 +64,7 @@ pub(crate) fn get_sync_push_changelogs_filter(
             .ok_or(SyncChangelogError::CentralSiteIdNotSet)?;
 
         return Ok(Some(ChangelogFilter::new().source_site_id(
-            EqualFilter::not_equal_to_i32(msupply_central_server_id),
+            EqualFilter::not_equal_to_or_null_i32(msupply_central_server_id),
         )));
     }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8432 

# 👩🏻‍💻 What does this PR do?

Adds a new filter option to allow not_equal_to_or_null
The problem with recently changes to allow central server to sync on behalf of remote sites was that it's own changes were being ignored as they were set to null.

Basically when we say not equal to something in SQL, null records are excluded.


`SELECT * FROM changelog WHERE source_site_id <> 1 ` 
<img width="921" alt="image" src="https://github.com/user-attachments/assets/be962a19-66da-4504-99eb-abefda5bdea1" />



`SELECT * FROM changelog WHERE source_site_id <> 1 or source_site_id is null`
<img width="921" alt="image" src="https://github.com/user-attachments/assets/d8066021-af60-41ce-af9b-1d588df6e899" />


## 💌 Any notes for the reviewer?

I think we don't need to worry about effects on non-central sites as it doesn't use the same filter now.
However, could it cause an issue with Central server?
What about the edge case of first sync after upgrading. Does it know that it's a central server fast enough?

Rather than adding this to equal filter should we create something special for changelog only?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ]  Try creating records on OMS Central, make sure they sync to Legacy mSupply (especially the records mentioned in the issue)
- [ ] Try to create some kind of sync loop or issue with syncing.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

