### PR TITLE
#8537 JSON Forms DatePicker "OK" button fix

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/Date.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Date.tsx
@@ -73,7 +73,6 @@ const UIComponent = (props: ControlProps) => {
           onError={validationError =>
             setCustomError(validationError ?? undefined)
           }
-          actions={['clear']}
         />
       }
     />

--- a/client/packages/programs/src/JsonForms/common/components/DateTime.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/DateTime.tsx
@@ -83,7 +83,6 @@ const UIComponent = (props: ControlProps) => {
     readOnly: !!props.uischema.options?.['readonly'],
     disabled: !props.enabled,
     error: zErrors ?? error ?? customError ?? props.errors,
-    actions: ['clear', 'today', 'accept'] as PickersActionBarAction[],
     dateAsEndOfDay: !!props.uischema.options?.['dateAsEndOfDay'],
     disableFuture: !!props.uischema.options?.['disableFuture'],
     ...(options?.monthOnly


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8537

# 👩🏻‍💻 What does this PR do?

I've removed the "actions" prop from *both* the "Date" and "DateTime" components to standardise their UIs -- now they'll both show an "OK" and a "Clear" button. (The DateTime one also offered a "Today" button, but this is not used anywhere else in the app and it defaults to the current date anyway, so seems unnecessary -- we can add it back as a UI Schema option later if it's needed).

## 💌 Any notes for the reviewer?

This problem doesn't seem to be mobile device-related -- it's like this in browser too.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to New Patient
- [ ] In the initial "Search" screen, start entering a Date of birth -- should see a Date picker with both "OK" and "Clear" buttons

<img width="662" height="668" alt="Screenshot 2025-07-31 at 10 33 57 AM" src="https://github.com/user-attachments/assets/e07575aa-7d2a-43b2-b4ba-e2e49e42e313" />


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

