### PR TITLE
#285(report-repo) Option to restrict JSON Forms date picker to year/month only

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/Date.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Date.tsx
@@ -42,10 +42,6 @@ const UIComponent = (props: ControlProps) => {
   const disableFuture = options?.disableFuture ?? false;
   const noDay = options?.noDay ?? false;
 
-  if (!props.visible) {
-    return null;
-  }
-
   const formatDate = useCallback(
     (date: Date) => {
       const d = noDay ? DateUtils.startOfMonth(date) : date;
@@ -53,6 +49,10 @@ const UIComponent = (props: ControlProps) => {
     },
     [formatDateTime, noDay]
   );
+
+  if (!props.visible) {
+    return null;
+  }
 
   return (
     <DetailInputWithLabelRow


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Required for the Report creation form for this report: https://github.com/msupply-foundation/open-msupply-reports/issues/285

# 👩🏻‍💻 What does this PR do?

Just adds an additional option, `noDay` to the JSON Forms DatePicker component, which restricts the UI to only select the month/year. The actual date saved (and displayed) will always be the *first* of the chosen month.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

You can test this on any JSON Forms form that is a standard "Date" field (not DOB, as that has a separate component)

You'll just need to add this to one of the "Date" fields in the **uischema**:

```json
"options": {
            "noDay": true
          }
```

This will restrict that particular instance of the Date picker to only month/year.

(If you already have form schemas set up in your database, it's quickest just to manually edit one of the JSON objects in the DB)

- [ ] Confirm `noDay` option restricts Date picker to month/year
- [ ] Confirm behaviour remains as unchanged when this option is *not* specified


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

