### PR TITLE
8524 Fix Item Ledger Navigation

### DIFF
--- a/client/packages/system/src/Item/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Item/DetailView/DetailView.tsx
@@ -36,12 +36,6 @@ export const ItemDetailView = () => {
   if (isLoading || !data) return <DetailFormSkeleton />;
 
   const onLedgerRowClick = (ledger: ItemLedgerFragment) => {
-    navigate(
-      RouteBuilder.create(AppRoute.Replenishment)
-        .addPart(AppRoute.InboundShipment)
-        .addPart(String(ledger.invoiceId))
-        .build()
-    );
     switch (ledger.invoiceType) {
       case InvoiceNodeType.InboundShipment:
         navigate(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8524

# 👩🏻‍💻 What does this PR do?


Corrects navigation from the item ledger

Inbound shipment navigation was being called before the navigation to `invoice type`. If the invoice type had a valid navigation, it would navigate to Inbound shipments and then the valid page eg outbound shipments. Not all invoice types can be navigated to eg inventory adjustment, so thees remained on Inbound shipment.

If the ledger item should not be navigated to, the row is not clickable and no navigation takes place

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

There is currently no difference on an invoice/invoice type level to differentiate between and inventory adjustment created by a stocktake, or an inventory adjustment created manually for the stockline. As there is no UI in place for viewing a manual inventory adjustment, invoices of this type this cannot navigate anywhere, which includes not implementing navigation to stocktakes

I'd like to keep the scope of this issue to the bug fix and have that addressed separately, as it will likely involve decisions about adding a new invoice type or other differentiating features

Related issue #7615 - this issue is actually resolved by this PR, however it has relevant discussion around the above. Particularly [this comment](https://github.com/msupply-foundation/open-msupply/issues/7615#issuecomment-2911246973)

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have an item with various ledger entries - including inventory adjustments, some shipments and returns
- [ ] Clicking on any of the shipments or returns types should navigate to the correct invoice
- [ ] Clicking 'back' in the browser will return you to the item ledger
- [ ] Clicking on any `Inventory adjustment` will not navigate at all

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

