### PR TITLE
8441 clinician gender sync fix

### DIFF
--- a/server/repository/src/db_diesel/name_row.rs
+++ b/server/repository/src/db_diesel/name_row.rs
@@ -86,6 +86,10 @@ allow_tables_to_appear_in_same_query!(name_oms_fields, master_list_name_join);
 allow_tables_to_appear_in_same_query!(name_oms_fields, master_list);
 allow_tables_to_appear_in_same_query!(name_oms_fields, program);
 
+// If adding to this enum remember that we need to add migrations.
+// Old versions may integrate through sync the new gender variant as `None`.
+// Your migration should address this by checking all records with `None` values and
+// convert them to the new more concrete variant you have added.
 #[derive(DbEnum, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[DbValueStyle = "SCREAMING_SNAKE_CASE"]

--- a/server/repository/src/migrations/v2_09_00/mod.rs
+++ b/server/repository/src/migrations/v2_09_00/mod.rs
@@ -7,6 +7,7 @@ mod add_shipped_number_of_packs_to_invoice_line;
 mod add_store_id_to_clinician;
 mod extend_name_table_fields;
 mod process_clinician_store_join_deletes;
+mod reintegrate_clinician_gender;
 mod remove_item_variant_doses_column;
 mod resync_existing_vaccination_records;
 mod resync_existing_vaccine_course_dose_and_item;
@@ -34,6 +35,7 @@ impl Migration for V2_09_00 {
             Box::new(add_excel_template_to_report::Migrate),
             Box::new(resync_existing_vaccination_records::Migrate),
             Box::new(remove_item_variant_doses_column::Migrate),
+            Box::new(reintegrate_clinician_gender::Migrate),
         ]
     }
 }

--- a/server/repository/src/migrations/v2_09_00/reintegrate_clinician_gender.rs
+++ b/server/repository/src/migrations/v2_09_00/reintegrate_clinician_gender.rs
@@ -1,0 +1,96 @@
+use anyhow::Context;
+use diesel::prelude::*;
+use serde::{
+    de::{value::StrDeserializer, IntoDeserializer},
+    Deserialize, Deserializer, Serialize,
+};
+
+use crate::{migrations::*, sync_buffer::sync_buffer, GenderType, SyncAction};
+
+pub fn empty_str_as_option_string<'de, D: Deserializer<'de>>(
+    d: D,
+) -> Result<Option<String>, D::Error> {
+    let s: Option<String> = Option::deserialize(d)?;
+    Ok(s.filter(|s| !s.is_empty()))
+}
+
+pub fn empty_str_as_option<'de, T: Deserialize<'de>, D: Deserializer<'de>>(
+    d: D,
+) -> Result<Option<T>, D::Error> {
+    let s: Option<String> = empty_str_as_option_string(d)?;
+
+    let Some(s) = s else { return Ok(None) };
+
+    let str_d: StrDeserializer<D::Error> = s.as_str().into_deserializer();
+    Ok(Some(T::deserialize(str_d)?))
+}
+
+pub fn ok_or_none<'de, T: Deserialize<'de>, D: Deserializer<'de>>(
+    d: D,
+) -> Result<Option<T>, D::Error> {
+    Ok(empty_str_as_option(d).map_or(None, |v| v))
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct ClinicianOmsFields {
+    #[serde(default)]
+    #[serde(deserialize_with = "ok_or_none")]
+    pub gender: Option<GenderType>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct LegacyClinicianRow {
+    female: bool,
+    oms_fields: Option<ClinicianOmsFields>,
+}
+
+table! {
+  clinician (id) {
+    id -> Text,
+    gender -> Nullable<crate::GenderTypeMapping>,
+  }
+}
+
+#[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq, Default)]
+#[diesel(table_name = clinician)]
+pub struct ClinicianRow {
+    pub id: String,
+    pub gender: Option<GenderType>,
+}
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "reintegrate_clinician_gender"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        let sync_buffer_rows = sync_buffer::table
+            .select((sync_buffer::record_id, sync_buffer::data))
+            .filter(
+                sync_buffer::action
+                    .eq(SyncAction::Upsert)
+                    .and(sync_buffer::table_name.eq("clinician")),
+            )
+            .load::<(String, String)>(connection.lock().connection())?;
+
+        for (id, data) in sync_buffer_rows {
+            let legacy_row = serde_json::from_str::<LegacyClinicianRow>(&data)
+                .with_context(|| format!("Cannot parse sync buffer row data: {}", data))?;
+
+            let Some(fields) = legacy_row.oms_fields else {
+                continue;
+            };
+
+            if let Some(gender) = fields.gender {
+                diesel::update(clinician::table)
+                    .filter(clinician::id.eq(id))
+                    .set(clinician::gender.eq(gender))
+                    .execute(connection.lock().connection())?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/server/service/src/sync/settings.rs
+++ b/server/service/src/sync/settings.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 // See README.md for description of when this API version needs to be updated
-pub(crate) static SYNC_V5_VERSION: u32 = 10; // bumped for v2.9 (https://github.com/msupply-foundation/msupply/pull/16772)
+pub(crate) static SYNC_V5_VERSION: u32 = 11; // bumped for v2.9 (https://github.com/msupply-foundation/msupply/pull/16870)
 pub(crate) static SYNC_V6_VERSION: u32 = 4;
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Default)]

--- a/server/service/src/sync/sync_serde.rs
+++ b/server/service/src/sync/sync_serde.rs
@@ -24,6 +24,14 @@ pub fn empty_str_as_option<'de, T: Deserialize<'de>, D: Deserializer<'de>>(
     Ok(Some(T::deserialize(str_d)?))
 }
 
+pub fn option_enum_invalid_none<'de, T: Deserialize<'de>, D: Deserializer<'de>>(
+    d: D,
+) -> Result<Option<T>, D::Error> {
+    let s = String::deserialize(d)?;
+    let str_d: StrDeserializer<D::Error> = s.as_str().into_deserializer();
+    Ok(T::deserialize(str_d).ok())
+}
+
 pub fn zero_date_as_option<'de, D: Deserializer<'de>>(d: D) -> Result<Option<NaiveDate>, D::Error> {
     let s: Option<String> = Option::deserialize(d)?;
     Ok(s.filter(|s| s != "0000-00-00")
@@ -33,7 +41,7 @@ pub fn zero_date_as_option<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Nai
 pub fn object_fields_as_option<'de, T: Deserialize<'de>, D: Deserializer<'de>>(
     d: D,
 ) -> Result<Option<T>, D::Error> {
-    // error if cannot deserialise into a Value (which includes null, empty string or empty object)
+    // error if cannot deserialize into a Value (which includes null, empty string or empty object)
     let value: Value = Value::deserialize(d)?;
     return match value {
         Value::Null => Ok(None),

--- a/server/service/src/sync/sync_serde.rs
+++ b/server/service/src/sync/sync_serde.rs
@@ -176,17 +176,14 @@ mod test {
     #[test]
     fn test_handle_object_fields_translation() {
         // case with populated fields
-        const LEGACY_ROW_1: (&str, &str) = (
-            "LEGACY_ROW_1",
-            r#"{
+        const LEGACY_ROW_1: &str = r#"{
                 "ID": "LEGACY_ROW_1",
                 "oms_fields": {
                     "foreign_exchange_rate": 1.6,
                     "contract_signed_datetime": "2021-01-22T15:16:00"
                 }
-            }"#,
-        );
-        let a = serde_json::from_str::<LegacyRowWithOmsObjectField>(&LEGACY_ROW_1.1);
+            }"#;
+        let a = serde_json::from_str::<LegacyRowWithOmsObjectField>(&LEGACY_ROW_1);
         assert!(a.is_ok());
         let fields = a.unwrap().oms_fields.unwrap();
         assert_eq!(fields.foreign_exchange_rate, Some(1.6));
@@ -199,45 +196,33 @@ mod test {
         assert_eq!(fields.advance_paid_datetime, None);
 
         // case with empty object
-        const LEGACY_ROW_2: (&str, &str) = (
-            "LEGACY_ROW_2",
-            r#"{
+        const LEGACY_ROW_2: &str = r#"{
                 "ID": "LEGACY_ROW_2",
                 "oms_fields": {}
-            }"#,
-        );
-        let b = serde_json::from_str::<LegacyRowWithOmsObjectField>(&LEGACY_ROW_2.1);
+            }"#;
+        let b = serde_json::from_str::<LegacyRowWithOmsObjectField>(&LEGACY_ROW_2);
         assert!(b.is_ok());
 
         // case with empty string
-        const LEGACY_ROW_3: (&str, &str) = (
-            "LEGACY_ROW_3",
-            r#"{
+        const LEGACY_ROW_3: &str = r#"{
                 "ID": "LEGACY_ROW_3",
                 "oms_fields": ""
-            }"#,
-        );
-        let c = serde_json::from_str::<LegacyRowWithOmsObjectField>(&LEGACY_ROW_3.1).unwrap();
+            }"#;
+        let c = serde_json::from_str::<LegacyRowWithOmsObjectField>(&LEGACY_ROW_3).unwrap();
         assert_eq!(c.oms_fields, None);
 
         // case with null
-        const LEGACY_ROW_4: (&str, &str) = (
-            "LEGACY_ROW_4",
-            r#"{
+        const LEGACY_ROW_4: &str = r#"{
                 "ID": "LEGACY_ROW_4",
                 "oms_fields": null
-            }"#,
-        );
-        let d = serde_json::from_str::<LegacyRowWithOmsObjectField>(&LEGACY_ROW_4.1);
+            }"#;
+        let d = serde_json::from_str::<LegacyRowWithOmsObjectField>(&LEGACY_ROW_4);
         assert!(d.is_ok());
 
         // case with no value
-        const LEGACY_ROW_5: (&str, &str) = (
-            "LEGACY_ROW_5",
-            r#"{
-                "ID": "LEGACY_ROW_5"            }"#,
-        );
-        let e = serde_json::from_str::<LegacyRowWithOmsObjectField>(&LEGACY_ROW_5.1);
+        const LEGACY_ROW_5: &str = r#"{
+                "ID": "LEGACY_ROW_5"            }"#;
+        let e = serde_json::from_str::<LegacyRowWithOmsObjectField>(&LEGACY_ROW_5);
         assert!(e.is_ok());
     }
 
@@ -261,7 +246,6 @@ mod test {
                 }
             }"#;
         let row = serde_json::from_str::<LegacyRowWithOmsObjectField>(&raw_json);
-        dbg!(&row);
         assert!(row.is_ok(), "null to None is OK");
         let fields = row.unwrap().oms_fields.unwrap();
         assert_eq!(fields.some_enum_field, None);

--- a/server/service/src/sync/test/test_data/clinician.rs
+++ b/server/service/src/sync/test/test_data/clinician.rs
@@ -23,26 +23,146 @@ const CLINICIAN_1: (&str, &str) = (
             "email": "",
             "female": true,
             "active": true,
-            "store_ID": "store_a"
+            "store_ID": "store_a",
+            "oms_fields": null
+    }"#,
+);
+const CLINICIAN_VALID_OMS_FIELDS_GENDER: (&str, &str) = (
+    "CLINICIAN_VALID_OMS_FIELDS_GENDER",
+    r#"{
+            "ID": "CLINICIAN_VALID_OMS_FIELDS_GENDER",
+            "code": "CLINICIAN_CODE",
+            "last_name": "Surname",
+            "initials": "FS",
+            "first_name": "First Name",
+            "address1": "",
+            "address2": "",
+            "phone": "",
+            "mobile": "",
+            "email": "",
+            "female": true,
+            "active": true,
+            "store_ID": "store_a",
+            "oms_fields": { "gender": "TRANSGENDER" }
+    }"#,
+);
+const CLINICIAN_INVALID_OMS_FIELDS_GENDER: (&str, &str) = (
+    "CLINICIAN_INVALID_OMS_FIELDS_GENDER",
+    r#"{
+            "ID": "CLINICIAN_INVALID_OMS_FIELDS_GENDER",
+            "code": "CLINICIAN_CODE",
+            "last_name": "Surname",
+            "initials": "FS",
+            "first_name": "First Name",
+            "address1": "",
+            "address2": "",
+            "phone": "",
+            "mobile": "",
+            "email": "",
+            "female": true,
+            "active": true,
+            "store_ID": "store_a",
+            "oms_fields": { "gender": "Not in the gender enum" }
+    }"#,
+);
+const CLINICIAN_OMS_FIELDS_GENDER_UNDEFINED: (&str, &str) = (
+    "CLINICIAN_INVALID_OMS_FIELDS_GENDER",
+    r#"{
+            "ID": "CLINICIAN_INVALID_OMS_FIELDS_GENDER",
+            "code": "CLINICIAN_CODE",
+            "last_name": "Surname",
+            "initials": "FS",
+            "first_name": "First Name",
+            "address1": "",
+            "address2": "",
+            "phone": "",
+            "mobile": "",
+            "email": "",
+            "female": true,
+            "active": true,
+            "store_ID": "store_a",
+            "oms_fields": {}
     }"#,
 );
 
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
-    vec![TestSyncIncomingRecord::new_pull_upsert(
-        CLINICIAN_TABLE,
-        CLINICIAN_1,
-        ClinicianRow {
-            id: CLINICIAN_1.0.to_owned(),
-            code: "CLINICIAN_CODE".to_string(),
-            last_name: "Surname".to_string(),
-            initials: "FS".to_string(),
-            first_name: Some("First Name".to_string()),
-            gender: Some(GenderType::Female),
-            is_active: true,
-            store_id: Some("store_a".to_string()),
-            ..Default::default()
-        },
-    )]
+    vec![
+        TestSyncIncomingRecord::new_pull_upsert(
+            CLINICIAN_TABLE,
+            CLINICIAN_1,
+            ClinicianRow {
+                id: CLINICIAN_1.0.to_owned(),
+                code: "CLINICIAN_CODE".to_string(),
+                last_name: "Surname".to_string(),
+                initials: "FS".to_string(),
+                first_name: Some("First Name".to_string()),
+                gender: Some(GenderType::Female),
+                is_active: true,
+                store_id: Some("store_a".to_string()),
+                ..Default::default()
+            },
+        ),
+        TestSyncIncomingRecord::new_pull_upsert(
+            CLINICIAN_TABLE,
+            CLINICIAN_VALID_OMS_FIELDS_GENDER,
+            ClinicianRow {
+                id: CLINICIAN_VALID_OMS_FIELDS_GENDER.0.to_owned(),
+                code: "CLINICIAN_CODE".to_string(),
+                last_name: "Surname".to_string(),
+                initials: "FS".to_string(),
+                first_name: Some("First Name".to_string()),
+                gender: Some(GenderType::Transgender),
+                is_active: true,
+                store_id: Some("store_a".to_string()),
+                ..Default::default()
+            },
+        ),
+        TestSyncIncomingRecord::new_pull_upsert(
+            CLINICIAN_TABLE,
+            CLINICIAN_INVALID_OMS_FIELDS_GENDER,
+            ClinicianRow {
+                id: CLINICIAN_INVALID_OMS_FIELDS_GENDER.0.to_owned(),
+                code: "CLINICIAN_CODE".to_string(),
+                last_name: "Surname".to_string(),
+                initials: "FS".to_string(),
+                first_name: Some("First Name".to_string()),
+                gender: None,
+                is_active: true,
+                store_id: Some("store_a".to_string()),
+                ..Default::default()
+            },
+        ),
+        TestSyncIncomingRecord::new_pull_upsert(
+            CLINICIAN_TABLE,
+            CLINICIAN_INVALID_OMS_FIELDS_GENDER,
+            ClinicianRow {
+                id: CLINICIAN_INVALID_OMS_FIELDS_GENDER.0.to_owned(),
+                code: "CLINICIAN_CODE".to_string(),
+                last_name: "Surname".to_string(),
+                initials: "FS".to_string(),
+                first_name: Some("First Name".to_string()),
+                gender: None,
+                is_active: true,
+                store_id: Some("store_a".to_string()),
+                ..Default::default()
+            },
+        ),
+        TestSyncIncomingRecord::new_pull_upsert(
+            CLINICIAN_TABLE,
+            CLINICIAN_OMS_FIELDS_GENDER_UNDEFINED,
+            ClinicianRow {
+                id: CLINICIAN_OMS_FIELDS_GENDER_UNDEFINED.0.to_owned(),
+                code: "CLINICIAN_CODE".to_string(),
+                last_name: "Surname".to_string(),
+                initials: "FS".to_string(),
+                first_name: Some("First Name".to_string()),
+                gender: None,
+                is_active: true,
+                store_id: Some("store_a".to_string()),
+                ..Default::default()
+            },
+        ),
+    ]
 }
 pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
     vec![TestSyncOutgoingRecord {
@@ -62,6 +182,7 @@ pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
             is_female: true,
             is_active: true,
             store_id: Some("store_a".to_string()),
+            oms_fields: None,
         }),
     }]
 }

--- a/server/service/src/sync/test/test_data/clinician.rs
+++ b/server/service/src/sync/test/test_data/clinician.rs
@@ -66,9 +66,9 @@ const CLINICIAN_INVALID_OMS_FIELDS_GENDER: (&str, &str) = (
     }"#,
 );
 const CLINICIAN_OMS_FIELDS_GENDER_UNDEFINED: (&str, &str) = (
-    "CLINICIAN_INVALID_OMS_FIELDS_GENDER",
+    "CLINICIAN_OMS_FIELDS_GENDER_UNDEFINED",
     r#"{
-            "ID": "CLINICIAN_INVALID_OMS_FIELDS_GENDER",
+            "ID": "CLINICIAN_OMS_FIELDS_GENDER_UNDEFINED",
             "code": "CLINICIAN_CODE",
             "last_name": "Surname",
             "initials": "FS",
@@ -81,7 +81,7 @@ const CLINICIAN_OMS_FIELDS_GENDER_UNDEFINED: (&str, &str) = (
             "female": true,
             "active": true,
             "store_ID": "store_a",
-            "oms_fields": {}
+            "oms_fields": { "someFutureField": 123 }
     }"#,
 );
 
@@ -134,21 +134,6 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
         ),
         TestSyncIncomingRecord::new_pull_upsert(
             CLINICIAN_TABLE,
-            CLINICIAN_INVALID_OMS_FIELDS_GENDER,
-            ClinicianRow {
-                id: CLINICIAN_INVALID_OMS_FIELDS_GENDER.0.to_owned(),
-                code: "CLINICIAN_CODE".to_string(),
-                last_name: "Surname".to_string(),
-                initials: "FS".to_string(),
-                first_name: Some("First Name".to_string()),
-                gender: None,
-                is_active: true,
-                store_id: Some("store_a".to_string()),
-                ..Default::default()
-            },
-        ),
-        TestSyncIncomingRecord::new_pull_upsert(
-            CLINICIAN_TABLE,
             CLINICIAN_OMS_FIELDS_GENDER_UNDEFINED,
             ClinicianRow {
                 id: CLINICIAN_OMS_FIELDS_GENDER_UNDEFINED.0.to_owned(),
@@ -164,6 +149,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
         ),
     ]
 }
+
 pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
     vec![TestSyncOutgoingRecord {
         table_name: CLINICIAN_TABLE.to_string(),

--- a/server/service/src/sync/test/test_data/clinician.rs
+++ b/server/service/src/sync/test/test_data/clinician.rs
@@ -3,11 +3,14 @@ use serde_json::json;
 
 use crate::sync::{
     test::{TestSyncIncomingRecord, TestSyncOutgoingRecord},
-    translations::clinician::LegacyClinicianRow,
+    translations::clinician::{ClinicianOmsFields, LegacyClinicianRow},
 };
 
 const CLINICIAN_TABLE: &str = "clinician";
 
+// We cannot test if the `oms_fields` does not contain `gender`. If we set it to None, the `female` property will be read on pull and populate
+// `gender: GenderType::Female` in the db. Then on push, it'll have `{ "gender": "FEMALE" }` and push_and_pull test will fail as it assumes all inputs
+// will be identical to outputs.
 const CLINICIAN_1: (&str, &str) = (
     "CLINICIAN_1",
     r#"{
@@ -24,7 +27,7 @@ const CLINICIAN_1: (&str, &str) = (
             "female": true,
             "active": true,
             "store_ID": "store_a",
-            "oms_fields": null
+            "oms_fields": { "gender": "FEMALE" }
     }"#,
 );
 const CLINICIAN_VALID_OMS_FIELDS_GENDER: (&str, &str) = (
@@ -40,7 +43,7 @@ const CLINICIAN_VALID_OMS_FIELDS_GENDER: (&str, &str) = (
             "phone": "",
             "mobile": "",
             "email": "",
-            "female": true,
+            "female": false,
             "active": true,
             "store_ID": "store_a",
             "oms_fields": { "gender": "TRANSGENDER" }
@@ -59,31 +62,32 @@ const CLINICIAN_INVALID_OMS_FIELDS_GENDER: (&str, &str) = (
             "phone": "",
             "mobile": "",
             "email": "",
-            "female": true,
+            "female": false,
             "active": true,
             "store_ID": "store_a",
             "oms_fields": { "gender": "Not in the gender enum" }
     }"#,
 );
-const CLINICIAN_OMS_FIELDS_GENDER_UNDEFINED: (&str, &str) = (
-    "CLINICIAN_OMS_FIELDS_GENDER_UNDEFINED",
-    r#"{
-            "ID": "CLINICIAN_OMS_FIELDS_GENDER_UNDEFINED",
-            "code": "CLINICIAN_CODE",
-            "last_name": "Surname",
-            "initials": "FS",
-            "first_name": "First Name",
-            "address1": "",
-            "address2": "",
-            "phone": "",
-            "mobile": "",
-            "email": "",
-            "female": true,
-            "active": true,
-            "store_ID": "store_a",
-            "oms_fields": { "someFutureField": 123 }
-    }"#,
-);
+//// We cannot effectively test fields that aren't in the ClinicianOmsFields struct, as they'll miss match push_and_pull test symmetry.
+// const CLINICIAN_OMS_FIELDS_GENDER_UNDEFINED: (&str, &str) = (
+//     "CLINICIAN_OMS_FIELDS_GENDER_UNDEFINED",
+//     r#"{
+//             "ID": "CLINICIAN_OMS_FIELDS_GENDER_UNDEFINED",
+//             "code": "CLINICIAN_CODE",
+//             "last_name": "Surname",
+//             "initials": "FS",
+//             "first_name": "First Name",
+//             "address1": "",
+//             "address2": "",
+//             "phone": "",
+//             "mobile": "",
+//             "email": "",
+//             "female": false,
+//             "active": true,
+//             "store_ID": "store_a",
+//             "oms_fields": { "someFutureField": 123 }
+//     }"#,
+// );
 
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
     vec![
@@ -132,43 +136,74 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
                 ..Default::default()
             },
         ),
-        TestSyncIncomingRecord::new_pull_upsert(
-            CLINICIAN_TABLE,
-            CLINICIAN_OMS_FIELDS_GENDER_UNDEFINED,
-            ClinicianRow {
-                id: CLINICIAN_OMS_FIELDS_GENDER_UNDEFINED.0.to_owned(),
-                code: "CLINICIAN_CODE".to_string(),
-                last_name: "Surname".to_string(),
-                initials: "FS".to_string(),
-                first_name: Some("First Name".to_string()),
-                gender: None,
-                is_active: true,
-                store_id: Some("store_a".to_string()),
-                ..Default::default()
-            },
-        ),
     ]
 }
 
 pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
-    vec![TestSyncOutgoingRecord {
-        table_name: CLINICIAN_TABLE.to_string(),
-        record_id: CLINICIAN_1.0.to_string(),
-        push_data: json!(LegacyClinicianRow {
-            id: CLINICIAN_1.0.to_string(),
-            code: "CLINICIAN_CODE".to_string(),
-            last_name: "Surname".to_string(),
-            initials: "FS".to_string(),
-            first_name: Some("First Name".to_string()),
-            address1: None,
-            address2: None,
-            phone: None,
-            mobile: None,
-            email: None,
-            is_female: true,
-            is_active: true,
-            store_id: Some("store_a".to_string()),
-            oms_fields: None,
-        }),
-    }]
+    vec![
+        TestSyncOutgoingRecord {
+            table_name: CLINICIAN_TABLE.to_string(),
+            record_id: CLINICIAN_1.0.to_string(),
+            push_data: json!(LegacyClinicianRow {
+                id: CLINICIAN_1.0.to_string(),
+                code: "CLINICIAN_CODE".to_string(),
+                last_name: "Surname".to_string(),
+                initials: "FS".to_string(),
+                first_name: Some("First Name".to_string()),
+                address1: None,
+                address2: None,
+                phone: None,
+                mobile: None,
+                email: None,
+                is_female: true,
+                is_active: true,
+                store_id: Some("store_a".to_string()),
+                oms_fields: Some(ClinicianOmsFields {
+                    gender: Some(GenderType::Female)
+                }),
+            }),
+        },
+        TestSyncOutgoingRecord {
+            table_name: CLINICIAN_TABLE.to_string(),
+            record_id: CLINICIAN_VALID_OMS_FIELDS_GENDER.0.to_string(),
+            push_data: json!(LegacyClinicianRow {
+                id: CLINICIAN_VALID_OMS_FIELDS_GENDER.0.to_string(),
+                code: "CLINICIAN_CODE".to_string(),
+                last_name: "Surname".to_string(),
+                initials: "FS".to_string(),
+                first_name: Some("First Name".to_string()),
+                address1: None,
+                address2: None,
+                phone: None,
+                mobile: None,
+                email: None,
+                is_female: false,
+                is_active: true,
+                store_id: Some("store_a".to_string()),
+                oms_fields: Some(ClinicianOmsFields {
+                    gender: Some(GenderType::Transgender)
+                }),
+            }),
+        },
+        TestSyncOutgoingRecord {
+            table_name: CLINICIAN_TABLE.to_string(),
+            record_id: CLINICIAN_INVALID_OMS_FIELDS_GENDER.0.to_string(),
+            push_data: json!(LegacyClinicianRow {
+                id: CLINICIAN_INVALID_OMS_FIELDS_GENDER.0.to_string(),
+                code: "CLINICIAN_CODE".to_string(),
+                last_name: "Surname".to_string(),
+                initials: "FS".to_string(),
+                first_name: Some("First Name".to_string()),
+                address1: None,
+                address2: None,
+                phone: None,
+                mobile: None,
+                email: None,
+                is_female: false,
+                is_active: true,
+                store_id: Some("store_a".to_string()),
+                oms_fields: Some(ClinicianOmsFields { gender: None }),
+            }),
+        },
+    ]
 }

--- a/server/service/src/sync/translations/clinician.rs
+++ b/server/service/src/sync/translations/clinician.rs
@@ -198,7 +198,13 @@ mod tests {
             assert!(translator.should_translate_from_sync_record(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_from_upsert_sync_record(&connection, &record.sync_buffer_row)
-                .unwrap();
+                .expect(
+                    format!(
+                        "try_translate_from_upsert_sync_record error {:?}",
+                        record.sync_buffer_row.record_id
+                    )
+                    .as_str(),
+                );
 
             assert_eq!(translation_result, record.translated_record);
         }

--- a/server/service/src/sync/translations/clinician.rs
+++ b/server/service/src/sync/translations/clinician.rs
@@ -6,17 +6,16 @@ use repository::{
 };
 
 use crate::sync::{
-    sync_serde::{empty_str_as_option_string, object_fields_as_option, option_enum_invalid_none},
+    sync_serde::{empty_str_as_option_string, object_fields_as_option, ok_or_none},
     translations::store::StoreTranslation,
 };
 
 use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
-#[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
 pub struct ClinicianOmsFields {
     #[serde(default)]
-    #[serde(deserialize_with = "option_enum_invalid_none")]
+    #[serde(deserialize_with = "ok_or_none")]
     pub gender: Option<GenderType>,
 }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8441

# 👩🏻‍💻 What does this PR do?

Updates clinician translators to use the `legacy_clinician_row.oms_fields` struct 

## 💌 Any notes for the reviewer?

This is quirky.

- If the `oms_fields` are None, then use the old `female` boolean
- else use `oms_fields`...
- If `oms_fields.gender` is None then set gender to None (ignore `female`)
- If `oms_fields.gender` is Some _valid_ `GenderType` variant then set gender to it
- If `oms_fields.gender` is Some* _invalid_ `GenderType` variant (say from a future version of OMS syncing it to an older version site) then set gender to None (* will write comment in PR code but it's actually if there is any error)
- If on migration to new versions of OMS that add `GenderType` variants, we should write migrations that check query `clinician.gender == None` and then lookup the sync_buffer to see if there is a valid variant to upsert on the clinician record.
- If a clinician is updated to some `GenderType` on it's homestore, then that clinician's homestore is moved to an old OMS site, then updated on that OMS site, if the GenderType was unsupported it'll sync out and overwrite it with `None`. Not ideal, but should be rare. Welcome ideas to prevent this.
- Our `pull_and_push` sync tests assume that the raw JSON going in will equal the raw JSON coming out. There are few scenarios in this gender handling logic that break that assumption. e.g. `"oms_fields": null,`, the incoming sync logic falls back to the boolean and populates the OMS record with `gender: GenderType::Male | GenderType::Female`. Then on "push" it'll translate that into the outgoing json `"oms_fields": { "gender": "MALE" | "FEMALE" },`. In this case the test fails as push JSON != pull JSON.
  - So that is to say I have definitely not written tests for everything as I didn't want to rewrite `pull_and_push` test...
- I'm not 100% sure our frontend is equipped to handle `clinician.gender` being null...

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] OG central with v2.9 OMS remote, and some v2.8.x OMS remote 
- [ ] OG Create a clinician and set gender to male and make visible to both OMS remotes. Both OMS remotes see a clinician with gender "Male"
- [ ] OG Create a clinician and set gender to female and make visible to both OMS remotes. Both OMS remotes see a clinician with gender "Female"
- [ ] <v2.8.x Remote create Male/Female clinicians (A and B) and sync
- [ ] Make them visible to 2.9 remote and OG. They show as correct gender on OG and 2.9 remote
- [ ] v2.9 create a Transgender clinician (C) and sync.
- [ ] Make them visible to 2.8.x remote and OG. They show as Male in both OG and 2.8.x (default db behaviour)
- [ ] Migrate 2.8.x to 2.9. Clinician C should show as Transgender. A and B are still Male and Female respectively
- [ ] Reinitialise 2.9 remote. Clinicians A, B and C are Male, Female and Transgender respectively.

# 📃 Documentation

Well... The exact behaviours would be disturbing to document...

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

