### PR TITLE
9381 not possible to enter decimals in pricing fields in stock line

### DIFF
--- a/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -47,8 +47,10 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
   const isSymbolLast = options.pattern.endsWith('!');
   const prefix = !isSymbolLast ? options.symbol : '';
   const suffix = isSymbolLast ? options.symbol : '';
-  const val = value !== undefined ? value : defaultValue;
-  const valueAsNumber = Number.isNaN(Number(val)) ? 0 : Number(val);
+  const defaultValueAsNumber = Number.isNaN(Number(defaultValue))
+    ? undefined
+    : Number(defaultValue);
+  const valueAsNumber = Number.isNaN(value) ? 0 : Number(value);
 
   return (
     <StyledCurrencyInput
@@ -64,7 +66,10 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
         color: disabled ? theme => theme.palette.text.disabled : undefined,
         width,
       }}
-      value={NumUtils.round(valueAsNumber, options.precision)}
+      defaultValue={NumUtils.round(
+        valueAsNumber ?? defaultValueAsNumber,
+        options.precision
+      )}
       onValueChange={newValue => onChangeNumber(c(newValue || '').value)}
       onFocus={e => e.target.select()}
       allowNegativeValue={allowNegativeValue}

--- a/client/packages/common/src/utils/quantities/quantities.test.ts
+++ b/client/packages/common/src/utils/quantities/quantities.test.ts
@@ -46,7 +46,7 @@ describe('QuantityUtils', () => {
     });
 
     it('handles cases with no doses per unit', () => {
-      const line = { packSize: 10 };
+      const line = { packSize: 10, dosesPerUnit: 1 };
       expect(QuantityUtils.packsToDoses(5, line)).toBe(50);
     });
 

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -211,7 +211,7 @@ export const StockLineForm = ({
               Input={
                 <CurrencyInput
                   autoFocus={!packEditable}
-                  defaultValue={draft.costPricePerPack}
+                  value={draft.costPricePerPack}
                   onChangeNumber={costPricePerPack =>
                     onUpdate({ costPricePerPack })
                   }
@@ -222,6 +222,7 @@ export const StockLineForm = ({
               label={t('label.sell-price')}
               Input={
                 <CurrencyInput
+                  key={draft.packSize}
                   value={draft.sellPricePerPack}
                   onChangeNumber={sellPricePerPack =>
                     onUpdate({ sellPricePerPack })


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9381

# 👩🏻‍💻 What does this PR do?
The currency component was changed to a controlled component to get the sell price to update... which was messing with the decimals... have changed this back to an uncontrolled component and forced the currency input to re-render if the sell price has changed

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to stock 
- [ ] Add new stock -> try to enter prices in decimals

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

