### PR TITLE
9020 prescription keyboard shortcuts

### DIFF
--- a/client/packages/invoices/src/Prescriptions/DetailView/AppBarButton.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/AppBarButton.tsx
@@ -11,6 +11,8 @@ import {
   SplitButton,
   PrinterIcon,
   SplitButtonOption,
+  useRegisterActions,
+  EnvUtils,
 } from '@openmsupply-client/common';
 import { usePrescription } from '../api';
 import { Draft } from '../../StockOut';
@@ -58,6 +60,21 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   const [selected, setSelected] = useState<SplitButtonOption<string>>(
     options[1]!
   );
+
+  const altOrOptionString = EnvUtils.os === 'Mac OS' ? 'Option' : 'Alt';
+
+  useRegisterActions([
+    {
+      id: 'add',
+      name: `${t('button.print')} (${altOrOptionString}+L)`,
+      shortcut: ['Alt+KeyL'],
+      perform: () => {
+        if (prescription) {
+          printPrescriptionLabels(prescription, prescription.lines.nodes);
+        }
+      },
+    },
+  ]);
 
   return (
     <AppBarButtonsPortal>

--- a/client/packages/invoices/src/Prescriptions/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/Footer/StatusChangeButton.tsx
@@ -10,6 +10,8 @@ import {
   InvoiceLineNodeType,
   useDisabledNotificationToast,
   useEditModal,
+  useRegisterActions,
+  EnvUtils,
 } from '@openmsupply-client/common';
 import {
   getNextPrescriptionStatus,
@@ -186,6 +188,17 @@ export const StatusChangeButton = () => {
     if (showPaymentWindow) return onOpen();
     return getConfirmation();
   };
+
+  const altOrOptionString = EnvUtils.os === 'Mac OS' ? 'Option' : 'Alt';
+
+  useRegisterActions([
+    {
+      id: 'add',
+      name: `${t('button.update-status')} (${altOrOptionString}+V)`,
+      shortcut: ['Alt+KeyV'],
+      perform: onStatusClick,
+    },
+  ]);
 
   if (!selectedOption) return null;
   if (isDisabled) return null;

--- a/client/packages/invoices/src/Prescriptions/LineEditView/NavBar.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/NavBar.tsx
@@ -8,7 +8,9 @@ import {
   ArrowRightIcon,
   Box,
   ButtonWithIcon,
+  EnvUtils,
   Typography,
+  useRegisterActions,
   useTranslation,
 } from '@openmsupply-client/common';
 import React from 'react';
@@ -35,7 +37,23 @@ export const NavBar = ({
   const totalCount =
     items.slice(-1)[0] === 'new' ? items.length - 1 : items.length;
 
+  const onClick = () => {
+    setItem(items[currentIndex + 1] ?? '');
+    scrollIntoView();
+  };
+
   const currentCount = currentIndex + 1;
+
+  const altOrOptionString = EnvUtils.os === 'Mac OS' ? 'Option' : 'Alt';
+
+  useRegisterActions([
+    {
+      id: 'next',
+      name: `${t('button.next')} (${altOrOptionString}+N)`,
+      shortcut: ['Alt+KeyN'],
+      perform: onClick,
+    },
+  ]);
 
   return (
     <Box
@@ -61,10 +79,7 @@ export const NavBar = ({
         label={t('button.next')}
         Icon={<ArrowRightIcon />}
         disabled={!hasNext}
-        onClick={() => {
-          setItem(items[currentIndex + 1] ?? '');
-          scrollIntoView();
-        }}
+        onClick={onClick}
       />
     </Box>
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9020 

# 👩🏻‍💻 What does this PR do?
Adds three keyboard shortcuts using the useRegfisterActions hook.

## 💌 Any notes for the reviewer?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] In OMS, go to the necessary parts of the app and confirm these work well:
 - [ ] `Alt + N` works from detail view, to add a new item. It should also work from line edit view - when viewing a saved line, `Alt + N` should add a new item to the prescription
 - [ ] From the detail view, `Alt + L` should print the prescription labels
 - [ ] From the detail view, `Alt + V` should verify the prescription (should still show confirmation modal, but can use enter key to confirm here

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: update users' list of keyboard shortcuts


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

