### PR TITLE
8691 Any auto-complete type dropdowns + enter key do not open up with options to select when using bluetooth keyboard on tablet

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Autocomplete/utils.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/utils.tsx
@@ -49,13 +49,17 @@ export const useOpenStateWithKeyboard = ({
 }: UseOpen): UseOpen => {
   const { keyboardIsEnabled, keyboardIsOpen } = useKeyboard();
   const [isComponentOpen, setIsComponentOpen] = useState(false);
-  const isKeyboardOpen = keyboardIsEnabled ? keyboardIsOpen : true;
+  // Keyboard can be enabled but not open due to external keyboard.
+  const shouldOpen =
+    !keyboardIsEnabled ||
+    keyboardIsOpen ||
+    (keyboardIsEnabled && !keyboardIsOpen);
 
   return {
     // Open should be false if keyboard is not open
     // If keyboard is open then open is either state provided through props (open)
     // or state requested/set by component (isComponentOpen)
-    open: isKeyboardOpen && (open ?? isComponentOpen),
+    open: shouldOpen && (open ?? isComponentOpen),
     onOpen: (...args) => {
       setIsComponentOpen(true);
       onOpen?.(...args);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8691

# 👩🏻‍💻 What does this PR do?
Fix autocomplete not opening on click when an external keyboard is connected.

APK: https://drive.google.com/drive/folders/1mY9yC82lSyh8KA6qAYmlDhla7OQRyb-_

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Grab APK above
- [ ] Have bluetooth keyboard connected to your android device
- [ ] Install and initialise
- [ ] Go to create a new patient
- [ ] Click on the gender autocomplete
- [ ] It should open up

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

