### PR TITLE
7444 Sort by pack cost on stock line

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -159,9 +159,12 @@ export enum ActivityLogNodeType {
   PurchaseOrderFinalised = 'PURCHASE_ORDER_FINALISED',
   PurchaseOrderLineCreated = 'PURCHASE_ORDER_LINE_CREATED',
   PurchaseOrderLineDeleted = 'PURCHASE_ORDER_LINE_DELETED',
+  PurchaseOrderLineStatusChangedFromSentToNew = 'PURCHASE_ORDER_LINE_STATUS_CHANGED_FROM_SENT_TO_NEW',
+  PurchaseOrderLineStatusClosed = 'PURCHASE_ORDER_LINE_STATUS_CLOSED',
   PurchaseOrderLineUpdated = 'PURCHASE_ORDER_LINE_UPDATED',
   PurchaseOrderRequestApproval = 'PURCHASE_ORDER_REQUEST_APPROVAL',
   PurchaseOrderSent = 'PURCHASE_ORDER_SENT',
+  PurchaseOrderStatusChangedFromSentToConfirmed = 'PURCHASE_ORDER_STATUS_CHANGED_FROM_SENT_TO_CONFIRMED',
   PurchaseOrderUnauthorised = 'PURCHASE_ORDER_UNAUTHORISED',
   QuantityForLineHasBeenSetToZero = 'QUANTITY_FOR_LINE_HAS_BEEN_SET_TO_ZERO',
   Repack = 'REPACK',
@@ -9287,6 +9290,7 @@ export type StockLineResponse = NodeError | StockLineNode;
 
 export enum StockLineSortFieldInput {
   Batch = 'batch',
+  CostPricePerPack = 'costPricePerPack',
   ExpiryDate = 'expiryDate',
   ItemCode = 'itemCode',
   ItemName = 'itemName',
@@ -9352,6 +9356,7 @@ export type StocktakeLineFilterInput = {
   itemCodeOrName?: InputMaybe<StringFilterInput>;
   itemId?: InputMaybe<EqualFilterStringInput>;
   locationId?: InputMaybe<EqualFilterStringInput>;
+  stockLineId?: InputMaybe<EqualFilterStringInput>;
   stocktakeId?: InputMaybe<EqualFilterStringInput>;
 };
 

--- a/client/packages/purchasing/src/purchase_order/api/operations.generated.ts
+++ b/client/packages/purchasing/src/purchase_order/api/operations.generated.ts
@@ -421,10 +421,7 @@ export type DeletePurchaseOrderMutation = {
     | {
         __typename: 'DeletePurchaseOrderError';
         error:
-          | {
-              __typename: 'CannotDeletePurchaseOrder';
-              description: string;
-            }
+          | { __typename: 'CannotDeletePurchaseOrder'; description: string }
           | { __typename: 'RecordNotFound'; description: string };
       }
     | { __typename: 'DeleteResponse'; id: string };

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -187,6 +187,7 @@ const StockListComponent: FC = () => {
         rowData.totalNumberOfPacks * rowData.costPricePerPack,
       Cell: CurrencyCell,
       description: 'description.total-cost',
+      sortable: false,
       width: 125,
       defaultHideOnMobile: true,
     },

--- a/client/packages/system/src/Stock/api/hooks/useStockList.ts
+++ b/client/packages/system/src/Stock/api/hooks/useStockList.ts
@@ -71,6 +71,8 @@ const toSortField = (
       return StockLineSortFieldInput.NumberOfPacks;
     case 'location':
       return StockLineSortFieldInput.LocationCode;
+    case 'costPricePerPack':
+      return StockLineSortFieldInput.CostPricePerPack;
     case 'expiryDate':
     default: {
       return StockLineSortFieldInput.ExpiryDate;

--- a/server/graphql/stock_line/src/lib.rs
+++ b/server/graphql/stock_line/src/lib.rs
@@ -29,6 +29,7 @@ pub enum StockLineSortFieldInput {
     PackSize,
     SupplierName,
     LocationCode,
+    CostPricePerPack,
     VvmStatusThenExpiry,
 }
 #[derive(InputObject)]

--- a/server/repository/src/db_diesel/stock_line.rs
+++ b/server/repository/src/db_diesel/stock_line.rs
@@ -48,6 +48,7 @@ pub enum StockLineSortField {
     PackSize,
     SupplierName,
     LocationCode,
+    CostPricePerPack,
     VvmStatusThenExpiry,
 }
 
@@ -144,6 +145,9 @@ impl<'a> StockLineRepository<'a> {
                 }
                 StockLineSortField::LocationCode => {
                     apply_sort_no_case!(query, sort, location::code);
+                }
+                StockLineSortField::CostPricePerPack => {
+                    apply_sort!(query, sort, stock_line::cost_price_per_pack);
                 }
                 StockLineSortField::VvmStatusThenExpiry => {
                     // Complex sort, not using apply_sort


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7444 

# 👩🏻‍💻 What does this PR do?

- Add sort functionality on the `Pack cost` column of View Stock
- Disable sorting of `Total` column - as per issue comment is a calculated value so difficulty sorting with pagination

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Inventory -> View stock
- [ ] Sort `Pack cost` column 
- [ ] Both ascending and descending should sort correctly
- [ ] Should not be able to sort on `Total` column

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

