### PR TITLE
4840 invoice translate legacy finalised date/time

### DIFF
--- a/server/service/src/sync/test/test_data/invoice.rs
+++ b/server/service/src/sync/test/test_data/invoice.rs
@@ -30,7 +30,7 @@ const TRANSACT_1: (&str, &str) = (
       "comment": "",
       "confirm_date": "2021-07-30",
       "confirm_time": 47046,
-      "finalised_date": "",
+      "finalised_date": "0000-00-00",
       "finalised_time": 0,
       "contact_id": "",
       "currency_ID": "NEW_ZEALAND_DOLLARS",
@@ -318,7 +318,7 @@ const TRANSACT_2: (&str, &str) = (
         "om_transport_reference": "transport reference",
         "programID": "missing_program",
         "om_expected_delivery_date": "",
-        "finalised_date": "",
+        "finalised_date": "0000-00-00",
         "finalised_time": 0
     }"#,
 );
@@ -1202,7 +1202,7 @@ const PRESCRIPTION_1: (&str, &str) = (
       "om_created_datetime": "",
       "om_transport_reference": "",
       "om_expected_delivery_date": "",
-      "finalised_date": "",
+      "finalised_date": "0000-00-00",
       "finalised_time": 0
   }"#,
 );
@@ -1412,7 +1412,7 @@ const CANCELLED_PRESCRIPTION: (&str, &str) = (
       "om_cancelled_datetime": "2022-08-24T09:33:00",
       "om_transport_reference": "",
       "om_expected_delivery_date": "",
-      "finalised_date": "",
+      "finalised_date": "0000-00-00",
       "finalised_time": 0
   }"#,
 );

--- a/server/service/src/sync/test/test_data/invoice.rs
+++ b/server/service/src/sync/test/test_data/invoice.rs
@@ -30,6 +30,8 @@ const TRANSACT_1: (&str, &str) = (
       "comment": "",
       "confirm_date": "2021-07-30",
       "confirm_time": 47046,
+      "finalised_date": "",
+      "finalised_time": 0,
       "contact_id": "",
       "currency_ID": "NEW_ZEALAND_DOLLARS",
       "currency_rate": 1.32,
@@ -179,8 +181,8 @@ fn transact_1_push_legacy_row() -> LegacyTransactRow {
         linked_transaction_id: None,
         entry_date: NaiveDate::from_ymd_opt(2021, 7, 30).unwrap(),
         entry_time: NaiveTime::from_hms_opt(13, 4, 6).unwrap(),
-        ship_date: None,
-        arrival_date_actual: Some(NaiveDate::from_ymd_opt(2021, 7, 30).unwrap()),
+        finalised_date: None,
+        finalised_time: NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
         confirm_date: Some(NaiveDate::from_ymd_opt(2021, 7, 30).unwrap()),
         confirm_time: NaiveTime::from_hms_opt(13, 4, 6).unwrap(),
         mode: TransactMode::Store,
@@ -315,7 +317,9 @@ const TRANSACT_2: (&str, &str) = (
         "waybill_number": "",
         "om_transport_reference": "transport reference",
         "programID": "missing_program",
-        "om_expected_delivery_date": ""
+        "om_expected_delivery_date": "",
+        "finalised_date": "",
+        "finalised_time": 0
     }"#,
 );
 fn transact_2_pull_record() -> TestSyncIncomingRecord {
@@ -388,8 +392,8 @@ fn transact_2_push_record() -> TestSyncOutgoingRecord {
             linked_transaction_id: None,
             entry_date: NaiveDate::from_ymd_opt(2021, 8, 3).unwrap(),
             entry_time: NaiveTime::from_hms_opt(12, 26, 46).unwrap(),
-            ship_date: None,
-            arrival_date_actual: None,
+            finalised_date: None,
+            finalised_time: NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
             confirm_date: None,
             confirm_time: NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
             mode: TransactMode::Store,
@@ -446,6 +450,8 @@ const TRANSACT_OM_FIELDS: (&str, &str) = (
         "comment": "",
         "confirm_date": "0000-00-00",
         "confirm_time": 44806,
+        "finalised_date": "2022-08-29",
+        "finalised_time": 34800,
         "contact_id": "",
         "currency_ID": "AUSTRALIAN_DOLLARS",
         "currency_rate": 1,
@@ -618,8 +624,8 @@ fn transact_om_fields_push_record() -> TestSyncOutgoingRecord {
             linked_transaction_id: None,
             entry_date: NaiveDate::from_ymd_opt(2022, 8, 24).unwrap(),
             entry_time: NaiveTime::from_hms_opt(9, 33, 0).unwrap(),
-            ship_date: Some(NaiveDate::from_ymd_opt(2022, 8, 27).unwrap()),
-            arrival_date_actual: Some(NaiveDate::from_ymd_opt(2022, 8, 28).unwrap()),
+            finalised_date: Some(NaiveDate::from_ymd_opt(2022, 8, 29).unwrap()),
+            finalised_time: NaiveTime::from_hms_opt(14, 33, 0).unwrap(),
             confirm_date: Some(NaiveDate::from_ymd_opt(2022, 8, 29).unwrap()),
             confirm_time: NaiveTime::from_hms_opt(14, 33, 0).unwrap(),
             mode: TransactMode::Store,
@@ -774,6 +780,7 @@ const INVENTORY_ADDITION: (&str, &str) = (
         "om_type": null,
         "om_transport_reference": null,
         "finalised_date": "2023-01-16",
+        "finalised_time": 0,
         "om_expected_delivery_date": null
     }"#,
 );
@@ -853,6 +860,8 @@ fn inventory_addition_push_record() -> TestSyncOutgoingRecord {
             entry_time: NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
             confirm_date: Some(NaiveDate::from_ymd_opt(2023, 1, 16).unwrap(),),
             confirm_time: NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
+            finalised_date: Some(NaiveDate::from_ymd_opt(2023, 1, 16).unwrap(),),
+            finalised_time: NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
             created_datetime: Some(
                 NaiveDate::from_ymd_opt(2023, 1, 16)
                     .unwrap()
@@ -869,14 +878,12 @@ fn inventory_addition_push_record() -> TestSyncOutgoingRecord {
             mode: TransactMode::Store,
             comment: Some("Stocktake 1; Added stock".to_string()),
 
-            arrival_date_actual: None,
             allocated_datetime: None,
             picked_datetime: None,
             shipped_datetime: None,
             delivered_datetime: None,
             // received_datetime: None
             om_colour: None,
-            ship_date: None,
             hold: false,
             their_ref: None,
             transport_reference: None,
@@ -986,6 +993,7 @@ const INVENTORY_REDUCTION: (&str, &str) = (
         "om_type": null,
         "om_transport_reference": null,
         "finalised_date": "2023-01-16",
+        "finalised_time": 0,
         "om_expected_delivery_date": null
     }"#,
 );
@@ -1065,6 +1073,8 @@ fn inventory_reduction_push_record() -> TestSyncOutgoingRecord {
             entry_time: NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
             confirm_date: Some(NaiveDate::from_ymd_opt(2023, 1, 16).unwrap(),),
             confirm_time: NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
+            finalised_date: Some(NaiveDate::from_ymd_opt(2023, 1, 16).unwrap(),),
+            finalised_time: NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
             created_datetime: Some(
                 NaiveDate::from_ymd_opt(2023, 1, 16)
                     .unwrap()
@@ -1080,14 +1090,12 @@ fn inventory_reduction_push_record() -> TestSyncOutgoingRecord {
             cancelled_datetime: None,
             mode: TransactMode::Store,
             comment: Some("Stocktake 2; Reduced stock".to_string()),
-            arrival_date_actual: None,
             allocated_datetime: None,
             picked_datetime: None,
             shipped_datetime: None,
             delivered_datetime: None,
             // received_datetime: None
             om_colour: None,
-            ship_date: None,
             hold: false,
             their_ref: None,
             transport_reference: None,
@@ -1193,7 +1201,9 @@ const PRESCRIPTION_1: (&str, &str) = (
       "om_verified_datetime": "",
       "om_created_datetime": "",
       "om_transport_reference": "",
-      "om_expected_delivery_date": ""
+      "om_expected_delivery_date": "",
+      "finalised_date": "",
+      "finalised_time": 0
   }"#,
 );
 fn prescription_1_pull_record() -> TestSyncIncomingRecord {
@@ -1272,8 +1282,8 @@ fn prescription_1_push_record() -> TestSyncOutgoingRecord {
             linked_transaction_id: None,
             entry_date: NaiveDate::from_ymd_opt(2021, 7, 30).unwrap(),
             entry_time: NaiveTime::from_hms_opt(13, 4, 6).unwrap(),
-            ship_date: None,
-            arrival_date_actual: None,
+            finalised_date: None,
+            finalised_time: NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
             confirm_date: Some(NaiveDate::from_ymd_opt(2021, 7, 30).unwrap()),
             confirm_time: NaiveTime::from_hms_opt(13, 4, 6).unwrap(),
             mode: TransactMode::Dispensary,
@@ -1401,7 +1411,9 @@ const CANCELLED_PRESCRIPTION: (&str, &str) = (
       "om_created_datetime": "",
       "om_cancelled_datetime": "2022-08-24T09:33:00",
       "om_transport_reference": "",
-      "om_expected_delivery_date": ""
+      "om_expected_delivery_date": "",
+      "finalised_date": "",
+      "finalised_time": 0
   }"#,
 );
 fn cancelled_prescription_pull_record() -> TestSyncIncomingRecord {
@@ -1485,8 +1497,8 @@ fn cancelled_prescription_push_record() -> TestSyncOutgoingRecord {
             linked_transaction_id: None,
             entry_date: NaiveDate::from_ymd_opt(2021, 7, 30).unwrap(),
             entry_time: NaiveTime::from_hms_opt(13, 4, 6).unwrap(),
-            ship_date: None,
-            arrival_date_actual: None,
+            finalised_date: None,
+            finalised_time: NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
             confirm_date: Some(NaiveDate::from_ymd_opt(2021, 7, 30).unwrap()),
             confirm_time: NaiveTime::from_hms_opt(13, 4, 6).unwrap(),
             mode: TransactMode::Dispensary,
@@ -1578,13 +1590,13 @@ fn transact_migrate_og_si_to_shipped_push() -> TestSyncOutgoingRecord {
             ID: TRANSACT_MIGRATE_OG_SI_STATUS_ID.to_string(),
             status: LegacyTransactStatus::Nw,
             om_status: Some(LegacyOmStatus::Shipped),
-            arrival_date_actual: None,
+            // arrival_date_actual: None,
             confirm_date: None,
             confirm_time: NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
             shipped_datetime: transact_1_push_legacy_row().delivered_datetime,
             delivered_datetime: None,
-            // received_datetime: None
-            ship_date: Some(transact_1_push_legacy_row().entry_date),
+            finalised_date: transact_1_push_legacy_row().finalised_date,
+            finalised_time: transact_1_push_legacy_row().finalised_time,
             ..transact_1_push_legacy_row()
         }),
     }

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -727,7 +727,8 @@ fn map_legacy(
 
     let finalised_datetime = data
         .finalised_date
-        .map(|finalised_date| NaiveDateTime::new(finalised_date, data.finalised_time));
+        .map(|finalised_date| NaiveDateTime::new(finalised_date, data.finalised_time))
+        .or(confirm_datetime);
 
     // Try to figure out if a legacy record was backdated
     let backdated_datetime = map_backdated_datetime(&mapping.created_datetime, &confirm_datetime);

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -1,15 +1,10 @@
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 use crate::sync::translations::{
     clinician::ClinicianTranslation, currency::CurrencyTranslation,
     diagnosis::DiagnosisTranslation, name::NameTranslation,
     name_insurance_join::NameInsuranceJoinTranslation, store::StoreTranslation, to_legacy_time,
 };
-
 use anyhow::Context;
-use util::sync_serde::{
-    date_from_date_time, date_option_to_isostring, date_to_isostring, empty_str_as_option,
-    empty_str_as_option_string, naive_time, zero_date_as_option, zero_f64_as_none,
-};
-
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use repository::{
     ChangelogRow, ChangelogTableName, CurrencyFilter, CurrencyRepository, EqualFilter, Invoice,
@@ -20,8 +15,10 @@ use repository::{
 };
 use serde::{Deserialize, Serialize};
 use util::constants::INVENTORY_ADJUSTMENT_NAME_CODE;
-
-use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
+use util::sync_serde::{
+    date_option_to_isostring, date_to_isostring, empty_str_as_option, empty_str_as_option_string,
+    naive_time, zero_date_as_option, zero_f64_as_none,
+};
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -176,20 +173,19 @@ pub struct LegacyTransactRow {
     /// time in seconds
     #[serde(deserialize_with = "naive_time")]
     pub entry_time: NaiveTime, // e.g. 47046,
-    /// shipped_datetime
-    #[serde(deserialize_with = "zero_date_as_option")]
-    #[serde(serialize_with = "date_option_to_isostring")]
-    pub ship_date: Option<NaiveDate>, // "0000-00-00",
-    /// delivered_datetime
-    #[serde(deserialize_with = "zero_date_as_option")]
-    #[serde(serialize_with = "date_option_to_isostring")]
-    pub arrival_date_actual: Option<NaiveDate>,
-    /// verified_datetime
+    /// delivered_datetime / picked_datetime
     #[serde(deserialize_with = "zero_date_as_option")]
     #[serde(serialize_with = "date_option_to_isostring")]
     pub confirm_date: Option<NaiveDate>,
     #[serde(deserialize_with = "naive_time")]
     pub confirm_time: NaiveTime,
+
+    /// verified_datetime / shipped_datetime
+    #[serde(deserialize_with = "zero_date_as_option")]
+    #[serde(serialize_with = "date_option_to_isostring")]
+    pub finalised_date: Option<NaiveDate>,
+    #[serde(deserialize_with = "naive_time")]
+    pub finalised_time: NaiveTime,
 
     pub mode: TransactMode,
     #[serde(rename = "tax_rate")]
@@ -491,7 +487,7 @@ impl SyncTranslation for InvoiceTranslation {
             return Err(anyhow::anyhow!("Invoice not found"));
         };
 
-        let confirm_datetime = to_legacy_confirm_time(&invoice.invoice_row);
+        let legacy_datetimes = to_legacy_datetime(&invoice.invoice_row);
 
         let Invoice {
             invoice_row:
@@ -544,8 +540,7 @@ impl SyncTranslation for InvoiceTranslation {
             Some(_type) => _type,
             None => {
                 return Ok(PushTranslateResult::Ignored(format!(
-                    "Unsupported invoice type {:?}",
-                    r#type
+                    "Unsupported invoice type {type:?}"
                 )))
             }
         };
@@ -554,8 +549,7 @@ impl SyncTranslation for InvoiceTranslation {
             Some(legacy_status) => legacy_status,
             None => {
                 return Ok(PushTranslateResult::Ignored(format!(
-                    "Unsupported invoice status: {:?}",
-                    status
+                    "Unsupported invoice status: {status:?}"
                 )))
             }
         };
@@ -575,12 +569,10 @@ impl SyncTranslation for InvoiceTranslation {
             linked_transaction_id: linked_invoice_id,
             entry_date: created_datetime.date(),
             entry_time: to_legacy_time(created_datetime),
-            ship_date: shipped_datetime
-                .map(|shipped_datetime| date_from_date_time(&shipped_datetime)),
-            arrival_date_actual: delivered_datetime
-                .map(|delivered_datetime| date_from_date_time(&delivered_datetime)),
-            confirm_date: confirm_datetime.0,
-            confirm_time: confirm_datetime.1,
+            confirm_date: legacy_datetimes.confirm_datetime.0,
+            confirm_time: legacy_datetimes.confirm_datetime.1,
+            finalised_date: legacy_datetimes.finalised_datetime.0,
+            finalised_time: legacy_datetimes.finalised_datetime.1,
             tax_percentage,
             mode: if r#type == InvoiceType::Prescription {
                 TransactMode::Dispensary
@@ -733,6 +725,10 @@ fn map_legacy(
         .confirm_date
         .map(|confirm_date| NaiveDateTime::new(confirm_date, data.confirm_time));
 
+    let finalised_datetime = data
+        .finalised_date
+        .map(|finalised_date| NaiveDateTime::new(finalised_date, data.finalised_time));
+
     // Try to figure out if a legacy record was backdated
     let backdated_datetime = map_backdated_datetime(&mapping.created_datetime, &confirm_datetime);
     if backdated_datetime.is_some() {
@@ -748,7 +744,7 @@ fn map_legacy(
             LegacyTransactStatus::Fn => {
                 mapping.allocated_datetime = confirm_datetime;
                 mapping.picked_datetime = confirm_datetime;
-                mapping.shipped_datetime = confirm_datetime;
+                mapping.shipped_datetime = finalised_datetime;
             }
             _ => {}
         },
@@ -763,7 +759,7 @@ fn map_legacy(
             LegacyTransactStatus::Fn => {
                 mapping.received_datetime = confirm_datetime;
                 mapping.delivered_datetime = confirm_datetime;
-                mapping.verified_datetime = confirm_datetime;
+                mapping.verified_datetime = finalised_datetime;
             }
             _ => {}
         },
@@ -773,38 +769,44 @@ fn map_legacy(
             }
             LegacyTransactStatus::Fn => {
                 mapping.picked_datetime = confirm_datetime;
-                mapping.verified_datetime = confirm_datetime;
+                mapping.verified_datetime = finalised_datetime;
             }
             _ => {}
         },
         InvoiceType::InventoryAddition | InvoiceType::InventoryReduction => match data.status {
             LegacyTransactStatus::Cn => {
-                mapping.verified_datetime = confirm_datetime;
+                mapping.verified_datetime = finalised_datetime;
             }
             LegacyTransactStatus::Fn => {
-                mapping.verified_datetime = confirm_datetime;
+                mapping.verified_datetime = finalised_datetime;
             }
             _ => {}
         },
         InvoiceType::Repack => {
             if let LegacyTransactStatus::Fn = data.status {
-                mapping.verified_datetime = confirm_datetime;
+                mapping.verified_datetime = finalised_datetime;
             }
         }
     };
     mapping
 }
 
-fn to_legacy_confirm_time(
+struct ToLegacyDatetime {
+    confirm_datetime: (Option<NaiveDate>, NaiveTime),
+    finalised_datetime: (Option<NaiveDate>, NaiveTime),
+}
+
+fn to_legacy_datetime(
     InvoiceRow {
         r#type,
         picked_datetime,
         received_datetime: delivered_datetime,
         verified_datetime,
+        shipped_datetime,
         ..
     }: &InvoiceRow,
-) -> (Option<NaiveDate>, NaiveTime) {
-    let datetime = match r#type {
+) -> ToLegacyDatetime {
+    let confirm_datetime = match r#type {
         InvoiceType::OutboundShipment => picked_datetime,
         InvoiceType::InboundShipment => delivered_datetime,
         InvoiceType::Prescription => picked_datetime,
@@ -816,11 +818,31 @@ fn to_legacy_confirm_time(
         InvoiceType::SupplierReturn => picked_datetime,
     };
 
-    let date = datetime.map(|datetime| datetime.date());
-    let time = datetime
+    let finalised_datetime = match r#type {
+        InvoiceType::OutboundShipment | InvoiceType::Prescription | InvoiceType::SupplierReturn => {
+            shipped_datetime
+        }
+        InvoiceType::InboundShipment
+        | InvoiceType::InventoryAddition
+        | InvoiceType::InventoryReduction
+        | InvoiceType::Repack
+        | InvoiceType::CustomerReturn => verified_datetime,
+    };
+
+    let confirm_date = confirm_datetime.map(|datetime| datetime.date());
+    let confirm_time = confirm_datetime
         .map(to_legacy_time)
         .unwrap_or(NaiveTime::from_hms_opt(0, 0, 0).unwrap());
-    (date, time)
+
+    let finalised_date = finalised_datetime.map(|datetime| datetime.date());
+    let finalised_time = finalised_datetime
+        .map(to_legacy_time)
+        .unwrap_or(NaiveTime::from_hms_opt(0, 0, 0).unwrap());
+
+    ToLegacyDatetime {
+        confirm_datetime: (confirm_date, confirm_time),
+        finalised_datetime: (finalised_date, finalised_time),
+    }
 }
 
 fn invoice_status(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #4840

# 👩🏻‍💻 What does this PR do?
Implement finalised date/time mapping to / from OG for invoices

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create some inbound / outbound shipments in OG or OMS
- [ ] Sync them
- [ ] Check finalised datetimes have been populated correctly. iOG status = fn maps to Outbound, Prescription and Supplier Return -> shipped datetime OR inbound shipment, inventory add/reduct, repack, customer return = verified datetime

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

