### PR TITLE
8415 reports print and excel export loading spinner

### DIFF
--- a/client/packages/reports/src/DetailView/AppBarButton.tsx
+++ b/client/packages/reports/src/DetailView/AppBarButton.tsx
@@ -6,6 +6,7 @@ import {
   EnvUtils,
   FilterIcon,
   Grid,
+  LoadingButton,
   Platform,
   PrinterIcon,
   SwipeIcon,
@@ -54,16 +55,18 @@ export const AppBarButtonsComponent = ({
           Icon={<FilterIcon />}
           onClick={() => onFilterOpen()}
         />
-        <ButtonWithIcon
+        <LoadingButton
+          isLoading={isPrinting}
           disabled={isPrinting}
           label={t('button.print')}
-          Icon={<PrinterIcon />}
+          startIcon={<PrinterIcon />}
           onClick={() => printReport()}
         />
-        <ButtonWithIcon
+        <LoadingButton
+          isLoading={isPrinting}
           disabled={isPrinting}
           label={t('button.export')}
-          Icon={<DownloadIcon />}
+          startIcon={<DownloadIcon />}
           onClick={() => exportReport()}
         />
       </Grid>

--- a/client/packages/reports/src/DetailView/DetailView.tsx
+++ b/client/packages/reports/src/DetailView/DetailView.tsx
@@ -63,7 +63,7 @@ const DetailViewInner = ({
     | { s: 'error'; errorMessage: string }
     | { s: 'loaded'; fileId: string }
   >({ s: 'loading' });
-  const { mutateAsync } = useGenerateReport();
+  const { mutateAsync, isLoading } = useGenerateReport();
 
   const { print, isPrinting } = usePrintReport();
   const { updateQuery } = useUrlQuery();
@@ -207,7 +207,7 @@ const DetailViewInner = ({
         onFilterOpen={openReportArgumentsModal}
         printReport={printReport}
         exportReport={exportExcelReport}
-        isPrinting={isPrinting}
+        isPrinting={isPrinting || isLoading}
       />
       <ReportArgumentsModal
         key={report.id}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

#8415
I refuse to say this "fixes" 8415 - 10 minutes to excel export 4000 rows of data is outrageous. A loading spinner doesn't cut it! The actual react page takes about 12s. Blasting that same data into excel (i.e. XML) should _very_ generously take less than 12s.

I used just the normal `Item Usage` report with 4000 items and it takes forever. For warehouses this would just be the tip of the iceberg! E.g. multiply that several times if talking about reports on 

# 👩🏻‍💻 What does this PR do?

<img width="682" height="404" alt="image" src="https://github.com/user-attachments/assets/51b36288-163a-4eac-8ba6-2b56927a6005" />

Use the LoadingButton. If you click either print or export it will spin both. LoadingButton expands width in loading state which looks bad, however the original suggested solution would just make the buttons disabled (which isn't the correct user feedback)

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Item usage report
- [ ] click export or print
- [ ] Both buttons turn to loading spinners regardless of which you pressed
- [ ] Once print or export completes they stop spinning

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

