### PR TITLE
Increase json parse limit for OMS central server sync requests

### DIFF
--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -39,7 +39,7 @@ use service::{
     token_bucket::TokenBucket,
 };
 
-use actix_web::{web::Data, App, HttpServer};
+use actix_web::{web, web::Data, App, HttpServer};
 use std::sync::{Arc, Mutex, RwLock};
 
 mod authentication;
@@ -345,6 +345,8 @@ pub async fn start_server(
             .wrap(compress_middleware())
             // needed for static files service
             .app_data(Data::new(closure_settings.clone()))
+            // Configure JSON payload limit (default is 2MB, setting to 10MB)
+            .app_data(web::JsonConfig::default().limit(10 * 1024 * 1024))
             // needed for cold chain service
             .app_data(service_provider.clone())
             .app_data(auth.clone())


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9413

# 👩🏻‍💻 What does this PR do?

Increases the upload JSON limit from 2MB to 10MB, should probably make this configurable from `config.yaml` but don't really want to do it right now when we have other things pressing?

Should also do something at the client end to make sure we don't create payloads that are too large, follow up issue?

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create 1 huge, or lots of large system log messages on your remote site 
- [ ] Try to push to OMS Central via sync
- [ ] Should get error in the issue
- [ ] Update central OMS to this branch
- [ ] No more errors (unless you created a 10MB+ upload)

Thanks for Claude, we have a nice python script to create a big message...

Please adapt for your own testing...

```
import sqlite3
import uuid
from datetime import datetime

# Path to your SQLite file
db_path = "omsupply-database.sqlite"

# Generate a large message (>2MB)
size_in_bytes = 2 * 1024 * 1024 + 100  # Slightly over 2MB
large_message = "X" * size_in_bytes

# Example values
log_id = str(uuid.uuid4())
log_type = "PROCESSOR_ERROR"
sync_site_id = 4
log_datetime = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
is_error = 1

# Connect and insert
conn = sqlite3.connect(db_path)
cursor = conn.cursor()

cursor.execute("""
    INSERT INTO system_log (id, type, sync_site_id, datetime, message, is_error)
    VALUES (?, ?, ?, ?, ?, ?)
""", (log_id, log_type, sync_site_id, log_datetime, large_message, is_error))

conn.commit()

cursor.execute("INSERT INTO changelog (table_name, record_id, row_action) VALUES (?, ?, ?)",
               ("system_log", log_id, "UPSERT"));
conn.commit()
conn.close()

print(f"Inserted system_log with message size: {len(large_message)} bytes")

```

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [X] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

