### PR TITLE
8688 Create scheduler for ledger fix

### DIFF
--- a/server/repository/src/db_diesel/key_value_store.rs
+++ b/server/repository/src/db_diesel/key_value_store.rs
@@ -56,6 +56,8 @@ pub enum KeyType {
     LogLevel,
     LogDirectory,
     LogFileName,
+
+    LastLedgerFixRun,
 }
 
 #[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq, Default)]

--- a/server/repository/src/migrations/v2_09_01/add_last_fix_ledger_run_enums.rs
+++ b/server/repository/src/migrations/v2_09_01/add_last_fix_ledger_run_enums.rs
@@ -1,0 +1,24 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_last_fix_ledger_run_key_value_store"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        if cfg!(feature = "postgres") {
+            sql!(
+                connection,
+                r#"
+                    ALTER TYPE key_type ADD VALUE IF NOT EXISTS 'LAST_LEDGER_FIX_RUN';
+                    ALTER TYPE system_log_type ADD VALUE IF NOT EXISTS 'LEDGER_FIX_ERROR';
+                    ALTER TYPE system_log_type ADD VALUE IF NOT EXISTS 'LEDGER_FIX';
+                "#
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_09_01/mod.rs
+++ b/server/repository/src/migrations/v2_09_01/mod.rs
@@ -3,6 +3,7 @@ use crate::StorageConnection;
 
 mod add_can_cancel_finalised_invoices_user_permission;
 mod add_delete_rnr_form_activity_log_enum;
+mod add_last_fix_ledger_run_enums;
 mod remove_rnr_form_line_entered_losses_default;
 
 pub(crate) struct V2_09_01;
@@ -21,6 +22,7 @@ impl Migration for V2_09_01 {
             Box::new(add_can_cancel_finalised_invoices_user_permission::Migrate),
             Box::new(add_delete_rnr_form_activity_log_enum::Migrate),
             Box::new(remove_rnr_form_line_entered_losses_default::Migrate),
+            Box::new(add_last_fix_ledger_run_enums::Migrate),
         ]
     }
 }

--- a/server/service/src/activity_log.rs
+++ b/server/service/src/activity_log.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 use chrono::Utc;
 use repository::{
     activity_log::{ActivityLog, ActivityLogFilter, ActivityLogRepository, ActivityLogSort},
@@ -7,8 +9,8 @@ use repository::{
 };
 
 use repository::{PaginationOption, RepositoryError};
-use util::constants::SYSTEM_USER_ID;
 use util::uuid::uuid;
+use util::{constants::SYSTEM_USER_ID, format_error};
 
 use crate::service_provider::ServiceContext;
 
@@ -102,6 +104,19 @@ pub fn system_log_entry(
     };
 
     let _change_log_id = SystemLogRowRepository::new(connection).insert_one(log)?;
+    Ok(())
+}
+
+// Will also log in file/console
+pub fn system_error_log(
+    connection: &StorageConnection,
+    log_type: SystemLogType,
+    error: &impl Error,
+    context: &str,
+) -> Result<(), RepositoryError> {
+    let error_message = format_error(error);
+    log::error!("{context} - {} - {error_message}", log_type.to_string());
+    system_log_entry(connection, log_type, &error_message)?;
     Ok(())
 }
 

--- a/server/service/src/ledger_fix/ledger_fix_driver.rs
+++ b/server/service/src/ledger_fix/ledger_fix_driver.rs
@@ -1,0 +1,134 @@
+use std::sync::Arc;
+
+use crate::{activity_log::system_error_log, service_provider::ServiceProvider};
+
+use chrono::{NaiveDateTime, TimeDelta, Utc};
+use repository::system_log_row::SystemLogType;
+use repository::{KeyType, KeyValueStoreRepository, RepositoryError};
+use tokio::{
+    sync::mpsc::{self, Receiver, Sender},
+    time::Duration,
+};
+
+pub struct LedgerFixDriver {
+    receiver: Receiver<Option<String>>,
+}
+
+#[derive(Clone)]
+pub struct LedgerFixTrigger {
+    sender: Sender<Option<String>>,
+}
+
+const FIRST_RUN_DELAY: Duration = Duration::from_secs(5);
+// This trigger is not to re-run ledger fix but to check if ledger fix is needed again
+// Will check against key values store LAST_LEDGER_FIX_RUN and LEDGER_FIX_INTERVAL
+const RE_TRIGGER_DELAY: Duration = Duration::from_secs(60 * 60); // 1 hour
+const LEDGER_FIX_INTERVAL: TimeDelta = TimeDelta::days(1);
+
+impl LedgerFixDriver {
+    pub fn init() -> (LedgerFixTrigger, LedgerFixDriver) {
+        // We use a single-element channel so that we can only have one ledger_fix pending at a time.
+        let (sender, receiver) = mpsc::channel(1);
+
+        (LedgerFixTrigger { sender }, LedgerFixDriver { receiver })
+    }
+
+    /// LedgerFixDriver entry point, this method is meant to be run within main `select!` macro
+    /// should fail only when database is not accessible or when all receivers were dropped
+    pub async fn run(mut self, service_provider: Arc<ServiceProvider>) {
+        let mut delay_duration = FIRST_RUN_DELAY;
+
+        loop {
+            let should_run_ledger_fix = tokio::select! {
+                should_run =
+                    delay(service_provider.clone(), delay_duration)
+                 => should_run,
+                Some(_) = self.receiver.recv() => true,
+            };
+
+            delay_duration = RE_TRIGGER_DELAY;
+
+            if !should_run_ledger_fix {
+                continue;
+            }
+
+            self.ledger_fix(service_provider.clone()).await;
+            set_last_ledger_fix_run(&service_provider);
+        }
+    }
+
+    pub async fn ledger_fix(&self, _service_provider: Arc<ServiceProvider>) {
+        log::info!("Performing ledger fix...");
+    }
+}
+
+impl LedgerFixTrigger {
+    pub fn trigger(&self) {
+        if let Err(error) = self.sender.try_send(None) {
+            log::error!("Problem triggering ledger fix {:#?}", error)
+        }
+    }
+
+    pub(crate) fn new_void() -> LedgerFixTrigger {
+        LedgerFixTrigger {
+            sender: mpsc::channel(1).0,
+        }
+    }
+}
+
+/// Delay for a given duration and check if ledger fix should be re-triggered
+/// Returns true if ledger fix should be run, otherwise false
+async fn delay(service_provider: Arc<ServiceProvider>, duration: Duration) -> bool {
+    tokio::time::sleep(duration).await;
+
+    let last_ledger_fix_run = get_last_ledger_fix_run(&service_provider)
+        .expect("Repository error while getting last ledger fix run");
+
+    // Do ledger fix if date is not set yet
+    let Some(last_ledger_fix_run) = last_ledger_fix_run else {
+        return true;
+    };
+
+    if (Utc::now().naive_utc() - last_ledger_fix_run) > LEDGER_FIX_INTERVAL {
+        return true;
+    }
+    return false;
+}
+
+fn get_last_ledger_fix_run(
+    service_provider: &ServiceProvider,
+) -> Result<Option<NaiveDateTime>, RepositoryError> {
+    let ctx = service_provider.basic_context().unwrap();
+    let key_value_store = KeyValueStoreRepository::new(&ctx.connection);
+
+    // Get and parse last ledger fix run, if not set or filed to parse return epoch
+    let Some(s) = key_value_store.get_string(KeyType::LastLedgerFixRun)? else {
+        return Ok(None);
+    };
+
+    match serde_json::from_str(&s) {
+        Ok(datetime) => Ok(Some(datetime)),
+        Err(e) => {
+            system_error_log(
+                &ctx.connection,
+                SystemLogType::LedgerFixError,
+                &e,
+                "Error parsing last ledger fix run datetime",
+            )?;
+            Ok(None)
+        }
+    }
+}
+
+fn set_last_ledger_fix_run(service_provider: &ServiceProvider) {
+    let ctx = service_provider.basic_context().unwrap();
+    let key_value_store = KeyValueStoreRepository::new(&ctx.connection);
+
+    let now = Utc::now().naive_utc();
+    let now_string =
+        serde_json::to_string(&now).expect("Failed to serialize last ledger fix run datetime");
+
+    key_value_store
+        .set_string(KeyType::LastLedgerFixRun, Some(now_string))
+        .expect("Database error while setting last ledger fix run");
+}

--- a/server/service/src/ledger_fix/mod.rs
+++ b/server/service/src/ledger_fix/mod.rs
@@ -1,0 +1,1 @@
+pub mod ledger_fix_driver;

--- a/server/service/src/lib.rs
+++ b/server/service/src/lib.rs
@@ -22,6 +22,7 @@ pub mod apis;
 pub mod app_data;
 pub mod boajs;
 pub mod campaign;
+pub mod ledger_fix;
 
 pub mod asset;
 pub mod auth;

--- a/server/service/src/service_provider.rs
+++ b/server/service/src/service_provider.rs
@@ -30,6 +30,7 @@ use crate::{
     item::ItemServiceTrait,
     item_stats::{ItemStatsService, ItemStatsServiceTrait},
     label_printer_settings_service::LabelPrinterSettingsServiceTrait,
+    ledger_fix::ledger_fix_driver::LedgerFixTrigger,
     localisations::Localisations,
     location::{LocationService, LocationServiceTrait},
     log_service::{LogService, LogServiceTrait},
@@ -142,6 +143,8 @@ pub struct ServiceProvider {
     processors_trigger: ProcessorsTrigger,
     pub sync_trigger: SyncTrigger,
     pub site_is_initialised_trigger: SiteIsInitialisedTrigger,
+    pub ledger_fix_trigger: LedgerFixTrigger,
+    // Settings
     pub display_settings_service: Box<dyn DisplaySettingsServiceTrait>,
     // Barcodes
     pub barcode_service: Box<dyn BarcodeServiceTrait>,
@@ -206,6 +209,7 @@ impl ServiceProvider {
             connection_manager,
             ProcessorsTrigger::new_void(),
             SyncTrigger::new_void(),
+            LedgerFixTrigger::new_void(),
             SiteIsInitialisedTrigger::new_void(),
             None, // Mail not required for test/CLI setups
         )
@@ -215,6 +219,7 @@ impl ServiceProvider {
         connection_manager: StorageConnectionManager,
         processors_trigger: ProcessorsTrigger,
         sync_trigger: SyncTrigger,
+        ledger_fix_trigger: LedgerFixTrigger,
         site_is_initialised_trigger: SiteIsInitialisedTrigger,
         mail_settings: Option<MailSettings>,
     ) -> Self {
@@ -289,6 +294,7 @@ impl ServiceProvider {
             preference_service: Box::new(PreferenceService {}),
             vvm_service: Box::new(VVMService {}),
             campaign_service: Box::new(CampaignService),
+            ledger_fix_trigger,
         }
     }
 

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -304,6 +304,8 @@ impl Synchroniser {
                 v6_sync.advance_push_cursor(&ctx.connection)?;
             }
             self.service_provider.site_is_initialised_trigger.trigger();
+            // Trigger ledger fix after initialisation
+            self.service_provider.ledger_fix_trigger.trigger();
         }
 
         ctx.processors_trigger

--- a/server/service/src/test_helpers.rs
+++ b/server/service/src/test_helpers.rs
@@ -8,6 +8,7 @@ use repository::{
 };
 
 use crate::{
+    ledger_fix::ledger_fix_driver::LedgerFixDriver,
     processors::Processors,
     service_provider::{ServiceContext, ServiceProvider},
     settings::{DiscoveryMode, MailSettings, ServerSettings, Settings},
@@ -66,12 +67,14 @@ pub(crate) async fn setup_all_with_data_and_service_provider(
     };
     let (file_sync_trigger, _) = FileSyncDriver::init(&settings);
     let (sync_trigger, _) = SynchroniserDriver::init(file_sync_trigger);
+    let (ledger_fix_trigger, _) = LedgerFixDriver::init();
     let (site_is_initialise_trigger, _) = SiteIsInitialisedCallback::init();
 
     let service_provider = Arc::new(ServiceProvider::new_with_triggers(
         connection_manager.clone(),
         processors_trigger,
         sync_trigger,
+        ledger_fix_trigger,
         site_is_initialise_trigger,
         settings.mail.clone(),
     ));


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8688

# 👩🏻‍💻 What does this PR do?

Add a scheduler for ledger fix, to run 5 seconds after startup (after going to this version) and then every day (first check if needs to run is 5 seconds after startup, then every hour, will run max once a day, unless manually triggered, for now this is only manually triggered after initialisation).

If there are errors, should be logged in oms system log and in console/file log, i also added

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

On startup after upgrading to this version should log "Performing ledger fix.." after 5 seconds, after that, on restart etc.. would only show this once a day, you can modify to the following to see this in action more frequently (also check key_value_store for date updates)
```
const FIRST_RUN_DELAY: Duration = Duration::from_secs(5);
// This trigger is not to re-run ledger fix but to check if ledger fix is needed again
// Will check against key values store LAST_LEDGER_FIX_RUN and LEDGER_FIX_INTERVAL
const RE_TRIGGER_DELAY: Duration = Duration::from_secs(2); // 1 hour
const LEDGER_FIX_INTERVAL: TimeDelta = TimeDelta::seconds(10);
```

After initialisation "Performing ledger fix.." should be triggered.

You can change date in key value store to see an error logged in console and added to system_log, but ledger fix message should still be called, and date updated

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

