### PR TITLE
8682 inbound shipment swap shipped and received columns

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -112,6 +112,18 @@ export const QuantityTableComponent = ({
       defaultHideOnMobile: true,
       align: ColumnAlign.Left,
     }),
+    {
+      key: 'shippedNumberOfPacks',
+      label: 'label.shipped-number-of-packs',
+      Cell: NumberOfPacksCell,
+      cellProps: {
+        decimalLimit: 0,
+      },
+      getIsDisabled: rowData => !!rowData.linkedInvoiceId,
+      width: 100,
+      align: ColumnAlign.Left,
+      setter: patch => updateDraftLine(patch),
+    },
     [
       'numberOfPacks',
       {
@@ -134,19 +146,7 @@ export const QuantityTableComponent = ({
           }
         },
       },
-    ],
-    {
-      key: 'shippedNumberOfPacks',
-      label: 'label.shipped-number-of-packs',
-      Cell: NumberOfPacksCell,
-      cellProps: {
-        decimalLimit: 0,
-      },
-      getIsDisabled: rowData => !!rowData.linkedInvoiceId,
-      width: 100,
-      align: ColumnAlign.Left,
-      setter: patch => updateDraftLine(patch),
-    }
+    ]
   );
 
   columnDefinitions.push({


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8682

# 👩🏻‍💻 What does this PR do?
Swap received and shipped columns as shipped means how many the supplier shipped and received is how many the customer received

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create Inbound Shipment
- [ ] See that shipped is before received

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

