### PR TITLE
8408 freezing part of the screen when scrolling the internal order

### DIFF
--- a/client/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -39,7 +39,26 @@ interface RenderRowsProps<T extends RecordWithId> {
   additionalRows?: JSX.Element[];
   /** will ignore onRowClick if defined. Allows opening in new tab */
   rowLinkBuilder?: (row: T) => string;
+  stickyColumnPositions?: Map<string | keyof T, number>;
 }
+
+const calculateStickyPositions = <T extends RecordWithId>(
+  columns: Column<T>[]
+): Map<string | keyof T, number> => {
+  const positions = new Map<string | keyof T, number>();
+  let currentPosition = 0;
+
+  columns.forEach(column => {
+    if (column.isSticky) {
+      positions.set(column.key, currentPosition);
+      const columnWidth = Number(column.width) || 120;
+      currentPosition += columnWidth;
+    }
+  });
+
+  return positions;
+};
+
 const RenderRows = <T extends RecordWithId>({
   mRef,
   data,
@@ -52,6 +71,7 @@ const RenderRows = <T extends RecordWithId>({
   isRowAnimated,
   additionalRows,
   rowLinkBuilder,
+  stickyColumnPositions,
 }: RenderRowsProps<T>) => {
   const t = useTranslation();
   const { localisedDate } = useFormatDateTime();
@@ -75,6 +95,7 @@ const RenderRows = <T extends RecordWithId>({
             localisedDate={localisedDate}
             isAnimated={isRowAnimated}
             rowLinkBuilder={rowLinkBuilder}
+            stickyColumnPositions={stickyColumnPositions}
           />
         ))}
         {additionalRows}
@@ -105,6 +126,7 @@ const RenderRows = <T extends RecordWithId>({
             localisedDate={localisedDate}
             isAnimated={isRowAnimated}
             rowLinkBuilder={rowLinkBuilder}
+            stickyColumnPositions={stickyColumnPositions}
           />
         )}
       </ViewportList>
@@ -144,9 +166,15 @@ const DataTableComponent = <T extends RecordWithId>({
 
   const columnsToDisplay = React.useMemo(() => {
     const cols = columns.filter(c => columnDisplayState[String(c.key)] ?? true);
-
     return cols.every(c => c.key === 'selection') ? [] : cols;
   }, [columns, columnDisplayState]);
+
+  const stickyColumnPositions = React.useMemo(() => {
+    return calculateStickyPositions(columnsToDisplay);
+  }, [columnsToDisplay]);
+  const sumStickyColumnWidths = Array.from(
+    stickyColumnPositions.values()
+  ).reduce((acc, width) => acc + width, 0);
 
   useRegisterActions([
     {
@@ -243,6 +271,9 @@ const DataTableComponent = <T extends RecordWithId>({
                 dense={dense}
                 column={column}
                 key={String(column.key)}
+                isSticky={column.isSticky}
+                stickyPosition={stickyColumnPositions.get(column.key) ?? 0}
+                stickyZIndex={sumStickyColumnWidths}
               />
             ))}
             {!!enableColumnSelection && (
@@ -278,6 +309,7 @@ const DataTableComponent = <T extends RecordWithId>({
             isRowAnimated={isRowAnimated}
             additionalRows={additionalRows}
             rowLinkBuilder={rowLinkBuilder}
+            stickyColumnPositions={stickyColumnPositions}
           />
         </TableBody>
       </MuiTable>

--- a/client/packages/common/src/ui/layout/tables/columns/types.ts
+++ b/client/packages/common/src/ui/layout/tables/columns/types.ts
@@ -111,6 +111,7 @@ export interface Column<T extends RecordWithId> {
   // When using browser autocomplete in tables, row data needs to be used to set autocompleteName
   // to a value that's related to row data (like item id)
   autocompleteProvider?: (rowDataValue: T) => string;
+  isSticky?: boolean;
 }
 
 export interface ColumnDefinition<T extends RecordWithId>

--- a/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -74,8 +74,6 @@ const DataRowComponent = <T extends RecordWithId>({
     if (rowLinkBuilder) rowLinkBuilder(rowData);
     else if (onClick) onClick(rowData);
   };
-  const backgroundColor =
-    rowIndex % 2 === 1 ? 'background.paper' : 'background.toolbar';
 
   useEffect(() => {
     if (isFocused) handleRowClick();
@@ -93,7 +91,10 @@ const DataRowComponent = <T extends RecordWithId>({
                 ? theme => alpha(theme.palette.secondary.main, 0.1)
                 : null,
               '&.MuiTableRow-root': {
-                backgroundColor,
+                backgroundColor:
+                  rowIndex % 2 === 1
+                    ? 'background.paper'
+                    : 'background.toolbar',
                 '&:hover': hasOnClick
                   ? theme => ({
                       backgroundColor: alpha(theme.palette.secondary.main, 0.1),
@@ -147,11 +148,8 @@ const DataRowComponent = <T extends RecordWithId>({
                           position: 'sticky',
                           left: stickyColumnPositions.get(column.key),
                           zIndex: 'stickyColumn',
-                          backgroundColor,
-                          boxShadow: dense
-                            ? 'none'
-                            : theme =>
-                                `inset 0 0.5px 0 0 ${alpha(theme.palette.gray.main, 0.5)}`,
+                          backgroundColor: 'inherit',
+                          boxShadow: 'inherit',
                           'tr:hover &': hasOnClick
                             ? {
                                 backgroundColor: '#edf2fa',

--- a/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -41,6 +41,7 @@ interface DataRowProps<T extends RecordWithId> {
   isAnimated: boolean;
   /** will ignore onClick if defined. Allows opening in new tab */
   rowLinkBuilder?: (rowData: T) => string;
+  stickyColumnPositions?: Map<string | keyof T, number>;
 }
 
 const DataRowComponent = <T extends RecordWithId>({
@@ -57,6 +58,7 @@ const DataRowComponent = <T extends RecordWithId>({
   localisedDate,
   isAnimated,
   rowLinkBuilder,
+  stickyColumnPositions,
 }: DataRowProps<T>): JSX.Element => {
   const hasOnClick = !!onClick || !!rowLinkBuilder;
   const { isExpanded } = useExpanded(rowData.id);
@@ -72,6 +74,8 @@ const DataRowComponent = <T extends RecordWithId>({
     if (rowLinkBuilder) rowLinkBuilder(rowData);
     else if (onClick) onClick(rowData);
   };
+  const backgroundColor =
+    rowIndex % 2 === 1 ? 'background.paper' : 'background.toolbar';
 
   useEffect(() => {
     if (isFocused) handleRowClick();
@@ -89,9 +93,7 @@ const DataRowComponent = <T extends RecordWithId>({
                 ? theme => alpha(theme.palette.secondary.main, 0.1)
                 : null,
               '&.MuiTableRow-root': {
-                '&:nth-of-type(even)': {
-                  backgroundColor: 'background.toolbar',
-                },
+                backgroundColor,
                 '&:hover': hasOnClick
                   ? theme => ({
                       backgroundColor: alpha(theme.palette.secondary.main, 0.1),
@@ -138,6 +140,23 @@ const DataRowComponent = <T extends RecordWithId>({
                           borderStyle: 'solid',
                           borderColor: 'error.main',
                           borderRadius: '8px',
+                        }
+                      : {}),
+                    ...(column.isSticky && stickyColumnPositions
+                      ? {
+                          position: 'sticky',
+                          left: stickyColumnPositions.get(column.key),
+                          zIndex: 'stickyColumn',
+                          backgroundColor,
+                          boxShadow: dense
+                            ? 'none'
+                            : theme =>
+                                `inset 0 0.5px 0 0 ${alpha(theme.palette.gray.main, 0.5)}`,
+                          'tr:hover &': hasOnClick
+                            ? {
+                                backgroundColor: '#edf2fa',
+                              }
+                            : {},
                         }
                       : {}),
                   }}

--- a/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -152,6 +152,7 @@ export const HeaderCell = <T extends RecordWithId>({
         position: 'sticky' as const,
         left: stickyPosition,
         backgroundColor: 'white',
+        // When position is at 0, need to add some padding to avoid overlap
         zIndex: `calc(${stickyZIndex} + 200)`,
       }
     : {};

--- a/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -32,11 +32,17 @@ export const HeaderRow: FC<
 interface HeaderCellProps<T extends RecordWithId> {
   column: Column<T>;
   dense?: boolean;
+  isSticky?: boolean;
+  stickyPosition?: number;
+  stickyZIndex?: number;
 }
 
 export const HeaderCell = <T extends RecordWithId>({
   column,
   dense = false,
+  isSticky = false,
+  stickyPosition,
+  stickyZIndex,
 }: HeaderCellProps<T>): JSX.Element => {
   const {
     maxWidth,
@@ -141,6 +147,15 @@ export const HeaderCell = <T extends RecordWithId>({
     child
   );
 
+  const stickyStyles = isSticky
+    ? {
+        position: 'sticky' as const,
+        left: stickyPosition,
+        backgroundColor: 'white',
+        zIndex: `calc(${stickyZIndex} + 200)`,
+      }
+    : {};
+
   return (
     <TableCell
       role="columnheader"
@@ -158,6 +173,7 @@ export const HeaderCell = <T extends RecordWithId>({
         fontWeight: 'bold',
         fontSize: dense ? '12px' : '14px',
         verticalAlign: 'bottom',
+        ...stickyStyles,
       }}
       aria-label={String(key)}
       sortDirection={isSorted ? direction : false}

--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.tsx
@@ -102,6 +102,7 @@ export const useStocktakeColumns = ({
           return row.item?.code ?? '';
         },
         accessor: ({ rowData }) => rowData.item?.code ?? '',
+        isSticky: true,
       },
     ],
     [
@@ -118,6 +119,7 @@ export const useStocktakeColumns = ({
             { path: ['lines', 'itemName'] },
             { path: ['itemName'], default: '' },
           ]),
+        isSticky: true,
       },
     ],
     [

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -103,6 +103,7 @@ export const useInboundShipmentColumns = ({
             { path: ['lines', 'item', 'code'] },
             { path: ['item', 'code'], default: '' },
           ]),
+        isSticky: true,
       },
     ],
     [
@@ -119,6 +120,7 @@ export const useInboundShipmentColumns = ({
             { path: ['lines', 'itemName'] },
             { path: ['itemName'], default: '' },
           ]),
+        isSticky: true,
       },
     ],
     [

--- a/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -87,6 +87,7 @@ export const useOutboundColumns = ({
             { path: ['lines', 'item', 'code'], default: '' },
             { path: ['item', 'code'], default: '' },
           ]),
+        isSticky: true,
       },
     ],
     [
@@ -103,6 +104,7 @@ export const useOutboundColumns = ({
             { path: ['lines', 'itemName'] },
             { path: ['itemName'], default: '' },
           ]),
+        isSticky: true,
       },
     ],
     [
@@ -118,7 +120,7 @@ export const useOutboundColumns = ({
             { path: ['lines', 'batch'] },
             { path: ['batch'] },
           ]),
-          defaultHideOnMobile: true,
+        defaultHideOnMobile: true,
       },
     ],
     [
@@ -134,7 +136,7 @@ export const useOutboundColumns = ({
             { path: ['lines', 'expiryDate'] },
             { path: ['expiryDate'] },
           ]),
-          defaultHideOnMobile: true,
+        defaultHideOnMobile: true,
       },
     ],
     [
@@ -167,7 +169,7 @@ export const useOutboundColumns = ({
             { path: ['lines', 'item', 'unitName'] },
             { path: ['item', 'unitName'], default: '' },
           ]),
-          defaultHideOnMobile: true,
+        defaultHideOnMobile: true,
       },
     ],
     [

--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -58,6 +58,7 @@ export const usePrescriptionColumn = ({
           ]),
         accessor: ({ rowData }) =>
           getColumnProperty(rowData, [{ path: ['item', 'code'], default: '' }]),
+        isSticky: true,
       },
     ],
     [
@@ -67,6 +68,7 @@ export const usePrescriptionColumn = ({
           getColumnPropertyAsString(row, [{ path: ['itemName'], default: '' }]),
         accessor: ({ rowData }) =>
           getColumnProperty(rowData, [{ path: ['itemName'], default: '' }]),
+        isSticky: true,
       },
     ],
     [

--- a/client/packages/invoices/src/Returns/CustomerDetailView/columns.ts
+++ b/client/packages/invoices/src/Returns/CustomerDetailView/columns.ts
@@ -50,6 +50,7 @@ export const useCustomerReturnColumns = ({
             { path: ['lines', 'itemCode'] },
             { path: ['itemCode'], default: '' },
           ]),
+        isSticky: true,
       },
     ],
     [
@@ -66,6 +67,7 @@ export const useCustomerReturnColumns = ({
             { path: ['lines', 'itemName'] },
             { path: ['itemName'], default: '' },
           ]),
+        isSticky: true,
       },
     ],
     [

--- a/client/packages/invoices/src/Returns/SupplierDetailView/columns.ts
+++ b/client/packages/invoices/src/Returns/SupplierDetailView/columns.ts
@@ -53,6 +53,7 @@ export const useSupplierReturnColumns = ({
             { path: ['lines', 'itemCode'] },
             { path: ['itemCode'], default: '' },
           ]),
+        isSticky: true,
       },
     ],
     [
@@ -69,6 +70,7 @@ export const useSupplierReturnColumns = ({
             { path: ['lines', 'itemName'] },
             { path: ['itemName'], default: '' },
           ]),
+        isSticky: true,
       },
     ],
     [

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
@@ -29,6 +29,9 @@ export const useRequestColumns = (manageVaccinesInDoses: boolean = false) => {
   const { store } = useAuthContext();
   const { getError } = useRequestRequisitionLineErrorContext();
   const { plugins } = usePluginProvider();
+  const showExtraColumns =
+    programName &&
+    store?.preferences.useConsumptionAndStockFromCustomersForInternalOrders;
 
   const columnDefinitions: ColumnDescription<RequestLineFragment>[] = [
     GenericColumnKey.Selection,
@@ -39,6 +42,7 @@ export const useRequestColumns = (manageVaccinesInDoses: boolean = false) => {
         width: 130,
         accessor: ({ rowData }) => rowData.item.code,
         getSortValue: rowData => rowData.item.code,
+        isSticky: true,
       },
     ],
     [
@@ -48,6 +52,7 @@ export const useRequestColumns = (manageVaccinesInDoses: boolean = false) => {
         width: 350,
         accessor: ({ rowData }) => rowData.itemName,
         getSortValue: rowData => rowData.itemName,
+        isSticky: true,
       },
     ],
     {
@@ -146,10 +151,7 @@ export const useRequestColumns = (manageVaccinesInDoses: boolean = false) => {
     }
   );
 
-  if (
-    programName &&
-    store?.preferences.useConsumptionAndStockFromCustomersForInternalOrders
-  ) {
+  if (showExtraColumns) {
     columnDefinitions.push(
       // TODO: Global pref to show/hide the next columns
       {

--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/line/useRequestLines.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/line/useRequestLines.ts
@@ -38,6 +38,7 @@ export const useRequestLines = (manageVaccinesInDoses: boolean = false) => {
     } else {
       return sorted?.filter(item => matchItem(itemFilter, item.item));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sortBy.key, sortBy.isDesc, lines, on, minMonthsOfStock, itemFilter]);
 
   return {

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
@@ -43,6 +43,7 @@ export const useResponseColumns = (manageVaccinesInDoses: boolean = false) => {
         accessor: ({ rowData }) => rowData.item.code,
         getSortValue: rowData => rowData.item.code,
         width: 125,
+        isSticky: true,
       },
     ],
     [
@@ -51,6 +52,7 @@ export const useResponseColumns = (manageVaccinesInDoses: boolean = false) => {
         Cell: TooltipTextCell,
         accessor: ({ rowData }) => rowData.item.name,
         getSortValue: rowData => rowData.item.name,
+        isSticky: true,
       },
     ],
     {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8408

# 👩🏻‍💻 What does this PR do?
Make the item and name columns sticky, so that they're always on the screen

https://github.com/user-attachments/assets/acee93b9-3940-424f-ada5-45ebc0982c84

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Best tested on small screens
- [ ] Go to any of the tables 
- [ ] Scroll
- [ ] Item name and code should always show

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

