### PR TITLE
8007 can't select vvm status when adding new stock line

### DIFF
--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -32,6 +32,7 @@ import {
   DonorSearchInput,
   ReasonOptionRowFragment,
   ReasonOptionsSearchInput,
+  VVMStatusSearchInput,
 } from '../..';
 import { INPUT_WIDTH, StyledInputRow } from './StyledInputRow';
 import { ItemVariantInput, useIsItemVariantsEnabled } from '../../Item';
@@ -332,10 +333,14 @@ export const StockLineForm = ({
           {draft?.item?.isVaccine && preferences?.manageVvmStatusForStock && (
             <StyledInputRow
               label={t('label.vvm-status')}
+              labelWidth={isNewModal ? '212px' : null}
               Input={
-                <BufferedTextInput
-                  disabled
-                  value={draft.vvmStatus?.description ?? ''}
+                <VVMStatusSearchInput
+                  selected={draft?.vvmStatus ?? null}
+                  onChange={vvmStatus => onUpdate({ vvmStatus })}
+                  disabled={!isNewModal}
+                  width={!isNewModal ? 160 : undefined}
+                  useDefault
                 />
               }
             />

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -63,6 +63,7 @@ export const StockLineForm = ({
     PreferenceKey.AllowTrackingOfStockByDonor,
     PreferenceKey.ManageVaccinesInDoses,
     PreferenceKey.ManageVvmStatusForStock,
+    PreferenceKey.SortByVvmStatusThenExpiry,
     PreferenceKey.UseCampaigns
   );
 
@@ -70,6 +71,10 @@ export const StockLineForm = ({
     useBarcodeScannerContext();
   const showItemVariantsInput = useIsItemVariantsEnabled();
   const { plugins } = usePluginProvider();
+  const showVVMStatus =
+    draft?.item?.isVaccine &&
+    (preferences?.manageVvmStatusForStock ||
+      preferences?.sortByVvmStatusThenExpiry);
 
   const supplierName = draft.supplierName
     ? draft.supplierName
@@ -330,7 +335,7 @@ export const StockLineForm = ({
             text={String(supplierName)}
             textProps={{ textAlign: 'end' }}
           />
-          {draft?.item?.isVaccine && preferences?.manageVvmStatusForStock && (
+          {showVVMStatus && (
             <StyledInputRow
               label={t('label.vvm-status')}
               labelWidth={isNewModal ? '212px' : null}

--- a/client/packages/system/src/Stock/Components/StyledInputRow.tsx
+++ b/client/packages/system/src/Stock/Components/StyledInputRow.tsx
@@ -6,12 +6,16 @@ import {
 
 export const INPUT_WIDTH = 160;
 
-export const StyledInputRow = ({ label, Input }: InputWithLabelRowProps) => (
+export const StyledInputRow = ({
+  label,
+  Input,
+  labelWidth,
+}: InputWithLabelRowProps) => (
   <InputWithLabelRow
     label={label}
     Input={Input}
     labelProps={{ sx: { textAlign: 'end' } }}
-    labelWidth="100px"
+    labelWidth={labelWidth ?? '100px'}
     sx={{
       justifyContent: 'space-between',
       '.MuiFormControl-root > .MuiInput-root, > input': {

--- a/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusInputCell.tsx
+++ b/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusInputCell.tsx
@@ -9,9 +9,6 @@ export const VVMStatusInputCell = <T extends RecordWithId>({
   isDisabled,
   useDefault = false,
 }: CellProps<T> & { useDefault?: boolean }) => {
-  const [defaultVal, setDefaultVal] = React.useState<
-    VvmStatusFragment | undefined
-  >(undefined);
   const selected = column.accessor({
     rowData,
   }) as VvmStatusFragment | null;
@@ -20,20 +17,12 @@ export const VVMStatusInputCell = <T extends RecordWithId>({
     column.setter({ ...rowData, vvmStatus });
   };
 
-  if (useDefault && defaultVal && !selected) {
-    column.setter({
-      ...rowData,
-      vvmStatus: defaultVal,
-    });
-  }
-
   return (
     <VVMStatusSearchInput
       disabled={!!isDisabled}
       selected={selected}
       onChange={onChange}
       useDefault={useDefault}
-      setDefaultVal={setDefaultVal}
     />
   );
 };

--- a/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
+++ b/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   Autocomplete,
   Tooltip,
@@ -11,7 +11,6 @@ interface VVMStatusSearchInputProps {
   disabled?: boolean;
   width?: number | string;
   useDefault?: boolean;
-  setDefaultVal?: (defaultValue?: VvmStatusFragment) => void;
 }
 
 export const VVMStatusSearchInput = ({
@@ -19,19 +18,22 @@ export const VVMStatusSearchInput = ({
   width,
   onChange,
   disabled,
-  setDefaultVal,
   useDefault = false,
 }: VVMStatusSearchInputProps) => {
   const t = useTranslation();
   const { data, isLoading } = useVvmStatusesEnabled();
 
-  if (!data) return null;
+  const defaultOption =
+    useDefault && data ? getHighestVvmStatusLevel(data) : null;
+  useMemo(() => {
+    if (useDefault && !selected && defaultOption) {
+      const defaultVvm = data?.find(status => status.id === defaultOption?.id);
+      onChange(defaultVvm);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [useDefault, selected, data, defaultOption]);
 
-  const defaultOption = useDefault ? getHighestVvmStatusLevel(data) : null;
-  if (useDefault && setDefaultVal) {
-    const defaultVvm = data.find(status => status.id === defaultOption?.id);
-    setDefaultVal(defaultVvm);
-  }
+  if (!data) return null;
 
   return (
     <Tooltip title={selected?.description ?? ''} placement="top">

--- a/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
+++ b/client/packages/system/src/Stock/Components/VVMStatusSearchInput/VVMStatusSearchInput.tsx
@@ -49,7 +49,7 @@ export const VVMStatusSearchInput = ({
         isOptionEqualToValue={(option, value) => option.id === value?.id}
         clearable={false}
         sx={{
-          width: '100%',
+          width: width ? `${width}px` : '100%',
         }}
       />
     </Tooltip>

--- a/client/packages/system/src/Stock/api/hooks/useStockLine.ts
+++ b/client/packages/system/src/Stock/api/hooks/useStockLine.ts
@@ -120,9 +120,9 @@ const useCreate = () => {
     location,
     onHold,
     itemVariantId,
-    vvmStatusId,
     donor,
     campaign,
+    vvmStatus,
   }: DraftStockLine) => {
     return await stockApi.insertStockLine({
       storeId,
@@ -140,7 +140,7 @@ const useCreate = () => {
         location: setNullableInput('id', location),
         reasonOptionId: reasonOption?.id,
         itemVariantId,
-        vvmStatusId,
+        vvmStatusId: vvmStatus?.id,
         donorId: donor?.id,
         campaignId: campaign?.id,
       },

--- a/client/packages/system/src/Stock/api/operations.generated.ts
+++ b/client/packages/system/src/Stock/api/operations.generated.ts
@@ -71,6 +71,8 @@ export type StockLineRowFragment = {
   vvmStatus?: {
     __typename: 'VvmstatusNode';
     id: string;
+    level: number;
+    unusable: boolean;
     description: string;
   } | null;
   donor?: { __typename: 'NameNode'; id: string } | null;
@@ -277,6 +279,8 @@ export type StockLinesQuery = {
       vvmStatus?: {
         __typename: 'VvmstatusNode';
         id: string;
+        level: number;
+        unusable: boolean;
         description: string;
       } | null;
       donor?: { __typename: 'NameNode'; id: string } | null;
@@ -369,6 +373,8 @@ export type StockLineQuery = {
       vvmStatus?: {
         __typename: 'VvmstatusNode';
         id: string;
+        level: number;
+        unusable: boolean;
         description: string;
       } | null;
       donor?: { __typename: 'NameNode'; id: string } | null;
@@ -498,6 +504,8 @@ export type UpdateStockLineMutation = {
         vvmStatus?: {
           __typename: 'VvmstatusNode';
           id: string;
+          level: number;
+          unusable: boolean;
           description: string;
         } | null;
         donor?: { __typename: 'NameNode'; id: string } | null;
@@ -785,6 +793,8 @@ export type InsertStockLineMutation = {
         vvmStatus?: {
           __typename: 'VvmstatusNode';
           id: string;
+          level: number;
+          unusable: boolean;
           description: string;
         } | null;
         donor?: { __typename: 'NameNode'; id: string } | null;
@@ -905,7 +915,10 @@ export const StockLineRowFragmentDoc = gql`
       }
     }
     vvmStatus {
+      __typename
       id
+      level
+      unusable
       description
     }
     donor(storeId: $storeId) {

--- a/client/packages/system/src/Stock/api/operations.graphql
+++ b/client/packages/system/src/Stock/api/operations.graphql
@@ -35,7 +35,10 @@ fragment StockLineRow on StockLineNode {
     }
   }
   vvmStatus {
+    __typename
     id
+    level
+    unusable
     description
   }
   donor(storeId: $storeId) {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8007

# 👩🏻‍💻 What does this PR do?
- Allows user to input VVM status when introducing new stock in Inventory Adjustment. 
- This defaults to the 'best' status
- Read only component in the stock edit page

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have manage VVM status OMS store preference on
- [ ] Stock > Add stock (select a vaccine item)
- [ ] Should see VVM status component and be able to interact with it
   - [ ] If unchanged, should save the default -> make sure vvm status log has been created
   - [ ] If changed, should save whatever the vvm status is -> make sure vvm status log has been created
- [ ] VVM status log should be READ ONLY in the stock page

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

