### PR TITLE
9061 Save fields on goods received

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -3053,6 +3053,7 @@ export type GoodsReceivedNode = {
   __typename: 'GoodsReceivedNode';
   comment?: Maybe<Scalars['String']['output']>;
   createdDatetime: Scalars['DateTime']['output'];
+  donor?: Maybe<NameNode>;
   finalisedDatetime?: Maybe<Scalars['NaiveDateTime']['output']>;
   id: Scalars['String']['output'];
   lines: GoodsReceivedLineConnector;
@@ -3061,9 +3062,14 @@ export type GoodsReceivedNode = {
   purchaseOrderNumber?: Maybe<Scalars['Int']['output']>;
   receivedDatetime?: Maybe<Scalars['NaiveDate']['output']>;
   status: GoodsReceivedNodeStatus;
+  store?: Maybe<StoreNode>;
   supplier?: Maybe<NameNode>;
   supplierReference?: Maybe<Scalars['String']['output']>;
   user?: Maybe<UserNode>;
+};
+
+export type GoodsReceivedNodeDonorArgs = {
+  storeId: Scalars['String']['input'];
 };
 
 export enum GoodsReceivedNodeStatus {
@@ -4428,6 +4434,7 @@ export type InvoiceLineFilterInput = {
   invoiceId?: InputMaybe<EqualFilterStringInput>;
   invoiceStatus?: InputMaybe<EqualFilterInvoiceStatusInput>;
   invoiceType?: InputMaybe<EqualFilterInvoiceTypeInput>;
+  isProgramInvoice?: InputMaybe<Scalars['Boolean']['input']>;
   itemId?: InputMaybe<EqualFilterStringInput>;
   locationId?: InputMaybe<EqualFilterStringInput>;
   numberOfPacks?: InputMaybe<EqualFilterBigFloatingNumberInput>;
@@ -4732,6 +4739,7 @@ export type ItemFilterInput = {
   hasStockOnHand?: InputMaybe<Scalars['Boolean']['input']>;
   id?: InputMaybe<EqualFilterStringInput>;
   isActive?: InputMaybe<Scalars['Boolean']['input']>;
+  isProgramItem?: InputMaybe<Scalars['Boolean']['input']>;
   isVaccine?: InputMaybe<Scalars['Boolean']['input']>;
   /** Items that are part of a masterlist which is visible in this store. This filter is ignored if `is_visible_or_on_hand` is true */
   isVisible?: InputMaybe<Scalars['Boolean']['input']>;
@@ -7063,6 +7071,18 @@ export type ProgramNode = {
   vaccineCourses?: Maybe<Array<VaccineCourseNode>>;
 };
 
+export type ProgramOrderTypeNode = {
+  __typename: 'ProgramOrderTypeNode';
+  id: Scalars['String']['output'];
+  isEmergency: Scalars['Boolean']['output'];
+  maxItemsInEmergencyOrder: Scalars['Int']['output'];
+  maxMos: Scalars['Float']['output'];
+  maxOrderPerPeriod: Scalars['Int']['output'];
+  name: Scalars['String']['output'];
+  programId: Scalars['String']['output'];
+  thresholdMos: Scalars['Float']['output'];
+};
+
 export type ProgramRequisitionOrderTypeNode = {
   __typename: 'ProgramRequisitionOrderTypeNode';
   availablePeriods: Array<PeriodNode>;
@@ -8518,6 +8538,7 @@ export type RequisitionFilterInput = {
   finalisedDatetime?: InputMaybe<DatetimeFilterInput>;
   id?: InputMaybe<EqualFilterStringInput>;
   isEmergency?: InputMaybe<Scalars['Boolean']['input']>;
+  isProgramRequisition?: InputMaybe<Scalars['Boolean']['input']>;
   orderType?: InputMaybe<EqualFilterStringInput>;
   otherPartyId?: InputMaybe<EqualFilterStringInput>;
   otherPartyName?: InputMaybe<StringFilterInput>;
@@ -9109,6 +9130,7 @@ export type StockLineFilterInput = {
   id?: InputMaybe<EqualFilterStringInput>;
   isActive?: InputMaybe<Scalars['Boolean']['input']>;
   isAvailable?: InputMaybe<Scalars['Boolean']['input']>;
+  isProgramStockLine?: InputMaybe<Scalars['Boolean']['input']>;
   itemCodeOrName?: InputMaybe<StringFilterInput>;
   itemId?: InputMaybe<EqualFilterStringInput>;
   location?: InputMaybe<LocationFilterInput>;
@@ -9149,6 +9171,7 @@ export type StockLineNode = {
   onHold: Scalars['Boolean']['output'];
   packSize: Scalars['Float']['output'];
   program?: Maybe<ProgramNode>;
+  programOrderType: Array<ProgramOrderTypeNode>;
   sellPricePerPack: Scalars['Float']['output'];
   storeId: Scalars['String']['output'];
   supplierName?: Maybe<Scalars['String']['output']>;
@@ -9161,6 +9184,10 @@ export type StockLineNode = {
 };
 
 export type StockLineNodeDonorArgs = {
+  storeId: Scalars['String']['input'];
+};
+
+export type StockLineNodeProgramOrderTypeArgs = {
   storeId: Scalars['String']['input'];
 };
 
@@ -9951,9 +9978,11 @@ export type UpdateGoodsReceivedError = {
 
 export type UpdateGoodsReceivedInput = {
   comment?: InputMaybe<Scalars['String']['input']>;
+  donorId?: InputMaybe<NullableStringUpdate>;
   id: Scalars['String']['input'];
   receivedDate?: InputMaybe<NullableDateUpdate>;
   status?: InputMaybe<GoodsReceivedNodeType>;
+  supplierReference?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type UpdateGoodsReceivedLineError = {

--- a/client/packages/purchasing/src/goods_received/DetailView/DetailView.tsx
+++ b/client/packages/purchasing/src/goods_received/DetailView/DetailView.tsx
@@ -76,7 +76,7 @@ export const DetailViewInner = (): ReactElement => {
       {data ? (
         <>
           <AppBarButtons />
-          <Toolbar />
+          <Toolbar isDisabled={isDisabled} />
           <DetailTabs tabs={tabs} />
           <Footer />
           <SidePanel isDisabled={isDisabled} />

--- a/client/packages/purchasing/src/goods_received/DetailView/DetailView.tsx
+++ b/client/packages/purchasing/src/goods_received/DetailView/DetailView.tsx
@@ -79,7 +79,7 @@ export const DetailViewInner = (): ReactElement => {
           <Toolbar />
           <DetailTabs tabs={tabs} />
           <Footer />
-          <SidePanel />
+          <SidePanel isDisabled={isDisabled} />
           {isOpen && lineId && (
             <GoodsReceivedLineEditModal
               lineId={lineId}

--- a/client/packages/purchasing/src/goods_received/DetailView/SidePanel.tsx
+++ b/client/packages/purchasing/src/goods_received/DetailView/SidePanel.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
 import {
   useTranslation,
   DetailPanelPortal,
@@ -8,16 +8,32 @@ import {
   PanelLabel,
   PanelField,
   DateUtils,
-  TextArea,
+  useBufferState,
+  useDebouncedValueCallback,
+  BufferedTextArea,
 } from '@openmsupply-client/common';
 import { DonorSearchInput } from '@openmsupply-client/system/src';
 import { useGoodsReceived } from '../api/hooks';
 
-export const SidePanel = (): ReactElement => {
+interface ToolbarProps {
+  isDisabled?: boolean;
+}
+
+export const SidePanel = ({ isDisabled }: ToolbarProps) => {
   const t = useTranslation();
   const {
     query: { data },
+    update: { update },
   } = useGoodsReceived();
+  const { comment } = data ?? {};
+
+  const [commentBuffer, setCommentBuffer] = useBufferState(comment ?? '');
+
+  const debouncedUpdate = useDebouncedValueCallback(
+    update,
+    [commentBuffer],
+    1500
+  );
 
   return (
     <DetailPanelPortal>
@@ -63,30 +79,23 @@ export const SidePanel = (): ReactElement => {
           >
             <PanelLabel>{t('label.donor')}</PanelLabel>
             <DonorSearchInput
-              donorId={''}
-              onChange={donor =>
-                console.info('TODO: Handle donor change', donor)
-              }
+              donorId={data?.donor?.id ?? null}
+              onChange={donor => update({ donor })}
+              disabled={isDisabled}
             />
           </PanelRow>
         </Grid>
       </DetailPanelSection>
 
       <DetailPanelSection title={t('heading.comment')}>
-        <TextArea
+        <BufferedTextArea
           fullWidth
-          value={data?.comment ?? ''}
-          onChange={e =>
-            console.info('TODO: Handle comment change', e.target.value)
-          }
-          sx={{
-            '& .MuiInputBase-root': {
-              backgroundColor: theme => theme.palette.background.white,
-              fontSize: '12px',
-              borderRadius: '4px',
-              minHeight: '80px',
-            },
+          disabled={isDisabled}
+          onChange={e => {
+            setCommentBuffer(e.target.value);
+            debouncedUpdate({ comment: e.target.value });
           }}
+          value={commentBuffer}
         />
       </DetailPanelSection>
     </DetailPanelPortal>

--- a/client/packages/purchasing/src/goods_received/DetailView/SidePanel.tsx
+++ b/client/packages/purchasing/src/goods_received/DetailView/SidePanel.tsx
@@ -82,6 +82,7 @@ export const SidePanel = ({ isDisabled }: ToolbarProps) => {
               donorId={data?.donor?.id ?? null}
               onChange={donor => update({ donor })}
               disabled={isDisabled}
+              clearable
             />
           </PanelRow>
         </Grid>

--- a/client/packages/purchasing/src/goods_received/DetailView/Toolbar.tsx
+++ b/client/packages/purchasing/src/goods_received/DetailView/Toolbar.tsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
   DateTimePickerInput,
   DateUtils,
+  Formatter,
 } from '@openmsupply-client/common';
 import { useGoodsReceived } from '../api/hooks';
 
@@ -19,6 +20,7 @@ export const Toolbar = ({ isDisabled }: ToolbarProps) => {
   const t = useTranslation();
   const {
     query: { data },
+    update: { update },
   } = useGoodsReceived();
 
   return (
@@ -42,7 +44,7 @@ export const Toolbar = ({ isDisabled }: ToolbarProps) => {
                   size="small"
                   value={data?.supplierReference ?? null}
                   onChange={e => {
-                    console.info('Supplier reference changed:', e.target.value);
+                    update({ supplierReference: e.target.value });
                   }}
                 />
               </Tooltip>
@@ -55,8 +57,9 @@ export const Toolbar = ({ isDisabled }: ToolbarProps) => {
               <DateTimePickerInput
                 value={DateUtils.getDateOrNull(data?.receivedDatetime)}
                 onChange={date =>
-                  console.info('Received delivery date changed:', date)
+                  update({ receivedDatetime: Formatter.naiveDate(date) })
                 }
+                disabled={isDisabled}
               />
             }
           />

--- a/client/packages/purchasing/src/goods_received/api/hooks/utils.ts
+++ b/client/packages/purchasing/src/goods_received/api/hooks/utils.ts
@@ -27,6 +27,8 @@ export const parseUpdateInput = (input: RecordPatch<GoodsReceivedFragment>) => {
     status: mapStatus(input.status),
     receivedDate: setNullableInput('receivedDatetime', input),
     comment: input.comment,
+    donorId: setNullableInput('id', input.donor),
+    supplierReference: input.supplierReference,
   };
 };
 

--- a/client/packages/purchasing/src/goods_received/api/operations.generated.ts
+++ b/client/packages/purchasing/src/goods_received/api/operations.generated.ts
@@ -44,6 +44,7 @@ export type GoodsReceivedFragment = {
   receivedDatetime?: string | null;
   supplierReference?: string | null;
   status: Types.GoodsReceivedNodeStatus;
+  donor?: { __typename: 'NameNode'; id: string; name: string } | null;
   user?: { __typename: 'UserNode'; username: string } | null;
   supplier?: { __typename: 'NameNode'; id: string; name: string } | null;
   lines: {
@@ -116,6 +117,7 @@ export type GoodsReceivedByIdQuery = {
         receivedDatetime?: string | null;
         supplierReference?: string | null;
         status: Types.GoodsReceivedNodeStatus;
+        donor?: { __typename: 'NameNode'; id: string; name: string } | null;
         user?: { __typename: 'UserNode'; username: string } | null;
         supplier?: { __typename: 'NameNode'; id: string; name: string } | null;
         lines: {
@@ -359,9 +361,6 @@ export const GoodsReceivedFragmentDoc = gql`
     __typename
     id
     comment
-    user {
-      username
-    }
     createdDatetime
     number
     finalisedDatetime
@@ -369,7 +368,14 @@ export const GoodsReceivedFragmentDoc = gql`
     purchaseOrderId
     receivedDatetime
     supplierReference
+    donor(storeId: $storeId) {
+      id
+      name
+    }
     status
+    user {
+      username
+    }
     supplier {
       id
       name

--- a/client/packages/purchasing/src/goods_received/api/operations.graphql
+++ b/client/packages/purchasing/src/goods_received/api/operations.graphql
@@ -45,6 +45,10 @@ fragment GoodsReceived on GoodsReceivedNode {
   purchaseOrderId
   receivedDatetime
   supplierReference
+  donor(storeId: $storeId) {
+    id
+    name
+  }
   status
   user {
     username

--- a/client/packages/purchasing/src/purchase_order/DetailView/SidePanel/OtherSection.tsx
+++ b/client/packages/purchasing/src/purchase_order/DetailView/SidePanel/OtherSection.tsx
@@ -39,6 +39,7 @@ export const OtherSection = ({
           <DonorSearchInput
             donorId={draft?.donor?.id ?? null}
             onChange={donor => onUpdate({ donor: donor })}
+            clearable
           />
         </PanelRow>
         {/* <PanelRow>

--- a/server/graphql/goods_received/src/mutations/update.rs
+++ b/server/graphql/goods_received/src/mutations/update.rs
@@ -55,6 +55,8 @@ pub struct UpdateInput {
     pub status: Option<GoodsReceivedNodeType>,
     pub received_date: Option<NullableUpdateInput<NaiveDate>>,
     pub comment: Option<String>,
+    pub donor_id: Option<NullableUpdateInput<String>>,
+    pub supplier_reference: Option<String>,
 }
 
 impl UpdateInput {
@@ -64,6 +66,8 @@ impl UpdateInput {
             status,
             received_date,
             comment,
+            donor_id,
+            supplier_reference,
         } = self;
 
         ServiceInput {
@@ -71,6 +75,8 @@ impl UpdateInput {
             status: status.map(GoodsReceivedNodeType::to_domain),
             received_date: received_date.map(|r| NullableUpdate { value: r.value }),
             comment,
+            donor_id: donor_id.map(|d| NullableUpdate { value: d.value }),
+            supplier_reference,
         }
     }
 }

--- a/server/service/src/goods_received/update/generate.rs
+++ b/server/service/src/goods_received/update/generate.rs
@@ -13,6 +13,8 @@ pub fn generate(
         status,
         received_date,
         comment,
+        donor_id,
+        supplier_reference,
     }: UpdateGoodsReceivedInput,
 ) -> Result<GoodsReceivedRow, RepositoryError> {
     let mut updated_goods_received = goods_received.clone();
@@ -29,6 +31,10 @@ pub fn generate(
     updated_goods_received.received_date =
         nullable_update(&received_date, updated_goods_received.received_date);
     updated_goods_received.comment = comment.or(updated_goods_received.comment);
+    updated_goods_received.donor_link_id =
+        nullable_update(&donor_id, updated_goods_received.donor_link_id);
+    updated_goods_received.supplier_reference =
+        supplier_reference.or(updated_goods_received.supplier_reference);
 
     Ok(updated_goods_received)
 }

--- a/server/service/src/goods_received/update/mod.rs
+++ b/server/service/src/goods_received/update/mod.rs
@@ -34,6 +34,8 @@ pub struct UpdateGoodsReceivedInput {
     pub status: Option<GoodsReceivedStatus>,
     pub received_date: Option<NullableUpdate<NaiveDate>>,
     pub comment: Option<String>,
+    pub donor_id: Option<NullableUpdate<String>>,
+    pub supplier_reference: Option<String>,
 }
 
 pub fn update_goods_received(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9061 
Fixes #9062

# 👩🏻‍💻 What does this PR do?

Can save the following fields on a goods received from detail view

Side panel: Donor, comment (linked issues)
<img width="311" height="400" alt="Screenshot 2025-09-09 at 12 54 10 PM" src="https://github.com/user-attachments/assets/bd13fff3-f524-4fb7-9a20-fb9bad0660d2" />

Toolbar: Supplier reference, received date
<img width="465" height="189" alt="Screenshot 2025-09-09 at 12 54 17 PM" src="https://github.com/user-attachments/assets/a6bd928a-944f-42de-988f-8fd55a20a4be" />

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Sorry this blew out a little.. These were all in varying half-done states, so included the extra fields whilst in the area

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Goods received -> open or create one
- [ ] See that the following fields in the `More` side panel can be edited and will save: Donor, comment
- [ ] See that the following fields in the `Toolbar` can be edited and will save: Supplier reference, Received date
- [ ] The donor field in the `More` section is clearable in goods received and in purchase orders 

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

