### PR TITLE
Fix vaccine card returns that were over-ridding stock and packsize

### DIFF
--- a/server/service/src/invoice_line/stock_in_line/insert/generate.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/generate.rs
@@ -50,7 +50,7 @@ pub fn generate(
         StockInType::InventoryAddition => false,
         // For customer returns, we only want to overwrite stock levels if the stock line does't already exist
         StockInType::CustomerReturn => old_stock_line.is_none(),
-        // For inbound shipments, we always create a new stock line, never update an existing one, so shouldn't overwrite stock levels based on the invoice when adding stock
+        // For inbound shipments, we always create a new stock line, never update an existing one, so should overwrite stock levels based on the invoice when adding stock
         StockInType::InboundShipment => true,
     };
 

--- a/server/service/src/invoice_line/stock_in_line/insert/generate.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/generate.rs
@@ -36,7 +36,16 @@ pub fn generate(
 
     let mut new_line = generate_line(input.clone(), item_row, existing_invoice_row.clone()); // include vvm status here
 
-    if StockInType::InventoryAddition != input.r#type && store_preferences.pack_to_one {
+    let should_overwrite_stock_levels = match &input.r#type {
+        // Even though we're `inserting` here, if a stock line already exists, we want to add to the existing quantity rather than replace it.
+        // for inventory adjustments and customer returns, the invoice only records the new additional stock to add to the stock line
+        StockInType::InventoryAddition => false,
+        StockInType::CustomerReturn => false,
+        // For inbound shipments, we always create a new stock line, never update an existing one, so shouldn't overwrite stock levels based on the invoice when adding stock
+        StockInType::InboundShipment => true,
+    };
+
+    if should_overwrite_stock_levels && store_preferences.pack_to_one {
         new_line = convert_invoice_line_to_single_pack(new_line);
     }
 
@@ -53,11 +62,7 @@ pub fn generate(
                     supplier_link_id: existing_invoice_row.name_link_id.clone(),
                     on_hold: input.stock_on_hold,
                     barcode_id: barcode_option.clone().map(|b| b.id.clone()),
-                    overwrite_stock_levels: match &input.r#type {
-                        // adjusting existing stock, we want to add to existing stock levels
-                        StockInType::InventoryAddition => false,
-                        _ => true,
-                    },
+                    overwrite_stock_levels: should_overwrite_stock_levels,
                 },
             )?;
 

--- a/server/service/src/invoice_line/stock_in_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/mod.rs
@@ -440,7 +440,6 @@ mod test {
         assert_eq!(stock_line.barcode_id, Some(barcode.barcode_row.id));
 
         // pack to one preference is set
-        // Pack size to one shouldn't affect customer returns they'll stay in the same pack size
         let pack_to_one = StorePreferenceRow {
             id: mock_store_b().id,
             pack_to_one: true,
@@ -473,9 +472,9 @@ mod test {
             inline_edit(&inbound_line, |mut u| {
                 u.id = "new_invoice_line_pack_to_one".to_string();
                 u.item_link_id = mock_item_a().id;
-                u.pack_size = 10.0;
-                u.number_of_packs = 20.0;
-                u.sell_price_per_pack = 100.0;
+                u.pack_size = 1.0;
+                u.number_of_packs = 200.0;
+                u.sell_price_per_pack = 10.0;
                 u
             })
         );

--- a/server/service/src/invoice_line/stock_in_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/mod.rs
@@ -440,6 +440,7 @@ mod test {
         assert_eq!(stock_line.barcode_id, Some(barcode.barcode_row.id));
 
         // pack to one preference is set
+        // Pack size to one shouldn't affect customer returns they'll stay in the same pack size
         let pack_to_one = StorePreferenceRow {
             id: mock_store_b().id,
             pack_to_one: true,
@@ -472,9 +473,9 @@ mod test {
             inline_edit(&inbound_line, |mut u| {
                 u.id = "new_invoice_line_pack_to_one".to_string();
                 u.item_link_id = mock_item_a().id;
-                u.pack_size = 1.0;
-                u.number_of_packs = 200.0;
-                u.sell_price_per_pack = 10.0;
+                u.pack_size = 10.0;
+                u.number_of_packs = 20.0;
+                u.sell_price_per_pack = 100.0;
                 u
             })
         );

--- a/server/service/src/vaccination/insert/mod.rs
+++ b/server/service/src/vaccination/insert/mod.rs
@@ -129,10 +129,7 @@ impl From<InsertStockOutLineError> for InsertVaccinationError {
 }
 impl From<UpdatePrescriptionError> for InsertVaccinationError {
     fn from(error: UpdatePrescriptionError) -> Self {
-        InsertVaccinationError::InternalError(format!(
-            "Could not finalise prescription: {:?}",
-            error
-        ))
+        InsertVaccinationError::InternalError(format!("Could not update prescription: {:?}", error))
     }
 }
 

--- a/server/service/src/vaccination/update/generate.rs
+++ b/server/service/src/vaccination/update/generate.rs
@@ -108,14 +108,13 @@ fn generate_not_given(
 
     let cancel_prescription = if update_transactions {
         existing_prescription.map(|p| CancelPrescription {
-            prescription_id: p.prescription_line.invoice_line_row.id.clone(),
+            prescription_id: p.prescription_line.invoice_row.id.clone(),
         })
     } else {
         None
     };
 
     // clear given status, item/transaction ids, apply reason
-
     let vaccination = VaccinationRow {
         given: false,
         given_store_id: None,

--- a/server/service/src/vaccination/update/mod.rs
+++ b/server/service/src/vaccination/update/mod.rs
@@ -135,10 +135,7 @@ impl From<InsertStockOutLineError> for UpdateVaccinationError {
 }
 impl From<UpdatePrescriptionError> for UpdateVaccinationError {
     fn from(error: UpdatePrescriptionError) -> Self {
-        UpdateVaccinationError::InternalError(format!(
-            "Could not finalise prescription: {:?}",
-            error
-        ))
+        UpdateVaccinationError::InternalError(format!("Could not update prescription: {:?}", error))
     }
 }
 

--- a/server/service/src/vaccination/update/mod.rs
+++ b/server/service/src/vaccination/update/mod.rs
@@ -1,14 +1,12 @@
 use crate::{
     activity_log::activity_log_entry,
     invoice::{
-        customer_return::{
-            insert::{insert_customer_return, InsertCustomerReturnError},
-            update_customer_return, UpdateCustomerReturnError,
-        },
-        insert_prescription, update_prescription, InsertPrescriptionError, UpdatePrescriptionError,
+        insert_prescription, update_prescription, InsertPrescriptionError, UpdatePrescription,
+        UpdatePrescriptionError, UpdatePrescriptionStatus,
     },
     invoice_line::stock_out_line::{insert_stock_out_line, InsertStockOutLineError},
     service_provider::ServiceContext,
+    vaccination::update::generate::CancelPrescription,
     NullableUpdate,
 };
 
@@ -18,7 +16,7 @@ use repository::{ActivityLogType, RepositoryError, Vaccination, VaccinationRowRe
 mod generate;
 mod validate;
 
-use generate::{generate, CreateCustomerReturn, GenerateResult};
+use generate::{generate, GenerateResult};
 use validate::validate;
 
 use super::{generate::CreatePrescription, query::get_vaccination};
@@ -68,7 +66,7 @@ pub fn update_vaccination(
 
             let GenerateResult {
                 vaccination,
-                create_customer_return,
+                cancel_prescription,
                 create_prescription,
             } = generate(store_id, validate_result, input.clone());
 
@@ -76,15 +74,16 @@ pub fn update_vaccination(
             VaccinationRowRepository::new(connection).upsert_one(&vaccination)?;
 
             // Reverse existing prescription if needed
-            if let Some(CreateCustomerReturn {
-                create_return,
-                finalise_return,
-            }) = create_customer_return
-            {
-                // Create customer return (in NEW status, with line)
-                insert_customer_return(ctx, create_return)?;
-                // Finalise, reintroducing stock, and add comment
-                update_customer_return(ctx, finalise_return)?;
+            // NOTE: We reverse the whole prescription so if in the future we want to reverse just some lines on the prescription this logic might need to change
+            if let Some(CancelPrescription { prescription_id }) = cancel_prescription {
+                update_prescription(
+                    ctx,
+                    UpdatePrescription {
+                        id: prescription_id,
+                        status: Some(UpdatePrescriptionStatus::Cancelled),
+                        ..Default::default()
+                    },
+                )?;
             }
 
             // Create new prescription if needed
@@ -119,23 +118,6 @@ pub fn update_vaccination(
 impl From<RepositoryError> for UpdateVaccinationError {
     fn from(error: RepositoryError) -> Self {
         UpdateVaccinationError::DatabaseError(error)
-    }
-}
-
-impl From<InsertCustomerReturnError> for UpdateVaccinationError {
-    fn from(error: InsertCustomerReturnError) -> Self {
-        UpdateVaccinationError::InternalError(format!(
-            "Could not create customer return: {:?}",
-            error
-        ))
-    }
-}
-impl From<UpdateCustomerReturnError> for UpdateVaccinationError {
-    fn from(error: UpdateCustomerReturnError) -> Self {
-        UpdateVaccinationError::InternalError(format!(
-            "Could not finalise customer return: {:?}",
-            error
-        ))
     }
 }
 impl From<InsertPrescriptionError> for UpdateVaccinationError {
@@ -625,7 +607,8 @@ mod update {
         assert_eq!(created_invoices.len(), 2);
         assert!(created_invoices
             .iter()
-            .any(|inv| inv.invoice_row.r#type == InvoiceType::CustomerReturn));
+            .any(|inv| inv.invoice_row.r#type == InvoiceType::Prescription
+                && inv.invoice_row.is_cancellation));
 
         // Check new stock was introduced
         let stock_line = StockLineRowRepository::new(&context.connection)
@@ -685,7 +668,8 @@ mod update {
         assert_eq!(created_invoices.len(), 2);
         assert!(created_invoices
             .iter()
-            .any(|inv| inv.invoice_row.r#type == InvoiceType::CustomerReturn));
+            .any(|inv| inv.invoice_row.r#type == InvoiceType::Prescription
+                && inv.invoice_row.is_cancellation));
 
         // Check stock was re-introduced
         let stock_line = StockLineRowRepository::new(&context.connection)

--- a/server/service/src/vaccination/update/validate.rs
+++ b/server/service/src/vaccination/update/validate.rs
@@ -1,6 +1,6 @@
 use repository::{
     EqualFilter, InvoiceLine, InvoiceLineFilter, InvoiceLineRepository, ItemRow, RepositoryError,
-    StockLine, StockLineRow, StorageConnection, Vaccination, VaccinationRow,
+    StockLine, StorageConnection, Vaccination, VaccinationRow,
 };
 
 use crate::{
@@ -30,19 +30,17 @@ pub struct ChangeToGiven {
 
 pub struct ChangeToNotGiven {
     pub existing_vaccination: VaccinationRow,
-    pub patient_id: String,
-    pub existing_prescription: Option<PrescriptionAndStockLine>,
+    pub existing_prescription: Option<VaccinationPrescription>,
 }
 
-pub struct PrescriptionAndStockLine {
+pub struct VaccinationPrescription {
     pub prescription_line: InvoiceLine,
-    pub stock_line_row: StockLineRow,
 }
 
 pub struct ChangeStockLine {
     pub existing_vaccination: VaccinationRow,
     pub patient_id: String,
-    pub existing_prescription: Option<PrescriptionAndStockLine>,
+    pub existing_prescription: Option<VaccinationPrescription>,
     pub new_stock_line: Option<StockLine>,
 }
 
@@ -128,10 +126,8 @@ pub fn validate(
 
             ValidateResult::ChangeToNotGiven(ChangeToNotGiven {
                 existing_vaccination: vaccination_row.clone(),
-                patient_id: encounter.patient_link_id,
                 existing_prescription: validate_existing_prescription(
                     connection,
-                    store_id,
                     &vaccination_row.invoice_id,
                 )?,
             })
@@ -146,7 +142,6 @@ pub fn validate(
                     patient_id: encounter.patient_link_id,
                     existing_prescription: validate_existing_prescription(
                         connection,
-                        store_id,
                         &vaccination_row.invoice_id,
                     )?,
                     new_stock_line: validate_new_stock_line(
@@ -168,9 +163,8 @@ pub fn validate(
 
 fn validate_existing_prescription(
     connection: &StorageConnection,
-    store_id: &str,
     invoice_id: &Option<String>,
-) -> Result<Option<PrescriptionAndStockLine>, UpdateVaccinationError> {
+) -> Result<Option<VaccinationPrescription>, UpdateVaccinationError> {
     // Get prescription line
     let prescription_line = match invoice_id {
         Some(invoice_id) => {
@@ -182,19 +176,7 @@ fn validate_existing_prescription(
         None => return Ok(None),
     };
 
-    let stock_line = match prescription_line.stock_line_option.clone().map(|s| s.id) {
-        Some(stock_line_id) => {
-            let stock_line = check_stock_line_exists(connection, store_id, &stock_line_id)?;
-            check_doses_defined(&stock_line.item_row)?;
-            stock_line
-        }
-        None => return Err(UpdateVaccinationError::StockLineDoesNotExist),
-    };
-
-    Ok(Some(PrescriptionAndStockLine {
-        prescription_line,
-        stock_line_row: stock_line.stock_line_row,
-    }))
+    Ok(Some(VaccinationPrescription { prescription_line }))
 }
 
 fn validate_new_stock_line(


### PR DESCRIPTION

<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8530

# 👩🏻‍💻 What does this PR do?

Previously there was an exception for packsize to 1 preference were it wasn't applied using the add stock mechanism.
This what's applied to customer returns though, so even though the invoice said to return a single dose to the line, it actually over-wrote the packsize breaking the ledger..

Now we're using a canceled prescription to reverse the existing prescription instead of customer returns for vaccinations

## 💌 Any notes for the reviewer?

I've left in a change to the customer return with only over-writes customer returns when there's no existing stockline.
That is an extra db request though, so maybe better remove it?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Turn on packsize to 1 pref
- [ ] Add vaccine stock to the store with packsize > 1
- [ ] Create a vaccine encounter for a patient and give them the stock line created above
- [ ] (one dose should now have been removed from available stock)
- [ ] Update encounter to say the vaccine wasn't given and select the revert stock transation option
- [ ] Check that the single dose gets returned back to the stockline.
- [ ] Check that stock is update correctly with normal customer returns and inbound shipments.


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

