### PR TITLE
8952 volume per pack not updating

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -215,8 +215,7 @@ export const BatchTable = ({
         setter: patch => {
           update({
             ...patch,
-            volumePerPack:
-              getVolumePerPackFromVariant(patch) ?? patch.volumePerPack,
+            volumePerPack: getVolumePerPackFromVariant(patch) ?? 0,
           });
         },
       });
@@ -250,11 +249,12 @@ export const BatchTable = ({
             patch.item?.defaultPackSize !== patch.packSize &&
             patch.item?.itemStoreProperties?.defaultSellPricePerPack ===
               patch.sellPricePerPack;
-          if (shouldClearSellPrice) {
-            update({ ...patch, sellPricePerPack: 0 });
-          } else {
-            update(patch);
-          }
+
+          update({
+            ...patch,
+            volumePerPack: getVolumePerPackFromVariant(patch) ?? 0,
+            sellPricePerPack: shouldClearSellPrice ? 0 : patch.sellPricePerPack,
+          });
         },
       }),
       {

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -30,6 +30,7 @@ import {
   getCampaignOrProgramColumn,
   getDonorColumn,
   getLocationInputColumn,
+  getVolumePerPackFromVariant,
   ItemVariantInputCell,
   PackSizeEntryCell,
   ReasonOptionRowFragment,
@@ -212,21 +213,11 @@ export const BatchTable = ({
           <ItemVariantInputCell {...props} itemId={props.rowData.item.id} />
         ),
         setter: patch => {
-          const { packSize, itemVariant } = patch;
-
-          if (itemVariant) {
-            const packaging = itemVariant.packagingVariants.find(
-              p => p.packSize === packSize
-            );
-            // Item variants save volume in L, but it is saved in m3 everywhere else
-            update({
-              ...patch,
-              volumePerPack:
-                ((packaging?.volumePerUnit ?? 0) / 1000) * (packSize ?? 1),
-            });
-          } else {
-            update(patch);
-          }
+          update({
+            ...patch,
+            volumePerPack:
+              getVolumePerPackFromVariant(patch) ?? patch.volumePerPack,
+          });
         },
       });
     }

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -38,6 +38,7 @@ import {
 import {
   getBatchExpiryColumns,
   getInboundDosesColumns,
+  getNewVolumePerPack,
   itemVariantColumn,
   NumberOfPacksCell,
   vvmStatusesColumn,
@@ -146,7 +147,10 @@ export const QuantityTableComponent = ({
       Cell: PackSizeEntryCell<DraftInboundLine>,
       setter: patch => {
         setPackRoundingMessage?.('');
-        updateDraftLine(patch);
+        updateDraftLine({
+          ...patch,
+          volumePerPack: getNewVolumePerPack(patch) ?? patch.volumePerPack,
+        });
       },
       label: 'label.received-pack-size',
       width: 100,

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -149,8 +149,7 @@ export const QuantityTableComponent = ({
         setPackRoundingMessage?.('');
         updateDraftLine({
           ...patch,
-          volumePerPack:
-            getVolumePerPackFromVariant(patch) ?? patch.volumePerPack,
+          volumePerPack: getVolumePerPackFromVariant(patch) ?? 0,
         });
       },
       label: 'label.received-pack-size',

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -31,6 +31,7 @@ import {
   getCampaignOrProgramColumn,
   getDonorColumn,
   getLocationInputColumn,
+  getVolumePerPackFromVariant,
   ItemRowFragment,
   LocationRowFragment,
   PackSizeEntryCell,
@@ -38,7 +39,6 @@ import {
 import {
   getBatchExpiryColumns,
   getInboundDosesColumns,
-  getNewVolumePerPack,
   itemVariantColumn,
   NumberOfPacksCell,
   vvmStatusesColumn,
@@ -149,7 +149,8 @@ export const QuantityTableComponent = ({
         setPackRoundingMessage?.('');
         updateDraftLine({
           ...patch,
-          volumePerPack: getNewVolumePerPack(patch) ?? patch.volumePerPack,
+          volumePerPack:
+            getVolumePerPackFromVariant(patch) ?? patch.volumePerPack,
         });
       },
       label: 'label.received-pack-size',

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/utils.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/utils.tsx
@@ -89,7 +89,7 @@ export const itemVariantColumn = (
   setter: patch => {
     updateDraftLine({
       ...patch,
-      volumePerPack: getVolumePerPackFromVariant(patch) ?? patch.volumePerPack,
+      volumePerPack: getVolumePerPackFromVariant(patch) ?? 0,
     });
   },
 });

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/utils.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/utils.tsx
@@ -11,10 +11,10 @@ import {
 } from '@openmsupply-client/common';
 import { DraftInboundLine } from '../../../../types';
 import {
+  getVolumePerPackFromVariant,
   ItemVariantInputCell,
   VVMStatusInputCell,
 } from '@openmsupply-client/system';
-import { InboundLineFragment } from '../../../api';
 
 const expiryInputColumn = getExpiryDateInputColumn<DraftInboundLine>();
 const getBatchColumn = (
@@ -89,7 +89,7 @@ export const itemVariantColumn = (
   setter: patch => {
     updateDraftLine({
       ...patch,
-      volumePerPack: getNewVolumePerPack(patch) ?? patch.volumePerPack,
+      volumePerPack: getVolumePerPackFromVariant(patch) ?? patch.volumePerPack,
     });
   },
 });
@@ -122,22 +122,3 @@ export const getInboundDosesColumns = (
     },
   },
 ];
-
-export const getNewVolumePerPack = ({
-  packSize,
-  itemVariant,
-}: {
-  packSize?: number | null;
-  itemVariant?: InboundLineFragment['itemVariant'];
-}): number | undefined => {
-  if (!itemVariant) return undefined;
-
-  const packaging = itemVariant.packagingVariants.find(
-    p => p.packSize === packSize
-  );
-
-  if (!packaging) return undefined;
-
-  // Item variants save volume in L, but it is saved in m3 everywhere else
-  return ((packaging?.volumePerUnit ?? 0) / 1000) * (packSize ?? 1);
-};

--- a/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnQuantitiesTable.tsx
@@ -59,8 +59,7 @@ export const QuantityReturnedTableComponent = ({
         setter: patch =>
           updateLine({
             ...patch,
-            volumePerPack:
-              getVolumePerPackFromVariant(patch) ?? patch.volumePerPack,
+            volumePerPack: getVolumePerPackFromVariant(patch) ?? 0,
           }),
         Cell: props => (
           <ItemVariantInputCell {...props} itemId={props.rowData.item.id} />
@@ -88,8 +87,7 @@ export const QuantityReturnedTableComponent = ({
         setter: patch =>
           updateLine({
             ...patch,
-            volumePerPack:
-              getVolumePerPackFromVariant(patch) ?? patch.volumePerPack,
+            volumePerPack: getVolumePerPackFromVariant(patch) ?? 0,
           }),
         getIsDisabled: () => isDisabled,
         label: 'label.pack-size',

--- a/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnQuantitiesTable.tsx
@@ -131,7 +131,7 @@ export const QuantityReturnedTableComponent = ({
         key: 'volumePerPack',
         label: t('label.volume-per-pack'),
         Cell: NumberInputCell,
-        cellProps: { decimalLimit: 2 },
+        cellProps: { decimalLimit: 10 },
         width: 100,
         accessor: ({ rowData }) => rowData?.volumePerPack,
         setter: updateLine,

--- a/client/packages/system/src/Item/utils.ts
+++ b/client/packages/system/src/Item/utils.ts
@@ -3,6 +3,7 @@ import {
   ItemRowFragment,
   ItemStockOnHandFragment,
   ItemWithPackSizeFragment,
+  PackagingVariantFragment,
 } from './api';
 import { styled } from '@common/styles';
 import { ItemFilterInput } from '@common/types';
@@ -72,3 +73,27 @@ export const itemFilterOptions = {
 export const getOptionLabel = <T extends { code: string; name: string }>(
   item: T
 ): string => `${item.code} ${item.name}`;
+
+export const getVolumePerPackFromVariant = ({
+  itemVariant,
+  packSize,
+}: {
+  packSize?: number | null;
+  itemVariant?: {
+    packagingVariants: Pick<
+      PackagingVariantFragment,
+      'packSize' | 'volumePerUnit'
+    >[];
+  } | null;
+}): number | undefined => {
+  if (!itemVariant) return undefined;
+
+  const packaging = itemVariant.packagingVariants.find(
+    p => p.packSize === packSize
+  );
+
+  if (!packaging) return undefined;
+
+  // Item variants save volume in L, but it is saved in m3 everywhere else
+  return ((packaging?.volumePerUnit ?? 0) / 1000) * (packSize ?? 1);
+};

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -362,7 +362,7 @@ export const StockLineForm = ({
 
                       onUpdate({
                         itemVariant: variant,
-                        volumePerPack: newVolume ?? draft.volumePerPack,
+                        volumePerPack: newVolume ?? 0,
                       });
                     }}
                   />

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -36,7 +36,11 @@ import {
   VVMStatusSearchInput,
 } from '../..';
 import { INPUT_WIDTH, StyledInputRow } from './StyledInputRow';
-import { ItemVariantInput, useIsItemVariantsEnabled } from '../../Item';
+import {
+  getVolumePerPackFromVariant,
+  ItemVariantInput,
+  useIsItemVariantsEnabled,
+} from '../../Item';
 import { CampaignOrProgramSelector } from './Campaign';
 
 interface StockLineFormProps {
@@ -351,16 +355,14 @@ export const StockLineForm = ({
                     selectedId={draft?.itemVariant?.id}
                     width={160}
                     onChange={variant => {
-                      const packaging = variant?.packagingVariants.find(
-                        p => p.packSize === draft.packSize
-                      );
-                      const volumePerPack =
-                        ((packaging?.volumePerUnit ?? 0) / 1000) *
-                        (draft?.packSize ?? 1);
+                      const newVolume = getVolumePerPackFromVariant({
+                        itemVariant: variant,
+                        packSize: draft.packSize,
+                      });
 
                       onUpdate({
                         itemVariant: variant,
-                        volumePerPack,
+                        volumePerPack: newVolume ?? draft.volumePerPack,
                       });
                     }}
                   />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8952

Fixes #8939

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Now, when updating pack size anywhere that also has a volume per pack input:

- If there is a selected item variant
- If that variant has a packaging variant which matches the new pack size
- The volume per pack will update according to that packaging variant
- Otherwise volume per pack is cleared

When changing the variant, if no pack size matches, volume per pack should be cleared.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] In stocktake line edit
- [ ] In customer return line edit
- [ ] In inbound shipment line edit
- [ ] In view stock:

The following should occur:
- If there is a selected item variant
- If that variant has a packaging variant which matches the new pack size
- The volume per pack will update according to that packaging variant
- Otherwise volume per pack is cleared

When changing the variant, if no pack size matches, volume per pack should be cleared.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

