### PR TITLE
9272 clicking on outstanding lines leads to endless loading

### DIFF
--- a/server/repository/src/db_diesel/purchase_order_line.rs
+++ b/server/repository/src/db_diesel/purchase_order_line.rs
@@ -103,7 +103,7 @@ impl<'a> PurchaseOrderLineRepository<'a> {
                     apply_sort!(query, sort, purchase_order_line::expected_delivery_date);
                 }
                 PurchaseOrderLineSortField::PurchaseOrderNumber => {
-                    apply_sort_no_case!(query, sort, purchase_order::purchase_order_number);
+                    apply_sort!(query, sort, purchase_order::purchase_order_number);
                 }
             }
         } else {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9276

# 👩🏻‍💻 What does this PR do?

Updated the macro used against to sort by `purchaseOrderNumber`, was using `apply_sort_no_case` (I believe is used for strings) to just `apply_sort` (supports BigInt which is purchaseOrderNumber). 
<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to Purchase Orders
- [ ] Click on Outstanding Lines
- [ ] Should NOT show a endless loading state / Should show outstanding lines

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

