### PR TITLE
8257 use soft delete for campaigns

### DIFF
--- a/server/repository/src/db_diesel/campaign/campaign_row.rs
+++ b/server/repository/src/db_diesel/campaign/campaign_row.rs
@@ -82,15 +82,13 @@ impl<'a> CampaignRowRepository<'a> {
         Ok(result)
     }
 
-    pub fn delete(&self, campaign_id: &str) -> Result<i64, RepositoryError> {
+    pub fn mark_deleted(&self, campaign_id: &str) -> Result<i64, RepositoryError> {
         diesel::update(campaign::table.filter(campaign::id.eq(campaign_id)))
             .set(campaign::deleted_datetime.eq(chrono::Utc::now().naive_utc()))
             .execute(self.connection.lock().connection())?;
 
-        // diesel::delete(campaign::table.filter(campaign::id.eq(campaign_id)))
-        //     .execute(self.connection.lock().connection())?;
-
-        self.insert_changelog(campaign_id.to_owned(), RowActionType::Delete)
+        // Upsert row action as this is a soft delete, not actual delete
+        self.insert_changelog(campaign_id.to_owned(), RowActionType::Upsert)
     }
 }
 

--- a/server/service/src/campaign/delete.rs
+++ b/server/service/src/campaign/delete.rs
@@ -27,7 +27,7 @@ pub fn delete_campaign(
                 return Err(DeleteCampaignError::CampaignDoesNotExist);
             }
 
-            CampaignRowRepository::new(connection).delete(&input.id)?;
+            CampaignRowRepository::new(connection).mark_deleted(&input.id)?;
             Ok(input.id.clone())
         })
         .map_err(|error| error.to_inner_error())?;

--- a/server/service/src/sync/translations/campaign.rs
+++ b/server/service/src/sync/translations/campaign.rs
@@ -68,14 +68,6 @@ impl SyncTranslation for CampaignTranslation {
             serde_json::to_value(row)?,
         ))
     }
-
-    fn try_translate_to_delete_sync_record(
-        &self,
-        _: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        Ok(PushTranslateResult::delete(changelog, self.table_name()))
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8257 

# 👩🏻‍💻 What does this PR do?

Deleting a campaign syncs from Central server to remote sites
Deleted campaigns no longer visible on remote sites  - when viewing any stocklines that were associated with the campaign, campaign is no longer visible

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

Implemented as a soft delete, any campaigns previously deleted will still retain a changelog DELETE record that will not translate
Discussed creating a migration to clean these (changing delete to upsert in the changelog) however migrations do not run by central/remote type. The sync buffer for the remote site will retain "Translator for record not found" Deletes.  However, there is no user impact for these to remain

Moving this from 2.10 to 2.9.3 to lessen any possible instances of this occurring

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have both central and remote sites running
- [ ] Ensure campaigns preference is on in Global Preferences
- [ ] In central server: go to Manage -> Campaigns and create some
- [ ] In remote site: Sync -> go to View Stock and see the available campaigns. Select one & save
- [ ] In central: delete this campaign
- [ ] In remote Sync -> see that on the same stockline the campaign is not selected and is no longer in the avaialble selections

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

