### PR TITLE
8415 improve report excel export performance

### DIFF
--- a/server/service/src/report/convert_to_excel.rs
+++ b/server/service/src/report/convert_to_excel.rs
@@ -192,7 +192,7 @@ fn apply_data_rows(
 
     for row in body.rows_and_cells().into_iter() {
         // Insert new row below (leave any footer from the excel template in place)
-        sheet.insert_new_row(&(row_idx + 1), &1);
+        // sheet.insert_new_row(&(row_idx + 1), &1);
 
         // Duplicate any formulae/formatting to the next row before populating
         for col in 0..sheet.get_highest_column() {

--- a/server/service/src/report/convert_to_excel.rs
+++ b/server/service/src/report/convert_to_excel.rs
@@ -619,6 +619,9 @@ mod report_to_excel_test {
             .unwrap()
             .unwrap();
 
+        // Note: this was tested on a M3 Macbook Pro and took around 1.6s. If your testing environment
+        // is significantly slower it may fail this assertion! Just make it bigger... for lack of an
+        // elegant way of scaling based on hardware info ;)
         assert!(
             duration_millisec < 5000,
             "Generate to excel should be FAST. Took: {}ms",

--- a/server/service/src/report/convert_to_excel.rs
+++ b/server/service/src/report/convert_to_excel.rs
@@ -189,11 +189,13 @@ fn apply_data_rows(
     index_to_column_index_map: &HashMap<u32, u32>,
 ) -> u32 {
     let mut row_idx = row_index;
+    let body_rows = body.rows_and_cells();
+    let rows_len = body_rows.len() as u32;
 
-    for row in body.rows_and_cells().into_iter() {
-        // Insert new row below (leave any footer from the excel template in place)
-        // sheet.insert_new_row(&(row_idx + 1), &1);
+    // Insert new rows below (leave any footer from the excel template in place)
+    sheet.insert_new_row(&(row_idx + 1), &rows_len);
 
+    for row in body_rows.into_iter() {
         // Duplicate any formulae/formatting to the next row before populating
         for col in 0..sheet.get_highest_column() {
             let col = col + 1;
@@ -604,12 +606,164 @@ mod report_to_excel_test {
 
         let start = std::time::Instant::now();
         apply_report(sheet, report);
-        let duration_secs = start.elapsed().as_secs();
-
+        let duration_secs = start.elapsed().as_millis();
+        dbg!(&duration_secs);
         assert!(
-            duration_secs < 5,
-            "Generate to excel should be FAST. Took: {}",
+            duration_secs < 5000,
+            "Generate to excel should be FAST. Took: {}ms",
             duration_secs
         );
+    }
+
+    #[test]
+    fn test_generate_excel_with_template() {
+        // Create a template Excel file with header and footer
+        let mut template_book = umya_spreadsheet::new_file();
+        template_book.set_sheet_name(0, "Report Template").unwrap();
+        let template_sheet = template_book
+            .get_sheet_by_name_mut("Report Template")
+            .unwrap();
+
+        // Add template header content
+        template_sheet
+            .get_cell_mut("A1")
+            .set_value("Company Report")
+            .get_style_mut()
+            .get_font_mut()
+            .set_bold(true);
+
+        template_sheet
+            .get_cell_mut("A2")
+            .set_value("Generated on: [Date]");
+
+        // Add template footer content (assume data ends around row 20, footer starts at row 22)
+        template_sheet
+            .get_cell_mut("A10")
+            .set_value("End of Report")
+            .get_style_mut()
+            .get_font_mut()
+            .set_bold(true);
+
+        template_sheet
+            .get_cell_mut("A11")
+            .set_value("Company Footer Info");
+
+        // Convert template to bytes (simulate how it would come from file storage)
+        let temp_path = "/tmp/test_template.xlsx";
+        umya_spreadsheet::writer::xlsx::write(&template_book, temp_path).unwrap();
+        let template_bytes = std::fs::read(temp_path).unwrap();
+
+        // Create HTML report with 10 rows of data
+        let mut data_rows = String::new();
+        for i in 1..=10 {
+            data_rows += &format!(
+                r#"<tr>
+                    <td>Item {}</td>
+                    <td>Unit {}</td>
+                    <td>{}.00</td>
+                </tr>"#,
+                i,
+                i,
+                i * 10
+            );
+        }
+
+        let report = GeneratedReport {
+            document: format!(
+                r#"<table excel-table-start-row="5">
+                    <thead>
+                        <tr>
+                            <th>Product</th>
+                            <th>Unit</th>
+                            <th>Price</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {}
+                        <tr excel-type="total-row">
+                            <td></td>
+                            <td>Total:</td>
+                            <td>550.00</td>
+                        </tr>
+                    </tbody>
+                </table>"#,
+                data_rows
+            ),
+            header: Some(r#"<div excel-cell="C2">Report Date: 2025-07-17</div>"#.to_string()),
+            footer: None,
+        };
+
+        // Test the full export function with template
+        let result = export_html_report_to_excel(
+            &None, // base_dir
+            report,
+            "test_with_template".to_string(),
+            &Some(template_bytes),
+        );
+
+        assert!(result.is_ok(), "Export should succeed with template");
+        let file_id = result.unwrap();
+
+        // Read back the generated file to verify content
+        let file_service = StaticFileService::new(&None).unwrap();
+        let generated_file = file_service
+            .find_file(&file_id, StaticFileCategory::Temporary)
+            .unwrap()
+            .unwrap();
+        let generated_book = umya_spreadsheet::reader::xlsx::read(&generated_file.path).unwrap();
+        let sheet = generated_book.get_sheet(&0).unwrap();
+
+        let get_value = |coord: &str| {
+            sheet
+                .get_cell(coord)
+                .map(|c| c.get_raw_value().to_string())
+                .unwrap_or_default()
+        };
+
+        let is_bold = |coord: &str| {
+            sheet
+                .get_cell(coord)
+                .and_then(|c| c.get_style().get_font())
+                .map(|f| *f.get_bold())
+                .unwrap_or(false)
+        };
+
+        // Verify original template header is preserved
+        assert_eq!(get_value("A1"), "Company Report");
+        assert!(is_bold("A1"), "Template header should remain bold");
+        assert_eq!(get_value("A2"), "Generated on: [Date]");
+
+        // Verify custom header from HTML was inserted
+        assert_eq!(get_value("C2"), "Report Date: 2025-07-17");
+
+        // Verify data table headers start at the specified row (5)
+        assert_eq!(get_value("A5"), "Product");
+        assert_eq!(get_value("B5"), "Unit");
+        assert_eq!(get_value("C5"), "Price");
+        assert!(is_bold("A5"), "Data headers should be bold");
+
+        // Verify first few data rows
+        assert_eq!(get_value("A6"), "Item 1");
+        assert_eq!(get_value("B6"), "Unit 1");
+        assert_eq!(get_value("C6"), "10"); // Note: Excel may strip trailing zeros
+
+        assert_eq!(get_value("A10"), "Item 5");
+
+        // Item 9 should be at row 14 (5 + 1 header + 8 data rows)
+        assert_eq!(get_value("A14"), "Item 9");
+        assert_eq!(get_value("C14"), "90"); // Item 9
+
+        // Verify total row (should be at row 17: 5 + 1 header + 10 data + 1 blank)
+        assert_eq!(get_value("B17"), "Total:");
+        assert_eq!(get_value("C17"), "550"); // Note: Excel may strip trailing zeros
+        assert!(is_bold("B17"), "Total row should be bold");
+
+        // Verify template footer is preserved
+        assert_eq!(get_value("A20"), "End of Report");
+        assert!(is_bold("A20"), "Template footer should remain bold");
+        assert_eq!(get_value("A21"), "Company Footer Info");
+
+        // Clean up temp file
+        std::fs::remove_file(temp_path).ok();
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8415 

# 👩🏻‍💻 What does this PR do?

Before:
100 rows: 0.12s
1000 rows: 9.5s
10000 rows: 1123s 
![flamegraph_before](https://github.com/user-attachments/assets/a56fdb08-a5d3-4b2e-b8a1-1bc938080b1b)

It appears the vast majority of time is `Worksheet::insert_new_row()`. Perhaps quadratic if not exponential big O as for every row added I am guessing it executes `rebuild_map_and_indicies`, as the sheet grows this gets slower. Oof. Soooo I removed it:

After: 10000 rows 1.6s
![flamegraph](https://github.com/user-attachments/assets/805b0929-baf6-4d0a-8829-a9032d494cfc)

(note our `apply_data_rows` is now a very minor player, and most of the time is in `scraper` code parsing the html rather than `umya` building the spreadsheet)

This appears to work correctly for item usage report which just does default direct mapping of html to excel, however I expect the current change to break footers if using a xlsx template. The intent with the insert rows is to push the footer rows of the template down. 

Turns out you can just `insert_new_row` with second parameter being how many rows to add, so you only really need to call it once. So now:

10000 rows: 1.6s (crudely timed maybe 50ms slower than without adding rows at all)
![flamegraph](https://github.com/user-attachments/assets/e4048360-c752-4453-8260-800ab4e8f296)

Virtually identical to not adding rows at all, but respects the excel template footer by pushing it down.

## 💌 Any notes for the reviewer?

So ya like flamegraphs? I spent the morning figuring out how to get a cli tool working on a particular test so you don't have to:

```sh
cargo install flamegraph
```
https://github.com/flamegraph-rs/flamegraph

```sh
cargo flamegraph --dev --unit-test service -- report::convert_to_excel::report_to_excel_test::test_generate_excel_perf
```

(Note, I'm using --dev cause otherwise it compiles release which takes forever. If you were flamegraphing the actual OMS server while running you might benefit from running release binary.)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] OMS site with 4000+ items
- [ ] item usage report takes <1min (definitely not 5mins+)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  3.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [x] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [x] Postgres
- [x] SQLite
- [x] Frontend

