### PR TITLE
8331 Packs issued box in a customer return should not be there

### DIFF
--- a/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnQuantitiesTable.tsx
@@ -94,9 +94,8 @@ export const QuantityReturnedTableComponent = ({
       })
     );
 
-    if (lines.some(l => l.numberOfPacksIssued !== null)) {
-      // if any line has a value, show the column
-
+    // if any line has a value, show the column
+    if (lines.some(l => !!l.numberOfPacksIssued)) {
       columnDefinitions.push([
         'numberOfPacks',
         {
@@ -131,7 +130,7 @@ export const QuantityReturnedTableComponent = ({
       }
     );
     return columnDefinitions;
-  }, [showItemVariantsColumn]);
+  }, [isDisabled, lines, showItemVariantsColumn]);
 
   const columns = useColumns(columnDefinitions, {}, [
     updateLine,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8331

# 👩🏻‍💻 What does this PR do?
Only show packs issued when customer return has been generated from an Outbound Shipment since it's populated by the outbound shipment's packs issued field

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a manual customer return
- [ ] Add a line -> Shouldn't see packs issued column
- [ ] Create a customer return from an Outbound Shipment
- [ ] Should see packs issued column

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

