### PR TITLE
9078 When item's default pack size is changed to something else & saved, all consecutive batches will default to pack size 1

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -22,7 +22,6 @@ import { AppRoute } from '@openmsupply-client/config';
 import {
   ActivityLogList,
   DocumentsTable,
-  toItemWithPackSize,
   UploadDocumentModal,
   useIsItemVariantsEnabled,
   useVvmStatusesEnabled,
@@ -83,7 +82,8 @@ const DetailViewInner = () => {
 
   const onRowClick = React.useCallback(
     (line: InboundItem | InboundLineFragment) => {
-      onOpen(toItemWithPackSize(line));
+      const item = 'lines' in line ? line.lines[0]?.item : line.item;
+      onOpen(item);
     },
     [onOpen]
   );


### PR DESCRIPTION
…tion

<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9078

# 👩🏻‍💻 What does this PR do?
toItemWithPackSize was saving pack size 1 by default. It's used for service lines which is fine, but not fine for invoice lines when you click on a row. Adding batch on an existing line should now default to item's default pack size

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Add line to inbound shipment
- [ ] Click ok
- [ ] Go back to line
- [ ] Click add new batch
- [ ] received pack size should be item's default pack size

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

