### PR TITLE
9151 Purchase Orders list view part 2

### DIFF
--- a/client/packages/purchasing/src/purchase_order/ListView/ListView.tsx
+++ b/client/packages/purchasing/src/purchase_order/ListView/ListView.tsx
@@ -19,11 +19,7 @@ import { PurchaseOrderRowFragment } from '../api/operations.generated';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
 import { Footer } from './Footer';
-import {
-  DeliveryStatus,
-  getDeliveryStatusTranslator,
-  getPurchaseOrderStatusTranslator,
-} from '../../utils';
+import { getPurchaseOrderStatusTranslator } from '../../utils';
 
 const ListView: FC = () => {
   const t = useTranslation();
@@ -117,26 +113,10 @@ const ListView: FC = () => {
         },
       ],
       {
-        key: 'deliveryStatus',
-        label: 'label.delivery-status',
-        accessor: ({}) => DeliveryStatus.NotDelivered, // Todo: Replace with actual delivery status calculation once we have goods received data (add rowData back)
-        formatter: status =>
-          getDeliveryStatusTranslator(t)(status as DeliveryStatus),
-      },
-      {
         key: 'targetMonths',
         label: 'label.target-months',
         accessor: ({ rowData }) => rowData.targetMonths,
         Cell: NumberCell,
-      },
-      {
-        key: 'deliveryDatetime',
-        label: 'label.delivered',
-        accessor: ({ rowData: _ }) => '', // rowData.deliveredDatetime,
-        // format: ColumnFormat.Date,
-        // accessor: ({ rowData }) => rowData.deliveredDatetime,
-        // TODO: Figure out how to get the delivery date from the goods received data
-        sortable: true,
       },
       {
         key: 'lines',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9151 

# 👩🏻‍💻 What does this PR do?


Removes `Delivered` and `Delivery status` columns


<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Purchase Orders
- [ ] See `Delivered` and `Delivery status` columns are no longer there

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

