### PR TITLE
9139 suppliers return displays sell price when it should be cost price

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1450,6 +1450,7 @@
   "label.unit-plural_one": "{{unit}}",
   "label.unit-plural_other": "{{unit}}s",
   "label.unit-price": "Unit Price",
+  "label.cost-price-per-unit": "Cost price per unit",
   "label.unit-quantity": "Unit Qty",
   "label.unit-sell-price": "Unit Sell Price",
   "label.unit-type": "{{unit}}",

--- a/client/packages/invoices/src/Returns/SupplierDetailView/columns.ts
+++ b/client/packages/invoices/src/Returns/SupplierDetailView/columns.ts
@@ -170,20 +170,20 @@ export const useSupplierReturnColumns = ({
       },
     ],
     {
-      label: 'label.unit-price',
-      key: 'sellPricePerUnit',
+      label: 'label.cost-price-per-unit',
+      key: 'costPricePerPack',
       align: ColumnAlign.Right,
       accessor: ({ rowData }) => {
         if ('lines' in rowData) {
           return c(
             Object.values(rowData.lines).reduce(
               (sum, batch) =>
-                sum + (batch.sellPricePerPack ?? 0) / batch.packSize,
+                sum + (batch.costPricePerPack ?? 0) / batch.packSize,
               0
             )
           ).format();
         } else {
-          return c((rowData.sellPricePerPack ?? 0) / rowData.packSize).format();
+          return c((rowData.costPricePerPack ?? 0) / rowData.packSize).format();
         }
       },
       getSortValue: rowData => {
@@ -191,12 +191,12 @@ export const useSupplierReturnColumns = ({
           return c(
             Object.values(rowData.lines).reduce(
               (sum, batch) =>
-                sum + (batch.sellPricePerPack ?? 0) / batch.packSize,
+                sum + (batch.costPricePerPack ?? 0) / batch.packSize,
               0
             )
           ).format();
         } else {
-          return c((rowData.sellPricePerPack ?? 0) / rowData.packSize).format();
+          return c((rowData.costPricePerPack ?? 0) / rowData.packSize).format();
         }
       },
     },
@@ -209,13 +209,13 @@ export const useSupplierReturnColumns = ({
           return c(
             Object.values(rowData.lines).reduce(
               (sum, batch) =>
-                sum + batch.sellPricePerPack * batch.numberOfPacks,
+                sum + batch.costPricePerPack * batch.numberOfPacks,
               0
             )
           ).format();
         } else {
           const x = c(
-            rowData.sellPricePerPack * rowData.numberOfPacks
+            rowData.costPricePerPack * rowData.numberOfPacks
           ).format();
           return x;
         }
@@ -225,12 +225,12 @@ export const useSupplierReturnColumns = ({
           return c(
             Object.values(row.lines).reduce(
               (sum, batch) =>
-                sum + batch.sellPricePerPack * batch.numberOfPacks,
+                sum + batch.costPricePerPack * batch.numberOfPacks,
               0
             )
           ).format();
         } else {
-          const x = c(row.sellPricePerPack * row.numberOfPacks).format();
+          const x = c(row.costPricePerPack * row.numberOfPacks).format();
           return x;
         }
       },

--- a/client/packages/invoices/src/Returns/SupplierDetailView/columns.ts
+++ b/client/packages/invoices/src/Returns/SupplierDetailView/columns.ts
@@ -170,9 +170,10 @@ export const useSupplierReturnColumns = ({
       },
     ],
     {
-      label: 'label.cost-price-per-unit',
+      label: 'label.unit-price',
       key: 'costPricePerPack',
       align: ColumnAlign.Right,
+      description: 'label.cost-price-per-unit',
       accessor: ({ rowData }) => {
         if ('lines' in rowData) {
           return c(

--- a/client/packages/invoices/src/Returns/api/operations.generated.ts
+++ b/client/packages/invoices/src/Returns/api/operations.generated.ts
@@ -130,7 +130,7 @@ export type SupplierReturnLineFragment = {
   expiryDate?: string | null;
   numberOfPacks: number;
   packSize: number;
-  sellPricePerPack: number;
+  costPricePerPack: number;
   item: {
     __typename: 'ItemNode';
     id: string;
@@ -414,7 +414,7 @@ export type SupplierReturnByNumberQuery = {
             expiryDate?: string | null;
             numberOfPacks: number;
             packSize: number;
-            sellPricePerPack: number;
+            costPricePerPack: number;
             item: {
               __typename: 'ItemNode';
               id: string;
@@ -488,7 +488,7 @@ export type SupplierReturnByIdQuery = {
             expiryDate?: string | null;
             numberOfPacks: number;
             packSize: number;
-            sellPricePerPack: number;
+            costPricePerPack: number;
             item: {
               __typename: 'ItemNode';
               id: string;
@@ -962,7 +962,7 @@ export const SupplierReturnLineFragmentDoc = gql`
     expiryDate
     numberOfPacks
     packSize
-    sellPricePerPack
+    costPricePerPack
     item {
       __typename
       id

--- a/client/packages/invoices/src/Returns/api/operations.graphql
+++ b/client/packages/invoices/src/Returns/api/operations.graphql
@@ -151,7 +151,7 @@ fragment SupplierReturnLine on InvoiceLineNode {
   expiryDate
   numberOfPacks
   packSize
-  sellPricePerPack
+  costPricePerPack
   item {
     __typename
     id


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9139

# 👩🏻‍💻 What does this PR do?
Change supplier return's sell price to cost price and also used description tooltip to inform that user that it is the cost price not the sell price

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have some stock lines with cost price
- [ ] Create a supplier return
- [ ] Add line
- [ ] The cost price should show in the detail view instead of the sell price

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

