### PR TITLE
9031 - Include Adjusted Units value when purchase order is confimed

### DIFF
--- a/client/packages/purchasing/src/purchase_order/DetailView/LineEdit/PurchaseOrderLineEdit.tsx
+++ b/client/packages/purchasing/src/purchase_order/DetailView/LineEdit/PurchaseOrderLineEdit.tsx
@@ -166,7 +166,7 @@ export const PurchaseOrderLineEdit = ({
                 draft?.numberOfPacks ?? 0,
                 {
                   onChange: value => {
-                    // Adjust the requested and adjusted number of units based
+                    // Adjust the requested or adjusted number of units based
                     // on the number of packs * pack size
                     const adjustedPatch = calculateUnitQuantities(status, {
                       ...draft,

--- a/client/packages/purchasing/src/purchase_order/DetailView/LineEdit/utils.ts
+++ b/client/packages/purchasing/src/purchase_order/DetailView/LineEdit/utils.ts
@@ -107,15 +107,9 @@ export const calculateUnitQuantities = (
   const totalUnits = numberOfPacks * requestedPackSize;
 
   // Only adjust the requested number of units if the status is not confirmed yet
-  if (status === PurchaseOrderNodeStatus.Confirmed) {
-    return {
-      adjustedNumberOfUnits: totalUnits,
-    };
-  }
-  return {
-    requestedNumberOfUnits: totalUnits,
-    adjustedNumberOfUnits: totalUnits,
-  };
+  return status === PurchaseOrderNodeStatus.Confirmed
+    ? { adjustedNumberOfUnits: totalUnits }
+    : { requestedNumberOfUnits: totalUnits };
 };
 
 type LineStatusOption = {

--- a/server/service/src/purchase_order/update/generate.rs
+++ b/server/service/src/purchase_order/update/generate.rs
@@ -186,6 +186,13 @@ fn update_lines(
                     PurchaseOrderStatus::Confirmed => {
                         line.purchase_order_line_row.status =
                             repository::PurchaseOrderLineStatus::Sent;
+
+                        // Insert requested units value to adjusted units field when purchase order changes to Confirmed status
+                        // Requested units is a fallback as status can change backwards from Sent to Confirmed, so value for adjusted units may already exist
+                        line.purchase_order_line_row.adjusted_number_of_units = line
+                            .purchase_order_line_row
+                            .adjusted_number_of_units
+                            .or(Some(line.purchase_order_line_row.requested_number_of_units))
                     }
                     PurchaseOrderStatus::Finalised => {
                         line.purchase_order_line_row.status =


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9031 

# 👩🏻‍💻 What does this PR do?

The adjusted units will now be automatically generated when a purchase order status is changed to Confirmed

Not quite as per issue.. Lines can no longer be added at Confirmed stage. However still needed fixing because if a quantity is not updated after reaching confirmed status, the adjusted amount will never be populated!

Simplified the utils function as adjusted units is only editable from confirmed status onward (sent status coming in 9165), and requested units only editable before confirmed

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a purchase order and add a line with a requested quantity. See no adjusted units value in the detail table
- [ ] Proceed to Confirmed status -> see the adjusted units populate with the value in requested column
- [ ] Update adjusted units in line edit view -> see only the adjusted value change

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

