### PR TITLE
7716 removing is program from a master list doesn't reflect correctly in oms

### DIFF
--- a/server/repository/src/db_diesel/item.rs
+++ b/server/repository/src/db_diesel/item.rs
@@ -357,7 +357,11 @@ fn create_filtered_query(store_id: String, filter: Option<ItemFilter>) -> BoxedI
         if let Some(is_program_item_filter) = is_program_item {
             let program_master_list_ids = program::table
                 .select(program::master_list_id)
-                .filter(program::master_list_id.is_not_null())
+                .filter(
+                    program::master_list_id
+                        .is_not_null()
+                        .and(program::deleted_datetime.is_null()),
+                )
                 .distinct()
                 .into_boxed();
 

--- a/server/repository/src/db_diesel/master_list.rs
+++ b/server/repository/src/db_diesel/master_list.rs
@@ -103,7 +103,11 @@ impl<'a> MasterListRepository<'a> {
             if let Some(is_program) = f.is_program {
                 let program_join_query = program::table
                     .select(program::master_list_id)
-                    .filter(program::master_list_id.is_not_null())
+                    .filter(
+                        program::master_list_id
+                            .is_not_null()
+                            .and(program::deleted_datetime.is_null()),
+                    )
                     .distinct()
                     .into_boxed();
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7716

# 👩🏻‍💻 What does this PR do?
Populate deleted_datetime if master list was a program but is no longer a program. 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a program master list
- [ ] Go to OG and make this master list no longer a program master list
- [ ] Go to internal order
- [ ] Click new order
- [ ] Click add from master list
- [ ] the ex-program master list should appear in the list

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

