### PR TITLE
9356 purchase order ui label navigation issues

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -444,6 +444,7 @@
   "error.provide-reason-stock-adjustment": "A reason must be provided before adjusting stock",
   "error.provide-valid-reason": "Adjustment reason does not match adjustment direction",
   "error.purchase-order-line-already-exists": "Purchase order line already exists",
+  "error.purchase-order-line-not-found": "Purchase order line not found",
   "error.purchase-order-not-finalised": "Purchase order is not finalised",
   "error.purchase-order-not-found": "Purchase order not found",
   "error.reasons-not-provided-program-requisition": "Reasons must be provided when suggested quantity differs from requested quantity.",

--- a/client/packages/purchasing/src/purchase_order/DetailView/AppBarButtons/AddButton.tsx
+++ b/client/packages/purchasing/src/purchase_order/DetailView/AppBarButtons/AddButton.tsx
@@ -1,19 +1,19 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { SplitButton, SplitButtonOption } from '@common/components';
-import { useTranslation } from '@common/intl';
-import { AddFromMasterListButton } from './AddFromMasterListButton';
-import { useToggle } from '@common/hooks';
-import { PlusCircleIcon } from '@common/icons';
-import { PurchaseOrderFragment } from '../../api';
-import { UserPermission } from '@common/types';
-import { LineImportModal } from '../ImportLines/LineImportModal';
 import {
   NonEmptyArray,
   useCallbackWithPermission,
   useQueryClient,
+  useToggle,
+  PlusCircleIcon,
+  UserPermission,
+  SplitButton,
+  SplitButtonOption,
+  useTranslation,
 } from '@openmsupply-client/common';
 import { UploadDocumentModal } from '@openmsupply-client/system';
-import { PURCHASE_ORDER } from '../../api/hooks/keys';
+import { PurchaseOrderFragment, PURCHASE_ORDER } from '../../api';
+import { LineImportModal } from '../ImportLines/LineImportModal';
+import { AddFromMasterListButton } from './AddFromMasterListButton';
 
 interface AddButtonProps {
   purchaseOrder: PurchaseOrderFragment | undefined;
@@ -114,7 +114,6 @@ export const AddButton = ({
         openFrom="bottom"
         Icon={<PlusCircleIcon />}
       />
-
       {masterListModalController.isOn && (
         <AddFromMasterListButton
           isOn={masterListModalController.isOn}

--- a/client/packages/purchasing/src/purchase_order/DetailView/ImportLines/ReviewTab.tsx
+++ b/client/packages/purchasing/src/purchase_order/DetailView/ImportLines/ReviewTab.tsx
@@ -160,7 +160,7 @@ export const ReviewTab = ({
           columns={columns}
           data={currentEquipmentPage}
           noDataElement={
-            <NothingHere body={t('error.purchase-order-not-found')} />
+            <NothingHere body={t('error.purchase-order-line-not-found')} />
           }
         />
       </Grid>

--- a/client/packages/purchasing/src/purchase_order/DetailView/LineEdit/PurchaseOrderLineEditModal.tsx
+++ b/client/packages/purchasing/src/purchase_order/DetailView/LineEdit/PurchaseOrderLineEditModal.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import { PurchaseOrderFragment } from '../../api';
-import { DialogButton, InlineSpinner, Typography } from '@common/components';
 import {
   Box,
   ModalMode,
@@ -9,10 +7,14 @@ import {
   useIntlUtils,
   useNotification,
   useTranslation,
+  DialogButton,
+  InlineSpinner,
+  Typography,
+  useUrlQuery,
 } from '@openmsupply-client/common';
 import { ItemStockOnHandFragment } from '@openmsupply-client/system';
+import { PurchaseOrderFragment, usePurchaseOrderLine } from '../../api';
 import { PurchaseOrderLineEdit } from './PurchaseOrderLineEdit';
-import { usePurchaseOrderLine } from '../../api/hooks/usePurchaseOrderLine';
 import { createDraftPurchaseOrderLine } from './utils';
 
 interface PurchaseOrderLineEditModalProps {
@@ -37,9 +39,10 @@ export const PurchaseOrderLineEditModal = ({
   openNext,
 }: PurchaseOrderLineEditModalProps) => {
   const t = useTranslation();
-  const { getPlural } = useIntlUtils();
   const { error } = useNotification();
   const { round } = useFormatNumber();
+  const { getPlural } = useIntlUtils();
+  const { updateQuery } = useUrlQuery();
 
   const lines = purchaseOrder.lines.nodes;
   const isUpdateMode = mode === ModalMode.Update;
@@ -66,6 +69,7 @@ export const PurchaseOrderLineEditModal = ({
     try {
       if (mode === ModalMode.Create) {
         await create();
+        updateQuery({ tab: t('label.general') });
       } else if (mode === ModalMode.Update) {
         const res = await update();
         const { success, error: updateError } = res;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9368

# 👩🏻‍💻 What does this PR do?

Have updated the text when you try to search for an item within the CSV import modal. And ensures that it opens the General tab after importing a CSV or adding a new line/item

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

Have done a few clean up of imports and have remove React fragments that are not needed

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Navigate to a purchase order (or create a new one)
- [ ] Click on the dropdown within Add Item and select Import Lines
- [ ] Upload a CSV file (or download the template and fill with values)
- [ ] Within the 1st tab try search for an item
- [ ] Text should say: `Purchase order lines not found`
- [ ] Remove search and click on Ok&Next
- [ ] If you're on a different tab should be redirected to `General` tab (try in a different language as well)
- [ ] -------------------------------------------------
- [ ] Within the same purchase order -> click on Add Item
- [ ] If you're on a different tab, should be redirected to `General` tab (try in a different language as well)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

