### PR TITLE
8533 date picker use dates in correct timezone

### DIFF
--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureBreach/Toolbar.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureBreach/Toolbar.tsx
@@ -40,12 +40,14 @@ export const Toolbar: FC<{ filter: FilterController }> = () => {
               elements: [
                 {
                   type: 'dateTime',
+                  showTimepicker: true,
                   name: t('label.from-start-datetime'),
                   urlParameter: 'datetime',
                   range: 'from',
                 },
                 {
                   type: 'dateTime',
+                  showTimepicker: true,
                   name: t('label.to-start-datetime'),
                   urlParameter: 'datetime',
                   range: 'to',

--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureLog/Toolbar.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureLog/Toolbar.tsx
@@ -41,6 +41,7 @@ export const Toolbar: FC<{ filter: FilterController }> = () => {
               elements: [
                 {
                   type: 'dateTime',
+                  showTimepicker: true,
                   name: t('label.from-datetime'),
                   urlParameter: 'datetime',
                   range: 'from',
@@ -49,6 +50,7 @@ export const Toolbar: FC<{ filter: FilterController }> = () => {
                 },
                 {
                   type: 'dateTime',
+                  showTimepicker: true,
                   name: t('label.to-datetime'),
                   urlParameter: 'datetime',
                   range: 'to',

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -42,10 +42,14 @@ import {
   FirstWeekContainsDate,
   ParseOptions,
   startOfMonth,
+  isMatch,
 } from 'date-fns';
 import { getTimezoneOffset } from 'date-fns-tz';
 
 export const MINIMUM_EXPIRY_MONTHS = 3;
+
+const URL_QUERY_DATE = 'yyyy-MM-dd';
+const URL_QUERY_DATE_TIME = 'yyyy-MM-dd HH:mm';
 
 const dateInputHandler = (date: Date | string | number): Date => {
   // Assume a string is an ISO date-time string
@@ -203,15 +207,13 @@ export const DateUtils = {
   HOUR,
   /** Number of milliseconds in one day */
   DAY,
+  isUrlQueryDateTime: (date: string) => isMatch(date, URL_QUERY_DATE_TIME),
 };
 
 export const useFormatDateTime = () => {
   const { currentLanguage } = useIntlUtils();
   const locale = getLocale(currentLanguage);
   const t = useTranslation();
-
-  const urlQueryDate = 'yyyy-MM-dd';
-  const urlQueryDateTime = 'yyyy-MM-dd HH:mm';
 
   const localisedDate = (date: Date | string | number): string =>
     formatIfValid(dateInputHandler(date), 'P', { locale });
@@ -270,14 +272,14 @@ export const useFormatDateTime = () => {
     const { months, days } = DateUtils.ageInMonthsAndDays(dob ?? '');
 
     if (patientAge >= 1) {
-      return `${t('label.age-years', {count: patientAge})}`;
+      return `${t('label.age-years', { count: patientAge })}`;
     } else
       return `${months > 0 ? t('label.age-months-and', { count: months }) : ''}${t('label.age-days', { count: days })}`;
   };
 
   return {
-    urlQueryDate,
-    urlQueryDateTime,
+    urlQueryDate: URL_QUERY_DATE,
+    urlQueryDateTime: URL_QUERY_DATE_TIME,
     customDate,
     dayMonthShort,
     dayMonthTime,

--- a/client/packages/common/src/ui/components/inputs/DateTimePickers/DateTimePickerInput/DateTimePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DateTimePickers/DateTimePickerInput/DateTimePickerInput.tsx
@@ -49,7 +49,6 @@ export const DateTimePickerInput = ({
   actions,
   dateAsEndOfDay,
   disableFuture,
-  displayAs,
   error,
   required,
   textFieldSx: inputSx,
@@ -68,7 +67,6 @@ export const DateTimePickerInput = ({
   actions?: PickersActionBarAction[];
   dateAsEndOfDay?: boolean;
   disableFuture?: boolean;
-  displayAs?: 'date' | 'dateTime';
   required?: boolean;
   textFieldSx?: SxProps;
 }) => {
@@ -79,7 +77,6 @@ export const DateTimePickerInput = ({
   const t = useTranslation();
   const format =
     props.format === undefined ? (showTime ? 'P p' : 'P') : props.format;
-  const displayDt = displayAs === 'date';
 
   const isDesktop = useMediaQuery('(pointer: fine)');
 
@@ -149,14 +146,14 @@ export const DateTimePickerInput = ({
             error: !!error || (!isInitialEntry && !!internalError),
             helperText: error || (!isInitialEntry ? (internalError ?? '') : ''),
             sx: {
-              ...getTextFieldSx(theme, !!label, !displayDt, inputSx, width),
+              ...getTextFieldSx(theme, !!label, !showTime, inputSx, width),
               width,
-              minWidth: displayDt ? 200 : undefined,
+              minWidth: showTime ? 200 : undefined,
             },
           },
 
           tabs: {
-            hidden: displayDt && !isDesktop ? false : true,
+            hidden: showTime && !isDesktop ? false : true,
           },
           ...slotProps,
         }}

--- a/client/packages/common/src/ui/components/inputs/Filters/DateFilter.tsx
+++ b/client/packages/common/src/ui/components/inputs/Filters/DateFilter.tsx
@@ -44,6 +44,7 @@ export const DateFilter = ({
 
       let date = selection;
 
+      // when user is only selecting the date, ensure the search filter is inclusive of start and end of day
       if (!showTimepicker && type === 'dateTime') {
         if (range === 'from') {
           date = DateUtils.startOfDay(selection);

--- a/client/packages/common/src/ui/components/inputs/Filters/DateFilter.tsx
+++ b/client/packages/common/src/ui/components/inputs/Filters/DateFilter.tsx
@@ -6,8 +6,13 @@ import { DateUtils, useFormatDateTime } from '@common/intl';
 import { PickersActionBarAction } from '@mui/x-date-pickers';
 
 export interface DateFilterDefinition extends FilterDefinitionCommon {
+  /**
+   * Use date where the stored date has no time (NaiveDate)
+   * Use dateTime where the stored date has a time. (NaiveDateTime)
+   * DateTime type will handle timezones
+   */
   type: 'date' | 'dateTime';
-  displayAs?: 'date' | 'dateTime';
+  showTimepicker?: boolean;
   range?: RangeOption;
   maxDate?: Date | string;
   minDate?: Date | string;
@@ -20,15 +25,8 @@ export const DateFilter = ({
 }: {
   filterDefinition: DateFilterDefinition;
 }) => {
-  const {
-    type,
-    urlParameter,
-    name,
-    range,
-    displayAs = type,
-    maxDate,
-    minDate,
-  } = filterDefinition;
+  const { type, urlParameter, name, range, maxDate, minDate, showTimepicker } =
+    filterDefinition;
   const { urlQuery, updateQuery } = useUrlQuery();
   const { customDate, urlQueryDate, urlQueryDateTime } = useFormatDateTime();
 
@@ -44,10 +42,15 @@ export const DateFilter = ({
         return;
       }
 
-      const date =
-        range === 'to' && displayAs === 'date' // if no time picker, set "TO" field to end of day
-          ? DateUtils.endOfDay(selection)
-          : selection;
+      let date = selection;
+
+      if (!showTimepicker && type === 'dateTime') {
+        if (range === 'from') {
+          date = DateUtils.startOfDay(selection);
+        } else if (range === 'to') {
+          date = DateUtils.endOfDay(selection);
+        }
+      }
 
       updateQuery({
         [urlParameter]: { [range]: customDate(date, dateTimeFormat) },
@@ -67,16 +70,11 @@ export const DateFilter = ({
     width: FILTER_WIDTH,
     onChange: handleChange,
     actions: ['clear', 'accept'] as PickersActionBarAction[],
-    displayAs,
+    type,
     ...getMinMaxDates(urlValue, range, minDate, maxDate),
   };
 
-  return (
-    <DateTimePickerInput
-      showTime={displayAs === 'dateTime'}
-      {...componentProps}
-    />
-  );
+  return <DateTimePickerInput showTime={showTimepicker} {...componentProps} />;
 };
 
 const getDateFromUrl = (

--- a/client/packages/invoices/src/InboundShipment/ListView/Toolbar.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/Toolbar.tsx
@@ -63,14 +63,12 @@ export const Toolbar = ({ filter, simplifiedTabletView }: ToolbarProps) => {
                 elements: [
                   {
                     type: 'dateTime',
-                    displayAs: 'date',
                     name: t('label.from-created-datetime'),
                     urlParameter: 'createdDatetime',
                     range: 'from',
                   },
                   {
                     type: 'dateTime',
-                    displayAs: 'date',
                     name: t('label.to-created-datetime'),
                     urlParameter: 'createdDatetime',
                     range: 'to',

--- a/client/packages/invoices/src/OutboundShipment/ListView/Toolbar.tsx
+++ b/client/packages/invoices/src/OutboundShipment/ListView/Toolbar.tsx
@@ -75,13 +75,13 @@ export const Toolbar = ({ filter, simplifiedTabletView }: ToolbarProps) => {
                 name: t('label.created-datetime'),
                 elements: [
                   {
-                    type: 'date',
+                    type: 'dateTime',
                     name: t('label.from-created-datetime'),
                     urlParameter: 'createdDatetime',
                     range: 'from',
                   },
                   {
-                    type: 'date',
+                    type: 'dateTime',
                     name: t('label.to-created-datetime'),
                     urlParameter: 'createdDatetime',
                     range: 'to',
@@ -93,13 +93,13 @@ export const Toolbar = ({ filter, simplifiedTabletView }: ToolbarProps) => {
                 name: t('label.shipped-datetime'),
                 elements: [
                   {
-                    type: 'date',
+                    type: 'dateTime',
                     name: t('label.from-shipped-datetime'),
                     urlParameter: 'shippedDatetime',
                     range: 'from',
                   },
                   {
-                    type: 'date',
+                    type: 'dateTime',
                     name: t('label.to-shipped-datetime'),
                     urlParameter: 'shippedDatetime',
                     range: 'to',

--- a/client/packages/invoices/src/Prescriptions/ListView/Toolbar.tsx
+++ b/client/packages/invoices/src/Prescriptions/ListView/Toolbar.tsx
@@ -64,14 +64,14 @@ export const Toolbar: FC<{ filter: FilterController }> = () => {
               name: t('label.date'),
               elements: [
                 {
-                  type: 'date',
+                  type: 'dateTime',
                   name: t('label.from-date'),
                   urlParameter: 'createdOrBackdatedDatetime',
                   range: 'from',
                   isDefault: true,
                 },
                 {
-                  type: 'date',
+                  type: 'dateTime',
                   name: t('label.to-date'),
                   urlParameter: 'createdOrBackdatedDatetime',
                   range: 'to',

--- a/client/packages/purchasing/src/purchase_order/ListView/ListView.tsx
+++ b/client/packages/purchasing/src/purchase_order/ListView/ListView.tsx
@@ -36,7 +36,7 @@ const ListView: FC = () => {
     initialSort: { key: 'createdDatetime', dir: 'desc' },
     filters: [
       { key: 'supplier' },
-      { key: 'createdDatetime' },
+      { key: 'createdDatetime', condition: 'between' },
       {
         key: 'status',
         condition: 'equalTo',

--- a/client/packages/purchasing/src/purchase_order/ListView/Toolbar.tsx
+++ b/client/packages/purchasing/src/purchase_order/ListView/Toolbar.tsx
@@ -55,14 +55,14 @@ export const Toolbar: FC<{ filter: FilterController }> = () => {
               name: t('label.date'),
               elements: [
                 {
-                  type: 'date',
+                  type: 'dateTime',
                   name: t('label.from-date'),
                   urlParameter: 'createdDatetime',
                   range: 'from',
                   isDefault: false,
                 },
                 {
-                  type: 'date',
+                  type: 'dateTime',
                   name: t('label.to-date'),
                   urlParameter: 'createdDatetime',
                   range: 'to',

--- a/client/packages/system/src/Encounter/ListView/Toolbar.tsx
+++ b/client/packages/system/src/Encounter/ListView/Toolbar.tsx
@@ -37,13 +37,13 @@ export const Toolbar = () => {
               name: t('label.start-date'),
               elements: [
                 {
-                  type: 'date',
+                  type: 'dateTime',
                   name: t('label.from-date'),
                   urlParameter: 'startDatetime',
                   range: 'from',
                 },
                 {
-                  type: 'date',
+                  type: 'dateTime',
                   name: t('label.to-date'),
                   urlParameter: 'startDatetime',
                   range: 'to',

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
@@ -216,14 +216,14 @@ export const ItemLedgerTab = ({
       name: t('label.datetime'),
       elements: [
         {
-          type: 'date',
+          type: 'dateTime',
           name: t('label.from-datetime'),
           urlParameter: 'datetime',
           range: 'from',
           isDefault: true,
         },
         {
-          type: 'date',
+          type: 'dateTime',
           name: t('label.to-datetime'),
           urlParameter: 'datetime',
           range: 'to',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8533


# 👩🏻‍💻 What does this PR do?

Filters with a date correctly use either date or dateTime filter types

Filters with dateTime (often a created date or similar) works with timezones, so that the resulting records (with localised dates) match the filtered date selection. Several filters that were using date have now been updated to dateTime

Filters where only a date is needed (eg expiry, DOB) use 'date' only as they have no time element

Some refactoring for more robust date type handling, and clarity on handling for showTime. Comments to help developers choose the correct date type when implementing or updating filters 

For the second part of the issue, selecting the dates all worked correctly for me and I couldn't reproduce the behaviour shown in the second video. Possibly this is also related to timezones? 

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create some outbound shipments. These will need to be created in timeframe where the timezone will create a difference between the local date and the UTC date. 
- Eg in NZ create them in the morning - a shipment saved on 20/8 at 10.46am local time is recorded in the database in UTC time, 19/08 10.48pm. 
This can be checked in the graphql or database to confirm the UTC date 
<img width="1644" height="371" alt="Screenshot 2025-08-20 at 6 41 56 PM" src="https://github.com/user-attachments/assets/8acaed3b-7dfb-4eab-b44e-a0527659a43d" />

- [ ] Filter by the local date created, all shipments where the Created date matches the filter will be in the list (also showing local date)
- [ ] Test that other list view date filters also behave correctly:
- Inbound shipment
- Prescriptions
- Stocktakes
- Purchase orders
- Encounter
- Item -> Item Ledger
- Temperature Breach & Temperature Log (these two also have time picker)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

