### PR TITLE
8497 Internal Orders: Doses shouldn't be displayed for MOS

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ModalContentPanels.ts
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ModalContentPanels.ts
@@ -20,6 +20,7 @@ export const getLeftPanel = (
       label: t('label.months-of-stock'),
       value: draft?.itemStats.availableMonthsOfStockOnHand,
       endAdornmentOverride: t('label.months'),
+      displayVaccinesInDoses: false,
     },
   ];
 
@@ -67,6 +68,7 @@ export const getExtraMiddlePanels = (
       label: t('label.days-out-of-stock'),
       value: draft?.daysOutOfStock,
       endAdornmentOverride: t('label.days'),
+      displayVaccinesInDoses: false,
     },
   ];
 };

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -96,20 +96,28 @@ export const RequestLineEdit = ({
   const renderValueInfoRows = useCallback(
     (info: ValueInfo[]) => (
       <>
-        {info.map(({ label, value, sx, endAdornmentOverride }) => (
-          <ValueInfoRow
-            key={label}
-            label={label}
-            value={value}
-            endAdornmentOverride={endAdornmentOverride}
-            defaultPackSize={defaultPackSize}
-            representation={representation}
-            unitName={unitName}
-            sx={sx}
-            displayVaccinesInDoses={displayVaccinesInDoses}
-            dosesPerUnit={currentItem?.doses}
-          />
-        ))}
+        {info.map(
+          ({
+            label,
+            value,
+            sx,
+            endAdornmentOverride,
+            displayVaccinesInDoses: showDoses,
+          }) => (
+            <ValueInfoRow
+              key={label}
+              label={label}
+              value={value}
+              endAdornmentOverride={endAdornmentOverride}
+              defaultPackSize={defaultPackSize}
+              representation={representation}
+              unitName={unitName}
+              sx={sx}
+              displayVaccinesInDoses={showDoses ?? displayVaccinesInDoses}
+              dosesPerUnit={currentItem?.doses}
+            />
+          )
+        )}
       </>
     ),
     [

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ContentLayout.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ContentLayout.tsx
@@ -182,6 +182,7 @@ interface NumericInputOptions {
   disabledOverride?: boolean;
   endAdornmentOverride?: string;
   sx?: Record<string, unknown>;
+  overrideDoseDisplay?: boolean;
 }
 
 export const createNumericInput =
@@ -206,6 +207,7 @@ export const createNumericInput =
       onChange = () => {},
       disabledOverride,
       endAdornmentOverride,
+      overrideDoseDisplay,
       sx = {},
     } = options;
 
@@ -215,7 +217,9 @@ export const createNumericInput =
         representation={commonProps.representation}
         unitName={commonProps.unitName}
         showExtraFields={commonProps.showExtraFields}
-        displayVaccinesInDoses={commonProps.displayVaccinesInDoses}
+        displayVaccinesInDoses={
+          overrideDoseDisplay ?? commonProps.displayVaccinesInDoses
+        }
         disabled={disabledOverride ?? commonProps.disabled}
         label={t(label)}
         value={value ?? 0}

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -136,6 +136,7 @@ export const ResponseLineEdit = ({
             {numericInput('label.days-out-of-stock', draft?.daysOutOfStock, {
               onChange: value => update({ daysOutOfStock: value }),
               endAdornmentOverride: t('label.days'),
+              overrideDoseDisplay: false,
             })}
           </>
         )}
@@ -303,6 +304,7 @@ export const ResponseLineEdit = ({
               sx: {
                 mb: 0,
               },
+              overrideDoseDisplay: false,
             })}
           </>
         ) : null}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8497 

# 👩🏻‍💻 What does this PR do?
Hide doses display for days out of stock and months of stock

<img width="384" height="254" alt="Screenshot 2025-07-17 at 8 46 00 AM" src="https://github.com/user-attachments/assets/46a70675-2dec-4521-bd9b-3375ea895de8" />

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to internal order -> add lines (make sure lines have consumption, and you have civ plugin)
- [ ] Shouldn't see doses helper for days out of stock or months of stock
- [ ] Go to requisition -> add lines -> enter values in every cell -> days out of stock and months of stock shouldn't have doses helper

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

