### PR TITLE
8453 excel exports are invalid files on android

### DIFF
--- a/client/packages/android/app/src/main/java/org/openmsupply/client/FileManager.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/FileManager.java
@@ -20,8 +20,11 @@ import java.util.zip.ZipOutputStream;
 public class FileManager {
     private static final int SAVE_FILE_REQUEST = 12321;
     private static final int SAVE_DATABASE_REQUEST = 12322;
+    private static final int SAVE_BINARY_FILE_REQUEST = 12323;
+
     private Activity activity;
     private String content;
+    private byte[] binaryData;
     private String successMessage;
     private File dbFile;
 
@@ -41,6 +44,19 @@ public class FileManager {
 
     }
 
+    public void SaveBinaryFile(String filename, byte[] data, String mimeType, String successMessage) {
+        Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType(mimeType);
+        intent.putExtra(Intent.EXTRA_TITLE, filename);
+        
+        // Store binary data and success message
+        this.binaryData = data;
+        this.successMessage = successMessage;
+
+        activity.startActivityForResult(intent, SAVE_BINARY_FILE_REQUEST);
+    }
+
     public void Save(String filename, String content, String mimeType, String successMessage) {
         Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
@@ -56,6 +72,7 @@ public class FileManager {
     }
 
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        // Saving a text based file
         if (requestCode == SAVE_FILE_REQUEST && resultCode == Activity.RESULT_OK && data != null) {
             Uri uri = data.getData();
             Context context = activity.getApplicationContext();
@@ -73,6 +90,25 @@ public class FileManager {
             }
         }
 
+        // Saving a binary file e.g. XLSX
+        if (requestCode == SAVE_BINARY_FILE_REQUEST && resultCode == Activity.RESULT_OK && data != null) {
+            Uri uri = data.getData();
+            Context context = activity.getApplicationContext();
+
+            try {
+                OutputStream outputStream = context.getContentResolver().openOutputStream(uri);
+                BufferedOutputStream bos = new BufferedOutputStream(outputStream);
+                bos.write(binaryData);
+                bos.flush();
+                bos.close();
+
+                Toast.makeText(context, successMessage, Toast.LENGTH_LONG).show();
+            } catch (Exception e) {
+                Toast.makeText(context, "Error: " + e.getMessage(), Toast.LENGTH_LONG).show();
+            }
+        }
+
+        // Saving the database file
         if (requestCode == SAVE_DATABASE_REQUEST && resultCode == Activity.RESULT_OK && data != null
                 && dbFile != null) {
             Uri uri = data.getData();

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/FileManager.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/FileManager.java
@@ -72,11 +72,14 @@ public class FileManager {
     }
 
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        // Saving a text based file
-        if (requestCode == SAVE_FILE_REQUEST && resultCode == Activity.RESULT_OK && data != null) {
-            Uri uri = data.getData();
-            Context context = activity.getApplicationContext();
+        if (resultCode != Activity.RESULT_OK || data == null) return;
 
+        Uri uri = data.getData();
+        Context context = activity.getApplicationContext();
+
+
+        // Saving a text based file
+        if (requestCode == SAVE_FILE_REQUEST) {
             try {
                 OutputStream outputStream = context.getContentResolver().openOutputStream(uri);
                 BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(outputStream));
@@ -91,10 +94,7 @@ public class FileManager {
         }
 
         // Saving a binary file e.g. XLSX
-        if (requestCode == SAVE_BINARY_FILE_REQUEST && resultCode == Activity.RESULT_OK && data != null) {
-            Uri uri = data.getData();
-            Context context = activity.getApplicationContext();
-
+        if (requestCode == SAVE_BINARY_FILE_REQUEST) {
             try {
                 OutputStream outputStream = context.getContentResolver().openOutputStream(uri);
                 BufferedOutputStream bos = new BufferedOutputStream(outputStream);
@@ -109,11 +109,7 @@ public class FileManager {
         }
 
         // Saving the database file
-        if (requestCode == SAVE_DATABASE_REQUEST && resultCode == Activity.RESULT_OK && data != null
-                && dbFile != null) {
-            Uri uri = data.getData();
-            Context context = activity.getApplicationContext();
-
+        if (requestCode == SAVE_DATABASE_REQUEST && dbFile != null) {
             // The db file name can be either `omsupply-database` or
             // `omsupply-database.sqlite`
             // The rust code automatically appends .sqlite to the file name if it doesn't

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/MainActivity.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/MainActivity.java
@@ -69,7 +69,9 @@ public class MainActivity extends BridgeActivity {
     public void SaveFile(String filename, String content, String mimeType, String successMessage) {
         fileManager.Save(filename, content, mimeType, successMessage);
     }
-
+    public void SaveBinaryFile(String filename, byte[] data, String mimeType, String successMessage) {
+        fileManager.SaveBinaryFile(filename, data, mimeType, successMessage);
+    }
     public void SaveDatabase(File file) {
         fileManager.SaveDatabase(file);
     }

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
@@ -560,7 +560,7 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
                     // Convert from base64 string to byte array
                     byte[] binaryData = android.util.Base64.decode(content, android.util.Base64.DEFAULT);
 
-                    mainActivity.SaveBinaryFile(filename, binaryData, mimeType, "Saved binary");
+                    mainActivity.SaveBinaryFile(filename, binaryData, mimeType, successMessage);
                     response.put("success", true);
                 } catch (Exception e) {
                     response.put("error", "Error processing binary data: " + e.getMessage());

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
@@ -548,9 +548,9 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
         String mimeType = data.getString("mimeType", "text/plain");
         String successMessage = data.getString("successMessage", "Saved successfully");
 
-               if (content == null) {
-           response.put("error", "No content");
-           response.put("success", false);
+        if (content == null) {
+            response.put("error", "No content");
+            response.put("success", false);
         } else {
             MainActivity mainActivity = (MainActivity) getActivity();
 
@@ -558,8 +558,8 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
             if (Boolean.TRUE.equals(isBinaryData)) {
                 try {
                     // Convert from base64 string to byte array
-                    byte[] binaryData;
-                    binaryData = android.util.Base64.decode(content, android.util.Base64.DEFAULT);
+                    byte[] binaryData = android.util.Base64.decode(content, android.util.Base64.DEFAULT);
+
                     mainActivity.SaveBinaryFile(filename, binaryData, mimeType, "Saved binary");
                     response.put("success", true);
                 } catch (Exception e) {

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
@@ -544,16 +544,32 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
 
         String filename = data.getString("filename", LOG_FILE_NAME);
         String content = data.getString("content");
+        Boolean isBinaryData = data.getBoolean("isBinaryData", false);
         String mimeType = data.getString("mimeType", "text/plain");
         String successMessage = data.getString("successMessage", "Saved successfully");
 
-        if (content == null) {
-            response.put("error", "No content");
-            response.put("success", false);
+               if (content == null) {
+           response.put("error", "No content");
+           response.put("success", false);
         } else {
             MainActivity mainActivity = (MainActivity) getActivity();
-            mainActivity.SaveFile(filename, content, mimeType, successMessage);
-            response.put("success", true);
+
+            // Check if provided data should be handled as binary format
+            if (Boolean.TRUE.equals(isBinaryData)) {
+                try {
+                    // Convert from base64 string to byte array
+                    byte[] binaryData;
+                    binaryData = android.util.Base64.decode(content, android.util.Base64.DEFAULT);
+                    mainActivity.SaveBinaryFile(filename, binaryData, mimeType, "Saved binary");
+                    response.put("success", true);
+                } catch (Exception e) {
+                    response.put("error", "Error processing binary data: " + e.getMessage());
+                    response.put("success", false);
+                }
+            } else {
+               mainActivity.SaveFile(filename, content, mimeType, successMessage);
+               response.put("success", true);
+            }
         }
 
         call.resolve(response);

--- a/client/packages/common/src/hooks/useNativeClient/types.ts
+++ b/client/packages/common/src/hooks/useNativeClient/types.ts
@@ -22,6 +22,8 @@ export type ConnectionResult = {
 };
 export type FileInfo = {
   content: string;
+  // Whether to base64 decode content before saving
+  isBinaryData?: boolean;
   mimeType?: string;
   filename?: string;
   successMessage?: string;

--- a/client/packages/common/src/utils/files/FileUtils.ts
+++ b/client/packages/common/src/utils/files/FileUtils.ts
@@ -20,13 +20,16 @@ const useExportFile = () => {
     type: string | undefined,
     filename: string
   ) => {
+    const isBinaryData = typeof data !== 'string';
+
     // On android, use the native client to save the file
     if (EnvUtils.platform === Platform.Android) {
-      // Content must be a string for the native client
-      const content = typeof data === 'string' ? data : await asBase64(data);
+      // Content must sent via string for capacitor
+      const content = isBinaryData ? await asBase64(data) : data;
 
       await nativeClient.saveFile({
         content,
+        isBinaryData,
         filename,
         mimeType: type,
         successMessage,
@@ -38,12 +41,11 @@ const useExportFile = () => {
       // Only run on browsers that support HTML5 download attribute
       if (link.download !== undefined) {
         // Content must be a Blob for the browser
-        const blob =
-          typeof data === 'string'
-            ? new Blob([data], {
-                type: `${type ?? 'text/plain'};charset=utf-8;`,
-              })
-            : data;
+        const blob = !isBinaryData
+          ? new Blob([data], {
+              type: `${type ?? 'text/plain'};charset=utf-8;`,
+            })
+          : data;
 
         const url = URL.createObjectURL(blob);
         link.download = filename;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8453

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Converts base64 encoded data back to binary before saving on android... so the excel files are valid & can be opened 🫠 

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] On APK
- [ ] Export a report to excel
- [ ] Transfer that excel file to your laptop
- [ ] Open file -> it opens valid excel file

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

