### PR TITLE
8425 Invisible donors disappear from stock lines

### DIFF
--- a/client/packages/system/src/Name/Components/DonorSearchInput/DonorSearchInput.tsx
+++ b/client/packages/system/src/Name/Components/DonorSearchInput/DonorSearchInput.tsx
@@ -21,13 +21,15 @@ export const DonorSearchInput = ({
   disabled = false,
   clearable = false,
 }: DonorSearchInputProps) => {
-  const { data, isLoading } = useName.document.donors();
   const t = useTranslation();
   const NameOptionRenderer = getNameOptionRenderer(t('label.on-hold'));
 
-  const options = data?.nodes ?? [];
+  const { data, isLoading } = useName.document.donors();
+  const { data: selectedDonor, isLoading: isLoadingSelected } =
+    useName.document.get(donorId || '');
 
-  const selectedOption = options.find(o => o.id === donorId);
+  const options = data?.nodes ?? [];
+  const selectedOption = options.find(o => o.id === donorId) || selectedDonor;
 
   return (
     <Autocomplete
@@ -39,7 +41,7 @@ export const DonorSearchInput = ({
           : null
       }
       filterOptionConfig={basicFilterOptions}
-      loading={isLoading}
+      loading={isLoading || isLoadingSelected}
       onChange={(_, name) => onChange(name)}
       options={options}
       renderOption={NameOptionRenderer}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8425

# 👩🏻‍💻 What does this PR do?
Invisible donors that have been saved to stock lines before they became invisible are still shown as a value (but not as a selectable option)
<img width="910" height="464" alt="inv_donor" src="https://github.com/user-attachments/assets/2d708a22-18c0-4bba-8644-cff7fbe1301c" />

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Introduce some stock with a donor saved on the stock line
- [ ] Go to OG and make that donor invisible to your store
- [ ] Go back to OMS, sync
- [ ] Now go to the stock line and see that the donor's name is still shown
- [ ] Try to change donors.. invisible donors shouldn't be selectable

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

