### PR TITLE
Round MOS to 1 dp

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/columns.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/columns.tsx
@@ -12,10 +12,15 @@ import {
   getLinesFromRow,
   usePluginProvider,
   UNDEFINED_STRING_VALUE,
+  CellProps,
 } from '@openmsupply-client/common';
 import { useRequest } from '../api';
 import { NumericCell, PackQuantityCell } from '@openmsupply-client/system';
 import { useRequestRequisitionLineErrorContext } from '../context';
+
+const MonthsOfStockCell = (props: CellProps<RequestLineFragment>) => (
+  <NumericCell {...props} precision={1} />
+);
 
 export const useRequestColumns = (manageVaccinesInDoses: boolean = false) => {
   const { maxMonthsOfStock, programName } = useRequest.document.fields([
@@ -113,7 +118,7 @@ export const useRequestColumns = (manageVaccinesInDoses: boolean = false) => {
       description: 'description.available-months-of-stock',
       align: ColumnAlign.Right,
       width: 150,
-      Cell: props => <NumericCell {...props} precision={1} />,
+      Cell: MonthsOfStockCell,
       accessor: ({ rowData }) => rowData.itemStats.availableMonthsOfStockOnHand,
     }
   );

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/columns.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/columns.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { RequestLineFragment } from '../api';
 import {
   ColumnAlign,
@@ -13,7 +14,7 @@ import {
   UNDEFINED_STRING_VALUE,
 } from '@openmsupply-client/common';
 import { useRequest } from '../api';
-import { PackQuantityCell } from '@openmsupply-client/system';
+import { NumericCell, PackQuantityCell } from '@openmsupply-client/system';
 import { useRequestRequisitionLineErrorContext } from '../context';
 
 export const useRequestColumns = (manageVaccinesInDoses: boolean = false) => {
@@ -112,7 +113,7 @@ export const useRequestColumns = (manageVaccinesInDoses: boolean = false) => {
       description: 'description.available-months-of-stock',
       align: ColumnAlign.Right,
       width: 150,
-      Cell: PackQuantityCell,
+      Cell: props => <NumericCell {...props} precision={1} />,
       accessor: ({ rowData }) => rowData.itemStats.availableMonthsOfStockOnHand,
     }
   );

--- a/client/packages/system/src/Item/Components/TableCell/NumericCell.tsx
+++ b/client/packages/system/src/Item/Components/TableCell/NumericCell.tsx
@@ -1,0 +1,46 @@
+import React, { ReactElement } from 'react';
+import {
+  RecordWithId,
+  CellProps,
+  BasicCellLayout,
+  useFormatNumber,
+  Box,
+  Typography,
+} from '@openmsupply-client/common';
+
+interface NumericCellProps<T extends RecordWithId> extends CellProps<T> {
+  precision?: number;
+}
+
+export const NumericCell = <T extends RecordWithId>({
+  isError,
+  rowData,
+  column,
+  precision,
+}: NumericCellProps<T>): ReactElement => {
+  const format = useFormatNumber();
+
+  const quantity = column.accessor({ rowData });
+  const displayQuantity = format.round(Number(quantity ?? 0), precision ?? 1);
+
+  return (
+    <BasicCellLayout isError={isError}>
+      <Box
+        sx={{
+          padding: '4px 8px',
+        }}
+      >
+        <Typography
+          style={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            textAlign: 'right',
+            fontSize: 'inherit',
+          }}
+        >
+          {displayQuantity}
+        </Typography>
+      </Box>
+    </BasicCellLayout>
+  );
+};

--- a/client/packages/system/src/Item/Components/TableCell/index.ts
+++ b/client/packages/system/src/Item/Components/TableCell/index.ts
@@ -1,0 +1,1 @@
+export * from './NumericCell';

--- a/client/packages/system/src/Item/Components/index.ts
+++ b/client/packages/system/src/Item/Components/index.ts
@@ -1,4 +1,5 @@
 export * from './PackSize';
+export * from './TableCell';
 export * from './ServiceItemSearchInput';
 export * from './StockItemSearchInput';
 export * from './ListItems';


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9210 

# 👩🏻‍💻 What does this PR do?

Displays months of stock as a single decimal place, which aligns better with customer requirements and the inherent precision of the measure.

## 💌 Any notes for the reviewer?

I created a new `NumericCell` component which does rounding but drops other `1.1..` precision and tool tips.

Looks like we're using PackSize Cell everywhere which really should be something more generic but 

Thoughts about naming? Should this have more configuration to enable it to replace `PackSizeCell` in future?
Should I just create a custom `MosCell` instead?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a requistion
- [ ] Check MOS is rounded to 1 dp

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

