### PR TITLE
8902 locations with no restricted type are invalid

### DIFF
--- a/client/packages/system/src/Location/Components/LocationSearchInput.tsx
+++ b/client/packages/system/src/Location/Components/LocationSearchInput.tsx
@@ -183,7 +183,7 @@ export const LocationSearchInput = ({
       }
     : null;
 
-  const isInvalidLocation = !!selectedLocation?.locationType?.id
+  const isInvalidLocation = !!selectedLocation
     ? checkInvalidLocationLines(restrictedToLocationTypeId ?? null, [
         { location: selectedLocation },
       ])

--- a/client/packages/system/src/Location/utils.test.ts
+++ b/client/packages/system/src/Location/utils.test.ts
@@ -24,13 +24,20 @@ describe('checkInvalidLocationLines', () => {
     expect(checkInvalidLocationLines('Fridge', lines)).toBe(false);
   });
 
-  it('returns false if restrictedLocationTypeId exists but locationTypeId is missing', () => {
+  it('returns true if restrictedLocationTypeId exists but location has no locationType', () => {
     const lines: TestLine[] = [
       { location: { locationType: { id: null, name: undefined } } },
-      { location: { locationType: undefined } },
-      { location: null },
-      {},
     ];
+    expect(checkInvalidLocationLines('Fridge', lines)).toBe(true);
+  });
+
+  it('returns true if restrictedLocationTypeId exists but locationType is undefined', () => {
+    const lines: TestLine[] = [{ location: { locationType: undefined } }];
+    expect(checkInvalidLocationLines('Fridge', lines)).toBe(true);
+  });
+
+  it('returns false if restrictedLocationTypeId exists but there is no location', () => {
+    const lines: TestLine[] = [{ location: null }, {}];
     expect(checkInvalidLocationLines('Fridge', lines)).toBe(false);
   });
 

--- a/client/packages/system/src/Location/utils.ts
+++ b/client/packages/system/src/Location/utils.ts
@@ -11,9 +11,9 @@ export const checkInvalidLocationLines = <
   currentLocationLines: T[]
 ): boolean => {
   return currentLocationLines.some(l => {
-    if (!restrictedLocationTypeId) return false;
+    if (!restrictedLocationTypeId || !l.location) return false;
     const lineLocationTypeId = l.location?.locationType?.id;
-    if (!lineLocationTypeId) return false;
+    if (!lineLocationTypeId) return true;
     return restrictedLocationTypeId !== lineLocationTypeId;
   });
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8902 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

A location with no location type is now treated as an `invalid` location for an item that has a restricted location type set

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->


- [ ] Have an item with a restricted location type
- [ ] Assign a batch of this item, to a location which has the correct location type
- [ ] Go to locations list - edit that location, remove the location type
- [ ] Create a blank stocktake and add the item to it. See the warning appear: `Some stock lines are in invalid locations. Please choose valid locations for them.`
- [ ] Go to the `Other` tab -> see red error highlighting the location with no location type set
- [ ] Batches with no location will not have an error
- [ ] The lines will not save with invalid locations (count this line should be checked + counted and reason filled)
- [ ] Adding the restricted type (same type as the item) back to the location in Inventory -> Locations will remove the error on rows with that location
- [ ] When all rows have either a location with a valid location type, or no location, the warning message will no longer appear and lines will save



# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

