### PR TITLE
8910 cant save service lines

### DIFF
--- a/client/packages/invoices/src/InboundShipment/api/api.test.ts
+++ b/client/packages/invoices/src/InboundShipment/api/api.test.ts
@@ -1,0 +1,40 @@
+import { InvoiceLineNodeType } from '@common/types';
+import { getInboundQueries } from './api';
+import { Sdk } from './operations.generated';
+import { DraftInboundLine } from '../../types';
+
+describe('getInboundQueries', () => {
+  it('should map service charges to the correct fields', () => {
+    const upsertInboundShipment = jest.fn();
+    const mockSdk = {
+      upsertInboundShipment,
+    } as unknown as Sdk;
+
+    const api = getInboundQueries(mockSdk, 'testStoreId');
+
+    const draftLines = [
+      {
+        isCreated: true,
+        type: InvoiceLineNodeType.Service,
+        item: { id: 'service-item' },
+      },
+    ] as DraftInboundLine[];
+
+    api.updateLines(draftLines);
+
+    expect(upsertInboundShipment).toHaveBeenCalledWith({
+      input: {
+        insertInboundShipmentLines: [],
+        updateInboundShipmentLines: [],
+        insertInboundShipmentServiceLines: [
+          expect.objectContaining({
+            itemId: 'service-item',
+          }),
+        ],
+        updateInboundShipmentServiceLines: [],
+        deleteInboundShipmentServiceLines: [],
+      },
+      storeId: 'testStoreId',
+    });
+  });
+});

--- a/client/packages/invoices/src/InboundShipment/api/api.ts
+++ b/client/packages/invoices/src/InboundShipment/api/api.ts
@@ -378,7 +378,12 @@ export const getInboundQueries = (sdk: Sdk, storeId: string) => ({
   updateLines: async (draftInboundLine: DraftInboundLine[]) => {
     const input = {
       insertInboundShipmentLines: draftInboundLine
-        .filter(line => line.isCreated && !isInboundPlaceholderRow(line))
+        .filter(
+          line =>
+            line.isCreated &&
+            line.type === InvoiceLineNodeType.StockIn &&
+            !isInboundPlaceholderRow(line)
+        )
         .map(inboundParsers.toInsertLine),
       updateInboundShipmentLines: draftInboundLine
         .filter(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8910

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Adds test to expose bug, and fix - service line was being saved as both regular line and service line, causing a "line already exists" error.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Configure service charges
- [ ] Add a service charge to an inbound shipment
- [ ] it saves successfully

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

