### PR TITLE
9137 Existing prescription items show in new item picker

### DIFF
--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEdit.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEdit.tsx
@@ -39,7 +39,7 @@ export const PrescriptionLineEdit = ({
   // changing item with the selector
   const [currentItemId, setCurrentItemId] = useBufferState(itemId);
 
-  const { isDisabled, rows: items } = usePrescription(); // TODO: how much can we strip now?
+  const { isDisabled, rows: lines } = usePrescription(); // TODO: how much can we strip now?
 
   const { clear, initialise, item } = useAllocationContext(
     ({ initialise, item, clear }) => ({
@@ -111,7 +111,7 @@ export const PrescriptionLineEdit = ({
             extraFilter={
               isDisabled
                 ? undefined
-                : item => !items?.some(({ id }) => id === item.id)
+                : item => !lines?.some(line => line.item.id === item.id)
             }
             programId={programId}
           />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9137

# 👩🏻‍💻 What does this PR do?
Filter out items that already exist in the prescription

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a prescription with some items
- [ ] Add some new items
- [ ] Items that already exist in the prescription shouldn't be included in the selection dropdown

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

