### PR TITLE
8928 ledger fix invoice status from log

### DIFF
--- a/server/graphql/general/src/queries/activity_log.rs
+++ b/server/graphql/general/src/queries/activity_log.rs
@@ -22,6 +22,7 @@ pub enum ActivityLogSortFieldInput {
     ActivityLogType,
     UserId,
     RecordId,
+    Datetime,
 }
 
 #[derive(InputObject)]
@@ -113,6 +114,7 @@ impl ActivityLogSortInput {
             from::ActivityLogType => to::ActivityLogType,
             from::UserId => to::UserId,
             from::RecordId => to::RecordId,
+            from::Datetime => to::Datetime,
         };
 
         ActivityLogSort {

--- a/server/repository/src/db_diesel/activity_log.rs
+++ b/server/repository/src/db_diesel/activity_log.rs
@@ -2,7 +2,7 @@ use super::{activity_log_row::activity_log, ActivityLogRow, DBType, StorageConne
 use diesel::prelude::*;
 
 use crate::{
-    diesel_macros::{apply_equal_filter, apply_sort_no_case},
+    diesel_macros::{apply_equal_filter, apply_sort, apply_sort_no_case},
     repository_error::RepositoryError,
     ActivityLogType,
 };
@@ -29,6 +29,7 @@ pub enum ActivityLogSortField {
     ActivityLogType,
     UserId,
     RecordId,
+    Datetime,
 }
 
 pub type ActivityLogSort = Sort<ActivityLogSortField>;
@@ -76,6 +77,9 @@ impl<'a> ActivityLogRepository<'a> {
                 }
                 ActivityLogSortField::RecordId => {
                     apply_sort_no_case!(query, sort, activity_log::record_id)
+                }
+                ActivityLogSortField::Datetime => {
+                    apply_sort!(query, sort, activity_log::datetime)
                 }
             }
         } else {

--- a/server/repository/src/db_diesel/activity_log_row.rs
+++ b/server/repository/src/db_diesel/activity_log_row.rs
@@ -26,7 +26,7 @@ table! {
 joinable!(activity_log -> user_account (user_id));
 joinable!(activity_log -> store (store_id));
 
-#[derive(DbEnum, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(DbEnum, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, Copy)]
 #[DbValueStyle = "SCREAMING_SNAKE_CASE"]
 pub enum ActivityLogType {
     UserLoggedIn,

--- a/server/repository/src/db_diesel/invoice_row.rs
+++ b/server/repository/src/db_diesel/invoice_row.rs
@@ -85,7 +85,7 @@ pub enum InvoiceType {
     CustomerReturn,
 }
 
-#[derive(DbEnum, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(DbEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[DbValueStyle = "SCREAMING_SNAKE_CASE"]
 pub enum InvoiceStatus {

--- a/server/repository/src/migrations/views/mod.rs
+++ b/server/repository/src/migrations/views/mod.rs
@@ -194,57 +194,74 @@ pub(crate) fn rebuild_views(connection: &StorageConnection) -> anyhow::Result<()
     ORDER BY datetime, type_precedence;
 
   CREATE VIEW stock_line_ledger_discrepancy AS 
-  WITH 
-  allocated_not_picked AS (
-      SELECT stock_line_id,
-          SUM(number_of_packs * pack_size) AS q
-      FROM invoice_line
-          JOIN invoice on invoice.id = invoice_line.invoice_id
-      WHERE invoice_line.type = 'STOCK_OUT'
-          AND invoice.status IN ('NEW', 'ALLOCATED')
-      GROUP BY 1
-  ),
-  max_ledger_datetime AS (
-      SELECT stock_line_id,
-          MAX(datetime) AS dt
-      FROM stock_movement
-      GROUP BY 1
-  ),
-  running_balance AS (
-      SELECT stock_line_ledger.stock_line_id,
-          running_balance AS q
-      FROM stock_line_ledger
-          JOIN max_ledger_datetime on stock_line_ledger.stock_line_id = max_ledger_datetime.stock_line_id
-          AND stock_line_ledger.datetime = max_ledger_datetime.dt
-  ),
-  current_balance AS (
-      SELECT stock_line.id AS stock_line_id,
-          store_id,
-          available_number_of_packs * pack_size AS a_q,
-          total_number_of_packs * pack_size AS t_q
-      from stock_line
-  )
-  SELECT DISTINCT stock_line_id
-  FROM stock_line_ledger
-  WHERE running_balance < 0
+  WITH
+	allocated_not_picked AS (
+		SELECT
+			stock_line_id,
+			SUM(number_of_packs * pack_size) AS q
+		FROM
+			invoice_line
+			JOIN invoice ON invoice.id = invoice_line.invoice_id
+		WHERE
+			invoice_line.type = 'STOCK_OUT'
+			AND invoice.status IN ('NEW', 'ALLOCATED')
+		GROUP BY
+			1
+	),
+	max_ledger_datetime AS (
+		SELECT
+			stock_line_id,
+			MAX(datetime) AS dt
+		FROM
+			stock_movement
+		GROUP BY
+			1
+	),
+	running_balance AS (
+		SELECT
+			stock_line_ledger.stock_line_id,
+			running_balance AS q
+		FROM
+			stock_line_ledger
+			JOIN max_ledger_datetime ON stock_line_ledger.stock_line_id = max_ledger_datetime.stock_line_id
+			AND stock_line_ledger.datetime = max_ledger_datetime.dt
+	),
+	current_balance AS (
+		SELECT
+			stock_line.id AS stock_line_id,
+			available_number_of_packs * pack_size AS a_q,
+			total_number_of_packs * pack_size AS t_q
+		FROM
+			stock_line
+	)
+  SELECT DISTINCT
+    stock_line_id
+  FROM
+    stock_line_ledger
+  WHERE
+    running_balance < 0
   UNION
-  SELECT running_balance.stock_line_id
-  FROM running_balance
-      JOIN current_balance ON running_balance.stock_line_id = current_balance.stock_line_id
-      LEFT JOIN allocated_not_picked ON running_balance.stock_line_id = allocated_not_picked.stock_line_id
-  WHERE NOT(
-          running_balance.q = current_balance.t_q
-          AND (
-              (
-                  allocated_not_picked.q IS NULL
-                  AND current_balance.t_q = current_balance.a_q
-              )
-              OR (
-                  allocated_not_picked.q IS NOT NULL
-                  AND current_balance.a_q + allocated_not_picked.q = current_balance.t_q
-              )
-          )
-      );
+  SELECT
+    current_balance.stock_line_id
+  FROM
+    current_balance
+    LEFT JOIN running_balance ON running_balance.stock_line_id = current_balance.stock_line_id
+    LEFT JOIN allocated_not_picked ON allocated_not_picked.stock_line_id = current_balance.stock_line_id
+  WHERE
+    NOT (
+      running_balance.q = current_balance.t_q
+      AND (
+        (
+          allocated_not_picked.q IS NULL
+          AND current_balance.t_q = current_balance.a_q
+        )
+        OR (
+          allocated_not_picked.q IS NOT NULL
+          AND current_balance.a_q + allocated_not_picked.q = current_balance.t_q
+        )
+      )
+    )
+    OR running_balance IS NULL;
 
   CREATE VIEW item_ledger AS
     WITH all_movements AS (

--- a/server/service/src/ledger_fix/fixes/adjust_invoice_status.rs
+++ b/server/service/src/ledger_fix/fixes/adjust_invoice_status.rs
@@ -1,0 +1,444 @@
+use repository::{
+    activity_log::{
+        ActivityLogFilter, ActivityLogRepository, ActivityLogSort, ActivityLogSortField,
+    },
+    stock_line_ledger::{StockLineLedgerFilter, StockLineLedgerRepository},
+    ActivityLogRow, ActivityLogType, EqualFilter, InvoiceLineFilter, InvoiceLineRepository,
+    InvoiceRow, InvoiceRowRepository, InvoiceStatus, Pagination, StockLineRowRepository,
+    StorageConnection,
+};
+
+use crate::ledger_fix::{fixes::LedgerFixError, ledger_balance_summary, LedgerBalanceSummary};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)] // Wanted to use InvoiceStatus, but need a good "other" variant
+enum Status {
+    New,
+    Allocated,
+    Picked,
+    Shipped,
+    Delivered,
+    Received,
+    Verified,
+    Cancelled,
+    Other,
+}
+
+impl From<ActivityLogType> for Status {
+    fn from(log_type: ActivityLogType) -> Self {
+        match log_type {
+            ActivityLogType::InvoiceCreated => Status::New,
+            ActivityLogType::InvoiceStatusAllocated => Status::Allocated,
+            ActivityLogType::InvoiceStatusPicked => Status::Picked,
+            ActivityLogType::InvoiceStatusShipped => Status::Shipped,
+            ActivityLogType::InvoiceStatusDelivered => Status::Delivered,
+            ActivityLogType::InvoiceStatusReceived => Status::Received,
+            ActivityLogType::InvoiceStatusVerified => Status::Verified,
+            ActivityLogType::InvoiceStatusCancelled => Status::Cancelled,
+            _ => Status::Other, // This isn't ideal, if someone adds more types the type system won't force us to add it here...
+        }
+    }
+}
+
+impl From<InvoiceStatus> for Status {
+    fn from(status: InvoiceStatus) -> Self {
+        match status {
+            InvoiceStatus::New => Status::New,
+            InvoiceStatus::Allocated => Status::Allocated,
+            InvoiceStatus::Picked => Status::Picked,
+            InvoiceStatus::Shipped => Status::Shipped,
+            InvoiceStatus::Received => Status::Received,
+            InvoiceStatus::Delivered => Status::Delivered,
+            InvoiceStatus::Verified => Status::Verified,
+            InvoiceStatus::Cancelled => Status::Cancelled,
+        }
+    }
+}
+
+pub(crate) fn fix(
+    connection: &StorageConnection,
+    operation_log: &mut String,
+    stock_line_id: &str,
+) -> Result<(), LedgerFixError> {
+    operation_log.push_str("Starting adjust_invoice_status\n");
+
+    let ledger_lines = StockLineLedgerRepository::new(connection).query_by_filter(
+        StockLineLedgerFilter::new().stock_line_id(EqualFilter::equal_to(stock_line_id)),
+    )?;
+
+    let balance_summary = ledger_balance_summary(connection, &ledger_lines, stock_line_id)?;
+    let LedgerBalanceSummary {
+        total,
+        running_balance,
+        available,
+        reserved_not_picked,
+        ..
+    } = balance_summary;
+
+    let should_adjust = total != running_balance || available + reserved_not_picked != total;
+
+    if !should_adjust {
+        operation_log.push_str(&format!(
+            "Ledger does not match use case for adjust_invoice_status {:?}.\n",
+            balance_summary
+        ));
+
+        return Ok(());
+    }
+    // Get stock_line -> invoice_lines -> invoices, the `activity_logs` corresponding to each, then check
+    // the latest status against invoice.status
+    if StockLineRowRepository::new(connection)
+        .find_one_by_id(stock_line_id)?
+        .is_none()
+    {
+        return LedgerFixError::other("Stock line not found");
+    };
+
+    let invoice_lines = InvoiceLineRepository::new(connection).query_by_filter(
+        InvoiceLineFilter::new().stock_line_id(EqualFilter::equal_to(stock_line_id)),
+    )?;
+
+    if invoice_lines.is_empty() {
+        operation_log.push_str(&format!(
+            "Ledger does not match use case as for adjust_invoice_status- there are no related invoice lines\n",
+        ));
+        return Ok(());
+    }
+
+    let mut invoices: Vec<InvoiceRow> = invoice_lines.into_iter().map(|l| l.invoice_row).collect();
+    invoices.sort_by(|a, b| a.id.cmp(&b.id));
+    invoices.dedup_by(|a, b| a.id == b.id);
+
+    'invoice_loop: for invoice in &mut invoices {
+        let logs = ActivityLogRepository::new(connection).query(
+            Pagination::all(),
+            Some(ActivityLogFilter::new().record_id(EqualFilter::equal_to(&invoice.id))),
+            Some(ActivityLogSort {
+                key: ActivityLogSortField::Datetime,
+                desc: Some(true),
+            }),
+        )?;
+
+        let logs: Vec<ActivityLogRow> = logs
+            .into_iter()
+            .filter(|l| {
+                matches!(
+                    l.activity_log_row.r#type,
+                    ActivityLogType::InvoiceCreated
+                        | ActivityLogType::InvoiceStatusAllocated
+                        | ActivityLogType::InvoiceStatusPicked
+                        | ActivityLogType::InvoiceStatusShipped
+                        | ActivityLogType::InvoiceStatusDelivered
+                        | ActivityLogType::InvoiceStatusReceived
+                        | ActivityLogType::InvoiceStatusVerified
+                        | ActivityLogType::InvoiceStatusCancelled
+                )
+            })
+            .map(|l| l.activity_log_row)
+            .collect();
+
+        // Check for duplicate statuses, skip to next invoice if found
+        let mut seen_statuses = std::collections::HashSet::new();
+        for log in &logs {
+            if let ActivityLogType::InvoiceStatusAllocated
+            | ActivityLogType::InvoiceStatusPicked
+            | ActivityLogType::InvoiceStatusShipped
+            | ActivityLogType::InvoiceStatusDelivered
+            | ActivityLogType::InvoiceStatusReceived
+            | ActivityLogType::InvoiceStatusVerified
+            | ActivityLogType::InvoiceStatusCancelled = log.r#type
+            {
+                if !seen_statuses.insert(log.r#type) {
+                    continue 'invoice_loop; // Skip to next invoice
+                }
+            }
+        }
+
+        // Recover invoice datetime values from corresponding logs
+        for log in &logs {
+            let date_field = match log.r#type {
+                ActivityLogType::InvoiceStatusAllocated => &mut invoice.allocated_datetime,
+                ActivityLogType::InvoiceStatusPicked => &mut invoice.picked_datetime,
+                ActivityLogType::InvoiceStatusShipped => &mut invoice.shipped_datetime,
+                ActivityLogType::InvoiceStatusDelivered => &mut invoice.delivered_datetime,
+                ActivityLogType::InvoiceStatusReceived => &mut invoice.received_datetime,
+                ActivityLogType::InvoiceStatusVerified => &mut invoice.verified_datetime,
+                ActivityLogType::InvoiceStatusCancelled => &mut invoice.cancelled_datetime,
+                _ => continue,
+            };
+            date_field.get_or_insert(log.datetime);
+        }
+
+        if let Some(log) = logs.last() {
+            match log.r#type {
+                ActivityLogType::InvoiceStatusAllocated
+                | ActivityLogType::InvoiceStatusPicked
+                | ActivityLogType::InvoiceStatusShipped
+                | ActivityLogType::InvoiceStatusDelivered
+                | ActivityLogType::InvoiceStatusReceived
+                | ActivityLogType::InvoiceStatusVerified
+                | ActivityLogType::InvoiceStatusCancelled => {
+                    let log_status: Status = log.r#type.into();
+                    let invoice_status: Status = invoice.status.into();
+                    if invoice_status < log_status {
+                        invoice.status = match log.r#type {
+                            ActivityLogType::InvoiceStatusAllocated => InvoiceStatus::Allocated,
+                            ActivityLogType::InvoiceStatusPicked => InvoiceStatus::Picked,
+                            ActivityLogType::InvoiceStatusShipped => InvoiceStatus::Shipped,
+                            ActivityLogType::InvoiceStatusDelivered => InvoiceStatus::Delivered,
+                            ActivityLogType::InvoiceStatusReceived => InvoiceStatus::Received,
+                            ActivityLogType::InvoiceStatusVerified => InvoiceStatus::Verified,
+                            ActivityLogType::InvoiceStatusCancelled => InvoiceStatus::Cancelled,
+                            _ => {
+                                continue;
+                            }
+                        };
+                    }
+                    operation_log.push_str(&format!("Adjusting invoice {invoice_id} status {invoice_status:?} to match latest log status: {log_status:?}.\n", invoice_id = invoice.id));
+                    InvoiceRowRepository::new(connection).upsert_one(invoice)?;
+                }
+                _ => continue,
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        ledger_fix::is_ledger_fixed,
+        test_helpers::{
+            make_movements, setup_all_with_data_and_service_provider, ServiceTestContext,
+        },
+    };
+    use repository::{
+        mock::{mock_item_a, mock_store_a, MockData, MockDataInserts},
+        InvoiceStatus, KeyValueStoreRepository, StockLineRow,
+    };
+
+    fn mock_data() -> MockData {
+        let total_does_not_match = StockLineRow {
+            id: "total_does_not_match".to_string(),
+            item_link_id: mock_item_a().id.clone(),
+            store_id: mock_store_a().id.clone(),
+            pack_size: 1.0,
+            available_number_of_packs: 40.0,
+            total_number_of_packs: 30.0,
+            ..Default::default()
+        };
+
+        let an_invoice_where_status_changed = StockLineRow {
+            id: "an_invoice_where_status_changed".to_string(),
+            available_number_of_packs: 20.0,
+            ..total_does_not_match.clone()
+        };
+
+        let mock_data = MockData {
+            stock_lines: vec![
+                total_does_not_match.clone(),
+                an_invoice_where_status_changed.clone(),
+            ],
+            ..Default::default()
+        }
+        // Movements are (date as day, quantity)
+        .join(make_movements(
+            total_does_not_match,
+            // -10 was double picked
+            vec![(2, 100), (3, -50), (4, -10)],
+        ));
+
+        let mut allocated_not_picked_movements = make_movements(
+            an_invoice_where_status_changed,
+            vec![(2, 100), (3, -50), (4, -10), (10, -20)],
+        );
+
+        let logs_mock = MockData {
+            activity_logs: mock_data
+                .invoices
+                .iter()
+                .flat_map(|invoice| {
+                    let mut logs = Vec::new();
+
+                    logs.push(ActivityLogRow {
+                        id: format!("{}_created", invoice.id),
+                        r#type: ActivityLogType::InvoiceCreated,
+                        user_id: Some("user_account_a".to_string()),
+                        store_id: Some(invoice.store_id.clone()),
+                        record_id: Some(invoice.id.clone()),
+                        datetime: invoice.created_datetime.clone(),
+                        changed_to: None,
+                        changed_from: None,
+                    });
+
+                    if let Some(allocated_datetime) = invoice.allocated_datetime {
+                        logs.push(ActivityLogRow {
+                            id: format!("{}_allocated", invoice.id),
+                            r#type: ActivityLogType::InvoiceStatusAllocated,
+                            user_id: Some("user_account_a".to_string()),
+                            store_id: Some(invoice.store_id.clone()),
+                            record_id: Some(invoice.id.clone()),
+                            datetime: allocated_datetime.clone(),
+                            changed_to: None,
+                            changed_from: None,
+                        });
+                    }
+
+                    if let Some(picked_datetime) = invoice.picked_datetime {
+                        logs.push(ActivityLogRow {
+                            id: format!("{}_picked", invoice.id),
+                            r#type: ActivityLogType::InvoiceStatusPicked,
+                            user_id: Some("user_account_a".to_string()),
+                            store_id: Some(invoice.store_id.clone()),
+                            record_id: Some(invoice.id.clone()),
+                            datetime: picked_datetime.clone(),
+                            changed_to: None,
+                            changed_from: None,
+                        });
+                    }
+
+                    if let Some(shipped_datetime) = invoice.shipped_datetime {
+                        logs.push(ActivityLogRow {
+                            id: format!("{}_shipped", invoice.id),
+                            r#type: ActivityLogType::InvoiceStatusShipped,
+                            user_id: Some("user_account_a".to_string()),
+                            store_id: Some(invoice.store_id.clone()),
+                            record_id: Some(invoice.id.clone()),
+                            datetime: shipped_datetime.clone(),
+                            changed_to: None,
+                            changed_from: None,
+                        });
+                    }
+
+                    if let Some(delivered_datetime) = invoice.delivered_datetime {
+                        logs.push(ActivityLogRow {
+                            id: format!("{}_delivered", invoice.id),
+                            r#type: ActivityLogType::InvoiceStatusDelivered,
+                            user_id: Some("user_account_a".to_string()),
+                            store_id: Some(invoice.store_id.clone()),
+                            record_id: Some(invoice.id.clone()),
+                            datetime: delivered_datetime.clone(),
+                            changed_to: None,
+                            changed_from: None,
+                        });
+                    }
+
+                    if let Some(received_datetime) = invoice.received_datetime {
+                        logs.push(ActivityLogRow {
+                            id: format!("{}_received", invoice.id),
+                            r#type: ActivityLogType::InvoiceStatusReceived,
+                            user_id: Some("user_account_a".to_string()),
+                            store_id: Some(invoice.store_id.clone()),
+                            record_id: Some(invoice.id.clone()),
+                            datetime: received_datetime.clone(),
+                            changed_to: None,
+                            changed_from: None,
+                        });
+                    }
+
+                    if let Some(verified_datetime) = invoice.verified_datetime {
+                        logs.push(ActivityLogRow {
+                            id: format!("{}_verified", invoice.id),
+                            r#type: ActivityLogType::InvoiceStatusVerified,
+                            user_id: Some("user_account_a".to_string()),
+                            store_id: Some(invoice.store_id.clone()),
+                            record_id: Some(invoice.id.clone()),
+                            datetime: verified_datetime.clone(),
+                            changed_to: None,
+                            changed_from: None,
+                        });
+                    }
+
+                    if let Some(cancelled_datetime) = invoice.cancelled_datetime {
+                        logs.push(ActivityLogRow {
+                            id: format!("{}_cancelled", invoice.id),
+                            r#type: ActivityLogType::InvoiceStatusCancelled,
+                            user_id: Some("user_account_a".to_string()),
+                            store_id: Some(invoice.store_id.clone()),
+                            record_id: Some(invoice.id.clone()),
+                            datetime: cancelled_datetime.clone(),
+                            changed_to: None,
+                            changed_from: None,
+                        });
+                    }
+
+                    logs
+                })
+                .collect(),
+            ..Default::default()
+        };
+
+        // Add reserved not picked
+        allocated_not_picked_movements.invoices[1].status = InvoiceStatus::Allocated;
+        allocated_not_picked_movements.invoices[1].picked_datetime = None;
+        allocated_not_picked_movements.invoices[1].shipped_datetime = None;
+        allocated_not_picked_movements.invoices[1].received_datetime = None;
+        allocated_not_picked_movements.invoices[1].verified_datetime = None;
+
+        mock_data
+            .join(allocated_not_picked_movements)
+            .join(logs_mock)
+    }
+
+    #[actix_rt::test]
+    async fn adjust_total_to_match_ledger_test() {
+        let ServiceTestContext { connection, .. } = setup_all_with_data_and_service_provider(
+            "adjust_total_to_match_ledger",
+            MockDataInserts::none().names().stores().units().items(),
+            mock_data(),
+        )
+        .await;
+
+        KeyValueStoreRepository::new(&connection)
+            .set_i32(
+                repository::KeyType::SettingsSyncSiteId,
+                Some(mock_store_a().site_id),
+            )
+            .unwrap();
+
+        assert_eq!(
+            is_ledger_fixed(&connection, "total_does_not_match"),
+            Ok(false)
+        );
+        let mut logs = String::new();
+        fix(&connection, &mut logs, "total_does_not_match").unwrap();
+        assert_eq!(
+            is_ledger_fixed(&connection, "total_does_not_match"),
+            Ok(false)
+        );
+
+        assert_eq!(
+            is_ledger_fixed(&connection, "an_invoice_where_status_changed"),
+            Ok(false)
+        );
+        let mut logs = String::new();
+        fix(&connection, &mut logs, "an_invoice_where_status_changed").unwrap();
+        assert_eq!(
+            is_ledger_fixed(&connection, "an_invoice_where_status_changed"),
+            Ok(true)
+        );
+
+        assert_eq!(
+            is_ledger_fixed(
+                &connection,
+                "an_invoice_where_status_change_is_duplicated_in_logs"
+            ),
+            Ok(false)
+        );
+        let mut logs = String::new();
+        fix(
+            &connection,
+            &mut logs,
+            "an_invoice_where_status_change_is_duplicated_in_logs",
+        )
+        .unwrap();
+        assert_eq!(
+            is_ledger_fixed(
+                &connection,
+                "an_invoice_where_status_change_is_duplicated_in_logs"
+            ),
+            Ok(false)
+        );
+    }
+}

--- a/server/service/src/ledger_fix/fixes/fix_cancellations.rs
+++ b/server/service/src/ledger_fix/fixes/fix_cancellations.rs
@@ -119,6 +119,12 @@ pub(crate) mod test {
         with_cancellation.invoices[3] = inline_edit(&with_cancellation.invoices[3], |mut u| {
             u.status = InvoiceStatus::Cancelled;
             u.r#type = InvoiceType::Prescription;
+            u.cancelled_datetime = Some(u.created_datetime.clone());
+            u.allocated_datetime = u.cancelled_datetime;
+            u.picked_datetime = u.cancelled_datetime;
+            u.received_datetime = u.cancelled_datetime;
+            u.delivered_datetime = u.cancelled_datetime;
+            u.verified_datetime = u.cancelled_datetime;
             u
         });
 
@@ -132,6 +138,12 @@ pub(crate) mod test {
             inline_edit(&with_multiple_cancellations.invoices[2], |mut u| {
                 u.status = InvoiceStatus::Cancelled;
                 u.r#type = InvoiceType::Prescription;
+                u.cancelled_datetime = Some(u.created_datetime);
+                u.allocated_datetime = u.cancelled_datetime;
+                u.picked_datetime = u.cancelled_datetime;
+                u.received_datetime = u.cancelled_datetime;
+                u.delivered_datetime = u.cancelled_datetime;
+                u.verified_datetime = u.cancelled_datetime;
                 u
             });
 
@@ -139,6 +151,12 @@ pub(crate) mod test {
             inline_edit(&with_multiple_cancellations.invoices[5], |mut u| {
                 u.status = InvoiceStatus::Cancelled;
                 u.r#type = InvoiceType::Prescription;
+                u.cancelled_datetime = Some(u.created_datetime);
+                u.allocated_datetime = u.cancelled_datetime;
+                u.picked_datetime = u.cancelled_datetime;
+                u.received_datetime = u.cancelled_datetime;
+                u.delivered_datetime = u.cancelled_datetime;
+                u.verified_datetime = u.cancelled_datetime;
                 u
             });
 

--- a/server/service/src/ledger_fix/fixes/mod.rs
+++ b/server/service/src/ledger_fix/fixes/mod.rs
@@ -22,6 +22,7 @@ use util::uuid::uuid;
 pub(crate) mod adjust_historic_incoming_invoices;
 
 pub(crate) mod adjust_all_to_match_available;
+pub(crate) mod adjust_invoice_status;
 pub(crate) mod adjust_total_to_match_ledger;
 pub(crate) mod fix_cancellations;
 pub(crate) mod inventory_adjustment_to_balance;

--- a/server/service/src/ledger_fix/ledger_fix_driver.rs
+++ b/server/service/src/ledger_fix/ledger_fix_driver.rs
@@ -82,7 +82,8 @@ async fn ledger_fix(service_provider: Arc<ServiceProvider>) {
 
     for (index, stock_line_id) in stock_line_ids.iter().enumerate() {
         let mut operation_log = format!(
-            "{index}/{} Fixing stock line {stock_line_id} {}\n",
+            "{}/{} Fixing stock line {stock_line_id} {}\n",
+            index + 1,
             stock_line_ids.len(),
             Utc::now().naive_utc()
         );

--- a/server/service/src/ledger_fix/stock_line_ledger_fix.rs
+++ b/server/service/src/ledger_fix/stock_line_ledger_fix.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 use crate::ledger_fix::{
     fixes::{
-        adjust_all_to_match_available, adjust_historic_incoming_invoices,
+        adjust_all_to_match_available, adjust_historic_incoming_invoices, adjust_invoice_status,
         adjust_total_to_match_ledger, fix_cancellations, inventory_adjustment_to_balance,
         LedgerFixError,
     },
@@ -23,12 +23,15 @@ pub(super) fn stock_line_ledger_fix(
     operation_log: &mut String,
     stock_line_id: &str,
 ) -> Result</* fixed fully */ bool, StockLineLedgerFixError> {
-    adjust_historic_incoming_invoices::fix(connection, operation_log, stock_line_id)?;
+    // Ledger fix that adjusts status on an invoice may fix several lines, so need to recheck needing the fix at the start
 
-    // TODO only check this if some action was done in ledger fix
+    adjust_invoice_status::fix(connection, operation_log, stock_line_id)?;
     if is_ledger_fixed(connection, stock_line_id)? {
         return Ok(true);
     }
+
+    adjust_historic_incoming_invoices::fix(connection, operation_log, stock_line_id)?;
+    // TODO only check this if some action was done in ledger fix
 
     inventory_adjustment_to_balance::fix(connection, operation_log, stock_line_id)?;
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8928 

# 👩🏻‍💻 What does this PR do?

- our discrepancy sql now includes stocklines that have no associated invoice_lines
- The ledger fix will use activity log to update the status of an invoice to eliminate discrepancies
  - if users have reprocessed a record, moving it's status forward again, then the fix will skip
  - will also update the datetime fields of the record based on the corresponding status change logs

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] in OMS on a clean store, add a inbound shipment with some stock of itemA and verify it
- [ ] sync
- [ ] delete your OMS db
- [ ] in OG revert the status of the invoice back to "new" or "allocated"
- [ ] reinitialise your OMS site
- [ ] The invoice is updated back to "verified"
- [ ] Ledger is nice
- [ ] system_log reports the applied ledger fix

Here is a 4D script that can revert the status of the last invoice added to the database (incl via sync)

```4dm
var $eInvoice : cs.transactEntity
var $esInvoices : cs.transactSelection
$esInvoices:=ds.transact.all()
For each ($eInvoice; $esInvoices.slice(-1))
	$eInvoice.status:="nw"
	$eInvoice.confirm_date:=Null
	$eInvoice.confirm_time:=Null
	$eInvoice.ship_date:=Null
	$eInvoice.arrival_date_estimated:=Null
	$eInvoice.arrival_date_actual:=Null
	$eInvoice.om_allocated_datetime:=Null
	$eInvoice.om_picked_datetime:=Null
	$eInvoice.om_shipped_datetime:=Null
	$eInvoice.om_delivered_datetime:=Null
	$eInvoice.om_verified_datetime:=Null
	$eInvoice.om_status:="NEW"
	$eInvoice.save()
End for each 
```

# 📃 Documentation

Great question...

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

