### PR TITLE
8335 json forms dynamic gender component

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/Select.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Select.tsx
@@ -86,12 +86,12 @@ type DisplayOption = {
   right?: string;
 };
 
-const getDisplayOptions = (
+export const getDisplayOptions = (
   t: TypedTFunction<LocaleKey>,
   schemaEnum: string[],
   preferenceKey?: PreferenceKey,
   options?: Options,
-  prefOptions?: Pick<PreferencesNode, PreferenceKey | '__typename'>
+  prefOptions?: Pick<PreferencesNode, PreferenceKey>
 ): DisplayOption[] => {
   if (preferenceKey) {
     switch (preferenceKey) {

--- a/client/packages/programs/src/JsonForms/common/components/Select.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Select.tsx
@@ -89,12 +89,11 @@ type DisplayOption = {
 export const getDisplayOptions = (
   t: TypedTFunction<LocaleKey>,
   schemaEnum: string[],
-  preferenceKey?: PreferenceKey,
   options?: Options,
   prefOptions?: Pick<PreferencesNode, PreferenceKey>
 ): DisplayOption[] => {
-  if (preferenceKey) {
-    switch (preferenceKey) {
+  if (options?.preferenceKey) {
+    switch (options?.preferenceKey) {
       case PreferenceKey.GenderOptions:
         return (
           prefOptions?.genderOptions?.map(option => ({
@@ -104,7 +103,7 @@ export const getDisplayOptions = (
         );
       default:
         console.warn(
-          `Unknown preference key: ${preferenceKey}. Returning empty options.`
+          `Unknown preference key: ${options?.preferenceKey}. Returning empty options.`
         );
         return [];
     }
@@ -289,13 +288,7 @@ const UIComponent = (props: ControlProps) => {
     value: DisplayOption | null
   ) => handleChange(path, value?.value);
 
-  const options = getDisplayOptions(
-    t,
-    items,
-    schemaOptions?.preferenceKey,
-    schemaOptions,
-    preference
-  );
+  const options = getDisplayOptions(t, items, schemaOptions, preference);
 
   const value = data ? options.find(o => o.value === data) : null;
 

--- a/client/packages/programs/src/JsonForms/common/components/tests/Select.test.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/tests/Select.test.tsx
@@ -1,0 +1,54 @@
+import { GenderType, PreferenceKey } from '@openmsupply-client/common';
+import { getDisplayOptions } from '../Select';
+
+describe('getDisplayOptions', () => {
+  const t = jest.fn(key => key);
+  const schemaEnum = ['A', 'B', 'C'];
+  it('returns schemaEnum as is', () => {
+    const result = getDisplayOptions(t, schemaEnum);
+    expect(result).toEqual([
+      { label: 'A', value: 'A' },
+      { label: 'B', value: 'B' },
+      { label: 'C', value: 'C' },
+    ]);
+  });
+
+  it('returns value from show if it is provided', () => {
+    const options = {
+      show: [
+        ['B', 'Bee'] as [string, string | undefined, ...(string | undefined)[]],
+        ['A', 'Ay'] as [string, string | undefined, ...(string | undefined)[]],
+      ],
+    };
+    const result = getDisplayOptions(t, schemaEnum, undefined, options);
+    expect(result).toEqual([
+      { value: 'B', label: 'Bee' },
+      { value: 'A', label: 'Ay' },
+    ]);
+  });
+
+  it('returns preference options when preferenceKey is GenderOptions', () => {
+    const prefOptions = {
+      __typename: 'PreferencesNode',
+      genderOptions: [GenderType.Female, GenderType.Male, GenderType.Unknown],
+      allowTrackingOfStockByDonor: true,
+      manageVaccinesInDoses: true,
+      manageVvmStatusForStock: true,
+      showContactTracing: true,
+      sortByVvmStatusThenExpiry: true,
+      useSimplifiedMobileUi: true,
+    };
+    const result = getDisplayOptions(
+      t,
+      [],
+      PreferenceKey.GenderOptions,
+      undefined,
+      prefOptions
+    );
+    expect(result).toEqual([
+      { label: 'gender.female', value: 'FEMALE' },
+      { label: 'gender.male', value: 'MALE' },
+      { label: 'gender.unknown', value: 'UNKNOWN' },
+    ]);
+  });
+});

--- a/client/packages/programs/src/JsonForms/common/components/tests/Select.test.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/tests/Select.test.tsx
@@ -20,14 +20,14 @@ describe('getDisplayOptions', () => {
         ['A', 'Ay'] as [string, string | undefined, ...(string | undefined)[]],
       ],
     };
-    const result = getDisplayOptions(t, schemaEnum, undefined, options);
+    const result = getDisplayOptions(t, schemaEnum, options);
     expect(result).toEqual([
       { value: 'B', label: 'Bee' },
       { value: 'A', label: 'Ay' },
     ]);
   });
 
-  it('returns preference options when preferenceKey is GenderOptions', () => {
+  it('returns preference options when preferenceKey is genderOptions', () => {
     const prefOptions = {
       __typename: 'PreferencesNode',
       genderOptions: [GenderType.Female, GenderType.Male, GenderType.Unknown],
@@ -38,13 +38,10 @@ describe('getDisplayOptions', () => {
       sortByVvmStatusThenExpiry: true,
       useSimplifiedMobileUi: true,
     };
-    const result = getDisplayOptions(
-      t,
-      [],
-      PreferenceKey.GenderOptions,
-      undefined,
-      prefOptions
-    );
+    const options = {
+      preferenceKey: PreferenceKey.GenderOptions,
+    };
+    const result = getDisplayOptions(t, [], options, prefOptions);
     expect(result).toEqual([
       { label: 'gender.female', value: 'FEMALE' },
       { label: 'gender.male', value: 'MALE' },

--- a/client/packages/system/src/Patient/CreatePatientModal/DefaultCreatePatientUISchema.json
+++ b/client/packages/system/src/Patient/CreatePatientModal/DefaultCreatePatientUISchema.json
@@ -31,14 +31,7 @@
           "scope": "#/properties/gender",
           "label": "label.gender",
           "options": {
-            "show": [
-              ["MALE", "gender.male"],
-              ["FEMALE", "gender.female"],
-              ["TRANSGENDER_MALE", "gender.transgender-male"],
-              ["TRANSGENDER_FEMALE", "gender.transgender-female"],
-              ["NON_BINARY", "gender.non-binary"],
-              ["UNKNOWN", "gender.unknown"]
-            ]
+            "preferenceKey": "genderOptions"
           }
         },
         {

--- a/client/packages/system/src/Patient/PatientView/DefaultPatientUISchema.json
+++ b/client/packages/system/src/Patient/PatientView/DefaultPatientUISchema.json
@@ -60,14 +60,7 @@
               "scope": "#/properties/gender",
               "label": "label.gender",
               "options": {
-                "show": [
-                  ["MALE", "gender.male"],
-                  ["FEMALE", "gender.female"],
-                  ["TRANSGENDER_MALE", "gender.transgender-male"],
-                  ["TRANSGENDER_FEMALE", "gender.transgender-female"],
-                  ["NON_BINARY", "gender.non-binary"],
-                  ["UNKNOWN", "gender.unknown"]
-                ]
+                "preferenceKey": "genderOptions"
               }
             },
             {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8335. Review this at the same time https://github.com/msupply-foundation/programschemas/pull/39

# 👩🏻‍💻 What does this PR do?
Amends the JSON `Select` component so that it can load options from preference instead of a hardcoded set of enums. Did it this way to keep compatibility and also cause we really not be needing that many custom components...

https://github.com/user-attachments/assets/87cd6ddc-ef8b-4055-91f2-f29442868eb0

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Make sure your database doesn't already have any `Patient creation` or `Patient` schemas
- [ ] Go to Global Preference -> select / unselect some options
- [ ] Go to create a patient -> the unselected genders shouldn't show
- [ ] Go to a patient detail page -> the unselected genders shouldn't show 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

