### PR TITLE
Log when the windows service is stopped

### DIFF
--- a/server/windows/src/windows.rs
+++ b/server/windows/src/windows.rs
@@ -114,7 +114,7 @@ mod omsupply_service {
 
                 // Handle stop
                 ServiceControl::Stop => {
-                    log::info!("Service stop requested");
+                    log::warn!("Service stop requested");
                     // update status to StopPending because actix_web can take a long time to stop
                     // as it has to wait for all threads to stop processing
                     let event_handler = move |_| -> ServiceControlHandlerResult {
@@ -129,7 +129,7 @@ mod omsupply_service {
                     );
 
                     let _ = futures::executor::block_on(shutdown_tx.send(()));
-                    log::info!("Service stopped");
+                    log::warn!("Service stopped");
 
                     ServiceControlHandlerResult::NoError
                 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9620

# 👩🏻‍💻 What does this PR do?
A request from support: log when the service is sent a stop request.

<!-- Explain the changes you made -->
Logs (at a `warn` level) when the stop request is made and after the server shuts down.
This is how it looked when testing (at an `info` level)

<img width="1100" height="98" alt="Screenshot 2025-10-28 at 2 31 02 PM" src="https://github.com/user-attachments/assets/324ddbd1-ba3c-4a85-8943-97b5f2ed1574" />


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?
To test the code you'll need to build the service on windows and run as a service. Or trust that this is what I've done, which I have 😉 

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Run the service
- [ ] Stop the service : should log if level is 'warn' or more verbose than that

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

