### PR TITLE
#8634 Sync badge updates

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1896,6 +1896,7 @@
   "preference.orderInPacks": "Order in packs",
   "preference.showContactTracing": "Show contact tracing",
   "preference.sortByVvmStatusThenExpiry": "Sort available batches by VVM status then expiry",
+  "preference.syncRecordsDisplayThreshold": "Sync records display threshold",
   "preference.useCampaigns": "Use Campaigns",
   "preference.useSimplifiedMobileUi": "Use simplified mobile UI",
   "prescription": "Prescriptions",

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -6187,6 +6187,7 @@ export enum PreferenceKey {
   OrderInPacks = 'orderInPacks',
   ShowContactTracing = 'showContactTracing',
   SortByVvmStatusThenExpiry = 'sortByVvmStatusThenExpiry',
+  SyncRecordsDisplayThreshold = 'syncRecordsDisplayThreshold',
   UseCampaigns = 'useCampaigns',
   UseSimplifiedMobileUi = 'useSimplifiedMobileUi',
 }
@@ -6221,6 +6222,7 @@ export type PreferencesNode = {
   orderInPacks: Scalars['Boolean']['output'];
   showContactTracing: Scalars['Boolean']['output'];
   sortByVvmStatusThenExpiry: Scalars['Boolean']['output'];
+  syncRecordsDisplayThreshold: Scalars['Int']['output'];
   useCampaigns: Scalars['Boolean']['output'];
   useSimplifiedMobileUi: Scalars['Boolean']['output'];
 };
@@ -10033,6 +10035,7 @@ export type UpsertPreferencesInput = {
   orderInPacks?: InputMaybe<Array<BoolStorePrefInput>>;
   showContactTracing?: InputMaybe<Scalars['Boolean']['input']>;
   sortByVvmStatusThenExpiry?: InputMaybe<Array<BoolStorePrefInput>>;
+  syncRecordsDisplayThreshold?: InputMaybe<Scalars['Int']['input']>;
   useCampaigns?: InputMaybe<Scalars['Boolean']['input']>;
   useSimplifiedMobileUi?: InputMaybe<Array<BoolStorePrefInput>>;
 };

--- a/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -176,7 +176,6 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
 
               '& .MuiBadge-badge:not(.MuiBadge-invisible)': drawer.isOpen
                 ? {
-                    // top: 'unset',
                     transform: 'scale(0.75) translate(100%, 0)',
                   }
                 : {

--- a/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -165,10 +165,19 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
             {...badgeProps}
             sx={{
               alignItems: 'center',
-              flexGrow: 1,
+              '& .MuiBadge-badge':
+                badgeProps?.color === 'default'
+                  ? {
+                      backgroundColor: 'gray.light',
+                      color: 'gray.dark',
+                    }
+                  : undefined,
+              // flexGrow: 1,
+
               '& .MuiBadge-badge:not(.MuiBadge-invisible)': drawer.isOpen
                 ? {
-                    transform: 'scale(0.75) translate(75%, -25%)',
+                    // top: 'unset',
+                    transform: 'scale(0.75) translate(100%, 0)',
                   }
                 : {
                     top: 'unset',

--- a/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
+++ b/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import {
   AlertIcon,
   AppNavLink,

--- a/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
+++ b/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
@@ -85,7 +85,7 @@ const getBadge = (
 
   if (isSyncError) {
     return {
-      badgeContent: <AlertIcon color="error" fontSize="small" />,
+      badgeContent: <AlertIcon color="error" />,
     };
   }
 

--- a/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
+++ b/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
@@ -63,7 +63,7 @@ const getBadge = (
 ): BadgeProps | undefined => {
   if (!syncStatus) return;
 
-  const { errorThreshold, warningThreshold, lastSuccessfulSync, error } =
+  const { warningThreshold, errorThreshold, lastSuccessfulSync, error } =
     syncStatus;
 
   const isSyncError =

--- a/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
+++ b/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
@@ -1,27 +1,83 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
   AlertIcon,
   AppNavLink,
   DateUtils,
+  PreferenceKey,
   RadioIcon,
   SyncErrorVariant,
+  usePreference,
   useTranslation,
+  useTheme,
 } from '@openmsupply-client/common';
+import { BadgeProps } from '@mui/material';
 import { useSync } from '@openmsupply-client/system';
 import { useSyncModal } from '../Sync';
-import { SyncInfoQuery } from 'packages/system/src/Sync/api/operations.generated';
 
-const POLLING_INTERVAL_IN_MILLISECONDS = 60 * 1000;
+const POLLING_INTERVAL_IN_MILLISECONDS = 60 * 1000; // 1 minute
 
 export const SyncNavLink = () => {
   const t = useTranslation();
+  const { data: preferences } = usePreference(
+    PreferenceKey.SyncRecordsDisplayThreshold
+  );
+  const theme = useTheme();
+
+  const syncRecordsDisplayThreshold =
+    preferences?.[PreferenceKey.SyncRecordsDisplayThreshold] ?? 0;
+
   const showSync = useSyncModal();
 
-  const { syncStatus } = useSync.utils.syncInfo(
+  const { syncStatus, numberOfRecordsInPushQueue = 0 } = useSync.utils.syncInfo(
     POLLING_INTERVAL_IN_MILLISECONDS
   );
 
-  const badgeProps = getBadge(syncStatus);
+  const getBadge = useCallback((): BadgeProps | undefined => {
+    if (!syncStatus) return;
+
+    const { errorThreshold, warningThreshold, lastSuccessfulSync, error } =
+      syncStatus;
+
+    const isSyncError =
+      error?.variant &&
+      // We allow connection errors until a threshold is reached (see below)
+      // all other errors should be flagged immediately
+      error.variant !== SyncErrorVariant.ConnectionError;
+
+    const now = new Date();
+    const daysSinceSuccessfulSync = DateUtils.differenceInDays(
+      now,
+      lastSuccessfulSync?.finished ?? now
+    );
+
+    const beyondWarningThreshold = daysSinceSuccessfulSync >= warningThreshold;
+    const beyondErrorThreshold = daysSinceSuccessfulSync >= errorThreshold;
+
+    const showCountBadge =
+      numberOfRecordsInPushQueue >= syncRecordsDisplayThreshold;
+
+    if (isSyncError) {
+      return {
+        badgeContent: <AlertIcon color="error" fontSize="small" />,
+      };
+    }
+
+    if (showCountBadge) {
+      return {
+        badgeContent: numberOfRecordsInPushQueue,
+        color: beyondErrorThreshold
+          ? 'error'
+          : beyondWarningThreshold
+            ? 'warning'
+            : 'default',
+      };
+    }
+  }, [
+    syncStatus,
+    numberOfRecordsInPushQueue,
+    syncRecordsDisplayThreshold,
+    theme,
+  ]);
 
   return (
     <AppNavLink
@@ -31,43 +87,14 @@ export const SyncNavLink = () => {
         e.preventDefault();
         showSync();
       }}
-      icon={<RadioIcon fontSize="small" color="primary" />}
+      icon={
+        <RadioIcon
+          fontSize="small"
+          color={syncStatus?.error ? 'disabled' : 'primary'}
+        />
+      }
       text={t('sync')}
-      badgeProps={badgeProps}
+      badgeProps={getBadge()}
     />
   );
-};
-
-const getBadge = (syncStatus: SyncInfoQuery['syncStatus']) => {
-  if (!syncStatus) return;
-
-  const { warningThreshold, errorThreshold, lastSuccessfulSync, error } =
-    syncStatus;
-
-  const isSyncError =
-    error?.variant &&
-    // We allow connection errors until a threshold is reached (see below)
-    // all other errors should be flagged immediately
-    error.variant !== SyncErrorVariant.ConnectionError;
-
-  const now = new Date();
-  const daysSinceSuccessfulSync = DateUtils.differenceInDays(
-    now,
-    lastSuccessfulSync?.finished ?? now
-  );
-
-  const beyondWarningThreshold = daysSinceSuccessfulSync >= warningThreshold;
-  const beyondErrorThreshold = daysSinceSuccessfulSync >= errorThreshold;
-
-  if (isSyncError || beyondWarningThreshold) {
-    return {
-      badgeContent: (
-        <AlertIcon
-          color={isSyncError || beyondErrorThreshold ? 'error' : 'warning'}
-          fontSize="small"
-        />
-      ),
-      color: 'default' as 'primary' | 'default',
-    };
-  }
 };

--- a/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
+++ b/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
@@ -8,7 +8,6 @@ import {
   SyncErrorVariant,
   usePreference,
   useTranslation,
-  useTheme,
 } from '@openmsupply-client/common';
 import { BadgeProps } from '@mui/material';
 import { useSync } from '@openmsupply-client/system';
@@ -21,8 +20,6 @@ export const SyncNavLink = () => {
   const { data: preferences } = usePreference(
     PreferenceKey.SyncRecordsDisplayThreshold
   );
-  const theme = useTheme();
-
   const syncRecordsDisplayThreshold =
     preferences?.[PreferenceKey.SyncRecordsDisplayThreshold] ?? 0;
 
@@ -72,12 +69,7 @@ export const SyncNavLink = () => {
             : 'default',
       };
     }
-  }, [
-    syncStatus,
-    numberOfRecordsInPushQueue,
-    syncRecordsDisplayThreshold,
-    theme,
-  ]);
+  }, [syncStatus, numberOfRecordsInPushQueue, syncRecordsDisplayThreshold]);
 
   return (
     <AppNavLink

--- a/client/packages/system/src/Manage/Preferences/EditPage/EditPreference.tsx
+++ b/client/packages/system/src/Manage/Preferences/EditPage/EditPreference.tsx
@@ -8,6 +8,8 @@ import {
   UpsertPreferencesInput,
   PreferenceDescriptionNode,
   useTranslation,
+  NumericTextInput,
+  useDebouncedValueCallback,
 } from '@openmsupply-client/common';
 import {
   EnumOptions,
@@ -29,6 +31,12 @@ export const EditPreference = ({
   // is invalidated - use local state for fast UI change
   const [value, setValue] = useState(preference.value);
 
+  const debouncedUpdate = useDebouncedValueCallback(
+    value => update(value),
+    [],
+    350
+  );
+
   switch (preference.valueType) {
     case PreferenceValueNodeType.Boolean:
       if (!isBoolean(value)) {
@@ -49,9 +57,16 @@ export const EditPreference = ({
       if (!isNumber(preference.value)) {
         return t('error.something-wrong');
       }
-      // Adding NumericTextInput here would currently get a type error,
-      // because there are no editPreference inputs that accept a number
-      return <>To be implemented</>;
+      console.log(preference.key, preference.value);
+      return (
+        <NumericTextInput
+          value={value}
+          onChange={newValue => {
+            setValue(newValue);
+            debouncedUpdate(newValue);
+          }}
+        />
+      );
 
     case PreferenceValueNodeType.MultiChoice:
       if (!Array.isArray(value)) {
@@ -66,7 +81,7 @@ export const EditPreference = ({
           value={value}
           onChange={newValue => {
             setValue(newValue);
-            update(newValue);
+            debouncedUpdate(newValue);
           }}
         />
       );

--- a/client/packages/system/src/Manage/Preferences/EditPage/EditPreference.tsx
+++ b/client/packages/system/src/Manage/Preferences/EditPage/EditPreference.tsx
@@ -57,7 +57,6 @@ export const EditPreference = ({
       if (!isNumber(preference.value)) {
         return t('error.something-wrong');
       }
-      console.log(preference.key, preference.value);
       return (
         <NumericTextInput
           value={value}

--- a/server/graphql/preference/src/upsert.rs
+++ b/server/graphql/preference/src/upsert.rs
@@ -18,6 +18,7 @@ pub struct UpsertPreferencesInput {
     pub gender_options: Option<Vec<GenderType>>,
     pub show_contact_tracing: Option<bool>,
     pub use_campaigns: Option<bool>,
+    pub sync_records_display_threshold: Option<i32>,
     // Store preferences
     pub manage_vaccines_in_doses: Option<Vec<BoolStorePrefInput>>,
     pub manage_vvm_status_for_stock: Option<Vec<BoolStorePrefInput>>,
@@ -55,6 +56,7 @@ impl UpsertPreferencesInput {
             allow_tracking_of_stock_by_donor,
             gender_options,
             show_contact_tracing,
+            sync_records_display_threshold,
             // Store preferences
             manage_vaccines_in_doses,
             manage_vvm_status_for_stock,
@@ -72,7 +74,9 @@ impl UpsertPreferencesInput {
                 .map(|i| i.iter().map(|i| i.to_domain()).collect()),
             show_contact_tracing: *show_contact_tracing,
             use_campaigns: *use_campaigns,
-            // Global preferences*show_contact_tracing
+            sync_records_display_threshold: *sync_records_display_threshold,
+
+            // Store preferences
             manage_vaccines_in_doses: manage_vaccines_in_doses
                 .as_ref()
                 .map(|i| i.iter().map(|i| i.to_domain()).collect()),

--- a/server/graphql/types/src/types/preferences.rs
+++ b/server/graphql/types/src/types/preferences.rs
@@ -33,6 +33,10 @@ impl PreferencesNode {
         self.load_preference(&self.preferences.use_campaigns)
     }
 
+    pub async fn sync_records_display_threshold(&self) -> Result<i32> {
+        self.load_preference(&self.preferences.sync_records_display_threshold)
+    }
+
     // Store preferences
     pub async fn manage_vaccines_in_doses(&self) -> Result<bool> {
         self.load_preference(&self.preferences.manage_vaccines_in_doses)
@@ -104,6 +108,7 @@ pub enum PreferenceKey {
     GenderOptions,
     ShowContactTracing,
     UseCampaigns,
+    SyncRecordsDisplayThreshold,
     // Store preferences
     ManageVaccinesInDoses,
     ManageVvmStatusForStock,
@@ -120,6 +125,7 @@ impl PreferenceKey {
             PrefKey::GenderOptions => PreferenceKey::GenderOptions,
             PrefKey::ShowContactTracing => PreferenceKey::ShowContactTracing,
             PrefKey::UseCampaigns => PreferenceKey::UseCampaigns,
+            PrefKey::SyncRecordsDisplayThreshold => PreferenceKey::SyncRecordsDisplayThreshold,
             // Store preferences
             PrefKey::ManageVaccinesInDoses => PreferenceKey::ManageVaccinesInDoses,
             PrefKey::ManageVvmStatusForStock => PreferenceKey::ManageVvmStatusForStock,

--- a/server/service/src/preference/mod.rs
+++ b/server/service/src/preference/mod.rs
@@ -29,6 +29,7 @@ pub trait PreferenceServiceTrait: Sync + Send {
             gender_options,
             show_contact_tracing,
             use_campaigns,
+            sync_records_display_threshold,
 
             // Store preferences
             manage_vaccines_in_doses,
@@ -57,6 +58,7 @@ pub trait PreferenceServiceTrait: Sync + Send {
         append_if_type(order_in_packs, &mut prefs, &input)?;
         append_if_type(sort_by_vvm_status_then_expiry, &mut prefs, &input)?;
         append_if_type(use_simplified_mobile_ui, &mut prefs, &input)?;
+        append_if_type(sync_records_display_threshold, &mut prefs, &input)?;
 
         Ok(prefs)
     }

--- a/server/service/src/preference/preferences/mod.rs
+++ b/server/service/src/preference/preferences/mod.rs
@@ -16,6 +16,8 @@ pub mod use_campaigns;
 pub use use_campaigns::*;
 pub mod order_in_packs;
 pub use order_in_packs::*;
+pub mod sync_records_display_threshold;
+pub use sync_records_display_threshold::*;
 
 pub struct PreferenceProvider {
     // Global preferences
@@ -23,6 +25,7 @@ pub struct PreferenceProvider {
     pub gender_options: GenderOptions,
     pub show_contact_tracing: ShowContactTracing,
     pub use_campaigns: UseCampaigns,
+    pub sync_records_display_threshold: SyncRecordsDisplayThreshold,
     // Store preferences
     pub manage_vaccines_in_doses: ManageVaccinesInDoses,
     pub manage_vvm_status_for_stock: ManageVvmStatusForStock,
@@ -38,6 +41,7 @@ pub fn get_preference_provider() -> PreferenceProvider {
         gender_options: GenderOptions,
         show_contact_tracing: ShowContactTracing,
         use_campaigns: UseCampaigns,
+        sync_records_display_threshold: SyncRecordsDisplayThreshold,
         // Store preferences
         manage_vaccines_in_doses: ManageVaccinesInDoses,
         manage_vvm_status_for_stock: ManageVvmStatusForStock,

--- a/server/service/src/preference/preferences/sync_records_display_threshold.rs
+++ b/server/service/src/preference/preferences/sync_records_display_threshold.rs
@@ -1,0 +1,19 @@
+use crate::preference::{PrefKey, Preference, PreferenceType, PreferenceValueType};
+
+pub struct SyncRecordsDisplayThreshold;
+
+impl Preference for SyncRecordsDisplayThreshold {
+    type Value = i32;
+
+    fn key(&self) -> PrefKey {
+        PrefKey::SyncRecordsDisplayThreshold
+    }
+
+    fn preference_type(&self) -> PreferenceType {
+        PreferenceType::Global
+    }
+
+    fn value_type(&self) -> PreferenceValueType {
+        PreferenceValueType::Integer
+    }
+}

--- a/server/service/src/preference/types.rs
+++ b/server/service/src/preference/types.rs
@@ -17,6 +17,7 @@ pub enum PrefKey {
     GenderOptions,
     ShowContactTracing,
     UseCampaigns,
+    SyncRecordsDisplayThreshold,
     // Store preferences
     ManageVaccinesInDoses,
     ManageVvmStatusForStock,

--- a/server/service/src/preference/upsert.rs
+++ b/server/service/src/preference/upsert.rs
@@ -15,6 +15,7 @@ pub struct UpsertPreferences {
     pub gender_options: Option<Vec<GenderType>>,
     pub show_contact_tracing: Option<bool>,
     pub use_campaigns: Option<bool>,
+    pub sync_records_display_threshold: Option<i32>,
     // Store preferences
     pub manage_vaccines_in_doses: Option<Vec<StorePrefUpdate<bool>>>,
     pub manage_vvm_status_for_stock: Option<Vec<StorePrefUpdate<bool>>>,
@@ -31,6 +32,7 @@ pub fn upsert_preferences(
         gender_options: gender_options_input,
         show_contact_tracing: show_contact_tracing_input,
         use_campaigns: use_campaigns_input,
+        sync_records_display_threshold: sync_records_display_threshold_input,
         // Store preferences
         manage_vaccines_in_doses: manage_vaccines_in_doses_input,
         manage_vvm_status_for_stock: manage_vvm_status_for_stock_input,
@@ -45,6 +47,7 @@ pub fn upsert_preferences(
         gender_options,
         show_contact_tracing,
         use_campaigns,
+        sync_records_display_threshold,
         // Store preferences
         manage_vaccines_in_doses,
         manage_vvm_status_for_stock,
@@ -70,6 +73,10 @@ pub fn upsert_preferences(
 
             if let Some(input) = use_campaigns_input {
                 use_campaigns.upsert(connection, input, None)?;
+            }
+
+            if let Some(input) = sync_records_display_threshold_input {
+                sync_records_display_threshold.upsert(connection, input, None)?;
             }
 
             // Store preferences, input could be array of store IDs and values - iterate and insert...


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8634 

as per [this comment](https://github.com/msupply-foundation/open-msupply/issues/8634#issuecomment-3130185025) (mostly -- I made a couple of other style tweaks, and kept the exising warning/error threshold functionality)

# 👩🏻‍💻 What does this PR do?

- Add `SyncRecordsDisplayThreshold` preference to server (integer value)
- Implement UI to edit preference:
  <img width="621" height="193" alt="Screenshot 2025-07-29 at 4 41 17 PM" src="https://github.com/user-attachments/assets/d3f90009-ea1f-47d7-a7a3-8f9205f50890" />
- Update Sync badge to reflect this preference, plus changes desribed in issue, plus couple of extra style tweaks


### Summary of Badge/Icon display

Normal display -- sync is working and all records are synced (or number is below threshold):
<img width="228" height="195" alt="Screenshot 2025-07-29 at 4 42 47 PM" src="https://github.com/user-attachments/assets/8db574e7-c0ae-4c54-baef-702b2362a5a8" />
(same as current)

When there is a *connection* error (e.g. out of range), not a more serious sync problem, we keep the UI change subtle, just by dulling the icon (Mark okay-ed this):

<img width="245" height="132" alt="Screenshot 2025-07-29 at 5 05 37 PM" src="https://github.com/user-attachments/assets/cefbeee1-a828-4c77-86aa-6aa55f3a640a" />

(The unpushed record count is below the threshold here)

Not connected, with record count above the threshold:

<img width="235" height="189" alt="Screenshot 2025-07-29 at 4 42 15 PM" src="https://github.com/user-attachments/assets/60a69367-17e0-4a01-9c33-e212d0668f39" />

Connected, with pending records to push:
<img width="230" height="152" alt="Screenshot 2025-07-29 at 4 43 28 PM" src="https://github.com/user-attachments/assets/73aa14a7-ab55-47ac-8c3e-3e26dba3ca51" />
To be honest, I'm not sure this case will ever arise, as it only checks the connection status when attempting to sync, which would then either sync the records or show a connection error

When there are unsynced records older than the "warning" threshold (1 day -- this functionality was already present, so just kept it):
<img width="251" height="150" alt="Screenshot 2025-07-29 at 4 45 34 PM" src="https://github.com/user-attachments/assets/2a07cc19-4330-4f23-8b10-6b92da1d1582" />

When there are unsynced records older than the "error" threshold (3 days):
<img width="203" height="137" alt="Screenshot 2025-07-29 at 4 45 59 PM" src="https://github.com/user-attachments/assets/e1d2373c-0858-4f80-9a52-48b29604df82" />

And finally, when there is a genuine sync error (i.e. something other than "no connection"):
<img width="236" height="135" alt="Screenshot 2025-07-29 at 4 48 41 PM" src="https://github.com/user-attachments/assets/8d634c56-b570-484c-9db4-616896d08158" />

## 💌 Any notes for the reviewer?

It seems to me that the (existing) polling interval constant is a bit pointless, as the query result doesn't actually change until an actual sync attempt is made, and then it gets updated automatically as a result of the sync. We might want to remove this at some point (at least in the SyncNavLink component, it does serve a purpose in the modal to update the UI *during* a sync)

See comments for further detail

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Check new pref is visible, editable and its value reflected in the display functionality
- [ ] Replicate the above scenarios and confirm the Sync indicator 

To be honest, the easiest way to test this is to just manually set the variable values in the code namely: `numberOfRecordsInPushQueue`, `beyondWarningThreshold`, `beyondErrorThreshold`

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

