### PR TITLE
#9712 Table inputs debouncing fix

### DIFF
--- a/client/packages/common/src/ui/layout/tables/material-react-table/components/NumberInputCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/components/NumberInputCell.tsx
@@ -13,11 +13,16 @@ interface NumberInputCellProps<T extends MRT_RowData>
   extends NumericTextInputProps {
   cell: MRT_Cell<T>;
   updateFn: (value: number) => void;
+  debounceTime?: number; // ms
 }
 
 export const NumberInputCell = <T extends MRT_RowData>({
   cell,
   updateFn,
+  // Normally debouncing should be done in the hook that handles the
+  // read/update logic, but leaving the functionality here for compatibility
+  // with existing implementations (e.g. allocation login in Outbound Shipments)
+  debounceTime = 0,
   ...numericTextProps
 }: NumberInputCellProps<T>) => {
   const { getValue, column, row } = cell;
@@ -47,7 +52,7 @@ export const NumberInputCell = <T extends MRT_RowData>({
       }
     },
     [updateFn],
-    300
+    debounceTime
   );
 
   return (

--- a/client/packages/common/src/ui/layout/tables/material-react-table/components/TextInputCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/components/TextInputCell.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BasicTextInput } from '@common/components';
 import { MRT_Cell, MRT_RowData } from 'material-react-table';
-import { useBufferState, useDebounceCallback } from '@common/hooks';
+import { useBufferState } from '@common/hooks';
 
 interface TextInputCell<T extends MRT_RowData> {
   cell: MRT_Cell<T>;
@@ -18,7 +18,6 @@ export const TextInputCell = <T extends MRT_RowData>({
 }: TextInputCell<T>) => {
   const value = cell.getValue<string>();
   const [buffer, setBuffer] = useBufferState(value);
-  const updater = useDebounceCallback(updateFn, [updateFn], 250);
 
   return (
     <BasicTextInput
@@ -27,7 +26,7 @@ export const TextInputCell = <T extends MRT_RowData>({
       onChange={e => {
         const newValue = e.target.value;
         setBuffer(newValue);
-        updater(newValue);
+        updateFn(newValue);
       }}
       autoFocus={autoFocus}
       fullWidth

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -51,7 +51,7 @@ interface QuantityTableProps extends TableProps {
   removeDraftLine: (id: string) => void;
 }
 
-export const QuantityTableComponent = ({
+export const QuantityTable = ({
   lines,
   updateDraftLine,
   removeDraftLine,
@@ -362,8 +362,6 @@ export const QuantityTableComponent = ({
 
   return <MaterialTable table={table} />;
 };
-
-export const QuantityTable = React.memo(QuantityTableComponent);
 
 export const PricingTableComponent = ({
   lines,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9712

# 👩🏻‍💻 What does this PR do?

For the most part, just removing the debouncing is the best solution -- if debouncing is needed it should be done at the hook level, not within the component itself.

The exception is the "Allocation" logic for the NumberInputCell (in OutboundShipments) -- there's some special-case logic for that and I didn't want to start unpicking that here, so have made that component take an optional "debounce" time, but with a default of 0. Seems to fix the immediate problem, but we might want to look at this again at some point.

<!-- Add a screenshot if there are UI changes  -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Confirm text and number inputs as described in issue work as expected
- [ ] Confirm OutboundShipment line input still working okay (with debouncing)
- [ ] Maybe check Prescriptions as well? (the batch table in line edit)

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

