### PR TITLE
8604 closed vial reasons for vaccines

### DIFF
--- a/client/packages/common/src/utils/reasons/ReasonOptionUtils.test.ts
+++ b/client/packages/common/src/utils/reasons/ReasonOptionUtils.test.ts
@@ -1,0 +1,61 @@
+import { getReasonOptionTypes } from './ReasonOptionsUtils';
+import { ReasonOptionNodeType } from '@common/types';
+
+describe('getReasonOptionTypes', () => {
+  it('returns PositiveInventoryAdjustment when not inventory reduction', () => {
+    expect(
+      getReasonOptionTypes({
+        isInventoryReduction: false,
+        isVaccine: false,
+        isDispensary: false,
+      })
+    ).toEqual([ReasonOptionNodeType.PositiveInventoryAdjustment]);
+    expect(
+      getReasonOptionTypes({
+        isInventoryReduction: false,
+        isVaccine: true,
+        isDispensary: true,
+      })
+    ).toEqual([ReasonOptionNodeType.PositiveInventoryAdjustment]);
+  });
+
+  it('returns NegativeInventoryAdjustment when inventory reduction and not vaccine', () => {
+    expect(
+      getReasonOptionTypes({
+        isInventoryReduction: true,
+        isVaccine: false,
+        isDispensary: false,
+      })
+    ).toEqual([ReasonOptionNodeType.NegativeInventoryAdjustment]);
+    expect(
+      getReasonOptionTypes({
+        isInventoryReduction: true,
+        isVaccine: false,
+        isDispensary: true,
+      })
+    ).toEqual([ReasonOptionNodeType.NegativeInventoryAdjustment]);
+  });
+
+  it('returns ClosedVialWastage for vaccine, not dispensary', () => {
+    expect(
+      getReasonOptionTypes({
+        isInventoryReduction: true,
+        isVaccine: true,
+        isDispensary: false,
+      })
+    ).toEqual([ReasonOptionNodeType.ClosedVialWastage]);
+  });
+
+  it('returns ClosedVialWastage and OpenVialWastage for vaccine and dispensary', () => {
+    expect(
+      getReasonOptionTypes({
+        isInventoryReduction: true,
+        isVaccine: true,
+        isDispensary: true,
+      })
+    ).toEqual([
+      ReasonOptionNodeType.ClosedVialWastage,
+      ReasonOptionNodeType.OpenVialWastage,
+    ]);
+  });
+});

--- a/client/packages/common/src/utils/reasons/ReasonOptionsUtils.ts
+++ b/client/packages/common/src/utils/reasons/ReasonOptionsUtils.ts
@@ -1,15 +1,30 @@
 import { ReasonOptionNodeType } from '@common/types';
 
-export const getReasonOptionType = (
-  isInventoryReduction: boolean,
-  isVaccine: boolean
-): ReasonOptionNodeType | ReasonOptionNodeType[] => {
-  if (isInventoryReduction && isVaccine)
-    return [
-      ReasonOptionNodeType.NegativeInventoryAdjustment,
-      ReasonOptionNodeType.OpenVialWastage,
-    ];
-  if (isInventoryReduction)
-    return ReasonOptionNodeType.NegativeInventoryAdjustment;
-  return ReasonOptionNodeType.PositiveInventoryAdjustment;
+export interface ReasonOptionTypesParams {
+  isInventoryReduction: boolean;
+  isVaccine: boolean;
+  isDispensary: boolean;
+}
+
+export const getReasonOptionTypes = ({
+  isInventoryReduction,
+  isVaccine,
+  isDispensary,
+}: ReasonOptionTypesParams): ReasonOptionNodeType[] => {
+  if (!isInventoryReduction) {
+    return [ReasonOptionNodeType.PositiveInventoryAdjustment];
+  }
+
+  if (!isVaccine) {
+    return [ReasonOptionNodeType.NegativeInventoryAdjustment];
+  }
+
+  // Vaccine items have their own set of reasons for negative inventory adjustments
+  const negativeVaccineReasons = [ReasonOptionNodeType.ClosedVialWastage];
+
+  // Dispensaries can also have open vial wastage
+  if (isDispensary)
+    negativeVaccineReasons.push(ReasonOptionNodeType.OpenVialWastage);
+
+  return negativeVaccineReasons;
 };

--- a/client/packages/inventory/src/Stocktake/DetailView/ReduceLinesToZeroModal.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/ReduceLinesToZeroModal.tsx
@@ -5,7 +5,9 @@ import {
   ConfirmationModalLayout,
   Grid,
   DialogButton,
-  ReasonOptionNodeType,
+  getReasonOptionTypes,
+  useAuthContext,
+  StoreModeNodeType,
 } from '@openmsupply-client/common';
 import {
   ReasonOptionRowFragment,
@@ -26,10 +28,12 @@ export const ReduceLinesToZeroConfirmationModal = ({
   clearSelected,
 }: ReduceLinesToZeroConfirmationModalProps) => {
   const t = useTranslation();
+  const { store } = useAuthContext();
 
   const [reason, setReason] = useState<ReasonOptionRowFragment | null>(null);
 
-  const onZeroQuantities = useStocktakeOld.line.zeroQuantities();
+  const { onZeroQuantities, allSelectedItemsAreVaccines } =
+    useStocktakeOld.line.zeroQuantities();
 
   const { data: reasonOptions } = useReasonOptions();
   const reasonIsRequired = reasonOptions?.totalCount !== 0;
@@ -64,7 +68,11 @@ export const ReduceLinesToZeroConfirmationModal = ({
           labelWidth="100px"
           Input={
             <ReasonOptionsSearchInput
-              type={ReasonOptionNodeType.NegativeInventoryAdjustment}
+              type={getReasonOptionTypes({
+                isInventoryReduction: true,
+                isVaccine: allSelectedItemsAreVaccines,
+                isDispensary: store?.storeMode === StoreModeNodeType.Dispensary,
+              })}
               value={reason}
               onChange={reason => setReason(reason)}
               width={160}

--- a/client/packages/inventory/src/Stocktake/DetailView/ReduceLinesToZeroModal.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/ReduceLinesToZeroModal.tsx
@@ -31,7 +31,7 @@ export const ReduceLinesToZeroConfirmationModal = ({
 
   const onZeroQuantities = useStocktakeOld.line.zeroQuantities();
 
-  const { data: reasonOptions, isLoading } = useReasonOptions();
+  const { data: reasonOptions } = useReasonOptions();
   const reasonIsRequired = reasonOptions?.totalCount !== 0;
 
   return (
@@ -67,8 +67,6 @@ export const ReduceLinesToZeroConfirmationModal = ({
               type={ReasonOptionNodeType.NegativeInventoryAdjustment}
               value={reason}
               onChange={reason => setReason(reason)}
-              reasonOptions={reasonOptions?.nodes ?? []}
-              loading={isLoading}
               width={160}
             />
           }

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -19,7 +19,6 @@ import {
   ColumnAlign,
   NumberCell,
   getReasonOptionTypes,
-  ReasonOptionNode,
   usePreference,
   PreferenceKey,
   useAuthContext,
@@ -113,8 +112,6 @@ const getCountThisLineColumn = (
 const getInventoryAdjustmentReasonInputColumn = (
   setter: DraftLineSetter,
   { getError }: UseStocktakeLineErrors,
-  reasonOptions: ReasonOptionNode[],
-  isLoading: boolean,
   initialStocktake?: boolean
 ): ColumnDescription<DraftStocktakeLine> => {
   return {
@@ -161,8 +158,6 @@ const getInventoryAdjustmentReasonInputColumn = (
             error: isAdjustmentReasonError,
           }}
           initialStocktake={initialStocktake}
-          reasonOptions={reasonOptions}
-          loading={isLoading}
         />
       );
     },
@@ -310,8 +305,6 @@ export const BatchTable = ({
       getInventoryAdjustmentReasonInputColumn(
         update,
         errorsContext,
-        reasonOptions?.nodes ?? [],
-        isLoading,
         isInitialStocktake
       )
     );

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -18,10 +18,12 @@ import {
   NumberInputCell,
   ColumnAlign,
   NumberCell,
-  getReasonOptionType,
+  getReasonOptionTypes,
   ReasonOptionNode,
   usePreference,
   PreferenceKey,
+  useAuthContext,
+  StoreModeNodeType,
 } from '@openmsupply-client/common';
 import { DraftStocktakeLine } from './utils';
 import {
@@ -122,6 +124,8 @@ const getInventoryAdjustmentReasonInputColumn = (
     width: 120,
     accessor: ({ rowData }) => rowData.reasonOption || '',
     Cell: ({ rowData, column, columnIndex, rowIndex }) => {
+      const { store } = useAuthContext();
+
       const value = column.accessor({
         rowData,
       }) as ReasonOptionRowFragment | null;
@@ -148,10 +152,11 @@ const getInventoryAdjustmentReasonInputColumn = (
           value={value}
           width={Number(column.width)}
           onChange={onChange}
-          type={getReasonOptionType(
+          type={getReasonOptionTypes({
             isInventoryReduction,
-            rowData.item.isVaccine
-          )}
+            isVaccine: rowData.item.isVaccine,
+            isDispensary: store?.storeMode === StoreModeNodeType.Dispensary,
+          })}
           inputProps={{
             error: isAdjustmentReasonError,
           }}

--- a/client/packages/inventory/src/Stocktake/api/hooks/line/useZeroStocktakeLines.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/line/useZeroStocktakeLines.ts
@@ -35,5 +35,9 @@ export const useZeroStocktakeLines = () => {
     }
   };
 
-  return onZeroQuantities;
+  const allSelectedItemsAreVaccines = selectedRows.every(
+    row => row.item.isVaccine
+  );
+
+  return { onZeroQuantities, allSelectedItemsAreVaccines };
 };

--- a/client/packages/invoices/src/Returns/modals/ReturnReasonsTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/ReturnReasonsTable.tsx
@@ -9,7 +9,6 @@ import {
   ReasonOptionRowFragment,
   ReasonOptionsSearchInput,
   INPUT_WIDTH,
-  useReasonOptions,
 } from '@openmsupply-client/system';
 import React from 'react';
 
@@ -29,7 +28,6 @@ const ReturnReasonCell = ({
   column,
   isDisabled,
 }: CellProps<ReturnWithReason>): JSX.Element => {
-  const { data: reasonOptions, isLoading } = useReasonOptions();
   return (
     <ReasonOptionsSearchInput
       type={ReasonOptionNodeType.ReturnReason}
@@ -38,8 +36,6 @@ const ReturnReasonCell = ({
       autoFocus={rowIndex === 0}
       width={INPUT_WIDTH}
       value={rowData.reasonOption}
-      reasonOptions={reasonOptions?.nodes ?? []}
-      loading={isLoading}
     />
   );
 };

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -4,7 +4,6 @@ import {
   ReasonOptionsSearchInput,
   RequestFragment,
   StockItemSearchInputWithStats,
-  useReasonOptions,
 } from '@openmsupply-client/system';
 import {
   useTranslation,
@@ -71,7 +70,6 @@ export const RequestLineEdit = ({
 }: RequestLineEditProps) => {
   const t = useTranslation();
   const { plugins } = usePluginProvider();
-  const { data: reasonOptions, isLoading } = useReasonOptions();
   const unitName = currentItem?.unitName || t('label.unit');
   const defaultPackSize = currentItem?.defaultPackSize || 1;
 
@@ -171,8 +169,6 @@ export const RequestLineEdit = ({
                 fullWidth
                 type={ReasonOptionNodeType.RequisitionLineVariance}
                 disabled={disableReasons}
-                reasonOptions={reasonOptions?.nodes ?? []}
-                loading={isLoading}
                 textSx={
                   disableReasons
                     ? {

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -13,7 +13,6 @@ import {
   ItemWithStatsFragment,
   ReasonOptionsSearchInput,
   StockItemSearchInputWithStats,
-  useReasonOptions,
 } from '@openmsupply-client/system';
 import { ResponseFragment, ResponseLineFragment } from '../../api';
 import {
@@ -60,7 +59,6 @@ export const ResponseLineEdit = ({
   setIsEditingSupply,
 }: ResponseLineEditProps) => {
   const t = useTranslation();
-  const { data: reasonOptions, isLoading } = useReasonOptions();
 
   const hasApproval =
     requisition.approvalStatus === RequisitionNodeApprovalStatus.Approved;
@@ -201,8 +199,6 @@ export const ResponseLineEdit = ({
                 }}
                 type={ReasonOptionNodeType.RequisitionLineVariance}
                 disabled={disableReasons}
-                reasonOptions={reasonOptions?.nodes ?? []}
-                loading={isLoading}
                 inputProps={{
                   error: isReasonsError,
                 }}

--- a/client/packages/system/src/ReasonOption/Components/ReasonOptionsSearchInput.tsx
+++ b/client/packages/system/src/ReasonOption/Components/ReasonOptionsSearchInput.tsx
@@ -7,17 +7,17 @@ import {
   ReasonOptionNode,
   ReasonOptionNodeType,
 } from '@openmsupply-client/common';
+import { useReasonOptions } from '../api';
 
 interface ReasonOptionsSearchInputProps
   extends Omit<
     AutocompleteProps<ReasonOptionNode>,
-    'value' | 'onChange' | 'options' | 'width'
+    'value' | 'onChange' | 'options' | 'width' | 'loading'
   > {
   value?: ReasonOptionNode | null;
   onChange: (reasonOption: ReasonOptionNode | null) => void;
   type: ReasonOptionNodeType | ReasonOptionNodeType[];
   initialStocktake?: boolean;
-  reasonOptions: ReasonOptionNode[];
   width?: number;
 }
 
@@ -27,17 +27,18 @@ export const ReasonOptionsSearchInput = ({
   onChange,
   type,
   initialStocktake,
-  reasonOptions,
   disabled,
   ...restProps
 }: ReasonOptionsSearchInputProps) => {
+  const { data: reasonOptions, isLoading } = useReasonOptions();
+
   const reasonFilter = (reasonOption: ReasonOptionNode) => {
     if (Array.isArray(type)) {
       return type.includes(reasonOption.type);
     }
     return reasonOption.type === type;
   };
-  const reasons = (reasonOptions ?? []).filter(reasonFilter);
+  const reasons = (reasonOptions?.nodes ?? []).filter(reasonFilter);
   const isRequired = reasons.length !== 0 && !initialStocktake;
 
   return (
@@ -60,6 +61,7 @@ export const ReasonOptionsSearchInput = ({
       onChange={(_, reason) => {
         onChange(reason);
       }}
+      loading={isLoading}
       options={defaultOptionMapper(reasons, 'reason')}
       renderOption={getDefaultOptionRenderer('reason')}
       isOptionEqualToValue={(option, value) => option?.id === value?.id}

--- a/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
+++ b/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
@@ -8,9 +8,11 @@ import {
   useNotification,
   AdjustmentTypeInput,
   useDialog,
-  getReasonOptionType,
+  getReasonOptionTypes,
   Checkbox,
   NumericTextDisplay,
+  useAuthContext,
+  StoreModeNodeType,
 } from '@openmsupply-client/common';
 import { StockLineRowFragment, useInventoryAdjustment } from '../../api';
 import { ReasonOptionsSearchInput, useReasonOptions } from '../../..';
@@ -29,6 +31,7 @@ export const InventoryAdjustmentModal = ({
 }: InventoryAdjustmentModalProps) => {
   const t = useTranslation();
   const { success, error } = useNotification();
+  const { store } = useAuthContext();
   const { Modal } = useDialog({ isOpen, onClose });
 
   const { draft, setDraft, create } = useInventoryAdjustment(stockLine);
@@ -96,10 +99,12 @@ export const InventoryAdjustmentModal = ({
                   disabled={draft.adjustment === 0}
                   onChange={reason => setDraft(state => ({ ...state, reason }))}
                   value={draft.reason}
-                  type={getReasonOptionType(
+                  type={getReasonOptionTypes({
                     isInventoryReduction,
-                    stockLine.item.isVaccine
-                  )}
+                    isVaccine: stockLine.item.isVaccine,
+                    isDispensary:
+                      store?.storeMode === StoreModeNodeType.Dispensary,
+                  })}
                   width={INPUT_WIDTH}
                   reasonOptions={data?.nodes ?? []}
                   loading={isLoading}

--- a/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
+++ b/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
@@ -15,7 +15,7 @@ import {
   StoreModeNodeType,
 } from '@openmsupply-client/common';
 import { StockLineRowFragment, useInventoryAdjustment } from '../../api';
-import { ReasonOptionsSearchInput, useReasonOptions } from '../../..';
+import { ReasonOptionsSearchInput } from '../../..';
 import { InventoryAdjustmentDirectionInput } from './InventoryAdjustmentDirectionSearchInput';
 import { INPUT_WIDTH, StyledInputRow } from '../StyledInputRow';
 
@@ -35,7 +35,6 @@ export const InventoryAdjustmentModal = ({
   const { Modal } = useDialog({ isOpen, onClose });
 
   const { draft, setDraft, create } = useInventoryAdjustment(stockLine);
-  const { data, isLoading } = useReasonOptions();
 
   const packUnit = String(stockLine.packSize);
   const saveDisabled = draft.adjustment === 0 || stockLine.onHold;
@@ -106,8 +105,6 @@ export const InventoryAdjustmentModal = ({
                       store?.storeMode === StoreModeNodeType.Dispensary,
                   })}
                   width={INPUT_WIDTH}
-                  reasonOptions={data?.nodes ?? []}
-                  loading={isLoading}
                 />
               </Box>
             }

--- a/client/packages/system/src/Stock/Components/NewStockLineModal.tsx
+++ b/client/packages/system/src/Stock/Components/NewStockLineModal.tsx
@@ -15,7 +15,7 @@ import {
 } from '@openmsupply-client/common';
 import { useStockLine } from '../api';
 import { StockLineForm } from './StockLineForm';
-import { StockItemSearchInput, useReasonOptions } from '../..';
+import { StockItemSearchInput } from '../..';
 import { AppRoute } from '@openmsupply-client/config';
 
 interface NewStockLineModalProps {
@@ -33,7 +33,6 @@ export const NewStockLineModal = ({
   const pluginEvents = usePluginEvents({
     isDirty: false,
   });
-  const { data: reasonOptions } = useReasonOptions();
 
   const { Modal } = useDialog({
     isOpen,
@@ -149,7 +148,6 @@ export const NewStockLineModal = ({
               packEditable
               isNewModal
               pluginEvents={pluginEvents}
-              reasonOptions={reasonOptions?.nodes}
             />
           </Grid>
         )}

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -30,7 +30,6 @@ import { DraftStockLine } from '../api';
 import { LocationSearchInput } from '../../Location/Components/LocationSearchInput';
 import {
   DonorSearchInput,
-  ReasonOptionRowFragment,
   ReasonOptionsSearchInput,
   VVMStatusSearchInput,
 } from '../..';
@@ -45,7 +44,6 @@ interface StockLineFormProps {
   pluginEvents: UsePluginEvents<{ isDirty: boolean }>;
   packEditable?: boolean;
   isNewModal?: boolean;
-  reasonOptions?: ReasonOptionRowFragment[];
 }
 export const StockLineForm = ({
   draft,
@@ -54,7 +52,6 @@ export const StockLineForm = ({
   pluginEvents,
   packEditable,
   isNewModal = false,
-  reasonOptions,
 }: StockLineFormProps) => {
   const t = useTranslation();
   const { error } = useNotification();
@@ -259,8 +256,6 @@ export const StockLineForm = ({
                   type={ReasonOptionNodeType.PositiveInventoryAdjustment}
                   value={draft.reasonOption}
                   onChange={reason => onUpdate({ reasonOption: reason })}
-                  reasonOptions={reasonOptions ?? []}
-                  loading={loading}
                   disabled={draft?.totalNumberOfPacks === 0}
                 />
               }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8604 

# 👩🏻‍💻 What does this PR do?

Shows inventory adjustment reasons as follows:

1. If the item is a vaccine, the list of reasons shown are the Closed vial wastage reasons
2. if the item is a vaccine and the store is a dispensary, add Open vial wastage reasons to the list
3. For all other items the list of reasons shown are the Negative inventory adjustment reasons

<img width="759" height="608" alt="Screenshot 2025-08-08 at 5 31 04 PM" src="https://github.com/user-attachments/assets/aed44490-f1d0-47f6-9c46-a5e65f7e3da2" />

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have some Open vial wastage and closed vial wastage reasons configured in OG: Admin -> Preferences -> Options
- [ ] View Stock -> select a non vaccine item -> inventory adjustment -> reduce stock -> See your negative inventory adjustment reasons
- [ ] If your store is a dispensary:
- [ ] View Stock -> select a vaccine item -> inventory adjustment -> reduce stock -> See open and closed vial wastage reasons
- [ ] If your store is NOT a dispensary:
- [ ] View Stock -> select a vaccine item -> inventory adjustment -> reduce stock -> See only closed vial wastage reasons 
- [ ] Repeat in stocktake line edit view
- [ ] For the stocktake Reduced to zero modal:
- [ ] If only vaccine item lines are selected -> see the vial wastage options
- [ ] If non-vaccine items or a mixture are selected see negative inventory adjustment reasons only

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

