### PR TITLE
9314 Adjusted Quantity Editing

### DIFF
--- a/client/packages/purchasing/src/purchase_order/DetailView/LineEdit/PurchaseOrderLineEdit.tsx
+++ b/client/packages/purchasing/src/purchase_order/DetailView/LineEdit/PurchaseOrderLineEdit.tsx
@@ -7,7 +7,9 @@ import {
   PurchaseOrderLineStatusNode,
   PurchaseOrderNodeStatus,
   Select,
+  useAuthContext,
   useMediaQuery,
+  UserPermission,
   useTranslation,
 } from '@openmsupply-client/common';
 import { PurchaseOrderLineFragment } from '../../api';
@@ -54,6 +56,11 @@ export const PurchaseOrderLineEdit = ({
   const t = useTranslation();
   const showContent = !!draft?.itemId;
   const isVerticalScreen = useMediaQuery('(max-width:800px)');
+  const { userHasPermission } = useAuthContext();
+
+  const userIsAuthorised = userHasPermission(
+    UserPermission.PurchaseOrderAuthorise
+  );
 
   // Disable input components. Individual inputs can override this
   const disabled =
@@ -192,6 +199,7 @@ export const PurchaseOrderLineEdit = ({
                   },
                   decimalLimit: 2,
                   autoFocus: true,
+                  disabled: !canEditRequestedQuantity && !userIsAuthorised,
                 }
               )}
               {numericInput('label.pack-size', draft?.requestedPackSize, {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9314

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Prevent users who do not have the `Authorise Purchase Orders` permission on from editing the adjusted packs in the purchase order line edit modal

A graphql error was already in place, this is a front end check which disables the adjusted quantity field if the user does not have permission to edit
<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->


- [ ]  Have OG user permission `Authorise Purchase Orders`: ON
- [ ]  Have Global Preference (OMS) Authorise purchase orders: ON
- [ ]  Create a purchase order and add a line with quantity - should be Requested Packs
- [ ]  Proceed through statuses until current status = `Ready for sending` (will need OG user permission on for the status changes if OMS Auth pref is on - turn user permission off afterwards)
- [ ]  Open the line -> See quantity editing is now Adjusted Packs. With user permission off this field will be disabled
- [ ] Turn user permission on -> same field will be enabled and allow editing
- [ ] Repeat all steps with Global Preference (OMS) Authorise purchase orders: OFF 

The graphql error can be dev tested by removing the field disabling, or in a graphql playground

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

