### PR TITLE
9382 Multiple repack lines created upon saving with slow internet connection

### DIFF
--- a/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
+++ b/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
@@ -58,7 +58,7 @@ export const RepackModal: FC<RepackModalControlProps> = ({
     repack: { repackData },
     draft,
     onChange,
-    onInsert,
+    onInsert: { mutateAsync: onInsert, isLoading: isInserting },
   } = useRepack({ stockLineId: stockLine?.id, invoiceId });
   const { columns } = useRepackColumns();
   // only display the message if there are lines to click on
@@ -135,7 +135,7 @@ export const RepackModal: FC<RepackModalControlProps> = ({
       okButton={
         <DialogButton
           variant="save"
-          disabled={!draft?.newPackSize || !draft?.numberOfPacks}
+          disabled={!draft?.newPackSize || !draft?.numberOfPacks || isInserting}
           onClick={async () => {
             try {
               const result = await onInsert();

--- a/client/packages/system/src/Stock/api/hooks/useRepack.ts
+++ b/client/packages/system/src/Stock/api/hooks/useRepack.ts
@@ -102,6 +102,6 @@ export const useRepack = ({ invoiceId, stockLineId }: UseRepackProps) => {
     draft,
     onChange,
     // Create
-    onInsert: mutation.mutateAsync,
+    onInsert: mutation,
   };
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9382

# 👩🏻‍💻 What does this PR do?
Disable `Ok` button if repack is saving so the user doesn't click it a jillion times and creates a jillion repacks '-'

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to stock -> click stockline -> click repack
- [ ] Throttle to 3G
- [ ] Create a repack
- [ ] Save button should be disabled.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

