### PR TITLE
9188 Supplier's Purchase Order tab

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React from 'react';
 import {
   AppBarContentPortal,
   Box,
@@ -15,9 +15,9 @@ import {
 } from '@openmsupply-client/common';
 import { CustomerSearchInput } from '@openmsupply-client/system';
 import { useOutbound } from '../api';
-import { AppRoute } from 'packages/config/src';
+import { AppRoute } from '@openmsupply-client/config';
 
-export const Toolbar: FC = () => {
+export const Toolbar = () => {
   const t = useTranslation();
   const { id, otherParty, theirReference, update, requisition } =
     useOutbound.document.fields([

--- a/client/packages/invoices/src/Returns/CustomerListView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/Returns/CustomerListView/AppBarButtons.tsx
@@ -20,7 +20,7 @@ import {
 import { CustomerSearchModal } from '@openmsupply-client/system';
 import { useReturns } from '../api';
 import { customerReturnsToCsv } from '../../utils';
-import { AppRoute } from 'packages/config/src';
+import { AppRoute } from '@openmsupply-client/config';
 
 export const AppBarButtonsComponent: FC<{
   modalController: ToggleState;

--- a/client/packages/system/src/Name/SupplierDetailView/PurchaseOrder.tsx
+++ b/client/packages/system/src/Name/SupplierDetailView/PurchaseOrder.tsx
@@ -16,7 +16,7 @@ import {
 import { PurchaseOrdersFragment } from '../apiModern/operations.generated';
 import { usePurchaseOrders } from '../apiModern';
 import { getStatusTranslator } from '../utils';
-import { AppRoute } from 'packages/config/src';
+import { AppRoute } from '@openmsupply-client/config';
 
 interface PurchaseOrderProps {
   supplierName: string;

--- a/client/packages/system/src/Name/SupplierDetailView/PurchaseOrder.tsx
+++ b/client/packages/system/src/Name/SupplierDetailView/PurchaseOrder.tsx
@@ -7,13 +7,16 @@ import {
   DataTable,
   NothingHere,
   PurchaseOrderNodeStatus,
+  RouteBuilder,
   TableProvider,
   useColumns,
+  useNavigate,
   useTranslation,
 } from '@openmsupply-client/common';
 import { PurchaseOrdersFragment } from '../apiModern/operations.generated';
 import { usePurchaseOrders } from '../apiModern';
 import { getStatusTranslator } from '../utils';
+import { AppRoute } from 'packages/config/src';
 
 interface PurchaseOrderProps {
   supplierName: string;
@@ -23,6 +26,7 @@ export const PurchaseOrder = ({
   supplierName,
 }: PurchaseOrderProps): ReactElement => {
   const t = useTranslation();
+  const navigate = useNavigate();
   const { data } = usePurchaseOrders(supplierName);
 
   const columnDefinitions: ColumnDefinition<PurchaseOrdersFragment>[] = [
@@ -83,6 +87,14 @@ export const PurchaseOrder = ({
           id="supplier-purchase-order"
           columns={columns}
           data={data}
+          onRowClick={row =>
+            navigate(
+              RouteBuilder.create(AppRoute.Replenishment)
+                .addPart(AppRoute.PurchaseOrder)
+                .addPart(row.id)
+                .build()
+            )
+          }
           noDataElement={<NothingHere body={t('error.no-purchase-orders')} />}
         />
       </Box>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9188

# 👩🏻‍💻 What does this PR do?
Redirect user to purchase order from supplier on row click

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have some purchase orders for some supplier
- [ ] Go to Replenishment -> Supplier -> Click on supplier with PO
- [ ] Go to PO tab
- [ ] Be redirected to correct PO

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

