### PR TITLE
8247 add purchase order line edit modal

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -3581,6 +3581,14 @@ export type InsertPurchaseOrderInput = {
   supplierId: Scalars['String']['input'];
 };
 
+export type InsertPurchaseOrderLineInput = {
+  id: Scalars['String']['input'];
+  itemId: Scalars['String']['input'];
+  purchaseOrderId: Scalars['String']['input'];
+};
+
+export type InsertPurchaseOrderLineResponse = IdResponse;
+
 export type InsertPurchaseOrderResponse = IdResponse;
 
 export type InsertRepackError = {
@@ -4974,6 +4982,7 @@ export type Mutations = {
   insertProgramRequestRequisition: InsertProgramRequestRequisitionResponse;
   insertProgramResponseRequisition: InsertProgramResponseRequisitionResponse;
   insertPurchaseOrder: InsertPurchaseOrderResponse;
+  insertPurchaseOrderLine: InsertPurchaseOrderLineResponse;
   insertRepack: InsertRepackResponse;
   insertRequestRequisition: InsertRequestRequisitionResponse;
   insertRequestRequisitionLine: InsertRequestRequisitionLineResponse;
@@ -5355,6 +5364,11 @@ export type MutationsInsertProgramResponseRequisitionArgs = {
 
 export type MutationsInsertPurchaseOrderArgs = {
   input: InsertPurchaseOrderInput;
+  storeId: Scalars['String']['input'];
+};
+
+export type MutationsInsertPurchaseOrderLineArgs = {
+  input: InsertPurchaseOrderLineInput;
   storeId: Scalars['String']['input'];
 };
 
@@ -6793,7 +6807,6 @@ export type Queries = {
   historicalStockLines: StockLinesResponse;
   /** Available without authorisation in operational and initialisation states */
   initialisationStatus: InitialisationStatusNode;
-  insertPrescription: InsertPrescriptionResponse;
   insurancePolicies: InsurancesResponse;
   insurancePolicy: InsuranceResponse;
   insuranceProviders: InsuranceProvidersResponse;
@@ -7168,11 +7181,6 @@ export type QueriesGetVvmStatusLogByStockLineArgs = {
 export type QueriesHistoricalStockLinesArgs = {
   datetime?: InputMaybe<Scalars['DateTime']['input']>;
   itemId: Scalars['String']['input'];
-  storeId: Scalars['String']['input'];
-};
-
-export type QueriesInsertPrescriptionArgs = {
-  input: InsertPrescriptionInput;
   storeId: Scalars['String']['input'];
 };
 

--- a/client/packages/purchase_orders/src/DetailView/DetailView.tsx
+++ b/client/packages/purchase_orders/src/DetailView/DetailView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import {
   AlertModal,
   createQueryParamsStore,
@@ -15,7 +15,6 @@ import {
 import { usePurchaseOrder } from '../api/hooks/usePurchaseOrder';
 import { AppRoute } from 'packages/config/src';
 import { PurchaseOrderLineFragment } from '../api';
-import { InboundItem } from 'packages/invoices/src/types';
 import { ContentArea } from './ContentArea';
 import { AppBarButtons } from './AppBarButtons';
 import { Toolbar } from './Toolbar';
@@ -44,12 +43,18 @@ export const DetailViewInner = () => {
     isOpen,
   } = useEditModal<string | null>();
 
-  const onRowClick = (line: PurchaseOrderLineFragment) => {
-    // eslint-disable-next-line no-console
-    console.log('TO-DO: Show Line Edit Modal for line:', line);
-  };
+  const onRowClick = useCallback(
+    (line: PurchaseOrderLineFragment) => {
+      onOpen(line.item.id);
+    },
+    [onOpen]
+  );
 
   if (isLoading) return <DetailViewSkeleton />;
+
+  const onAddItem = () => {
+    onOpen();
+  };
 
   const isDisabled = !data || data?.status !== PurchaseOrderNodeStatus.New;
 
@@ -59,7 +64,7 @@ export const DetailViewInner = () => {
     >
       {data ? (
         <>
-          <AppBarButtons isDisabled={isDisabled} onAddItem={onOpen} />
+          <AppBarButtons isDisabled={isDisabled} onAddItem={onAddItem} />
 
           <Toolbar isDisabled={isDisabled} />
 
@@ -104,9 +109,7 @@ export const PurchaseOrderDetailView = () => {
   return (
     <TableProvider
       createStore={createTableStore}
-      queryParamsStore={createQueryParamsStore<
-        PurchaseOrderLineFragment | InboundItem
-      >({
+      queryParamsStore={createQueryParamsStore<PurchaseOrderLineFragment>({
         initialSortBy: {
           key: 'itemName',
         },

--- a/client/packages/purchase_orders/src/DetailView/DetailView.tsx
+++ b/client/packages/purchase_orders/src/DetailView/DetailView.tsx
@@ -8,6 +8,7 @@ import {
   RouteBuilder,
   TableProvider,
   useBreadcrumbs,
+  useEditModal,
   useNavigate,
   useTranslation,
 } from '@openmsupply-client/common';
@@ -19,6 +20,7 @@ import { ContentArea } from './ContentArea';
 import { AppBarButtons } from './AppBarButtons';
 import { Toolbar } from './Toolbar';
 import { Footer } from './Footer';
+import { PurchaseOrderLineEditModal } from './LineEdit/PurchaseOrderLineEditModal';
 
 export const DetailViewInner = () => {
   const {
@@ -34,10 +36,13 @@ export const DetailViewInner = () => {
     setCustomBreadcrumbs({ 1: data?.number.toString() ?? '' });
   }, [setCustomBreadcrumbs, data?.number]);
 
-  const onOpen = () => {
-    // eslint-disable-next-line no-console
-    console.log('TO-DO: Show Line Edit Modal');
-  };
+  const {
+    onOpen,
+    onClose,
+    mode,
+    entity: itemId,
+    isOpen,
+  } = useEditModal<string | null>();
 
   const onRowClick = (line: PurchaseOrderLineFragment) => {
     // eslint-disable-next-line no-console
@@ -66,21 +71,16 @@ export const DetailViewInner = () => {
           />
 
           <Footer />
-          {/* <SidePanel /> */}
 
-          {/* {isOpen && (
-            <InboundLineEdit
-              isDisabled={isDisabled}
+          {isOpen && (
+            <PurchaseOrderLineEditModal
               isOpen={isOpen}
               onClose={onClose}
               mode={mode}
-              item={entity}
-              currency={data.currency}
-              isExternalSupplier={!data.otherParty.store}
-              hasVvmStatusesEnabled={!!vvmStatuses && vvmStatuses.length > 0}
-              hasItemVariantsEnabled={hasItemVariantsEnabled}
+              itemId={itemId}
+              purchaseOrder={data}
             />
-          )} */}
+          )}
         </>
       ) : (
         <AlertModal

--- a/client/packages/purchase_orders/src/DetailView/LineEdit/PurchaseOrderLineEdit.tsx
+++ b/client/packages/purchase_orders/src/DetailView/LineEdit/PurchaseOrderLineEdit.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import {
+  Divider,
+  Box,
+  useTranslation,
+  TableCell,
+  styled,
+  useFormatNumber,
+  Tooltip,
+  NumUtils,
+} from '@openmsupply-client/common';
+import { CurrencyRowFragment } from '@openmsupply-client/system';
+import { min } from 'lodash';
+
+export interface OutboundLineEditTableProps {}
+
+const PlaceholderCell = styled(TableCell)(({ theme }) => ({
+  fontSize: 12,
+  padding: '4px 20px 4px 12px',
+  color: theme.palette.secondary.main,
+}));
+
+const TotalCell = styled(TableCell)(({ theme }) => ({
+  fontSize: 14,
+  padding: '8px 12px 4px 12px',
+  fontWeight: 'bold',
+  position: 'sticky',
+  bottom: 0,
+  background: theme.palette.background.white,
+  borderTop: `1px solid ${theme.palette.divider}`,
+}));
+
+const PlaceholderRow = ({
+  quantity,
+  extraColumnOffset,
+  dosesPerUnit,
+}: {
+  quantity: number | null;
+  extraColumnOffset: number;
+  dosesPerUnit?: number;
+}) => {
+  const t = useTranslation();
+
+  const formattedValue = useFormatNumber().round(quantity ?? 0, 2);
+
+  // TODO - maybe should be editable? Can't clear when manually allocating..
+  return quantity === null ? null : (
+    <tr>
+      <PlaceholderCell
+        colSpan={5 + extraColumnOffset}
+        sx={{ color: 'secondary.main' }}
+      >
+        {t('label.placeholder')}
+      </PlaceholderCell>
+      <PlaceholderCell style={{ textAlign: 'right', paddingRight: '14px' }}>
+        1
+      </PlaceholderCell>
+      {!!dosesPerUnit && (
+        <PlaceholderCell style={{ textAlign: 'right', paddingRight: '14px' }}>
+          {dosesPerUnit}
+        </PlaceholderCell>
+      )}
+      <PlaceholderCell colSpan={dosesPerUnit ? 2 : 3}></PlaceholderCell>
+      <Tooltip title={quantity.toString()}>
+        <PlaceholderCell style={{ textAlign: 'right' }}>
+          {!!NumUtils.hasMoreThanTwoDp(quantity)
+            ? `${formattedValue}...`
+            : formattedValue}
+        </PlaceholderCell>
+      </Tooltip>
+    </tr>
+  );
+};
+
+const TotalRow = ({
+  allocatedQuantity,
+  extraColumnOffset,
+}: {
+  allocatedQuantity: number;
+  extraColumnOffset: number;
+}) => {
+  const t = useTranslation();
+  const formattedValue = useFormatNumber().round(allocatedQuantity, 2);
+
+  return (
+    <tr>
+      <TotalCell colSpan={3}>{t('label.total-quantity')}</TotalCell>
+      <TotalCell colSpan={6 + extraColumnOffset}></TotalCell>
+      <Tooltip title={allocatedQuantity.toString()}>
+        <TotalCell
+          style={{
+            textAlign: 'right',
+            paddingRight: 20,
+          }}
+        >
+          {!!NumUtils.hasMoreThanTwoDp(allocatedQuantity)
+            ? `${formattedValue}...`
+            : formattedValue}
+        </TotalCell>
+      </Tooltip>
+      <TotalCell colSpan={2} />
+    </tr>
+  );
+};
+
+export const PurchaseOrderLineEdit = ({}: OutboundLineEditTableProps) => {
+  return (
+    <Box style={{ width: '100%' }}>
+      <Divider margin={10} />
+      <Box
+        style={{
+          maxHeight: min([screen.height - 570, 325]),
+          display: 'flex',
+          flexDirection: 'column',
+          overflowX: 'hidden',
+          overflowY: 'auto',
+        }}
+      >
+        hello
+      </Box>
+    </Box>
+  );
+};

--- a/client/packages/purchase_orders/src/DetailView/LineEdit/PurchaseOrderLineEdit.tsx
+++ b/client/packages/purchase_orders/src/DetailView/LineEdit/PurchaseOrderLineEdit.tsx
@@ -1,123 +1,63 @@
 import React from 'react';
+import { BasicTextInput, Grid } from '@openmsupply-client/common';
+import { PurchaseOrderLineFragment } from '../../api';
 import {
-  Divider,
-  Box,
-  useTranslation,
-  TableCell,
-  styled,
-  useFormatNumber,
-  Tooltip,
-  NumUtils,
-} from '@openmsupply-client/common';
-import { CurrencyRowFragment } from '@openmsupply-client/system';
-import { min } from 'lodash';
+  ItemWithStatsFragment,
+  StockItemSearchInputWithStats,
+} from '@openmsupply-client/system/src';
 
-export interface OutboundLineEditTableProps {}
+export type PurchaseOrderLineItem = Partial<PurchaseOrderLineFragment>;
+export interface PurchaseOrderLineEditProps {
+  isUpdateMode?: boolean;
+  currentItem?: PurchaseOrderLineFragment;
+  lines: PurchaseOrderLineFragment[];
+  onChangeItem: (item: ItemWithStatsFragment) => void;
+  // TODO add line update
+  // onUpdate: (patch: Partial<PurchaseOrderLineFragment>) => void;
+}
 
-const PlaceholderCell = styled(TableCell)(({ theme }) => ({
-  fontSize: 12,
-  padding: '4px 20px 4px 12px',
-  color: theme.palette.secondary.main,
-}));
-
-const TotalCell = styled(TableCell)(({ theme }) => ({
-  fontSize: 14,
-  padding: '8px 12px 4px 12px',
-  fontWeight: 'bold',
-  position: 'sticky',
-  bottom: 0,
-  background: theme.palette.background.white,
-  borderTop: `1px solid ${theme.palette.divider}`,
-}));
-
-const PlaceholderRow = ({
-  quantity,
-  extraColumnOffset,
-  dosesPerUnit,
-}: {
-  quantity: number | null;
-  extraColumnOffset: number;
-  dosesPerUnit?: number;
-}) => {
-  const t = useTranslation();
-
-  const formattedValue = useFormatNumber().round(quantity ?? 0, 2);
-
-  // TODO - maybe should be editable? Can't clear when manually allocating..
-  return quantity === null ? null : (
-    <tr>
-      <PlaceholderCell
-        colSpan={5 + extraColumnOffset}
-        sx={{ color: 'secondary.main' }}
-      >
-        {t('label.placeholder')}
-      </PlaceholderCell>
-      <PlaceholderCell style={{ textAlign: 'right', paddingRight: '14px' }}>
-        1
-      </PlaceholderCell>
-      {!!dosesPerUnit && (
-        <PlaceholderCell style={{ textAlign: 'right', paddingRight: '14px' }}>
-          {dosesPerUnit}
-        </PlaceholderCell>
-      )}
-      <PlaceholderCell colSpan={dosesPerUnit ? 2 : 3}></PlaceholderCell>
-      <Tooltip title={quantity.toString()}>
-        <PlaceholderCell style={{ textAlign: 'right' }}>
-          {!!NumUtils.hasMoreThanTwoDp(quantity)
-            ? `${formattedValue}...`
-            : formattedValue}
-        </PlaceholderCell>
-      </Tooltip>
-    </tr>
-  );
-};
-
-const TotalRow = ({
-  allocatedQuantity,
-  extraColumnOffset,
-}: {
-  allocatedQuantity: number;
-  extraColumnOffset: number;
-}) => {
-  const t = useTranslation();
-  const formattedValue = useFormatNumber().round(allocatedQuantity, 2);
-
+export const PurchaseOrderLineEdit = ({
+  isUpdateMode,
+  currentItem,
+  lines,
+  onChangeItem,
+  // TODO add line update
+  // onUpdate,
+}: PurchaseOrderLineEditProps) => {
   return (
-    <tr>
-      <TotalCell colSpan={3}>{t('label.total-quantity')}</TotalCell>
-      <TotalCell colSpan={6 + extraColumnOffset}></TotalCell>
-      <Tooltip title={allocatedQuantity.toString()}>
-        <TotalCell
-          style={{
-            textAlign: 'right',
-            paddingRight: 20,
-          }}
-        >
-          {!!NumUtils.hasMoreThanTwoDp(allocatedQuantity)
-            ? `${formattedValue}...`
-            : formattedValue}
-        </TotalCell>
-      </Tooltip>
-      <TotalCell colSpan={2} />
-    </tr>
-  );
-};
-
-export const PurchaseOrderLineEdit = ({}: OutboundLineEditTableProps) => {
-  return (
-    <Box style={{ width: '100%' }}>
-      <Divider margin={10} />
-      <Box
-        style={{
-          maxHeight: min([screen.height - 570, 325]),
-          display: 'flex',
-          flexDirection: 'column',
-          overflowX: 'hidden',
-          overflowY: 'auto',
-        }}
-      >
-        hello
-      </Box>
-    </Box>
+    <Grid
+      container
+      spacing={1}
+      direction="row"
+      bgcolor="background.toolbar"
+      padding={2}
+      paddingBottom={1}
+    >
+      <Grid size={12} sx={{ mb: 2 }}>
+        {(isUpdateMode && (
+          <BasicTextInput
+            value={`${currentItem?.item?.code}     ${currentItem?.item?.name}`}
+            disabled
+            fullWidth
+          />
+        )) || (
+          <StockItemSearchInputWithStats
+            autoFocus={!currentItem}
+            openOnFocus={!currentItem}
+            disabled={false}
+            currentItemId={currentItem?.id}
+            onChange={(newItem: ItemWithStatsFragment | null) =>
+              newItem && onChangeItem(newItem)
+            }
+            extraFilter={item => !lines.some(line => line.item.id === item.id)}
+          />
+        )}
+      </Grid>
+      <Grid size={12} container spacing={2}>
+        {/* <Grid size={6}>{}</Grid>
+        TODO add update line fields here
+        <Grid size={6}>{}</Grid> */}
+      </Grid>
+    </Grid>
   );
 };

--- a/client/packages/purchase_orders/src/DetailView/LineEdit/PurchaseOrderLineEditModal.tsx
+++ b/client/packages/purchase_orders/src/DetailView/LineEdit/PurchaseOrderLineEditModal.tsx
@@ -1,12 +1,12 @@
 import { ModalMode, useDialog, useNotification } from '@common/hooks';
-import { PurchaseOrderFragment, PurchaseOrderLineFragment } from '../../api';
+import { PurchaseOrderFragment } from '../../api';
 import { DialogButton, InlineSpinner } from '@common/components';
 import { useTranslation, Box } from '@openmsupply-client/common';
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState } from 'react';
 import { PurchaseOrderLineEdit } from './PurchaseOrderLineEdit';
-
-type PurchaseOrderLineItem = PurchaseOrderLineFragment['item'];
-
+import { usePurchaseOrderLine } from '../../api/hooks/usePurchaseOrderLine';
+import { ItemWithStatsFragment } from '@openmsupply-client/system';
+import { createDraftPurchaseOrderLine } from './utils';
 interface PurchaseOrderLineEditModalProps {
   itemId: string | null;
   purchaseOrder: PurchaseOrderFragment;
@@ -25,21 +25,69 @@ export const PurchaseOrderLineEditModal = ({
   const t = useTranslation();
   const { error } = useNotification();
 
-  const lines = useMemo(
-    () =>
-      purchaseOrder.lines.nodes
-        .slice()
-        .sort((a, b) => a.item.name.localeCompare(b.item.name)) ?? [],
-    [purchaseOrder.lines.nodes]
+  const lines = purchaseOrder.lines.nodes;
+
+  const [currentItem, setCurrentItem] = useState(
+    lines.find(line => line.item.id === itemId) ?? undefined
   );
 
-  const [currentItem, setCurrentItem] = useState<PurchaseOrderLineItem | null>(
-    lines.find(line => line.item.id === itemId)?.item ?? null
-  );
+  const {
+    create: { create, isCreating },
+    draft,
+    updatePatch,
+  } = usePurchaseOrderLine(currentItem?.item.id);
+
+  const deletePreviousLine = () => {
+    const shouldDelete = shouldDeleteLine(mode, currentItem?.id, false);
+    if (currentItem?.id && shouldDelete) {
+      // TODO implement line delete
+    }
+  };
+
+  const onChangeItem = (item: ItemWithStatsFragment) => {
+    if (mode === ModalMode.Create) {
+      deletePreviousLine();
+    }
+    const draftLine = createDraftPurchaseOrderLine(item, purchaseOrder.id);
+    item &&
+      updatePatch({
+        ...draftLine,
+      });
+    setCurrentItem({
+      ...draftLine,
+      __typename: 'PurchaseOrderLineNode',
+      item: item,
+    });
+  };
+
+  const handleSave = async () => {
+    try {
+      await create();
+      updatePatch(draft);
+      return true;
+      // TODO add proper error handling by returning type errors from API
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        error(e.message)();
+      } else {
+        error('unknown error')();
+      }
+      return false;
+    }
+  };
+
+  // TODO handle next item workflow
+  // const onSave = async () => {
+  //   const success = await handleSave();
+  //   if (!success) return false;
+  //   // if (mode === ModalMode.Update && false setCurrentItem(next);
+  //   // else if (mode === ModalMode.Create) setCurrentItem(undefined);
+  //   // else onClose();
+  //   onClose();
+  //   return true;
+  // };
 
   const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
-
-  const isLoading = false;
 
   return (
     <Modal
@@ -49,28 +97,23 @@ export const PurchaseOrderLineEditModal = ({
           : t('heading.edit-item')
       }
       cancelButton={<DialogButton variant="cancel" onClick={onClose} />}
-      nextButton={
-        <DialogButton
-          variant="next-and-ok"
-          onClick={async () => {
-            console.log('clicked');
-          }}
-        />
-      }
+      // TODO add next button functionality
+      // nextButton={<DialogButton variant="next-and-ok" onClick={onSave} />}
       okButton={
         <DialogButton
           variant="ok"
           disabled={!currentItem}
           onClick={async () => {
-            console.log('clicked');
+            const success = await handleSave();
+            if (success) onClose();
           }}
         />
       }
       height={700}
       width={1200}
-      enableAutocomplete /* Required for previously entered batches to be remembered and suggested in future shipments */
+      enableAutocomplete
     >
-      {isLoading ? (
+      {isCreating ? (
         <Box
           display="flex"
           flex={1}
@@ -82,9 +125,22 @@ export const PurchaseOrderLineEditModal = ({
         </Box>
       ) : (
         <PurchaseOrderLineEdit
-          isExternalSupplier={false}
+          currentItem={currentItem}
+          isUpdateMode={mode === ModalMode.Update}
+          lines={lines}
+          onChangeItem={onChangeItem}
         ></PurchaseOrderLineEdit>
       )}
     </Modal>
   );
+};
+
+export const shouldDeleteLine = (
+  mode: ModalMode | null,
+  draftId?: string,
+  isDisabled?: boolean
+): boolean => {
+  if (mode === ModalMode.Create) return true;
+  if (!draftId || isDisabled || mode === ModalMode.Update) return false;
+  return false;
 };

--- a/client/packages/purchase_orders/src/DetailView/LineEdit/PurchaseOrderLineEditModal.tsx
+++ b/client/packages/purchase_orders/src/DetailView/LineEdit/PurchaseOrderLineEditModal.tsx
@@ -37,17 +37,7 @@ export const PurchaseOrderLineEditModal = ({
     updatePatch,
   } = usePurchaseOrderLine(currentItem?.item.id);
 
-  const deletePreviousLine = () => {
-    const shouldDelete = shouldDeleteLine(mode, currentItem?.id, false);
-    if (currentItem?.id && shouldDelete) {
-      // TODO implement line delete
-    }
-  };
-
   const onChangeItem = (item: ItemWithStatsFragment) => {
-    if (mode === ModalMode.Create) {
-      deletePreviousLine();
-    }
     const draftLine = createDraftPurchaseOrderLine(item, purchaseOrder.id);
     item &&
       updatePatch({
@@ -133,14 +123,4 @@ export const PurchaseOrderLineEditModal = ({
       )}
     </Modal>
   );
-};
-
-export const shouldDeleteLine = (
-  mode: ModalMode | null,
-  draftId?: string,
-  isDisabled?: boolean
-): boolean => {
-  if (mode === ModalMode.Create) return true;
-  if (!draftId || isDisabled || mode === ModalMode.Update) return false;
-  return false;
 };

--- a/client/packages/purchase_orders/src/DetailView/LineEdit/PurchaseOrderLineEditModal.tsx
+++ b/client/packages/purchase_orders/src/DetailView/LineEdit/PurchaseOrderLineEditModal.tsx
@@ -1,0 +1,90 @@
+import { ModalMode, useDialog, useNotification } from '@common/hooks';
+import { PurchaseOrderFragment, PurchaseOrderLineFragment } from '../../api';
+import { DialogButton, InlineSpinner } from '@common/components';
+import { useTranslation, Box } from '@openmsupply-client/common';
+import React, { useState, useEffect, useMemo } from 'react';
+import { PurchaseOrderLineEdit } from './PurchaseOrderLineEdit';
+
+type PurchaseOrderLineItem = PurchaseOrderLineFragment['item'];
+
+interface PurchaseOrderLineEditModalProps {
+  itemId: string | null;
+  purchaseOrder: PurchaseOrderFragment;
+  mode: ModalMode | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const PurchaseOrderLineEditModal = ({
+  itemId,
+  purchaseOrder,
+  mode,
+  isOpen,
+  onClose,
+}: PurchaseOrderLineEditModalProps) => {
+  const t = useTranslation();
+  const { error } = useNotification();
+
+  const lines = useMemo(
+    () =>
+      purchaseOrder.lines.nodes
+        .slice()
+        .sort((a, b) => a.item.name.localeCompare(b.item.name)) ?? [],
+    [purchaseOrder.lines.nodes]
+  );
+
+  const [currentItem, setCurrentItem] = useState<PurchaseOrderLineItem | null>(
+    lines.find(line => line.item.id === itemId)?.item ?? null
+  );
+
+  const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
+
+  const isLoading = false;
+
+  return (
+    <Modal
+      title={
+        mode === ModalMode.Create
+          ? t('heading.add-item')
+          : t('heading.edit-item')
+      }
+      cancelButton={<DialogButton variant="cancel" onClick={onClose} />}
+      nextButton={
+        <DialogButton
+          variant="next-and-ok"
+          onClick={async () => {
+            console.log('clicked');
+          }}
+        />
+      }
+      okButton={
+        <DialogButton
+          variant="ok"
+          disabled={!currentItem}
+          onClick={async () => {
+            console.log('clicked');
+          }}
+        />
+      }
+      height={700}
+      width={1200}
+      enableAutocomplete /* Required for previously entered batches to be remembered and suggested in future shipments */
+    >
+      {isLoading ? (
+        <Box
+          display="flex"
+          flex={1}
+          height={300}
+          justifyContent="center"
+          alignItems="center"
+        >
+          <InlineSpinner />
+        </Box>
+      ) : (
+        <PurchaseOrderLineEdit
+          isExternalSupplier={false}
+        ></PurchaseOrderLineEdit>
+      )}
+    </Modal>
+  );
+};

--- a/client/packages/purchase_orders/src/DetailView/LineEdit/utils.ts
+++ b/client/packages/purchase_orders/src/DetailView/LineEdit/utils.ts
@@ -1,0 +1,14 @@
+import { ItemWithStatsFragment } from '@openmsupply-client/system';
+import { DraftPurchaseOrderLine } from "../../api/hooks/usePurchaseOrderLine";
+import { FnUtils } from "@common/utils";
+
+export const createDraftPurchaseOrderLine = (
+  item: ItemWithStatsFragment,
+  purchaseOrderId: string
+): DraftPurchaseOrderLine => {
+  return {
+    id: FnUtils.generateUUID(),
+    purchaseOrderId,
+    itemId: item.id,
+  };
+}

--- a/client/packages/purchase_orders/src/api/hooks/usePurchaseOrder.ts
+++ b/client/packages/purchase_orders/src/api/hooks/usePurchaseOrder.ts
@@ -13,8 +13,8 @@ import { PurchaseOrderFragment } from '../operations.generated';
 import { useMemo } from 'react';
 import { usePurchaseOrderColumns } from '../../DetailView/columns';
 
-export const usePurchaseOrder = (pid?: string) => {
-  const { purchaseOrderId = pid } = useParams();
+export const usePurchaseOrder = (id?: string) => {
+  const { purchaseOrderId = id } = useParams();
 
   const { purchaseOrderApi, storeId } = usePurchaseOrderGraphQL();
 

--- a/client/packages/purchase_orders/src/api/hooks/usePurchaseOrderLine.ts
+++ b/client/packages/purchase_orders/src/api/hooks/usePurchaseOrderLine.ts
@@ -1,0 +1,101 @@
+import {  useMutation, usePatchState, useQuery } from "@openmsupply-client/common/src";
+import { usePurchaseOrderGraphQL } from "../usePurchaseOrderGraphQL";
+import { PURCHASE_ORDER_LINE } from "./keys";
+import { PurchaseOrderLineFragment } from "../operations.generated";
+
+export type DraftPurchaseOrderLine = Omit<
+  PurchaseOrderLineFragment,
+  "__typename"| "item"> & {
+  purchaseOrderId: string;
+  itemId: string;
+  }
+
+const defaultPurchaseOrderLine: DraftPurchaseOrderLine = {
+    id: "",
+    purchaseOrderId: "",
+    itemId: "",
+};
+
+export function usePurchaseOrderLine(id?: string) {
+
+ const { data, isLoading, error } = useGet(id ?? '');
+
+  const {
+    mutateAsync: createMutation,
+    isLoading: isCreating,
+    error: createError,
+  } = useCreate();
+
+    const { patch, updatePatch, resetDraft, isDirty } =
+      usePatchState<DraftPurchaseOrderLine>(data?.nodes[0] ?? {});
+
+    const draft: DraftPurchaseOrderLine = data
+      ? { ...defaultPurchaseOrderLine, ...data?.nodes[0], ...patch }
+      : { ...defaultPurchaseOrderLine, ...patch };
+    const create = async () => {
+      const result = await createMutation(draft);
+      resetDraft();
+      return result;
+    };
+
+    return {
+    query: { data: data?.nodes[0], isLoading, error },
+    create: { create, isCreating, createError },
+    draft,
+    resetDraft,
+    isDirty,
+    updatePatch,
+  };
+}
+
+
+const useGet = (id: string) => {
+  const { purchaseOrderApi, storeId } = usePurchaseOrderGraphQL();
+
+  const queryFn = async () => {
+    const result = await purchaseOrderApi.purchaseOrderLine({
+      id,
+      storeId,
+    });
+
+    if (result.purchaseOrderLines.__typename === 'PurchaseOrderLineConnector') {
+      return result.purchaseOrderLines;
+    }
+  };
+
+  const query = useQuery({
+    queryKey: [PURCHASE_ORDER_LINE, id],
+    queryFn,
+    enabled: id !== '',
+  });
+
+  return query;
+};
+
+const useCreate = () => {
+  const { purchaseOrderApi, storeId, queryClient } = usePurchaseOrderGraphQL();
+
+  const mutationFn = async ({
+    purchaseOrderId,
+    itemId,
+    id,
+  }: DraftPurchaseOrderLine) => {
+    return await purchaseOrderApi.insertPurchaseOrderLine({
+      storeId,
+      input: {
+        id,
+        // TODO better way of handling non item id
+        itemId: itemId,
+        purchaseOrderId,
+        
+      },
+    });
+  };
+
+  return useMutation({
+    mutationFn,
+    onSuccess: () =>
+      // Purchase order line list needs to be re-fetched to include the new purchase order line
+      queryClient.invalidateQueries([PURCHASE_ORDER_LINE]),
+  });
+};

--- a/client/packages/purchase_orders/src/api/hooks/usePurchaseOrderLine.ts
+++ b/client/packages/purchase_orders/src/api/hooks/usePurchaseOrderLine.ts
@@ -1,6 +1,6 @@
 import {  useMutation, usePatchState, useQuery } from "@openmsupply-client/common/src";
 import { usePurchaseOrderGraphQL } from "../usePurchaseOrderGraphQL";
-import { PURCHASE_ORDER_LINE } from "./keys";
+import { LIST, PURCHASE_ORDER, PURCHASE_ORDER_LINE } from "./keys";
 import { PurchaseOrderLineFragment } from "../operations.generated";
 
 export type DraftPurchaseOrderLine = Omit<
@@ -95,7 +95,6 @@ const useCreate = () => {
   return useMutation({
     mutationFn,
     onSuccess: () =>
-      // Purchase order line list needs to be re-fetched to include the new purchase order line
-      queryClient.invalidateQueries([PURCHASE_ORDER_LINE]),
+      queryClient.invalidateQueries([LIST, PURCHASE_ORDER, storeId]),
   });
 };

--- a/client/packages/purchase_orders/src/api/operations.generated.ts
+++ b/client/packages/purchase_orders/src/api/operations.generated.ts
@@ -57,6 +57,7 @@ export type PurchaseOrderFragment = {
       id: string;
       authorisedQuantity?: number | null;
       expectedDeliveryDate?: string | null;
+      purchaseOrderId: string;
       numberOfPacks?: number | null;
       requestedQuantity?: number | null;
       packSize?: number | null;
@@ -80,6 +81,7 @@ export type PurchaseOrderLineFragment = {
   id: string;
   authorisedQuantity?: number | null;
   expectedDeliveryDate?: string | null;
+  purchaseOrderId: string;
   numberOfPacks?: number | null;
   requestedQuantity?: number | null;
   packSize?: number | null;
@@ -172,6 +174,7 @@ export type PurchaseOrderByIdQuery = {
             id: string;
             authorisedQuantity?: number | null;
             expectedDeliveryDate?: string | null;
+            purchaseOrderId: string;
             numberOfPacks?: number | null;
             requestedQuantity?: number | null;
             packSize?: number | null;
@@ -202,6 +205,97 @@ export type InsertPurchaseOrderMutation = {
   insertPurchaseOrder: { __typename: 'IdResponse'; id: string };
 };
 
+export type PurchaseOrderLinesQueryVariables = Types.Exact<{
+  storeId: Types.Scalars['String']['input'];
+  first?: Types.InputMaybe<Types.Scalars['Int']['input']>;
+  offset?: Types.InputMaybe<Types.Scalars['Int']['input']>;
+  key: Types.PurchaseOrderLineSortFieldInput;
+  desc?: Types.InputMaybe<Types.Scalars['Boolean']['input']>;
+  filter?: Types.InputMaybe<Types.PurchaseOrderLineFilterInput>;
+}>;
+
+export type PurchaseOrderLinesQuery = {
+  __typename: 'Queries';
+  purchaseOrderLines: {
+    __typename: 'PurchaseOrderLineConnector';
+    totalCount: number;
+    nodes: Array<{
+      __typename: 'PurchaseOrderLineNode';
+      id: string;
+      authorisedQuantity?: number | null;
+      expectedDeliveryDate?: string | null;
+      purchaseOrderId: string;
+      numberOfPacks?: number | null;
+      requestedQuantity?: number | null;
+      packSize?: number | null;
+      requestedDeliveryDate?: string | null;
+      totalReceived?: number | null;
+      item: {
+        __typename: 'ItemNode';
+        id: string;
+        code: string;
+        name: string;
+        unitName?: string | null;
+      };
+    }>;
+  };
+};
+
+export type PurchaseOrderLineQueryVariables = Types.Exact<{
+  id: Types.Scalars['String']['input'];
+  storeId: Types.Scalars['String']['input'];
+}>;
+
+export type PurchaseOrderLineQuery = {
+  __typename: 'Queries';
+  purchaseOrderLines: {
+    __typename: 'PurchaseOrderLineConnector';
+    totalCount: number;
+    nodes: Array<{
+      __typename: 'PurchaseOrderLineNode';
+      id: string;
+      authorisedQuantity?: number | null;
+      expectedDeliveryDate?: string | null;
+      purchaseOrderId: string;
+      numberOfPacks?: number | null;
+      requestedQuantity?: number | null;
+      packSize?: number | null;
+      requestedDeliveryDate?: string | null;
+      totalReceived?: number | null;
+      item: {
+        __typename: 'ItemNode';
+        id: string;
+        code: string;
+        name: string;
+        unitName?: string | null;
+      };
+    }>;
+  };
+};
+
+export type PurchaseOrderLinesCountQueryVariables = Types.Exact<{
+  filter?: Types.InputMaybe<Types.PurchaseOrderLineFilterInput>;
+  storeId: Types.Scalars['String']['input'];
+}>;
+
+export type PurchaseOrderLinesCountQuery = {
+  __typename: 'Queries';
+  purchaseOrderLines: {
+    __typename: 'PurchaseOrderLineConnector';
+    totalCount: number;
+  };
+};
+
+export type InsertPurchaseOrderLineMutationVariables = Types.Exact<{
+  input: Types.InsertPurchaseOrderLineInput;
+  storeId: Types.Scalars['String']['input'];
+}>;
+
+export type InsertPurchaseOrderLineMutation = {
+  __typename: 'Mutations';
+  insertPurchaseOrderLine: { __typename: 'IdResponse'; id: string };
+};
+
 export const PurchaseOrderRowFragmentDoc = gql`
   fragment PurchaseOrderRow on PurchaseOrderNode {
     id
@@ -228,6 +322,7 @@ export const PurchaseOrderLineFragmentDoc = gql`
     id
     authorisedQuantity
     expectedDeliveryDate
+    purchaseOrderId
     item {
       id
       code
@@ -348,6 +443,73 @@ export const InsertPurchaseOrderDocument = gql`
     }
   }
 `;
+export const PurchaseOrderLinesDocument = gql`
+  query purchaseOrderLines(
+    $storeId: String!
+    $first: Int
+    $offset: Int
+    $key: PurchaseOrderLineSortFieldInput!
+    $desc: Boolean
+    $filter: PurchaseOrderLineFilterInput
+  ) {
+    purchaseOrderLines(
+      storeId: $storeId
+      filter: $filter
+      page: { first: $first, offset: $offset }
+      sort: { key: $key, desc: $desc }
+    ) {
+      ... on PurchaseOrderLineConnector {
+        __typename
+        nodes {
+          __typename
+          ...PurchaseOrderLine
+        }
+        totalCount
+      }
+    }
+  }
+  ${PurchaseOrderLineFragmentDoc}
+`;
+export const PurchaseOrderLineDocument = gql`
+  query purchaseOrderLine($id: String!, $storeId: String!) {
+    purchaseOrderLines(storeId: $storeId, filter: { id: { equalTo: $id } }) {
+      ... on PurchaseOrderLineConnector {
+        __typename
+        nodes {
+          __typename
+          ...PurchaseOrderLine
+        }
+        totalCount
+      }
+    }
+  }
+  ${PurchaseOrderLineFragmentDoc}
+`;
+export const PurchaseOrderLinesCountDocument = gql`
+  query purchaseOrderLinesCount(
+    $filter: PurchaseOrderLineFilterInput
+    $storeId: String!
+  ) {
+    purchaseOrderLines(storeId: $storeId, filter: $filter) {
+      ... on PurchaseOrderLineConnector {
+        __typename
+        totalCount
+      }
+    }
+  }
+`;
+export const InsertPurchaseOrderLineDocument = gql`
+  mutation insertPurchaseOrderLine(
+    $input: InsertPurchaseOrderLineInput!
+    $storeId: String!
+  ) {
+    insertPurchaseOrderLine(input: $input, storeId: $storeId) {
+      ... on IdResponse {
+        id
+      }
+    }
+  }
+`;
 
 export type SdkFunctionWrapper = <T>(
   action: (requestHeaders?: Record<string, string>) => Promise<T>,
@@ -412,6 +574,70 @@ export function getSdk(
             { ...requestHeaders, ...wrappedRequestHeaders }
           ),
         'insertPurchaseOrder',
+        'mutation',
+        variables
+      );
+    },
+    purchaseOrderLines(
+      variables: PurchaseOrderLinesQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders
+    ): Promise<PurchaseOrderLinesQuery> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<PurchaseOrderLinesQuery>(
+            PurchaseOrderLinesDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'purchaseOrderLines',
+        'query',
+        variables
+      );
+    },
+    purchaseOrderLine(
+      variables: PurchaseOrderLineQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders
+    ): Promise<PurchaseOrderLineQuery> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<PurchaseOrderLineQuery>(
+            PurchaseOrderLineDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'purchaseOrderLine',
+        'query',
+        variables
+      );
+    },
+    purchaseOrderLinesCount(
+      variables: PurchaseOrderLinesCountQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders
+    ): Promise<PurchaseOrderLinesCountQuery> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<PurchaseOrderLinesCountQuery>(
+            PurchaseOrderLinesCountDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'purchaseOrderLinesCount',
+        'query',
+        variables
+      );
+    },
+    insertPurchaseOrderLine(
+      variables: InsertPurchaseOrderLineMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders
+    ): Promise<InsertPurchaseOrderLineMutation> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<InsertPurchaseOrderLineMutation>(
+            InsertPurchaseOrderLineDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'insertPurchaseOrderLine',
         'mutation',
         variables
       );

--- a/client/packages/purchase_orders/src/api/operations.graphql
+++ b/client/packages/purchase_orders/src/api/operations.graphql
@@ -78,6 +78,7 @@ fragment PurchaseOrderLine on PurchaseOrderLineNode {
   id
   authorisedQuantity
   expectedDeliveryDate
+  purchaseOrderId
   item {
     id
     code
@@ -134,6 +135,67 @@ mutation insertPurchaseOrder(
   $storeId: String!
 ) {
   insertPurchaseOrder(input: $input, storeId: $storeId) {
+    ... on IdResponse {
+      id
+    }
+  }
+}
+
+query purchaseOrderLines(
+  $storeId: String!
+  $first: Int
+  $offset: Int
+  $key: PurchaseOrderLineSortFieldInput!
+  $desc: Boolean
+  $filter: PurchaseOrderLineFilterInput
+) {
+  purchaseOrderLines(
+    storeId: $storeId
+    filter: $filter
+    page: { first: $first, offset: $offset }
+    sort: { key: $key, desc: $desc }
+  ) {
+    ... on PurchaseOrderLineConnector {
+      __typename
+      nodes {
+        __typename
+        ...PurchaseOrderLine
+      }
+      totalCount
+    }
+  }
+}
+
+query purchaseOrderLine($id: String!, $storeId: String!) {
+  purchaseOrderLines(storeId: $storeId, filter: { id: { equalTo: $id } }) {
+    ... on PurchaseOrderLineConnector {
+      __typename
+      nodes {
+        __typename
+        ...PurchaseOrderLine
+      }
+      totalCount
+    }
+  }
+}
+
+query purchaseOrderLinesCount(
+  $filter: PurchaseOrderLineFilterInput
+  $storeId: String!
+) {
+  purchaseOrderLines(storeId: $storeId, filter: $filter) {
+    ... on PurchaseOrderLineConnector {
+      __typename
+      totalCount
+    }
+  }
+}
+
+mutation insertPurchaseOrderLine(
+  $input: InsertPurchaseOrderLineInput!
+  $storeId: String!
+) {
+  insertPurchaseOrderLine(input: $input, storeId: $storeId) {
     ... on IdResponse {
       id
     }


### PR DESCRIPTION
Fixes #8490 

# 👩🏻‍💻 What does this PR do?

Adds basic edit purchase order line edit modal.

Currently only plugged in to insert api - leaving update and delete api for later PR.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to purchase orders
- [ ] Click add item
- [ ] select and item and click OK
- [ ] See purchase order line added to purchase orders

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

