### PR TITLE
#9607 Fix for Program sort in Encounters

### DIFF
--- a/client/packages/system/src/Encounter/ListView/columns.ts
+++ b/client/packages/system/src/Encounter/ListView/columns.ts
@@ -64,12 +64,12 @@ export const useEncounterListColumns = ({
 
   const columnList: ColumnDescription<EncounterRowFragment>[] = [
     {
-      key: 'type',
+      key: 'Type',
       label: 'label.encounter-type',
       accessor: ({ rowData }) => rowData?.document.documentRegistry?.name,
     },
     {
-      key: 'program',
+      key: 'Program',
       label: 'label.program',
       accessor: ({ rowData }) =>
         enrolmentRegistries?.nodes.find(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9607

# 👩🏻‍💻 What does this PR do?

I think the original issue description was a bit of a red herring, in that it's just sorting by "Program" in the Encounters list that causes the problem -- playing around with Vaccination course settings doesn't seems to affect it.

Turns out the sort keys for "Program" (and "Type") are capitalised in GraphQL. Not sure why, but I've left them alone and just changed the column keys in the front-end to match.

## 💌 Any notes for the reviewer?

Tempted to change the sort keys in the back-end to not be capitalised, but waiting on an explanation before doing that. When we migrate this table to the new table pattern, it might be good to re-visit that.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to a Patient, and click on their "Encounters" tab (or just load all "Encounters) from the main menu
- [ ] Click on the "Program" (and "Type") column headers and confirm that the table re-sorts correctly with no errors or endless loading
