### PR TITLE
8877 locations update on save

### DIFF
--- a/client/packages/system/src/Location/Components/LocationSearchInput.tsx
+++ b/client/packages/system/src/Location/Components/LocationSearchInput.tsx
@@ -106,6 +106,9 @@ export const LocationSearchInput = ({
   const theme = useTheme();
   const { round } = useFormatNumber();
 
+  const [originalSelectedLocation] = useState<LocationRowFragment | null>(
+    selectedLocation
+  );
   const [filter, setFilter] = useState<LocationFilter>(LocationFilter.All);
 
   const {
@@ -131,7 +134,11 @@ export const LocationSearchInput = ({
         return location.stock?.totalCount === 0;
 
       case LocationFilter.Available:
-        return location.volume - location.volumeUsed >= (volumeRequired ?? 0);
+        return (
+          // If stock is already in the location, consider that location available
+          location.id === originalSelectedLocation?.id ||
+          location.volume - location.volumeUsed >= (volumeRequired ?? 0)
+        );
 
       case LocationFilter.All:
       default:

--- a/client/packages/system/src/Location/Components/LocationSearchInput.tsx
+++ b/client/packages/system/src/Location/Components/LocationSearchInput.tsx
@@ -25,6 +25,7 @@ interface LocationSearchInputProps {
   volumeRequired?: number;
   fullWidth?: boolean;
   enableAPI?: boolean;
+  originalSelectedLocation?: LocationRowFragment | null;
 }
 
 interface LocationOption {
@@ -101,14 +102,12 @@ export const LocationSearchInput = ({
   restrictedToLocationTypeId,
   volumeRequired,
   enableAPI = true,
+  originalSelectedLocation = null,
 }: LocationSearchInputProps) => {
   const t = useTranslation();
   const theme = useTheme();
   const { round } = useFormatNumber();
 
-  const [originalSelectedLocation] = useState<LocationRowFragment | null>(
-    selectedLocation
-  );
   const [filter, setFilter] = useState<LocationFilter>(LocationFilter.All);
 
   const {

--- a/client/packages/system/src/Location/api/hooks/useLocationList.ts
+++ b/client/packages/system/src/Location/api/hooks/useLocationList.ts
@@ -58,7 +58,7 @@ const useGetList = (enabled?: boolean, queryParams?: ListParams) => {
   };
 
   const query = useQuery({
-    queryKey: [queryKey, enabled],
+    queryKey: [...queryKey, enabled],
     queryFn,
     enabled,
   });

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -27,7 +27,7 @@ import {
   QuantityUtils,
   Alert,
 } from '@openmsupply-client/common';
-import { DraftStockLine } from '../api';
+import { DraftStockLine, StockLineRowFragment } from '../api';
 import { LocationSearchInput } from '../../Location/Components/LocationSearchInput';
 import {
   checkInvalidLocationLines,
@@ -46,6 +46,7 @@ interface StockLineFormProps {
   pluginEvents: UsePluginEvents<{ isDirty: boolean }>;
   packEditable?: boolean;
   isNewModal?: boolean;
+  existingStockLine?: StockLineRowFragment | null;
 }
 export const StockLineForm = ({
   draft,
@@ -54,6 +55,7 @@ export const StockLineForm = ({
   pluginEvents,
   packEditable,
   isNewModal = false,
+  existingStockLine = null,
 }: StockLineFormProps) => {
   const t = useTranslation();
   const { error } = useNotification();
@@ -327,6 +329,7 @@ export const StockLineForm = ({
                   disabled={false}
                   selectedLocation={location}
                   width={160}
+                  originalSelectedLocation={existingStockLine?.location}
                   onChange={location => {
                     onUpdate({ location, locationId: location?.id });
                   }}

--- a/client/packages/system/src/Stock/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Stock/DetailView/DetailView.tsx
@@ -109,6 +109,7 @@ export const StockLineDetailView: React.FC = () => {
           draft={draft}
           onUpdate={updatePatch}
           pluginEvents={pluginEvents}
+          existingStockLine={data}
         />
       ),
       value: t('label.details'),

--- a/client/packages/system/src/Stock/api/hooks/useStockLine.ts
+++ b/client/packages/system/src/Stock/api/hooks/useStockLine.ts
@@ -5,7 +5,11 @@ import {
   usePatchState,
   useQuery,
 } from '@openmsupply-client/common';
-import { ReasonOptionRowFragment, StockLineRowFragment } from '../../..';
+import {
+  LOCATION,
+  ReasonOptionRowFragment,
+  StockLineRowFragment,
+} from '../../..';
 import { STOCK_LINE } from './keys';
 import { useStockGraphQL } from '../useStockGraphQL';
 
@@ -212,6 +216,9 @@ const useUpdate = (id: string) => {
 
   return useMutation({
     mutationFn,
-    onSuccess: () => queryClient.invalidateQueries([STOCK_LINE, id]),
+    onSuccess: () => {
+      queryClient.invalidateQueries([STOCK_LINE, id]);
+      queryClient.invalidateQueries([LOCATION]); // Invalidate location queries to update available volume
+    },
   });
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8877

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

On stock line save, refresh the locations, so available volume percentages are updated:

<img width="433" height="298" alt="Screenshot 2025-08-15 at 10 58 44 AM" src="https://github.com/user-attachments/assets/37215946-8149-4969-8302-f291a29fe882" />

Also ensures the currently saved location for the item always shows in the `available` tab

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have at least a couple of locations, with volumes configured
- [ ] Go to view stock for a stock line
- [ ] Ensure the stock line has a volume per pack
- [ ] Change the location of the stockline and save
- [ ] Don't refresh
- [ ] Reopen the location dropdown
- [ ] Available volumes have updated (selected location % used increased, previous location has been reduced)
- [ ] `Available` tab shows your saved location, even if it exceeds 100% used

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

