### PR TITLE
Add spacer to re-instate padding

### DIFF
--- a/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -172,7 +172,6 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
                       color: 'gray.dark',
                     }
                   : undefined,
-              // flexGrow: 1,
 
               '& .MuiBadge-badge:not(.MuiBadge-invisible)': drawer.isOpen
                 ? {
@@ -193,11 +192,10 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
                     selected || isSelectedParentItem ? 'bold' : 'normal',
                   color: isSelectedParentItem ? 'primary.main' : undefined,
                 },
-                flexGrow: 0,
               }}
             />
           </Badge>
-
+          <span style={{ flexGrow: 1 }} />
           <ListItemIcon
             sx={{
               minWidth: 20,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Follow up for #8652 to restore the NavLink arrow padding

# 👩🏻‍💻 What does this PR do?

There was a change in #8652 to remove a `flexGrow` in order to make the sync badge attach to the icon rather than floating out on its own. That inadvertantly also made the Nav link arrows (chevron) no longer push out to the end of the button.

This fixes the latter, while keeping the intended spacing for the actual sync badge.

## 💌 Any notes for the reviewer?

It may seem a bit hacky adding an empty `span` in order to create padding. However, I would argue that it's less so than what was there originally -- it was using the `Badge` container to add the flex-grow, even when there was no badge, which was confusing and unclear. At least it's now explicit where the extra padding is coming from.

I tried setting the width of the container to "100%" (or slightly less), but it wasn't exactly the same as it used to be, and it would require more potentially regressive tweaks to wrangle it into place.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Sync badge is still snug with the icon:
  <img width="240" height="81" alt="Screenshot 2025-08-04 at 2 37 06 PM" src="https://github.com/user-attachments/assets/be972260-d7ec-46b0-a886-569fa3246aa8" />
- [ ] Padding for menu item arrows is as it used to be -- arrows are pushed to the right
  <img width="197" height="82" alt="Screenshot 2025-08-04 at 2 38 25 PM" src="https://github.com/user-attachments/assets/b9694e7c-694f-4832-8f4c-902da9f12be1" />


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

