### PR TITLE
Change datepicker to using theme.palette.background.menu styling, similar to other related components

### DIFF
--- a/client/packages/common/src/ui/components/inputs/DateTimePickers/styles.ts
+++ b/client/packages/common/src/ui/components/inputs/DateTimePickers/styles.ts
@@ -10,7 +10,7 @@ export const getTextFieldSx = (
   border: 'none',
   color: 'gray',
   '& .MuiPickersOutlinedInput-root': {
-    backgroundColor: theme.palette.background.drawer,
+    backgroundColor: theme.palette.background.menu,
     height: '36px',
     marginTop: hasLabel ? '16px' : 0,
     padding: '0 8px',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9076

# 👩🏻‍💻 What does this PR do?

See PR for the change, but main point is to separate it from the drawer styling which is more likely to change.



## 💌 Any notes for the reviewer?

This is consistent with NumericTextInput which uses this logic
```
             sx: {
                  backgroundColor: props.disabled
                    ? 'background.toolbar'
                    : 'background.menu',
                },
```

I think a better solution is probably to create a new theme entriesd for disabledInput and enabledInput or something similar. We'd then need to go through all the places we've used menu and other similar colours to retrofit, felt like too much for now, a quick fix?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Add custom theme
 ```
{
    "palette": {
        "drawerDivider": "#C60C30",
        "primary": {
            "main": "#C60C30",
            "light": "#f3395d",
            "dark": "#77071d",
            "contrastText": "#fff"
        },
        "secondary": {
            "main": "#002664",
            "light": "#236E00",
            "dark": "#001b46",
            "contrastText": "#fff"
        },
        "background": {
            "drawer": "#34495e"
        }
    },
    "mixins": {
        "drawer": {
            "iconColor": "#C60C30",
            "selectedBackgroundColor": "rgba(255,255,255,0.2)",
            "textColor": "#FECB00"
        },
        "gradient": {
            "primary": "linear-gradient(156deg, #C60C30 4%, #002664 96%)"
        }
    },
    "typography": {
        "login": {
            "color": "#fbde4a"
        }
    }
}```

Make sure dateinputs are readable.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [X] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

