### PR TITLE
8981 custom translations syncing to remote sites

### DIFF
--- a/client/packages/host/src/components/Sync/SyncModal.tsx
+++ b/client/packages/host/src/components/Sync/SyncModal.tsx
@@ -10,7 +10,6 @@ import {
   RadioIcon,
   Typography,
   UNDEFINED_STRING_VALUE,
-  CUSTOM_TRANSLATIONS_NAMESPACE,
   useAppTheme,
   useAuthContext,
   useFormatDateTime,
@@ -18,7 +17,7 @@ import {
   useQueryClient,
   useTranslation,
   useMediaQuery,
-  useIntl,
+  useIntlUtils,
 } from '@openmsupply-client/common';
 import { useSync } from '@openmsupply-client/system';
 import { SyncProgress } from '../SyncProgress';
@@ -46,7 +45,7 @@ const useHostSync = (enabled: boolean) => {
   // true by default to wait for first syncStatus api result
   const [isLoading, setIsLoading] = useState(true);
   const queryClient = useQueryClient();
-  const { i18n } = useIntl();
+  const { invalidateCustomTranslations } = useIntlUtils();
 
   useEffect(() => {
     if (!syncStatus) {
@@ -63,7 +62,7 @@ const useHostSync = (enabled: boolean) => {
       allowSleep();
       queryClient.invalidateQueries(); // refresh the page user is on after sync finishes
       // Reload custom translations, in case we received new ones via sync
-      i18n.reloadResources(undefined, CUSTOM_TRANSLATIONS_NAMESPACE);
+      invalidateCustomTranslations();
     }
   }, [syncStatus?.isSyncing]);
 

--- a/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/CustomTranslationsModal.tsx
+++ b/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/CustomTranslationsModal.tsx
@@ -5,11 +5,7 @@ import {
   LoadingButton,
 } from '@common/components';
 import { EditIcon, SaveIcon } from '@common/icons';
-import {
-  CUSTOM_TRANSLATIONS_NAMESPACE,
-  useIntl,
-  useTranslation,
-} from '@common/intl';
+import { useIntlUtils, useTranslation } from '@common/intl';
 import { useDialog, useNotification, useToggle } from '@common/hooks';
 import { mapTranslationsToArray, mapTranslationsToObject } from './helpers';
 import { TranslationsTable } from './TranslationsInputTable';
@@ -61,7 +57,7 @@ export const CustomTranslationsModal = ({
 }) => {
   const t = useTranslation();
   const defaultTranslation = useTranslation('common');
-  const { i18n } = useIntl();
+  const { invalidateCustomTranslations } = useIntlUtils();
   const { success, error } = useNotification();
 
   const { Modal } = useDialog({ isOpen: true, onClose, disableBackdrop: true });
@@ -71,27 +67,6 @@ export const CustomTranslationsModal = ({
   const [translations, setTranslations] = useState(
     mapTranslationsToArray(value, defaultTranslation)
   );
-
-  const invalidateCustomTranslations = () => {
-    // Clear from local storage cache
-    Object.keys(localStorage)
-      .filter(
-        key =>
-          key.startsWith('i18next_res_') &&
-          key.endsWith(CUSTOM_TRANSLATIONS_NAMESPACE)
-      )
-      .forEach(key => localStorage.removeItem(key));
-
-    // Clear from i18next cache (specifically for when we delete a translation)
-    for (const lang of i18n.languages) {
-      i18n.removeResourceBundle(lang, CUSTOM_TRANSLATIONS_NAMESPACE);
-    }
-
-    // Then reload from backend
-    // Note - this is still requires the components in question to
-    // re-render to pick up the new translations
-    i18n.reloadResources(undefined, CUSTOM_TRANSLATIONS_NAMESPACE);
-  };
 
   const saveAndClose = async () => {
     const hasInvalidTranslations = translations.some(tr => tr.isInvalid);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8981 

# 👩🏻‍💻 What does this PR do?


Remote sites correctly sync new/updated/deleted custom translations

invalidateCustomTranslations function is now accessible as a util to be used when saving custom translations (central server) or syncing (remote site)


<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Looked into the order of queries to prevent refresh being required, even if invalidation of the translations happens prior to the sync invalidation, the translations are being returned after the re-render of the page. 
Low impact, it is unlikely the user will be on the page & sync when a translation is updated & it will still show on the next render

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a Central Server setup and a Remote Site setup
- [ ] On your Central Server, go to Global Preferences -> update a few translation keys
- [ ] Sync your Remote Site -> refresh the page or navigate to a place where the translation will be shown
- [ ] See the custom translation
- [ ] Repeat with deleting a translation -> should revert to the original on the remote site

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

