### PR TITLE
Outbound shipment line edit total should sit outside table scroll

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
@@ -219,11 +219,6 @@ export const OutboundLineEditTable = ({
       dosesPerUnit={item?.doses}
       key="placeholder-row"
     />,
-    <TotalRow
-      key="total-row"
-      allocatedQuantity={allocatedQuantity + (placeholderQuantity ?? 0)}
-      extraColumnOffset={extraColumnOffset}
-    />,
   ];
 
   return (
@@ -245,6 +240,11 @@ export const OutboundLineEditTable = ({
           dense
           additionalRows={additionalRows}
           enableColumnSelection={true}
+        />
+        <TotalRow
+          key="total-row"
+          allocatedQuantity={allocatedQuantity + (placeholderQuantity ?? 0)}
+          extraColumnOffset={extraColumnOffset}
         />
       </Box>
     </Box>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7837

# 👩🏻‍💻 What does this PR do?

Moves the total row to the bottom of the table so it is always visible, as requested in the issue.

https://github.com/user-attachments/assets/f3326700-9dc8-4bf0-9633-e84a45370b29

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Make sure you have an item with 7+ batches
- [ ] Go to outbound shipments, click add item, and attempt to add that item to the outbound shipment.
- [ ] Check that the total row is visible as you are scroll through the list of batches.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

