### PR TITLE
Remove disabled option from report selector

### DIFF
--- a/client/packages/invoices/src/Prescriptions/DetailView/AppBarButton.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/AppBarButton.tsx
@@ -56,7 +56,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   ];
 
   const [selected, setSelected] = useState<SplitButtonOption<string>>(
-    options[0]!
+    options[1]!
   );
 
   return (

--- a/client/packages/invoices/src/Prescriptions/DetailView/AppBarButton.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/AppBarButton.tsx
@@ -70,7 +70,6 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
         <ReportSelector
           context={ReportContext.Prescription}
           dataId={prescription?.id ?? ''}
-          disabled={isDisabled}
           CustomButton={({ onPrint }) => {
             const handleClick = (
               option: SplitButtonOption<string>,

--- a/client/packages/system/src/Patient/PatientView/AppBarButtons.tsx
+++ b/client/packages/system/src/Patient/PatientView/AppBarButtons.tsx
@@ -32,11 +32,7 @@ export const AppBarButtons: FC<{
           store={store}
         />
         {store?.preferences.omProgramModule && (
-          <ReportSelector
-            dataId={patientId}
-            context={ReportContext.Patient}
-            disabled={disabled}
-          />
+          <ReportSelector dataId={patientId} context={ReportContext.Patient} />
         )}
       </Grid>
     </AppBarButtonsPortal>

--- a/client/packages/system/src/Report/components/ReportSelector.tsx
+++ b/client/packages/system/src/Report/components/ReportSelector.tsx
@@ -102,7 +102,7 @@ export const ReportSelector: FC<PropsWithChildren<ReportSelectorProps>> = ({
         <CustomButton onPrint={modalOpen.toggleOn} />
       ) : (
         <LoadingButton
-          disabled={initialLoading}
+          disabled={initialLoading || !dataId}
           isLoading={isPrinting}
           startIcon={<PrinterIcon />}
           onClick={modalOpen.toggleOn}

--- a/client/packages/system/src/Report/components/ReportSelector.tsx
+++ b/client/packages/system/src/Report/components/ReportSelector.tsx
@@ -20,8 +20,6 @@ interface ReportSelectorProps {
   context?: ReportContext;
   subContext?: string;
   dataId: string;
-  /** Disable the whole control */
-  disabled?: boolean;
   queryParams?: ReportListParams;
   extraArguments?: Record<string, string | number | undefined>;
   sort?: PrintReportSortInput;
@@ -33,7 +31,6 @@ interface ReportSelectorProps {
 export const ReportSelector: FC<PropsWithChildren<ReportSelectorProps>> = ({
   context,
   subContext,
-  disabled = false,
   queryParams,
   extraArguments,
   dataId,
@@ -97,7 +94,7 @@ export const ReportSelector: FC<PropsWithChildren<ReportSelectorProps>> = ({
           label: translateDynamicKey(`report-code.${report.code}`, report.name),
         }))
       : [];
-  }, [data, disabled]);
+  }, [data]);
 
   return (
     <>
@@ -105,7 +102,7 @@ export const ReportSelector: FC<PropsWithChildren<ReportSelectorProps>> = ({
         <CustomButton onPrint={modalOpen.toggleOn} />
       ) : (
         <LoadingButton
-          disabled={initialLoading || disabled}
+          disabled={initialLoading}
           isLoading={isPrinting}
           startIcon={<PrinterIcon />}
           onClick={modalOpen.toggleOn}

--- a/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
+++ b/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
@@ -50,7 +50,6 @@ export const RepackModal: FC<RepackModalControlProps> = ({
   const { Modal } = useDialog({ isOpen, onClose });
 
   const [invoiceId, setInvoiceId] = useState<string | undefined>(undefined);
-  const [reportDisabled, setReportDisabled] = useState<boolean>(false);
   const [isNew, setIsNew] = useState<boolean>(false);
 
   const { data: logData } = useActivityLog(stockLine?.id ?? '');
@@ -71,7 +70,6 @@ export const RepackModal: FC<RepackModalControlProps> = ({
 
   const onRowClick = (rowData: RepackFragment) => {
     setInvoiceId(rowData.id);
-    setReportDisabled(false);
     setIsNew(false);
   };
 
@@ -181,7 +179,6 @@ export const RepackModal: FC<RepackModalControlProps> = ({
         <ReportSelector
           context={ReportContext.Repack}
           dataId={invoiceId || ''}
-          disabled={reportDisabled || !invoiceId}
         />
       }
     >


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8431

# 👩🏻‍💻 What does this PR do?

Removes the option to disable the report selector, as we generally always want to allow report or printing if the use can view.

## 💌 Any notes for the reviewer?

Is there some reason why we do want to disable this? Examples seemed to be ok to me...

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Check reports/printing isn't disabled in prescriptions when verified.
- [ ] Check we haven't broken any reports or other functionality

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [X] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [X] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

