### PR TITLE
Add authorised sync

### DIFF
--- a/server/service/src/sync/test/test_data/purchase_order.rs
+++ b/server/service/src/sync/test/test_data/purchase_order.rs
@@ -80,7 +80,8 @@ const PURCHASE_ORDER_1: (&str, &str) = (
             "sent_datetime": "2025-01-15T01:02:03",
             "supplier_discount_percentage": 10.0, 
             "authorised_datetime": "2025-01-22T00:00:00",
-            "finalised_datetime": "2025-01-22T00:00:00"
+            "finalised_datetime": "2025-01-22T00:00:00",
+            "status": "AUTHORISED"
         }
     }"#,
 );

--- a/server/service/src/sync/test/test_data/purchase_order.rs
+++ b/server/service/src/sync/test/test_data/purchase_order.rs
@@ -193,6 +193,7 @@ fn purchase_order_1_push_record() -> TestSyncOutgoingRecord {
             advance_paid_date: Some(NaiveDate::from_ymd_opt(2025, 1, 22).unwrap()),
             received_at_port_date: Some(NaiveDate::from_ymd_opt(2025, 1, 22).unwrap()),
             curr_rate: Some(1.6),
+            is_authorised: false,
             oms_fields: Some(PurchaseOrderOmsFields {
                 expected_delivery_date: Some(NaiveDate::from_ymd_opt(2025, 1, 22).unwrap()),
                 created_datetime: NaiveDate::from_ymd_opt(2021, 1, 22)
@@ -392,6 +393,7 @@ fn purchase_order_2_migration_push_record() -> TestSyncOutgoingRecord {
             contract_signed_date: None,
             advance_paid_date: None,
             received_at_port_date: None,
+            is_authorised: false,
             oms_fields: Some(PurchaseOrderOmsFields {
                 created_datetime: NaiveDate::from_ymd_opt(2021, 3, 15)
                     .unwrap()
@@ -522,6 +524,7 @@ fn purchase_order_3_empty_string_push_record() -> TestSyncOutgoingRecord {
             contract_signed_date: None,
             advance_paid_date: None,
             received_at_port_date: None,
+            is_authorised: false,
             oms_fields: Some(PurchaseOrderOmsFields {
                 expected_delivery_date: None,
                 created_datetime: NaiveDate::from_ymd_opt(2021, 1, 22)
@@ -643,6 +646,7 @@ fn purchase_order_4_empty_object_push_record() -> TestSyncOutgoingRecord {
             contract_signed_date: None,
             advance_paid_date: None,
             received_at_port_date: None,
+            is_authorised: false,
             oms_fields: Some(PurchaseOrderOmsFields {
                 created_datetime: NaiveDate::from_ymd_opt(2020, 1, 22)
                     .unwrap()
@@ -763,6 +767,7 @@ fn purchase_order_5_null_push_record() -> TestSyncOutgoingRecord {
             contract_signed_date: None,
             advance_paid_date: None,
             received_at_port_date: None,
+            is_authorised: false,
             oms_fields: Some(PurchaseOrderOmsFields {
                 created_datetime: NaiveDate::from_ymd_opt(2020, 1, 22)
                     .unwrap()
@@ -880,6 +885,7 @@ fn purchase_order_6_no_fields_push_record() -> TestSyncOutgoingRecord {
             contract_signed_date: None,
             advance_paid_date: None,
             received_at_port_date: None,
+            is_authorised: false,
             oms_fields: Some(PurchaseOrderOmsFields {
                 created_datetime: NaiveDate::from_ymd_opt(2020, 1, 22)
                     .unwrap()

--- a/server/service/src/sync/test/test_data/purchase_order.rs
+++ b/server/service/src/sync/test/test_data/purchase_order.rs
@@ -225,6 +225,7 @@ fn purchase_order_1_push_record() -> TestSyncOutgoingRecord {
                         .and_hms_opt(0, 0, 0)
                         .unwrap()
                 ),
+                status: PurchaseOrderStatus::Authorised,
             }),
         }),
     }
@@ -411,6 +412,7 @@ fn purchase_order_2_migration_push_record() -> TestSyncOutgoingRecord {
                         .and_hms_opt(0, 0, 0)
                         .unwrap(),
                 ),
+                status: PurchaseOrderStatus::Confirmed,
                 ..Default::default()
             }),
         }),

--- a/server/service/src/sync/test/test_data/purchase_order.rs
+++ b/server/service/src/sync/test/test_data/purchase_order.rs
@@ -20,7 +20,7 @@ const PURCHASE_ORDER_1: (&str, &str) = (
         "ID": "12e889c0f0d211eb8dddb54df6d741hx",
         "creation_date": "2021-01-22",
         "target_months": 2.1,
-        "status": "nw",
+        "status": "cn",
         "serial_number": 1,
         "store_ID": "store_b",
         "comment": "some test comment",
@@ -59,7 +59,7 @@ const PURCHASE_ORDER_1: (&str, &str) = (
         "include_in_on_order_calcs": "",
         "colour": "",
         "user_field_1": "",
-        "is_authorised": "",
+        "is_authorised": true,
         "auth_checksum": "",
         "donor_id": "donor_a",
         "user_field_2": "",
@@ -95,7 +95,7 @@ fn purchase_order_1_pull_record() -> TestSyncIncomingRecord {
             created_by: Some("some user".to_string()),
             supplier_name_link_id: "name_store_b".to_string(),
             purchase_order_number: 1,
-            status: PurchaseOrderStatus::New,
+            status: PurchaseOrderStatus::Authorised,
             created_datetime: NaiveDate::from_ymd_opt(2021, 1, 22)
                 .unwrap()
                 .and_hms_opt(0, 0, 0)
@@ -163,7 +163,7 @@ fn purchase_order_1_push_record() -> TestSyncOutgoingRecord {
             id: PURCHASE_ORDER_1.0.to_string(),
             creation_date: NaiveDate::from_ymd_opt(2021, 1, 22).unwrap(),
             target_months: Some(2.1),
-            status: LegacyPurchaseOrderStatus::Nw,
+            status: LegacyPurchaseOrderStatus::Cn,
             comment: Some("some test comment".to_string()),
             currency_id: Some("currency_a".to_string()),
             reference: Some("test reference".to_string()),
@@ -193,7 +193,7 @@ fn purchase_order_1_push_record() -> TestSyncOutgoingRecord {
             advance_paid_date: Some(NaiveDate::from_ymd_opt(2025, 1, 22).unwrap()),
             received_at_port_date: Some(NaiveDate::from_ymd_opt(2025, 1, 22).unwrap()),
             curr_rate: Some(1.6),
-            is_authorised: false,
+            is_authorised: true,
             oms_fields: Some(PurchaseOrderOmsFields {
                 expected_delivery_date: Some(NaiveDate::from_ymd_opt(2025, 1, 22).unwrap()),
                 created_datetime: NaiveDate::from_ymd_opt(2021, 1, 22)

--- a/server/service/src/sync/translations/purchase_order.rs
+++ b/server/service/src/sync/translations/purchase_order.rs
@@ -330,7 +330,8 @@ impl SyncTranslation for PurchaseOrderTranslation {
             .and_then(|oms_field| oms_field.finalised_datetime);
 
         let status = oms_fields
-            .and_then(|oms_field| oms_field.status)
+            .clone()
+            .map(|oms_field| oms_field.status)
             .unwrap_or_else(|| from_legacy_status(&status, is_authorised));
 
         let result = PurchaseOrderRow {

--- a/server/service/src/sync/translations/purchase_order.rs
+++ b/server/service/src/sync/translations/purchase_order.rs
@@ -524,7 +524,7 @@ fn to_legacy_status(status: &PurchaseOrderStatus) -> LegacyPurchaseOrderStatus {
 fn check_is_authorised(status: &PurchaseOrderStatus) -> bool {
     matches!(
         status,
-        PurchaseOrderStatus::Authorised | PurchaseOrderStatus::Finalised // Assuming Finalised is always authorised, but might be skipped in some cases
+        PurchaseOrderStatus::Authorised | PurchaseOrderStatus::Finalised // Assuming Finalised is always authorised, but the action might be skipped if authorisation is not required due to global preference
     )
 }
 

--- a/server/service/src/sync/translations/purchase_order.rs
+++ b/server/service/src/sync/translations/purchase_order.rs
@@ -54,6 +54,8 @@ pub struct PurchaseOrderOmsFields {
     pub authorised_datetime: Option<NaiveDateTime>,
     #[serde(default)]
     pub finalised_datetime: Option<NaiveDateTime>,
+    #[serde(default)]
+    pub status: PurchaseOrderStatus,
 }
 
 /** Example record
@@ -327,13 +329,17 @@ impl SyncTranslation for PurchaseOrderTranslation {
             .clone()
             .and_then(|oms_field| oms_field.finalised_datetime);
 
+        let status = oms_fields
+            .and_then(|oms_field| oms_field.status)
+            .unwrap_or_else(|| from_legacy_status(&status, is_authorised));
+
         let result = PurchaseOrderRow {
             id,
             created_by,
             purchase_order_number,
             store_id,
             supplier_name_link_id: name_id,
-            status: from_legacy_status(&status, is_authorised),
+            status,
             created_datetime,
             confirmed_datetime,
             target_months,
@@ -431,6 +437,7 @@ impl SyncTranslation for PurchaseOrderTranslation {
             supplier_discount_percentage,
             authorised_datetime,
             finalised_datetime,
+            status: status.clone(),
         };
 
         let donor_id = map_optional_name_link_id_to_name_id(connection, donor_link_id)?;

--- a/server/service/src/sync/translations/purchase_order.rs
+++ b/server/service/src/sync/translations/purchase_order.rs
@@ -515,7 +515,7 @@ fn to_legacy_status(status: &PurchaseOrderStatus) -> LegacyPurchaseOrderStatus {
     let legacy_status = match status {
         PurchaseOrderStatus::New => LegacyPurchaseOrderStatus::Nw,
         PurchaseOrderStatus::Confirmed => LegacyPurchaseOrderStatus::Cn,
-        PurchaseOrderStatus::Authorised => LegacyPurchaseOrderStatus::Cn, // should also set is_authorised to true
+        PurchaseOrderStatus::Authorised => LegacyPurchaseOrderStatus::Cn, // We will also set is_authorised to true (See check_is_authorised)
         PurchaseOrderStatus::Finalised => LegacyPurchaseOrderStatus::Fn,
     };
     legacy_status


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8639 

# 👩🏻‍💻 What does this PR do?

Translates the is_authorised boolean to a new `Authorised` status in OMS.
Add status to oms_fields

## 💌 Any notes for the reviewer?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Try initialising a OMS Site from a Legacy site with purchase orders
- [ ] Check that ones that have been authorised show up as Authorised or Finalised (depending)
- [ ] Check nothing it broken...

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

