### PR TITLE
9765 District Store/program manager cannot select destination Store while creating internal order for programs 

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
@@ -99,7 +99,7 @@ export const Toolbar = () => {
               label={t('label.destination-customer')}
               Input={
                 <CustomerSearchInput
-                  disabled={isDisabled || isProgram}
+                  disabled={isDisabled}
                   value={destinationCustomer ?? null}
                   onChange={destinationCustomer =>
                     update({


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9765

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
Remove is program check to enable destination customer selection for program internal orders

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a program Internal Order from Store A to Store B
- [ ] Go to Store B, create an Internal Order from Requisition above to Store C
- [ ] Should be able to select destination customer

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

