### PR TITLE
8741 Campaign date selector shows incorrect dates

### DIFF
--- a/client/packages/system/src/Manage/Campaigns/ListView/CampaignEditModal.tsx
+++ b/client/packages/system/src/Manage/Campaigns/ListView/CampaignEditModal.tsx
@@ -7,7 +7,6 @@ import {
   DialogButton,
   InputWithLabelRow,
   BasicTextInput,
-  DateUtils,
   DateTimePickerInput,
 } from '@openmsupply-client/common';
 import { DraftCampaign, defaultDraftCampaign } from '../api';
@@ -66,7 +65,7 @@ export const CampaignEditModal: FC<CampaignEditModalProps> = ({
             Input={
               <DateTimePickerInput
                 width={250}
-                value={DateUtils.getNaiveDate(startDate)}
+                value={new Date(startDate ?? '')}
                 onChange={startDate => updateDraft({ startDate })}
               />
             }
@@ -77,7 +76,7 @@ export const CampaignEditModal: FC<CampaignEditModalProps> = ({
             Input={
               <DateTimePickerInput
                 width={250}
-                value={DateUtils.getNaiveDate(endDate)}
+                value={new Date(endDate ?? '')}
                 onChange={endDate => updateDraft({ endDate })}
               />
             }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8741

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Remove conversion to "naive date" when passing into the input - every call to `getNaiveDate` subtracts the timezone offset, so in NZ, that means every time you select a date, it would subtract 12hr. Therefore, every second click, changed to the previous day.

Instead, just pass the date straight into the input. It displays correctly. It is converted back to a naive date (date with no time zone info) by the hook, on save.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] On OMS Central
- [ ] Go to Manage > Campaigns
- [ ] Add or edit a campaign
- [ ] In the modal, click around the start & end date pickers
- [ ] Change the date several times, the date you choose always stays selected
- [ ] On save, it still shows the correct date

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

