### PR TITLE
9396 make group by item a table toggle

### DIFF
--- a/client/packages/common/src/ui/layout/tables/context/hooks/useIsGrouped.ts
+++ b/client/packages/common/src/ui/layout/tables/context/hooks/useIsGrouped.ts
@@ -35,20 +35,3 @@ export const useIsGrouped = (key: keyof GroupByItem): IsGroupedControl => {
 
   return { isGrouped: !!groupByItem?.[key], toggleIsGrouped };
 };
-
-export const useIsGroupedState = (key: keyof GroupByItem): IsGroupedControl => {
-  const [groupByItem, setGroupByItem] = useLocalStorage('/groupbyitem', {
-    outboundShipment: false,
-    inboundShipment: false,
-    supplierReturn: false,
-    customerReturn: false,
-    stocktake: true,
-  });
-
-  const toggleIsGrouped = useCallback(() => {
-    const newVal = !groupByItem?.[key];
-    setGroupByItem({ ...groupByItem, [key]: newVal });
-  }, [groupByItem, key, setGroupByItem]);
-
-  return { isGrouped: !!groupByItem?.[key], toggleIsGrouped };
-};

--- a/client/packages/common/src/ui/layout/tables/material-react-table/tableState/index.ts
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/tableState/index.ts
@@ -3,3 +3,4 @@ export * from './useColumnOrder';
 export * from './useColumnPinning';
 export * from './useColumnSizing';
 export * from './useColumnVisibility';
+export * from './useIsGrouped';

--- a/client/packages/common/src/ui/layout/tables/material-react-table/tableState/useColumnOrder.ts
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/tableState/useColumnOrder.ts
@@ -13,7 +13,7 @@ export const useColumnOrder = <T extends MRT_RowData>(
   tableId: string,
   columns: MRT_ColumnDef<T>[],
   enableRowSelection: MRT_TableOptions<T>['enableRowSelection'],
-  groupByField?: string
+  isGrouped: boolean
 ) => {
   const initial = useMemo(
     () =>
@@ -21,11 +21,11 @@ export const useColumnOrder = <T extends MRT_RowData>(
         columns,
         state: {},
         enableRowSelection, // adds `mrt-row-select`
-        enableExpanding: !!groupByField, // adds `mrt-row-expand`
+        enableExpanding: !!isGrouped, // adds `mrt-row-expand`
         positionExpandColumn: 'first', // this is the default, but needs to be explicitly set here
       } as MRT_StatefulTableOptions<MRT_RowData>),
 
-    []
+    [isGrouped, columns]
   );
 
   const [state, setState] = useState<MRT_ColumnOrderState>(

--- a/client/packages/common/src/ui/layout/tables/material-react-table/tableState/useIsGrouped.ts
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/tableState/useIsGrouped.ts
@@ -1,0 +1,26 @@
+import { useCallback, useState } from 'react';
+import { getSavedState, updateSavedState } from './utils';
+
+export const useIsGrouped = (
+  tableId: string,
+  defaultValue: boolean = false
+) => {
+  const [state, setState] = useState<boolean>(
+    getSavedState(tableId).isGrouped ?? defaultValue
+  );
+
+  const toggleGrouped = useCallback(
+    () =>
+      setState(prev => {
+        const isGrouped = !prev;
+
+        updateSavedState(tableId, { isGrouped });
+        return isGrouped;
+      }),
+    []
+  );
+
+  const resetGrouped = () => setState(defaultValue);
+
+  return { isGrouped: state, toggleGrouped, resetGrouped };
+};

--- a/client/packages/common/src/ui/layout/tables/material-react-table/tableState/utils.ts
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/tableState/utils.ts
@@ -14,6 +14,7 @@ export interface ManagedTableState {
   columnPinning?: MRT_ColumnPinningState;
   columnOrder?: MRT_ColumnOrderState;
   columnSizing?: MRT_ColumnSizingState;
+  isGrouped?: boolean;
 }
 
 export const hasSavedState = (tableId: string): boolean => {

--- a/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
@@ -77,7 +77,8 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
   );
 
   const processedData = useMemo(
-    () => getGroupedRows(isGrouped, data ?? [], 'itemName', t),
+    () =>
+      getGroupedRows(isGrouped, data ?? [], grouping?.field ?? 'itemName', t),
     [data, isGrouped, t]
   );
 

--- a/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
@@ -17,6 +17,7 @@ import {
   useColumnSizing,
   useColumnVisibility,
   useColumnPinning,
+  useIsGrouped,
 } from './tableState';
 import { clearSavedState } from './tableState/utils';
 import { NothingHere } from '@common/components';
@@ -30,7 +31,14 @@ export interface BaseTableConfig<T extends MRT_RowData>
   getIsPlaceholderRow?: (row: T) => boolean;
   /** Whether row should be greyed out - still potentially clickable */
   getIsRestrictedRow?: (row: T) => boolean;
-  groupByField?: string;
+  grouping?: {
+    /** Defaults to false */
+    enabled: boolean;
+    /** Defaults to 'itemName' */
+    field?: string;
+    /** Defaults to false */
+    groupedByDefault?: boolean;
+  };
   columns: ColumnDef<T>[];
   initialSort?: { key: string; dir: 'asc' | 'desc' };
   noDataElement?: React.ReactNode;
@@ -45,7 +53,7 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
   getIsRestrictedRow,
   columns: omsColumns,
   data,
-  groupByField,
+  grouping,
   enableRowSelection = true,
   enableColumnResizing = true,
   manualFiltering = false,
@@ -63,9 +71,14 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
   const { columnFilters, onColumnFiltersChange } = useTableFiltering(columns);
   const { sorting, onSortingChange } = useUrlSortManagement(initialSort);
 
+  const { isGrouped, toggleGrouped, resetGrouped } = useIsGrouped(
+    tableId,
+    grouping?.groupedByDefault
+  );
+
   const processedData = useMemo(
-    () => getGroupedRows(data ?? [], groupByField, t),
-    [data, groupByField]
+    () => getGroupedRows(isGrouped, data ?? [], 'itemName', t),
+    [data, isGrouped, t]
   );
 
   const density = useColumnDensity(tableId);
@@ -76,7 +89,7 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
     tableId,
     columns,
     enableRowSelection,
-    groupByField
+    isGrouped
   );
 
   const resetTableState = () => {
@@ -89,6 +102,7 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
     table.resetColumnOrder();
     table.resetColumnPinning();
     table.resetColumnSizing();
+    resetGrouped();
 
     // Visibility `initial` could change if prefs have come on/screen size changed
     // so reset to latest initial value rather than default initial mount state
@@ -98,13 +112,14 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
     table.setDensity(density.initial);
   };
 
-  const displayOptions = useTableDisplayOptions(
+  const displayOptions = useTableDisplayOptions({
     tableId,
+    toggleGrouped: grouping?.enabled ? toggleGrouped : undefined,
     resetTableState,
     onRowClick,
     getIsPlaceholderRow,
-    getIsRestrictedRow
-  );
+    getIsRestrictedRow,
+  });
 
   const table = useMaterialReactTable<T>({
     columns,
@@ -126,7 +141,7 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
 
     // Disable bottom footer - use OMS custom action footer instead
     enableBottomToolbar: false,
-    enableExpanding: !!groupByField,
+    enableExpanding: isGrouped,
 
     // Disable selection Toolbar, we use our own custom footer for this
     positionToolbarAlertBanner: 'none',

--- a/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
@@ -114,6 +114,7 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
 
   const displayOptions = useTableDisplayOptions({
     tableId,
+    isGrouped,
     toggleGrouped: grouping?.enabled ? toggleGrouped : undefined,
     resetTableState,
     onRowClick,

--- a/client/packages/common/src/ui/layout/tables/material-react-table/useTableDisplayOptions.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useTableDisplayOptions.tsx
@@ -11,6 +11,7 @@ import {
   CheckboxCheckedIcon,
   CheckboxEmptyIcon,
   CheckboxIndeterminateIcon,
+  MedicineIcon,
   RefreshIcon,
 } from '@common/icons';
 import { MenuItem, Typography } from '@mui/material';
@@ -19,13 +20,21 @@ import { IconButton } from '@common/components';
 import { useTranslation } from '@common/intl';
 import { hasSavedState } from './tableState/utils';
 
-export const useTableDisplayOptions = <T extends MRT_RowData>(
-  tableId: string,
-  resetTableState: () => void,
-  onRowClick?: (row: T) => void,
-  getIsPlaceholderRow: (row: T) => boolean = () => false,
-  getIsRestrictedRow: (row: T) => boolean = () => false
-): Partial<MRT_TableOptions<T>> => {
+export const useTableDisplayOptions = <T extends MRT_RowData>({
+  tableId,
+  resetTableState,
+  onRowClick,
+  toggleGrouped,
+  getIsPlaceholderRow = () => false,
+  getIsRestrictedRow = () => false,
+}: {
+  tableId: string;
+  resetTableState: () => void;
+  onRowClick?: (row: T) => void;
+  toggleGrouped?: () => void;
+  getIsPlaceholderRow?: (row: T) => boolean;
+  getIsRestrictedRow?: (row: T) => boolean;
+}): Partial<MRT_TableOptions<T>> => {
   const t = useTranslation();
   return {
     // Add description to column menu
@@ -54,6 +63,14 @@ export const useTableDisplayOptions = <T extends MRT_RowData>(
     // Add reset state button to toolbar
     renderToolbarInternalActions: ({ table }) => (
       <>
+        {toggleGrouped && (
+          <IconButton
+            icon={<MedicineIcon />}
+            onClick={toggleGrouped}
+            label={t('label.group-by-item')}
+            sx={iconButtonProps}
+          />
+        )}
         <MRT_ToggleFiltersButton table={table} />
         <MRT_ToggleDensePaddingButton table={table} />
         <MRT_ShowHideColumnsButton table={table} />
@@ -62,11 +79,7 @@ export const useTableDisplayOptions = <T extends MRT_RowData>(
           onClick={resetTableState}
           label={t('label.reset-table-defaults')}
           disabled={!hasSavedState(tableId)}
-          sx={{
-            width: '40px',
-            height: '40px',
-            '& svg': { fontSize: '1.2rem' },
-          }}
+          sx={iconButtonProps}
         />
         <MRT_ToggleFullScreenButton table={table} />
       </>
@@ -256,4 +269,10 @@ export const useTableDisplayOptions = <T extends MRT_RowData>(
       },
     },
   };
+};
+
+const iconButtonProps = {
+  width: '40px',
+  height: '40px',
+  '& svg': { fontSize: '1.2rem' },
 };

--- a/client/packages/common/src/ui/layout/tables/material-react-table/useTableDisplayOptions.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useTableDisplayOptions.tsx
@@ -24,6 +24,7 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
   tableId,
   resetTableState,
   onRowClick,
+  isGrouped,
   toggleGrouped,
   getIsPlaceholderRow = () => false,
   getIsRestrictedRow = () => false,
@@ -31,6 +32,7 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
   tableId: string;
   resetTableState: () => void;
   onRowClick?: (row: T) => void;
+  isGrouped: boolean;
   toggleGrouped?: () => void;
   getIsPlaceholderRow?: (row: T) => boolean;
   getIsRestrictedRow?: (row: T) => boolean;
@@ -69,6 +71,7 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
             onClick={toggleGrouped}
             label={t('label.group-by-item')}
             sx={iconButtonProps}
+            color={isGrouped ? 'secondary' : undefined}
           />
         )}
         <MRT_ToggleFiltersButton table={table} />

--- a/client/packages/common/src/ui/layout/tables/material-react-table/utils.test.ts
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/utils.test.ts
@@ -6,11 +6,20 @@ describe('getGroupedRows', () => {
   it('should return original data when no groupByField is provided', () => {
     const data = [
       { name: 'Item 1', category: 'A' },
-      { name: 'Item 2', category: 'B' },
+      { name: 'Item 2', category: 'A' },
     ];
 
-    const result = getGroupedRows(data, undefined, mockT);
+    const result = getGroupedRows(true, data, undefined, mockT);
 
+    expect(result).toEqual(data);
+  });
+  it('should return original data when isGrouped is false', () => {
+    const data = [
+      { name: 'Item 1', category: 'A' },
+      { name: 'Item 2', category: 'A' },
+    ];
+
+    const result = getGroupedRows(false, data, 'category', mockT);
     expect(result).toEqual(data);
   });
 
@@ -20,7 +29,7 @@ describe('getGroupedRows', () => {
       { name: 'Item 2', category: 'B' },
     ];
 
-    const result = getGroupedRows(data, 'category', mockT);
+    const result = getGroupedRows(true, data, 'category', mockT);
 
     expect(result).toHaveLength(2);
     expect(result[0]).toEqual({ name: 'Item 1', category: 'A' });
@@ -33,7 +42,7 @@ describe('getGroupedRows', () => {
       { name: 'Item 2', category: 'A', price: 20 },
     ];
 
-    const result = getGroupedRows(data, 'category', mockT);
+    const result = getGroupedRows(true, data, 'category', mockT);
 
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({
@@ -54,7 +63,7 @@ describe('getGroupedRows', () => {
       { name: 'Item 3', category: 'A', status: 'active' },
     ];
 
-    const result = getGroupedRows(data, 'category', mockT);
+    const result = getGroupedRows(true, data, 'category', mockT);
 
     expect(result).toHaveLength(1);
     expect(result[0]!.status).toBe('active'); // Should preserve equal value
@@ -68,7 +77,7 @@ describe('getGroupedRows', () => {
       { category: 'A', details: { type: 'large', color: 'red' } },
     ];
 
-    const result = getGroupedRows(data, 'category', mockT);
+    const result = getGroupedRows(true, data, 'category', mockT);
 
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({
@@ -89,7 +98,7 @@ describe('getGroupedRows', () => {
       { name: 'Item 4', category: 'C' },
     ];
 
-    const result = getGroupedRows(data, 'category', mockT);
+    const result = getGroupedRows(true, data, 'category', mockT);
 
     expect(result).toEqual([
       // Single item group A

--- a/client/packages/common/src/ui/layout/tables/material-react-table/utils.ts
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/utils.ts
@@ -43,11 +43,12 @@ export const mergeCellProps = <TData extends Record<string, any>>(
 };
 
 export const getGroupedRows = <T extends MRT_RowData>(
+  isGrouped: boolean,
   data: T[],
   groupByField: keyof T | undefined,
   t: TypedTFunction<LocaleKey>
 ): Groupable<T>[] => {
-  if (!groupByField) return data;
+  if (!isGrouped || !groupByField) return data;
 
   // Group rows by groupByField
   const grouped = data.reduce(

--- a/client/packages/inventory/src/Stocktake/DetailView/DetailView.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/DetailView.tsx
@@ -14,7 +14,6 @@ import {
   Groupable,
   NothingHere,
   MaterialTable,
-  useIsGroupedState,
 } from '@openmsupply-client/common';
 import { ActivityLogList } from '@openmsupply-client/system';
 import { Toolbar } from './Toolbar';
@@ -63,7 +62,6 @@ const DetailViewInner = () => {
     []
   );
 
-  const { isGrouped } = useIsGroupedState('stocktake');
   const columns = useStocktakeColumns();
 
   const { table, selectedRows } = useNonPaginatedMaterialTable<
@@ -74,7 +72,7 @@ const DetailViewInner = () => {
     isLoading: rowsLoading,
     data: lines,
     onRowClick: row => onOpen(row.item),
-    groupByField: isGrouped ? 'itemName' : undefined,
+    grouping: { enabled: true, groupedByDefault: true },
     initialSort: { key: 'itemName', dir: 'asc' },
     getIsPlaceholderRow,
     noDataElement: (

--- a/client/packages/inventory/src/Stocktake/DetailView/Toolbar.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/Toolbar.tsx
@@ -14,16 +14,12 @@ import {
   TypedTFunction,
   LocaleKey,
   FieldUpdateMutation,
-  Box,
-  Switch,
-  useIsGroupedState,
 } from '@openmsupply-client/common';
 import { StocktakeFragment, useStocktakeOld } from '../api';
 
 export const Toolbar = () => {
   const isDisabled = useStocktakeOld.utils.isDisabled();
   const t = useTranslation();
-  const { isGrouped, toggleIsGrouped } = useIsGroupedState('stocktake');
   const { isLocked, stocktakeDate, description, update } =
     useStocktakeOld.document.fields([
       'isLocked',
@@ -59,35 +55,17 @@ export const Toolbar = () => {
             />
           </Grid>
         ) : (
-          <>
-            <Grid display="flex" flex={1} flexDirection="column" gap={1}>
-              <InformationFields
-                isDisabled={isDisabled}
-                descriptionBuffer={descriptionBuffer}
-                setDescriptionBuffer={setDescriptionBuffer}
-                update={update}
-                t={t}
-                stocktakeDate={stocktakeDate}
-                infoMessage={infoMessage}
-              />
-            </Grid>
-            <Grid
-              display="flex"
-              gap={1}
-              justifyContent="flex-end"
-              alignItems="center"
-            >
-              <Box sx={{ marginRight: 2 }}>
-                <Switch
-                  label={t('label.group-by-item')}
-                  onChange={toggleIsGrouped}
-                  checked={isGrouped}
-                  size="small"
-                  color="secondary"
-                />
-              </Box>
-            </Grid>
-          </>
+          <Grid display="flex" flex={1} flexDirection="column" gap={1}>
+            <InformationFields
+              isDisabled={isDisabled}
+              descriptionBuffer={descriptionBuffer}
+              setDescriptionBuffer={setDescriptionBuffer}
+              update={update}
+              t={t}
+              stocktakeDate={stocktakeDate}
+              infoMessage={infoMessage}
+            />
+          </Grid>
         )}
       </Grid>
     </AppBarContentPortal>

--- a/client/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
@@ -14,7 +14,6 @@ import {
   InvoiceLineNodeType,
   MaterialTable,
   NothingHere,
-  useIsGroupedState,
   Groupable,
 } from '@openmsupply-client/common';
 import {
@@ -53,7 +52,6 @@ export const DetailView = () => {
   } = useEditModal<string[]>();
 
   const { data, isLoading } = useOutbound.document.get();
-  const { isGrouped } = useIsGroupedState('outboundShipment');
   const { data: rows } = useOutboundLines();
 
   const { setCustomBreadcrumbs } = useBreadcrumbs();
@@ -100,7 +98,7 @@ export const DetailView = () => {
     tableId: 'outbound-shipment-detail-view',
     columns,
     data: rows,
-    groupByField: isGrouped ? 'itemName' : undefined,
+    grouping: { enabled: true },
     isLoading: false,
     initialSort: { key: 'itemName', dir: 'asc' },
     onRowClick: !isDisabled ? onRowClick : undefined,

--- a/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
 import {
   AppBarContentPortal,
-  Box,
   InputWithLabelRow,
   BasicTextInput,
-  Grid,
   useTranslation,
   useBufferState,
-  Switch,
-  useIsGroupedState,
   Tooltip,
   useNavigate,
   RouteBuilder,
@@ -26,7 +22,6 @@ export const Toolbar = () => {
       'theirReference',
       'requisition',
     ]);
-  const { isGrouped, toggleIsGrouped } = useIsGroupedState('outboundShipment');
   const [theirReferenceBuffer, setTheirReferenceBuffer] =
     useBufferState(theirReference);
   const navigate = useNavigate();
@@ -35,79 +30,59 @@ export const Toolbar = () => {
   const isDisabled = useOutbound.utils.isDisabled();
 
   return (
-    <AppBarContentPortal sx={{ display: 'flex', flex: 1, marginBottom: 1 }}>
-      <Grid
-        container
-        flexDirection="row"
-        display="flex"
-        flex={1}
-        alignItems="flex-end"
-      >
-        <Grid display="flex" flex={1}>
-          <Box display="flex" flex={1} flexDirection="column" gap={1}>
-            {otherParty && (
-              <InputWithLabelRow
-                label={t('label.customer-name')}
-                sx={{ minWidth: 100 }}
-                Input={
-                  <CustomerSearchInput
-                    disabled={isDisabled || !!requisition}
-                    value={otherParty}
-                    onChange={async v => {
-                      if (!v) return;
-                      const otherPartyId = v.id;
-                      const newId = await updateName({ id, otherPartyId });
-                      // When changing customer name, the whole invoice is
-                      // deleted and re-created, so we'll need to re-direct to
-                      // the new ID
-                      navigate(
-                        RouteBuilder.create(AppRoute.Distribution)
-                          .addPart(AppRoute.OutboundShipment)
-                          .addPart(newId)
-                          .build(),
-                        { replace: true }
-                      );
-                    }}
-                  />
-                }
-              />
-            )}
-            <InputWithLabelRow
-              label={t('label.customer-ref')}
-              Input={
-                <Tooltip title={theirReferenceBuffer} placement="bottom-start">
-                  <BasicTextInput
-                    disabled={isDisabled}
-                    size="small"
-                    sx={{ width: 250 }}
-                    value={theirReferenceBuffer ?? ''}
-                    onChange={event => {
-                      setTheirReferenceBuffer(event.target.value);
-                      update({ theirReference: event.target.value });
-                    }}
-                  />
-                </Tooltip>
-              }
+    <AppBarContentPortal
+      sx={{
+        display: 'flex',
+        flex: 1,
+        marginY: 1,
+        gap: 1,
+        flexWrap: 'wrap',
+      }}
+    >
+      {otherParty && (
+        <InputWithLabelRow
+          label={t('label.customer-name')}
+          sx={{ minWidth: 100 }}
+          Input={
+            <CustomerSearchInput
+              disabled={isDisabled || !!requisition}
+              value={otherParty}
+              onChange={async v => {
+                if (!v) return;
+                const otherPartyId = v.id;
+                const newId = await updateName({ id, otherPartyId });
+                // When changing customer name, the whole invoice is
+                // deleted and re-created, so we'll need to re-direct to
+                // the new ID
+                navigate(
+                  RouteBuilder.create(AppRoute.Distribution)
+                    .addPart(AppRoute.OutboundShipment)
+                    .addPart(newId)
+                    .build(),
+                  { replace: true }
+                );
+              }}
             />
-          </Box>
-        </Grid>
-        <Grid
-          display="flex"
-          gap={1}
-          justifyContent="flex-end"
-          alignItems="center"
-        >
-          <Box sx={{ marginRight: 2 }}>
-            <Switch
-              label={t('label.group-by-item')}
-              onChange={toggleIsGrouped}
-              checked={isGrouped}
+          }
+        />
+      )}
+      <InputWithLabelRow
+        label={t('label.customer-ref')}
+        Input={
+          <Tooltip title={theirReferenceBuffer} placement="bottom-start">
+            <BasicTextInput
+              disabled={isDisabled}
               size="small"
-              color="secondary"
+              sx={{ width: 250 }}
+              value={theirReferenceBuffer ?? ''}
+              onChange={event => {
+                setTheirReferenceBuffer(event.target.value);
+                update({ theirReference: event.target.value });
+              }}
             />
-          </Box>
-        </Grid>
-      </Grid>
+          </Tooltip>
+        }
+      />
     </AppBarContentPortal>
   );
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9396

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

Move group by item to toolbar:
<img width="325" height="143" alt="Screenshot 2025-09-29 at 11 31 06 AM" src="https://github.com/user-attachments/assets/79795a86-427d-4f4b-830a-d670d47319dd" />


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Outbound shipment
- [ ] List view there is no group by option
- [ ] Detail view -> there is no longer a group by item toggle in the main toolbar
- [ ] there is a group by option in the table toolbar
- [ ] Click to group lines by item
- [ ] The `reset table to defaults` button also clears grouping
- [ ] In stocktake detail view, items are grouped by default

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

