### PR TITLE
Unusable master list doesn't seem to work

### DIFF
--- a/server/service/src/stocktake/update/generate.rs
+++ b/server/service/src/stocktake/update/generate.rs
@@ -560,6 +560,7 @@ pub fn generate(
         store_id: store_id.to_string(),
         status: InvoiceStatus::New,
         verified_datetime: Some(now),
+        program_id: stocktake.program_id.clone(),
         // Default
         currency_id: Some(currency.currency_row.id),
         currency_rate: 1.0,
@@ -583,7 +584,6 @@ pub fn generate(
         original_shipment_id: None,
         backdated_datetime: None,
         diagnosis_id: None,
-        program_id: None,
         name_insurance_join_id: None,
         insurance_discount_amount: None,
         insurance_discount_percentage: None,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #https://github.com/msupply-foundation/open-msupply-reports/issues/242

# 👩🏻‍💻 What does this PR do?
Program id wasn't being populated on the invoice created from stocktake

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have correct datafile 
- [ ] Have finalised stock takes with unusable reasons
- [ ] Generate report
- [ ] Should generate regardless of whether you select program id or not 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

