### PR TITLE
8624 Add permission mapping to resource

### DIFF
--- a/server/graphql/purchase_order/src/purchase_order_queries.rs
+++ b/server/graphql/purchase_order/src/purchase_order_queries.rs
@@ -4,12 +4,13 @@ use graphql_core::{
     map_filter,
     pagination::PaginationInput,
     simple_generic_errors::RecordNotFound,
-    standard_graphql_error::StandardGraphqlError,
+    standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
 use graphql_types::types::{PurchaseOrderConnector, PurchaseOrderNode, PurchaseOrderNodeStatus};
 use repository::{DatetimeFilter, EqualFilter, PaginationOption, StringFilter};
 use repository::{PurchaseOrderFilter, PurchaseOrderSort, PurchaseOrderSortField};
+use service::auth::{Resource, ResourceAccessRequest};
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq)]
 #[graphql(rename_items = "camelCase")]
@@ -61,9 +62,16 @@ pub fn get_purchase_order(
     store_id: &str,
     id: &str,
 ) -> Result<PurchaseOrderResponse> {
-    // TODO add auth validation once permissions finalised
+    let user = validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::QueryPurchaseOrder,
+            store_id: Some(store_id.to_string()),
+        },
+    )?;
+
     let service_provider = ctx.service_provider();
-    let service_context = service_provider.context(store_id.to_string(), "".to_string())?;
+    let service_context = service_provider.context(store_id.to_string(), user.user_id)?;
 
     match service_provider
         .purchase_order_service
@@ -90,9 +98,17 @@ pub fn get_purchase_orders(
     filter: Option<PurchaseOrderFilterInput>,
     sort: Option<Vec<PurchaseOrderSortInput>>,
 ) -> Result<PurchaseOrdersResponse> {
-    // TODO add auth validation once permissions finalised
+
+    let user = validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::QueryPurchaseOrder,
+            store_id: Some(store_id.to_string()),
+        },
+    )?;
+
     let service_provider = ctx.service_provider();
-    let service_context = service_provider.context(store_id.to_string(), "".to_string())?;
+    let service_context = service_provider.context(store_id.to_string(), user.user_id)?;
 
     let result = service_provider
         .purchase_order_service

--- a/server/service/src/auth.rs
+++ b/server/service/src/auth.rs
@@ -153,6 +153,10 @@ pub enum Resource {
     // Campaigns
     QueryCampaigns,
     MutateCampaigns,
+    // Purchase Order
+    PurchaseOrderQuery,
+    PurchaseOrderMutate,
+    PurchaseOrderAuthorise,
 }
 
 fn all_permissions() -> HashMap<Resource, PermissionDSL> {
@@ -681,6 +685,19 @@ fn all_permissions() -> HashMap<Resource, PermissionDSL> {
     map.insert(
         Resource::QueryCampaigns,
         PermissionDSL::Any(vec![PermissionDSL::HasStoreAccess]),
+    );
+
+    map.insert(
+        Resource::PurchaseOrderQuery,
+        PermissionDSL::HasPermission(PermissionType::PurchaseOrderQuery),
+    );
+    map.insert(
+        Resource::PurchaseOrderMutate,
+        PermissionDSL::HasPermission(PermissionType::PurchaseOrderMutate),
+    );
+    map.insert(
+        Resource::PurchaseOrderAuthorise,
+        PermissionDSL::HasPermission(PermissionType::PurchaseOrderAuthorise),
     );
 
     map

--- a/server/service/src/auth.rs
+++ b/server/service/src/auth.rs
@@ -154,9 +154,9 @@ pub enum Resource {
     QueryCampaigns,
     MutateCampaigns,
     // Purchase Order
-    PurchaseOrderQuery,
-    PurchaseOrderMutate,
-    PurchaseOrderAuthorise,
+    QueryPurchaseOrder,
+    MutatePurchaseOrder,
+    AuthorisePurchaseOrder,
 }
 
 fn all_permissions() -> HashMap<Resource, PermissionDSL> {
@@ -688,15 +688,15 @@ fn all_permissions() -> HashMap<Resource, PermissionDSL> {
     );
 
     map.insert(
-        Resource::PurchaseOrderQuery,
+        Resource::QueryPurchaseOrder,
         PermissionDSL::HasPermission(PermissionType::PurchaseOrderQuery),
     );
     map.insert(
-        Resource::PurchaseOrderMutate,
+        Resource::MutatePurchaseOrder,
         PermissionDSL::HasPermission(PermissionType::PurchaseOrderMutate),
     );
     map.insert(
-        Resource::PurchaseOrderAuthorise,
+        Resource::AuthorisePurchaseOrder,
         PermissionDSL::HasPermission(PermissionType::PurchaseOrderAuthorise),
     );
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8624 

# 👩🏻‍💻 What does this PR do?

Implements permissions and auth for purchase orders' graphql API.

## 💌 Any notes for the reviewer?

Enjoy your weekend!

# 🧪 Testing

- [ ] Try and run a query for the purchase order object in the GraphiQL explorer.
- [ ] Check it works.
- [ ] In 4D, remove permission for querying purchase orders.
- [ ] Try and run the query again.
- [ ] Check it fails with a permission denied error.
- [ ] Try and run an InsertPurchaseOrders mutuation in the explorer.
- [ ] Check it works.
- [ ] In 4D remove permission for mutating purchase orders (called 'edit purchase orders' or similar in 4D).
- [ ] Check it fails with a permission denied error.
- [ ] In 4D, reinstate permision for *querying* purchase orders.
- [ ] Try and run a query for the purchase order line object in the explorer.
- [ ] Check it works.
- [ ] In 4D, remove permision for *querying* purchase orders.
- [ ] Check it fails with a permission denied error.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

