### PR TITLE
8654 Stop updates of owned records in sync

### DIFF
--- a/server/repository/src/migrations/v2_09_02/mod.rs
+++ b/server/repository/src/migrations/v2_09_02/mod.rs
@@ -7,7 +7,7 @@ pub(crate) struct V2_09_02;
 
 impl Migration for V2_09_02 {
     fn version(&self) -> Version {
-        Version::from_str("2.9.1")
+        Version::from_str("2.9.2")
     }
 
     fn migrate(&self, _connection: &StorageConnection) -> anyhow::Result<()> {

--- a/server/service/src/ledger_fix/ledger_fix_driver.rs
+++ b/server/service/src/ledger_fix/ledger_fix_driver.rs
@@ -65,7 +65,7 @@ impl LedgerFixDriver {
         log::info!(
             "Performing ledger fix on {} lines...",
             find_stock_line_ledger_discrepancies(&ctx.connection)
-                .unwrap()
+                .unwrap_or_else(|_| vec![])
                 .len()
         );
     }

--- a/server/service/src/processors/transfer/invoice/update_outbound_invoice_status.rs
+++ b/server/service/src/processors/transfer/invoice/update_outbound_invoice_status.rs
@@ -29,7 +29,7 @@ impl InvoiceTransferProcessor for UpdateOutboundInvoiceStatusProcessor {
     /// 6. Source invoice is from mSupply thus the status will be `New`. Shouldn't happen for OMS since
     ///     OMS will follow OMS status sequence
     ///
-    /// Can only run two times (one for Delivered and one for Verified status):
+    /// Can only run three times (one for Delivered, Received and one for Verified status):
     /// 7. Because linked outbound invoice status will be updated to source inbound invoice status and `5.` will never be true again
     ///    and business rules guarantee that Inbound invoice can only change status to Delivered and Verified
     ///    and status cannot be changed backwards
@@ -69,6 +69,14 @@ impl InvoiceTransferProcessor for UpdateOutboundInvoiceStatusProcessor {
         }
         // 6.
         if inbound_invoice.invoice_row.status == InvoiceStatus::New {
+            return Ok(None);
+        }
+        // 7.
+        // Original unknown but we did have om system user updated outbound back to picked
+        if !matches!(
+            inbound_invoice.invoice_row.status,
+            InvoiceStatus::Delivered | InvoiceStatus::Received | InvoiceStatus::Verified
+        ) {
             return Ok(None);
         }
 

--- a/server/service/src/processors/transfer/invoice/update_outbound_invoice_status.rs
+++ b/server/service/src/processors/transfer/invoice/update_outbound_invoice_status.rs
@@ -73,11 +73,13 @@ impl InvoiceTransferProcessor for UpdateOutboundInvoiceStatusProcessor {
         }
         // 7.
         // Original unknown but we did have om system user updated outbound back to picked
-        if !matches!(
-            inbound_invoice.invoice_row.status,
-            InvoiceStatus::Delivered | InvoiceStatus::Received | InvoiceStatus::Verified
-        ) {
-            return Ok(None);
+        match inbound_invoice.invoice_row.status {
+            InvoiceStatus::Delivered | InvoiceStatus::Received | InvoiceStatus::Verified => {}
+            InvoiceStatus::New
+            | InvoiceStatus::Picked
+            | InvoiceStatus::Shipped
+            | InvoiceStatus::Allocated
+            | InvoiceStatus::Cancelled => return Ok(None),
         }
 
         // Execute

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -949,7 +949,7 @@ fn check_owned_invoice_update(
         .find_one_by_id(&invoice_upsert.store_ID)?
         .context("Store not found")?;
 
-    if (store.site_id != site_id) {
+    if store.site_id != site_id {
         return Ok(());
     }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8654

# 👩🏻‍💻 What does this PR do?

* Stops updates of owned records via sync, inserts are allowed
* Stops updates of outbound shipment from inbound shipment to status below Delivered

## 💌 Any notes for the reviewer?

I haven't added check for total below available, since we have ledger fix once a day now, i feel a bit more confident about it, and was worried that user/support/dev would get stumbled when dealing with that use case ? 

# 🧪 Testing

As per issue, i don't quite know what small data file to use, but the data file provided in issue would work, also test [steps in this one](https://github.com/msupply-foundation/msupply/issues/16945)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

