### PR TITLE
#9573 Internal Order fix for Program orders

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/columns.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/columns.tsx
@@ -181,7 +181,7 @@ export const useRequestColumns = () => {
         includeColumn: showExtraColumns,
         accessorFn: row => row.reason?.reason,
         getIsError: row =>
-          errors[row.id]?.__typename === 'RequisitionReasonNotProvided',
+          errors?.[row.id]?.__typename === 'RequisitionReasonNotProvided',
       },
 
       // --- Remote authorisation columns


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9573

# 👩🏻‍💻 What does this PR do?

Very tiny fix -- just needed to make the "errors" object optional when indexing, as it can be `undefined`.

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

This fixes the reported crash. However, I haven't completely confirmed that the errors show up correctly when they're supposed to, as I assume this was done when the table was migrated. If you feel like verifying this behaviour, that would be handy.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Open (or create) a new internal order that is connected to a Program, confirm it doesn't crash


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

