### PR TITLE
9100 Purchase order detail view query fix

### DIFF
--- a/client/packages/purchasing/src/purchase_order/api/hooks/usePurchaseOrder.ts
+++ b/client/packages/purchasing/src/purchase_order/api/hooks/usePurchaseOrder.ts
@@ -32,31 +32,8 @@ export type PurchaseOrderLineInsertFromCsvInput = Partial<
 export const usePurchaseOrder = (id?: string) => {
   const { purchaseOrderId = id } = useParams();
 
-  const { purchaseOrderApi, storeId } = usePurchaseOrderGraphQL();
-
-  const queryKey = [PURCHASE_ORDER, LIST_KEY, storeId];
-
   // QUERY
-  const queryFn = async (): Promise<PurchaseOrderFragment | undefined> => {
-    if (!purchaseOrderId) return;
-
-    const result = await purchaseOrderApi.purchaseOrderById({
-      purchaseOrderId,
-      storeId,
-    });
-    const purchaseOrder = result?.purchaseOrder;
-    if (purchaseOrder.__typename === 'PurchaseOrderNode') return purchaseOrder;
-    else {
-      console.error('No purchase order found', purchaseOrderId);
-      throw new Error(`Could not find purchase order ${purchaseOrderId}`);
-    }
-  };
-
-  const { data, isLoading, isError } = useQuery({
-    queryKey,
-    queryFn,
-    enabled: !!purchaseOrderId,
-  });
+  const { data, isLoading, isError } = useGetById(purchaseOrderId);
 
   const isDisabled = data ? isPurchaseOrderDisabled(data) : false;
 
@@ -121,6 +98,34 @@ export const usePurchaseOrder = (id?: string) => {
     draft,
     handleChange,
   };
+};
+
+const useGetById = (purchaseOrderId: string | undefined) => {
+  const { purchaseOrderApi, storeId } = usePurchaseOrderGraphQL();
+
+  const queryFn = async (): Promise<PurchaseOrderFragment | undefined> => {
+    const result = await purchaseOrderApi.purchaseOrderById({
+      purchaseOrderId: purchaseOrderId ?? '',
+      storeId,
+    });
+
+    const purchaseOrder = result?.purchaseOrder;
+
+    if (purchaseOrder?.__typename === 'PurchaseOrderNode') {
+      return purchaseOrder;
+    } else {
+      console.error('No purchase order found', purchaseOrderId);
+      throw new Error(`Could not find purchase order ${purchaseOrderId}`);
+    }
+  };
+
+  const query = useQuery({
+    queryKey: [PURCHASE_ORDER, LIST_KEY, purchaseOrderId],
+    queryFn,
+    enabled: !!purchaseOrderId,
+  });
+
+  return query;
 };
 
 const useCreate = () => {

--- a/client/packages/purchasing/src/purchase_order/api/hooks/usePurchaseOrder.ts
+++ b/client/packages/purchasing/src/purchase_order/api/hooks/usePurchaseOrder.ts
@@ -109,23 +109,18 @@ const useGetById = (purchaseOrderId: string | undefined) => {
       storeId,
     });
 
-    const purchaseOrder = result?.purchaseOrder;
-
-    if (purchaseOrder?.__typename === 'PurchaseOrderNode') {
-      return purchaseOrder;
-    } else {
-      console.error('No purchase order found', purchaseOrderId);
-      throw new Error(`Could not find purchase order ${purchaseOrderId}`);
+    if (result?.purchaseOrder?.__typename === 'PurchaseOrderNode') {
+      return result.purchaseOrder;
     }
+
+    throw new Error(`Could not find purchase order ${purchaseOrderId}`);
   };
 
-  const query = useQuery({
+  return useQuery({
     queryKey: [PURCHASE_ORDER, LIST_KEY, purchaseOrderId],
     queryFn,
     enabled: !!purchaseOrderId,
   });
-
-  return query;
 };
 
 const useCreate = () => {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9100

# 👩🏻‍💻 What does this PR do?

Changed the detail view query to access the isLoading state correctly. This then allows the loading skeleton to be triggered when loading, instead of seeing the previously opened purchase order

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Optional: In Chrome inspector -> network tab -> throttle network (slow 4g, or 3g)
- [ ] Go to purchase orders -> have or create several purchase orders with lines
- [ ] Open a purchase order -> see lines & purchase order number on the top left
- [ ] Go back to list view, then open a different purchase order
- [ ] See loading skeleton, then new purchase order load
- [ ] Should NOT see any information of the previously opened purchase order


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

