### PR TITLE
Tweak purchase order columns and add derived delivery status

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2154,5 +2154,9 @@
   "warning.check-before-vaccinating": "Vaccination records from other stores may not be up to date. Ensure you have synced recently, and always confirm against the patient's physical vaccination card first.",
   "warning.field-not-parsed": "{{field}} not parsed",
   "warning.manual-store-requisition": "Entering a requisition for this store may result in duplicates if the store also submits an Internal Order.",
-  "warning.nothing-to-supply": "Nothing left to supply!"
+  "warning.nothing-to-supply": "Nothing left to supply!",
+  "label.not-delivered": "Not delivered",
+  "label.partially-delivered": "Partially delivered",
+  "label.fully-delivered": "Fully delivered",
+  "label.delivery-status": "Delivery Status"
 }

--- a/client/packages/host/src/components/Navigation/ReplenishmentNav.tsx
+++ b/client/packages/host/src/components/Navigation/ReplenishmentNav.tsx
@@ -47,13 +47,6 @@ export const ReplenishmentNav = ({
           <AppNavLink
             end
             to={RouteBuilder.create(AppRoute.Replenishment)
-              .addPart(AppRoute.PurchaseOrder)
-              .build()}
-            text={t('purchase-order')}
-          />
-          <AppNavLink
-            end
-            to={RouteBuilder.create(AppRoute.Replenishment)
               .addPart(AppRoute.InboundShipment)
               .build()}
             text={t('inbound-shipment')}

--- a/client/packages/purchase_orders/src/ListView/ListView.tsx
+++ b/client/packages/purchase_orders/src/ListView/ListView.tsx
@@ -18,7 +18,11 @@ import { PurchaseOrderRowFragment } from '../api/operations.generated';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
 import { Footer } from './Footer';
-import { getStatusTranslator } from '../utils';
+import {
+  DeliveryStatus,
+  getDeliveryStatusTranslator,
+  getStatusTranslator,
+} from '../utils';
 
 const ListView: FC = () => {
   const t = useTranslation();
@@ -98,10 +102,17 @@ const ListView: FC = () => {
         },
       ],
       {
-        key: 'targetMonths',
-        label: 'label.target-months',
-        // format: ColumnFormat.Date,
-        accessor: ({ rowData }) => rowData.targetMonths,
+        key: 'deliveryStatus',
+        label: 'label.delivery-status',
+        accessor: ({}) => DeliveryStatus.NotDelivered, // Todo: Replace with actual delivery status calculation once we have goods received data (add rowData back)
+        formatter: status =>
+          getDeliveryStatusTranslator(t)(status as DeliveryStatus),
+      },
+      {
+        key: 'expectedDeliveryDate',
+        label: 'label.expected-delivery-date',
+        format: ColumnFormat.Date,
+        accessor: ({ rowData }) => rowData.expectedDeliveryDatetime,
         sortable: true,
       },
       {
@@ -116,7 +127,7 @@ const ListView: FC = () => {
         label: 'label.lines',
         accessor: ({ rowData }) => rowData.lines.totalCount,
         maxWidth: 80,
-        // sortable: true,
+        sortable: false,
       },
       ['comment'],
     ],

--- a/client/packages/purchase_orders/src/api/operations.generated.ts
+++ b/client/packages/purchase_orders/src/api/operations.generated.ts
@@ -12,6 +12,7 @@ export type PurchaseOrderRowFragment = {
   status: Types.PurchaseOrderNodeStatus;
   targetMonths?: number | null;
   deliveredDatetime?: string | null;
+  expectedDeliveryDatetime?: string | null;
   comment?: string | null;
   supplier?: { __typename: 'NameNode'; id: string; name: string } | null;
   lines: { __typename: 'PurchaseOrderLineConnector'; totalCount: number };
@@ -117,6 +118,7 @@ export type PurchaseOrdersQuery = {
       status: Types.PurchaseOrderNodeStatus;
       targetMonths?: number | null;
       deliveredDatetime?: string | null;
+      expectedDeliveryDatetime?: string | null;
       comment?: string | null;
       supplier?: { __typename: 'NameNode'; id: string; name: string } | null;
       lines: { __typename: 'PurchaseOrderLineConnector'; totalCount: number };
@@ -216,6 +218,7 @@ export const PurchaseOrderRowFragmentDoc = gql`
     status
     targetMonths
     deliveredDatetime
+    expectedDeliveryDatetime
     lines {
       totalCount
     }

--- a/client/packages/purchase_orders/src/api/operations.graphql
+++ b/client/packages/purchase_orders/src/api/operations.graphql
@@ -12,6 +12,7 @@ fragment PurchaseOrderRow on PurchaseOrderNode {
   status
   targetMonths
   deliveredDatetime
+  expectedDeliveryDatetime
   lines {
     totalCount
   }

--- a/client/packages/purchase_orders/src/utils.ts
+++ b/client/packages/purchase_orders/src/utils.ts
@@ -8,11 +8,32 @@ const statusTranslation: Record<PurchaseOrderNodeStatus, LocaleKey> = {
   FINALISED: 'label.finalised',
 };
 
+export enum DeliveryStatus {
+  NotDelivered = 'NOT_DELIVERED',
+  PartiallyDelivered = 'PARTIALLY_DELIVERED',
+  FullyDelivered = 'FULLY_DELIVERED',
+}
+
+const deliveryStatusTranslation: Record<DeliveryStatus, LocaleKey> = {
+  NOT_DELIVERED: 'label.not-delivered',
+  PARTIALLY_DELIVERED: 'label.partially-delivered',
+  FULLY_DELIVERED: 'label.fully-delivered',
+};
+
 export const getStatusTranslator =
   (t: ReturnType<typeof useTranslation>) =>
   (currentStatus: PurchaseOrderNodeStatus): string => {
     return t(
       statusTranslation[currentStatus] ??
         statusTranslation[PurchaseOrderNodeStatus.New]
+    );
+  };
+
+export const getDeliveryStatusTranslator =
+  (t: ReturnType<typeof useTranslation>) =>
+  (currentStatus: DeliveryStatus): string => {
+    return t(
+      deliveryStatusTranslation[currentStatus] ??
+        deliveryStatusTranslation[DeliveryStatus.NotDelivered]
     );
   };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8216

# 👩🏻‍💻 What does this PR do?

<img width="1644" height="278" alt="image" src="https://github.com/user-attachments/assets/0a26923d-3bbd-455b-b280-57f23780cddb" />



- [x] Add Estimated Delivery date on the Purchase Order List View
- [x] Remove Target Months from List View
- [x] Add a New derived column showing a Delivery Status

Fully Delivered
Partially Delivered
Not Delivered

## 💌 Any notes for the reviewer?

I've added the delivery status column as requested but to calculate it we really need to know how many lines are fully delivered which requires goods received integration so can't be fully done yet.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Check you can see expected delivery date if set.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

