### PR TITLE
Fix Inbound Form Displaying Broken Logo

### DIFF
--- a/standard_forms/inbound/2_6/report-manifest.json
+++ b/standard_forms/inbound/2_6/report-manifest.json
@@ -1,6 +1,6 @@
 {
   "is_custom": false,
-  "version": "2.10.00",
+  "version": "2.6.4",
   "code": "inbound",
   "context": "INBOUND_SHIPMENT",
   "name": "Inbound Shipment",

--- a/standard_forms/inbound/2_6/src/footer.html
+++ b/standard_forms/inbound/2_6/src/footer.html
@@ -1,0 +1,3 @@
+<div style="font-size: 10px; padding-top: 8px; text-align: right; width: 100%;">
+<span class="pageNumber"></span>
+</div>

--- a/standard_forms/inbound/2_6/src/header.html
+++ b/standard_forms/inbound/2_6/src/header.html
@@ -1,0 +1,48 @@
+{% macro dateOrNA(datetime) %}
+{% if datetime %}{{ datetime | date(format="%d/%m/%Y", timezone=arguments.timezone) }}{% else
+%}{{t(k="messages.not-applicable", f="N/A")}}{% endif %}
+{% endmacro input %}
+
+<table class="header_image_section" style="width: 100%;height: 98%;">
+    <tr>
+        <th style="text-align:left; width:10%;height:70%;">
+            <img class="logo" src="{{data.store.logo}}" />
+        </th>
+        <th style="text-align:left;width:20%">
+            <span style="font-size: 12pt; font-weight: bold;">{{ data.store.storeName }}</span><br>
+            <span style="font-size: 10pt;">{{ data.store.name.address1 }}</span><br>
+            <span style="font-size: 10pt;">{{ data.store.name.address2 }}</span><br>
+            <span style="font-size:6pt;">
+                {{t(k="label.phone",f="Telephone")}}: {{ data.store.name.phone }}
+            </span><br>
+            <span style="font-size:6pt;">
+                {{t(k="label.email",f="Email")}}: {{ data.store.name.email }}
+            </span>
+        </th>
+        <th style="text-align:right;width:70%;font-size:28pt;">{{ t(k="report.inbound-form", f="Inbound Shipment Form")
+            }}</th>
+    </tr>
+</table>
+
+<div class="header_supplied_section" style="display: flex; justify-content: space-between; padding: 0.1em;">
+    <div class="header_left_section">
+        <span>{{t(k="report.received-from",f="Received from")}}:</span>
+    </div>
+    <div class="header_details_section">
+        <span>{{ data.invoice.otherPartyName }}</span><br>
+        <span>{{ data.invoice.otherParty.code }}</span><br>
+        <span>{{ data.invoice.otherParty.address1 }}</span><br>
+        <span>{{ data.invoice.otherParty.address2 }}</span>
+    </div>
+    <div class="header_right_section">
+        <span>{{ t(k="label.number", f="Number") }}: {{ data.invoice.invoiceNumber }}</span><br>
+        <span>{{t(k="report.printed-date",f="Printed date")}}: {{ now() | date(format="%d/%m/%Y") }}</span><br>
+        <span>{{t(k="report.their-ref",f="Their ref")}}:
+            {% if data.invoice.theirReference %}
+            {{ data.invoice.theirReference }}
+            {% else %}
+            {{ t(k="messages.not-applicable", f="N/A") }}
+            {% endif %}</span><br>
+        <span>{{t(k="report.confirmed-date", f="Confirmed date")}}:{{
+            self::dateOrNA(datetime=data.invoice.deliveredDatetime) }}</span><br>
+    </div>

--- a/standard_forms/inbound/2_6/src/inbound.graphql
+++ b/standard_forms/inbound/2_6/src/inbound.graphql
@@ -1,0 +1,107 @@
+query InvoiceQuery(
+  $storeId: String!
+  $dataId: String!
+  $sort: PrintReportSortInput
+) {
+  invoice(storeId: $storeId, id: $dataId) {
+    ... on InvoiceNode {
+      id
+      otherPartyId
+      comment
+      status
+      invoiceNumber
+      theirReference
+      createdDatetime
+      pickedDatetime
+      shippedDatetime
+      deliveredDatetime
+      allocatedDatetime
+      otherPartyName
+      type
+      pricing {
+        serviceTotalAfterTax
+        serviceTotalBeforeTax
+        stockTotalAfterTax
+        stockTotalBeforeTax
+        taxPercentage
+        totalAfterTax
+        totalBeforeTax
+      }
+      otherParty(storeId: $storeId) {
+        name
+        id
+        isSupplier
+        isCustomer
+        code
+        address1
+        address2
+      }
+      user {
+        username
+      }
+    }
+    ... on NodeError {
+      __typename
+      error {
+        description
+      }
+    }
+  }
+  invoiceLines(
+    storeId: $storeId
+    filter: { invoiceId: { equalTo: $dataId } }
+    reportSort: $sort
+  ) {
+    ... on InvoiceLineConnector {
+      nodes {
+        id
+        itemId
+        itemCode
+        itemName
+        locationName
+        item {
+          unitName
+        }
+        packSize
+        expiryDate
+        batch
+        numberOfPacks
+        packSize
+        sellPricePerPack
+        costPricePerPack
+        pricing {
+          serviceTotalAfterTax
+          serviceTotalBeforeTax
+          stockTotalAfterTax
+          stockTotalBeforeTax
+          taxPercentage
+          totalAfterTax
+          totalBeforeTax
+        }
+        location {
+          code
+        }
+      }
+    }
+  }
+  store(id: $storeId) {
+    ... on StoreNode {
+      code
+      storeName
+      logo
+      id
+      name(storeId: $storeId) {
+        address1
+        address2
+        chargeCode
+        code
+        comment
+        country
+        email
+        name
+        phone
+        website
+      }
+    }
+  }
+}

--- a/standard_forms/inbound/2_6/src/style.css
+++ b/standard_forms/inbound/2_6/src/style.css
@@ -1,0 +1,114 @@
+@media print{
+    @page {
+        size: A4 landscape 
+    }
+}
+
+@page {
+    font-family: Tahoma;
+    font-size: 8pt;
+    counter-increment: page;
+    content: "Page " counter(page);
+}
+
+.logo {
+    display: block;
+    height: 96px;
+}
+
+.header_image_section, .header_supplied_section, .header_date_section, .body_section, .body_total_section {
+    margin-left: 8px;
+    width: 100%;
+}
+
+.header_supplied_section {
+    width: 100%;
+    font-family: Tahoma;
+    font-size: 8pt;
+    border-bottom: 0.5px solid black;
+} 
+
+.header_image_section {
+    width: 100%;
+    font-family: Tahoma;
+    font-size: 8pt;
+    border-bottom: 0.5px solid black;
+    padding-top: 8pt;
+} 
+
+.header_date_section {
+    width: 100%;
+    font-family: Tahoma;
+    font-size: 8pt;
+    border-bottom: 0.5px solid black;
+    padding-top: 1pt;
+}
+
+.header_section_field_right {
+    text-align: right;
+    font-family: Tahoma;
+    font-size: 8pt;
+}
+
+.header_section_field_left {
+    text-align: left;
+    font-family: Tahoma;
+    font-size: 8pt;
+}
+
+.line_number, .quantity, .pack, .expiry, .cost_price, .total_quantity, .total_extension {
+    text-align: right;
+    font-family: Tahoma;
+    font-size: 8pt;
+}
+
+.location_code, .item_name, .batch {
+    text-align: left;
+    font-family: Tahoma;
+    font-size: 8pt
+}
+
+.body_section, .body_total_section {
+    width: 100%;
+    font-family: Tahoma;
+}
+
+.body_section tr.body_column_label th {
+    border-bottom: 0.5px solid black;
+}
+
+.body_value td {
+    border-bottom: 0.5px solid black;
+}
+
+hr {
+    width: 100%; 
+    margin-left: 8px; 
+    border: 0.1px solid black;
+}
+
+.header_left_section {
+    text-align: left;
+    font-family: Tahoma;
+    font-size: 8pt;
+    flex: 0 1 auto;
+    margin-right: 10px;
+}
+
+.header_details_section {
+    flex: 1 1 0;
+    text-align: left;
+    font-family: Tahoma;
+    font-size: 8pt;
+}
+
+.header_right_section {
+  text-align: right;
+  font-family: Tahoma;
+  font-size: 8pt;
+  flex: 0 1 auto;
+}
+
+.batch-wrap {
+    word-break: break-word;
+}

--- a/standard_forms/inbound/2_6/src/template.html
+++ b/standard_forms/inbound/2_6/src/template.html
@@ -1,0 +1,73 @@
+<style>
+    {% include "style.css" %}
+</style>
+
+{% macro dateOrNA(datetime) %} 
+{% if datetime %}{{ datetime | date(format="%d/%m/%Y", timezone=arguments.timezone) }}{% else %}{{t(k="messages.not-applicable", f="N/A")}}{% endif %} 
+{% endmacro input %}
+
+<table class="header_date_section">
+    <tr>
+        <td class="header_section_field_left">{{t(k="label.entered-by",f="Entered by")}}: {{ data.invoice.user.username | default(value='') }}</td>
+        <td class="header_section_field_right">{{t(k="report.shipped-date",f="Shipped date")}}: {{ self::dateOrNA(datetime=data.invoice.shippedDatetime) }}</td>
+    </tr>
+    <tr> 
+        <td class="header_section_field_left">{{t(k="report.created-date",f="Created date")}}: {{ data.invoice.createdDatetime | date(format="%d/%m/%Y", timezone=arguments.timezone) }}</td>
+        <td></td>
+    </tr>
+</table>
+
+<body>
+    <table class="body_section" cellpadding="2" cellspacing="0">
+        <thead>
+            <tr class="body_column_label">
+                <th class="location_code" style="width: 80px;">{{t(k="label.location",f="Location")}}</th>
+                <th class="location_code" style="width: 50px;">{{t(k="report.item-code",f="Item code")}}</th>
+                <th class="item_name" style="width: 350px;">{{t(k="report.item-name", f="Item name")}}</th>
+                <th class="quantity" style="width: 50px;">{{t(k="label.quantity",f="Quantity")}}</th>
+                <th class="pack" style="width: 50px;">{{t(k="report.pack-size",f="Pack size")}}</th>
+                <th class="pack" style="width: 50px;">{{t(k="label.unit-quantity",f="Unit Qty")}}</th>
+                <th class="batch" style="width: 50px;">{{t(k="label.batch", f="Batch")}}</th>
+                <th class="expiry" style="width: 80px;">{{t(k="label.expiry",f="Expiry")}}</th>
+                <th class="cost_price" style="width: 80px;">{{t(k="description.pack-cost",f="Cost price per pack")}}</th>
+                <th class="cost_price" style="width: 80px;">{{t(k="label.cost-per-unit",f="Cost per unit")}}</th>
+                <th class="total_extension" style="width: 50px;">{{t(k="label.line-total",f="Line total")}}</th>
+            </tr>
+        </thead>
+        {% for line in data.invoiceLines.nodes -%}
+        <tr class="body_value">
+            {% if line.location.code %}
+                <td class="location_code" style="width: 80px;">{{ line.location.code }}</td>
+            {% else %}
+                <td class="location_code" style="width: 80px;"></td>
+            {% endif %}
+            <td class="location_code" style="width: 50px;">{{ line.itemCode }}</td>
+            <td class="item_name" style="width: 350px;">{{ line.itemName }}</td>
+            <td class="quantity" style="width: 50px;">{{ line.numberOfPacks }}</td>
+            <td class="pack" style="width: 50px;">{{ line.packSize }}</td>
+            <td class="pack" style="width: 50px;">{{ line.packSize * line.numberOfPacks }}</td>
+            <td class="batch batch-wrap" style="width: 50px;">{{ line.batch }}</td>
+            <td class="expiry" style="width: 80px;">{{ self::dateOrNA(datetime=line.expiryDate) }}</td>
+            <td class="cost_price" style="width: 80px;">{{ line.costPricePerPack }}</td>
+            {% if line.costPricePerPack and line.packSize %}
+            <td class="cost_price" style="width: 80px;">{{ line.costPricePerPack / line.packSize | round(precision=2) }}</td>
+            {% else %} 
+            <td class="cost_price" style="width: 80px;">0</td>
+            {% endif %}
+            <td class="total_extension" style="width: 50px;">{{ line.numberOfPacks * line.costPricePerPack }}</td>
+        </tr>
+        {%- endfor %}
+    </table>
+</body>
+
+<table class="body_total_section" cellpadding="2" cellspacing="0">
+    <tr class="body_total_column_label">
+        <th class="header_section_field_right">{{t(k="heading.sub-total",f="Sub total")}}: {{ data.invoice.pricing.totalBeforeTax | round(precision=2) }}</th>
+    </tr>
+      <tr class="body_total_column_label">
+        <th class="header_section_field_right">{{t(k="heading.tax",f="Tax")}}: {{ data.invoice.pricing.taxPercentage }}</th>
+    </tr>
+    <tr class="body_total_column_label">
+        <th class="header_section_field_right">{{t(k="heading.total",f="Total")}}: {{ data.invoice.pricing.totalAfterTax }}</th>
+    </tr>
+</table>

--- a/standard_forms/inbound/latest/src/header.html
+++ b/standard_forms/inbound/latest/src/header.html
@@ -1,48 +1,65 @@
-{% macro dateOrNA(datetime) %}
-{% if datetime %}{{ datetime | date(format="%d/%m/%Y", timezone=arguments.timezone) }}{% else
-%}{{t(k="messages.not-applicable", f="N/A")}}{% endif %}
-{% endmacro input %}
+{% macro dateOrNA(datetime) %} {% if datetime %}{{ datetime |
+date(format="%d/%m/%Y", timezone=arguments.timezone) }}{% else
+%}{{t(k="messages.not-applicable", f="N/A")}}{% endif %} {% endmacro input %}
 
-<table class="header_image_section" style="width: 100%;height: 98%;">
-    <tr>
-        <th style="text-align:left; width:10%;height:70%;">
-            <img class="logo" src="{{data.store.logo}}" />
-        </th>
-        <th style="text-align:left;width:20%">
-            <span style="font-size: 12pt; font-weight: bold;">{{ data.store.storeName }}</span><br>
-            <span style="font-size: 10pt;">{{ data.store.name.address1 }}</span><br>
-            <span style="font-size: 10pt;">{{ data.store.name.address2 }}</span><br>
-            <span style="font-size:6pt;">
-                {{t(k="label.phone",f="Telephone")}}: {{ data.store.name.phone }}
-            </span><br>
-            <span style="font-size:6pt;">
-                {{t(k="label.email",f="Email")}}: {{ data.store.name.email }}
-            </span>
-        </th>
-        <th style="text-align:right;width:70%;font-size:28pt;">{{ t(k="report.inbound-form", f="Inbound Shipment Form")
-            }}</th>
-    </tr>
+<table class="header_image_section" style="width: 100%; height: 98%">
+  <tr>
+    {% if data.store.logo %}
+    <th style="text-align: left; width: 10%; height: 70%">
+      <img class="logo" src="{{data.store.logo}}" />
+    </th>
+    {% endif %}
+    <th style="text-align: left; width: 20%">
+      <span style="font-size: 12pt; font-weight: bold"
+        >{{ data.store.storeName }}</span
+      ><br />
+      <span style="font-size: 10pt">{{ data.store.name.address1 }}</span><br />
+      <span style="font-size: 10pt">{{ data.store.name.address2 }}</span><br />
+      <span style="font-size: 6pt">
+        {{t(k="label.phone",f="Telephone")}}: {{ data.store.name.phone }} </span
+      ><br />
+      <span style="font-size: 6pt">
+        {{t(k="label.email",f="Email")}}: {{ data.store.name.email }}
+      </span>
+      <br />
+      <br />
+    </th>
+    <th style="text-align: right; width: 70%; font-size: 28pt">
+      {{ t(k="report.inbound-form", f="Inbound Shipment Form") }}
+    </th>
+  </tr>
 </table>
 
-<div class="header_supplied_section" style="display: flex; justify-content: space-between; padding: 0.1em;">
-    <div class="header_left_section">
-        <span>{{t(k="report.received-from",f="Received from")}}:</span>
-    </div>
-    <div class="header_details_section">
-        <span>{{ data.invoice.otherPartyName }}</span><br>
-        <span>{{ data.invoice.otherParty.code }}</span><br>
-        <span>{{ data.invoice.otherParty.address1 }}</span><br>
-        <span>{{ data.invoice.otherParty.address2 }}</span>
-    </div>
-    <div class="header_right_section">
-        <span>{{ t(k="label.number", f="Number") }}: {{ data.invoice.invoiceNumber }}</span><br>
-        <span>{{t(k="report.printed-date",f="Printed date")}}: {{ now() | date(format="%d/%m/%Y") }}</span><br>
-        <span>{{t(k="report.their-ref",f="Their ref")}}:
-            {% if data.invoice.theirReference %}
-            {{ data.invoice.theirReference }}
-            {% else %}
-            {{ t(k="messages.not-applicable", f="N/A") }}
-            {% endif %}</span><br>
-        <span>{{t(k="report.confirmed-date", f="Confirmed date")}}:{{
-            self::dateOrNA(datetime=data.invoice.deliveredDatetime) }}</span><br>
-    </div>
+<div
+  class="header_supplied_section"
+  style="display: flex; justify-content: space-between; padding: 0.1em"
+>
+  <div class="header_left_section">
+    <span>{{t(k="report.received-from",f="Received from")}}:</span>
+  </div>
+  <div class="header_details_section">
+    <span>{{ data.invoice.otherPartyName }}</span><br />
+    <span>{{ data.invoice.otherParty.code }}</span><br />
+    <span>{{ data.invoice.otherParty.address1 }}</span><br />
+    <span>{{ data.invoice.otherParty.address2 }}</span>
+  </div>
+  <div class="header_right_section">
+    <span
+      >{{ t(k="label.number", f="Number") }}: {{ data.invoice.invoiceNumber
+      }}</span
+    ><br />
+    <span
+      >{{t(k="report.printed-date",f="Printed date")}}: {{ now() |
+      date(format="%d/%m/%Y") }}</span
+    ><br />
+    <span
+      >{{t(k="report.their-ref",f="Their ref")}}: {% if
+      data.invoice.theirReference %} {{ data.invoice.theirReference }} {% else
+      %} {{ t(k="messages.not-applicable", f="N/A") }} {% endif %}</span
+    ><br />
+    <span
+      >{{t(k="report.confirmed-date", f="Confirmed date")}}:{{
+      self::dateOrNA(datetime=data.invoice.deliveredDatetime) }}</span
+    ><br />
+  </div>
+</div>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8613 

# 👩🏻‍💻 What does this PR do?

Adds a filter to the template so that if there is no logo, the logo section is not included in the printed report.
Also adds some spacing so that the report will have consistent spacing whether or not the logo is displayed.

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Download [this database](https://drive.google.com/file/d/1j7UcTLoCVj4aNJ0eWA2xCX_CwXx8iOmm/view?usp=drive_link) and put it in open-msupply/server.
- [ ] Download [this file](https://drive.google.com/file/d/16Sg7pnYvP7ziXgRetYe2Z1Rk-DtsYy_k/view?usp=drive_link) and put it in open-msupply/standard_reports. If you already have a file of the same name in there, replace it with this one.
- [ ] Run the server.
- [ ] With open-msupply/server as your working directory, run this command (with the file paths that make sense for your environment) `./target/debug/remote_server_cli show-report --path /Users/zachariah/code/open-msupply/standard_forms/purchase-order/latest --config /Users/zachariah/code/open-msupply/standard_reports`
- [ ] The report should display in your browser. Check it has no broken images displaying and that the spacing looks good.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

