### PR TITLE
Fall back to normal reasons if no vaccine reasons exist

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/ReduceLinesToZeroModal.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/ReduceLinesToZeroModal.tsx
@@ -8,6 +8,7 @@ import {
   getReasonOptionTypes,
   useAuthContext,
   StoreModeNodeType,
+  ReasonOptionNodeType,
 } from '@openmsupply-client/common';
 import {
   ReasonOptionRowFragment,
@@ -73,6 +74,7 @@ export const ReduceLinesToZeroConfirmationModal = ({
                 isVaccine: allSelectedItemsAreVaccines,
                 isDispensary: store?.storeMode === StoreModeNodeType.Dispensary,
               })}
+              fallbackType={ReasonOptionNodeType.NegativeInventoryAdjustment}
               value={reason}
               onChange={reason => setReason(reason)}
               width={160}

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -23,6 +23,7 @@ import {
   PreferenceKey,
   useAuthContext,
   StoreModeNodeType,
+  ReasonOptionNodeType,
 } from '@openmsupply-client/common';
 import { DraftStocktakeLine } from './utils';
 import {
@@ -160,6 +161,11 @@ const getInventoryAdjustmentReasonInputColumn = (
             isVaccine: rowData.item.isVaccine,
             isDispensary: store?.storeMode === StoreModeNodeType.Dispensary,
           })}
+          fallbackType={
+            isInventoryReduction
+              ? ReasonOptionNodeType.NegativeInventoryAdjustment
+              : ReasonOptionNodeType.PositiveInventoryAdjustment
+          }
           inputProps={{
             error: isAdjustmentReasonError,
           }}

--- a/client/packages/system/src/ReasonOption/Components/ReasonOptionsSearchInput.tsx
+++ b/client/packages/system/src/ReasonOption/Components/ReasonOptionsSearchInput.tsx
@@ -17,6 +17,7 @@ interface ReasonOptionsSearchInputProps
   value?: ReasonOptionNode | null;
   onChange: (reasonOption: ReasonOptionNode | null) => void;
   type: ReasonOptionNodeType | ReasonOptionNodeType[];
+  fallbackType?: ReasonOptionNodeType;
   initialStocktake?: boolean;
   width?: number;
 }
@@ -26,6 +27,7 @@ export const ReasonOptionsSearchInput = ({
   width,
   onChange,
   type,
+  fallbackType,
   initialStocktake,
   disabled,
   ...restProps
@@ -38,7 +40,14 @@ export const ReasonOptionsSearchInput = ({
     }
     return reasonOption.type === type;
   };
-  const reasons = (reasonOptions?.nodes ?? []).filter(reasonFilter);
+  let reasons = (reasonOptions?.nodes ?? []).filter(reasonFilter);
+
+  if (reasons.length === 0 && fallbackType) {
+    reasons = (reasonOptions?.nodes ?? []).filter(
+      reasonOption => reasonOption.type === fallbackType
+    );
+  }
+
   const isRequired = reasons.length !== 0 && !initialStocktake;
 
   return (

--- a/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
+++ b/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
@@ -13,6 +13,7 @@ import {
   NumericTextDisplay,
   useAuthContext,
   StoreModeNodeType,
+  ReasonOptionNodeType,
 } from '@openmsupply-client/common';
 import { StockLineRowFragment, useInventoryAdjustment } from '../../api';
 import { ReasonOptionsSearchInput } from '../../..';
@@ -104,6 +105,11 @@ export const InventoryAdjustmentModal = ({
                     isDispensary:
                       store?.storeMode === StoreModeNodeType.Dispensary,
                   })}
+                  fallbackType={
+                    isInventoryReduction
+                      ? ReasonOptionNodeType.NegativeInventoryAdjustment
+                      : ReasonOptionNodeType.PositiveInventoryAdjustment
+                  }
                   width={INPUT_WIDTH}
                 />
               </Box>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9262

# 👩🏻‍💻 What does this PR do?

When we have no reasons available for a vaccine, it will fall back to the normal adjustment reasons.
This allows us to keep the backend simple and not do extra logic there that might vary from the frontend logic

## 💌 Any notes for the reviewer?

Have I missed anywhere? Is this a good solution?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [X] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [X] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [X] Frontend

