### PR TITLE
Lock simple log version to 2.3.0

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -7947,9 +7947,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple-log"
-version = "2.4.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8030713cfe4aa369ef3c8cbf5e391cc18d7f6fba1f2a68ec959c5504413e51"
+checksum = "b08896e123e7fc00305e1df04999a25679768122daf636ccc01c7ca5465163ea"
 dependencies = [
  "log",
  "log4rs",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -29,11 +29,11 @@ reqwest = { version = "0.12.22", features = [
   "multipart",
   "blocking",
 ], default-features = false }
-serde = { version = "^1.0.219",  features = ["derive"] }
+serde = { version = "^1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 serde_yaml = "0.9.34"
 sha2 = "0.10.9"
-simple-log = { version = "2.3.0" }
+simple-log = { version = "=2.3.0" }
 strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "2.0.2"
 tokio = { version = "1.46.1", features = ["macros", "process"] }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9588

# 👩🏻‍💻 What does this PR do?

Locks the simple log version to `=2.3.0`
Previously we had the version as `2.3.0` however due to semver, 2.4.0 was considered compatible, so this was `accidentially` updated in an unrelated PR from Roxy.
https://github.com/msupply-foundation/open-msupply/commit/01a5685a7df931ca7d300f7f930ecd950f4cf601
https://github.com/msupply-foundation/open-msupply/pull/9479

2.4.0 turns on a `background_rotation` feature, so I think this is very likely the reason for the regression
https://github.com/baoyachi/simple-log/compare/v2.3.1...v2.4.0


Note: For my machine 2.4.0 seems to be work fine, but I think this is likely a windows related issue with that feature, or possibly dependant on some other configuration that @rukmal-msupply has? Maybe Central and Remote writing to the same Log or something that can cause locking?

## 💌 Any notes for the reviewer?

I haven't actually proved this fixes the problem, I think it's best to just merge this and then get Rukmal to test to night's build, or I could build a specific test build...

Not `max_file_count` appears to be the number of archive files, etc if you set it to `2` you'll get something like this...

```
146K Oct 28 11:33 remote_server.log
38K Oct 28 11:32 remote_server.log.0.gz
87K Oct 28 11:24 remote_server.log.1.gz
```

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Setup logging in OMS server on Windows.
- [ ] Create a lot of logs!
- [ ] Make sure that the max_file_count is respected.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

