### PR TITLE
8787 add pack size

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -676,7 +676,7 @@
   "label.adjust-by": "by",
   "label.adjusted": "Adjusted",
   "label.adjustments": "Adjustments",
-  "label.adjusted-quantity": "Adjusted Quantity",
+  "label.adjusted-quantity": "Adjusted",
   "label.advanced-paid": "Advanced Paid",
   "label.age": "Age",
   "label.age-days_one": "{{count}} day",

--- a/client/packages/purchasing/src/purchase_order/DetailView/LineEdit/columns.ts
+++ b/client/packages/purchasing/src/purchase_order/DetailView/LineEdit/columns.ts
@@ -62,6 +62,9 @@ export const usePurchaseOrderLineEditColumns = ({
                 setter: (patch: Partial<DraftPurchaseOrderLine>) => {
                   updatePatch({ ...patch });
                 },
+                cellProps: {
+                  isDisabled: true, // Edited via number of packs for now
+                },
               },
             ]
           : []),
@@ -73,7 +76,7 @@ export const usePurchaseOrderLineEditColumns = ({
             updatePatch({ ...patch });
           },
           cellProps: {
-            isDisabled: status === PurchaseOrderNodeStatus.Confirmed,
+            isDisabled: true, // Edited via number of packs for now
           },
         },
 

--- a/client/packages/purchasing/src/purchase_order/DetailView/LineEdit/columns.ts
+++ b/client/packages/purchasing/src/purchase_order/DetailView/LineEdit/columns.ts
@@ -9,7 +9,7 @@ import {
   PurchaseOrderNodeStatus,
   useColumns,
 } from '@openmsupply-client/common/src';
-import { calculatePricesAndDiscount } from './utils';
+import { calculatePricesAndDiscount, calculateUnitQuantities } from './utils';
 
 export const usePurchaseOrderLineEditColumns = ({
   draft,
@@ -23,6 +23,36 @@ export const usePurchaseOrderLineEditColumns = ({
   const columnDefinitions: ColumnDescription<DraftPurchaseOrderLine>[] =
     useMemo(
       () => [
+        {
+          Cell: NumberInputCell,
+          key: 'numberOfPacks',
+          label: 'label.requested-packs',
+          setter: patch => {
+            // Adjust the requested and adjusted number of units based on the number of packs
+            const adjustedPatch = calculateUnitQuantities(
+              'numberOfPacks',
+              status,
+              patch,
+              draft
+            );
+            updatePatch({ ...patch, ...adjustedPatch });
+          },
+        },
+        {
+          Cell: NumberInputCell,
+          key: 'requestedPackSize',
+          label: 'label.pack-size',
+          setter: patch => {
+            // Adjust the requested and adjusted number of units based on the new pack size
+            const adjustedPatch = calculateUnitQuantities(
+              'packSize',
+              status,
+              patch,
+              draft
+            );
+            updatePatch({ ...patch, ...adjustedPatch });
+          },
+        },
         ...(status === PurchaseOrderNodeStatus.Confirmed
           ? [
               {
@@ -46,6 +76,7 @@ export const usePurchaseOrderLineEditColumns = ({
             isDisabled: status === PurchaseOrderNodeStatus.Confirmed,
           },
         },
+
         {
           Cell: NumberInputCell,
           key: 'pricePerUnitBeforeDiscount',

--- a/client/packages/purchasing/src/purchase_order/api/hooks/usePurchaseOrderLine.ts
+++ b/client/packages/purchasing/src/purchase_order/api/hooks/usePurchaseOrderLine.ts
@@ -18,6 +18,7 @@ export type DraftPurchaseOrderLine = Omit<
   purchaseOrderId: string;
   itemId: string;
   discountPercentage: number;
+  numberOfPacks: number;
 };
 
 export type DraftPurchaseOrderLineFromCSV = Omit<
@@ -40,6 +41,7 @@ const defaultPurchaseOrderLine: DraftPurchaseOrderLine = {
   pricePerUnitAfterDiscount: 0,
   // This value not actually saved to DB
   discountPercentage: 0,
+  numberOfPacks: 0,
 };
 
 export function usePurchaseOrderLine(id?: string) {

--- a/client/packages/purchasing/src/purchase_order/api/hooks/usePurchaseOrderLine.ts
+++ b/client/packages/purchasing/src/purchase_order/api/hooks/usePurchaseOrderLine.ts
@@ -63,12 +63,20 @@ export function usePurchaseOrderLine(id?: string) {
         100
       : 0;
 
+  // Number of packs is not in the DB, so we derived it from the draft
+  const initialNumberOfPacks = data?.nodes[0]?.requestedNumberOfUnits
+    ? (data?.nodes[0]?.adjustedNumberOfUnits ??
+        data?.nodes[0]?.requestedNumberOfUnits ??
+        0) / (data?.nodes[0]?.requestedPackSize ?? 1)
+    : 0;
+
   const draft: DraftPurchaseOrderLine = data
     ? {
         ...defaultPurchaseOrderLine,
         ...data?.nodes[0],
         itemId: data?.nodes[0]?.item.id ?? '',
         discountPercentage: initialDiscountPercentage,
+        numberOfPacks: initialNumberOfPacks,
         ...patch,
       }
     : { ...defaultPurchaseOrderLine, ...patch, itemId: '' };

--- a/server/graphql/purchase_order_line/src/mutations/update.rs
+++ b/server/graphql/purchase_order_line/src/mutations/update.rs
@@ -40,7 +40,7 @@ impl UpdateInput {
             item_id,
             requested_pack_size,
             requested_number_of_units,
-            adjusted_number_of_units, // TODO: Maybe should just have one number in the request and map it to adjusted or requested in backend?
+            adjusted_number_of_units,
             requested_delivery_date,
             expected_delivery_date,
             price_per_unit_before_discount,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8787

# 👩🏻‍💻 What does this PR do?

Adds number of packs, and packsize and changes the adjusted and requested packs to be calculated.

<img width="1321" height="781" alt="image" src="https://github.com/user-attachments/assets/5e45353d-e6f4-463d-bc15-cd0e7abd672e" />

## 💌 Any notes for the reviewer?

Could make the unit quantity trigger the calculations too, but feels unnecessary for now.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Check that changing packsize and number of packs updates the adjusted or requested quantity
- [ ] adjusted should only change after confirmed
- [ ] requested should only change before confirmed
- [ ] finalised shouldn't allow any changes.
- [ ] Reloading/reopening purchase order lines should show correct number of packs

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

