### PR TITLE
9305 add expected delivery date to purchase order toolbar

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1470,7 +1470,7 @@
   "label.unusable-vvm-status": "Unusable VVM status",
   "label.update-expected-delivery-date": "Update expected delivery date",
   "label.update-live-location": "Update live location",
-  "label.update-purchase-order-expected-delivery-date-for-all-lines": "This will update expected delivery date for all lines in this Purchase Order. Do you want to continue?",
+  "label.update-purchase-order-expected-delivery-date-for-all-lines": "This will update the expected delivery date for all lines in this Purchase Order. Do you want to continue?",
   "label.update-purchase-order-expected-delivery-date-for-selected-lines_few": "This will update expected delivery date for the selected lines in this Purchase Order. Do you want to continue?",
   "label.update-purchase-order-expected-delivery-date-for-selected-lines_many": "This will update expected delivery date for the selected lines in this Purchase Order. Do you want to continue?",
   "label.update-purchase-order-expected-delivery-date-for-selected-lines_one": "This will update expected delivery date for 1 line in this Purchase Order. Do you want to continue?",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1470,6 +1470,7 @@
   "label.unusable-vvm-status": "Unusable VVM status",
   "label.update-expected-delivery-date": "Update expected delivery date",
   "label.update-live-location": "Update live location",
+  "label.update-purchase-order-expected-delivery-date-for-all-lines": "This will update expected delivery date for all lines in this Purchase Order. Do you want to continue?",
   "label.update-purchase-order-expected-delivery-date-for-selected-lines_few": "This will update expected delivery date for the selected lines in this Purchase Order. Do you want to continue?",
   "label.update-purchase-order-expected-delivery-date-for-selected-lines_many": "This will update expected delivery date for the selected lines in this Purchase Order. Do you want to continue?",
   "label.update-purchase-order-expected-delivery-date-for-selected-lines_one": "This will update expected delivery date for 1 line in this Purchase Order. Do you want to continue?",

--- a/client/packages/purchasing/src/purchase_order/DetailView/Toolbar.tsx
+++ b/client/packages/purchasing/src/purchase_order/DetailView/Toolbar.tsx
@@ -12,6 +12,7 @@ import {
   Formatter,
   useNotification,
   NumericTextInput,
+  useConfirmationModal,
 } from '@openmsupply-client/common';
 import {
   CurrencyAutocomplete,
@@ -20,7 +21,8 @@ import {
 } from '@openmsupply-client/system';
 import { usePurchaseOrder } from '../api/hooks/usePurchaseOrder';
 import { NameFragment } from 'packages/system/src/Name/api/operations.generated';
-import { PurchaseOrderFragment } from '../api';
+import { PurchaseOrderFragment, usePurchaseOrderLine } from '../api';
+import { isFieldDisabled, StatusGroup } from '../../utils';
 
 interface ToolbarProps {
   isDisabled?: boolean;
@@ -36,10 +38,29 @@ export const Toolbar = ({ isDisabled }: ToolbarProps) => {
     update: { update },
     handleChange,
   } = usePurchaseOrder();
+  const { updateLines } = usePurchaseOrderLine();
 
   const [requestedDeliveryDate, setRequestedDeliveryDate] = useState(
     DateUtils.getDateOrNull(data?.requestedDeliveryDate)
   );
+
+  const getMostRecentExpectedDate = () => {
+    const dates = data?.lines?.nodes
+      ?.map(line => line.expectedDeliveryDate)
+      .sort((a, b) => (b || '').localeCompare(a || ''));
+    return dates?.[0] ? dates[0] : null;
+  };
+
+  const [expectedDeliveryDate, setExpectedDeliveryDate] = useState(
+    DateUtils.getDateOrNull(getMostRecentExpectedDate())
+  );
+
+  const disabledRequestedDeliveryDate = data?.status
+    ? isFieldDisabled(data.status, StatusGroup.AfterConfirmed)
+    : false;
+  const disabledExpectedDeliveryDate = data?.status
+    ? isFieldDisabled(data.status, StatusGroup.AfterSent)
+    : false;
 
   const handleUpdate = (input: Partial<PurchaseOrderFragment>) => {
     try {
@@ -54,6 +75,33 @@ export const Toolbar = ({ isDisabled }: ToolbarProps) => {
     handleChange({
       currencyId: currency.id,
       foreignExchangeRate: currency.rate,
+    });
+  };
+
+  const updateExpectedDeliveryChange = async (date: Date | null) => {
+    if (!data) return;
+    const formattedDate = Formatter.naiveDate(date);
+    await updateLines(data?.lines?.nodes, {
+      expectedDeliveryDate: formattedDate,
+    });
+  };
+
+  const confirmModal = useConfirmationModal({
+    title: t('heading.are-you-sure'),
+    message: t(
+      'label.update-purchase-order-expected-delivery-date-for-all-lines'
+    ),
+    onConfirm: () => {},
+  });
+
+  const handleExpectedDeliveryDateChange = (newDate: Date | null) => {
+    if (!newDate) return;
+    const previousDate = expectedDeliveryDate;
+
+    setExpectedDeliveryDate(newDate);
+    confirmModal({
+      onConfirm: () => updateExpectedDeliveryChange(newDate),
+      onCancel: () => setExpectedDeliveryDate(previousDate),
     });
   };
 
@@ -125,24 +173,38 @@ export const Toolbar = ({ isDisabled }: ToolbarProps) => {
             }
           />
         </Grid>
-        <Grid display="flex" flexGrow={1} flexDirection="column" gap={1}>
-          <InputWithLabelRow
-            label={t('label.requested-delivery-date')}
-            Input={
-              <DateTimePickerInput
-                value={requestedDeliveryDate}
-                onChange={date => {
-                  setRequestedDeliveryDate(date);
-                  const formattedDate = Formatter.naiveDate(date);
-                  handleUpdate({
-                    requestedDeliveryDate: formattedDate,
-                  });
-                }}
-                width={250}
-              />
-            }
-          />
-          <Grid justifyContent="flex-end" display="flex">
+        <Grid display="flex" flexGrow={1} gap={1}>
+          <Grid display="flex" flexDirection="column" gap={1}>
+            <InputWithLabelRow
+              label={t('label.requested-delivery-date')}
+              Input={
+                <DateTimePickerInput
+                  value={requestedDeliveryDate}
+                  onChange={date => {
+                    setRequestedDeliveryDate(date);
+                    const formattedDate = Formatter.naiveDate(date);
+                    handleUpdate({
+                      requestedDeliveryDate: formattedDate,
+                    });
+                  }}
+                  width={250}
+                  disabled={disabledRequestedDeliveryDate}
+                />
+              }
+            />
+            <InputWithLabelRow
+              label={t('label.expected-delivery-date')}
+              Input={
+                <DateTimePickerInput
+                  value={expectedDeliveryDate}
+                  onChange={handleExpectedDeliveryDateChange}
+                  width={250}
+                  disabled={disabledExpectedDeliveryDate}
+                />
+              }
+            />
+          </Grid>
+          <Grid display="flex" flexGrow={1} justifyContent="flex-end">
             <SearchBar
               placeholder={t('placeholder.filter-items')}
               value={itemFilter ?? ''}

--- a/client/packages/purchasing/src/utils.ts
+++ b/client/packages/purchasing/src/utils.ts
@@ -114,9 +114,9 @@ export const disabledStatusGroup: Record<
 };
 
 /**
-Determines if a field should be editable or disabled based on the status of the purchase order
-If the status is in the disabled group, the function will return true
-When passed into the input, it overrides the 'base' disabled bool 
+  Determines if a field should be editable or disabled based on the status of the purchase order
+  If the status is in the disabled group, the function will return true
+  When passed into the input, it overrides the 'base' disabled bool 
 */
 export const isFieldDisabled = (
   status: PurchaseOrderNodeStatus,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9305 

# 👩🏻‍💻 What does this PR do?

Added expected delivery date to the toolbar. This sets the expected delivery date for ALL of the lines. 

<img width="1522" height="630" alt="Screenshot 2025-09-23 at 1 15 39 PM" src="https://github.com/user-attachments/assets/4d9cd80b-afe3-49bf-a3ac-c6befd2cdc26" />

<img width="1154" height="685" alt="Screenshot 2025-09-23 at 1 15 45 PM" src="https://github.com/user-attachments/assets/d922806a-05bc-46f0-b378-e5dc9df53a2c" />

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to a Purchase Order (or create a New one)
- [ ] Click on the Expected Delivery Date's Calendar icon to see date selection (or manually enter)
- [ ] On new date select (or after manually entering) a confirmation modal will show
- [ ] Clicking on Ok within the confirmation modal will update expected delivery date for ALL of the lines
- [ ] Clicking on Cancel doesn't update the lines
- [ ] -------------------------------------------
- [ ] Click on Calendar icon to see date selection
- [ ] Clicking on clear temporarily removes the SelectedDate
- [ ] -------------------------------------------
- [ ] If lines already have an expected delivery date
- [ ] The input will use the latest expected delivery date from the lines
- [ ] Otherwise defaults to no value

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

