### PR TITLE
Fix stocktake add batch not clearing sell price

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/utils.ts
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/utils.ts
@@ -43,6 +43,11 @@ export const DraftLine = {
         isVaccine: item.isVaccine,
         doses: item.doses,
         defaultPackSize: item.defaultPackSize,
+        itemStoreProperties: {
+          __typename: 'ItemStorePropertiesNode',
+          defaultSellPricePerPack:
+            item.itemStoreProperties?.defaultSellPricePerPack ?? 0,
+        },
       },
     };
   },


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8589

# 👩🏻‍💻 What does this PR do?
Fixes change in pack size not clearing sell price in stocktake

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have default sell price for an item
- [ ] Create stocktake -> add the item with default sell price
- [ ] Click `+`
- [ ] Change pack size
- [ ] Sell price should be 0

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

