### PR TITLE
8451 cannot add a new patient through a prescription if search find matching patients

### DIFF
--- a/client/packages/system/src/Patient/Components/PatientSearchInput/PatientSearchInput.tsx
+++ b/client/packages/system/src/Patient/Components/PatientSearchInput/PatientSearchInput.tsx
@@ -64,11 +64,10 @@ export const PatientSearchInput = ({
 
   const handlePatientClose = (selectedPatient?: PatientColumnData) => {
     setCreatePatientOpen(false);
-    if (selectedPatient) {
-      onChange(asOption(selectedPatient));
-    } else if (createNewPatient) {
-      onChange(asOption(createNewPatient));
-    } else return;
+    const patientToSelect = selectedPatient ?? createNewPatient;
+    if (patientToSelect) {
+      onChange(asOption(patientToSelect));
+    }
     setInput('');
   };
 

--- a/client/packages/system/src/Patient/Components/PatientSearchInput/PatientSearchInput.tsx
+++ b/client/packages/system/src/Patient/Components/PatientSearchInput/PatientSearchInput.tsx
@@ -72,8 +72,7 @@ export const PatientSearchInput = ({
     setInput('');
   };
 
-  const showCreate =
-    allowCreate && patients.length === 0 && input !== '' && !isLoading;
+  const showCreate = allowCreate && input !== '' && !isLoading;
 
   const CreatePatient = mountSlidePanel
     ? CreatePatientSlider
@@ -120,7 +119,7 @@ export const PatientSearchInput = ({
             : t('messages.type-to-search')
         }
         clickableOption={
-          showCreate && setCreatePatientOpen
+          showCreate
             ? {
                 label: t('label.new-patient'),
                 onClick: () => {

--- a/client/packages/system/src/Patient/Components/PatientSearchInput/PatientSearchInput.tsx
+++ b/client/packages/system/src/Patient/Components/PatientSearchInput/PatientSearchInput.tsx
@@ -42,7 +42,7 @@ export const PatientSearchInput = ({
   const { createNewPatient } = usePatientStore();
   const { getLocalisedFullName } = useIntlUtils();
 
-  const [input, setInput] = useState('');
+  const [input, setInput] = useState<string | undefined>(undefined);
   const [createPatientOpen, setCreatePatientOpen] = useState(false);
   const [editPatientModalOpen, setEditPatientModalOpen] = useState(false);
 
@@ -51,7 +51,7 @@ export const PatientSearchInput = ({
       setInput(value.name);
       search(value.name);
     }
-  }, [value]);
+  }, [search, value]);
 
   const asOption = (
     patient: CreateNewPatient | PatientColumnData
@@ -68,7 +68,7 @@ export const PatientSearchInput = ({
     if (patientToSelect) {
       onChange(asOption(patientToSelect));
     }
-    setInput('');
+    setInput(undefined);
   };
 
   const showCreate = allowCreate && input !== '' && !isLoading;
@@ -112,11 +112,7 @@ export const PatientSearchInput = ({
         }}
         filterOptions={options => options}
         sx={{ width: '100%', ...sx }}
-        noOptionsText={
-          input.length > 0
-            ? t('messages.no-matching-patients')
-            : t('messages.type-to-search')
-        }
+        noOptionsText={t('messages.type-to-search')}
         clickableOption={
           showCreate
             ? {

--- a/client/packages/system/src/Patient/Components/PatientSearchInput/PatientSearchInput.tsx
+++ b/client/packages/system/src/Patient/Components/PatientSearchInput/PatientSearchInput.tsx
@@ -71,7 +71,7 @@ export const PatientSearchInput = ({
     setInput(undefined);
   };
 
-  const showCreate = allowCreate && input !== '' && !isLoading;
+  const showCreate = allowCreate && !!input && !isLoading;
 
   const CreatePatient = mountSlidePanel
     ? CreatePatientSlider
@@ -80,7 +80,7 @@ export const PatientSearchInput = ({
   const options = patients as SearchInputPatient[];
 
   return (
-    <Box width={`${width}px`} display={'flex'} alignItems="center">
+    <Box width={`${width}px`} display="flex" alignItems="center">
       <Autocomplete
         autoFocus={autoFocus}
         options={options}
@@ -108,7 +108,7 @@ export const PatientSearchInput = ({
           },
           // reset input value to previous selected patient if user clicks away
           // without selecting a patient
-          onBlur: () => setInput(value?.name ?? ''),
+          onBlur: () => setInput(value?.name ?? undefined),
         }}
         filterOptions={options => options}
         sx={{ width: '100%', ...sx }}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8451

# 👩🏻‍💻 What does this PR do?
Always show create patient in search results regardless of matching patients. Only time it will not show is when there is no input

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to create patient
- [ ] Search for existing patient -> see create new patient option available
- [ ] Clear input (not empty spaces, use the delete key) -> shouldn't see new patient option

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

