### PR TITLE
8640 & 8641 rnr default values not on internal order

### DIFF
--- a/server/service/src/rnr_form/finalise.rs
+++ b/server/service/src/rnr_form/finalise.rs
@@ -198,10 +198,16 @@ fn generate(
                     approval_comment: None,
                     comment: rnr_form_line_row.comment,
                     initial_stock_on_hand_units: rnr_form_line_row.initial_balance,
-                    incoming_units: rnr_form_line_row.entered_quantity_received.unwrap_or(0.0),
-                    outgoing_units: rnr_form_line_row.entered_quantity_consumed.unwrap_or(0.0),
+                    incoming_units: rnr_form_line_row
+                        .entered_quantity_received
+                        .unwrap_or(rnr_form_line_row.snapshot_quantity_received),
+                    outgoing_units: rnr_form_line_row
+                        .entered_quantity_consumed
+                        .unwrap_or(rnr_form_line_row.snapshot_quantity_consumed),
                     loss_in_units: rnr_form_line_row.entered_losses.unwrap_or(0.0),
-                    addition_in_units: rnr_form_line_row.entered_adjustments.unwrap_or(0.0),
+                    addition_in_units: rnr_form_line_row
+                        .entered_adjustments
+                        .unwrap_or(rnr_form_line_row.snapshot_adjustments),
                     expiring_units: 0.0,
                     days_out_of_stock: rnr_form_line_row.stock_out_duration as f64,
                     option_id: None,

--- a/server/service/src/rnr_form/finalise.rs
+++ b/server/service/src/rnr_form/finalise.rs
@@ -1,5 +1,6 @@
 use crate::{
     activity_log::activity_log_entry, number::next_number, service_provider::ServiceContext,
+    store_preference::get_store_preferences,
 };
 
 use chrono::Utc;
@@ -122,6 +123,9 @@ fn generate(
         period_row,
         ..
     } = rnr_form;
+
+    let store_preferences = get_store_preferences(&ctx.connection, &rnr_form_row.store_id)?;
+
     // Create an internal order based on the RnR form
     // Internal Orders are known as requisitions in the code base
     let requisition_row = RequisitionRow {
@@ -142,9 +146,9 @@ fn generate(
         expected_delivery_date: None,
         colour: None,
         comment: Some("Automatically created from R&R Form".to_string()),
-        max_months_of_stock: 0.0,
+        max_months_of_stock: store_preferences.months_overstock,
         their_reference: rnr_form_row.their_reference.clone(),
-        min_months_of_stock: 0.0,
+        min_months_of_stock: store_preferences.months_understock,
         approval_status: None,
         linked_requisition_id: None,
         program_id: Some(rnr_form_row.program_id.clone()),

--- a/server/service/src/rnr_form/tests/finalise.rs
+++ b/server/service/src/rnr_form/tests/finalise.rs
@@ -168,6 +168,9 @@ mod finalise {
             requisition.requisition_row.their_reference,
             Some("form B reference".to_string())
         );
+        // No store prefs in default mock data so use OMS defaults (6 and 3 months)
+        assert_eq!(requisition.requisition_row.max_months_of_stock, 6.0);
+        assert_eq!(requisition.requisition_row.min_months_of_stock, 3.0);
 
         // Check the store of the internal order is the same as the RnR form
         assert_eq!(requisition.requisition_row.store_id, mock_store_a().id);

--- a/server/service/src/rnr_form/tests/finalise.rs
+++ b/server/service/src/rnr_form/tests/finalise.rs
@@ -1,12 +1,15 @@
 #[cfg(test)]
 mod finalise {
-    use repository::mock::{mock_item_c, mock_rnr_form_a, mock_rnr_form_b, mock_store_a, MockData};
+    use repository::mock::{
+        mock_item_a, mock_item_b, mock_item_c, mock_rnr_form_a, mock_rnr_form_b, mock_store_a,
+        MockData,
+    };
     use repository::mock::{mock_store_b, MockDataInserts};
-    use repository::test_db::{setup_all, setup_all_with_data};
+    use repository::test_db::setup_all_with_data;
     use repository::{
         EqualFilter, RequisitionFilter, RequisitionLineFilter, RequisitionLineRepository,
-        RequisitionRepository, RequisitionStatus, RnRFormLineRow, RnRFormLineRowRepository,
-        RnRFormRowRepository, RnRFormStatus,
+        RequisitionRepository, RequisitionStatus, RnRFormLineRow, RnRFormRowRepository,
+        RnRFormStatus,
     };
 
     use crate::rnr_form::finalise::{FinaliseRnRForm, FinaliseRnRFormError};
@@ -91,8 +94,40 @@ mod finalise {
 
     #[actix_rt::test]
     async fn finalise_rnr_form_success() {
-        let (_, _, connection_manager, _) =
-            setup_all("finalise_rnr_form_success", MockDataInserts::all()).await;
+        fn auto_populated_line() -> RnRFormLineRow {
+            RnRFormLineRow {
+                id: "auto_populated_line".to_string(),
+                rnr_form_id: mock_rnr_form_b().id,
+                item_link_id: mock_item_a().id,
+                snapshot_quantity_received: 5.0,
+                snapshot_quantity_consumed: 7.0,
+                snapshot_adjustments: 1.0,
+                calculated_requested_quantity: 10.0,
+                ..Default::default()
+            }
+        }
+        fn manually_entered_line() -> RnRFormLineRow {
+            RnRFormLineRow {
+                id: "manually_entered_line".to_string(),
+                rnr_form_id: mock_rnr_form_b().id,
+                item_link_id: mock_item_b().id,
+                entered_quantity_received: Some(10.0),
+                entered_quantity_consumed: Some(14.0),
+                entered_adjustments: Some(5.0),
+                entered_requested_quantity: Some(12.0),
+                entered_losses: Some(2.0),
+                ..Default::default()
+            }
+        }
+        let (_, _, connection_manager, _) = setup_all_with_data(
+            "finalise_rnr_form_success",
+            MockDataInserts::all(),
+            MockData {
+                rnr_form_lines: vec![auto_populated_line(), manually_entered_line()],
+                ..Default::default()
+            },
+        )
+        .await;
 
         let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
@@ -138,19 +173,43 @@ mod finalise {
         assert_eq!(requisition.requisition_row.store_id, mock_store_a().id);
 
         // Check the same number of lines in the internal order as the RnR form
-        let rnr_lines = RnRFormLineRowRepository::new(&context.connection)
-            .find_many_by_rnr_form_id(&mock_rnr_form_b().id)
+        let requisition_lines = RequisitionLineRepository::new(&context.connection)
+            .query_by_filter(
+                RequisitionLineFilter::new()
+                    .requisition_id(EqualFilter::equal_to(&requisition.requisition_row.id)),
+            )
             .unwrap();
 
-        let rnr_line_count = rnr_lines.len();
-        let requisition_line_count = RequisitionLineRepository::new(&context.connection)
-            .count(Some(RequisitionLineFilter::new().requisition_id(
-                EqualFilter::equal_to(&requisition.requisition_row.id),
-            )))
-            .unwrap() as usize;
+        assert_eq!(requisition_lines.len(), 3); // 1 from rnr_form mock data, plus 2 (above)
 
-        assert_eq!(rnr_line_count, requisition_line_count);
+        // Check correct data was populated
+        let auto_populated_line = &requisition_lines
+            .iter()
+            .find(|line| {
+                line.requisition_line_row.item_link_id == auto_populated_line().item_link_id
+            })
+            .unwrap()
+            .requisition_line_row;
 
-        assert!(rnr_lines.iter().all(|l| l.requisition_line_id.is_some()));
+        // Requisition line populated using the snapshot data
+        assert_eq!(auto_populated_line.requested_quantity, 10.0);
+        assert_eq!(auto_populated_line.incoming_units, 5.0);
+        assert_eq!(auto_populated_line.outgoing_units, 7.0);
+        assert_eq!(auto_populated_line.addition_in_units, 1.0);
+
+        let manually_entered_line = &requisition_lines
+            .iter()
+            .find(|line| {
+                line.requisition_line_row.item_link_id == manually_entered_line().item_link_id
+            })
+            .unwrap()
+            .requisition_line_row;
+
+        // Requisition line populated using the manually entered data
+        assert_eq!(manually_entered_line.requested_quantity, 12.0);
+        assert_eq!(manually_entered_line.incoming_units, 10.0);
+        assert_eq!(manually_entered_line.outgoing_units, 14.0);
+        assert_eq!(manually_entered_line.addition_in_units, 5.0);
+        assert_eq!(manually_entered_line.loss_in_units, 2.0);
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8641 and #8640

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Defaults to snapshot values where nothing is manually entered

and

Populates requisition min/max MOS based on store pref:
<img width="588" height="113" alt="Screenshot 2025-07-29 at 11 20 45 AM" src="https://github.com/user-attachments/assets/3478cd81-bd10-4844-8dd5-3d87d1e85877" />


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have some consumption data during a period
- [ ] Create an RnR form for that period
- [ ] See rows auto-populate with calculated values from consumption data
- [ ] Edit some lines, leave others as their calculated values
- [ ] Finalise
- [ ] View the generated response requisition in the supplying store
- [ ] Lines where you edited the value, show the edited value
- [ ] Calculated values are present when not data entered was edited
- [ ] Check the generated internal order > reorder threshold MOS/max MOS in the toolbar
- [ ] Values should reflect the store prefs of the requesting store

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

