### PR TITLE
5061 invalidate translations on update

### DIFF
--- a/client/packages/common/src/intl/README.md
+++ b/client/packages/common/src/intl/README.md
@@ -20,4 +20,4 @@ Colocation of all helpers for working with translations & all localisation files
 
 Custom translations can be configured via a Global preference on OMS Central. These are then exposed via the rest endpoint `YOUR_SERVER_URL/custom-translations`. IntlContext has this endpoint configured as one of it's 'backends'.
 
-IntlStrings uses them via the `custom_preference_overrides` namespace which means custom translations take precedence over our defaults.
+IntlStrings uses them via the `CUSTOM_TRANSLATIONS_NAMESPACE` which means custom translations take precedence over our defaults.

--- a/client/packages/common/src/intl/README.md
+++ b/client/packages/common/src/intl/README.md
@@ -18,6 +18,6 @@ Colocation of all helpers for working with translations & all localisation files
 
 ## Custom Translation Overrides
 
-Custom translations can be configured via a Global preference on OMS Central. These are then exposed via the rest endpoint `YOUR_SERVER_URL/custom-translations`. IntlContext has this endpoint configured as one of it's 'backends'.
+Custom translations can be configured via a Global preference on OMS Central. These are then exposed via the REST endpoint `YOUR_SERVER_URL/custom-translations`. IntlContext has this endpoint configured as one of it's 'backends'.
 
 IntlStrings uses them via the `CUSTOM_TRANSLATIONS_NAMESPACE` which means custom translations take precedence over our defaults.

--- a/client/packages/common/src/intl/context/IntlContext.tsx
+++ b/client/packages/common/src/intl/context/IntlContext.tsx
@@ -14,6 +14,7 @@ const appVersion = require('../../../../../../package.json').version; // eslint-
 // Only for web, otherwise default to app version
 declare const LANG_VERSION: string;
 
+export const CUSTOM_TRANSLATIONS_NAMESPACE = 'custom-translations';
 const defaultNS = 'common';
 const minuteInMilliseconds = 60 * 1000;
 const isDevelopment = process.env['NODE_ENV'] === 'development';
@@ -63,9 +64,6 @@ export function initialiseI18n({
           {
             /* options for translation overrides backend (http api request) */
             loadPath: customTranslationsLoadPath,
-            queryStringParams: {
-              v: languageVersion,
-            },
           },
         ],
       },

--- a/client/packages/common/src/intl/strings/IntlStrings.ts
+++ b/client/packages/common/src/intl/strings/IntlStrings.ts
@@ -3,6 +3,7 @@ import { TOptions } from 'i18next';
 import { useTranslation as useTranslationNext } from 'react-i18next';
 import { LocaleKey } from '../locales';
 import { useIntl } from '../utils';
+import { CUSTOM_TRANSLATIONS_NAMESPACE } from '../context';
 
 export { UseTranslationResponse } from 'react-i18next';
 
@@ -15,7 +16,7 @@ export const useTranslation = (): TypedTFunction<LocaleKey> => {
   const { i18n } = useIntl();
   // Use custom namespace to apply Global Preference translation overrides.
   // Otherwise defaults to values in "common.json"
-  const { t } = useTranslationNext('custom_preference_overrides', { i18n });
+  const { t } = useTranslationNext(CUSTOM_TRANSLATIONS_NAMESPACE, { i18n });
 
   return useCallback(
     (key, opts) => {

--- a/client/packages/host/src/components/Sync/SyncModal.tsx
+++ b/client/packages/host/src/components/Sync/SyncModal.tsx
@@ -10,6 +10,7 @@ import {
   RadioIcon,
   Typography,
   UNDEFINED_STRING_VALUE,
+  CUSTOM_TRANSLATIONS_NAMESPACE,
   useAppTheme,
   useAuthContext,
   useFormatDateTime,
@@ -17,6 +18,7 @@ import {
   useQueryClient,
   useTranslation,
   useMediaQuery,
+  useIntl,
 } from '@openmsupply-client/common';
 import { useSync } from '@openmsupply-client/system';
 import { SyncProgress } from '../SyncProgress';
@@ -44,6 +46,7 @@ const useHostSync = (enabled: boolean) => {
   // true by default to wait for first syncStatus api result
   const [isLoading, setIsLoading] = useState(true);
   const queryClient = useQueryClient();
+  const { i18n } = useIntl();
 
   useEffect(() => {
     if (!syncStatus) {
@@ -59,6 +62,8 @@ const useHostSync = (enabled: boolean) => {
     } else {
       allowSleep();
       queryClient.invalidateQueries(); // refresh the page user is on after sync finishes
+      // Reload custom translations, in case we received new ones via sync
+      i18n.reloadResources(undefined, CUSTOM_TRANSLATIONS_NAMESPACE);
     }
   }, [syncStatus?.isSyncing]);
 

--- a/client/packages/system/src/Manage/Preferences/EditPage/EditPreference.tsx
+++ b/client/packages/system/src/Manage/Preferences/EditPage/EditPreference.tsx
@@ -10,6 +10,8 @@ import {
   useTranslation,
   useNotification,
   TextArea,
+  useIntl,
+  CUSTOM_TRANSLATIONS_NAMESPACE,
 } from '@openmsupply-client/common';
 import {
   EnumOptions,
@@ -22,11 +24,14 @@ export const EditPreference = ({
   disabled = false,
 }: {
   preference: PreferenceDescriptionNode;
-  update: (input: UpsertPreferencesInput[keyof UpsertPreferencesInput]) => void;
+  update: (
+    input: UpsertPreferencesInput[keyof UpsertPreferencesInput]
+  ) => Promise<void>;
   disabled?: boolean;
 }) => {
   const t = useTranslation();
   const { error } = useNotification();
+  const { i18n } = useIntl();
 
   // The preference.value only updates after mutation completes and cache
   // is invalidated - use local state for fast UI change
@@ -77,10 +82,14 @@ export const EditPreference = ({
     case PreferenceValueNodeType.CustomTranslations:
       return (
         <TextArea
-          onChange={e => {
+          onChange={async e => {
             const newValue = JSON.parse(e.target.value); // Validate JSON format
             setValue(newValue);
-            update(newValue);
+            await update(newValue);
+            // Note - this is still requires the component in question to
+            // re-render to pick up the new translations
+            // TODO: Could trigger full refresh on modal save?
+            i18n.reloadResources(undefined, CUSTOM_TRANSLATIONS_NAMESPACE);
           }}
           value={JSON.stringify(value)}
           maxRows={10}

--- a/client/packages/system/src/Name/ListView/Stores/EditStorePreferences.tsx
+++ b/client/packages/system/src/Name/ListView/Stores/EditStorePreferences.tsx
@@ -35,11 +35,11 @@ export const EditStorePreferences = ({ storeId }: { storeId: string }) => {
           <EditPreference
             disabled={!isCentralServer}
             preference={pref}
-            update={value => {
+            update={value =>
               update({
                 [pref.key]: [{ storeId, value }],
-              });
-            }}
+              })
+            }
           />
         }
         sx={{


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Part 3 #5061

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

As you edit the global pref custom translations, invalidates the cached values so they are re-queried from the backend.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

Note - translations aren't considered props to a component, so invalidating them doesn't cause them to re-render. Translations will be applied the next time the component is re-rendered.

When we do modal for entering translations, could consider refreshing the page on save? Not sure about on sync... 

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] OMS central > Global prefs
- [ ] Add/edit a translation
- [ ] Go to the page where that translation applies (without refreshing the page)
- [ ] See custom translation applied
- [ ] Have a remote site, sync
- [ ] Go to the page
- [ ] See custom translation

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

