### PR TITLE
8610 sync delete records

### DIFF
--- a/server/repository/src/db_diesel/goods_received_line_row.rs
+++ b/server/repository/src/db_diesel/goods_received_line_row.rs
@@ -143,8 +143,8 @@ impl Upsert for GoodsReceivedLineRow {
 }
 
 #[derive(Debug)]
-pub struct GoodsReceivedLineRowDelete(pub String);
-impl Delete for GoodsReceivedLineRowDelete {
+pub struct GoodsReceivedLineDelete(pub String);
+impl Delete for GoodsReceivedLineDelete {
     fn delete(&self, con: &StorageConnection) -> Result<Option<i64>, RepositoryError> {
         GoodsReceivedLineRowRepository::new(con).delete(&self.0)?;
         Ok(None)

--- a/server/repository/src/db_diesel/goods_received_row.rs
+++ b/server/repository/src/db_diesel/goods_received_row.rs
@@ -1,12 +1,11 @@
-use crate::Delete;
 use crate::{
-    ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RepositoryError, RowActionType,
-    StorageConnection, Upsert,
+    ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, Delete, RepositoryError,
+    RowActionType, StorageConnection, Upsert,
 };
 use chrono::{NaiveDate, NaiveDateTime};
+use diesel::dsl::max;
 use diesel::prelude::*;
 use diesel_derive_enum::DbEnum;
-use diesel::dsl::max;
 use serde::{Deserialize, Serialize};
 
 table! {
@@ -109,12 +108,19 @@ impl<'a> GoodsReceivedRowRepository<'a> {
             .optional()?;
         Ok(result)
     }
+    pub fn delete(&self, goods_receiving_id: &str) -> Result<Option<i64>, RepositoryError> {
+        let old_row = self.find_one_by_id(goods_receiving_id)?;
+        let change_log_id = match old_row {
+            Some(old_row) => self.insert_changelog(old_row, RowActionType::Delete)?,
+            None => {
+                return Ok(None);
+            }
+        };
 
-    pub fn delete(&self, id: &str) -> Result<(), RepositoryError> {
         diesel::delete(goods_received::table)
-            .filter(goods_received::id.eq(id))
+            .filter(goods_received::id.eq(goods_receiving_id))
             .execute(self.connection.lock().connection())?;
-        Ok(())
+        Ok(Some(change_log_id))
     }
 
     pub fn find_max_goods_received_number(
@@ -144,14 +150,13 @@ impl Upsert for GoodsReceivedRow {
     }
 }
 
-#[derive(Debug)]
-pub struct GoodsReceivedRowDelete(pub String);
-impl Delete for GoodsReceivedRowDelete {
+#[derive(Debug, Clone)]
+pub struct GoodsReceivedDelete(pub String);
+impl Delete for GoodsReceivedDelete {
     fn delete(&self, con: &StorageConnection) -> Result<Option<i64>, RepositoryError> {
-        GoodsReceivedRowRepository::new(con).delete(&self.0)?;
-        Ok(None)
+        let change_log_id = GoodsReceivedRowRepository::new(con).delete(&self.0)?;
+        Ok(change_log_id)
     }
-
     // Test only
     fn assert_deleted(&self, con: &StorageConnection) {
         assert_eq!(

--- a/server/repository/src/db_diesel/purchase_order_line_row.rs
+++ b/server/repository/src/db_diesel/purchase_order_line_row.rs
@@ -1,15 +1,14 @@
-use crate::db_diesel::item_row::item;
-use crate::db_diesel::purchase_order_row::purchase_order;
-use crate::{db_diesel::item_link_row::item_link, Upsert};
-
-use crate::repository_error::RepositoryError;
-use crate::StorageConnection;
+use crate::{
+    db_diesel::{item_link_row::item_link, item_row::item, purchase_order_row::purchase_order},
+    Delete, Upsert,
+};
+use crate::{
+    ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RepositoryError, RowActionType,
+    StorageConnection,
+};
+use chrono::NaiveDate;
 use diesel::{dsl::max, prelude::*};
 use serde::{Deserialize, Serialize};
-
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
-
-use chrono::NaiveDate;
 
 table! {
     purchase_order_line (id) {
@@ -179,6 +178,22 @@ impl Upsert for PurchaseOrderLineRow {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct PurchaseOrderLineDelete(pub String);
+impl Delete for PurchaseOrderLineDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<Option<i64>, RepositoryError> {
+        let change_log_id = PurchaseOrderLineRowRepository::new(con).delete(&self.0)?;
+        Ok(change_log_id)
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            PurchaseOrderLineRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
+        )
+    }
+}
+
 // purchase order line basic upsert and query operation test:
 #[cfg(test)]
 mod tests {
@@ -206,7 +221,7 @@ mod tests {
             supplier_name_link_id: mock_name_c().id,
             status: PurchaseOrderStatus::New,
             store_id: mock_store_a().id.clone(),
-            created_datetime: chrono::Utc::now().naive_utc().into(),
+            created_datetime: chrono::Utc::now().naive_utc(),
             purchase_order_number: 1,
 
             ..Default::default()

--- a/server/repository/src/db_diesel/purchase_order_row.rs
+++ b/server/repository/src/db_diesel/purchase_order_row.rs
@@ -3,7 +3,7 @@ use crate::{
     ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, Delete, RepositoryError,
     RowActionType, StorageConnection, Upsert,
 };
-use chrono::{NaiveDate. NaiveDateTime};
+use chrono::{NaiveDate, NaiveDateTime};
 use diesel::{dsl::max, prelude::*};
 use diesel_derive_enum::DbEnum;
 use serde::{Deserialize, Serialize};

--- a/server/repository/src/db_diesel/purchase_order_row.rs
+++ b/server/repository/src/db_diesel/purchase_order_row.rs
@@ -1,9 +1,8 @@
 use crate::{
     db_diesel::{item_link_row::item_link, item_row::item},
-    ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RepositoryError, RowActionType,
-    StorageConnection, Upsert,
+    ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, Delete, RepositoryError,
+    RowActionType, StorageConnection, Upsert,
 };
-
 use chrono::NaiveDate;
 use chrono::NaiveDateTime;
 use diesel::{dsl::max, prelude::*};
@@ -189,11 +188,19 @@ impl<'a> PurchaseOrderRowRepository<'a> {
         Ok(result)
     }
 
-    pub fn delete(&self, purchase_order_id: &str) -> Result<(), RepositoryError> {
+    pub fn delete(&self, purchase_order_id: &str) -> Result<Option<i64>, RepositoryError> {
+        let old_row = self.find_one_by_id(purchase_order_id)?;
+        let change_log_id = match old_row {
+            Some(old_row) => self.insert_changelog(old_row, RowActionType::Delete)?,
+            None => {
+                return Ok(None);
+            }
+        };
+
         diesel::delete(purchase_order::table)
             .filter(purchase_order::id.eq(purchase_order_id))
             .execute(self.connection.lock().connection())?;
-        Ok(())
+        Ok(Some(change_log_id))
     }
 
     pub fn find_max_purchase_order_number(
@@ -223,6 +230,22 @@ impl Upsert for PurchaseOrderRow {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct PurchaseOrderDelete(pub String);
+impl Delete for PurchaseOrderDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<Option<i64>, RepositoryError> {
+        let change_log_id = PurchaseOrderRowRepository::new(con).delete(&self.0)?;
+        Ok(change_log_id)
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            PurchaseOrderRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
+        )
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::mock::{mock_name_c, mock_store_a, MockDataInserts};
@@ -245,9 +268,9 @@ mod test {
             let row = PurchaseOrderRow {
                 id: id.clone(),
                 supplier_name_link_id: mock_name_c().id,
-                status: status,
+                status,
                 store_id: mock_store_a().id.clone(),
-                created_datetime: chrono::Utc::now().naive_utc().into(),
+                created_datetime: chrono::Utc::now().naive_utc(),
                 purchase_order_number: po_number,
                 ..Default::default()
             };

--- a/server/repository/src/db_diesel/purchase_order_row.rs
+++ b/server/repository/src/db_diesel/purchase_order_row.rs
@@ -3,8 +3,7 @@ use crate::{
     ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, Delete, RepositoryError,
     RowActionType, StorageConnection, Upsert,
 };
-use chrono::NaiveDate;
-use chrono::NaiveDateTime;
+use chrono::{NaiveDate. NaiveDateTime};
 use diesel::{dsl::max, prelude::*};
 use diesel_derive_enum::DbEnum;
 use serde::{Deserialize, Serialize};

--- a/server/service/src/sync/test/pull_and_push.rs
+++ b/server/service/src/sync/test/pull_and_push.rs
@@ -1,3 +1,10 @@
+use super::{
+    insert_all_extra_data,
+    test_data::{
+        get_all_pull_delete_central_test_records, get_all_pull_delete_remote_test_records,
+        get_all_pull_upsert_central_test_records, get_all_pull_upsert_remote_test_records,
+    },
+};
 use crate::sync::{
     api::SyncAction,
     sync_buffer::SyncBufferSource,
@@ -11,18 +18,11 @@ use crate::sync::{
         translate_changelogs_to_sync_records, PushSyncRecord, ToSyncRecordTranslationType,
     },
 };
+use pretty_assertions::assert_eq;
 use repository::{
     mock::{mock_store_b, MockData, MockDataInserts},
     test_db, ChangelogRepository, KeyType, KeyValueStoreRow, SyncBufferRow,
     SyncBufferRowRepository,
-};
-
-use super::{
-    insert_all_extra_data,
-    test_data::{
-        get_all_pull_delete_central_test_records, get_all_pull_delete_remote_test_records,
-        get_all_pull_upsert_central_test_records, get_all_pull_upsert_remote_test_records,
-    },
 };
 
 #[actix_rt::test]
@@ -120,17 +120,18 @@ async fn test_sync_pull_and_push() {
         .map(|r| (r.record_id.clone(), r.table_name.clone()))
         .collect::<Vec<(String, String)>>();
 
-    let mut i = 0;
-    for translated_record in changelog_translated_records_id_and_table_name.clone() {
+    for (i, translated_record) in changelog_translated_records_id_and_table_name
+        .clone()
+        .into_iter()
+        .enumerate()
+    {
         let test_record = &test_outgoing_sync_records_id_and_table_name[i];
         if &translated_record != test_record {
             println!(
-                "First mismatched record changelog: {:?} and test_data: {:?}",
-                translated_record, test_record
+                "First mismatched record changelog: {translated_record:?} and test_data: {test_record:?}"
             );
             break;
         }
-        i += 1;
     }
 
     // Test ids and table names

--- a/server/service/src/sync/test/test_data/goods_received.rs
+++ b/server/service/src/sync/test/test_data/goods_received.rs
@@ -38,7 +38,7 @@ const GOODS_RECEIVED_2: (&str, &str) = (
         "entry_date": "2025-07-24",
         "linked_transaction_ID": "",
         "purchase_order_ID": "",
-        "received_date": "2025-07-24",
+        "received_date": "",
         "serial_number": 2,
         "status": "nw",
         "store_ID": "4E27CEB263354EB7B1B33CEA8F7884D8",
@@ -73,31 +73,6 @@ pub(crate) fn test_pull_upsert_record_1() -> TestSyncIncomingRecord {
     )
 }
 
-pub(crate) fn test_pull_upsert_record_2() -> TestSyncIncomingRecord {
-    TestSyncIncomingRecord::new_pull_upsert(
-        TABLE_NAME,
-        GOODS_RECEIVED_2,
-        GoodsReceivedRow {
-            id: "3486239A597646B2B7259D91A24988E9".to_owned(),
-            store_id: "4E27CEB263354EB7B1B33CEA8F7884D8".to_owned(),
-            purchase_order_id: None,
-            inbound_shipment_id: None,
-            goods_received_number: 2,
-            status: GoodsReceivedStatus::New,
-            received_date: Some("2025-07-24".parse().unwrap()),
-            comment: None,
-            supplier_reference: Some("test po 2".to_string()),
-            donor_link_id: None,
-            created_datetime: NaiveDate::from_ymd_opt(2025, 7, 24)
-                .unwrap()
-                .and_hms_opt(0, 0, 0)
-                .unwrap(),
-            finalised_datetime: None,
-            created_by: Some("user1".to_string()),
-        },
-    )
-}
-
 fn goods_received_push_record() -> TestSyncOutgoingRecord {
     TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
@@ -119,6 +94,31 @@ fn goods_received_push_record() -> TestSyncOutgoingRecord {
     }
 }
 
+pub(crate) fn test_pull_upsert_record_2() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
+        TABLE_NAME,
+        GOODS_RECEIVED_2,
+        GoodsReceivedRow {
+            id: "3486239A597646B2B7259D91A24988E9".to_owned(),
+            store_id: "4E27CEB263354EB7B1B33CEA8F7884D8".to_owned(),
+            purchase_order_id: None,
+            inbound_shipment_id: None,
+            goods_received_number: 2,
+            status: GoodsReceivedStatus::New,
+            received_date: None,
+            comment: None,
+            supplier_reference: Some("test po 2".to_string()),
+            donor_link_id: None,
+            created_datetime: NaiveDate::from_ymd_opt(2025, 7, 24)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap(),
+            finalised_datetime: None,
+            created_by: Some("user1".to_string()),
+        },
+    )
+}
+
 fn goods_received_2_push_record() -> TestSyncOutgoingRecord {
     TestSyncOutgoingRecord {
         table_name: TABLE_NAME.to_string(),
@@ -131,7 +131,7 @@ fn goods_received_2_push_record() -> TestSyncOutgoingRecord {
             goods_received_number: 2,
             status: LegacyGoodsReceivedStatus::New,
             created_datetime: NaiveDate::from_ymd_opt(2025, 7, 24).unwrap(),
-            received_date: Some(NaiveDate::from_ymd_opt(2025, 7, 24).unwrap()),
+            received_date: None,
             comment: None,
             supplier_reference: Some("test po 2".to_string()),
             donor_link_id: None,

--- a/server/service/src/sync/test/test_data/goods_received.rs
+++ b/server/service/src/sync/test/test_data/goods_received.rs
@@ -3,9 +3,7 @@ use crate::sync::{
     translations::goods_received::{LegacyGoodsReceived, LegacyGoodsReceivedStatus},
 };
 use chrono::NaiveDate;
-use repository::goods_received_row::{
-    GoodsReceivedRow, GoodsReceivedRowDelete, GoodsReceivedStatus,
-};
+use repository::goods_received_row::{GoodsReceivedDelete, GoodsReceivedRow, GoodsReceivedStatus};
 use serde_json::json;
 
 const TABLE_NAME: &str = "Goods_received";
@@ -45,7 +43,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
             comment: None,
             supplier_reference: Some("test po 1".to_string()),
             donor_link_id: Some("1FB32324AF8049248D929CFB35F255BA".to_string()),
-            created_datetime: NaiveDate::from_ymd_opt(2025, 07, 24)
+            created_datetime: NaiveDate::from_ymd_opt(2025, 7, 24)
                 .unwrap()
                 .and_hms_opt(0, 0, 0)
                 .unwrap(),
@@ -66,8 +64,8 @@ fn goods_received_push_record() -> TestSyncOutgoingRecord {
             inbound_shipment_id: Some("12e889c0f0d211eb8dddb54df6d741bc".to_string()),
             goods_received_number: 1,
             status: LegacyGoodsReceivedStatus::New,
-            created_datetime: NaiveDate::from_ymd_opt(2025, 07, 24).unwrap(),
-            received_date: Some(NaiveDate::from_ymd_opt(2025, 07, 24).unwrap()),
+            created_datetime: NaiveDate::from_ymd_opt(2025, 7, 24).unwrap(),
+            received_date: Some(NaiveDate::from_ymd_opt(2025, 7, 24).unwrap()),
             comment: None,
             supplier_reference: Some("test po 1".to_string()),
             donor_link_id: Some("1FB32324AF8049248D929CFB35F255BA".to_string()),
@@ -80,7 +78,7 @@ pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
     vec![TestSyncIncomingRecord::new_pull_delete(
         TABLE_NAME,
         GOODS_RECEIVED.0,
-        GoodsReceivedRowDelete(GOODS_RECEIVED.0.to_string()),
+        GoodsReceivedDelete(GOODS_RECEIVED.0.to_string()),
     )]
 }
 

--- a/server/service/src/sync/test/test_data/goods_received.rs
+++ b/server/service/src/sync/test/test_data/goods_received.rs
@@ -28,8 +28,28 @@ const GOODS_RECEIVED: (&str, &str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
-    vec![TestSyncIncomingRecord::new_pull_upsert(
+const GOODS_RECEIVED_2: (&str, &str) = (
+    "3486239A597646B2B7259D91A24988E9",
+    r#"{
+        "ID": "3486239A597646B2B7259D91A24988E9",
+        "budget_ID": "",
+        "comment": "",
+        "donor_id": "",
+        "entry_date": "2025-07-24",
+        "linked_transaction_ID": "",
+        "purchase_order_ID": "",
+        "received_date": "2025-07-24",
+        "serial_number": 2,
+        "status": "nw",
+        "store_ID": "4E27CEB263354EB7B1B33CEA8F7884D8",
+        "supplier_reference": "test po 2",
+        "user_id_created": "user1",
+        "user_id_modified": "user1"
+    }"#,
+);
+
+pub(crate) fn test_pull_upsert_record_1() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
         GOODS_RECEIVED,
         GoodsReceivedRow {
@@ -38,7 +58,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
             purchase_order_id: Some("sync_test_purchase_order_1".to_string()),
             inbound_shipment_id: Some("12e889c0f0d211eb8dddb54df6d741bc".to_string()),
             goods_received_number: 1,
-            status: GoodsReceivedStatus::New.to_owned(),
+            status: GoodsReceivedStatus::New,
             received_date: Some("2025-07-24".parse().unwrap()),
             comment: None,
             supplier_reference: Some("test po 1".to_string()),
@@ -50,7 +70,32 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
             finalised_datetime: None,
             created_by: Some("user1".to_string()),
         },
-    )]
+    )
+}
+
+pub(crate) fn test_pull_upsert_record_2() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
+        TABLE_NAME,
+        GOODS_RECEIVED_2,
+        GoodsReceivedRow {
+            id: "3486239A597646B2B7259D91A24988E9".to_owned(),
+            store_id: "4E27CEB263354EB7B1B33CEA8F7884D8".to_owned(),
+            purchase_order_id: None,
+            inbound_shipment_id: None,
+            goods_received_number: 2,
+            status: GoodsReceivedStatus::New,
+            received_date: Some("2025-07-24".parse().unwrap()),
+            comment: None,
+            supplier_reference: Some("test po 2".to_string()),
+            donor_link_id: None,
+            created_datetime: NaiveDate::from_ymd_opt(2025, 7, 24)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap(),
+            finalised_datetime: None,
+            created_by: Some("user1".to_string()),
+        },
+    )
 }
 
 fn goods_received_push_record() -> TestSyncOutgoingRecord {
@@ -74,14 +119,39 @@ fn goods_received_push_record() -> TestSyncOutgoingRecord {
     }
 }
 
+fn goods_received_2_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
+        table_name: TABLE_NAME.to_string(),
+        record_id: GOODS_RECEIVED_2.0.to_string(),
+        push_data: json!(LegacyGoodsReceived {
+            id: "3486239A597646B2B7259D91A24988E9".to_string(),
+            store_id: "4E27CEB263354EB7B1B33CEA8F7884D8".to_string(),
+            purchase_order_id: None,
+            inbound_shipment_id: None,
+            goods_received_number: 2,
+            status: LegacyGoodsReceivedStatus::New,
+            created_datetime: NaiveDate::from_ymd_opt(2025, 7, 24).unwrap(),
+            received_date: Some(NaiveDate::from_ymd_opt(2025, 7, 24).unwrap()),
+            comment: None,
+            supplier_reference: Some("test po 2".to_string()),
+            donor_link_id: None,
+            created_by: Some("user1".to_string()),
+        }),
+    }
+}
+
 pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
     vec![TestSyncIncomingRecord::new_pull_delete(
         TABLE_NAME,
-        GOODS_RECEIVED.0,
-        GoodsReceivedDelete(GOODS_RECEIVED.0.to_string()),
+        GOODS_RECEIVED_2.0,
+        GoodsReceivedDelete(GOODS_RECEIVED_2.0.to_string()),
     )]
 }
 
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
+    vec![test_pull_upsert_record_1(), test_pull_upsert_record_2()]
+}
+
 pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
-    vec![goods_received_push_record()]
+    vec![goods_received_push_record(), goods_received_2_push_record()]
 }

--- a/server/service/src/sync/test/test_data/goods_received_line.rs
+++ b/server/service/src/sync/test/test_data/goods_received_line.rs
@@ -1,11 +1,10 @@
-use chrono::NaiveDate;
-use repository::{GoodsReceivedLineRow, GoodsReceivedLineRowDelete};
-use serde_json::json;
-
 use crate::sync::{
     test::{TestSyncIncomingRecord, TestSyncOutgoingRecord},
     translations::goods_received_line::LegacyGoodsReceivedLineRow,
 };
+use chrono::NaiveDate;
+use repository::{GoodsReceivedLineDelete, GoodsReceivedLineRow};
+use serde_json::json;
 
 const TABLE_NAME: &str = "Goods_received_line";
 
@@ -104,6 +103,6 @@ pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
     vec![TestSyncIncomingRecord::new_pull_delete(
         TABLE_NAME,
         GOODS_RECEIVED_LINE.0,
-        GoodsReceivedLineRowDelete(GOODS_RECEIVED_LINE.0.to_string()),
+        GoodsReceivedLineDelete(GOODS_RECEIVED_LINE.0.to_string()),
     )]
 }

--- a/server/service/src/sync/test/test_data/mod.rs
+++ b/server/service/src/sync/test/test_data/mod.rs
@@ -221,6 +221,7 @@ pub(crate) fn get_all_pull_delete_remote_test_records() -> Vec<TestSyncIncomingR
     test_records.append(&mut indicator_value::test_pull_delete_records());
     test_records.append(&mut preference::test_pull_delete_records());
     test_records.append(&mut purchase_order::test_pull_delete_records());
+    test_records.append(&mut purchase_order_line::test_pull_delete_records());
     test_records
 }
 

--- a/server/service/src/sync/test/test_data/mod.rs
+++ b/server/service/src/sync/test/test_data/mod.rs
@@ -220,6 +220,7 @@ pub(crate) fn get_all_pull_delete_remote_test_records() -> Vec<TestSyncIncomingR
     test_records.append(&mut name_tag_join::test_pull_delete_records());
     test_records.append(&mut indicator_value::test_pull_delete_records());
     test_records.append(&mut preference::test_pull_delete_records());
+    test_records.append(&mut purchase_order::test_pull_delete_records());
     test_records
 }
 

--- a/server/service/src/sync/test/test_data/purchase_order.rs
+++ b/server/service/src/sync/test/test_data/purchase_order.rs
@@ -5,7 +5,7 @@ use crate::sync::{
     },
 };
 use chrono::NaiveDate;
-use repository::{PurchaseOrderRow, PurchaseOrderStatus};
+use repository::{PurchaseOrderDelete, PurchaseOrderRow, PurchaseOrderStatus};
 use serde_json::json;
 
 use super::TestSyncOutgoingRecord;
@@ -847,4 +847,12 @@ pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
         purchase_order_5_null_push_record(),
         purchase_order_6_no_fields_push_record(),
     ]
+}
+
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_delete(
+        TABLE_NAME,
+        PURCHASE_ORDER_1.0,
+        PurchaseOrderDelete(PURCHASE_ORDER_1.0.to_string()),
+    )]
 }

--- a/server/service/src/sync/test/test_data/purchase_order.rs
+++ b/server/service/src/sync/test/test_data/purchase_order.rs
@@ -852,7 +852,7 @@ pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
 pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
     vec![TestSyncIncomingRecord::new_pull_delete(
         TABLE_NAME,
-        PURCHASE_ORDER_1.0,
-        PurchaseOrderDelete(PURCHASE_ORDER_1.0.to_string()),
+        PURCHASE_ORDER_5.0,
+        PurchaseOrderDelete(PURCHASE_ORDER_5.0.to_string()),
     )]
 }

--- a/server/service/src/sync/test/test_data/purchase_order_line.rs
+++ b/server/service/src/sync/test/test_data/purchase_order_line.rs
@@ -50,6 +50,47 @@ const PURCHASE_ORDER_LINE_1: (&str, &str) = (
     }"#,
 );
 
+const PURCHASE_ORDER_LINE_UNLINKED: (&str, &str) = (
+    "sync_test_purchase_order_5_line_unlinked",
+    r#"{
+    "ID": "sync_test_purchase_order_5_line_unlinked",
+    "purchase_order_ID": "12e889c0f0d211eb8dddb54df6d7fsadsa",
+    "item_ID": "item_a",
+	"item_name": "Item A",
+    "store_ID": "store_a",
+    "batch": "",
+    "comment": "comment a!",
+    "cost_from_invoice": 0,
+    "cost_local": 0,
+    "delivery_date_expected": "0000-00-00",
+    "delivery_date_requested": "2018-03-19",
+    "expiry": "0000-00-00",
+    "kit_data": null,
+    "line_number": 1,
+    "location_ID": "",
+    "manufacturer_ID": "",
+    "non_stock_name_ID": "",
+    "note": "",
+    "note_has_been_actioned": false,
+    "note_show_on_goods_rec": false,
+    "oms_fields": null,
+    "pack_units": "",
+    "packsize_ordered": 0,
+    "price_expected_after_discount": 0.0,
+    "price_extension_expected": 0.0,
+    "price_per_pack_before_discount": 0,
+    "quan_adjusted_order": 0,
+    "quan_original_order": 0,
+    "quan_rec_to_date": 0,
+    "quote_line_ID": "",
+    "snapshotQuantity": 0,
+    "spare_estmated_cost": 0,
+    "suggestedQuantity": 0,
+    "supplier_code": "",
+    "volume_per_pack": 0
+    }"#,
+);
+
 fn purchase_order_line_pull_record() -> TestSyncIncomingRecord {
     TestSyncIncomingRecord::new_pull_upsert(
         TABLE_NAME,
@@ -102,18 +143,76 @@ fn purchase_order_line_push_record() -> TestSyncOutgoingRecord {
     }
 }
 
+fn purchase_order_line_unlinked_pull_record() -> TestSyncIncomingRecord {
+    TestSyncIncomingRecord::new_pull_upsert(
+        TABLE_NAME,
+        PURCHASE_ORDER_LINE_UNLINKED,
+        PurchaseOrderLineRow {
+            id: PURCHASE_ORDER_LINE_UNLINKED.0.to_string(),
+            purchase_order_id: "12e889c0f0d211eb8dddb54df6d7fsadsa".to_string(),
+            line_number: 1,
+            item_link_id: "item_a".to_string(),
+            requested_delivery_date: Some(NaiveDate::from_ymd_opt(2018, 3, 19).unwrap()),
+            expected_delivery_date: None,
+            item_name: "Item A".to_string(),
+            requested_pack_size: 0.0,
+            requested_number_of_units: 0.0,
+            authorised_number_of_units: None,
+            received_number_of_units: 0.0,
+            stock_on_hand_in_units: 0.0,
+            supplier_item_code: None,
+            price_per_unit_before_discount: 0.0,
+            price_per_unit_after_discount: 0.0,
+            store_id: "store_a".to_string(),
+            comment: Some("comment a!".to_string()),
+        },
+    )
+}
+
+fn purchase_order_line_unlinked_push_record() -> TestSyncOutgoingRecord {
+    TestSyncOutgoingRecord {
+        table_name: TABLE_NAME.to_string(),
+        record_id: PURCHASE_ORDER_LINE_UNLINKED.0.to_string(),
+        push_data: json!(LegacyPurchaseOrderLineRow {
+            id: PURCHASE_ORDER_LINE_UNLINKED.0.to_string(),
+            store_id: "store_a".to_string(),
+            purchase_order_id: "12e889c0f0d211eb8dddb54df6d7fsadsa".to_string(),
+            line_number: 1,
+            item_link_id: "item_a".to_string(),
+            item_name: "Item A".to_string(),
+            quan_rec_to_date: 0.0,
+            delivery_date_requested: Some(NaiveDate::from_ymd_opt(2018, 3, 19).unwrap()),
+            delivery_date_expected: None,
+            snapshot_quantity: 0.0,
+            packsize_ordered: 0.0,
+            quan_original_order: 0.0,
+            quan_adjusted_order: None,
+            supplier_item_code: None,
+            price_extension_expected: 0.0,
+            price_expected_after_discount: 0.0,
+            comment: Some("comment a!".to_string()),
+        }),
+    }
+}
+
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
-    vec![purchase_order_line_pull_record()]
+    vec![
+        purchase_order_line_pull_record(),
+        purchase_order_line_unlinked_pull_record(),
+    ]
 }
 
 pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
-    vec![purchase_order_line_push_record()]
+    vec![
+        purchase_order_line_push_record(),
+        purchase_order_line_unlinked_push_record(),
+    ]
 }
 
 pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
     vec![TestSyncIncomingRecord::new_pull_delete(
         TABLE_NAME,
-        PURCHASE_ORDER_LINE_1.0,
-        PurchaseOrderLineDelete(PURCHASE_ORDER_LINE_1.0.to_string()),
+        PURCHASE_ORDER_LINE_UNLINKED.0,
+        PurchaseOrderLineDelete(PURCHASE_ORDER_LINE_UNLINKED.0.to_string()),
     )]
 }

--- a/server/service/src/sync/test/test_data/purchase_order_line.rs
+++ b/server/service/src/sync/test/test_data/purchase_order_line.rs
@@ -2,7 +2,7 @@ use crate::sync::{
     test::TestSyncIncomingRecord, translations::purchase_order_line::LegacyPurchaseOrderLineRow,
 };
 use chrono::NaiveDate;
-use repository::PurchaseOrderLineRow;
+use repository::{PurchaseOrderLineDelete, PurchaseOrderLineRow};
 use serde_json::json;
 
 use super::TestSyncOutgoingRecord;
@@ -114,6 +114,6 @@ pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
     vec![TestSyncIncomingRecord::new_pull_delete(
         TABLE_NAME,
         PURCHASE_ORDER_LINE_1.0,
-        PurchaseOrderDelete(PURCHASE_ORDER_LINE_1.0.to_string()),
+        PurchaseOrderLineDelete(PURCHASE_ORDER_LINE_1.0.to_string()),
     )]
 }

--- a/server/service/src/sync/test/test_data/purchase_order_line.rs
+++ b/server/service/src/sync/test/test_data/purchase_order_line.rs
@@ -109,3 +109,11 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
 pub(crate) fn test_push_records() -> Vec<TestSyncOutgoingRecord> {
     vec![purchase_order_line_push_record()]
 }
+
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_delete(
+        TABLE_NAME,
+        PURCHASE_ORDER_LINE_1.0,
+        PurchaseOrderDelete(PURCHASE_ORDER_LINE_1.0.to_string()),
+    )]
+}

--- a/server/service/src/sync/translations/goods_received.rs
+++ b/server/service/src/sync/translations/goods_received.rs
@@ -1,17 +1,16 @@
+use crate::sync::translations::{
+    invoice::InvoiceTranslation, purchase_order::PurchaseOrderTranslation, PullTranslateResult,
+    PushTranslateResult, SyncTranslation,
+};
 use chrono::NaiveDate;
 use repository::{
     goods_received_row::{
-        GoodsReceivedRow, GoodsReceivedRowDelete, GoodsReceivedRowRepository, GoodsReceivedStatus,
+        GoodsReceivedDelete, GoodsReceivedRow, GoodsReceivedRowRepository, GoodsReceivedStatus,
     },
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::empty_str_as_option;
-
-use crate::sync::translations::{
-    invoice::InvoiceTranslation, purchase_order::PurchaseOrderTranslation, PullTranslateResult,
-    PushTranslateResult, SyncTranslation,
-};
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
 pub enum LegacyGoodsReceivedStatus {
@@ -147,7 +146,7 @@ impl SyncTranslation for GoodsReceivedTranslation {
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
     ) -> Result<PullTranslateResult, anyhow::Error> {
-        Ok(PullTranslateResult::delete(GoodsReceivedRowDelete(
+        Ok(PullTranslateResult::delete(GoodsReceivedDelete(
             sync_record.record_id.clone(),
         )))
     }
@@ -155,9 +154,8 @@ impl SyncTranslation for GoodsReceivedTranslation {
 
 #[cfg(test)]
 mod tests {
-    use repository::{mock::MockDataInserts, test_db::setup_all};
-
     use crate::sync::translations::{goods_received::GoodsReceivedTranslation, SyncTranslation};
+    use repository::{mock::MockDataInserts, test_db::setup_all};
 
     #[actix_rt::test]
     async fn test_goods_received_translation() {

--- a/server/service/src/sync/translations/goods_received.rs
+++ b/server/service/src/sync/translations/goods_received.rs
@@ -10,7 +10,9 @@ use repository::{
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
 };
 use serde::{Deserialize, Serialize};
-use util::sync_serde::empty_str_as_option;
+use util::sync_serde::{
+    date_option_to_isostring, date_to_isostring, empty_str_as_option, zero_date_as_option,
+};
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
 pub enum LegacyGoodsReceivedStatus {
@@ -39,7 +41,10 @@ pub struct LegacyGoodsReceived {
     pub goods_received_number: i64,
     pub status: LegacyGoodsReceivedStatus,
     #[serde(rename = "entry_date")]
+    #[serde(serialize_with = "date_to_isostring")]
     pub created_datetime: NaiveDate,
+    #[serde(deserialize_with = "zero_date_as_option")]
+    #[serde(serialize_with = "date_option_to_isostring")]
     #[serde(rename = "received_date")]
     pub received_date: Option<NaiveDate>,
     #[serde(default)]

--- a/server/service/src/sync/translations/goods_received_line.rs
+++ b/server/service/src/sync/translations/goods_received_line.rs
@@ -5,9 +5,8 @@ use crate::sync::translations::{
 };
 use chrono::NaiveDate;
 use repository::{
-    goods_received_row::GoodsReceivedDelete, ChangelogRow, ChangelogTableName,
-    GoodsReceivedLineDelete, GoodsReceivedLineRow, GoodsReceivedLineRowRepository,
-    GoodsReceivedLineStatus, StorageConnection, SyncBufferRow,
+    ChangelogRow, ChangelogTableName, GoodsReceivedLineDelete, GoodsReceivedLineRow,
+    GoodsReceivedLineRowRepository, GoodsReceivedLineStatus, StorageConnection, SyncBufferRow,
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{

--- a/server/service/src/sync/translations/goods_received_line.rs
+++ b/server/service/src/sync/translations/goods_received_line.rs
@@ -1,19 +1,18 @@
-use crate::sync::translations::goods_received::GoodsReceivedTranslation;
-use crate::sync::translations::item::ItemTranslation;
-use crate::sync::translations::purchase_order::PurchaseOrderTranslation;
-use crate::sync::translations::{location::LocationTranslation, name::NameTranslation};
-use crate::sync::translations::{PullTranslateResult, PushTranslateResult, SyncTranslation};
+use crate::sync::translations::{
+    goods_received::GoodsReceivedTranslation, item::ItemTranslation, location::LocationTranslation,
+    name::NameTranslation, purchase_order::PurchaseOrderTranslation, PullTranslateResult,
+    PushTranslateResult, SyncTranslation,
+};
 use chrono::NaiveDate;
 use repository::{
-    ChangelogRow, GoodsReceivedLineRow, GoodsReceivedLineRowDelete, GoodsReceivedLineRowRepository,
-    GoodsReceivedLineStatus,
+    goods_received_row::GoodsReceivedDelete, ChangelogRow, ChangelogTableName,
+    GoodsReceivedLineDelete, GoodsReceivedLineRow, GoodsReceivedLineRowRepository,
+    GoodsReceivedLineStatus, StorageConnection, SyncBufferRow,
 };
-use repository::{ChangelogTableName, StorageConnection, SyncBufferRow};
 use serde::{Deserialize, Serialize};
-use util::sync_serde::empty_str_as_option_string;
-use util::sync_serde::zero_f64_as_none;
-use util::sync_serde::{date_option_to_isostring, zero_date_as_option};
-
+use util::sync_serde::{
+    date_option_to_isostring, empty_str_as_option_string, zero_date_as_option, zero_f64_as_none,
+};
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct LegacyGoodsReceivedLineRow {
@@ -98,6 +97,16 @@ impl SyncTranslation for GoodsReceivedLineTranslation {
         Ok(PullTranslateResult::upsert(result))
     }
 
+    fn try_translate_from_delete_sync_record(
+        &self,
+        _: &StorageConnection,
+        sync_record: &SyncBufferRow,
+    ) -> Result<PullTranslateResult, anyhow::Error> {
+        Ok(PullTranslateResult::delete(GoodsReceivedLineDelete(
+            sync_record.record_id.clone(),
+        )))
+    }
+
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
@@ -141,14 +150,12 @@ impl SyncTranslation for GoodsReceivedLineTranslation {
         ))
     }
 
-    fn try_translate_from_delete_sync_record(
+    fn try_translate_to_delete_sync_record(
         &self,
         _: &StorageConnection,
-        sync_record: &SyncBufferRow,
-    ) -> Result<PullTranslateResult, anyhow::Error> {
-        Ok(PullTranslateResult::delete(GoodsReceivedLineRowDelete(
-            sync_record.record_id.clone(),
-        )))
+        changelog: &ChangelogRow,
+    ) -> Result<PushTranslateResult, anyhow::Error> {
+        Ok(PushTranslateResult::delete(changelog, self.table_name()))
     }
 }
 

--- a/server/service/src/sync/translations/purchase_order.rs
+++ b/server/service/src/sync/translations/purchase_order.rs
@@ -1,22 +1,20 @@
-use chrono::NaiveDate;
-use chrono::NaiveDateTime;
-use repository::PurchaseOrderDelete;
-use repository::PurchaseOrderStatsRow;
+use crate::sync::{
+    sync_utils::{map_name_link_id_to_name_id, map_optional_name_link_id_to_name_id},
+    translations::{
+        name::NameTranslation, store::StoreTranslation, PullTranslateResult, PushTranslateResult,
+        SyncTranslation,
+    },
+};
+use chrono::{NaiveDate, NaiveDateTime};
 use repository::{
-    ChangelogRow, ChangelogTableName, EqualFilter, PurchaseOrderFilter, PurchaseOrderRepository,
-    PurchaseOrderRow, PurchaseOrderStatus, StorageConnection, SyncBufferRow,
+    ChangelogRow, ChangelogTableName, EqualFilter, PurchaseOrderDelete, PurchaseOrderFilter,
+    PurchaseOrderRepository, PurchaseOrderRow, PurchaseOrderStatsRow, PurchaseOrderStatus,
+    StorageConnection, SyncBufferRow,
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{
     date_option_to_isostring, empty_str_as_option, object_fields_as_option, zero_date_as_option,
     zero_f64_as_none,
-};
-
-use crate::sync::sync_utils::map_name_link_id_to_name_id;
-use crate::sync::sync_utils::map_optional_name_link_id_to_name_id;
-use crate::sync::translations::{
-    name::NameTranslation, store::StoreTranslation, PullTranslateResult, PushTranslateResult,
-    SyncTranslation,
 };
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]

--- a/server/service/src/sync/translations/purchase_order.rs
+++ b/server/service/src/sync/translations/purchase_order.rs
@@ -508,6 +508,15 @@ mod tests {
                 .unwrap();
             assert_eq!(translation_result, record.translated_record);
         }
+
+        for record in test_data::test_pull_delete_records() {
+            assert!(translator.should_translate_from_sync_record(&record.sync_buffer_row));
+            let translation_result = translator
+                .try_translate_from_delete_sync_record(&connection, &record.sync_buffer_row)
+                .unwrap();
+
+            assert_eq!(translation_result, record.translated_record);
+        }
     }
 
     #[actix_rt::test]

--- a/server/service/src/sync/translations/purchase_order_line.rs
+++ b/server/service/src/sync/translations/purchase_order_line.rs
@@ -231,6 +231,15 @@ mod tests {
 
             assert_eq!(translation_result, record.translated_record);
         }
+
+        for record in test_data::test_pull_delete_records() {
+            assert!(translator.should_translate_from_sync_record(&record.sync_buffer_row));
+            let translation_result = translator
+                .try_translate_from_delete_sync_record(&connection, &record.sync_buffer_row)
+                .unwrap();
+
+            assert_eq!(translation_result, record.translated_record);
+        }
     }
 
     #[actix_rt::test]
@@ -273,15 +282,6 @@ mod tests {
                 translated[0].record.record_data["ID"],
                 json!(changelog.record_id)
             );
-        }
-
-        for record in test_data::test_pull_delete_records() {
-            assert!(translator.should_translate_from_sync_record(&record.sync_buffer_row));
-            let translation_result = translator
-                .try_translate_from_delete_sync_record(&connection, &record.sync_buffer_row)
-                .unwrap();
-
-            assert_eq!(translation_result, record.translated_record);
         }
     }
 }

--- a/server/service/src/sync/translations/purchase_order_line.rs
+++ b/server/service/src/sync/translations/purchase_order_line.rs
@@ -1,3 +1,7 @@
+use crate::sync::translations::{
+    item::ItemTranslation, purchase_order::PurchaseOrderTranslation, PullTranslateResult,
+    PushTranslateResult, SyncTranslation,
+};
 use chrono::NaiveDate;
 use repository::{
     ChangelogRow, ChangelogTableName, PurchaseOrderLineRow, PurchaseOrderLineRowRepository,
@@ -6,11 +10,6 @@ use repository::{
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{
     date_option_to_isostring, empty_str_as_option, zero_date_as_option, zero_f64_as_none,
-};
-
-use crate::sync::translations::{
-    item::ItemTranslation, purchase_order::PurchaseOrderTranslation, PullTranslateResult,
-    PushTranslateResult, SyncTranslation,
 };
 
 #[allow(non_snake_case)]


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8610

# 👩🏻‍💻 What does this PR do?
Sync deletes for pull / push: 
- Purchase orders & lines
- Goods received & lines

There's a weird side affect going on whereas if you delete the line, the costs in the purchase order has changed? I'm told that this is done in a view... but erm would suggest a change in architecture here @andreievg 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create some purchase orders in OMS
- [ ] Sync
- [ ] Delete
- [ ] Sync
- [ ] Check OG
- [ ] Do same with the lines / goods received

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

