### PR TITLE
7841 cannot verify inbound shipment with lines with 0 quantity

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1474,6 +1474,7 @@
   "messages.cant-delete-generic": "You cannot delete one or more of the selected items",
   "messages.cant-delete-requisitions": "Can only delete requisitions with a status of 'Draft'",
   "messages.cant-delete-transferred": "You cannot delete items that have been transferred from another store. Please reduce those lines to zero instead.",
+  "messages.cant-return-lines-with-no-received-stock": "Cannot return lines which have no received stock",
   "messages.cant-return-shipment": "Cannot process return of lines until the status is 'Shipped'",
   "messages.cant-return-shipment-replenishment": "Cannot return lines until the status is 'Verified'",
   "messages.cant-send-order": "Cannot send Internal Order because there are no lines or because all lines have a requested quantity of 0",

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -21,7 +21,7 @@ import { InboundItem } from './../../../types';
 import { InboundLineFragment } from '../../api';
 import { isInboundPlaceholderRow } from '../../../utils';
 import { useInboundShipmentLineErrorContext } from '../../context/inboundShipmentLineError';
-import { getDosesQuantityColumn } from 'packages/invoices/src/DoseQtyColumn';
+import { getDosesQuantityColumn } from '../../../DoseQtyColumn';
 
 const getUnitQuantity = (row: InboundLineFragment) =>
   row.packSize * row.numberOfPacks;
@@ -327,7 +327,7 @@ export const useExpansionColumns = (
 ): Column<InboundLineFragment>[] => {
   const { data: preferences } = usePreference(
     PreferenceKey.AllowTrackingOfStockByDonor,
-    PreferenceKey.UseCampaigns,
+    PreferenceKey.UseCampaigns
   );
 
   const columns: ColumnDescription<InboundLineFragment>[] = [

--- a/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -55,7 +55,7 @@ const DetailViewInner = () => {
     mode: returnModalMode,
     setMode: setReturnMode,
   } = useEditModal<string[]>();
-  const { info, error } = useNotification();
+  const { info } = useNotification();
   const { clearSelected } = useTableStore();
   const { data: preference } = usePreference(
     PreferenceKey.ManageVaccinesInDoses
@@ -85,8 +85,9 @@ const DetailViewInner = () => {
       return;
     }
     if (selectedLines.some(line => !line.stockLine)) {
-      const errMsg = 'No stock line associated with the selected line(s).';
-      const selectLinesSnack = error(`${t('error.something-wrong')} ${errMsg}`);
+      const selectLinesSnack = info(
+        t('messages.cant-return-lines-with-no-received-stock')
+      );
       selectLinesSnack();
       return;
     }

--- a/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.test.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.test.ts
@@ -1,21 +1,45 @@
-import { InvoiceNodeStatus } from '@common/types';
 import { validateEmptyInvoice } from './StatusChangeButton';
+import { InboundLineFragment } from '../../api';
+import { InvoiceLineNodeType } from '@common/types';
 
 describe('validateEmptyInvoice', () => {
-  it('should allow status change for non-New status', () => {
+  it('should not allow status change when no lines', () => {
     const lines = { totalCount: 0, nodes: [] };
-    expect(validateEmptyInvoice(InvoiceNodeStatus.Shipped, lines)).toBe(true);
+    expect(validateEmptyInvoice(lines)).toBe(false);
   });
-  it('should allow status change for New status when has lines', () => {
-    const lines = { totalCount: 1, nodes: [{ numberOfPacks: 4 }] };
-    expect(validateEmptyInvoice(InvoiceNodeStatus.Shipped, lines)).toBe(true);
+
+  it('should not allow status change when lines have no packs', () => {
+    const lines = {
+      totalCount: 1,
+      nodes: [makeLine({ numberOfPacks: 0 })],
+    };
+    expect(validateEmptyInvoice(lines)).toBe(false);
   });
-  it('should not allow status change for New status with no lines', () => {
-    const lines = { totalCount: 0, nodes: [] };
-    expect(validateEmptyInvoice(InvoiceNodeStatus.New, lines)).toBe(false);
+  it('should allow status change when has lines with received packs', () => {
+    const lines = {
+      totalCount: 1,
+      nodes: [makeLine({ numberOfPacks: 4 })],
+    };
+    expect(validateEmptyInvoice(lines)).toBe(true);
   });
-  it('should not allow status change for New status with lines but no packs', () => {
-    const lines = { totalCount: 1, nodes: [{ numberOfPacks: 0 }] };
-    expect(validateEmptyInvoice(InvoiceNodeStatus.New, lines)).toBe(false);
+  it('should allow status change when has lines with shipped packs', () => {
+    const lines = {
+      totalCount: 1,
+      nodes: [makeLine({ numberOfPacks: 0, shippedNumberOfPacks: 3 })],
+    };
+    expect(validateEmptyInvoice(lines)).toBe(true);
   });
 });
+
+const makeLine = ({
+  numberOfPacks,
+  shippedNumberOfPacks,
+}: {
+  numberOfPacks: number;
+  shippedNumberOfPacks?: number;
+}) =>
+  ({
+    type: InvoiceLineNodeType.StockIn,
+    numberOfPacks,
+    shippedNumberOfPacks,
+  }) as InboundLineFragment;

--- a/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.test.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.test.ts
@@ -1,0 +1,21 @@
+import { InvoiceNodeStatus } from '@common/types';
+import { validateEmptyInvoice } from './StatusChangeButton';
+
+describe('validateEmptyInvoice', () => {
+  it('should allow status change for non-New status', () => {
+    const lines = { totalCount: 0, nodes: [] };
+    expect(validateEmptyInvoice(InvoiceNodeStatus.Shipped, lines)).toBe(true);
+  });
+  it('should allow status change for New status when has lines', () => {
+    const lines = { totalCount: 1, nodes: [{ numberOfPacks: 4 }] };
+    expect(validateEmptyInvoice(InvoiceNodeStatus.Shipped, lines)).toBe(true);
+  });
+  it('should not allow status change for New status with no lines', () => {
+    const lines = { totalCount: 0, nodes: [] };
+    expect(validateEmptyInvoice(InvoiceNodeStatus.New, lines)).toBe(false);
+  });
+  it('should not allow status change for New status with lines but no packs', () => {
+    const lines = { totalCount: 1, nodes: [{ numberOfPacks: 0 }] };
+    expect(validateEmptyInvoice(InvoiceNodeStatus.New, lines)).toBe(false);
+  });
+});

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
@@ -25,6 +25,7 @@ import {
 import { TabLayout } from './TabLayout';
 import { CurrencyRowFragment } from '@openmsupply-client/system';
 import { QuantityTable } from './TabTables';
+import { isInboundPlaceholderRow } from '../../../../utils';
 
 type InboundLineItem = InboundLineFragment['item'];
 interface InboundLineEditProps {
@@ -68,7 +69,7 @@ export const InboundLineEdit = ({
   } = useDraftInboundLines(currentItem);
   const okNextDisabled =
     (mode === ModalMode.Update && nextDisabled) || !currentItem;
-  const zeroNumberOfPacks = draftLines.some(line => line.numberOfPacks === 0);
+  const zeroNumberOfPacks = draftLines.some(isInboundPlaceholderRow);
   const simplifiedTabletView = useSimplifiedTabletUI();
 
   useEffect(() => {

--- a/client/packages/invoices/src/InboundShipment/api/api.ts
+++ b/client/packages/invoices/src/InboundShipment/api/api.ts
@@ -23,7 +23,7 @@ import {
   UpdateDonorInput,
 } from '@openmsupply-client/common';
 import { DraftInboundLine } from './../../types';
-import { isA } from '../../utils';
+import { isA, isInboundPlaceholderRow } from '../../utils';
 import {
   Sdk,
   InboundFragment,
@@ -370,12 +370,7 @@ export const getInboundQueries = (sdk: Sdk, storeId: string) => ({
   updateLines: async (draftInboundLine: DraftInboundLine[]) => {
     const input = {
       insertInboundShipmentLines: draftInboundLine
-        .filter(
-          ({ type, isCreated, numberOfPacks }) =>
-            isCreated &&
-            type === InvoiceLineNodeType.StockIn &&
-            numberOfPacks > 0
-        )
+        .filter(line => line.isCreated && !isInboundPlaceholderRow(line))
         .map(inboundParsers.toInsertLine),
       updateInboundShipmentLines: draftInboundLine
         .filter(

--- a/client/packages/invoices/src/utils.test.ts
+++ b/client/packages/invoices/src/utils.test.ts
@@ -1,4 +1,6 @@
-import { getNextItemId } from './utils';
+import { InvoiceLineNodeType } from '@common/types';
+import { getNextItemId, isInboundPlaceholderRow } from './utils';
+import { InboundLineFragment } from './InboundShipment';
 
 describe('getNextItemId', () => {
   it('gets next item in array', () => {
@@ -31,5 +33,32 @@ describe('getNextItemId', () => {
     expect(getNextItemId(rows, '1')).toBe('2');
     expect(getNextItemId(rows, '2')).toBe('3');
     expect(getNextItemId(rows, '3')).toBeUndefined();
+  });
+});
+
+describe('isInboundPlaceholderRow', () => {
+  it('returns true for placeholder rows', () => {
+    const row = {
+      type: InvoiceLineNodeType.StockIn,
+      numberOfPacks: 0,
+      shippedNumberOfPacks: 0,
+    } as InboundLineFragment;
+    expect(isInboundPlaceholderRow(row)).toBe(true);
+  });
+  it('returns false when has some received packs', () => {
+    const row = {
+      type: InvoiceLineNodeType.StockIn,
+      numberOfPacks: 1,
+      shippedNumberOfPacks: 0,
+    } as InboundLineFragment;
+    expect(isInboundPlaceholderRow(row)).toBe(false);
+  });
+  it('returns false when has some shipped packs', () => {
+    const row = {
+      type: InvoiceLineNodeType.StockIn,
+      numberOfPacks: 0,
+      shippedNumberOfPacks: 1,
+    } as InboundLineFragment;
+    expect(isInboundPlaceholderRow(row)).toBe(false);
   });
 });

--- a/client/packages/invoices/src/utils.ts
+++ b/client/packages/invoices/src/utils.ts
@@ -257,7 +257,9 @@ export const isInboundListItemDisabled = (
 };
 
 export const isInboundPlaceholderRow = (row: InboundLineFragment): boolean =>
-  row.type === InvoiceLineNodeType.StockIn && row.numberOfPacks === 0;
+  row.type === InvoiceLineNodeType.StockIn &&
+  row.numberOfPacks === 0 &&
+  !row.shippedNumberOfPacks;
 
 export const isInboundStatusChangeDisabled = (
   inbound: InboundFragment | CustomerReturnFragment

--- a/server/graphql/logger.rs
+++ b/server/graphql/logger.rs
@@ -136,6 +136,8 @@ impl Extension for LoggerExtension {
             let info = info.inner.lock().await;
             let query_id = info.id;
 
+            // TODO: Log our structured errors too!
+
             // Log errors to the info level
             if resp.is_err() {
                 for err in &resp.errors {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7841

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Allow inbound shipments to be verified after setting received packs to 0.

Allow reducing received quantity to 0 in the edit modal.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create outbound shipment in one store, mark as shipped so it transfers to second store
- [ ] In second store, mark as received
- [ ] Open line - you can set `packs received` to 0 and save the modal
- [ ] After setting all received lines to 0 (you can do this with mass select) - you can still mark as Verified
- [ ] In a manually created inbound, you can save the modal when EITHER received or shipped packs is set
- [ ] Cannot change a NEW manually created inbound to delivered while all lines have no Received packs

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

