### PR TITLE
Clear if received pack size changed not shipped

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -112,7 +112,6 @@ export const QuantityTableComponent = ({
       width: 100,
       Cell: PackSizeEntryCell<DraftInboundLine>,
       setter: patch => {
-        setPackRoundingMessage?.('');
         updateDraftLine(patch);
       },
       getIsDisabled: rowData => !!rowData.linkedInvoiceId,

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -113,19 +113,7 @@ export const QuantityTableComponent = ({
       Cell: PackSizeEntryCell<DraftInboundLine>,
       setter: patch => {
         setPackRoundingMessage?.('');
-        const shouldClearSellPrice =
-          patch.item?.defaultPackSize !== patch.packSize &&
-          patch.item?.itemStoreProperties?.defaultSellPricePerPack ===
-            patch.sellPricePerPack;
-
-        if (shouldClearSellPrice) {
-          updateDraftLine({
-            ...patch,
-            sellPricePerPack: 0,
-          });
-        } else {
-          updateDraftLine(patch);
-        }
+        updateDraftLine(patch);
       },
       getIsDisabled: rowData => !!rowData.linkedInvoiceId,
       defaultHideOnMobile: true,
@@ -146,10 +134,15 @@ export const QuantityTableComponent = ({
     getColumnLookupWithOverrides('packSize', {
       Cell: PackSizeEntryCell<DraftInboundLine>,
       setter: patch => {
-        setPackRoundingMessage?.('');
+        const shouldClearSellPrice =
+          patch.item?.defaultPackSize !== patch.packSize &&
+          patch.item?.itemStoreProperties?.defaultSellPricePerPack ===
+            patch.sellPricePerPack;
+
         updateDraftLine({
           ...patch,
           volumePerPack: getVolumePerPackFromVariant(patch) ?? 0,
+          sellPricePerPack: shouldClearSellPrice ? 0 : patch.sellPricePerPack,
         });
       },
       label: 'label.received-pack-size',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8971

# 👩🏻‍💻 What does this PR do?
Was clearing in shipped pack size but with received pack size variable in the check... have moved this to received pack size. Not we're not re-populating the default sell price back if the pack size matches default... not sure if this is something we want and probably very edge case

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have default sell price set for an item
- [ ] Create an Inbound Shipment 
- [ ] Add item to inbound shipment 
- [ ] Change received pack size
- [ ] Sell price should clear

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

