### PR TITLE
Retain program in selection

### DIFF
--- a/client/packages/programs/src/JsonForms/components/ProgramSearch.tsx
+++ b/client/packages/programs/src/JsonForms/components/ProgramSearch.tsx
@@ -101,10 +101,6 @@ const UIComponent = (props: ControlProps) => {
           optionKey="name"
           onChange={(_, newVal) => {
             if (!newVal) return;
-            if (newVal?.id === 'AllProgramsSelector') {
-              onChange(null);
-              return;
-            }
             newVal &&
               newVal.id !== program?.id &&
               onChange(newVal as ProgramFragment);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9017

# 👩🏻‍💻 What does this PR do?
We want to retain `All programs` in the autocomplete when the user selects it

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Upsert CIV reports
- [ ] Click on any report with the program filter
- [ ] Click `All program` option
- [ ] See that it is retained
- [ ] Note this doesn't retain when you go back into the filters... I think should be obvious that it's all program.. does it need to be set??

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

