### PR TITLE
Show doses values in internal order detail view

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/columns.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/columns.tsx
@@ -12,10 +12,13 @@ import {
   usePluginProvider,
   UNDEFINED_STRING_VALUE,
   usePreferences,
+  UnitsAndMaybeDoses,
+  CellProps,
 } from '@openmsupply-client/common';
 import { useRequest } from '../api';
 import { PackQuantityCell } from '@openmsupply-client/system';
 import { useRequestRequisitionLineErrorContext } from '../context';
+import React from 'react';
 
 export const useRequestColumns = () => {
   const { maxMonthsOfStock, programName } = useRequest.document.fields([
@@ -95,7 +98,7 @@ export const useRequestColumns = () => {
       description: 'description.available-soh',
       align: ColumnAlign.Right,
       width: 200,
-      Cell: PackQuantityCell,
+      Cell: UnitsAndMaybeDosesCell,
       accessor: ({ rowData }) => rowData.itemStats.availableStockOnHand,
       getSortValue: rowData => rowData.itemStats.availableStockOnHand,
     },
@@ -104,7 +107,7 @@ export const useRequestColumns = () => {
       {
         width: 150,
         align: ColumnAlign.Right,
-        Cell: PackQuantityCell,
+        Cell: UnitsAndMaybeDosesCell,
         accessor: ({ rowData }) => rowData.itemStats.averageMonthlyConsumption,
         getSortValue: rowData => rowData.itemStats.averageMonthlyConsumption,
       },
@@ -127,7 +130,7 @@ export const useRequestColumns = () => {
       description: 'description.target-stock',
       align: ColumnAlign.Right,
       width: 150,
-      Cell: PackQuantityCell,
+      Cell: UnitsAndMaybeDosesCell,
       accessor: ({ rowData }) =>
         rowData.itemStats.averageMonthlyConsumption * maxMonthsOfStock,
       getSortValue: rowData =>
@@ -140,7 +143,7 @@ export const useRequestColumns = () => {
       description: 'description.forecast-quantity',
       align: ColumnAlign.Right,
       width: 200,
-      Cell: PackQuantityCell,
+      Cell: UnitsAndMaybeDosesCell,
       getSortValue: rowData => rowData.suggestedQuantity,
     },
     {
@@ -148,7 +151,7 @@ export const useRequestColumns = () => {
       label: 'label.requested',
       align: ColumnAlign.Right,
       width: 150,
-      Cell: PackQuantityCell,
+      Cell: UnitsAndMaybeDosesCell,
       getSortValue: rowData => rowData.requestedQuantity,
     }
   );
@@ -163,7 +166,7 @@ export const useRequestColumns = () => {
         align: ColumnAlign.Right,
         sortable: false,
         description: 'description.initial-stock-on-hand',
-        Cell: PackQuantityCell,
+        Cell: UnitsAndMaybeDosesCell,
         accessor: ({ rowData }) => rowData.initialStockOnHandUnits,
       },
       {
@@ -172,7 +175,7 @@ export const useRequestColumns = () => {
         width: 100,
         align: ColumnAlign.Right,
         sortable: false,
-        Cell: PackQuantityCell,
+        Cell: UnitsAndMaybeDosesCell,
         accessor: ({ rowData }) => rowData.incomingUnits,
       },
       {
@@ -181,7 +184,7 @@ export const useRequestColumns = () => {
         width: 100,
         align: ColumnAlign.Right,
         sortable: false,
-        Cell: PackQuantityCell,
+        Cell: UnitsAndMaybeDosesCell,
         accessor: ({ rowData }) => rowData.outgoingUnits,
       },
       {
@@ -190,7 +193,7 @@ export const useRequestColumns = () => {
         width: 100,
         align: ColumnAlign.Right,
         sortable: false,
-        Cell: PackQuantityCell,
+        Cell: UnitsAndMaybeDosesCell,
         accessor: ({ rowData }) => rowData.lossInUnits,
       },
       {
@@ -199,7 +202,7 @@ export const useRequestColumns = () => {
         width: 100,
         align: ColumnAlign.Right,
         sortable: false,
-        Cell: PackQuantityCell,
+        Cell: UnitsAndMaybeDosesCell,
         accessor: ({ rowData }) => rowData.additionInUnits,
       },
       {
@@ -208,7 +211,7 @@ export const useRequestColumns = () => {
         width: 100,
         align: ColumnAlign.Right,
         sortable: false,
-        Cell: PackQuantityCell,
+        Cell: UnitsAndMaybeDosesCell,
         accessor: ({ rowData }) => rowData.expiringUnits,
       },
       {
@@ -264,4 +267,19 @@ export const useRequestColumns = () => {
   );
 
   return { columns, sortBy, onChangeSortBy: updateSortQuery };
+};
+
+const UnitsAndMaybeDosesCell = (props: CellProps<RequestLineFragment>) => {
+  const { rowData, column } = props;
+  const units = Number(column.accessor({ rowData })) ?? 0;
+  const { isVaccine, doses } = rowData.item;
+
+  return (
+    <UnitsAndMaybeDoses
+      numberCellProps={props}
+      units={units}
+      isVaccine={isVaccine}
+      dosesPerUnit={doses}
+    />
+  );
 };


### PR DESCRIPTION
Fixes #9003

# 👩🏻‍💻 What does this PR do?

Changes cell types so that they display quantities in both doses and units when the appropriate pref is turned on.

## 💌 Any notes for the reviewer?

Maybe worth putting the cell type into a shared component - will write a refactor issue for this.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Turn on Manage vaccines in doses pref
- [ ] Go to internal orders
- [ ] Add a vaccine item to an internal order
- [ ] Check the following columns display values in both units and doses:
- [ ] Available SOH
- [ ] AMC
- [ ] Target stock
- [ ] Suggested Quantity
- [ ] Requested

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

