### PR TITLE
8420 on tablet when creating a new patient some fields go outside the modal when virtual keyboard is up

### DIFF
--- a/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
@@ -35,11 +35,10 @@ export const BasicTextInput = React.forwardRef<
   ) => {
     const inputRef = useRef<HTMLDivElement | null>(null);
     useEffect(() => {
-      if (focusOnRender) {
-        inputRef?.current;
-        inputRef?.current?.focus();
+      if (focusOnRender && inputRef.current) {
+        inputRef.current.focus();
       }
-    }, []);
+    }, [focusOnRender]);
 
     return (
       <Box

--- a/client/packages/common/src/ui/components/panels/SlidePanel/SlidePanel.tsx
+++ b/client/packages/common/src/ui/components/panels/SlidePanel/SlidePanel.tsx
@@ -61,16 +61,18 @@ export const SlidePanel = ({
             zIndex: 1399,
           }}
         >
-          <Typography
-            sx={theme => ({
-              padding: 2,
-              color: theme.typography.body1.color,
-              fontSize: theme.typography.body1.fontSize,
-              fontWeight: 'bold',
-            })}
-          >
-            {title}
-          </Typography>
+          {title && (
+            <Typography
+              sx={theme => ({
+                padding: 2,
+                color: theme.typography.body1.color,
+                fontSize: theme.typography.body1.fontSize,
+                fontWeight: 'bold',
+              })}
+            >
+              {title}
+            </Typography>
+          )}
           <Box overflow="auto" flex={1}>
             {children}
           </Box>

--- a/client/packages/common/src/ui/components/panels/SlidePanel/SlidePanel.tsx
+++ b/client/packages/common/src/ui/components/panels/SlidePanel/SlidePanel.tsx
@@ -47,8 +47,6 @@ export const SlidePanel = ({
         right: 0,
         bottom: 0,
         width,
-        height: '100%',
-        overflow: 'hidden',
         zIndex: 1399,
       }}
     >
@@ -73,9 +71,11 @@ export const SlidePanel = ({
           >
             {title}
           </Typography>
-          <Box flex={1}>{children}</Box>
+          <Box overflow="auto" flex={1}>
+            {children}
+          </Box>
           {(okButton || cancelButton) && (
-            <Box display="flex" justifyContent="center" pb={5} gap={1}>
+            <Box display="flex" justifyContent="center" pb={5} gap={1} pt={1.5}>
               {cancelButton}
               {okButton}
             </Box>

--- a/client/packages/common/src/ui/components/steppers/HorizontalStepper/HorizontalStepper.tsx
+++ b/client/packages/common/src/ui/components/steppers/HorizontalStepper/HorizontalStepper.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React from 'react';
 import Box from '@mui/material/Box';
 import Stepper from '@mui/material/Stepper';
 import Step from '@mui/material/Step';
@@ -183,11 +183,11 @@ const getTestId = (step: StepDefinition) => {
 };
 
 /* alternativeLabel shows icons on top */
-export const HorizontalStepper: FC<StepperProps> = ({
+export const HorizontalStepper = ({
   colour = 'secondary',
   steps,
   nowrap = false,
-}) => {
+}: StepperProps) => {
   const paletteColour = usePaletteColour(colour);
   const StyledConnector = getConnector(paletteColour);
 
@@ -215,10 +215,17 @@ export const HorizontalStepper: FC<StepperProps> = ({
               completed={completed}
             >
               <StepLabel
-                StepIconComponent={stepIcon}
                 optional={optional}
                 icon={icon}
                 error={error}
+                slots={{
+                  stepIcon: stepIcon,
+                }}
+                sx={{
+                  '& .MuiStepLabel-alternativeLabel': {
+                    mt: 0.2,
+                  },
+                }}
               >
                 <Box
                   flexDirection="row"

--- a/client/packages/common/src/ui/components/steppers/WizardStepper/WizardStepper.tsx
+++ b/client/packages/common/src/ui/components/steppers/WizardStepper/WizardStepper.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React from 'react';
 import Typography from '@mui/material/Typography';
 import { HorizontalStepper, StepDefinition } from '../HorizontalStepper';
 
@@ -12,11 +12,7 @@ interface StepperProps {
   nowrap?: boolean;
 }
 
-export const WizardStepper: FC<StepperProps> = ({
-  activeStep,
-  nowrap,
-  steps,
-}) => {
+export const WizardStepper = ({ activeStep, nowrap, steps }: StepperProps) => {
   const wizardSteps = steps.map((step, index) => {
     const active = index === activeStep;
     const completed = index <= activeStep;

--- a/client/packages/common/src/ui/forms/Detail/InputWithLabelRow.tsx
+++ b/client/packages/common/src/ui/forms/Detail/InputWithLabelRow.tsx
@@ -1,13 +1,6 @@
 import React, { FC, ReactNode } from 'react';
-import {
-  FormLabel,
-  Box,
-  FormLabelProps,
-  StandardTextFieldProps,
-  SxProps,
-  Theme,
-} from '@mui/material';
-import { BasicTextInput } from '@common/components';
+import { FormLabel, Box, FormLabelProps, SxProps, Theme } from '@mui/material';
+import { BasicTextInput, BasicTextInputProps } from '@common/components';
 
 interface InputWithLabelRowProps {
   sx?: SxProps<Theme>;
@@ -16,7 +9,7 @@ interface InputWithLabelRowProps {
   label: string;
   labelWidthPercentage?: number;
   labelProps?: FormLabelProps;
-  inputProps?: StandardTextFieldProps;
+  inputProps?: BasicTextInputProps;
   inputSx?: SxProps<Theme>;
   /** flex-{$inputAlignment} alignment of the input field  */
   inputAlignment?: 'start' | 'end';

--- a/client/packages/programs/src/JsonForms/common/components/Text.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Text.tsx
@@ -38,6 +38,7 @@ const Options = z
      * Should component debounce it's input, optional default = true
      */
     useDebounce: z.boolean().optional(),
+    autoFocus: z.boolean().optional(),
   })
   .strict()
   .optional();
@@ -150,6 +151,7 @@ const UIComponent = (props: ControlProps) => {
   const width = schemaOptions?.width ?? '100%';
   const flexBasis = schemaOptions?.flexBasis ?? '100%';
   const useDebounce = schemaOptions?.useDebounce ?? true;
+  const autoFocus = schemaOptions?.autoFocus ?? false;
 
   return (
     <DetailInputWithLabelRow
@@ -172,6 +174,7 @@ const UIComponent = (props: ControlProps) => {
         required: props.required,
         multiline,
         rows,
+        focusOnRender: autoFocus,
       }}
       labelWidthPercentage={FORM_LABEL_WIDTH}
       inputAlignment={'start'}

--- a/client/packages/system/src/Clinician/CreateClinicianForm.tsx
+++ b/client/packages/system/src/Clinician/CreateClinicianForm.tsx
@@ -32,6 +32,7 @@ export const CreateClinicianForm = ({
             onChange={event => {
               updateDraft({ code: event.target.value.toUpperCase() });
             }}
+            autoFocus
             required
           />
         }

--- a/client/packages/system/src/Patient/CreatePatientModal/DefaultCreatePatientUISchema.json
+++ b/client/packages/system/src/Patient/CreatePatientModal/DefaultCreatePatientUISchema.json
@@ -8,7 +8,10 @@
         {
           "type": "Control",
           "scope": "#/properties/firstName",
-          "label": "label.first-name"
+          "label": "label.first-name",
+          "options": {
+            "autoFocus": true
+          }
         },
         {
           "type": "Control",

--- a/client/packages/system/src/Patient/CreatePatientModal/PatientFormTab.tsx
+++ b/client/packages/system/src/Patient/CreatePatientModal/PatientFormTab.tsx
@@ -1,23 +1,23 @@
-import React, { FC } from 'react';
+import React from 'react';
+import {
+  Alert,
+  BasicSpinner,
+  useTranslation,
+  ObjUtils,
+} from '@openmsupply-client/common';
 import {
   Gender,
   JsonData,
   JsonForm,
   JsonFormsReactProps,
   useFormSchema,
+  IdGenerator,
+  idGeneratorTester,
   usePatientStore,
 } from '@openmsupply-client/programs';
 import { PatientPanel } from './PatientPanel';
-import { ObjUtils } from '@common/utils';
-
 import defaultPatientSchema from './DefaultCreatePatientSchema.json';
 import defaultPatientUISchema from './DefaultCreatePatientUISchema.json';
-import {
-  Alert,
-  BasicSpinner,
-  useTranslation,
-} from '@openmsupply-client/common';
-import { IdGenerator, idGeneratorTester } from '@openmsupply-client/programs';
 
 type Patient = {
   code?: string;
@@ -30,11 +30,11 @@ type Patient = {
   phone?: string;
 };
 
-export const PatientFormTab: FC<PatientPanel & JsonFormsReactProps> = ({
+export const PatientFormTab = ({
   patient,
   value,
   onChange,
-}) => {
+}: PatientPanel & JsonFormsReactProps) => {
   const t = useTranslation();
   const { updateCreateNewPatient } = usePatientStore();
   const {
@@ -71,7 +71,7 @@ export const PatientFormTab: FC<PatientPanel & JsonFormsReactProps> = ({
 
   return (
     <PatientPanel value={value} patient={patient}>
-      <Alert severity="info"> {t('messages.patients-search')}</Alert>
+      <Alert severity="info">{t('messages.patients-search')}</Alert>
       <JsonForm
         data={(patient as JsonData) || {}}
         jsonSchema={patientCreationUI?.jsonSchema || defaultPatientSchema}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8420

# 👩🏻‍💻 What does this PR do?
Make overflow on child only and tried to make some more space in the create patient modal...

## 💌 Any notes for the reviewer?
The patient creation can do with some UI / UX rework... only can see the first name 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Build APK or use android debug mode
- [ ] Slider component (when creating new patient or new clinician) should shrink to whatever screen size is with keyboard
- [ ] Can see buttons always
- [ ] Scroll to see rest of components

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

