### PR TITLE
9318 No footer in Inbound Shipments detail view - also cannot change statuses

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -198,7 +198,7 @@ const DetailViewInner = () => {
 
             <DetailTabs tabs={tabs} />
 
-            {tab === InboundShipmentDetailTabs.Details && (
+            {(tab === InboundShipmentDetailTabs.Details || !tab) && (
               <Footer onReturnLines={onReturn} />
             )}
             <SidePanel />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9318

# 👩🏻‍💻 What does this PR do?
Fixes footer not showing up in Inbound Shipment detail view when you first go into it.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to an inbound shipment
- [ ] Should see footer with statuses

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

