### PR TITLE
8845 cant receive 0 shipped packs lines from prev versions

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.test.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.test.ts
@@ -15,6 +15,13 @@ describe('validateEmptyInvoice', () => {
     };
     expect(validateEmptyInvoice(lines)).toBe(false);
   });
+  it('should allow status change when lines are from a transfer', () => {
+    const lines = {
+      totalCount: 1,
+      nodes: [makeLine({ numberOfPacks: 0, linkedInvoiceId: '123' })],
+    };
+    expect(validateEmptyInvoice(lines)).toBe(true);
+  });
   it('should allow status change when has lines with received packs', () => {
     const lines = {
       totalCount: 1,
@@ -34,12 +41,15 @@ describe('validateEmptyInvoice', () => {
 const makeLine = ({
   numberOfPacks,
   shippedNumberOfPacks,
+  linkedInvoiceId,
 }: {
   numberOfPacks: number;
   shippedNumberOfPacks?: number;
+  linkedInvoiceId?: string;
 }) =>
   ({
     type: InvoiceLineNodeType.StockIn,
     numberOfPacks,
     shippedNumberOfPacks,
+    linkedInvoiceId,
   }) as InboundLineFragment;

--- a/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
@@ -227,8 +227,13 @@ export const validateEmptyInvoice = (lines: {
   totalCount: number;
   nodes: InboundLineFragment[];
 }): boolean => {
-  // Should only proceed if there is at least one line, with received or shipped packs defined
-  if (lines.totalCount === 0 || lines.nodes.every(isInboundPlaceholderRow))
+  // Should only proceed if there is at least one line
+  // If lines are from transfer, they can be 0
+  // Manually added lines must have either received or shipped packs defined
+  if (
+    lines.totalCount === 0 ||
+    lines.nodes.every(l => !l.linkedInvoiceId && isInboundPlaceholderRow(l))
+  )
     return false;
   return true;
 };

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
@@ -72,7 +72,10 @@ export const InboundLineEdit = ({
   } = useDraftInboundLines(currentItem, scannedBatchData);
   const okNextDisabled =
     (mode === ModalMode.Update && nextDisabled) || !currentItem;
-  const zeroNumberOfPacks = draftLines.some(isInboundPlaceholderRow);
+  const manualLinesWithZeroNumberOfPacks = draftLines.some(
+    // should be able to save with `0` lines if they're from a transfer
+    l => !l.linkedInvoiceId && isInboundPlaceholderRow(l)
+  );
   const simplifiedTabletView = useSimplifiedTabletUI();
 
   useEffect(() => {
@@ -133,7 +136,7 @@ export const InboundLineEdit = ({
         nextButton={
           <DialogButton
             variant="next-and-ok"
-            disabled={okNextDisabled || zeroNumberOfPacks}
+            disabled={okNextDisabled || manualLinesWithZeroNumberOfPacks}
             onClick={async () => {
               await saveLines();
               if (mode === ModalMode.Update && nextItem) {
@@ -148,7 +151,7 @@ export const InboundLineEdit = ({
         okButton={
           <DialogButton
             variant="ok"
-            disabled={!currentItem || zeroNumberOfPacks}
+            disabled={!currentItem || manualLinesWithZeroNumberOfPacks}
             onClick={async () => {
               try {
                 await saveLines();


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8845

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

In the case where we have transfers from 2.8, then upgrade to 2.9/2.10 - those transfers will show shipped number of packs input as disabled (because it is a transfer) but the value of 0, because we didn't add that field until 2.10.

If its a transfer, 0 lines should be allowed.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Set up use case above (create a transfer to a store on a site running 2.8, then upgrade that site to this branch) - or just create a transfer, then in DB, edit that invoice line to have shipped number of packs = 0
- [ ] Set received number of packs also to 0
- [ ] You can save the modal
- [ ] When this is the only line/all lines are like this (transfers with shipped and received = 0) you can still update invoice status
- [ ] You still can't save manually added lines when both shipped and received packs = 0

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

