### PR TITLE
8668 auto allocate placeholders on open

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1459,6 +1459,7 @@
   "messages.allocated-lines_one": "Allocated {{count}} line",
   "messages.allocated-lines_other": "Allocated {{count}} lines",
   "messages.asset-saved": "Asset saved 🥳",
+  "messages.auto-allocated-lines": "Placeholder quantity has been auto-allocated.",
   "messages.breach-ongoing": "This breach is ongoing and cannot be acknowledged until it has ended.",
   "messages.bundled-item-saved": "Bundled item saved successfully",
   "messages.by-user": "by {{username}}",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1793,6 +1793,7 @@
   "messages.patients-search": "Please enter the required patient details to check if the patient is already within the mSupply system.",
   "messages.period-not-available": "No available periods",
   "messages.placeholder-allocated-doses": "Not enough stock is available to allocate all {{ requestedQuantity }} doses. A placeholder has been added for {{placeholderQuantity}} doses.",
+  "messages.placeholder-allocated-packs": "Not enough stock is available to allocate all {{ requestedQuantity }} packs of {{ packSize }}. A placeholder has been added for {{placeholderQuantity}} units.",
   "messages.placeholder-allocated-units": "Not enough stock is available to allocate all {{ requestedQuantity }} units. A placeholder has been added for {{placeholderQuantity}} units.",
   "messages.prescription-created": "Prescription #{{count}} created",
   "messages.prescription-given": "Prescribed {{amount}} {{item}} on {{date}}",

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/Allocation.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/Allocation.tsx
@@ -13,6 +13,7 @@ import {
   useIntlUtils,
   BasicSpinner,
   Divider,
+  useFormatNumber,
 } from '@openmsupply-client/common';
 import { OutboundLineEditTable } from './OutboundLineEditTable';
 import {
@@ -48,6 +49,8 @@ export const Allocation = ({
   scannedBatch,
   prefOptions: { sortByVvmStatus, manageVaccinesInDoses },
 }: AllocationProps) => {
+  const t = useTranslation();
+  const { format } = useFormatNumber();
   const { initialise, item } = useAllocationContext(({ initialise, item }) => ({
     initialise,
     item,
@@ -76,19 +79,24 @@ export const Allocation = ({
             }
           : undefined;
 
-      initialise({
-        itemData: data,
-        strategy: sortByVvmStatus
-          ? AllocationStrategy.VVMStatus
-          : AllocationStrategy.FEFO,
-        allowPlaceholder,
-        scannedBatch,
-        // Default to allocate in doses for vaccines if pref is on
-        allocateIn:
-          manageVaccinesInDoses && data.item.isVaccine
-            ? { type: AllocateInType.Doses }
-            : allocateInPacksize,
-      });
+      initialise(
+        {
+          itemData: data,
+          strategy: sortByVvmStatus
+            ? AllocationStrategy.VVMStatus
+            : AllocationStrategy.FEFO,
+          allowPlaceholder,
+          scannedBatch,
+          // Default to allocate in doses for vaccines if pref is on
+
+          allocateIn:
+            manageVaccinesInDoses && data.item.isVaccine
+              ? { type: AllocateInType.Doses }
+              : allocateInPacksize,
+        },
+        format,
+        t
+      );
     });
     // Expect dependencies to be stable
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/Allocation.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/Allocation.tsx
@@ -159,7 +159,7 @@ const AllocationInner = () => {
         <Divider margin={10} />
 
         <Box display="flex" alignItems="flex-start" gap={2}>
-          <Grid container alignItems="center" pt={1}>
+          <Grid container alignItems="center" pt={1} gap={1}>
             <AutoAllocateField />
             <AllocateInSelector includePackSizeOptions />
           </Grid>

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEdit.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEdit.tsx
@@ -3,6 +3,7 @@ import {
   BasicSpinner,
   Grid,
   useBufferState,
+  useFormatNumber,
   useTranslation,
 } from '@openmsupply-client/common';
 import { usePrescription } from '../api';
@@ -35,6 +36,7 @@ export const PrescriptionLineEdit = ({
   const isNew = !itemId;
 
   const t = useTranslation();
+  const { format } = useFormatNumber();
 
   // Needs to update when user clicks on different item in the list, or when
   // changing item with the selector
@@ -66,21 +68,25 @@ export const PrescriptionLineEdit = ({
     queryData().then(({ data }) => {
       if (!data) return;
 
-      initialise({
-        itemData: data,
-        strategy: sortByVvmStatus
-          ? AllocationStrategy.VVMStatus
-          : AllocationStrategy.FEFO,
-        allowPlaceholder: false,
-        allowPrescribedQuantity: true,
-        ignoreNonAllocatableLines: true,
-        // In prescriptions, default to allocate in doses for vaccines
-        // if pref is on
-        allocateIn:
-          allocateVaccineItemsInDoses && data.item.isVaccine
-            ? { type: AllocateInType.Doses }
-            : undefined,
-      });
+      initialise(
+        {
+          itemData: data,
+          strategy: sortByVvmStatus
+            ? AllocationStrategy.VVMStatus
+            : AllocationStrategy.FEFO,
+          allowPlaceholder: false,
+          allowPrescribedQuantity: true,
+          ignoreNonAllocatableLines: true,
+          // In prescriptions, default to allocate in doses for vaccines
+          // if pref is on
+          allocateIn:
+            allocateVaccineItemsInDoses && data.item.isVaccine
+              ? { type: AllocateInType.Doses }
+              : undefined,
+        },
+        format,
+        t
+      );
     });
     // Expect dependencies to be stable
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/packages/invoices/src/StockOut/Components/AllocateInSelector.tsx
+++ b/client/packages/invoices/src/StockOut/Components/AllocateInSelector.tsx
@@ -7,7 +7,6 @@ import {
   useIntlUtils,
   useFormatNumber,
   Typography,
-  Box,
 } from '@openmsupply-client/common';
 import { AllocateInType, useAllocationContext } from '../useAllocationContext';
 import { canAutoAllocate } from '../utils';
@@ -43,7 +42,10 @@ export const AllocateInSelector = ({
   const includeDosesOption = item?.isVaccine && prefs?.manageVaccinesInDoses;
 
   // EARLY RETURN - if only allocating in units, don't show the selector
-  if (!includePackSizeOptions && !includeDosesOption) {
+  if (
+    (!includePackSizeOptions || !availablePackSizes.length) &&
+    !includeDosesOption
+  ) {
     return <Typography sx={{ fontSize: 12 }}>{pluralisedUnitName}</Typography>;
   }
 
@@ -87,20 +89,17 @@ export const AllocateInSelector = ({
   };
 
   return (
-    <>
-      <Box marginLeft={1} />
-      <Select
-        options={options}
-        value={
-          allocateIn.type === AllocateInType.Packs
-            ? allocateIn.packSize
-            : allocateIn.type
-        }
-        onChange={e =>
-          handleAllocateInChange(e.target.value as AllocateInType | number)
-        }
-        sx={{ width: '150px' }}
-      />
-    </>
+    <Select
+      options={options}
+      value={
+        allocateIn.type === AllocateInType.Packs
+          ? allocateIn.packSize
+          : allocateIn.type
+      }
+      onChange={e =>
+        handleAllocateInChange(e.target.value as AllocateInType | number)
+      }
+      sx={{ width: '150px' }}
+    />
   );
 };

--- a/client/packages/invoices/src/StockOut/useAllocationContext.ts
+++ b/client/packages/invoices/src/StockOut/useAllocationContext.ts
@@ -17,6 +17,7 @@ import {
   DraftItem,
   DraftStockOutLineFragment,
   normaliseToUnits,
+  unitsToQuantity,
 } from '.';
 import { allocateQuantities } from './allocateQuantities';
 
@@ -61,15 +62,19 @@ interface AllocationContext {
   prescribedUnits: number | null;
   note: string | null;
 
-  initialise: (params: {
-    itemData: OutboundLineEditData;
-    strategy: AllocationStrategy;
-    allowPlaceholder: boolean;
-    allowPrescribedQuantity?: boolean;
-    scannedBatch?: string;
-    allocateIn?: AllocateInOption;
-    ignoreNonAllocatableLines?: boolean;
-  }) => void;
+  initialise: (
+    params: {
+      itemData: OutboundLineEditData;
+      strategy: AllocationStrategy;
+      allowPlaceholder: boolean;
+      allowPrescribedQuantity?: boolean;
+      scannedBatch?: string;
+      allocateIn?: AllocateInOption;
+      ignoreNonAllocatableLines?: boolean;
+    },
+    format: (value: number, options?: Intl.NumberFormatOptions) => string,
+    t: TypedTFunction<LocaleKey>
+  ) => void;
 
   setAlerts: (alerts: StockOutAlert[]) => void;
   setPrescribedQuantity: (quantity: number) => void;
@@ -83,6 +88,10 @@ interface AllocationContext {
   setIsDirty: (isDirty: boolean) => void;
   clear: () => void;
 
+  reallocateLines: (
+    format: (value: number, options?: Intl.NumberFormatOptions) => string,
+    t: TypedTFunction<LocaleKey>
+  ) => void;
   manualAllocate: (
     lineId: string,
     quantity: number,
@@ -114,15 +123,20 @@ export const useAllocationContext = create<AllocationContext>((set, get) => ({
   allocateIn: { type: AllocateInType.Units },
   note: null,
 
-  initialise: ({
-    itemData: { item, draftLines, placeholderUnits, prescribedUnits, note },
-    strategy,
-    allowPlaceholder,
-    allowPrescribedQuantity,
-    scannedBatch,
-    allocateIn,
-    ignoreNonAllocatableLines,
-  }) => {
+  initialise: (
+    {
+      itemData: { item, draftLines, placeholderUnits, prescribedUnits, note },
+      strategy,
+      allowPlaceholder,
+      allowPrescribedQuantity,
+      scannedBatch,
+      allocateIn: inputAllocateIn,
+      ignoreNonAllocatableLines,
+    },
+    format,
+    t
+  ) => {
+    const { reallocateLines } = get();
     const sortedLines = draftLines.sort(SorterByStrategy[strategy]);
 
     // Separate lines here, so only dealing with allocatable lines going forward
@@ -137,11 +151,12 @@ export const useAllocationContext = create<AllocationContext>((set, get) => ({
       }
     );
 
+    const allocateIn = inputAllocateIn ?? { type: AllocateInType.Units };
     set({
       isDirty: false,
       item,
       note,
-      allocateIn: allocateIn ?? { type: AllocateInType.Units },
+      allocateIn,
 
       draftLines: allocatableLines,
       // When not ignored, we still want to display non-allocatable lines to the user
@@ -152,6 +167,16 @@ export const useAllocationContext = create<AllocationContext>((set, get) => ({
       prescribedUnits: allowPrescribedQuantity ? (prescribedUnits ?? 0) : null,
       alerts: [],
     });
+
+    const allocatedQuantity = getAllocatedQuantity({
+      draftLines: allocatableLines,
+      allocateIn,
+    });
+
+    // If no quantity has yet been allocated, attempt to allocate the placeholder on initialise
+    if (allocatedQuantity === 0) {
+      reallocateLines(format, t);
+    }
   },
 
   clear: () =>
@@ -170,7 +195,7 @@ export const useAllocationContext = create<AllocationContext>((set, get) => ({
     })),
 
   setAllocateIn: (allocateIn, format, t) => {
-    const { draftLines, placeholderUnits, autoAllocate } = get();
+    const { reallocateLines } = get();
 
     set(state => ({
       ...state,
@@ -182,17 +207,27 @@ export const useAllocationContext = create<AllocationContext>((set, get) => ({
     // but changing which pack size to allocate in means we might
     // need to redistribute the stock.
     if (allocateIn.type === AllocateInType.Packs) {
-      const existingQuantityInUnits =
-        getAllocatedQuantity({
-          draftLines,
-          allocateIn: { type: AllocateInType.Units },
-        }) + (placeholderUnits ?? 0);
-
-      const quantityInNewPackSize =
-        existingQuantityInUnits / allocateIn.packSize;
-
-      autoAllocate(quantityInNewPackSize, format, t);
+      reallocateLines(format, t);
     }
+  },
+
+  reallocateLines: (format, t) => {
+    const { draftLines, allocateIn, placeholderUnits, autoAllocate, item } =
+      get();
+
+    const unitQuantityIncludingPlaceholder =
+      getAllocatedQuantity({
+        draftLines,
+        allocateIn: { type: AllocateInType.Units },
+      }) + (placeholderUnits ?? 0);
+
+    const quantityInNewPackSize = unitsToQuantity(
+      allocateIn,
+      unitQuantityIncludingPlaceholder,
+      item?.doses ?? 0
+    );
+
+    autoAllocate(quantityInNewPackSize, format, t);
   },
 
   setAlerts: alerts =>

--- a/client/packages/invoices/src/StockOut/useAllocationContext.ts
+++ b/client/packages/invoices/src/StockOut/useAllocationContext.ts
@@ -176,6 +176,13 @@ export const useAllocationContext = create<AllocationContext>((set, get) => ({
     // If no quantity has yet been allocated, attempt to allocate the placeholder on initialise
     if (allocatedQuantity === 0) {
       reallocateLines(format, t);
+      set(state => ({
+        ...state,
+        alerts: [
+          ...state.alerts,
+          { message: t('messages.auto-allocated-lines'), severity: 'warning' },
+        ],
+      }));
     }
   },
 

--- a/client/packages/invoices/src/StockOut/utils.test.ts
+++ b/client/packages/invoices/src/StockOut/utils.test.ts
@@ -1,10 +1,11 @@
 import { FnUtils } from '@common/utils';
-import { DraftStockOutLineFragment, AllocateInType } from '.';
+import { DraftStockOutLineFragment, AllocateInType, AllocateInOption } from '.';
 import {
   canAutoAllocate,
   getAllocatedQuantity,
   getDoseQuantity,
   issue,
+  unitsToQuantity,
 } from './utils';
 
 describe('getDoseQuantity', () => {
@@ -232,6 +233,37 @@ describe('canAutoAllocate ', () => {
     const packSize2 = createTestLine({ packSize: 2 });
     expect(canAutoAllocate(packSize2, 2)).toEqual(true);
     expect(canAutoAllocate(packSize2, 3)).toEqual(false);
+  });
+});
+
+describe('unitsToQuantity', () => {
+  it('converts units to doses (dosesPerUnit=2)', () => {
+    const result = unitsToQuantity({ type: AllocateInType.Doses }, 5, 2);
+    expect(result).toBe(10);
+  });
+
+  it('converts units to doses (dosesPerUnit=0, treat as 1)', () => {
+    const result = unitsToQuantity({ type: AllocateInType.Doses }, 5, 0);
+    expect(result).toBe(5);
+  });
+
+  it('converts units to units', () => {
+    const result = unitsToQuantity({ type: AllocateInType.Units }, 7, 3);
+    expect(result).toBe(7);
+  });
+
+  it('converts units to packs', () => {
+    const result = unitsToQuantity(
+      { type: AllocateInType.Packs, packSize: 10 },
+      20,
+      3
+    );
+    expect(result).toBe(2);
+  });
+
+  it('throws for unknown allocation type', () => {
+    const badAllocateIn = { type: 'Unknown' } as unknown as AllocateInOption;
+    expect(() => unitsToQuantity(badAllocateIn, 1, 1)).toThrow();
   });
 });
 

--- a/client/packages/invoices/src/StockOut/utils.ts
+++ b/client/packages/invoices/src/StockOut/utils.ts
@@ -339,12 +339,5 @@ export const getAllocationAlerts = (
     });
   }
 
-  // If we allocated stock automatically, alert the user
-  if (allocatedQuantity) {
-    alerts.push({
-      message: t('messages.auto-allocated-lines'),
-      severity: 'warning',
-    });
-  }
   return alerts;
 };

--- a/client/packages/invoices/src/StockOut/utils.ts
+++ b/client/packages/invoices/src/StockOut/utils.ts
@@ -339,5 +339,12 @@ export const getAllocationAlerts = (
     });
   }
 
+  // If we allocated stock automatically, alert the user
+  if (allocatedQuantity) {
+    alerts.push({
+      message: t('messages.auto-allocated-lines'),
+      severity: 'warning',
+    });
+  }
   return alerts;
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8668

# 👩🏻‍💻 What does this PR do?
 When selecting an outbound shipment line, auto allocate stock IF there is a placeholder and no stocklines have previously been allocated. This will ensure that whether the allocation type is in doses, units, or packs of X the placeholder will automatically be allocated when first opening the line
- If a line has been allocated, if won't be changed automatically if reopened
- Update to the allocation message to read better if allocation is in packs

- added a message for auto allocation
<img width="769" height="253" alt="Screenshot 2025-07-31 at 4 24 32 PM" src="https://github.com/user-attachments/assets/e1be80af-1dca-44a9-82bc-f50579bf6c41" />

<!-- Explain the changes you made -->

Bonus: fixes pack size selector being empty when no available pack sizes - instead show units:

<img width="400" height="348" alt="Screenshot 2025-07-29 at 2 56 35 PM" src="https://github.com/user-attachments/assets/b9d01caf-f5b0-4e19-8a13-2451d824caf0" />
<img width="400" height="311" alt="Screenshot 2025-07-29 at 2 56 44 PM" src="https://github.com/user-attachments/assets/b1b8675a-f281-48d6-9b71-5559f95a9037" />

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have doses preference on
- [ ] Create a requisition with some lines, including vaccines
- [ ] Include a line to supply more quantity than you currently have on hand for that item
- [ ] Create an Outbound Shipment from the requisition
- [ ] In the shipment, open a vaccine line -> See the doses automatically allocate
- [ ] Open a non-vaccine line -> See the units automatically allocate
- [ ] Open the line which had the larger placeholder than you have stock available
- [ ] All available stock should be allocated, and remaining value in a placeholder (there should be a warning)
- [ ] Make a manual change to one of those fully allocated stock lines, reduce value allocated -> Ok -> reopen the line
- [ ] See the allocation _not_ change from what was set previously (automatic allocation did not fire when you opened)
- [ ] Try with a line, where available stock lines all have same pack size, pack size > 1 (this causes modal to show in "packs of {pack size}" rather than units)
- [ ] Open a line for an item with no available stock lines (e.g. all expired)
  - [ ] Says `[unitname]` next to "allocate" section, rather than empty picker


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

