### PR TITLE
#9175 Persist table settings in local storage

### DIFF
--- a/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
@@ -9,19 +9,23 @@ import {
   CheckboxEmptyIcon,
   CheckboxIndeterminateIcon,
 } from '@common/icons';
+import { useTableLocalStorage } from './useTableLocalStorage';
+import { useEffect } from 'react';
 
-interface NonPaginatedTableConfig<T extends MRT_RowData>
+export interface BaseMRTableConfig<T extends MRT_RowData>
   extends MRT_TableOptions<T> {
+  tableId: string; // key for local storage
   onRowClick?: (row: T) => void;
   isLoading: boolean;
 }
 
 export const useBaseMaterialTable = <T extends MRT_RowData>({
+  tableId,
   isLoading,
   onRowClick,
   state,
   ...tableOptions
-}: NonPaginatedTableConfig<T>) => {
+}: BaseMRTableConfig<T>) => {
   const table = useMaterialReactTable<T>({
     enablePagination: false,
     enableColumnResizing: true,
@@ -33,6 +37,26 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
     // Disable bottom footer - use OMS custom action footer instead
     enableBottomToolbar: false,
 
+    // onColumnPinningChange: columnPinning => {
+    //   console.log('Column pinning changed:', columnPinning());
+    // },
+    // onDensityChange: density => {
+    //   console.log('Density changed:', density);
+    //   updateTableState('density', density);
+    // },
+    // onColumnOrderChange: columns => {
+    //   updateTableState('columnOrder', columns);
+    //   console.log('Column order changed:', columns);
+    // },
+    // onColumnSizingChange: widths => {
+    //   // updateTableState('columnWidths', widths);
+    //   console.log('Column widths changed:', widths());
+    // },
+    // onColumnSizingInfoChange: info => {
+    //   // updateTableState('columnSizingInfo', info);
+    //   console.log('Column sizing info changed:', info);
+    // },
+
     initialState: {
       density: 'compact',
       columnPinning: { left: ['mrt-row-select'] },
@@ -41,6 +65,10 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
     state: {
       showProgressBars: isLoading,
       ...state,
+      // density: tableState.density,
+      columnOrder:
+        // tableState.columnOrder ??
+        tableOptions.columns.map(c => c.id ?? c.accessorKey ?? ''),
     },
 
     // Styling
@@ -103,5 +131,8 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
 
     ...tableOptions,
   });
+
+  useTableLocalStorage(tableId, table);
+
   return table;
 };

--- a/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
@@ -9,8 +9,12 @@ import {
   CheckboxEmptyIcon,
   CheckboxIndeterminateIcon,
 } from '@common/icons';
-import { useTableLocalStorage } from './useTableLocalStorage';
-import { useEffect } from 'react';
+import {
+  getSavedTableState,
+  // resetSavedTableState,
+  useTableLocalStorage,
+} from './useTableLocalStorage';
+import { useRef } from 'react';
 
 export interface BaseMRTableConfig<T extends MRT_RowData>
   extends MRT_TableOptions<T> {
@@ -26,6 +30,8 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
   state,
   ...tableOptions
 }: BaseMRTableConfig<T>) => {
+  const initialState = useRef(getSavedTableState(tableId));
+
   const table = useMaterialReactTable<T>({
     enablePagination: false,
     enableColumnResizing: true,
@@ -37,38 +43,13 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
     // Disable bottom footer - use OMS custom action footer instead
     enableBottomToolbar: false,
 
-    // onColumnPinningChange: columnPinning => {
-    //   console.log('Column pinning changed:', columnPinning());
-    // },
-    // onDensityChange: density => {
-    //   console.log('Density changed:', density);
-    //   updateTableState('density', density);
-    // },
-    // onColumnOrderChange: columns => {
-    //   updateTableState('columnOrder', columns);
-    //   console.log('Column order changed:', columns);
-    // },
-    // onColumnSizingChange: widths => {
-    //   // updateTableState('columnWidths', widths);
-    //   console.log('Column widths changed:', widths());
-    // },
-    // onColumnSizingInfoChange: info => {
-    //   // updateTableState('columnSizingInfo', info);
-    //   console.log('Column sizing info changed:', info);
-    // },
-
     initialState: {
-      density: 'compact',
-      columnPinning: { left: ['mrt-row-select'] },
       ...tableOptions.initialState,
+      ...initialState.current,
     },
     state: {
       showProgressBars: isLoading,
       ...state,
-      // density: tableState.density,
-      columnOrder:
-        // tableState.columnOrder ??
-        tableOptions.columns.map(c => c.id ?? c.accessorKey ?? ''),
     },
 
     // Styling
@@ -128,6 +109,25 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
         '& td': { borderBottom: '1px solid rgba(224, 224, 224, 1)' },
       },
     }),
+
+    // TO-DO: Add a "reset all" button
+    // renderToolbarInternalActions: ({ table }) => {
+    //   return (
+    //     <>
+    //       <button
+    //         onClick={() => {
+    //           console.log('Custom action clicked');
+    //           resetSavedTableState(tableId);
+    //           table.resetColumnOrder();
+    //         }}
+    //       >
+    //         Custom Action
+    //       </button>
+    //       <MRT_ShowHideColumnsButton table={table} />
+    //       <MRT_ToggleFullScreenButton table={table} />{' '}
+    //     </>
+    //   );
+    // },
 
     ...tableOptions,
   });

--- a/client/packages/common/src/ui/layout/tables/material-react-table/useNonPaginatedMaterialTable.ts
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useNonPaginatedMaterialTable.ts
@@ -1,22 +1,15 @@
+import { MRT_RowData, MRT_RowSelectionState } from 'material-react-table';
 import {
-  MRT_RowData,
-  MRT_RowSelectionState,
-  MRT_TableOptions,
-} from 'material-react-table';
-import { useBaseMaterialTable } from './useBaseMaterialTable';
+  BaseMRTableConfig,
+  useBaseMaterialTable,
+} from './useBaseMaterialTable';
 import { useMemo, useState } from 'react';
-
-interface NonPaginatedTableConfig<T extends MRT_RowData>
-  extends MRT_TableOptions<T> {
-  onRowClick?: (row: T) => void;
-  isLoading: boolean;
-}
 
 export const useNonPaginatedMaterialTable = <T extends MRT_RowData>({
   isLoading,
   onRowClick,
   ...tableOptions
-}: NonPaginatedTableConfig<T>) => {
+}: BaseMRTableConfig<T>) => {
   const [rowSelection, setRowSelection] = useState<MRT_RowSelectionState>({});
 
   const table = useBaseMaterialTable<T>({

--- a/client/packages/common/src/ui/layout/tables/material-react-table/usePaginatedMaterialTable.ts
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/usePaginatedMaterialTable.ts
@@ -15,7 +15,10 @@ import {
   MRT_ColumnFiltersState,
 } from 'material-react-table';
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { useBaseMaterialTable } from './useBaseMaterialTable';
+import {
+  BaseMRTableConfig,
+  useBaseMaterialTable,
+} from './useBaseMaterialTable';
 
 type FilterType = 'none' | 'text' | 'number' | 'enum' | 'dateRange';
 
@@ -31,9 +34,7 @@ export type PaginatedTableColumnDefinition<T extends MRT_RowData> =
   };
 
 interface PaginatedTableConfig<T extends MRT_RowData>
-  extends MRT_TableOptions<T> {
-  onRowClick?: (row: T) => void;
-  isLoading: boolean;
+  extends BaseMRTableConfig<T> {
   totalCount: number;
   initialSort?: { key: string; dir: 'asc' | 'desc' };
   columns: PaginatedTableColumnDefinition<T>[];

--- a/client/packages/common/src/ui/layout/tables/material-react-table/usePaginatedMaterialTable.ts
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/usePaginatedMaterialTable.ts
@@ -6,7 +6,6 @@ import {
 } from '@openmsupply-client/common';
 import {
   MRT_RowData,
-  MRT_TableOptions,
   MRT_RowSelectionState,
   MRT_SortingState,
   MRT_Updater,

--- a/client/packages/common/src/ui/layout/tables/material-react-table/useTableLocalStorage.ts
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useTableLocalStorage.ts
@@ -1,0 +1,89 @@
+import { useDebouncedValue } from '@common/hooks';
+import {
+  MRT_DensityState,
+  MRT_RowData,
+  MRT_TableInstance,
+} from 'material-react-table';
+import { useEffect, useState } from 'react';
+
+export interface TableLocalStorage {
+  density: MRT_DensityState;
+  hidden?: string[];
+  pinned?: {
+    left: string[];
+    right: string[];
+  };
+  columnOrder?: string[];
+  columnSizing?: Record<string, number>;
+}
+
+const getTableState = (tableId: string): TableLocalStorage => {
+  const state = localStorage.getItem(`@openmsupply-client/tables/${tableId}`);
+  return state ? JSON.parse(state) : { density: 'compact' };
+};
+
+export const useTableLocalStorage = <T extends MRT_RowData>(
+  tableId: string,
+  table: MRT_TableInstance<T>
+) => {
+  const {
+    density,
+    columnPinning,
+    columnSizing,
+    columnVisibility,
+    columnOrder,
+  } = table.getState();
+
+  const debouncedColumnSizing = useDebouncedValue(columnSizing, 1000);
+
+  useEffect(() => {
+    // console.log('density', density);
+    console.log('debouncedColumnSizing', debouncedColumnSizing);
+    // console.log('columnPinning', columnPinning);
+    // console.log('columnVisibility', columnVisibility);
+    console.log('columnOrder', columnOrder);
+
+    const hidden = Object.entries(columnVisibility)
+      .filter(([_, isVisible]) => !isVisible)
+      .map(([columnId]) => columnId);
+
+    console.log('hidden', hidden);
+
+    localStorage.setItem(
+      `@openmsupply-client/tables/${tableId}`,
+      JSON.stringify({
+        density,
+        hidden,
+        pinned: columnPinning,
+        columnSizing: debouncedColumnSizing,
+      })
+    );
+  }, [
+    density,
+    debouncedColumnSizing,
+    columnPinning,
+    columnVisibility,
+    // The column order reference is not stable, so we monitor a stringified
+    // version to prevent unnecessary updates
+    JSON.stringify(columnOrder),
+  ]);
+
+  // const updateTableState = (key: keyof TableLocalStorage, value: any) => {
+  //   const newState = { ...tableState, [key]: value };
+  //   setTableState(newState);
+  //   localStorage.setItem(
+  //     `@openmsupply-client/tables/${tableId}`,
+  //     JSON.stringify(newState)
+  //   );
+  // };
+
+  // const resetTableState = () => {
+  //   localStorage.removeItem(`@openmsupply-client/tables/${tableId}`);
+  // };
+
+  return {
+    // tableState,
+    // updateTableState,
+    // resetTableState,
+  };
+};

--- a/client/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
@@ -143,6 +143,7 @@ const DetailViewInner = () => {
 
   const { table, selectedRows, resetRowSelection } =
     useNonPaginatedMaterialTable<StockOutLineFragment | StockOutItem>({
+      tableId: 'outbound-shipment-detail-view',
       columns: mrtColumns,
       data: rows ?? [],
       onRowClick: onRowClick ? row => onRowClick(row) : () => {},

--- a/client/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/client/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -161,6 +161,8 @@ const OutboundShipmentListViewComponent: FC = () => {
           header: '',
           enableColumnActions: false,
           enableSorting: false,
+          enableResizing: false,
+          size: 20,
           // width: 0,
           Cell: ({ cell }) => {
             const t = useTranslation();

--- a/client/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/client/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -195,6 +195,7 @@ const OutboundShipmentListViewComponent: FC = () => {
 
   const { table, selectedRows, resetRowSelection } =
     usePaginatedMaterialTable<OutboundRowFragment>({
+      tableId: 'outbound-shipment-list-view',
       isLoading,
       onRowClick: row => navigate(row.id),
       columns: mrtColumns,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9175

# 👩🏻‍💻 What does this PR do?

Tried a couple of different approaches here, but this is the most robust. The problem with the event handlers (e.g. `onColumnSizingChange`) is that by invoking them you have to manage the state for those properties as well, which adds a lot of additional complexity. You can just use them as a "listener".

So the simplest solution for our case is to monitor the changes with `useEffect`, which is a solution suggested by the Tanstack table developers: https://github.com/TanStack/table/discussions/4238

I've abstracted this "listener" into its own hook, so it doesn't interact with the core functionality at all -- it just listens and updates local storage accordingly.

There is a simple "getSavedTableState" method for parsing the local storage -- this has to exist outside the above hook, as it needs to run *before* the table is instantiated (as it passes the `initialState` to it), whereas the hook needs to be called *after* the table definition, as it needs to calll `table.` methods.

## 💌 Any notes for the reviewer?

See comments.

TO-DO: I think we probably want a "Reset all" button somewhere, but will do that in a later issue, as I think it needs a bit of discussion where to put it/what it should look like)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

You should be able to change any of the following table properties, and have the settings persist when reloading the table or refreshing the page:
- [ ] Table density
- [ ] Column show/hide
- [ ] Colum ordering
- [ ] "Pinned" (sticky) columns
- [ ] Column widths

(There is one tiny bug -- see if you can find it, and is it important enough to try and fix? (I don't think so for now))


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

