### PR TITLE
8918 Not all batches show up when creating a stocktake for an item

### DIFF
--- a/client/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -228,9 +228,7 @@ const DataTableComponent = <T extends RecordWithId>({
     const testIsBottom =
       scrollHeight - Math.ceil(scrollTop) - clientHeight < 50;
 
-    console.log('testIsBottom', testIsBottom);
     setIsBottom(testIsBottom);
-    console.log('isBottom', isBottom);
   };
 
   if (isLoading) return <BasicSpinner />;

--- a/client/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -221,15 +221,12 @@ const DataTableComponent = <T extends RecordWithId>({
   const [isBottom, setIsBottom] = useState(false);
 
   const handleBottom = (e: React.UIEvent<HTMLDivElement, UIEvent>) => {
-    console.log('height:', e.target.scrollHeight);
-    console.log('top', e.target.scrollTop);
-    console.log('clientheight', e.target.clientHeight);
+    const scrollHeight = (e.target as HTMLElement).scrollHeight;
+    const scrollTop = (e.target as HTMLElement).scrollTop;
+    const clientHeight = (e.target as HTMLElement).clientHeight;
 
     const testIsBottom =
-      e.target.scrollHeight -
-        Math.ceil(e.target.scrollTop) -
-        e.target.clientHeight <
-      50;
+      scrollHeight - Math.ceil(scrollTop) - clientHeight < 50;
 
     console.log('testIsBottom', testIsBottom);
     setIsBottom(testIsBottom);
@@ -339,7 +336,7 @@ const DataTableComponent = <T extends RecordWithId>({
             width: '100%',
             height: '75px',
             background:
-              'linear-gradient(to bottom, transparent, rgba(13, 255, 0, 0.9))',
+              'linear-gradient(to bottom, transparent, rgba(255, 255, 255, 0.9))',
             pointerEvents: 'none', // Ensure it doesn't block any interactions
           }}
         />

--- a/client/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -157,6 +157,7 @@ const DataTableComponent = <T extends RecordWithId>({
   additionalRows,
   width = '100%',
   rowLinkBuilder,
+  gradientBottom,
 }: TableProps<T>): JSX.Element => {
   const t = useTranslation();
   const { setRows, setDisabledRows, setFocus } = useTableStore();
@@ -217,6 +218,24 @@ const DataTableComponent = <T extends RecordWithId>({
 
   const ref = useRef<HTMLDivElement>(null);
 
+  const [isBottom, setIsBottom] = useState(false);
+
+  const handleBottom = (e: React.UIEvent<HTMLDivElement, UIEvent>) => {
+    console.log('height:', e.target.scrollHeight);
+    console.log('top', e.target.scrollTop);
+    console.log('clientheight', e.target.clientHeight);
+
+    const testIsBottom =
+      e.target.scrollHeight -
+        Math.ceil(e.target.scrollTop) -
+        e.target.clientHeight <
+      50;
+
+    console.log('testIsBottom', testIsBottom);
+    setIsBottom(testIsBottom);
+    console.log('isBottom', isBottom);
+  };
+
   if (isLoading) return <BasicSpinner />;
 
   if (isError) {
@@ -251,6 +270,7 @@ const DataTableComponent = <T extends RecordWithId>({
         overflowY: 'auto',
         width,
       }}
+      onScroll={event => handleBottom(event)}
     >
       <MuiTable style={{ borderCollapse: 'separate' }}>
         <TableHead
@@ -309,6 +329,22 @@ const DataTableComponent = <T extends RecordWithId>({
           />
         </TableBody>
       </MuiTable>
+
+      {gradientBottom && !isBottom && (
+        <Box
+          sx={{
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            width: '100%',
+            height: '75px',
+            background:
+              'linear-gradient(to bottom, transparent, rgba(13, 255, 0, 0.9))',
+            pointerEvents: 'none', // Ensure it doesn't block any interactions
+          }}
+        />
+      )}
+
       <Box
         sx={{
           flex: 0,

--- a/client/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -256,75 +256,101 @@ const DataTableComponent = <T extends RecordWithId>({
   }
 
   return (
-    <TableContainer
-      ref={ref}
+    <Box
       sx={{
         display: 'flex',
         flexDirection: 'column',
         overflowX,
         overflowY: 'auto',
+        position: 'relative', // Ensure the MoreContent gradient overlay can be positioned relative to the container
         width,
       }}
-      onScroll={event => handleBottom(event)}
     >
-      <MuiTable style={{ borderCollapse: 'separate' }}>
-        <TableHead
+      <TableContainer ref={ref} onScroll={event => handleBottom(event)}>
+        <MuiTable style={{ borderCollapse: 'separate' }}>
+          <TableHead
+            sx={{
+              backgroundColor: 'background.white',
+              position: 'sticky',
+              top: 0,
+              zIndex: 'tableHeader',
+              boxShadow: dense ? null : theme => theme.shadows[2],
+            }}
+          >
+            <HeaderRow dense={dense} sx={headerSx}>
+              {columnsToDisplay.map(column => (
+                <HeaderCell
+                  dense={dense}
+                  column={column}
+                  key={String(column.key)}
+                  isSticky={column.isSticky}
+                  stickyPosition={stickyColumnPositions.get(column.key) ?? 0}
+                />
+              ))}
+              {!!enableColumnSelection && (
+                <TableCell
+                  role="columnheader"
+                  padding={'none'}
+                  sx={{
+                    backgroundColor: 'transparent',
+                    borderBottom: '0px',
+                    width: 30,
+                  }}
+                >
+                  <ColumnPicker
+                    columns={columns}
+                    columnDisplayState={columnDisplayState}
+                    toggleColumn={toggleColumn}
+                    showAllColumns={showAllColumns}
+                  />
+                </TableCell>
+              )}
+            </HeaderRow>
+          </TableHead>
+          <TableBody>
+            <RenderRows
+              mRef={ref}
+              data={data}
+              ExpandContent={ExpandContent}
+              columnsToDisplay={columnsToDisplay}
+              onRowClick={onRowClick}
+              dense={dense}
+              clickFocusedRow={clickFocusedRow}
+              generateRowTooltip={generateRowTooltip}
+              isRowAnimated={isRowAnimated}
+              additionalRows={additionalRows}
+              rowLinkBuilder={rowLinkBuilder}
+              stickyColumnPositions={stickyColumnPositions}
+            />
+          </TableBody>
+        </MuiTable>
+
+        <Box
           sx={{
-            backgroundColor: 'background.white',
+            flex: 0,
+            display: 'flex',
+            flexDirection: 'column',
             position: 'sticky',
-            top: 0,
-            zIndex: 'tableHeader',
-            boxShadow: dense ? null : theme => theme.shadows[2],
+            left: 0,
+            insetBlockEnd: 0,
+            backgroundColor: 'white',
+            justifyContent: 'flex-end',
+            zIndex: 100,
           }}
         >
-          <HeaderRow dense={dense} sx={headerSx}>
-            {columnsToDisplay.map(column => (
-              <HeaderCell
-                dense={dense}
-                column={column}
-                key={String(column.key)}
-                isSticky={column.isSticky}
-                stickyPosition={stickyColumnPositions.get(column.key) ?? 0}
-              />
-            ))}
-            {!!enableColumnSelection && (
-              <TableCell
-                role="columnheader"
-                padding={'none'}
-                sx={{
-                  backgroundColor: 'transparent',
-                  borderBottom: '0px',
-                  width: 30,
-                }}
-              >
-                <ColumnPicker
-                  columns={columns}
-                  columnDisplayState={columnDisplayState}
-                  toggleColumn={toggleColumn}
-                  showAllColumns={showAllColumns}
-                />
-              </TableCell>
-            )}
-          </HeaderRow>
-        </TableHead>
-        <TableBody>
-          <RenderRows
-            mRef={ref}
-            data={data}
-            ExpandContent={ExpandContent}
-            columnsToDisplay={columnsToDisplay}
-            onRowClick={onRowClick}
-            dense={dense}
-            clickFocusedRow={clickFocusedRow}
-            generateRowTooltip={generateRowTooltip}
-            isRowAnimated={isRowAnimated}
-            additionalRows={additionalRows}
-            rowLinkBuilder={rowLinkBuilder}
-            stickyColumnPositions={stickyColumnPositions}
-          />
-        </TableBody>
-      </MuiTable>
+          {pagination && onChangePage && (
+            <PaginationRow
+              page={pagination.page}
+              offset={pagination.offset}
+              first={pagination.first}
+              total={pagination.total ?? 0}
+              onChange={onChangePage}
+            />
+          )}
+        </Box>
+      </TableContainer>
 
+      {/* Show a gradient at the bottom of the table if there is more content to scroll to */}
       {gradientBottom && !isBottom && (
         <Box
           sx={{
@@ -339,31 +365,7 @@ const DataTableComponent = <T extends RecordWithId>({
           }}
         />
       )}
-
-      <Box
-        sx={{
-          flex: 0,
-          display: 'flex',
-          flexDirection: 'column',
-          position: 'sticky',
-          left: 0,
-          insetBlockEnd: 0,
-          backgroundColor: 'white',
-          justifyContent: 'flex-end',
-          zIndex: 100,
-        }}
-      >
-        {pagination && onChangePage && (
-          <PaginationRow
-            page={pagination.page}
-            offset={pagination.offset}
-            first={pagination.first}
-            total={pagination.total ?? 0}
-            onChange={onChangePage}
-          />
-        )}
-      </Box>
-    </TableContainer>
+    </Box>
   );
 };
 

--- a/client/packages/common/src/ui/layout/tables/types.ts
+++ b/client/packages/common/src/ui/layout/tables/types.ts
@@ -16,6 +16,7 @@ export interface QueryResponse<T> {
 }
 
 export interface TableProps<T extends RecordWithId> {
+  gradientBottom?: boolean;
   children?: ReactNode;
   columns: Column<T>[];
   data?: T[];

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -23,7 +23,6 @@ import {
   PreferenceKey,
   useAuthContext,
   StoreModeNodeType,
-  TableContainer,
 } from '@openmsupply-client/common';
 import { DraftStocktakeLine } from './utils';
 import {
@@ -325,26 +324,15 @@ export const BatchTable = ({
   ]);
 
   return (
-    <TableContainer
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        overflowX: 'unset',
-        overflowY: 'auto',
-        width: '100%',
-        position: 'relative', // Ensure the Box can be positioned relative to the container
-      }}
-    >
-      <DataTable
-        id="stocktake-batch"
-        isDisabled={isDisabled}
-        columns={columns}
-        data={batches}
-        noDataMessage={t('label.add-new-line')}
-        dense
-        gradientBottom={true}
-      />
-    </TableContainer>
+    <DataTable
+      id="stocktake-batch"
+      isDisabled={isDisabled}
+      columns={columns}
+      data={batches}
+      noDataMessage={t('label.add-new-line')}
+      dense
+      gradientBottom={true}
+    />
   );
 };
 
@@ -379,26 +367,15 @@ export const PricingTable = ({
   ]);
 
   return (
-    <TableContainer
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        overflowX: 'unset',
-        overflowY: 'auto',
-        width: '100%',
-        position: 'relative', // Ensure the Box can be positioned relative to the container
-      }}
-    >
-      <DataTable
-        id="stocktake-pricing"
-        isDisabled={isDisabled}
-        columns={columns}
-        data={batches}
-        noDataMessage={t('label.add-new-line')}
-        dense
-        gradientBottom={true}
-      />
-    </TableContainer>
+    <DataTable
+      id="stocktake-pricing"
+      isDisabled={isDisabled}
+      columns={columns}
+      data={batches}
+      noDataMessage={t('label.add-new-line')}
+      dense
+      gradientBottom={true}
+    />
   );
 };
 
@@ -463,25 +440,14 @@ export const LocationTable = ({
   const columns = useColumns(columnDefinitions, {}, [columnDefinitions]);
 
   return (
-    <TableContainer
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        overflowX: 'unset',
-        overflowY: 'auto',
-        width: '100%',
-        position: 'relative', // Ensure the Box can be positioned relative to the container
-      }}
-    >
-      <DataTable
-        id="stocktake-location"
-        isDisabled={isDisabled}
-        columns={columns}
-        data={batches}
-        noDataMessage={t('label.add-new-line')}
-        dense
-        gradientBottom={true}
-      />
-    </TableContainer>
+    <DataTable
+      id="stocktake-location"
+      isDisabled={isDisabled}
+      columns={columns}
+      data={batches}
+      noDataMessage={t('label.add-new-line')}
+      dense
+      gradientBottom={true}
+    />
   );
 };

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -326,26 +326,15 @@ export const BatchTable = ({
   ]);
 
   return (
-    <TableContainer
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        overflowX: 'unset',
-        overflowY: 'auto',
-        width: '100%',
-        position: 'relative', // Ensure the Box can be positioned relative to the container
-      }}
-    >
-      <DataTable
-        id="stocktake-batch"
-        isDisabled={isDisabled}
-        columns={columns}
-        data={batches}
-        noDataMessage={t('label.add-new-line')}
-        dense
-        gradientBottom={true}
-      />
-    </TableContainer>
+    <DataTable
+      id="stocktake-batch"
+      isDisabled={isDisabled}
+      columns={columns}
+      data={batches}
+      noDataMessage={t('label.add-new-line')}
+      dense
+      gradientBottom={true}
+    />
   );
 };
 

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -380,14 +380,26 @@ export const PricingTable = ({
   ]);
 
   return (
-    <DataTable
-      id="stocktake-pricing"
-      isDisabled={isDisabled}
-      columns={columns}
-      data={batches}
-      noDataMessage={t('label.add-new-line')}
-      dense
-    />
+    <TableContainer
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        overflowX: 'unset',
+        overflowY: 'auto',
+        width: '100%',
+        position: 'relative', // Ensure the Box can be positioned relative to the container
+      }}
+    >
+      <DataTable
+        id="stocktake-pricing"
+        isDisabled={isDisabled}
+        columns={columns}
+        data={batches}
+        noDataMessage={t('label.add-new-line')}
+        dense
+        gradientBottom={true}
+      />
+    </TableContainer>
   );
 };
 
@@ -452,7 +464,16 @@ export const LocationTable = ({
   const columns = useColumns(columnDefinitions, {}, [columnDefinitions]);
 
   return (
-    <Box display="flex" flexDirection="column" width="100%">
+    <TableContainer
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        overflowX: 'unset',
+        overflowY: 'auto',
+        width: '100%',
+        position: 'relative', // Ensure the Box can be positioned relative to the container
+      }}
+    >
       <DataTable
         id="stocktake-location"
         isDisabled={isDisabled}
@@ -460,7 +481,8 @@ export const LocationTable = ({
         data={batches}
         noDataMessage={t('label.add-new-line')}
         dense
+        gradientBottom={true}
       />
-    </Box>
+    </TableContainer>
   );
 };

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -205,6 +205,7 @@ export const BatchTable = ({
         },
       ],
     ];
+
     if (itemVariantsEnabled) {
       columnDefinitions.push({
         key: 'itemVariantId',
@@ -234,6 +235,7 @@ export const BatchTable = ({
         setter: patch => update({ ...patch }),
       });
     }
+
     columnDefinitions.push(
       getColumnLookupWithOverrides('packSize', {
         Cell: PackSizeEntryCell<DraftStocktakeLine>,
@@ -322,6 +324,7 @@ export const BatchTable = ({
   const columns = useColumns<DraftStocktakeLine>(columnDefinitions, {}, [
     columnDefinitions,
   ]);
+
   return (
     <TableContainer
       sx={{
@@ -340,19 +343,7 @@ export const BatchTable = ({
         data={batches}
         noDataMessage={t('label.add-new-line')}
         dense
-      />
-      {/* Gradient Bottom (Overlapping the final row) */}
-      <Box
-        sx={{
-          position: 'absolute',
-          bottom: 0, // Align to the top of the container
-          left: 0,
-          width: '100%',
-          height: '75px',
-          background:
-            'linear-gradient(to bottom, transparent, rgba(255, 255, 255, 0.9))',
-          pointerEvents: 'none', // Ensure it doesn't block any interactions
-        }}
+        gradientBottom={true}
       />
     </TableContainer>
   );

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -24,6 +24,7 @@ import {
   Box,
   useAuthContext,
   StoreModeNodeType,
+  TableContainer,
 } from '@openmsupply-client/common';
 import { DraftStocktakeLine } from './utils';
 import {
@@ -322,14 +323,38 @@ export const BatchTable = ({
     columnDefinitions,
   ]);
   return (
-    <DataTable
-      id="stocktake-batch"
-      isDisabled={isDisabled}
-      columns={columns}
-      data={batches}
-      noDataMessage={t('label.add-new-line')}
-      dense
-    />
+    <TableContainer
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        overflowX: 'unset',
+        overflowY: 'auto',
+        width: '100%',
+        position: 'relative', // Ensure the Box can be positioned relative to the container
+      }}
+    >
+      <DataTable
+        id="stocktake-batch"
+        isDisabled={isDisabled}
+        columns={columns}
+        data={batches}
+        noDataMessage={t('label.add-new-line')}
+        dense
+      />
+      {/* Gradient Bottom (Overlapping the final row) */}
+      <Box
+        sx={{
+          position: 'absolute',
+          bottom: 0, // Align to the top of the container
+          left: 0,
+          width: '100%',
+          height: '75px',
+          background:
+            'linear-gradient(to bottom, transparent, rgba(255, 255, 255, 0.9))',
+          pointerEvents: 'none', // Ensure it doesn't block any interactions
+        }}
+      />
+    </TableContainer>
   );
 };
 

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -21,7 +21,6 @@ import {
   getReasonOptionTypes,
   usePreference,
   PreferenceKey,
-  Box,
   useAuthContext,
   StoreModeNodeType,
   TableContainer,

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -326,15 +326,26 @@ export const BatchTable = ({
   ]);
 
   return (
-    <DataTable
-      id="stocktake-batch"
-      isDisabled={isDisabled}
-      columns={columns}
-      data={batches}
-      noDataMessage={t('label.add-new-line')}
-      dense
-      gradientBottom={true}
-    />
+    <TableContainer
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        overflowX: 'unset',
+        overflowY: 'auto',
+        width: '100%',
+        position: 'relative', // Ensure the Box can be positioned relative to the container
+      }}
+    >
+      <DataTable
+        id="stocktake-batch"
+        isDisabled={isDisabled}
+        columns={columns}
+        data={batches}
+        noDataMessage={t('label.add-new-line')}
+        dense
+        gradientBottom={true}
+      />
+    </TableContainer>
   );
 };
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8918 

# 👩🏻‍💻 What does this PR do?

Adds a gradient bottom to the bottom of batch table so you can see that there is more stuff down there if you scroll.

<img width="840" height="324" alt="Screenshot 2025-08-28 at 10-01-19 Stocktakes Open mSupply" src="https://github.com/user-attachments/assets/68fd732b-14c5-40e7-bf6c-bb4c79948669" />

## 💌 Any notes for the reviewer?

Maybe deploy this fix elsewhere? (See discussion in original issue.)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Stock takes > click the button to create a new stock take > tick the box to make it a blank stock take.
- [ ] In the stock take you created, click add item.
- [ ] Select an item.
- [ ] Check the list of batches that is displayed has a gradient bottom.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

