### PR TITLE
8487 VVM status set to first status level by default on an Inbound Shipment

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/utils.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/utils.tsx
@@ -95,6 +95,9 @@ export const vvmStatusesColumn = (
   label: 'label.vvm-status',
   width: 170,
   Cell: VVMStatusInputCell,
+  cellProps: {
+    useDefault: true,
+  },
   accessor: ({ rowData }) => rowData.vvmStatusId,
   setter: updateDraftLine,
 });

--- a/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusInputCell.tsx
+++ b/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusInputCell.tsx
@@ -8,6 +8,9 @@ export const VVMStatusInputCell = <T extends RecordWithId>({
   isDisabled,
   useDefault = false,
 }: CellProps<T> & { useDefault?: boolean }) => {
+  const [defaultVal, setDefaultVal] = React.useState<string | undefined>(
+    undefined
+  );
   const selectedId = column.accessor({
     rowData,
   }) as string | null;
@@ -16,12 +19,17 @@ export const VVMStatusInputCell = <T extends RecordWithId>({
     column.setter({ ...rowData, vvmStatusId });
   };
 
+  if (useDefault && defaultVal && !selectedId) {
+    column.setter({ ...rowData, vvmStatusId: defaultVal });
+  }
+
   return (
     <VVMStatusSearchInput
       disabled={!!isDisabled}
       selectedId={selectedId}
       onChange={onChange}
       useDefault={useDefault}
+      setDefaultVal={setDefaultVal}
     />
   );
 };

--- a/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusInputCell.tsx
+++ b/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusInputCell.tsx
@@ -7,7 +7,7 @@ export const VVMStatusInputCell = <T extends RecordWithId>({
   column,
   isDisabled,
   useDefault = false,
-}: CellProps<T>) => {
+}: CellProps<T> & { useDefault?: boolean }) => {
   const selectedId = column.accessor({
     rowData,
   }) as string | null;

--- a/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusInputCell.tsx
+++ b/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusInputCell.tsx
@@ -6,6 +6,7 @@ export const VVMStatusInputCell = <T extends RecordWithId>({
   rowData,
   column,
   isDisabled,
+  useDefault = false,
 }: CellProps<T>) => {
   const selectedId = column.accessor({
     rowData,
@@ -20,6 +21,7 @@ export const VVMStatusInputCell = <T extends RecordWithId>({
       disabled={!!isDisabled}
       selectedId={selectedId}
       onChange={onChange}
+      useDefault={useDefault}
     />
   );
 };

--- a/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
+++ b/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
@@ -11,6 +11,7 @@ interface VVMStatusSearchInputProps {
   onChange: (variantId: string | null) => void;
   disabled?: boolean;
   width?: number | string;
+  useDefault?: boolean;
 }
 
 export const VVMStatusSearchInput = ({
@@ -18,6 +19,7 @@ export const VVMStatusSearchInput = ({
   width,
   onChange,
   disabled,
+  useDefault = false,
 }: VVMStatusSearchInputProps) => {
   const t = useTranslation();
   const { data, isLoading } = useVvmStatusesEnabled();
@@ -28,9 +30,13 @@ export const VVMStatusSearchInput = ({
     id: status?.id,
     code: status?.code,
     description: status?.description,
+    level: status?.level,
   }));
 
   const selected = options.find(option => option.id === selectedId) ?? null;
+  const defaultOption = useDefault
+    ? (options.find(option => option.level === 1) ?? null)
+    : null;
 
   return (
     <Tooltip title={selected?.description ?? ''} placement="top">
@@ -38,7 +44,7 @@ export const VVMStatusSearchInput = ({
         disabled={disabled}
         width="100%"
         popperMinWidth={Math.min(Number(width), 200)}
-        value={selected ?? null}
+        value={selected ?? defaultOption}
         loading={isLoading}
         onChange={(_, option) => onChange(option?.id ?? null)}
         options={options}

--- a/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
+++ b/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
@@ -48,7 +48,6 @@ export const VVMStatusSearchInput = ({
     <Tooltip title={selected?.description ?? ''} placement="top">
       <Autocomplete
         disabled={disabled}
-        width="100%"
         popperMinWidth={Math.min(Number(width), 200)}
         value={selected ?? defaultOption}
         loading={isLoading}
@@ -57,7 +56,10 @@ export const VVMStatusSearchInput = ({
         getOptionLabel={option => option.description ?? ''}
         noOptionsText={t('messages.no-vvm-statuses')}
         isOptionEqualToValue={(option, value) => option.id === value?.id}
-        clearable={false} // VVM status shouldn't be cleared once set
+        clearable={false}
+        sx={{
+          width: '100%',
+        }}
       />
     </Tooltip>
   );

--- a/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
+++ b/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
@@ -37,11 +37,11 @@ export const VVMStatusSearchInput = ({
   if (!data) return null;
 
   const options: VvmStatusOption[] = data.map((status: VvmStatusFragment) => ({
-    id: status?.id,
-    code: status?.code,
-    description: status?.description,
-    level: status?.level,
-    unusable: status?.unusable,
+    id: status.id,
+    code: status.code,
+    description: status.description,
+    level: status.level,
+    unusable: status.unusable,
   }));
 
   const selected = options.find(option => option.id === selectedId) ?? null;

--- a/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
+++ b/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
@@ -12,7 +12,7 @@ interface VVMStatusSearchInputProps {
   disabled?: boolean;
   width?: number | string;
   useDefault?: boolean;
-  setDefaultVal: (defaultValue: string) => void;
+  setDefaultVal?: (defaultValue: string) => void;
 }
 
 export const VVMStatusSearchInput = ({
@@ -40,7 +40,7 @@ export const VVMStatusSearchInput = ({
     ? options.find(option => option.level === 1)
     : null;
 
-  if (useDefault && defaultOption) {
+  if (useDefault && defaultOption && setDefaultVal) {
     setDefaultVal(defaultOption.id);
   }
 

--- a/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
+++ b/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
@@ -12,6 +12,7 @@ interface VVMStatusSearchInputProps {
   disabled?: boolean;
   width?: number | string;
   useDefault?: boolean;
+  setDefaultVal: (defaultValue: string) => void;
 }
 
 export const VVMStatusSearchInput = ({
@@ -19,6 +20,7 @@ export const VVMStatusSearchInput = ({
   width,
   onChange,
   disabled,
+  setDefaultVal,
   useDefault = false,
 }: VVMStatusSearchInputProps) => {
   const t = useTranslation();
@@ -37,6 +39,10 @@ export const VVMStatusSearchInput = ({
   const defaultOption = useDefault
     ? options.find(option => option.level === 1)
     : null;
+
+  if (useDefault && defaultOption) {
+    setDefaultVal(defaultOption.id);
+  }
 
   return (
     <Tooltip title={selected?.description ?? ''} placement="top">

--- a/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
+++ b/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
@@ -35,7 +35,7 @@ export const VVMStatusSearchInput = ({
 
   const selected = options.find(option => option.id === selectedId) ?? null;
   const defaultOption = useDefault
-    ? (options.find(option => option.level === 1) ?? null)
+    ? options.find(option => option.level === 1)
     : null;
 
   return (

--- a/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
+++ b/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
@@ -6,6 +6,14 @@ import {
 } from '@openmsupply-client/common';
 import { useVvmStatusesEnabled, VvmStatusFragment } from '../../api';
 
+type VvmStatusOption = {
+  id: string;
+  code: string;
+  description: string;
+  level: number;
+  unusable: boolean;
+};
+
 interface VVMStatusSearchInputProps {
   selectedId: string | null;
   onChange: (variantId: string | null) => void;
@@ -28,17 +36,16 @@ export const VVMStatusSearchInput = ({
 
   if (!data) return null;
 
-  const options = data.map((status: VvmStatusFragment) => ({
+  const options: VvmStatusOption[] = data.map((status: VvmStatusFragment) => ({
     id: status?.id,
     code: status?.code,
     description: status?.description,
     level: status?.level,
+    unusable: status?.unusable,
   }));
 
   const selected = options.find(option => option.id === selectedId) ?? null;
-  const defaultOption = useDefault
-    ? options.find(option => option.level === 1)
-    : null;
+  const defaultOption = useDefault ? getHighestVvmStatusLevel(options) : null;
 
   if (useDefault && defaultOption && setDefaultVal) {
     setDefaultVal(defaultOption.id);
@@ -63,4 +70,10 @@ export const VVMStatusSearchInput = ({
       />
     </Tooltip>
   );
+};
+
+const getHighestVvmStatusLevel = (statuses: VvmStatusOption[]) => {
+  const usableStatuses = statuses.filter(status => !status.unusable);
+  usableStatuses.sort((a, b) => b.level - a.level);
+  return usableStatuses[usableStatuses.length - 1];
 };

--- a/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
+++ b/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
@@ -74,6 +74,6 @@ export const VVMStatusSearchInput = ({
 
 const getHighestVvmStatusLevel = (statuses: VvmStatusOption[]) => {
   const usableStatuses = statuses.filter(status => !status.unusable);
-  usableStatuses.sort((a, b) => b.level - a.level);
+  usableStatuses.sort((a, b) => a.level - b.level);
   return usableStatuses[usableStatuses.length - 1];
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8487 

# 👩🏻‍💻 What does this PR do?
Defaults vvm status to first vvm status for Inbound Shipment. Having a prop passed in since the cell will be re-used in Outbound Shipment.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have VVM statuses set up in OG
- [ ] Have `Manage VVM status` pref on
- [ ] Create an Inbound Shipment
- [ ] Add vaccine line -> should have 1st vvm status level pre-populated and saved
- [ ] Create an OS with vaccine line with vvm status -> transfer 
- [ ] Go to Store B click on IS -> vaccine line -> vvm status should be the same as the OS line

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

