### PR TITLE
8345 make the confirm finalise button in requisitions smaller   users are complaining clicking it and making errors

### DIFF
--- a/client/packages/common/src/ui/components/buttons/standard/SplitButton.tsx
+++ b/client/packages/common/src/ui/components/buttons/standard/SplitButton.tsx
@@ -16,6 +16,7 @@ export interface SplitButtonOption<T> {
   label: string;
   value?: T;
   isDisabled?: boolean;
+  Icon?: ButtonWithIconProps['Icon'];
 }
 
 export interface SplitButtonProps<T> {
@@ -82,6 +83,7 @@ export const SplitButton = <T,>({
     },
     label: buttonLabel,
   };
+  const icon = selectedOption.Icon || Icon;
 
   return (
     <>
@@ -98,11 +100,11 @@ export const SplitButton = <T,>({
           {isLoadingType ? (
             <LoadingButton
               isLoading={isLoading}
-              startIcon={Icon}
+              startIcon={icon}
               {...sharedButtonProps}
             />
           ) : (
-            <ButtonWithIcon Icon={Icon} {...sharedButtonProps} />
+            <ButtonWithIcon Icon={icon} {...sharedButtonProps} />
           )}
 
           <ShrinkableBaseButton

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/Footer.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/Footer.tsx
@@ -15,9 +15,13 @@ import { StatusChangeButton } from './StatusChangeButton';
 import { CreateShipmentButton } from './CreateShipmentButton';
 
 export const createStatusLog = (requisition: ResponseFragment) => {
-  const statusLog: Record<RequisitionNodeStatus, null | undefined | string> = {
+  const statusLog: Record<
+    RequisitionNodeStatus | 'create-shipment',
+    null | undefined | string
+  > = {
     [RequisitionNodeStatus.New]: requisition.createdDatetime,
     [RequisitionNodeStatus.Finalised]: requisition.finalisedDatetime,
+    'create-shipment': null,
     // Keeping typescript happy, not used for response requisitions.
     [RequisitionNodeStatus.Draft]: null,
     [RequisitionNodeStatus.Sent]: null,

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/Footer.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/Footer.tsx
@@ -12,7 +12,6 @@ import {
 import { responseStatuses, getRequisitionTranslator } from '../../../utils';
 import { ResponseFragment, useResponse } from '../../api';
 import { StatusChangeButton } from './StatusChangeButton';
-import { CreateShipmentButton } from './CreateShipmentButton';
 
 export const createStatusLog = (requisition: ResponseFragment) => {
   const statusLog: Record<
@@ -68,7 +67,6 @@ export const Footer: FC = () => {
               />
 
               <Box flex={1} display="flex" justifyContent="flex-end" gap={2}>
-                <CreateShipmentButton />
                 <StatusChangeButton requisition={data} />
               </Box>
             </Box>

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/Footer.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/Footer.tsx
@@ -14,13 +14,9 @@ import { ResponseFragment, useResponse } from '../../api';
 import { StatusChangeButton } from './StatusChangeButton';
 
 export const createStatusLog = (requisition: ResponseFragment) => {
-  const statusLog: Record<
-    RequisitionNodeStatus | 'create-shipment',
-    null | undefined | string
-  > = {
+  const statusLog: Record<RequisitionNodeStatus, null | undefined | string> = {
     [RequisitionNodeStatus.New]: requisition.createdDatetime,
     [RequisitionNodeStatus.Finalised]: requisition.finalisedDatetime,
-    'create-shipment': null,
     // Keeping typescript happy, not used for response requisitions.
     [RequisitionNodeStatus.Draft]: null,
     [RequisitionNodeStatus.Sent]: null,
@@ -61,9 +57,7 @@ export const Footer = () => {
               height={64}
             >
               <StatusCrumbs
-                statuses={responseStatuses.filter(
-                  status => status !== 'create-shipment'
-                )}
+                statuses={responseStatuses}
                 statusLog={createStatusLog(data)}
                 statusFormatter={getRequisitionTranslator(t)}
               />

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/Footer.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/Footer.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React from 'react';
 import {
   Box,
   StatusCrumbs,
@@ -29,7 +29,7 @@ export const createStatusLog = (requisition: ResponseFragment) => {
   return statusLog;
 };
 
-export const Footer: FC = () => {
+export const Footer = () => {
   const { data } = useResponse.document.get();
   const t = useTranslation();
   const { selectedRows, confirmAndDelete } = useResponse.line.delete();
@@ -61,7 +61,9 @@ export const Footer: FC = () => {
               height={64}
             >
               <StatusCrumbs
-                statuses={responseStatuses}
+                statuses={responseStatuses.filter(
+                  status => status !== 'create-shipment'
+                )}
                 statusLog={createStatusLog(data)}
                 statusFormatter={getRequisitionTranslator(t)}
               />

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/StatusChangeButton.tsx
@@ -10,6 +10,7 @@ import {
   mapKeys,
   mapValues,
   noOtherVariants,
+  PlusCircleIcon,
 } from '@openmsupply-client/common';
 import { getNextResponseStatus, getStatusTranslation } from '../../../utils';
 import { ResponseFragment, useResponse } from '../../api';
@@ -35,6 +36,7 @@ const getStatusOptions = (
       value: 'create-shipment',
       label: getCreateShipmentLabel,
       isDisabled: true,
+      Icon: <PlusCircleIcon />,
     },
     {
       value: RequisitionNodeStatus.Finalised,

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/StatusChangeButton.tsx
@@ -63,21 +63,15 @@ const getNextStatusOption = (
 
   const nextStatus = getNextResponseStatus(status);
 
-  if (
-    status === RequisitionNodeStatus.New &&
-    (placeholderOrEmpty || !linesFullySupplied)
-  ) {
-    const createShipmentOption = options.find(
-      o => o.value === 'create-shipment'
-    );
-    return createShipmentOption || null;
-  }
-
-  if (status === RequisitionNodeStatus.New && linesFullySupplied) {
-    const finalisedOption = options.find(
-      o => o.value === RequisitionNodeStatus.Finalised
-    );
-    return finalisedOption || null;
+  if (status === RequisitionNodeStatus.New) {
+    if (placeholderOrEmpty || !linesFullySupplied) {
+      return options.find(o => o.value === 'create-shipment') || null;
+    }
+    if (linesFullySupplied) {
+      return (
+        options.find(o => o.value === RequisitionNodeStatus.Finalised) || null
+      );
+    }
   }
 
   const nextStatusOption = options.find(o => o.value === nextStatus);
@@ -208,7 +202,12 @@ const useStatusChangeButton = (requisition: ResponseFragment) => {
   // Otherwise, it would be set to the current status, which is now a disabled option.
   useEffect(() => {
     setSelectedOption(() =>
-      getNextStatusOption(status, options, linesFullySupplied)
+      getNextStatusOption(
+        status,
+        options,
+        linesFullySupplied,
+        placeholderOrEmpty
+      )
     );
   }, [status, options, linesFullySupplied]);
 

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/StatusChangeButton.tsx
@@ -59,7 +59,6 @@ const getNextStatusOption = (
   linesFullySupplied: boolean
 ): SplitButtonOption<RequisitionNodeStatus | 'create-shipment'> | null => {
   if (!status) return options[0] ?? null;
-  console.log('linesFullySupplied', linesFullySupplied);
 
   const nextStatus = getNextResponseStatus(status);
 

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/useCreateShipment.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/useCreateShipment.ts
@@ -1,7 +1,4 @@
-import React from 'react';
 import {
-  ButtonWithIcon,
-  PlusCircleIcon,
   useTranslation,
   useConfirmationModal,
   useAlertModal,
@@ -13,14 +10,13 @@ import {
 import { useResponse } from '../../api';
 import { AppRoute } from '@openmsupply-client/config/src';
 
-export const CreateShipmentButtonComponent = () => {
+export const useCreateShipment = () => {
   const { lines, linesRemainingToSupply } = useResponse.document.fields([
     'lines',
     'linesRemainingToSupply',
   ]);
   const t = useTranslation();
   const { mutateAsync } = useResponse.utils.createOutbound();
-  const isDisabled = useResponse.utils.isDisabled();
   const navigate = useNavigate();
   const createOutbound = () => {
     mutateAsync().then(invoiceId => {
@@ -46,7 +42,7 @@ export const CreateShipmentButtonComponent = () => {
         ? 'message.all-lines-have-no-supply-quantity'
         : 'message.all-lines-have-been-fulfilled'
     ),
-    onOk: () => { },
+    onOk: () => {},
   });
 
   const onCreateShipment = () => {
@@ -63,15 +59,5 @@ export const CreateShipmentButtonComponent = () => {
     t('error.no-create-outbound-shipment-permission')
   );
 
-  return (
-    <ButtonWithIcon
-      Icon={<PlusCircleIcon />}
-      label={t('button.create-shipment')}
-      onClick={handleClick}
-      disabled={isDisabled}
-      color="secondary"
-    />
-  );
+  return { onCreateShipment: handleClick };
 };
-
-export const CreateShipmentButton = React.memo(CreateShipmentButtonComponent);

--- a/client/packages/requisitions/src/utils.ts
+++ b/client/packages/requisitions/src/utils.ts
@@ -20,7 +20,7 @@ export const requestStatuses = [
   RequisitionNodeStatus.Finalised,
 ];
 
-export const responseStatuses: Array<RequisitionNodeStatus> = [
+export const responseStatuses = [
   RequisitionNodeStatus.New,
   RequisitionNodeStatus.Finalised,
 ];

--- a/client/packages/requisitions/src/utils.ts
+++ b/client/packages/requisitions/src/utils.ts
@@ -20,27 +20,35 @@ export const requestStatuses = [
   RequisitionNodeStatus.Finalised,
 ];
 
-// TODO: When response requisitions can be manually created, the status of DRAFT
-// becomes possible and such will need to be handled.
-export const responseStatuses = [
+// create-shipment is a special status for response requisitions
+export const responseStatuses: Array<
+  RequisitionNodeStatus | 'create-shipment'
+> = [
   RequisitionNodeStatus.New,
+  'create-shipment',
   RequisitionNodeStatus.Finalised,
 ];
 
-const requisitionStatusToLocaleKey: Record<RequisitionNodeStatus, LocaleKey> = {
+const requisitionStatusToLocaleKey: Record<
+  RequisitionNodeStatus | 'create-shipment',
+  LocaleKey
+> = {
   [RequisitionNodeStatus.Draft]: 'label.draft',
   [RequisitionNodeStatus.New]: 'label.new',
+  'create-shipment': 'button.create-shipment',
   [RequisitionNodeStatus.Sent]: 'label.sent',
   [RequisitionNodeStatus.Finalised]: 'label.finalised',
 };
 
-export const getStatusTranslation = (status: RequisitionNodeStatus) => {
+export const getStatusTranslation = (
+  status: RequisitionNodeStatus | 'create-shipment'
+) => {
   return requisitionStatusToLocaleKey[status];
 };
 
 export const getRequisitionTranslator =
   (t: ReturnType<typeof useTranslation>) =>
-  (currentStatus: RequisitionNodeStatus): string =>
+  (currentStatus: RequisitionNodeStatus | 'create-shipment'): string =>
     t(getStatusTranslation(currentStatus));
 
 export const getNextRequestStatus = (
@@ -54,8 +62,8 @@ export const getNextRequestStatus = (
 };
 
 export const getNextResponseStatus = (
-  currentStatus: RequisitionNodeStatus
-): RequisitionNodeStatus | null => {
+  currentStatus: RequisitionNodeStatus | 'create-shipment'
+): RequisitionNodeStatus | 'create-shipment' | null => {
   const currentStatusIdx = responseStatuses.findIndex(
     status => currentStatus === status
   );

--- a/client/packages/requisitions/src/utils.ts
+++ b/client/packages/requisitions/src/utils.ts
@@ -21,34 +21,25 @@ export const requestStatuses = [
 ];
 
 // create-shipment is a special status for response requisitions
-export const responseStatuses: Array<
-  RequisitionNodeStatus | 'create-shipment'
-> = [
+export const responseStatuses: Array<RequisitionNodeStatus> = [
   RequisitionNodeStatus.New,
-  'create-shipment',
   RequisitionNodeStatus.Finalised,
 ];
 
-const requisitionStatusToLocaleKey: Record<
-  RequisitionNodeStatus | 'create-shipment',
-  LocaleKey
-> = {
+const requisitionStatusToLocaleKey: Record<RequisitionNodeStatus, LocaleKey> = {
   [RequisitionNodeStatus.Draft]: 'label.draft',
   [RequisitionNodeStatus.New]: 'label.new',
-  'create-shipment': 'button.create-shipment',
   [RequisitionNodeStatus.Sent]: 'label.sent',
   [RequisitionNodeStatus.Finalised]: 'label.finalised',
 };
 
-export const getStatusTranslation = (
-  status: RequisitionNodeStatus | 'create-shipment'
-) => {
+export const getStatusTranslation = (status: RequisitionNodeStatus) => {
   return requisitionStatusToLocaleKey[status];
 };
 
 export const getRequisitionTranslator =
   (t: ReturnType<typeof useTranslation>) =>
-  (currentStatus: RequisitionNodeStatus | 'create-shipment'): string =>
+  (currentStatus: RequisitionNodeStatus): string =>
     t(getStatusTranslation(currentStatus));
 
 export const getNextRequestStatus = (

--- a/client/packages/requisitions/src/utils.ts
+++ b/client/packages/requisitions/src/utils.ts
@@ -20,7 +20,6 @@ export const requestStatuses = [
   RequisitionNodeStatus.Finalised,
 ];
 
-// create-shipment is a special status for response requisitions
 export const responseStatuses: Array<RequisitionNodeStatus> = [
   RequisitionNodeStatus.New,
   RequisitionNodeStatus.Finalised,
@@ -53,8 +52,8 @@ export const getNextRequestStatus = (
 };
 
 export const getNextResponseStatus = (
-  currentStatus: RequisitionNodeStatus | 'create-shipment'
-): RequisitionNodeStatus | 'create-shipment' | null => {
+  currentStatus: RequisitionNodeStatus
+): RequisitionNodeStatus | null => {
   const currentStatusIdx = responseStatuses.findIndex(
     status => currentStatus === status
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8345

# 👩🏻‍💻 What does this PR do?
- Move the `Create Shipment` button to be within split buttons
- Users will have to manually click arrow and click finalise button if they want to finalise
- Allow different icons for split buttons

https://github.com/user-attachments/assets/4b951d96-0daa-40f6-a1b7-58775651440e

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Make sure the `Create Shipment` and `Finalise` buttons in Requisitions still works as it's supposed to
- [ ] To finalise the user will have to click the arrow button and change the button to 'Finalise'

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1. Update the behaviour of the buttons in Requisition documentation
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

