### PR TITLE
Add a separate palette colour option for inputs

### DIFF
--- a/client/packages/common/src/styles/theme.ts
+++ b/client/packages/common/src/styles/theme.ts
@@ -132,6 +132,10 @@ declare module '@mui/material/styles/createPalette' {
     success: string;
     row: string;
     group: string;
+    input: {
+      main: string;
+      disabled: string;
+    };
   }
 
   interface TypeForm {
@@ -231,6 +235,7 @@ export const themeOptions = {
       toolbar: '#fafafc',
       white: '#fff',
       success: 'rgb(237, 247, 237)',
+      input: { main: '#f2f2f5', disabled: '#fafafc' },
     },
     form: {
       field: '#555770',

--- a/client/packages/common/src/ui/components/buttons/standard/TextInputButton.tsx
+++ b/client/packages/common/src/ui/components/buttons/standard/TextInputButton.tsx
@@ -13,8 +13,8 @@ export const StyledTextInputButton = styled(MuiButton)(({
     color: theme.palette.gray.dark,
 
     backgroundColor: disabled
-      ? theme.palette.background.toolbar
-      : theme.palette.background.menu,
+      ? theme.palette.background.input.disabled
+      : theme.palette.background.input.main,
     height: '36px',
     justifyContent: 'space-between',
     '& .MuiButton-endIcon': {

--- a/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -56,8 +56,8 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
         maxWidth,
         backgroundColor: theme =>
           disabled
-            ? theme.palette.background.toolbar
-            : theme.palette.background.menu,
+            ? theme.palette.background.input.disabled
+            : theme.palette.background.input.main,
         '&:hover': {
           borderBottom: disabled ? 'none' : undefined,
         },

--- a/client/packages/common/src/ui/components/inputs/DateTimePickers/DateTimePickerInput/DateTimePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DateTimePickers/DateTimePickerInput/DateTimePickerInput.tsx
@@ -6,7 +6,6 @@ import {
   DateValidationError,
   PickersActionBarAction,
 } from '@mui/x-date-pickers';
-import { useAppTheme } from '@common/styles';
 import { Box, SxProps, Typography, useMediaQuery } from '@mui/material';
 import {
   DateUtils,
@@ -70,7 +69,6 @@ export const DateTimePickerInput = ({
   required?: boolean;
   textFieldSx?: SxProps;
 }) => {
-  const theme = useAppTheme();
   const [internalError, setInternalError] = useState<string | null>(null);
   const [value, setValue] = useBufferState<Date | null>(props.value ?? null);
   const [isInitialEntry, setIsInitialEntry] = useState(true);
@@ -128,11 +126,11 @@ export const DateTimePickerInput = ({
         }}
         label={label}
         slotProps={{
-          mobilePaper: { sx: getPaperSx(theme) },
-          desktopPaper: { sx: getPaperSx(theme) },
+          mobilePaper: { sx: getPaperSx() },
+          desktopPaper: { sx: getPaperSx() },
           actionBar: {
             actions: actions ?? ['clear', 'accept'],
-            sx: getActionBarSx(theme),
+            sx: getActionBarSx(),
           },
           textField: {
             onBlur: () => {
@@ -146,7 +144,7 @@ export const DateTimePickerInput = ({
             error: !!error || (!isInitialEntry && !!internalError),
             helperText: error || (!isInitialEntry ? (internalError ?? '') : ''),
             sx: {
-              ...getTextFieldSx(theme, !!label, !showTime, inputSx, width),
+              ...getTextFieldSx(!!label, !showTime, inputSx, width),
               width,
               minWidth: showTime ? 200 : undefined,
             },

--- a/client/packages/common/src/ui/components/inputs/DateTimePickers/styles.ts
+++ b/client/packages/common/src/ui/components/inputs/DateTimePickers/styles.ts
@@ -1,7 +1,6 @@
-import { SxProps, Theme } from '@mui/material';
+import { SxProps } from '@mui/material';
 
 export const getTextFieldSx = (
-  theme: Theme,
   hasLabel: boolean,
   dateOnly: boolean,
   inputSx?: SxProps,
@@ -10,7 +9,7 @@ export const getTextFieldSx = (
   border: 'none',
   color: 'gray',
   '& .MuiPickersOutlinedInput-root': {
-    backgroundColor: theme.palette.background.menu,
+    backgroundColor: 'background.input.main',
     height: '36px',
     marginTop: hasLabel ? '16px' : 0,
     padding: '0 8px',
@@ -19,7 +18,7 @@ export const getTextFieldSx = (
       '& .MuiPickersOutlinedInput-notchedOutline': {
         border: 'none',
         borderBottom: 'solid 2px',
-        borderColor: `${theme.palette.secondary.light}`,
+        borderColor: 'secondary.light',
         borderRadius: 0,
       },
     },
@@ -28,6 +27,9 @@ export const getTextFieldSx = (
         borderWidth: '2px',
         borderStyle: 'solid',
       },
+    },
+    '&.Mui-disabled': {
+      backgroundColor: 'background.input.disabled',
     },
     ...inputSx,
   },
@@ -53,20 +55,20 @@ export const getTextFieldSx = (
   },
 });
 
-export const getPaperSx = (theme: Theme) => ({
+export const getPaperSx = () => ({
   '& .Mui-selected': {
-    backgroundColor: `${theme.palette.secondary.main}!important`,
+    backgroundColor: 'secondary.main!important',
   },
   '& .Mui-selected:focus': {
-    backgroundColor: `${theme.palette.secondary.main}`,
+    backgroundColor: 'secondary.main',
   },
   '& .Mui-selected:hover': {
-    backgroundColor: `${theme.palette.secondary.main}`,
+    backgroundColor: 'secondary.main',
   },
 });
 
-export const getActionBarSx = (theme: Theme) => ({
+export const getActionBarSx = () => ({
   '& .MuiButton-root': {
-    color: `${theme.palette.secondary.main}`,
+    color: 'secondary.main',
   },
 });

--- a/client/packages/common/src/ui/components/inputs/SearchBar/SearchBar.tsx
+++ b/client/packages/common/src/ui/components/inputs/SearchBar/SearchBar.tsx
@@ -130,7 +130,7 @@ export const SearchBar = ({
                     },
                   }
                 : {}),
-              backgroundColor: theme => theme.palette.background.menu,
+              backgroundColor: theme => theme.palette.background.input.main,
             },
           },
         }}

--- a/client/packages/common/src/ui/components/inputs/Select/Select.tsx
+++ b/client/packages/common/src/ui/components/inputs/Select/Select.tsx
@@ -51,8 +51,8 @@ export const Select = React.forwardRef<HTMLDivElement, SelectProps>(
               color: 'secondary',
               sx: {
                 backgroundColor: props.disabled
-                  ? 'background.toolbar'
-                  : 'background.menu',
+                  ? 'background.input.disabled'
+                  : 'background.input.main',
                 borderRadius: 2,
                 padding: '4px 8px',
               },

--- a/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
@@ -83,8 +83,8 @@ export const BasicTextInput = React.forwardRef<
                   error ? `2px solid ${theme.palette.error.main}` : 'none',
                 backgroundColor: theme =>
                   props.disabled
-                    ? theme.palette.background.toolbar
-                    : theme.palette.background.menu,
+                    ? theme.palette.background.input.disabled
+                    : theme.palette.background.input.main,
                 borderRadius: 2,
                 padding: 0.5,
                 // Ignoring below, see https://github.com/mui/material-ui/issues/45041

--- a/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/NumericTextInput.tsx
@@ -311,8 +311,8 @@ export const NumericTextInput = React.forwardRef<
               htmlInput: {
                 sx: {
                   backgroundColor: props.disabled
-                    ? 'background.toolbar'
-                    : 'background.menu',
+                    ? 'background.input.disabled'
+                    : 'background.input.main',
                 },
               },
             },

--- a/client/packages/host/src/Help/ContactForm.tsx
+++ b/client/packages/host/src/Help/ContactForm.tsx
@@ -100,7 +100,7 @@ export const ContactForm = () => {
             slotProps={{
               input: {
                 sx: {
-                  backgroundColor: 'background.menu',
+                  backgroundColor: 'background.input.main',
                 },
               },
             }}

--- a/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
@@ -100,8 +100,8 @@ export const Toolbar = ({ simplifiedTabletView }: ToolbarProps) => {
                         sx: {
                           backgroundColor: theme =>
                             isDisabled
-                              ? theme.palette.background.toolbar
-                              : theme.palette.background.menu,
+                              ? theme.palette.background.input.disabled
+                              : theme.palette.background.input.main,
                         },
                       },
                     }}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Heh cheeky PR

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Input styling has bothered me for a while, why is it "menu" when enabled and "toolbar" when disabled??

Also fixes date field background colour not changing when disabled

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Check inputs throughout the app, in enabled and disabled state, they're still the right colour

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

