### PR TITLE
9298 Fix negative balance for RnR Forms

### DIFF
--- a/server/service/src/ledger_fix/fixes/delete_unused_orphan_stock_lines.rs
+++ b/server/service/src/ledger_fix/fixes/delete_unused_orphan_stock_lines.rs
@@ -229,7 +229,7 @@ pub(crate) mod test {
             is_ledger_fixed(&connection, "legacy_stock_line_with_invoice_line"),
             Ok(false)
         );
-        assert!(logs.contains("stock_line referenced in another table:"));
+        assert!(logs.contains("stock_line referenced in another table"));
 
         // No invoice lines but referenced in stocktake line
         let mut logs = String::new();
@@ -251,6 +251,6 @@ pub(crate) mod test {
             is_ledger_fixed(&connection, "legacy_stock_line_with_stock_take_line"),
             Ok(false)
         );
-        assert!(logs.contains("stock_line referenced in another table:"));
+        assert!(logs.contains("stock_line referenced in another table"));
     }
 }

--- a/server/service/src/rnr_form/generate_rnr_form_lines.rs
+++ b/server/service/src/rnr_form/generate_rnr_form_lines.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, ops::Neg};
 
-use chrono::{Duration, NaiveDate};
+use chrono::{Duration, NaiveDate, Utc};
 use repository::{
     AdjustmentFilter, AdjustmentRepository, ConsumptionFilter, ConsumptionRepository, DateFilter,
     DatetimeFilter, EqualFilter, MasterListLineFilter, MasterListLineRepository, Pagination,
@@ -275,7 +275,7 @@ pub fn get_opening_balance(
         .item_id(EqualFilter::equal_to(item_id))
         .datetime(DatetimeFilter::date_range(
             start_date.into(),
-            date_now().into(),
+            Utc::now().naive_utc(),
         ));
 
     let stock_movement_rows = StockMovementRepository::new(connection).query(Some(filter))?;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9298

# 👩🏻‍💻 What does this PR do?

Previously we weren't including any stock allocated from today (utc time) in the stock we were removing from the pre-saved SOH view, now we use current time, which should include everything unless we somehow have future dated invocies.

Note:I feel like I've fixed this before, but maybe in different context? Makes sense to use some kind of shared logic for these kinds of operations that are being done in a few places now.
Was there another reason I'm not aware of for trying to use `today` rather than `now`?

## 💌 Any notes for the reviewer?

There's a few ways to skin this cat now. Currently went for the smallest code diff, however could also do things like.

- [ ] Call getHistoricalStockLines for that date (does similar code)
- [ ] Use new `stock_ledger` view 

Consolidating all these things is probably a good refactor issue that I should create? Feel like we probably don't need/want it in a patch though?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Remove some stock for an item in an R&R form now.
- [ ] Make sure that `Today` in utc doesn't include this new stock transaction
- [ ] Try creating an R&R form for a masterlist/period that doesn't have a previous RnR form
- [ ] Check that initial balance is correct, could be too high or too low depending on the transactions not included.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [X] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [X] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

