### PR TITLE
#9577 Fix for JSON Forms telephone save problem

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/Text.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Text.tsx
@@ -58,7 +58,6 @@ const UIComponent = (props: ControlProps) => {
   const error = !!errors || !!zErrors;
   const onChange = (value: string | undefined) =>
     handleChange(path, !!value ? value : undefined);
-
   const { text, onChange: onDebounceChange } = useDebouncedTextInput(
     data,
     onChange


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9577

# 👩🏻‍💻 What does this PR do?

Makes the "Telephone" field for the Djibouti Patient contact info clearable.

## 💌 Any notes for the reviewer?

It was a bit bewildering why the Telephone field in for the patient contact had this problem but the Telephone field for the next of kin (on the same) form didn't. Turns out the one for the patient is actually structured in an *array* of contact info data in the schema. But we're only using one, so we use the "FirstItemArray" component. The problem was in that component -- the "onChange" function wasn't being called in the component when it's child's onChange passed up an empty value, so the parent data didn't get updated.

I've replaced the child "JsonForm" component in that component with the "JsonFormsDispatch" component, which is the correct way to do nested Json Forms, and is consistent with how the other Array components do it, which fixes the problem (I could have just modified the `onChange` method, but this is more thorough).

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Confirm that the problem reported in the issue has been remedied

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

