### PR TITLE
#9181 Additional table style tweaks

### DIFF
--- a/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
@@ -123,6 +123,9 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
     enableBottomToolbar: false,
     enableExpanding: !!groupByField,
 
+    // Disable selection Toolbar, we use our own custom footer for this
+    positionToolbarAlertBanner: 'none',
+
     manualFiltering,
     onColumnFiltersChange,
     onSortingChange,

--- a/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
@@ -118,6 +118,7 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
     enableColumnDragging: false,
     enableRowSelection,
     enableFacetedValues: true,
+    enableStickyHeader: true,
 
     // Disable bottom footer - use OMS custom action footer instead
     enableBottomToolbar: false,

--- a/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
@@ -138,7 +138,7 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
       columnOrder: columnOrder.initial,
     },
     state: {
-      showProgressBars: isLoading,
+      showLoadingOverlay: isLoading,
       columnFilters,
       sorting,
       density: density.state,

--- a/client/packages/common/src/ui/layout/tables/material-react-table/usePaginatedMaterialTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/usePaginatedMaterialTable.tsx
@@ -43,10 +43,8 @@ export const usePaginatedMaterialTable = <T extends MRT_RowData>({
         const current = { pageIndex: page, pageSize: first };
         const newPaginationValue = paginationUpdate(current);
         paginationRef.current = Date.now();
-        // There is a bug where this function is called twice in quick
-        // succession the first time it's triggered. This is a hacky workaround
-        // for now, but we should investigate further at some point, or report
-        // the bug to MRT devs
+        // This is a hacky workaround for this bug:
+        // https://github.com/KevinVandy/material-react-table/issues/1251
         if (paginationRef.current - lastUpdate < 300) return;
         updatePaginationQuery(
           newPaginationValue.pageIndex,
@@ -68,7 +66,6 @@ export const usePaginatedMaterialTable = <T extends MRT_RowData>({
     rowCount: totalCount,
     state: {
       pagination: { pageIndex: pagination.page, pageSize: pagination.first },
-      showProgressBars: isLoading,
       rowSelection,
     },
 

--- a/client/packages/common/src/ui/layout/tables/material-react-table/useTableDisplayOptions.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useTableDisplayOptions.tsx
@@ -171,13 +171,6 @@ export const useTableDisplayOptions = <T extends MRT_RowData>(
           : 'inherit',
         fontStyle: row.getCanExpand() ? 'italic' : 'normal',
         cursor: onRowClick ? 'pointer' : 'default',
-        '&.Mui-selected': {
-          backgroundColor: 'background.secondary',
-        },
-        '& td::after': {
-          backgroundColor: 'transparent',
-        },
-        // TO-DO: Figure out how to target the "hover" state for these rows
       },
     }),
 
@@ -219,10 +212,11 @@ export const useTableDisplayOptions = <T extends MRT_RowData>(
           row.original?.['isSubRow'] && cell.column.id !== 'mrt-row-select'
             ? '2em'
             : undefined,
-        backgroundColor: column.getIsPinned()
-          ? // Remove transparency from pinned backgrounds
-            'rgba(252, 252, 252, 1)'
-          : undefined,
+        backgroundColor:
+          column.getIsPinned() || row.getIsSelected()
+            ? // Remove transparency from pinned backgrounds
+              'rgba(252, 252, 252, 1)'
+            : undefined,
       },
     }),
 

--- a/client/packages/common/src/ui/layout/tables/material-react-table/useTableDisplayOptions.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useTableDisplayOptions.tsx
@@ -148,6 +148,13 @@ export const useTableDisplayOptions = <T extends MRT_RowData>(
           : 'inherit',
         fontStyle: row.getCanExpand() ? 'italic' : 'normal',
         cursor: onRowClick ? 'pointer' : 'default',
+        '&.Mui-selected': {
+          backgroundColor: 'background.secondary',
+        },
+        '& td::after': {
+          backgroundColor: 'transparent',
+        },
+        // TO-DO: Figure out how to target the "hover" state for these rows
       },
     }),
 

--- a/client/packages/common/src/ui/layout/tables/material-react-table/useTableDisplayOptions.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useTableDisplayOptions.tsx
@@ -97,17 +97,19 @@ export const useTableDisplayOptions = <T extends MRT_RowData>(
         flexDirection: 'column',
       },
     },
-    muiTableProps: {
+    muiTableProps: ({ table }) => ({
       // Need to apply this here so that relative sizes (ems, %) within table
       // are correct
       sx: theme => ({
         // Need to apply this here so that relative sizes (ems, %) within table are correct
         fontSize: theme.typography.body1.fontSize,
-        display: 'flex',
-        flex: 1,
-        flexDirection: 'column',
+        // Make the NothingHere component vertically centered when there are no
+        // rows (in conjunction with muiTableBodyProps below)
+        ...(table.getRowCount() === 0
+          ? { display: 'flex', flex: 1, flexDirection: 'column' }
+          : {}),
       }),
-    },
+    }),
 
     muiTableHeadCellProps: ({ column, table }) => ({
       sx: {

--- a/client/packages/common/src/ui/layout/tables/material-react-table/useTableDisplayOptions.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useTableDisplayOptions.tsx
@@ -116,6 +116,7 @@ export const useTableDisplayOptions = <T extends MRT_RowData>(
         lineHeight: 1.2,
         verticalAlign: 'bottom',
         justifyContent: 'space-between',
+        opacity: 1,
         '& .MuiTableSortLabel-root': {
           display: column.getIsSorted() ? undefined : 'none',
         },
@@ -174,10 +175,12 @@ export const useTableDisplayOptions = <T extends MRT_RowData>(
       },
     }),
 
-    muiTableBodyCellProps: ({ cell, row, table }) => ({
+    muiTableBodyCellProps: ({ cell, row, column, table }) => ({
       sx: {
         fontSize: table.getState().density === 'compact' ? '0.90em' : '1em',
         fontWeight: 400,
+        // Remove transparency from pinned backgrounds
+        opacity: 1,
         color: getIsPlaceholderRow(row.original)
           ? 'secondary.light'
           : getIsRestrictedRow(row.original)
@@ -210,6 +213,10 @@ export const useTableDisplayOptions = <T extends MRT_RowData>(
           row.original?.['isSubRow'] && cell.column.id !== 'mrt-row-select'
             ? '2em'
             : undefined,
+        backgroundColor: column.getIsPinned()
+          ? // Remove transparency from pinned backgrounds
+            'rgba(252, 252, 252, 1)'
+          : undefined,
       },
     }),
 

--- a/client/packages/common/src/ui/layout/tables/material-react-table/useTableDisplayOptions.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useTableDisplayOptions.tsx
@@ -76,10 +76,26 @@ export const useTableDisplayOptions = <T extends MRT_RowData>(
 
     // Styling
     muiTablePaperProps: {
-      sx: { width: '100%', display: 'flex', flexDirection: 'column' },
+      sx: {
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        // Reduce the height and padding of the Actions toolbar
+        '& > .MuiBox-root': {
+          minHeight: '2.5rem',
+          height: 'unset',
+        },
+        '& > .MuiBox-root > .MuiBox-root': {
+          paddingY: 0,
+        },
+      },
     },
     muiTableContainerProps: {
-      sx: { flex: 1, display: 'flex', flexDirection: 'column' },
+      sx: {
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+      },
     },
     muiTableProps: {
       // Need to apply this here so that relative sizes (ems, %) within table

--- a/client/packages/common/src/ui/layout/tables/material-react-table/useTableDisplayOptions.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useTableDisplayOptions.tsx
@@ -149,10 +149,14 @@ export const useTableDisplayOptions = <T extends MRT_RowData>(
       },
     }),
 
-    muiTableBodyProps: ({ table }) => ({
-      // Make the NothingHere component vertically centered when there are no rows
-      sx: { height: table.getRowCount() === 0 ? '100%' : 'auto' },
-    }),
+    muiTableBodyProps: ({ table }) =>
+      // Make the NothingHere component vertically centered when there are no
+      // rows
+      table.getRowCount() === 0
+        ? {
+            sx: { height: '100%' },
+          }
+        : {},
 
     muiTableBodyRowProps: ({ row }) => ({
       onClick: () => {

--- a/client/packages/common/src/ui/layout/tables/material-react-table/useTableDisplayOptions.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useTableDisplayOptions.tsx
@@ -218,5 +218,16 @@ export const useTableDisplayOptions = <T extends MRT_RowData>(
     muiToolbarAlertBannerProps: {
       sx: { backgroundColor: 'unset' },
     },
+    displayColumnDefOptions: {
+      'mrt-row-select': {
+        size: 50,
+        muiTableHeadCellProps: {
+          align: 'center',
+        },
+        muiTableBodyCellProps: {
+          align: 'center',
+        },
+      },
+    },
   };
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9181 (partially)

# 👩🏻‍💻 What does this PR do?

Addresses these issues from the [original list](https://github.com/msupply-foundation/open-msupply/issues/9181#issue-3392446149):
- [x] Selected rows should be pale blue rather than orange
- [x] Remove `rows selected` from table header - it's already in our custom footer
- [x] Width of "Selection" row -- change according to density, and make sure header icon is in line ([image](https://github.com/msupply-foundation/open-msupply/issues/9181#issuecomment-3273012812))
- [x] Pinned columns are a little see through?
- [x] Reduce space between Header row and buttons ([image](https://github.com/msupply-foundation/open-msupply/issues/9181#issuecomment-3272252734))
- [x] Column headers need to be fixed in the list view (i.e. sticky when scrolling)
- [x] Use standard loading UI rather than progress toolbars (as discussed)


## 💌 Any notes for the reviewer?

See inline comments for details

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

Check the above points and make sure they are correct/look acceptable/don't cause any problems

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

