### PR TITLE
285 mfrhc datepicker component

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2227,6 +2227,7 @@
   "report.lost-to-follow-up": "Lost to Follow Up",
   "report.lost-to-follow-up-(detailed)": "Lost to Follow Up (Detailed)",
   "report.months-cover": "Months of cover",
+  "report.month-to-report-on": "Month to report on",
   "report.mos": "MOS",
   "report.multi-month-dispensing-eligibility": "Multi-month Dispensing Eligibility",
   "report.net-decrease": "Net Decrease",

--- a/client/packages/common/src/ui/components/inputs/DateTimePickers/DatePickerInput/DatePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DateTimePickers/DatePickerInput/DatePickerInput.tsx
@@ -1,0 +1,186 @@
+import React, { useState } from 'react';
+import {
+  DatePicker,
+  DatePickerProps,
+  DateTimeValidationError,
+  DateValidationError,
+  PickersActionBarAction,
+} from '@mui/x-date-pickers';
+import { Box, SxProps, Typography, useMediaQuery } from '@mui/material';
+import {
+  DateUtils,
+  LocaleKey,
+  TypedTFunction,
+  useTranslation,
+} from '@common/intl';
+import { useBufferState } from '@common/hooks';
+import { getActionBarSx, getPaperSx, getTextFieldSx } from '../styles';
+
+const getFormattedDateError = (
+  t: TypedTFunction<LocaleKey>,
+  validationError: DateValidationError | DateTimeValidationError
+) => {
+  switch (validationError) {
+    case 'invalidDate':
+      return t('error.date_invalidDate');
+    case 'minDate':
+      return t('error.date_minDate');
+    case 'maxDate':
+      return t('error.date_maxDate');
+    case 'disablePast':
+      return t('error.date_disablePast');
+    case 'disableFuture':
+      return t('error.date_disableFuture');
+    default:
+      return validationError ?? '';
+  }
+};
+
+export const DatePickerInput = ({
+  onChange,
+  onError,
+  setIsOpen,
+  width,
+  label,
+  minDate,
+  maxDate,
+  showTime,
+  actions,
+  dateAsEndOfDay,
+  disableFuture,
+  error,
+  required,
+  textFieldSx: inputSx,
+  slotProps,
+  ...props
+}: Omit<DatePickerProps<true>, 'onChange'> & {
+  error?: string | undefined;
+  width?: number | string;
+  label?: string;
+  onChange: (value: Date | null) => void;
+  onError?: (validationError: string, date?: Date | null) => void;
+  // This allows a calling component to know whether the date was changed via
+  // keyboard input or the picker UI
+  setIsOpen?: (open: boolean) => void;
+  showTime?: boolean;
+  actions?: PickersActionBarAction[];
+  dateAsEndOfDay?: boolean;
+  disableFuture?: boolean;
+  required?: boolean;
+  textFieldSx?: SxProps;
+}) => {
+  const [internalError, setInternalError] = useState<string | null>(null);
+  const [value, setValue] = useBufferState<Date | null>(props.value ?? null);
+  const [isInitialEntry, setIsInitialEntry] = useState(true);
+  const t = useTranslation();
+  const format =
+    props.format === undefined ? (showTime ? 'P p' : 'P') : props.format;
+
+  const isDesktop = useMediaQuery('(pointer: fine)');
+
+  const updateDate = (date: Date | null) => {
+    setValue(date);
+    onChange(date);
+  };
+
+  // Max/Min should be restricted by the UI, but it's not restricting TIME input
+  // (only Date component). So this function will enforce the max/min after
+  // input
+  const handleDateInput = (date: Date | null) => {
+    if (minDate && date && date < minDate) {
+      updateDate(minDate);
+      return;
+    }
+    if (maxDate && date && date > maxDate) {
+      updateDate(maxDate);
+      return;
+    }
+
+    const dateToSave = date && dateAsEndOfDay ? DateUtils.endOfDay(date) : date;
+    updateDate(dateToSave);
+  };
+
+  return (
+    <Box sx={{ display: 'flex', width: '100%', maxWidth: width }}>
+      <DatePicker
+        format={format}
+        onChange={(date, context) => {
+          const { validationError } = context;
+
+          if (validationError) {
+            const translatedError = getFormattedDateError(t, validationError);
+            if (onError) onError(translatedError, date);
+            else setInternalError(validationError ? translatedError : null);
+
+            // If there is a validation error, set internal value (so user can
+            // keep typing) but not the external one via handleDateInput
+            setValue(date);
+            return;
+          }
+          if (!validationError) {
+            setIsInitialEntry(false);
+            setInternalError(null);
+          }
+
+          handleDateInput(date);
+        }}
+        label={label}
+        slotProps={{
+          mobilePaper: { sx: getPaperSx() },
+          desktopPaper: { sx: getPaperSx() },
+          actionBar: {
+            actions: actions ?? ['clear', 'accept'],
+            sx: getActionBarSx(),
+          },
+          textField: {
+            onBlur: () => {
+              setIsInitialEntry(false);
+              // Apply max/mins on blur if present
+              if (minDate || maxDate) {
+                setInternalError(null);
+                handleDateInput(value);
+              }
+            },
+            error: !!error || (!isInitialEntry && !!internalError),
+            helperText: error || (!isInitialEntry ? (internalError ?? '') : ''),
+            sx: {
+              ...getTextFieldSx(!!label, !showTime, inputSx, width),
+              width,
+              minWidth: showTime ? 200 : undefined,
+            },
+          },
+
+          // tabs: {
+          //   hidden: showTime && !isDesktop ? false : true,
+          // },
+          ...slotProps,
+        }}
+        // views={
+        //   showTime
+        //     ? ['year', 'month', 'day', 'hours', 'minutes']
+        //     : ['year', 'month', 'day']
+        // }
+        minDate={minDate}
+        maxDate={maxDate}
+        disableFuture={disableFuture}
+        onOpen={() => setIsOpen?.(true)}
+        onClose={() => setIsOpen?.(false)}
+        {...props}
+        value={value}
+      />
+      {required && (
+        <Typography
+          sx={{
+            width: '0px', // Prevents asterisk from taking up space - hack but consistent with other inputs
+            color: 'primary.light',
+            fontSize: '17px',
+            marginRight: 0.5,
+            pl: 0.2,
+          }}
+        >
+          *
+        </Typography>
+      )}
+    </Box>
+  );
+};

--- a/client/packages/common/src/ui/components/inputs/DateTimePickers/DatePickerInput/index.ts
+++ b/client/packages/common/src/ui/components/inputs/DateTimePickers/DatePickerInput/index.ts
@@ -1,0 +1,1 @@
+export * from './DatePickerInput';

--- a/client/packages/common/src/ui/components/inputs/DateTimePickers/index.ts
+++ b/client/packages/common/src/ui/components/inputs/DateTimePickers/index.ts
@@ -1,3 +1,4 @@
 export * from './DateTimePickerInput';
+export * from './DatePickerInput';
 export * from './ExpiryDateInput';
 export * from './TimePickerInput';

--- a/client/packages/programs/src/JsonForms/common/components/Date.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Date.tsx
@@ -8,6 +8,7 @@ import {
   LocaleKey,
   useTranslation,
   DateTimePickerInput,
+  DatePickerInput,
 } from '@openmsupply-client/common';
 import { DefaultFormRowSx, FORM_LABEL_WIDTH } from '../styleConstants';
 import { z } from 'zod';
@@ -63,24 +64,45 @@ const UIComponent = (props: ControlProps) => {
       labelWidthPercentage={FORM_LABEL_WIDTH}
       inputAlignment="start"
       Input={
-        <DateTimePickerInput
-          width="100%"
-          // undefined is displayed as "now" and null as unset
-          value={DateUtils.getNaiveDate(data)}
-          onChange={e => {
-            handleChange(path, !e ? undefined : formatDate(e));
-            if (customError) setCustomError(undefined);
-          }}
-          views={noDay ? ['year', 'month'] : ['year', 'month', 'day']}
-          openTo={noDay ? 'month' : 'day'}
-          format={noDay ? 'MM/yyyy' : 'P'}
-          disabled={!props.enabled}
-          error={customError ?? props.errors ?? zErrors ?? ''}
-          disableFuture={disableFuture}
-          onError={validationError =>
-            setCustomError(validationError ?? undefined)
-          }
-        />
+        noDay ? (
+          <DatePickerInput
+            width="100%"
+            // undefined is displayed as "now" and null as unset
+            value={DateUtils.getNaiveDate(data)}
+            onChange={e => {
+              handleChange(path, !e ? undefined : formatDate(e));
+              if (customError) setCustomError(undefined);
+            }}
+            views={noDay ? ['year', 'month'] : ['year', 'month', 'day']}
+            openTo={noDay ? 'month' : 'day'}
+            format={noDay ? 'MM/yyyy' : 'P'}
+            disabled={!props.enabled}
+            error={customError ?? props.errors ?? zErrors ?? ''}
+            disableFuture={disableFuture}
+            onError={validationError =>
+              setCustomError(validationError ?? undefined)
+            }
+          />
+        ) : (
+          <DateTimePickerInput
+            width="100%"
+            // undefined is displayed as "now" and null as unset
+            value={DateUtils.getNaiveDate(data)}
+            onChange={e => {
+              handleChange(path, !e ? undefined : formatDate(e));
+              if (customError) setCustomError(undefined);
+            }}
+            views={noDay ? ['year', 'month'] : ['year', 'month', 'day']}
+            openTo={noDay ? 'month' : 'day'}
+            format={noDay ? 'MM/yyyy' : 'P'}
+            disabled={!props.enabled}
+            error={customError ?? props.errors ?? zErrors ?? ''}
+            disableFuture={disableFuture}
+            onError={validationError =>
+              setCustomError(validationError ?? undefined)
+            }
+          />
+        )
       }
     />
   );

--- a/client/packages/programs/src/JsonForms/common/components/Date.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Date.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { rankWith, ControlProps, isDateControl } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import {
@@ -17,6 +17,9 @@ import { useJSONFormsCustomError } from '../hooks/useJSONFormsCustomError';
 const Options = z
   .object({
     disableFuture: z.boolean().optional(),
+    // Use to provide year/month selector only, day will be fixed to first of
+    // month
+    noDay: z.boolean().optional(),
   })
   .strict()
   .optional();
@@ -38,6 +41,16 @@ const UIComponent = (props: ControlProps) => {
 
   const disableFuture = options?.disableFuture ?? false;
 
+  const noDay = options?.noDay ?? false;
+
+  const formatDate = useCallback(
+    (date: Date) => {
+      const d = noDay ? DateUtils.startOfMonth(date) : date;
+      return formatDateTime.customDate(d, 'yyyy-MM-dd');
+    },
+    [formatDateTime, noDay]
+  );
+
   if (!props.visible) {
     return null;
   }
@@ -55,13 +68,12 @@ const UIComponent = (props: ControlProps) => {
           // undefined is displayed as "now" and null as unset
           value={DateUtils.getNaiveDate(data)}
           onChange={e => {
-            handleChange(
-              path,
-              !e ? undefined : formatDateTime.customDate(e, 'yyyy-MM-dd')
-            );
+            handleChange(path, !e ? undefined : formatDate(e));
             if (customError) setCustomError(undefined);
           }}
-          format="P"
+          views={noDay ? ['year', 'month'] : ['year', 'month', 'day']}
+          openTo={noDay ? 'month' : 'day'}
+          format={noDay ? 'MM/yyyy' : 'P'}
           disabled={!props.enabled}
           error={customError ?? props.errors ?? zErrors ?? ''}
           disableFuture={disableFuture}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #285 

(in the reports repo)
(this one: https://github.com/msupply-foundation/open-msupply-reports/issues/285)

# 👩🏻‍💻 What does this PR do?

Adds supporting code for the MFRHC report.

## 💌 Any notes for the reviewer?

Adds new common component.
This branch was made off 2.11.2-RC. At the time when I am making this PR, that branch seems to no longer be available? I made 2.11.1-RC the base branch instead for now just to get the PR in, but there are some strange parts in the diff.

# 🧪 Testing

- [ ] In OMS, use the MFRHC report as described in https://github.com/msupply-foundation/open-msupply-reports/pull/294
- [ ] Check that when you are using it, you are only able to input month and year in the date picker.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**: internal documentation of the new component


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

