### PR TITLE
8042 UI ux pt 5

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/ExpandoTable.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/ExpandoTable.tsx
@@ -26,14 +26,8 @@ export const Expand = ({
     const withDoseColumns =
       (displayDoseColumns && rowData.lines[0]?.item.isVaccine) ?? false;
 
-    const unitName = rowData.lines[0]?.item.unitName ?? undefined;
-
     return (
-      <ExpandInner
-        rows={rowData.lines}
-        withDoseColumns={withDoseColumns}
-        unitName={unitName}
-      />
+      <ExpandInner rows={rowData.lines} withDoseColumns={withDoseColumns} />
     );
   } else {
     return null;
@@ -43,22 +37,19 @@ export const Expand = ({
 const ExpandInner = ({
   rows,
   withDoseColumns,
-  unitName,
 }: {
   rows: StockOutLineFragment[];
   withDoseColumns: boolean;
-  unitName?: string;
 }) => {
   const t = useTranslation();
-  const expandoColumns = useExpansionColumns(withDoseColumns, t, unitName);
+  const expandoColumns = useExpansionColumns(withDoseColumns, t);
 
   return <MiniTable rows={rows} columns={expandoColumns} />;
 };
 
 const useExpansionColumns = (
   withDoseColumns: boolean,
-  t: TypedTFunction<LocaleKey>,
-  unitName?: string
+  t: TypedTFunction<LocaleKey>
 ): Column<StockOutLineFragment>[] => {
   const columns: ColumnDescription<StockOutLineFragment>[] = [
     'batch',
@@ -79,7 +70,7 @@ const useExpansionColumns = (
   ];
 
   if (withDoseColumns) {
-    columns.push(getDosesPerUnitColumn(t, unitName));
+    columns.push(getDosesPerUnitColumn(t));
   }
   columns.push('numberOfPacks', [
     'unitQuantity',

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/Allocation.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/Allocation.tsx
@@ -151,7 +151,7 @@ const AllocationInner = () => {
         <Divider margin={10} />
 
         <Box display="flex" alignItems="flex-start" gap={2}>
-          <Grid container alignItems="center" pt={1}>
+          <Grid container alignItems="center" pt={1} gap={1}>
             <AutoAllocateField />
             <AllocateInSelector includePackSizeOptions />
           </Grid>

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
@@ -8,8 +8,6 @@ import {
   DropdownMenuItem,
   TextArea,
   InputWithLabelRow,
-  usePreference,
-  PreferenceKey,
 } from '@openmsupply-client/common';
 import { AccordionPanelSection } from './PanelSection';
 import { getPrescriptionDirections } from './getPrescriptionDirections';
@@ -32,28 +30,24 @@ export const PrescriptionLineEditForm = ({
   isNew,
 }: PrescriptionLineEditFormProps) => {
   const t = useTranslation();
-  const { data: prefs } = usePreference(
-    PreferenceKey.ManageVaccinesInDoses,
-    PreferenceKey.SortByVvmStatusThenExpiry
-  );
 
-  const { draftLines, item, note, allocatedQuantity, setNote } =
+  const { draftLines, item, note, allocatedQuantity, allocateInType, setNote } =
     useAllocationContext(state => ({
       draftLines: state.draftLines,
       item: state.item,
       note: state.note,
       setNote: state.setNote,
       allocatedQuantity: getAllocatedQuantity(state),
+      allocateInType: state.allocateIn.type,
     }));
 
   const [defaultDirection, setDefaultDirection] = useState('');
   const [abbreviation, setAbbreviation] = useState('');
 
   const isDirectionsDisabled = !allocatedQuantity;
-  const displayInDoses = !!prefs?.manageVaccinesInDoses && !!item?.isVaccine;
 
   const { data: options = [] } = useAbbreviations();
-  const { summarise, dosesSummary } = useClosedSummary();
+  const summarise = useClosedSummary();
 
   const saveAbbreviation = () => {
     if (!abbreviation) return;
@@ -79,11 +73,12 @@ export const PrescriptionLineEditForm = ({
 
         <AccordionPanelSection
           title={t('label.quantity')}
-          closedSummary={
-            displayInDoses
-              ? dosesSummary(t, draftLines)
-              : summarise(t, item.unitName ?? t('label.unit'), draftLines)
-          }
+          closedSummary={summarise(
+            t,
+            draftLines,
+            allocateInType,
+            item.unitName
+          )}
           defaultExpanded={isNew && !disabled}
         >
           <Grid

--- a/client/packages/invoices/src/Prescriptions/LineEditView/hooks/useClosedSummary.ts
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/hooks/useClosedSummary.ts
@@ -5,7 +5,10 @@ import {
   useIntlUtils,
 } from '@common/intl';
 import { NumUtils } from '@common/utils';
-import { DraftStockOutLineFragment } from 'packages/invoices/src/StockOut';
+import {
+  AllocateInType,
+  DraftStockOutLineFragment,
+} from '../../../../../invoices/src/StockOut';
 
 export const useClosedSummary = () => {
   const { round } = useFormatNumber();
@@ -18,7 +21,7 @@ export const useClosedSummary = () => {
       : `${formatted} `;
   };
 
-  const summarise = (
+  const unitsSummary = (
     t: TypedTFunction<LocaleKey>,
     unitName: string,
     lines: DraftStockOutLineFragment[]
@@ -88,5 +91,17 @@ export const useClosedSummary = () => {
     return [{ displayValue, text: unitWord }];
   };
 
-  return { summarise, dosesSummary };
+  const summarise = (
+    t: TypedTFunction<LocaleKey>,
+    lines: DraftStockOutLineFragment[],
+    allocationInType: AllocateInType,
+    unitName?: string | null
+  ) => {
+    if (allocationInType === AllocateInType.Doses) {
+      return dosesSummary(t, lines);
+    }
+    return unitsSummary(t, unitName ?? t('label.unit'), lines);
+  };
+
+  return summarise;
 };

--- a/client/packages/invoices/src/StockOut/Components/AllocateInSelector.tsx
+++ b/client/packages/invoices/src/StockOut/Components/AllocateInSelector.tsx
@@ -7,7 +7,6 @@ import {
   useIntlUtils,
   useFormatNumber,
   Typography,
-  Box,
 } from '@openmsupply-client/common';
 import { AllocateInType, useAllocationContext } from '../useAllocationContext';
 import { canAutoAllocate } from '../utils';
@@ -43,7 +42,10 @@ export const AllocateInSelector = ({
   const includeDosesOption = item?.isVaccine && prefs?.manageVaccinesInDoses;
 
   // EARLY RETURN - if only allocating in units, don't show the selector
-  if (!includePackSizeOptions && !includeDosesOption) {
+  if (
+    (!includePackSizeOptions || !availablePackSizes.length) &&
+    !includeDosesOption
+  ) {
     return <Typography sx={{ fontSize: 12 }}>{pluralisedUnitName}</Typography>;
   }
 
@@ -87,20 +89,17 @@ export const AllocateInSelector = ({
   };
 
   return (
-    <>
-      <Box marginLeft={1} />
-      <Select
-        options={options}
-        value={
-          allocateIn.type === AllocateInType.Packs
-            ? allocateIn.packSize
-            : allocateIn.type
-        }
-        onChange={e =>
-          handleAllocateInChange(e.target.value as AllocateInType | number)
-        }
-        sx={{ width: '150px' }}
-      />
-    </>
+    <Select
+      options={options}
+      value={
+        allocateIn.type === AllocateInType.Packs
+          ? allocateIn.packSize
+          : allocateIn.type
+      }
+      onChange={e =>
+        handleAllocateInChange(e.target.value as AllocateInType | number)
+      }
+      sx={{ width: '150px' }}
+    />
   );
 };

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
@@ -88,10 +88,21 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
     if (openOnFocus) {
       setTimeout(() => selectControl.toggleOn(), DEBOUNCE_TIMEOUT);
     }
+
+    // Force focus after component mounts (this can conflict with openOnFocus)
+    if (autoFocus) {
+      setTimeout(() => {
+        const input = document.querySelector<HTMLInputElement>(
+          'input[id="stock-item-search-input"]'
+        );
+        input?.focus();
+      }, 50);
+    }
   }, []);
 
   return (
     <Autocomplete
+      id="stock-item-search-input"
       pages={data?.pages ?? []}
       pageNumber={pageNumber}
       rowsPerPage={ROWS_PER_PAGE}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8042

# 👩🏻‍💻 What does this PR do?

Last one!



13. Collapsed view respects allocation lens:

https://github.com/user-attachments/assets/37a16b8a-80b3-418c-83a6-ba7f988f1ee2

15. Some fields say Doses per Unit, some say Doses per VI (whatever Unit we specify) -> change to only "doses per unit":
<img width="904" height="195" alt="Screenshot 2025-07-29 at 3 08 52 PM" src="https://github.com/user-attachments/assets/77f25b24-94e7-4768-a6c0-949c98651f88" />

17. autofocus when selecting new item in prescription:
<img width="1056" height="239" alt="Screenshot 2025-07-29 at 3 44 24 PM" src="https://github.com/user-attachments/assets/bb93fef9-a765-430a-9bb8-71f4c117635e" />


Bonus: fixes pack size selector being empty when no available pack sizes - instead show units:

<img width="400" height="348" alt="Screenshot 2025-07-29 at 2 56 35 PM" src="https://github.com/user-attachments/assets/b9d01caf-f5b0-4e19-8a13-2451d824caf0" />
<img width="400" height="311" alt="Screenshot 2025-07-29 at 2 56 44 PM" src="https://github.com/user-attachments/assets/b1b8675a-f281-48d6-9b71-5559f95a9037" />


<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Prescription line edit > with manage vaccines in doses pref on
  - [ ] Vaccine item - allocate some doses
  - [ ] Collapse the view - shows total doses
  - [ ] Reopen, change lens to Units
  - [ ] Collapse the view - shows total units
- [ ] Click `new item`
  - [ ] Item picker auto-focuses
- [ ] Outbound shipment detail view
  - [ ] Have multiple lines for the same vaccine item
  - [ ] Select `group by item`
  - [ ] Open the `expand` view
  - [ ] See "doses per unit" column (rather than "doses per vial" (or your unit name))
- [ ] Open line edit view for an item with no available lines (e.g. all expired)
  - [ ] Says `[unitname]` next to "allocate" section, rather than empty picker

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

