### PR TITLE
8728 Sort by "Approved packs" in internal order

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/columns.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/columns.tsx
@@ -249,7 +249,8 @@ export const useRequestColumns = () => {
       Cell: PackQuantityCell,
       accessor: ({ rowData }) =>
         rowData.linkedRequisitionLine?.approvedQuantity ?? 0,
-      sortable: false,
+      getSortValue: rowData =>
+        rowData.linkedRequisitionLine?.approvedQuantity ?? 0,
     });
     columnDefinitions.push({
       key: 'approvalComment',

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
@@ -248,6 +248,7 @@ export const useResponseColumns = () => {
       sortable: true,
       Cell: PackQuantityCell,
       accessor: ({ rowData }) => rowData.approvedQuantity,
+      getSortValue: rowData => rowData.approvedQuantity,
     });
     columnDefinitions.push({
       key: 'approvalComment',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8728

# 👩🏻‍💻 What does this PR do?
Sort by approved quantity in internal orders and requisitions

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have auth set up (prefs and all)
- [ ] Create Internal Order / Requisition
- [ ] Add some lines
- [ ] Go to auth app and set some amounts for approved quantity
- [ ] Check that the approved quantity column is sortable

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

