### PR TITLE
9040 requisition does not show the right mos of the customer as displayed in the internal order

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ContentLayout.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ContentLayout.tsx
@@ -61,7 +61,7 @@ export const NumInputRow = ({
     defaultPackSize,
     value
   );
-  const roundedValue = NumUtils.round(valueInUnitsOrPacks, 2);
+  const roundedValue = NumUtils.round(valueInUnitsOrPacks);
 
   const endAdornment = useEndAdornment(
     t,

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -289,7 +289,7 @@ export const ResponseLineEdit = ({
                 pt: 1,
               },
             })}
-            {numericInput('label.months-of-stock', mos, {
+            {numericInput('label.months-of-stock', mos(), {
               disabledOverride: true,
               endAdornmentOverride: t('label.months'),
               sx: {

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/utils.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/utils.ts
@@ -9,10 +9,21 @@ export const useStockCalculations = (draft?: DraftResponseLine | null) => {
       (draft?.lossInUnits ?? 0) + (draft?.outgoingUnits ?? 0);
     const available =
       (draft?.initialStockOnHandUnits ?? 0) + incomingStock - outgoingStock;
-    const mos =
-      draft?.averageMonthlyConsumption !== 0
-        ? available / (draft?.averageMonthlyConsumption ?? 1)
-        : 0;
+    const mos = () => {
+      if (draft?.linkedRequisitionLine) {
+        return draft.linkedRequisitionLine.itemStats
+          .availableMonthsOfStockOnHand;
+      }
+
+      if (
+        draft?.averageMonthlyConsumption &&
+        draft.averageMonthlyConsumption > 0
+      ) {
+        return available / draft.averageMonthlyConsumption;
+      }
+
+      return 0;
+    };
 
     return {
       available,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9040

# 👩🏻‍💻 What does this PR do?
If the requisition has been created by an Internal Order, then use the MOS from the internal order, else calculate it. Also round to 0dp to match how Internal Order is rounding.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an Internal Order with an item that has usage
- [ ] Send to Store B
- [ ] Go to Store B
- [ ] Go to the corresponding Requisition
- [ ] Click on item and see that MOS is the same as the Internal Order

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

