### PR TITLE
9083 When store preference "Set pack to one" is active, the "shipped pack size" of a manual inbound shipment is also set to 1 and the conversion is changing the shipped packs to match the Received packs

### DIFF
--- a/server/service/src/invoice_line/stock_in_line/generate.rs
+++ b/server/service/src/invoice_line/stock_in_line/generate.rs
@@ -11,7 +11,7 @@ pub fn convert_invoice_line_to_single_pack(invoice_line: InvoiceLineRow) -> Invo
         volume_per_pack: invoice_line.volume_per_pack / invoice_line.pack_size,
         shipped_number_of_packs: invoice_line
             .shipped_number_of_packs
-            .map(|shipped| shipped * invoice_line.pack_size),
+            .map(|shipped| shipped * invoice_line.shipped_pack_size.unwrap_or(1.0)),
         shipped_pack_size: Some(1.0),
         pack_size: 1.0,
         ..invoice_line


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9083

# 👩🏻‍💻 What does this PR do?
Shipped numbers of packs was being multiplied by received pack size instead of shipped pack size

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an inbound shipment
- [ ] Add line
- [ ] Make sure shipped pack size is different from received pack size
- [ ] Save line
- [ ] Go back, shipped number of packs should be calculated to pack size 1 corerctly

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

