### PR TITLE
#9559 New table date range filter fix

### DIFF
--- a/client/packages/common/src/ui/layout/tables/material-react-table/useGetColumnDefDefaults.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useGetColumnDefDefaults.tsx
@@ -66,8 +66,9 @@ export const useGetColumnTypeDefaults = () => {
                 return {
                   minDate: start ? new Date(start) : undefined,
                 };
+              default:
+                return {};
             }
-            return {};
           },
         };
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9559 

# 👩🏻‍💻 What does this PR do?

Prevents invalid date selection in Date range filter, i.e. end date can't be earlier than start date and vice versa

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

Go to any new table with a Date Range filter (e.g. Outbound shipments)
- [ ] Enable filters, confirm that Date range has no restrictions on date selections
- [ ] Select a start date, then confirm that the "End date" is restricted to dates later than the start date
- [ ] Select an end date, then confirm that the "Start date" is restricted to dates earlier than the end date

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

