### PR TITLE
8245 delete purchase order line mutations

### DIFF
--- a/server/graphql/purchase_order_line/src/lib.rs
+++ b/server/graphql/purchase_order_line/src/lib.rs
@@ -1,15 +1,14 @@
 mod purchase_order_line_queries;
+use crate::mutations::{
+    delete::{delete_purchase_order_line, DeleteInput, DeleteResponse},
+    insert::{insert_purchase_order_line, InsertInput, InsertResponse},
+    update::{update_purchase_order_line, UpdateInput, UpdateResponse},
+};
 use async_graphql::{Context, Object, Result};
 use graphql_core::pagination::PaginationInput;
 
 pub mod mutations;
-
 use purchase_order_line_queries::*;
-
-use crate::mutations::{
-    insert::{insert_purchase_order_line, InsertInput, InsertResponse},
-    update::{update_purchase_order_line, UpdateInput, UpdateResponse},
-};
 
 #[derive(Default, Clone)]
 pub struct PurchaseOrderLineQueries;
@@ -58,5 +57,14 @@ impl PurchaseOrderLineMutations {
         input: UpdateInput,
     ) -> Result<UpdateResponse> {
         update_purchase_order_line(ctx, &store_id, input)
+    }
+
+    pub async fn delete_purchase_order_line(
+        &self,
+        ctx: &Context<'_>,
+        store_id: String,
+        input: DeleteInput,
+    ) -> Result<DeleteResponse> {
+        delete_purchase_order_line(ctx, &store_id, input)
     }
 }

--- a/server/graphql/purchase_order_line/src/mutations/delete.rs
+++ b/server/graphql/purchase_order_line/src/mutations/delete.rs
@@ -1,0 +1,91 @@
+use async_graphql::*;
+use graphql_core::{
+    simple_generic_errors::RecordNotFound,
+    standard_graphql_error::{validate_auth, StandardGraphqlError},
+    ContextExt,
+};
+use graphql_types::types::DeleteResponse as GenericDeleteResponse;
+use service::{
+    auth::{Resource, ResourceAccessRequest},
+    purchase_order_line::delete::DeletePurchaseOrderLineError as ServiceError,
+};
+
+#[derive(Interface)]
+#[graphql(name = "DeletePurchaseOrderLineInterface")]
+#[graphql(field(name = "description", ty = "String"))]
+pub enum DeleteErrorInterface {
+    RecordNotFound(RecordNotFound),
+}
+
+#[derive(SimpleObject)]
+#[graphql(name = "DeletePurchaseOrderLineError")]
+pub struct DeleteError {
+    pub error: DeleteErrorInterface,
+}
+
+#[derive(InputObject)]
+#[graphql(name = "DeletePurchaseOrderLineInput")]
+pub struct DeleteInput {
+    pub id: String,
+}
+
+impl DeleteInput {
+    pub fn to_domain(&self) -> String {
+        self.id.clone()
+    }
+}
+
+#[derive(Union)]
+#[graphql(name = "DeletePurchaseOrderLineResponse")]
+pub enum DeleteResponse {
+    Error(DeleteError),
+    Response(GenericDeleteResponse),
+}
+
+pub fn delete_purchase_order_line(
+    ctx: &Context<'_>,
+    store_id: &str,
+    input: DeleteInput,
+) -> Result<DeleteResponse> {
+    let user = validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::ServerAdmin, // Temporary permission for now
+            store_id: Some(store_id.to_string()),
+        },
+    )?;
+
+    let service_provider = ctx.service_provider();
+    let service_context = service_provider.context(store_id.to_string(), user.user_id)?;
+
+    map_response(
+        service_provider
+            .purchase_order_line_service
+            .delete_purchase_order_line(&service_context, input.to_domain()),
+    )
+}
+
+fn map_response(from: Result<String, ServiceError>) -> Result<DeleteResponse> {
+    let result = match from {
+        Ok(id) => DeleteResponse::Response(GenericDeleteResponse(id)),
+        Err(error) => DeleteResponse::Error(DeleteError {
+            error: map_error(error)?,
+        }),
+    };
+
+    Ok(result)
+}
+
+fn map_error(error: ServiceError) -> Result<DeleteErrorInterface> {
+    use StandardGraphqlError::*;
+    let formatted_error = format!("{:#?}", error);
+
+    let graphql_error = match error {
+        ServiceError::PurchaseOrderLineDoesNotExist => {
+            return Ok(DeleteErrorInterface::RecordNotFound(RecordNotFound {}))
+        }
+        ServiceError::DatabaseError(_) => InternalError(formatted_error),
+    };
+
+    Err(graphql_error.extend())
+}

--- a/server/graphql/purchase_order_line/src/mutations/mod.rs
+++ b/server/graphql/purchase_order_line/src/mutations/mod.rs
@@ -1,2 +1,3 @@
+pub mod delete;
 pub mod insert;
 pub mod update;

--- a/server/service/src/purchase_order_line/delete/mod.rs
+++ b/server/service/src/purchase_order_line/delete/mod.rs
@@ -1,0 +1,36 @@
+use repository::{PurchaseOrderLineRowRepository, RepositoryError};
+
+use crate::service_provider::ServiceContext;
+
+mod test;
+mod validate;
+use validate::validate;
+
+#[derive(PartialEq, Debug)]
+pub enum DeletePurchaseOrderLineError {
+    PurchaseOrderLineDoesNotExist,
+    DatabaseError(RepositoryError),
+}
+
+pub fn delete_purchase_order_line(
+    ctx: &ServiceContext,
+    id: String,
+) -> Result<String, DeletePurchaseOrderLineError> {
+    let purchase_order_line_id = ctx
+        .connection
+        .transaction_sync(|connection| {
+            validate(&id, connection)?;
+            match PurchaseOrderLineRowRepository::new(connection).delete(&id) {
+                Ok(_) => Ok(id),
+                Err(err) => Err(DeletePurchaseOrderLineError::from(err)),
+            }
+        })
+        .map_err(|error| error.to_inner_error())?;
+    Ok(purchase_order_line_id)
+}
+
+impl From<RepositoryError> for DeletePurchaseOrderLineError {
+    fn from(error: RepositoryError) -> Self {
+        DeletePurchaseOrderLineError::DatabaseError(error)
+    }
+}

--- a/server/service/src/purchase_order_line/delete/test.rs
+++ b/server/service/src/purchase_order_line/delete/test.rs
@@ -1,0 +1,62 @@
+#[cfg(test)]
+mod delete {
+    use repository::{
+        mock::{mock_item_a, mock_store_a, mock_user_account_a, MockDataInserts},
+        test_db::setup_all,
+    };
+
+    use crate::{
+        purchase_order_line::{
+            delete::DeletePurchaseOrderLineError, insert::InsertPurchaseOrderLineInput,
+        },
+        service_provider::ServiceProvider,
+    };
+
+    #[actix_rt::test]
+    async fn delete_purchase_order_line_errors() {
+        let (_, _, connection_manager, _) =
+            setup_all("delete_purchase_order_line_errors", MockDataInserts::all()).await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context(mock_store_a().id, mock_user_account_a().id)
+            .unwrap();
+
+        // PurchaseOrderLineNotFound
+        assert_eq!(
+            service_provider
+                .purchase_order_line_service
+                .delete_purchase_order_line(&context, "purchase_order_line_id_1".to_string()),
+            Err(DeletePurchaseOrderLineError::PurchaseOrderLineDoesNotExist)
+        );
+    }
+
+    #[actix_rt::test]
+    async fn delete_purchase_order_line_success() {
+        let (_, _, connection_manager, _) =
+            setup_all("delete_purchase_order_line_success", MockDataInserts::all()).await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider.basic_context().unwrap();
+        let service = service_provider.purchase_order_line_service;
+
+        // Create a purchase order line
+        service
+            .insert_purchase_order_line(
+                &context,
+                &mock_store_a().id,
+                InsertPurchaseOrderLineInput {
+                    id: "purchase_order_line_id_1".to_string(),
+                    purchase_order_id: "test_purchase_order_a".to_string(),
+                    item_id: mock_item_a().id.to_string(),
+                },
+            )
+            .unwrap();
+
+        let id = service
+            .delete_purchase_order_line(&context, "purchase_order_line_id_1".to_string())
+            .unwrap();
+
+        assert_eq!(id, "purchase_order_line_id_1");
+    }
+}

--- a/server/service/src/purchase_order_line/delete/validate.rs
+++ b/server/service/src/purchase_order_line/delete/validate.rs
@@ -1,0 +1,13 @@
+use repository::{PurchaseOrderLineRowRepository, StorageConnection};
+
+use crate::purchase_order_line::delete::DeletePurchaseOrderLineError;
+
+pub fn validate(
+    id: &str,
+    connection: &StorageConnection,
+) -> Result<(), DeletePurchaseOrderLineError> {
+    PurchaseOrderLineRowRepository::new(connection)
+        .find_one_by_id(id)?
+        .ok_or(DeletePurchaseOrderLineError::PurchaseOrderLineDoesNotExist)
+        .map(|_| ())
+}

--- a/server/service/src/purchase_order_line/mod.rs
+++ b/server/service/src/purchase_order_line/mod.rs
@@ -2,6 +2,7 @@ use self::query::{get_purchase_order_line, get_purchase_order_lines};
 pub mod query;
 use crate::{
     purchase_order_line::{
+        delete::{delete_purchase_order_line, DeletePurchaseOrderLineError},
         insert::{
             insert_purchase_order_line, InsertPurchaseOrderLineError, InsertPurchaseOrderLineInput,
         },
@@ -19,6 +20,7 @@ use repository::{
     RepositoryError,
 };
 
+pub mod delete;
 pub mod insert;
 pub mod update;
 
@@ -59,6 +61,14 @@ pub trait PurchaseOrderLineServiceTrait: Sync + Send {
         input: UpdatePurchaseOrderLineInput,
     ) -> Result<PurchaseOrderLine, UpdatePurchaseOrderLineInputError> {
         update_purchase_order_line(ctx, store_id, input)
+    }
+
+    fn delete_purchase_order_line(
+        &self,
+        ctx: &ServiceContext,
+        id: String,
+    ) -> Result<String, DeletePurchaseOrderLineError> {
+        delete_purchase_order_line(ctx, id)
     }
 }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8245

# 👩🏻‍💻 What does this PR do?

Delete mutation for Purchase Order Line

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->
Must have an existing PurchaseOrder and PurchaseOrderLine

- [ ] Navigate to GraphQL playground -> Mutations
- [ ] Write a mutation for UpdatePurchaseOrderLine -> Fill in desired values
- [ ] Should work if ID provided exists!
- [ ] Should return an error if ID provided doesn't exist

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

