### PR TITLE
Extra localised string for Encounters

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -110,6 +110,7 @@
   "button.retry": "Retry",
   "button.return-lines": "Return selected lines",
   "button.save": "Save",
+  "button.save-progress": "Save Progress",
   "button.save-and-confirm-status": "Confirm {{status}}",
   "button.save-log": "Save log",
   "button.scan": "Scan",

--- a/client/packages/common/src/intl/locales/fr/common.json
+++ b/client/packages/common/src/intl/locales/fr/common.json
@@ -111,6 +111,7 @@
   "button.retry": "Réessayer",
   "button.return-lines": "Retourner les lignes sélectionnées",
   "button.save": "Enregistrer",
+  "button.save-progress": "Enregistrer le progrès",
   "button.save-and-confirm-status": "Confirmer {{status}}",
   "button.save-log": "Enregistrer le journal",
   "button.scan": "Scanner",

--- a/client/packages/system/src/Encounter/DetailView/Footer.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Footer.tsx
@@ -121,7 +121,7 @@ export const Footer: FC<FooterProps> = ({
               isLoading={isSaving}
               onClick={onSave}
               startIcon={<SaveIcon />}
-              label={t('button.save')}
+              label={t('button.save-progress')}
             />
             {encounter?.status &&
               // Status no longer editable once visited


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

From @Rajajajaja 's [requests](https://docs.google.com/document/d/1TfkpMN1STVLOjbNm9MsO7OBDRZq1rvtknZS1TI_0jlw/edit?tab=t.cbq26y41gbmz).

# 👩🏻‍💻 What does this PR do?

Adds additional "Save progress" button for use in Encounters

## 💌 Any notes for the reviewer?

I think this makes sense, and it can be put back to just plain old "Save" using custom translations if people don't think it should be different to normal "Save".

