### PR TITLE
9377 Email notifications from Open mSupply need to indicate which client they are for

### DIFF
--- a/server/service/src/processors/contact_form/queue_email.rs
+++ b/server/service/src/processors/contact_form/queue_email.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use repository::{
     contact_form::{ContactForm, ContactFormFilter, ContactFormRepository},
     contact_form_row::ContactType,
-    ChangelogRow, ChangelogTableName, EqualFilter, KeyType,
+    ChangelogRow, ChangelogTableName, EqualFilter, KeyType, KeyValueStoreRepository,
 };
 use tera::{Context, Tera};
 use util::constants::{FEEDBACK_EMAIL, SUPPORT_EMAIL};
@@ -48,7 +48,10 @@ impl Processor for QueueContactEmailProcessor {
                 changelog.record_id.clone(),
             ))?;
 
-        let email = create_email(&contact_form);
+        let settings_sync_url =
+            KeyValueStoreRepository::new(connection).get_string(KeyType::SettingsSyncUrl)?;
+
+        let email = create_email(&contact_form, settings_sync_url);
 
         let email = match email {
             Ok(email) => email,
@@ -99,7 +102,10 @@ impl Processor for QueueContactEmailProcessor {
     }
 }
 
-fn create_email(contact_form: &ContactForm) -> Result<EnqueueEmailData, EmailServiceError> {
+fn create_email(
+    contact_form: &ContactForm,
+    settings_sync_url: Option<String>,
+) -> Result<EnqueueEmailData, EmailServiceError> {
     let ContactForm {
         contact_form_row,
         store_row,
@@ -128,6 +134,7 @@ fn create_email(contact_form: &ContactForm) -> Result<EnqueueEmailData, EmailSer
     context.insert("reply_email", &contact_form_row.reply_email);
     context.insert("submission_time", &submission_time);
     context.insert("store_name", &store_name);
+    context.insert("sync_url", &settings_sync_url);
     context.insert("site_id", &store_row.site_id);
     context.insert("body", &contact_form_row.body);
 
@@ -144,7 +151,7 @@ fn create_email(contact_form: &ContactForm) -> Result<EnqueueEmailData, EmailSer
     let html_body = match html_body {
         Ok(html_body) => html_body,
         Err(e) => {
-            log::error!("Failed to render {}: {:?}", template_name, e);
+            log::error!("Failed to render {template_name}: {e:?}");
             return Err(EmailServiceError::GenericError(e.to_string()));
         }
     };
@@ -181,7 +188,7 @@ mod email_test {
     use util::constants::SUPPORT_EMAIL;
 
     use crate::{
-        processors::contact_form::{ContactFormProcessor, QueueContactEmailProcessor},
+        processors::{contact_form::QueueContactEmailProcessor, general_processor::Processor},
         test_helpers::{
             email_test::send_test_emails, setup_all_with_data_and_service_provider,
             ServiceTestContext,
@@ -205,8 +212,9 @@ mod email_test {
             store_row: mock_store_a(),
             name_row: mock_name_store_a(),
         };
+        let sync_url = Some("https://sync-url.test".to_string());
 
-        let email = create_email(&contact_form);
+        let email = create_email(&contact_form, sync_url);
 
         assert!(email.is_ok());
 
@@ -215,6 +223,7 @@ mod email_test {
         assert!(email_body.contains("Feedback Submission"));
         assert!(email_body.contains("Reply email: reply@test.com"));
         assert!(email_body.contains("Store: Store A (code)"));
+        assert!(email_body.contains("Sync URL: https://sync-url.test"));
         assert!(email_body.contains("Feedback message"));
     }
 
@@ -223,6 +232,7 @@ mod email_test {
         let ServiceTestContext {
             connection,
             service_provider,
+            service_context,
             ..
         } = setup_all_with_data_and_service_provider(
             "send_contact_form_emails",
@@ -249,7 +259,8 @@ mod email_test {
         };
 
         QueueContactEmailProcessor
-            .try_process_record(&connection, &changelog)
+            .try_process_record(&service_context, &service_provider, &changelog)
+            .await
             .unwrap();
 
         // Check that the email was queued

--- a/server/service/src/processors/contact_form/templates/contact.html
+++ b/server/service/src/processors/contact_form/templates/contact.html
@@ -14,6 +14,9 @@
   Store: {{store_name}}
 </p>
 <p style="font-size: 14px; line-height: 160%">
+  Sync URL: {{sync_url}}
+</p>
+<p style="font-size: 14px; line-height: 160%">
   Site ID: {{site_id}}
 </p>
 

--- a/server/service/src/test_helpers.rs
+++ b/server/service/src/test_helpers.rs
@@ -157,7 +157,7 @@ pub(crate) fn make_movements(stock_line: StockLineRow, date_quantity: Vec<(i64, 
                     ..Default::default()
                 },
                 InvoiceLineRow {
-                    id: format!("line_{}", invoice_id),
+                    id: format!("line_{invoice_id}"),
                     invoice_id,
                     item_link_id: stock_line.item_link_id.clone(),
                     stock_line_id: Some(stock_line.id.clone()),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9377

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
Adds sync url to the email template so that support can see what url the email has been sent from

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Set up [MailHog](https://github.com/mailhog/MailHog)
- [ ] Try sending an email from your sync site (should show URL in the body)
- [ ] Run tests `cargo test --features=email-tests --package service --lib -- email_test --nocapture`

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

