### PR TITLE
9306 - Update line status when editing adjusted packs

### DIFF
--- a/server/service/src/purchase_order/update/generate.rs
+++ b/server/service/src/purchase_order/update/generate.rs
@@ -205,7 +205,6 @@ fn update_lines(
                             .or(requested_delivery_date);
                     }
                     PurchaseOrderStatus::Sent => {
-                        // Don't update line status if the line is already Closed
                         if line.purchase_order_line_row.status
                             != repository::PurchaseOrderLineStatus::Closed
                         {

--- a/server/service/src/purchase_order/update/generate.rs
+++ b/server/service/src/purchase_order/update/generate.rs
@@ -205,8 +205,13 @@ fn update_lines(
                             .or(requested_delivery_date);
                     }
                     PurchaseOrderStatus::Sent => {
-                        line.purchase_order_line_row.status =
-                            repository::PurchaseOrderLineStatus::Sent;
+                        // Don't update line status if the line is already Closed
+                        if line.purchase_order_line_row.status
+                            != repository::PurchaseOrderLineStatus::Closed
+                        {
+                            line.purchase_order_line_row.status =
+                                repository::PurchaseOrderLineStatus::Sent;
+                        }
                     }
                     PurchaseOrderStatus::Finalised => {
                         line.purchase_order_line_row.status =

--- a/server/service/src/purchase_order/update/test.rs
+++ b/server/service/src/purchase_order/update/test.rs
@@ -8,12 +8,15 @@ mod update {
         },
         test_db::setup_all,
         ActivityLogRowRepository, ActivityLogType, PreferenceRow, PreferenceRowRepository,
-        PurchaseOrderLineRowRepository, PurchaseOrderRowRepository, PurchaseOrderStatus,
+        PurchaseOrderLineRowRepository, PurchaseOrderLineStatus, PurchaseOrderRowRepository,
+        PurchaseOrderStatus,
     };
 
     use crate::{
         preference::{AuthorisePurchaseOrder, Preference},
-        purchase_order_line::insert::InsertPurchaseOrderLineInput,
+        purchase_order_line::{
+            insert::InsertPurchaseOrderLineInput, update::UpdatePurchaseOrderLineInput,
+        },
     };
     use crate::{
         purchase_order::{
@@ -165,10 +168,11 @@ mod update {
             .insert_purchase_order_line(
                 &context,
                 InsertPurchaseOrderLineInput {
-                    id: "purchase_order_line_without_delivery_date".to_string(),
+                    id: "purchase_order_line_a".to_string(),
                     purchase_order_id: purchase_order_id.clone(),
                     item_id_or_code: mock_item_a().id.to_string(),
                     requested_pack_size: Some(5.0),
+                    requested_number_of_units: Some(10.0),
                     ..Default::default()
                 },
             )
@@ -180,10 +184,11 @@ mod update {
             .insert_purchase_order_line(
                 &context,
                 InsertPurchaseOrderLineInput {
-                    id: "purchase_order_line_with_a_delivery_date".to_string(),
+                    id: "purchase_order_line_b".to_string(),
                     purchase_order_id: purchase_order_id.clone(),
                     item_id_or_code: mock_item_b().id.to_string(),
                     requested_pack_size: Some(3.0),
+                    requested_number_of_units: Some(9.0),
                     requested_delivery_date: Some(NaiveDate::from_ymd_opt(2023, 12, 3).unwrap()),
                     ..Default::default()
                 },
@@ -242,25 +247,110 @@ mod update {
         assert_eq!(result.status, PurchaseOrderStatus::Confirmed);
 
         // Check the requested delivery date is now saved on the purchase order lines
-
-        let line = PurchaseOrderLineRowRepository::new(&context.connection)
-            .find_one_by_id("purchase_order_line_without_delivery_date")
-            .unwrap()
-            .unwrap();
-
-        assert_eq!(line.requested_delivery_date, result.requested_delivery_date);
-
-        // But only if the line didn't already have a date
-
-        let line = PurchaseOrderLineRowRepository::new(&context.connection)
-            .find_one_by_id("purchase_order_line_with_a_delivery_date")
-            .unwrap()
+        let lines = PurchaseOrderLineRowRepository::new(&context.connection)
+            .find_many_by_purchase_order_ids(&[purchase_order_id.clone()])
             .unwrap();
 
         assert_eq!(
-            line.requested_delivery_date,
+            lines[0].requested_delivery_date,
+            result.requested_delivery_date
+        );
+
+        // But not on line B which already had a date
+        assert_eq!(
+            lines[1].requested_delivery_date,
             Some(NaiveDate::from_ymd_opt(2023, 12, 03).unwrap())
         );
+
+        // Change Purchase Order status to Sent
+        service
+            .update_purchase_order(
+                &context,
+                store_id,
+                UpdatePurchaseOrderInput {
+                    id: purchase_order_id.clone(),
+                    status: Some(PurchaseOrderStatus::Sent),
+                    ..Default::default()
+                },
+                None,
+            )
+            .unwrap();
+
+        // The lines will now both be at Sent status
+        let lines = PurchaseOrderLineRowRepository::new(&context.connection)
+            .find_many_by_purchase_order_ids(&[purchase_order_id.clone()])
+            .unwrap();
+
+        assert_eq!(lines[0].status, PurchaseOrderLineStatus::Sent);
+        assert_eq!(lines[1].status, PurchaseOrderLineStatus::Sent);
+
+        // Close line A
+        service_provider
+            .purchase_order_line_service
+            .update_purchase_order_line(
+                &context,
+                store_id,
+                UpdatePurchaseOrderLineInput {
+                    id: "purchase_order_line_a".to_string(),
+                    status: Some(PurchaseOrderLineStatus::Closed),
+                    ..Default::default()
+                },
+                Some(true),
+            )
+            .unwrap();
+
+        // Edit the adjusted quantity on line B
+        service_provider
+            .purchase_order_line_service
+            .update_purchase_order_line(
+                &context,
+                store_id,
+                UpdatePurchaseOrderLineInput {
+                    id: "purchase_order_line_b".to_string(),
+                    adjusted_number_of_units: Some(12.0),
+                    ..Default::default()
+                },
+                Some(true),
+            )
+            .unwrap();
+
+        // Line A remains Closed and line B will now be at New status
+        let lines = PurchaseOrderLineRowRepository::new(&context.connection)
+            .find_many_by_purchase_order_ids(&[purchase_order_id.clone()])
+            .unwrap();
+
+        assert_eq!(lines[0].status, PurchaseOrderLineStatus::Closed);
+        assert_eq!(lines[1].status, PurchaseOrderLineStatus::New);
+
+        // The purchase order status will now be Confirmed
+        let purchase_order = PurchaseOrderRowRepository::new(&context.connection)
+            .find_one_by_id(&purchase_order_id.clone())
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(purchase_order.status, PurchaseOrderStatus::Confirmed);
+
+        // Send the purchase order again
+        service
+            .update_purchase_order(
+                &context,
+                store_id,
+                UpdatePurchaseOrderInput {
+                    id: purchase_order_id.clone(),
+                    status: Some(PurchaseOrderStatus::Sent),
+                    ..Default::default()
+                },
+                None,
+            )
+            .unwrap();
+
+        // Line A is still Closed and line B is now Sent
+        let lines = PurchaseOrderLineRowRepository::new(&context.connection)
+            .find_many_by_purchase_order_ids(&[purchase_order_id.clone()])
+            .unwrap();
+
+        assert_eq!(lines[0].status, PurchaseOrderLineStatus::Closed);
+        assert_eq!(lines[1].status, PurchaseOrderLineStatus::Sent);
     }
 
     #[actix_rt::test]

--- a/server/service/src/purchase_order_line/update/validate.rs
+++ b/server/service/src/purchase_order_line/update/validate.rs
@@ -60,11 +60,9 @@ pub fn validate(
         // Only validate if the status is actually changing
         if new_status != line.status {
             let is_purchase_order_sent = purchase_order.status >= PurchaseOrderStatus::Sent;
-            let is_valid_status_change = match (new_status, is_purchase_order_sent) {
-                (PurchaseOrderLineStatus::New, false) => true,
-                (PurchaseOrderLineStatus::New, true) => false,
-                (_, true) => true,
-                (_, false) => false,
+            let is_valid_status_change = match new_status {
+                PurchaseOrderLineStatus::New => !is_purchase_order_sent,
+                _ => is_purchase_order_sent,
             };
 
             if !is_valid_status_change {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9306 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Context: When a purchase order is in Sent status and the adjusted packs field is updated on a line, the purchase order status changes to Confirmed (Ready for Sending)

The line status will now also update when the adjusted packs is updated, from Sent to New. This is done separately to the order status, as multiple lines may need to be updated & should all have the line status update to New when changing a quantity

Allows changing of other fields when status is sent - relying on front end disabled fields. Line status changes are still validated server-side

If a line status is Closed, changing other lines or the purchase order status back to Sent does not impact the Closed line - it remains Closed.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

If a line is Closed & Purchase order status has been taken back to Confirmed by another line:
- The line status cannot change between Closed and Sent (due to PO status) and the PO would need to move to Sent before that line status/line can be edited again
- Viewing the Closed line while PO is at Confirmed -> selecting Ok or Ok & Next throws error because these buttons trigger a line update call. Probably should implement an isDirty state or similar in another issue

Comment on issue re Goods received status - to be done with GR work in a new issue
Some refactoring as per comments referenced in original issue

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [x] Create a purchase order with some lines -> update until status is `Sent`
- [x] Be able to update line status between `Sent` and `Closed`. Start with sent lines "1" "2" and a closed line "3"
- [x] On line 1 edit any field other than adjusted packs -> should save changes but make no status changes
  - [x] Activity log entry for `Purchase Order Line Updated`
- [x] Edit the adjusted packs -> Purchase order status changes to `Ready for Sending` and line status changes to `New`
  - [x] Activity log entry for `Purchase Order Line Updated from [sent] to [new]`
  - [x] Activity log entry for `Purchase Order Line Updated from [sent] to [confirmed]` (being updated in another issue)
- [x] Open line 2 -> see line status `Sent`
- [x] Edit line 2 -> see line status update to `New`
  - [x] Activity log entry for `Purchase Order Line Updated from [sent] to [new]`
  - [x] See line 3 is still Closed & unable to edit
 - [x] Update purchase order status to `Sent`
  - [x] See lines 1 and 2 are `Sent`
  - [x] See line 3 is still `Closed`

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

