### PR TITLE
8993 cant save stocktake with on hold location

### DIFF
--- a/server/service/src/invoice_line/stock_out_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_out_line/update/validate.rs
@@ -72,7 +72,7 @@ pub fn validate(
     if !check_batch_on_hold(&batch_pair.main_batch) {
         return Err(BatchIsOnHold);
     }
-    check_location_on_hold(&batch_pair.main_batch).map_err(|e| match e {
+    check_location_on_hold(&batch_pair.main_batch.location_row).map_err(|e| match e {
         LocationIsOnHoldError::LocationIsOnHold => LocationIsOnHold,
     })?;
 

--- a/server/service/src/invoice_line/stock_out_line/validate.rs
+++ b/server/service/src/invoice_line/stock_out_line/validate.rs
@@ -1,6 +1,6 @@
 use repository::{
-    EqualFilter, InvoiceLineRow, InvoiceLineRowRepository, ItemRow, RepositoryError, StockLine,
-    StockLineFilter, StockLineRepository, StorageConnection,
+    EqualFilter, InvoiceLineRow, InvoiceLineRowRepository, ItemRow, LocationRow, RepositoryError,
+    StockLine, StockLineFilter, StockLineRepository, StorageConnection,
 };
 
 const LAST_PACK_THRESHOLD: f64 = 0.001;
@@ -72,10 +72,12 @@ pub enum LocationIsOnHoldError {
     LocationIsOnHold,
 }
 
-pub fn check_location_on_hold(batch: &StockLine) -> Result<(), LocationIsOnHoldError> {
+pub fn check_location_on_hold(
+    location_row: &Option<LocationRow>,
+) -> Result<(), LocationIsOnHoldError> {
     use LocationIsOnHoldError::*;
 
-    match &batch.location_row {
+    match location_row {
         Some(location) => {
             if location.on_hold {
                 return Err(LocationIsOnHold);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8993

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

When doing a stock reduction - we were doing the location validation based where the stock line _currently_ was, rather than where we are moving it to in the stocktake.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

Note - this only applies to stock reduction - matching count and increasing stock should work successfully either way.

- [ ] Have stock which is NOT in an on hold location
- [ ] Create a stocktake including that stock line
- [ ] Cause a stock reduction - set counted packs to less than snapshot
- [ ] Set the location to an on hold location
- [ ] Save & finalise stocktake - you get an error that location is on hold
- [ ] Have stock in an on hold location
- [ ] Create a stocktake including that stock line
- [ ] Cause a stock reduction - set counted packs to less than snapshot
- [ ] Clear the location/set to a not-on-hold location
- [ ] Save & finalise stocktake - saves successfully


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

