### PR TITLE
#9593 Fix table keyboard navigation

### DIFF
--- a/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
@@ -152,7 +152,9 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
     enableStickyHeader: true,
     // We want tab navigation to follow our normal behaviour of moving to the
     // next INPUT, not move through every table cell. If we need specific Table
-    // keyboard navigation in future, we can enable this in a more granular way.
+    // keyboard navigation in future, we can enable this in a more granular way
+    // using our own custom shortcuts:
+    // https://www.material-react-table.com/docs/guides/accessibility#custom-keyboard-shortcuts
     enableKeyboardShortcuts: false,
 
     // Disable bottom footer - use OMS custom action footer instead


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9593

# 👩🏻‍💻 What does this PR do?

Turns out this was actually a quick fix. By disabling MRT's internal keyboard navigation, we restore our normal tab navigation, where focus will go to the next or previous *input*, not every cell.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Any downsides to this?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to a table that has some input cells (e.g. Line Edit table in Outbound Shipment)
- [ ] Confirm that Tab/Shift-tab navigates between input cells, not all cells
- [ ] Check for any possible regressions or undesirable behaviours as a result of this change

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

