### PR TITLE
8442 Login errors expand inputs to full width

### DIFF
--- a/client/packages/common/src/ui/components/errors/BoxedErrorWithDetails.tsx
+++ b/client/packages/common/src/ui/components/errors/BoxedErrorWithDetails.tsx
@@ -13,7 +13,11 @@ export type BoxedErrorWithDetailsProps = {
   hint?: string;
 };
 
-export const BoxedErrorWithDetails = ({ error, details, hint }: BoxedErrorWithDetailsProps) => {
+export const BoxedErrorWithDetails = ({
+  error,
+  details,
+  hint,
+}: BoxedErrorWithDetailsProps) => {
   const t = useTranslation();
   const [expand, setExpand] = useState(false);
   const hasMoreInformation = !!(details || hint);
@@ -29,6 +33,7 @@ export const BoxedErrorWithDetails = ({ error, details, hint }: BoxedErrorWithDe
       sx={{ backgroundColor: 'error.background', borderRadius: 2 }}
       gap={1}
       padding={1}
+      width={300}
     >
       <Box display="flex" flexDirection="column">
         <Box display="flex" flexDirection="row">


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8442

# 👩🏻‍💻 What does this PR do?
Fix the width of the error box so that it doesn't grow in width with longer error messages.

https://github.com/user-attachments/assets/ebe7790e-299e-432d-a93e-a59e58a5da3e

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to login page
- [ ] Stop server
- [ ] Try login
- [ ] Click `more information` in the error box -> box shouldn't expand horizontally

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

