### PR TITLE
9666 handle invoice line sync via line processor

### DIFF
--- a/server/graphql/invoice_line/src/invoice_line_queries.rs
+++ b/server/graphql/invoice_line/src/invoice_line_queries.rs
@@ -49,6 +49,7 @@ pub struct InvoiceLineFilterInput {
     pub verified_datetime: Option<DatetimeFilterInput>,
     pub program_id: Option<EqualFilterStringInput>,
     pub is_program_invoice: Option<bool>,
+    pub linked_invoice_id: Option<EqualFilterStringInput>,
 }
 
 impl From<InvoiceLineFilterInput> for InvoiceLineFilter {
@@ -82,6 +83,7 @@ impl From<InvoiceLineFilterInput> for InvoiceLineFilter {
             delivered_datetime: None,
             has_prescribed_quantity: None,
             has_note: None,
+            linked_invoice_id: f.linked_invoice_id.map(EqualFilter::from),
         }
     }
 }

--- a/server/repository/src/db_diesel/activity_log_row.rs
+++ b/server/repository/src/db_diesel/activity_log_row.rs
@@ -165,6 +165,7 @@ impl<'a> ActivityLogRowRepository<'a> {
             row_action: action,
             store_id: row.store_id.clone(),
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/assets/asset_catalogue_item_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_catalogue_item_row.rs
@@ -74,6 +74,7 @@ impl<'a> AssetCatalogueItemRowRepository<'a> {
             row_action: action,
             store_id: None,
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/assets/asset_category_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_category_row.rs
@@ -58,6 +58,7 @@ impl<'a> AssetCategoryRowRepository<'a> {
             row_action: action,
             store_id: None,
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/assets/asset_class_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_class_row.rs
@@ -51,6 +51,7 @@ impl<'a> AssetClassRowRepository<'a> {
             row_action: action,
             store_id: None,
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/assets/asset_internal_location_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_internal_location_row.rs
@@ -63,6 +63,7 @@ impl<'a> AssetInternalLocationRowRepository<'a> {
             row_action: action,
             store_id,
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/assets/asset_log_reason_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_log_reason_row.rs
@@ -75,6 +75,7 @@ impl<'a> AssetLogReasonRowRepository<'a> {
             row_action: action,
             store_id: None,
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/assets/asset_property_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_property_row.rs
@@ -83,6 +83,7 @@ impl<'a> AssetPropertyRowRepository<'a> {
             row_action: action,
             store_id: None,
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/assets/asset_type_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_type_row.rs
@@ -55,6 +55,7 @@ impl<'a> AssetTypeRowRepository<'a> {
             row_action: action,
             store_id: None,
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/backend_plugin_row.rs
+++ b/server/repository/src/db_diesel/backend_plugin_row.rs
@@ -108,6 +108,7 @@ impl<'a> BackendPluginRowRepository<'a> {
             row_action: action,
             store_id: None,
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/barcode_row.rs
+++ b/server/repository/src/db_diesel/barcode_row.rs
@@ -68,6 +68,7 @@ impl<'a> BarcodeRowRepository<'a> {
             row_action: action,
             store_id: None,
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -26,6 +26,7 @@ table! {
         store_id -> Nullable<Text>,
         is_sync_update -> Bool,
         source_site_id -> Nullable<Integer>,
+        invoice_id -> Nullable<Text>,
     }
 }
 
@@ -39,6 +40,7 @@ table! {
         store_id -> Nullable<Text>,
         is_sync_update -> Bool,
         source_site_id -> Nullable<Integer>,
+        invoice_id -> Nullable<Text>,
     }
 }
 
@@ -226,6 +228,7 @@ pub struct ChangeLogInsertRow {
     pub row_action: RowActionType,
     pub name_link_id: Option<String>,
     pub store_id: Option<String>,
+    pub invoice_id: Option<String>,
 }
 
 #[derive(Clone, Queryable, Debug, PartialEq, Insertable, Serialize, Deserialize, TS)]
@@ -240,6 +243,7 @@ pub struct ChangelogRow {
     pub store_id: Option<String>,
     pub is_sync_update: bool,
     pub source_site_id: Option<i32>,
+    pub invoice_id: Option<String>,
 }
 
 #[derive(Default, Clone, Serialize, Deserialize, Debug, TS)]
@@ -258,6 +262,8 @@ pub struct ChangelogFilter {
     pub is_sync_update: Option<EqualFilter<bool>>,
     #[ts(optional)]
     pub source_site_id: Option<EqualFilter<i32>>,
+    #[ts(optional)]
+    pub invoice_id: Option<EqualFilter<String>>,
 }
 
 pub struct ChangelogRepository<'a> {
@@ -277,6 +283,7 @@ impl ChangelogRow {
             store_id: row.store_id,
             is_sync_update: row.is_sync_update,
             source_site_id: row.source_site_id,
+            invoice_id: row.invoice_id,
         }
     }
 }
@@ -500,6 +507,7 @@ fn create_filtered_query(earliest: u64, filter: Option<ChangelogFilter>) -> Boxe
             is_sync_update,
             action,
             source_site_id,
+            invoice_id,
         } = f;
 
         apply_equal_filter!(query, table_name, changelog_deduped::table_name);
@@ -509,6 +517,7 @@ fn create_filtered_query(earliest: u64, filter: Option<ChangelogFilter>) -> Boxe
         apply_equal_filter!(query, action, changelog_deduped::row_action);
         apply_equal_filter!(query, is_sync_update, changelog_deduped::is_sync_update);
         apply_equal_filter!(query, source_site_id, changelog_deduped::source_site_id);
+        apply_equal_filter!(query, invoice_id, changelog_deduped::invoice_id);
     }
 
     query
@@ -698,6 +707,7 @@ impl Default for ChangelogRow {
             store_id: Default::default(),
             is_sync_update: Default::default(),
             source_site_id: Default::default(),
+            invoice_id: Default::default(),
         }
     }
 }
@@ -739,6 +749,11 @@ impl ChangelogFilter {
 
     pub fn source_site_id(mut self, filter: EqualFilter<i32>) -> Self {
         self.source_site_id = Some(filter);
+        self
+    }
+
+    pub fn invoice_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.invoice_id = Some(filter);
         self
     }
 }

--- a/server/repository/src/db_diesel/changelog/test.rs
+++ b/server/repository/src/db_diesel/changelog/test.rs
@@ -226,6 +226,7 @@ async fn test_changelog_filter() {
         store_id: Some("store1".to_string()),
         is_sync_update: false,
         source_site_id: None,
+        ..Default::default()
     };
 
     let log2 = ChangelogRow {
@@ -237,6 +238,7 @@ async fn test_changelog_filter() {
         store_id: Some("store2".to_string()),
         is_sync_update: false,
         source_site_id: None,
+        ..Default::default()
     };
 
     let log3 = ChangelogRow {
@@ -248,6 +250,7 @@ async fn test_changelog_filter() {
         store_id: Some("store3".to_string()),
         is_sync_update: false,
         source_site_id: None,
+        ..Default::default()
     };
 
     let log4 = ChangelogRow {
@@ -259,6 +262,7 @@ async fn test_changelog_filter() {
         store_id: None,
         is_sync_update: false,
         source_site_id: None,
+        ..Default::default()
     };
 
     for log in [&log1, &log2, &log3, &log4] {

--- a/server/repository/src/db_diesel/clinician_row.rs
+++ b/server/repository/src/db_diesel/clinician_row.rs
@@ -111,8 +111,9 @@ impl<'a> ClinicianRowRepository<'a> {
             table_name: ChangelogTableName::Clinician,
             record_id: row.id.clone(),
             row_action: action,
-            store_id: None,
+            store_id: row.store_id.clone(),
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/clinician_store_join_row.rs
+++ b/server/repository/src/db_diesel/clinician_store_join_row.rs
@@ -74,8 +74,9 @@ impl<'a> ClinicianStoreJoinRowRepository<'a> {
             table_name: ChangelogTableName::ClinicianStoreJoin,
             record_id: row.id.clone(),
             row_action: action,
-            store_id: None,
+            store_id: Some(row.store_id.clone()),
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/contact_form_row.rs
+++ b/server/repository/src/db_diesel/contact_form_row.rs
@@ -95,6 +95,7 @@ impl<'a> ContactFormRowRepository<'a> {
             row_action: action,
             store_id: Some(row.store_id),
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/currency_row.rs
+++ b/server/repository/src/db_diesel/currency_row.rs
@@ -60,6 +60,7 @@ impl<'a> CurrencyRowRepository<'a> {
             row_action: action,
             store_id: None,
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/document.rs
+++ b/server/repository/src/db_diesel/document.rs
@@ -242,6 +242,7 @@ impl<'a> DocumentRepository<'a> {
             row_action: action,
             store_id: None,
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/form_schema_row.rs
+++ b/server/repository/src/db_diesel/form_schema_row.rs
@@ -100,6 +100,7 @@ impl<'a> FormSchemaRowRepository<'a> {
             row_action: action,
             store_id: None,
             name_link_id: None,
+            ..Default::default()
         };
         ChangelogRepository::new(self.connection).insert(&row)
     }

--- a/server/repository/src/db_diesel/frontend_plugin_row.rs
+++ b/server/repository/src/db_diesel/frontend_plugin_row.rs
@@ -121,6 +121,7 @@ impl<'a> FrontendPluginRowRepository<'a> {
             row_action: action,
             store_id: None,
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/goods_received_line_row.rs
+++ b/server/repository/src/db_diesel/goods_received_line_row.rs
@@ -124,6 +124,7 @@ impl<'a> GoodsReceivedLineRowRepository<'a> {
             row_action: action,
             store_id: Some(store_id),
             name_link_id: None,
+            ..Default::default()
         };
         ChangelogRepository::new(self.connection).insert(&row)
     }

--- a/server/repository/src/db_diesel/goods_received_row.rs
+++ b/server/repository/src/db_diesel/goods_received_row.rs
@@ -97,6 +97,7 @@ impl<'a> GoodsReceivedRowRepository<'a> {
             row_action: action,
             store_id: Some(row.store_id),
             name_link_id: None,
+            ..Default::default()
         };
         ChangelogRepository::new(self.connection).insert(&row)
     }

--- a/server/repository/src/db_diesel/indicator_value_row.rs
+++ b/server/repository/src/db_diesel/indicator_value_row.rs
@@ -76,8 +76,9 @@ impl<'a> IndicatorValueRowRepository<'a> {
             table_name: ChangelogTableName::IndicatorValue,
             record_id: row.id.clone(),
             row_action: action,
-            store_id: None,
+            store_id: Some(row.store_id.clone()),
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/insurance_provider_row.rs
+++ b/server/repository/src/db_diesel/insurance_provider_row.rs
@@ -87,6 +87,7 @@ impl<'a> InsuranceProviderRowRepository<'a> {
             row_action: action,
             store_id: None,
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/invoice_line.rs
+++ b/server/repository/src/db_diesel/invoice_line.rs
@@ -92,6 +92,7 @@ pub struct InvoiceLineFilter {
     pub has_note: Option<bool>,
     pub program_id: Option<EqualFilter<String>>,
     pub is_program_invoice: Option<bool>,
+    pub linked_invoice_id: Option<EqualFilter<String>>,
 }
 
 impl InvoiceLineFilter {
@@ -191,6 +192,11 @@ impl InvoiceLineFilter {
 
     pub fn is_program_invoice(mut self, filter: bool) -> Self {
         self.is_program_invoice = Some(filter);
+        self
+    }
+
+    pub fn linked_invoice_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.linked_invoice_id = Some(filter);
         self
     }
 }
@@ -334,12 +340,14 @@ fn create_filtered_query(filter: Option<InvoiceLineFilter>) -> BoxedInvoiceLineQ
             has_note,
             program_id,
             is_program_invoice,
+            linked_invoice_id,
         } = f;
 
         apply_equal_filter!(query, id, invoice_line::id);
         apply_equal_filter!(query, store_id, invoice::store_id);
         apply_equal_filter!(query, requisition_id, invoice::requisition_id);
         apply_equal_filter!(query, invoice_id, invoice_line::invoice_id);
+        apply_equal_filter!(query, linked_invoice_id, invoice_line::linked_invoice_id);
         apply_equal_filter!(query, location_id, invoice_line::location_id);
         apply_equal_filter!(query, item_id, item_link::item_id);
         apply_equal_filter!(query, r#type, invoice_line::type_);

--- a/server/repository/src/db_diesel/invoice_line_row.rs
+++ b/server/repository/src/db_diesel/invoice_line_row.rs
@@ -149,6 +149,7 @@ impl<'a> InvoiceLineRowRepository<'a> {
             row_action: action,
             store_id: Some(invoice.store_id.clone()),
             name_link_id: Some(invoice.name_link_id.clone()),
+            invoice_id: Some(row.invoice_id.clone()),
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/invoice_row.rs
+++ b/server/repository/src/db_diesel/invoice_row.rs
@@ -179,6 +179,7 @@ impl<'a> InvoiceRowRepository<'a> {
             row_action: action,
             store_id: Some(row.store_id.clone()),
             name_link_id: Some(row.name_link_id.clone()),
+            invoice_id: Some(row.id.clone()),
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/key_value_store.rs
+++ b/server/repository/src/db_diesel/key_value_store.rs
@@ -27,6 +27,7 @@ pub enum KeyType {
     SyncPushCursorV6,
     RemoteSyncPushCursor,
     ShipmentTransferProcessorCursor,
+    InvoiceLineTransferProcessorCursor,
     RequisitionTransferProcessorCursor,
     ContactFormProcessorCursor,
     LoadPluginProcessorCursor,

--- a/server/repository/src/db_diesel/location_movement_row.rs
+++ b/server/repository/src/db_diesel/location_movement_row.rs
@@ -63,6 +63,7 @@ impl<'a> LocationMovementRowRepository<'a> {
             row_action: action,
             store_id: Some(row.store_id.clone()),
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/location_row.rs
+++ b/server/repository/src/db_diesel/location_row.rs
@@ -66,6 +66,7 @@ impl<'a> LocationRowRepository<'a> {
             row_action: action,
             store_id: Some(row.store_id.clone()),
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/name_insurance_join_row.rs
+++ b/server/repository/src/db_diesel/name_insurance_join_row.rs
@@ -139,6 +139,7 @@ impl<'a> NameInsuranceJoinRowRepository<'a> {
             row_action: action,
             store_id: None,
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/name_property_row.rs
+++ b/server/repository/src/db_diesel/name_property_row.rs
@@ -68,6 +68,7 @@ impl<'a> NamePropertyRowRepository<'a> {
             row_action: action,
             store_id: None,
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/name_store_join.rs
+++ b/server/repository/src/db_diesel/name_store_join.rs
@@ -92,6 +92,7 @@ impl<'a> NameStoreJoinRepository<'a> {
             row_action: action,
             store_id: Some(row.store_id.clone()),
             name_link_id: Some(row.name_link_id.clone()),
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/plugin_data_row.rs
+++ b/server/repository/src/db_diesel/plugin_data_row.rs
@@ -77,6 +77,7 @@ impl<'a> PluginDataRowRepository<'a> {
             row_action: action,
             store_id,
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/preference_row.rs
+++ b/server/repository/src/db_diesel/preference_row.rs
@@ -59,6 +59,7 @@ impl<'a> PreferenceRowRepository<'a> {
             row_action: action,
             store_id: row.store_id.clone(),
             name_link_id: None,
+            ..Default::default()
         };
         ChangelogRepository::new(self.connection).insert(&row)
     }

--- a/server/repository/src/db_diesel/property_row.rs
+++ b/server/repository/src/db_diesel/property_row.rs
@@ -71,6 +71,7 @@ impl<'a> PropertyRowRepository<'a> {
             row_action: action,
             store_id: None,
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/purchase_order_line_row.rs
+++ b/server/repository/src/db_diesel/purchase_order_line_row.rs
@@ -122,6 +122,7 @@ impl<'a> PurchaseOrderLineRowRepository<'a> {
             row_action: action,
             store_id: Some(purchase_order.store_id.clone()),
             name_link_id: None,
+            ..Default::default()
         };
 
         let purchase_order_row = ChangeLogInsertRow {
@@ -130,6 +131,7 @@ impl<'a> PurchaseOrderLineRowRepository<'a> {
             row_action: RowActionType::Upsert,
             store_id: Some(purchase_order.store_id),
             name_link_id: None,
+            ..Default::default()
         };
 
         let _ = ChangelogRepository::new(self.connection).insert(&row);

--- a/server/repository/src/db_diesel/purchase_order_row.rs
+++ b/server/repository/src/db_diesel/purchase_order_row.rs
@@ -165,6 +165,7 @@ impl<'a> PurchaseOrderRowRepository<'a> {
             row_action: action,
             store_id: Some(row.store_id),
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/report_row.rs
+++ b/server/repository/src/db_diesel/report_row.rs
@@ -133,6 +133,7 @@ impl<'a> ReportRowRepository<'a> {
             row_action: action,
             store_id: None,
             name_link_id: None,
+            ..Default::default()
         };
         ChangelogRepository::new(self.connection).insert(&row)
     }

--- a/server/repository/src/db_diesel/requisition/requisition_row.rs
+++ b/server/repository/src/db_diesel/requisition/requisition_row.rs
@@ -146,6 +146,7 @@ impl<'a> RequisitionRowRepository<'a> {
             row_action: action,
             store_id: Some(row.store_id.clone()),
             name_link_id: Some(row.name_link_id.clone()),
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/requisition_line/requisition_line_row.rs
+++ b/server/repository/src/db_diesel/requisition_line/requisition_line_row.rs
@@ -134,6 +134,7 @@ impl<'a> RequisitionLineRowRepository<'a> {
             row_action: action,
             store_id: Some(requisition.store_id.clone()),
             name_link_id: Some(requisition.name_link_id.clone()),
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/rnr_form_line_row.rs
+++ b/server/repository/src/db_diesel/rnr_form_line_row.rs
@@ -160,6 +160,7 @@ impl<'a> RnRFormLineRowRepository<'a> {
             row_action: action,
             store_id,
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/rnr_form_row.rs
+++ b/server/repository/src/db_diesel/rnr_form_row.rs
@@ -104,6 +104,7 @@ impl<'a> RnRFormRowRepository<'a> {
             row_action: action,
             store_id: Some(row.store_id),
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/sensor_row.rs
+++ b/server/repository/src/db_diesel/sensor_row.rs
@@ -93,6 +93,7 @@ impl<'a> SensorRowRepository<'a> {
             row_action: action,
             store_id: Some(row.store_id.clone()),
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/stock_line_row.rs
+++ b/server/repository/src/db_diesel/stock_line_row.rs
@@ -111,6 +111,7 @@ impl<'a> StockLineRowRepository<'a> {
             row_action: action,
             store_id: Some(row.store_id.clone()),
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/stocktake_line_row.rs
+++ b/server/repository/src/db_diesel/stocktake_line_row.rs
@@ -122,6 +122,7 @@ impl<'a> StocktakeLineRowRepository<'a> {
             row_action: action,
             store_id: Some(stocktake.store_id.clone()),
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/stocktake_row.rs
+++ b/server/repository/src/db_diesel/stocktake_row.rs
@@ -93,6 +93,7 @@ impl<'a> StocktakeRowRepository<'a> {
             row_action: action,
             store_id: Some(row.store_id.clone()),
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/sync_message_row.rs
+++ b/server/repository/src/db_diesel/sync_message_row.rs
@@ -109,6 +109,7 @@ impl<'a> SyncMessageRowRepository<'a> {
             row_action: RowActionType::Upsert,
             name_link_id: None,
             store_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/system_log_row.rs
+++ b/server/repository/src/db_diesel/system_log_row.rs
@@ -80,6 +80,7 @@ impl<'a> SystemLogRowRepository<'a> {
             row_action: action,
             store_id: None,
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/temperature_breach_config_row.rs
+++ b/server/repository/src/db_diesel/temperature_breach_config_row.rs
@@ -70,6 +70,7 @@ impl<'a> TemperatureBreachConfigRowRepository<'a> {
             row_action: action,
             store_id: Some(row.store_id.clone()),
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/temperature_breach_row.rs
+++ b/server/repository/src/db_diesel/temperature_breach_row.rs
@@ -94,6 +94,7 @@ impl<'a> TemperatureBreachRowRepository<'a> {
             row_action: action,
             store_id: Some(row.store_id.clone()),
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/temperature_log_row.rs
+++ b/server/repository/src/db_diesel/temperature_log_row.rs
@@ -66,6 +66,7 @@ impl<'a> TemperatureLogRowRepository<'a> {
             row_action: action,
             store_id: Some(row.store_id.clone()),
             name_link_id: None,
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/db_diesel/vaccination_row.rs
+++ b/server/repository/src/db_diesel/vaccination_row.rs
@@ -130,6 +130,7 @@ impl<'a> VaccinationRowRepository<'a> {
             row_action: action,
             store_id: None,
             name_link_id: Some(row.patient_link_id),
+            ..Default::default()
         };
 
         ChangelogRepository::new(self.connection).insert(&row)

--- a/server/repository/src/migrations/v2_13_00/add_invoice_id_to_changelog.rs
+++ b/server/repository/src/migrations/v2_13_00/add_invoice_id_to_changelog.rs
@@ -1,0 +1,21 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_invoice_id_to_changelog"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        sql!(
+            connection,
+            r#"
+                ALTER TABLE changelog ADD COLUMN invoice_id TEXT;
+                CREATE INDEX index_changelog_invoice_id_fkey ON changelog(invoice_id);
+            "#,
+        )?;
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_13_00/add_invoice_line_transfer_processor_cursor_pg_enum.rs
+++ b/server/repository/src/migrations/v2_13_00/add_invoice_line_transfer_processor_cursor_pg_enum.rs
@@ -1,0 +1,22 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_invoice_line_transfer_processor_cursor"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        if cfg!(feature = "postgres") {
+            sql!(
+                connection,
+                r#"
+                    ALTER TYPE key_type ADD VALUE IF NOT EXISTS 'INVOICE_LINE_TRANSFER_PROCESSOR_CURSOR';
+                "#
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_13_00/mod.rs
+++ b/server/repository/src/migrations/v2_13_00/mod.rs
@@ -3,6 +3,7 @@ use crate::StorageConnection;
 
 mod add_created_from_req_ids_to_requisition;
 mod add_invoice_id_to_changelog;
+mod add_invoice_line_transfer_processor_cursor_pg_enum;
 
 pub(crate) struct V2_13_00;
 impl Migration for V2_13_00 {
@@ -16,6 +17,7 @@ impl Migration for V2_13_00 {
 
     fn migrate_fragments(&self) -> Vec<Box<dyn MigrationFragment>> {
         vec![
+            Box::new(add_invoice_line_transfer_processor_cursor_pg_enum::Migrate),
             Box::new(add_created_from_req_ids_to_requisition::Migrate),
             Box::new(add_invoice_id_to_changelog::Migrate),
         ]

--- a/server/repository/src/migrations/v2_13_00/mod.rs
+++ b/server/repository/src/migrations/v2_13_00/mod.rs
@@ -2,6 +2,7 @@ use super::{version::Version, Migration, MigrationFragment};
 use crate::StorageConnection;
 
 mod add_created_from_req_ids_to_requisition;
+mod add_invoice_id_to_changelog;
 
 pub(crate) struct V2_13_00;
 impl Migration for V2_13_00 {
@@ -14,7 +15,10 @@ impl Migration for V2_13_00 {
     }
 
     fn migrate_fragments(&self) -> Vec<Box<dyn MigrationFragment>> {
-        vec![Box::new(add_created_from_req_ids_to_requisition::Migrate)]
+        vec![
+            Box::new(add_created_from_req_ids_to_requisition::Migrate),
+            Box::new(add_invoice_id_to_changelog::Migrate),
+        ]
     }
 }
 

--- a/server/repository/src/migrations/views/changelog_deduped.rs
+++ b/server/repository/src/migrations/views/changelog_deduped.rs
@@ -29,6 +29,7 @@ impl ViewMigrationFragment for ViewMigration {
         c.row_action,
         c.name_link_id,
         c.store_id,
+        c.invoice_id,
         c.is_sync_update,
         c.source_site_id
     FROM (

--- a/server/service/src/invoice_line/outbound_shipment_service_line/delete/mod.rs
+++ b/server/service/src/invoice_line/outbound_shipment_service_line/delete/mod.rs
@@ -20,6 +20,10 @@ pub fn delete_outbound_shipment_service_line(
             Ok(line.id) as Result<String, OutError>
         })
         .map_err(|error| error.to_inner_error())?;
+
+    ctx.processors_trigger
+        .trigger_invoice_line_transfer_processors();
+
     Ok(line_id)
 }
 
@@ -64,9 +68,10 @@ mod test {
         InvoiceLineRowRepository,
     };
 
+    use super::DeleteOutboundShipmentServiceLineError;
     use crate::{
         invoice_line::stock_out_line::delete::DeleteStockOutLine, service_provider::ServiceProvider,
-    };    use super::DeleteOutboundShipmentServiceLineError;
+    };
 
     type ServiceError = DeleteOutboundShipmentServiceLineError;
 

--- a/server/service/src/invoice_line/outbound_shipment_service_line/insert/mod.rs
+++ b/server/service/src/invoice_line/outbound_shipment_service_line/insert/mod.rs
@@ -41,6 +41,10 @@ pub fn insert_outbound_shipment_service_line(
                 .ok_or(OutError::NewlyCreatedLineDoesNotExist)
         })
         .map_err(|error| error.to_inner_error())?;
+
+    ctx.processors_trigger
+        .trigger_invoice_line_transfer_processors();
+
     Ok(new_line)
 }
 

--- a/server/service/src/invoice_line/outbound_shipment_service_line/update/mod.rs
+++ b/server/service/src/invoice_line/outbound_shipment_service_line/update/mod.rs
@@ -46,6 +46,9 @@ pub fn update_outbound_shipment_service_line(
         })
         .map_err(|error| error.to_inner_error())?;
 
+    ctx.processors_trigger
+        .trigger_invoice_line_transfer_processors();
+
     Ok(updated_line)
 }
 
@@ -94,7 +97,6 @@ mod test {
         test_db::setup_all,
         InvoiceLineRow, InvoiceLineRowRepository,
     };
-   
 
     use crate::{
         invoice_line::{

--- a/server/service/src/invoice_line/stock_out_line/delete/mod.rs
+++ b/server/service/src/invoice_line/stock_out_line/delete/mod.rs
@@ -60,6 +60,10 @@ pub fn delete_stock_out_line(
             Ok(line.id) as Result<String, OutError>
         })
         .map_err(|error| error.to_inner_error())?;
+
+    ctx.processors_trigger
+        .trigger_invoice_line_transfer_processors();
+
     Ok(line_id)
 }
 
@@ -95,7 +99,6 @@ mod test {
         InvoiceLineRow, InvoiceLineRowRepository, InvoiceLineType, InvoiceRow, InvoiceStatus,
         StockLineRowRepository,
     };
-   
 
     use crate::{
         invoice_line::stock_out_line::{

--- a/server/service/src/invoice_line/stock_out_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_out_line/insert/mod.rs
@@ -116,6 +116,10 @@ pub fn insert_stock_out_line(
                 .ok_or(OutError::NewlyCreatedLineDoesNotExist)
         })
         .map_err(|error| error.to_inner_error())?;
+
+    ctx.processors_trigger
+        .trigger_invoice_line_transfer_processors();
+
     Ok(new_line)
 }
 

--- a/server/service/src/invoice_line/stock_out_line/update/mod.rs
+++ b/server/service/src/invoice_line/stock_out_line/update/mod.rs
@@ -99,6 +99,10 @@ pub fn update_stock_out_line(
                 .ok_or(OutError::UpdatedLineDoesNotExist)
         })
         .map_err(|error| error.to_inner_error())?;
+
+    ctx.processors_trigger
+        .trigger_invoice_line_transfer_processors();
+
     Ok(updated_line)
 }
 

--- a/server/service/src/processors/transfer/invoice/README.md
+++ b/server/service/src/processors/transfer/invoice/README.md
@@ -24,6 +24,17 @@ When an outbound invoice is updated and an inbound invoice is already generated,
 
 You may want to refer to [requisition transfer docs](../requisition/README.md#same-site-transfer-both-stores-on-same-site) for example of how one instance of triggered processor can itself upsert records and process them in the next iteration
 
+## Invoice Line Transfer Processor
+
+Handles **line-level** changes for stock transfers:
+
+- Syncs individual line additions, updates, and deletions
+- Only processes lines when invoice status is PICKED
+- Matches lines by item, batch, and expiry date
+- Works in conjunction with Invoice Transfer Processor
+
+See [invoice_line/README.md](./invoice_line/README.md) for details.
+
 ## Returns
 
 Returns are invoices, with outbounds and inbounds, just the same as shipments. As such, they are transferred by the same processor. The flow is shown below:

--- a/server/service/src/processors/transfer/invoice/create_inbound_invoice.rs
+++ b/server/service/src/processors/transfer/invoice/create_inbound_invoice.rs
@@ -90,7 +90,7 @@ impl InvoiceTransferProcessor for CreateInboundInvoiceProcessor {
 
         // 4.
         if linked_invoice.is_some() {
-            return Ok(InvoiceTransferOutput::NoLinkedInvoice);
+            return Ok(InvoiceTransferOutput::AlreadyLinked);
         }
 
         // 5.

--- a/server/service/src/processors/transfer/invoice/update_inbound_invoice.rs
+++ b/server/service/src/processors/transfer/invoice/update_inbound_invoice.rs
@@ -125,7 +125,7 @@ impl InvoiceTransferProcessor for UpdateInboundInvoiceProcessor {
 
         let updated_inbound_invoice = InvoiceRow {
             // 6.
-            status: InvoiceStatus::Shipped,
+            status: outbound_invoice_row.status.clone(),
             picked_datetime: outbound_invoice_row.picked_datetime,
             shipped_datetime: outbound_invoice_row.shipped_datetime,
             their_reference: Some(formatted_ref),

--- a/server/service/src/processors/transfer/invoice/update_inbound_invoice.rs
+++ b/server/service/src/processors/transfer/invoice/update_inbound_invoice.rs
@@ -30,9 +30,6 @@ impl InvoiceTransferProcessor for UpdateInboundInvoiceProcessor {
     /// 4. Linked inbound invoice is Picked (Inbound invoice can only be updated before it turns to Shipped status)
     /// 5. Source outbound invoice is Shipped
     ///
-    /// NOTE: Invoice LINES are already synced by UpdateInboundInvoiceLineProcessor while both invoices are PICKED.
-    /// This processor only updates the invoice HEADER (status, timestamps, references, etc.)
-    ///
     /// Only runs once:
     /// 6. Because linked inbound invoice will be changed to Shipped status and `4.` will never be true again
     fn try_process_record(

--- a/server/service/src/processors/transfer/invoice/update_inbound_invoice.rs
+++ b/server/service/src/processors/transfer/invoice/update_inbound_invoice.rs
@@ -1,19 +1,16 @@
 use repository::{
-    InvoiceLineRowRepository, InvoiceRow, InvoiceRowRepository, InvoiceStatus, InvoiceType,
-    RepositoryError, StorageConnection,
+    InvoiceRow, InvoiceRowRepository, InvoiceStatus, InvoiceType, RepositoryError,
+    StorageConnection,
 };
 
 use crate::{
     activity_log::{log_type_from_invoice_status, system_activity_log_entry},
-    invoice::common::get_lines_for_invoice,
     processors::transfer::invoice::InvoiceTransferOutput,
-    store_preference::get_store_preferences,
 };
 
 use super::{
-    common::{convert_invoice_line_to_single_pack, generate_inbound_lines},
-    create_inbound_invoice::InboundInvoiceType,
-    InvoiceTransferProcessor, InvoiceTransferProcessorRecord, Operation,
+    create_inbound_invoice::InboundInvoiceType, InvoiceTransferProcessor,
+    InvoiceTransferProcessorRecord, Operation,
 };
 
 const DESCRIPTION: &str = "Update inbound invoice from outbound invoice";
@@ -32,6 +29,9 @@ impl InvoiceTransferProcessor for UpdateInboundInvoiceProcessor {
     /// 3. Linked invoice exists (the inbound invoice)
     /// 4. Linked inbound invoice is Picked (Inbound invoice can only be updated before it turns to Shipped status)
     /// 5. Source outbound invoice is Shipped
+    ///
+    /// NOTE: Invoice LINES are already synced by UpdateInboundInvoiceLineProcessor while both invoices are PICKED.
+    /// This processor only updates the invoice HEADER (status, timestamps, references, etc.)
     ///
     /// Only runs once:
     /// 6. Because linked inbound invoice will be changed to Shipped status and `4.` will never be true again
@@ -73,32 +73,7 @@ impl InvoiceTransferProcessor for UpdateInboundInvoiceProcessor {
             ));
         }
 
-        // Execute
-        let lines_to_delete = get_lines_for_invoice(connection, &inbound_invoice.invoice_row.id)?;
-        let new_inbound_lines = generate_inbound_lines(
-            connection,
-            &inbound_invoice.invoice_row.id,
-            &inbound_invoice.store_row.id,
-            outbound_invoice,
-        )?;
-
-        let store_preferences =
-            get_store_preferences(connection, &inbound_invoice.invoice_row.store_id)?;
-        let new_inbound_lines = match store_preferences.pack_to_one {
-            true => convert_invoice_line_to_single_pack(new_inbound_lines),
-            false => new_inbound_lines,
-        };
-
-        let invoice_line_repository = InvoiceLineRowRepository::new(connection);
-
-        for line in lines_to_delete.iter() {
-            invoice_line_repository.delete(&line.invoice_line_row.id)?;
-        }
-
-        for line in new_inbound_lines.iter() {
-            invoice_line_repository.upsert_one(line)?;
-        }
-
+        // Execute - update invoice
         let outbound_invoice_row = &outbound_invoice.invoice_row;
 
         let formatted_ref = match &outbound_invoice_row.their_reference {
@@ -149,16 +124,8 @@ impl InvoiceTransferProcessor for UpdateInboundInvoiceProcessor {
         )?;
 
         let result = format!(
-            "invoice ({}) deleted lines ({:?}) inserted lines ({:?})",
-            updated_inbound_invoice.id,
-            lines_to_delete
-                .into_iter()
-                .map(|l| l.invoice_row.id)
-                .collect::<Vec<String>>(),
-            new_inbound_lines
-                .into_iter()
-                .map(|r| r.id)
-                .collect::<Vec<String>>(),
+            "Inbound invoice {} updated to status {:?}",
+            updated_inbound_invoice.id, updated_inbound_invoice.status
         );
 
         Ok(InvoiceTransferOutput::Processed(result))

--- a/server/service/src/processors/transfer/invoice_line/README.md
+++ b/server/service/src/processors/transfer/invoice_line/README.md
@@ -1,0 +1,150 @@
+# Invoice Line Transfer Processor
+
+## Overview
+
+The Invoice Line Transfer Processor handles **individual line-level changes** during stock transfers between sites. It works alongside the [Invoice Transfer Processor](../invoice/README.md) to provide real-time synchronization of invoice lines.
+
+## Architecture
+
+### Separation of Concerns
+
+| Processor | Triggers On | Responsibility |
+|-----------|-------------|----------------|
+| **Invoice Processor** | Invoice status changes | Creates/updates/deletes invoices, manages invoice metadata |
+| **Line Processor** | Invoice line changes | Syncs individual line changes (quantity, batch, expiry) |
+
+### When Does It Run?
+
+The line processor processes changes when:
+- ✅ Invoice status is **PICKED** (editable state)
+- ✅ Line is added, updated, or deleted
+- ✅ Linked inbound invoice exists
+- ❌ **Does NOT run** when invoice is SHIPPED/VERIFIED/CANCELLED
+
+## Flow Diagram
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Outbound Shipment                         │
+│                    (PICKED Status)                           │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            │ User edits line
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│              Invoice Line Service Layer                      │
+│  (insert_stock_out_line / update_stock_out_line / delete)   │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            │ Creates changelog
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│           Invoice Line Transfer Processor                    │
+│              (UpdateInboundInvoiceLineProcessor)             │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ├─ UPSERT: Find or create inbound line
+                            │          Update quantity/batch/expiry
+                            │
+                            └─ DELETE: Find matching inbound line
+                                       Delete from inbound invoice
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    Inbound Shipment                          │
+│              (Lines synced in real-time)                     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Line Matching Logic
+
+Lines are matched between outbound and inbound invoices using:
+
+1. **Item ID** (`item_link_id`)
+2. **Batch** (optional, can be `None`)
+3. **Expiry Date** (optional, can be `None`)
+
+```rust
+fn lines_match(outbound: &InvoiceLineRow, inbound: &InvoiceLineRow) -> bool {
+    outbound.item_link_id == inbound.item_link_id
+        && outbound.batch == inbound.batch
+        && outbound.expiry_date == inbound.expiry_date
+}
+```
+
+## Validation Rules
+
+The processor will **skip** processing if:
+
+1. ❌ Outbound invoice status is not `PICKED`
+2. ❌ No linked inbound invoice exists
+3. ❌ Line type is `UnallocatedStock` (placeholder lines)
+4. ❌ Operation type is not `UPSERT` or `DELETE`
+
+## Example Scenarios
+
+### Scenario 1: Add Line After Invoice Created
+
+```
+1. Create outbound shipment (ALLOCATED)
+2. Pick shipment → Invoice processor creates inbound ✅
+3. Add new line to outbound → Line processor creates inbound line ✅
+4. Ship outbound → Invoice processor updates inbound status ✅
+```
+
+### Scenario 2: Update Line Quantity
+
+```
+1. Outbound line: 10 packs
+2. User updates to 20 packs
+3. Line processor finds matching inbound line
+4. Updates inbound line: 10 → 20 packs ✅
+```
+
+### Scenario 3: Delete Line
+
+```
+1. Outbound has 3 lines
+2. User deletes line 1
+3. Line processor finds matching inbound line
+4. Deletes inbound line
+5. Inbound now has 2 lines ✅
+```
+
+## Relationship to Invoice Processor
+
+### Before Line Processor (Old Behavior)
+
+```
+Invoice PICKED  → Create inbound + lines
+Invoice SHIPPED → Regenerate ALL lines ❌
+```
+
+**Problem**: All lines dropped and recreated on status change, losing any manual edits.
+
+### After Line Processor (New Behavior)
+
+```
+Invoice PICKED  → Create inbound + initial lines
+Line changed    → Sync individual line changes ✅
+Invoice SHIPPED → Update invoice status only ✅
+```
+
+**Benefit**: Real-time line sync, invoice processor only handles invoice metadata.
+
+This happens in **both** invoice and line processors.
+
+## Related Documentation
+
+- [Invoice Transfer Processor](../invoice/README.md) - Invoice-level operations
+- [Transfer Processors Overview](../README.md) - General processor architecture
+- [Invoice Line Service](../../../invoice_line/README.md) - Service layer that triggers processors
+
+## Code Structure
+
+```
+invoice_line/
+├── mod.rs                              # Processor registration
+├── update_inbound_invoice_line.rs      # Main processor logic
+└── test.rs                             # Integration tests
+```

--- a/server/service/src/processors/transfer/invoice_line/mod.rs
+++ b/server/service/src/processors/transfer/invoice_line/mod.rs
@@ -1,0 +1,156 @@
+use crate::{
+    cursor_controller::CursorController,
+    processors::log_system_error,
+    service_provider::ServiceProvider,
+    sync::{ActiveStoresOnSite, GetActiveStoresOnSiteError},
+};
+use repository::{
+    ChangelogFilter, ChangelogRepository, ChangelogRow, ChangelogTableName, EqualFilter, KeyType,
+    RepositoryError, RowActionType, StorageConnection,
+};
+use thiserror::Error;
+
+pub(crate) mod update_inbound_invoice_line;
+
+use update_inbound_invoice_line::UpdateInboundInvoiceLineProcessor;
+
+const CHANGELOG_BATCH_SIZE: u32 = 50;
+
+#[derive(Clone, Debug)]
+pub(crate) struct InvoiceLineTransferProcessorRecord {
+    pub operation: RowActionType,
+    pub invoice_id: String,
+    pub invoice_store_id: String,
+    pub invoice_line_id: String,
+    pub other_party_store_id: String,
+}
+
+#[derive(Error, Debug)]
+pub(crate) enum ProcessInvoiceLineTransfersError {
+    #[error("{0:?}")]
+    DatabaseError(#[from] RepositoryError),
+    #[error("{0}")]
+    GetActiveStoresOnSiteError(#[from] GetActiveStoresOnSiteError),
+    #[error("{0}")]
+    ProcessorError(ProcessorError),
+    #[error("Name id is missing from invoice line changelog {0:?}")]
+    NameIdIsMissingFromChangelog(ChangelogRow),
+    #[error("Name is not an active store {0:?}")]
+    NameIsNotAnActiveStore(ChangelogRow),
+}
+
+#[derive(Debug)]
+pub(crate) enum InvoiceLineTransferOutput {
+    Processed(String),
+    WrongOperation,
+    WrongInvoiceType,
+    WrongInvoiceStatus,
+    WrongStoreInvoice(#[allow(dead_code)] String),
+    InboundNotEditable,
+    NoLinkedInvoice,
+}
+
+#[derive(Error, Debug)]
+#[error("Database error in processor ({0}) {1:?}")]
+pub(crate) struct ProcessorError(String, RepositoryError);
+
+pub(crate) trait InvoiceLineTransferProcessor: Send + Sync {
+    fn get_description(&self) -> String;
+
+    fn try_process_record(
+        &self,
+        connection: &StorageConnection,
+        record: &InvoiceLineTransferProcessorRecord,
+    ) -> Result<InvoiceLineTransferOutput, RepositoryError>;
+}
+
+fn get_processors() -> Vec<Box<dyn InvoiceLineTransferProcessor>> {
+    vec![Box::new(UpdateInboundInvoiceLineProcessor)]
+}
+
+fn process_change_log(
+    connection: &StorageConnection,
+    log: &ChangelogRow,
+    processors: &[Box<dyn InvoiceLineTransferProcessor>],
+    active_stores: &ActiveStoresOnSite,
+) -> Result<(), ProcessInvoiceLineTransfersError> {
+    use ProcessInvoiceLineTransfersError as Error;
+
+    let name_id = log
+        .name_id
+        .as_ref()
+        .ok_or_else(|| Error::NameIdIsMissingFromChangelog(log.clone()))?;
+
+    let record = InvoiceLineTransferProcessorRecord {
+        operation: log.row_action.clone(),
+        invoice_id: log.invoice_id.clone().unwrap_or_default(),
+        invoice_store_id: log.store_id.clone().unwrap_or_default(),
+        invoice_line_id: log.record_id.clone(),
+        other_party_store_id: active_stores
+            .get_store_id_for_name_id(name_id)
+            .ok_or_else(|| Error::NameIsNotAnActiveStore(log.clone()))?,
+    };
+
+    // Try record against all processors
+    for processor in processors.iter() {
+        let output = connection
+            .transaction_sync(|connection| processor.try_process_record(connection, &record))
+            .map_err(|e| ProcessorError(processor.get_description(), e.to_inner_error()))
+            .map_err(Error::ProcessorError)?;
+
+        match output {
+            InvoiceLineTransferOutput::Processed(result) => {
+                log::info!(
+                    "Processor ({}) processed invoice line ({}): {}",
+                    processor.get_description(),
+                    log.record_id,
+                    result
+                );
+                break;
+            }
+            _ => continue, // Try next processor
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn process_invoice_line_transfers(
+    service_provider: &ServiceProvider,
+) -> Result<(), ProcessInvoiceLineTransfersError> {
+    use ProcessInvoiceLineTransfersError as Error;
+
+    let processors = get_processors();
+    let ctx = service_provider
+        .basic_context()
+        .map_err(Error::DatabaseError)?;
+
+    let active_stores = ActiveStoresOnSite::get(&ctx.connection)?;
+
+    let changelog_repo = ChangelogRepository::new(&ctx.connection);
+    let cursor_controller = CursorController::new(KeyType::InvoiceLineTransferProcessorCursor);
+
+    let filter = ChangelogFilter::new()
+        .table_name(ChangelogTableName::InvoiceLine.equal_to())
+        .name_id(EqualFilter::equal_any(active_stores.name_ids().clone()));
+
+    loop {
+        let cursor = cursor_controller.get(&ctx.connection)?;
+        let logs = changelog_repo.changelogs(cursor, CHANGELOG_BATCH_SIZE, Some(filter.clone()))?;
+
+        if logs.is_empty() {
+            break;
+        }
+
+        for log in logs.iter() {
+            let result = process_change_log(&ctx.connection, &log, &processors, &active_stores);
+
+            if let Err(e) = result {
+                log_system_error(&ctx.connection, &e).map_err(Error::DatabaseError)?;
+            }
+
+            cursor_controller.update(&ctx.connection, (log.cursor + 1) as u64)?;
+        }
+    }
+
+    Ok(())
+}

--- a/server/service/src/processors/transfer/invoice_line/test.rs
+++ b/server/service/src/processors/transfer/invoice_line/test.rs
@@ -1,0 +1,623 @@
+use crate::{
+    invoice::outbound_shipment::update::{UpdateOutboundShipment, UpdateOutboundShipmentStatus},
+    invoice_line::stock_out_line::{
+        DeleteStockOutLine, InsertStockOutLine, StockOutType, UpdateStockOutLine,
+    },
+    processors::test_helpers::exec_concurrent,
+    service_provider::ServiceProvider,
+    test_helpers::{setup_all_with_data_and_service_provider, ServiceTestContext},
+};
+use repository::{
+    mock::{MockData, MockDataInserts},
+    EqualFilter, InvoiceFilter, InvoiceLineFilter, InvoiceLineRepository, InvoiceLineRow,
+    InvoiceLineType, InvoiceRepository, InvoiceRow, InvoiceStatus, InvoiceType, ItemRow, KeyType,
+    KeyValueStoreRow, NameRow, StockLineRow, StockLineRowRepository, StorageConnection, StoreRow,
+};
+use util::uuid::uuid;
+
+/// Test that invoice line changes trigger the processor and update inbound invoices
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn invoice_line_transfers() {
+    let site_id = 25;
+
+    let outbound_store_name = NameRow {
+        id: uuid(),
+        name: uuid(),
+        ..Default::default()
+    };
+
+    let outbound_store = StoreRow {
+        id: uuid(),
+        name_link_id: outbound_store_name.id.clone(),
+        site_id,
+        ..Default::default()
+    };
+
+    let inbound_store_name = NameRow {
+        id: uuid(),
+        name: uuid(),
+        ..Default::default()
+    };
+
+    let inbound_store = StoreRow {
+        id: uuid(),
+        name_link_id: inbound_store_name.id.clone(),
+        site_id,
+        ..Default::default()
+    };
+
+    let item1 = ItemRow {
+        id: uuid(),
+        default_pack_size: 10.0,
+        ..Default::default()
+    };
+
+    let site_id_settings = KeyValueStoreRow {
+        id: KeyType::SettingsSyncSiteId,
+        value_int: Some(site_id),
+        ..Default::default()
+    };
+
+    let ServiceTestContext {
+        service_provider,
+        processors_task,
+        ..
+    } = setup_all_with_data_and_service_provider(
+        "invoice_line_transfers",
+        MockDataInserts::none()
+            .stores()
+            .names()
+            .items()
+            .units()
+            .currencies(),
+        MockData {
+            names: vec![inbound_store_name.clone(), outbound_store_name.clone()],
+            stores: vec![inbound_store.clone(), outbound_store.clone()],
+            items: vec![item1.clone()],
+            key_value_store_rows: vec![site_id_settings],
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let test_input = (
+        service_provider,
+        inbound_store,
+        inbound_store_name,
+        outbound_store,
+        outbound_store_name,
+        item1,
+    );
+
+    let number_of_instances = 6;
+
+    let test_handle = exec_concurrent(
+        test_input,
+        number_of_instances,
+        |_, test_input| async move {
+            let (
+                service_provider,
+                inbound_store,
+                inbound_store_name,
+                outbound_store,
+                _outbound_store_name,
+                item1,
+            ) = test_input;
+
+            let ctx = service_provider.basic_context().unwrap();
+
+            let mut tester = InvoiceLineTransferTester::new(
+                &outbound_store,
+                &inbound_store,
+                &inbound_store_name,
+                &item1,
+            );
+
+            // Test full flow: create → update → delete
+            tester.insert_outbound_shipment(&ctx.connection);
+            tester.add_outbound_line(&service_provider);
+
+            tester.update_outbound_shipment_to_picked(&service_provider);
+            ctx.processors_trigger.await_events_processed().await;
+
+            tester.check_inbound_shipment_created(&ctx.connection);
+            tester.check_two_inbound_lines_created(&ctx.connection);
+
+            tester.update_outbound_line(&service_provider);
+            ctx.processors_trigger.await_events_processed().await;
+            tester.check_inbound_line_updated(&ctx.connection);
+
+            tester.delete_outbound_line(&service_provider);
+            ctx.processors_trigger.await_events_processed().await;
+            tester.check_inbound_line_deleted(&ctx.connection);
+        },
+    );
+
+    tokio::select! {
+        Err(err) = processors_task => unreachable!("{}", err),
+        _ = test_handle => (),
+    };
+}
+
+/// Test that multiple batches of the same item are handled correctly
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn invoice_line_transfers_multiple_batches() {
+    let site_id = 26;
+
+    let outbound_store_name = NameRow {
+        id: uuid(),
+        name: uuid(),
+        ..Default::default()
+    };
+
+    let outbound_store = StoreRow {
+        id: uuid(),
+        name_link_id: outbound_store_name.id.clone(),
+        site_id,
+        ..Default::default()
+    };
+
+    let inbound_store_name = NameRow {
+        id: uuid(),
+        name: uuid(),
+        ..Default::default()
+    };
+
+    let inbound_store = StoreRow {
+        id: uuid(),
+        name_link_id: inbound_store_name.id.clone(),
+        site_id,
+        ..Default::default()
+    };
+
+    let item1 = ItemRow {
+        id: uuid(),
+        default_pack_size: 10.0,
+        ..Default::default()
+    };
+
+    let site_id_settings = KeyValueStoreRow {
+        id: KeyType::SettingsSyncSiteId,
+        value_int: Some(site_id),
+        ..Default::default()
+    };
+
+    let ServiceTestContext {
+        service_provider,
+        processors_task,
+        ..
+    } = setup_all_with_data_and_service_provider(
+        "invoice_line_transfers_multiple_batches",
+        MockDataInserts::none()
+            .stores()
+            .names()
+            .items()
+            .units()
+            .currencies(),
+        MockData {
+            names: vec![inbound_store_name.clone(), outbound_store_name.clone()],
+            stores: vec![inbound_store.clone(), outbound_store.clone()],
+            items: vec![item1.clone()],
+            key_value_store_rows: vec![site_id_settings],
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let test_handle = tokio::spawn(async move {
+        let ctx = service_provider.basic_context().unwrap();
+
+        // Create shipment with 2 lines of same item, different batches
+        let mut tester = InvoiceLineTransferTester::new_with_multiple_batches(
+            &outbound_store,
+            &inbound_store,
+            &inbound_store_name,
+            &item1,
+        );
+
+        tester.insert_outbound_shipment_with_two_batches(&ctx.connection);
+        tester.update_outbound_shipment_to_picked(&service_provider);
+        ctx.processors_trigger.await_events_processed().await;
+
+        tester.check_two_inbound_lines_created(&ctx.connection);
+
+        tester.delete_first_batch(&service_provider);
+        ctx.processors_trigger.await_events_processed().await;
+
+        tester.check_first_batch_deleted_second_remains(&ctx.connection);
+    });
+
+    tokio::select! {
+        Err(err) = processors_task => unreachable!("{}", err),
+        _ = test_handle => {},
+    };
+}
+
+/// Simulates invoice line transfer flow
+#[allow(dead_code)]
+struct InvoiceLineTransferTester {
+    outbound_store: StoreRow,
+    inbound_store: StoreRow,
+    outbound_invoice: InvoiceRow,
+    inbound_invoice: Option<InvoiceRow>,
+    outbound_line: InvoiceLineRow,
+    outbound_line_batch2: Option<InvoiceLineRow>,
+    stock_line: StockLineRow,
+    stock_line_batch2: Option<StockLineRow>,
+    extra_mock_data: MockData,
+}
+
+impl InvoiceLineTransferTester {
+    fn new(
+        outbound_store: &StoreRow,
+        inbound_store: &StoreRow,
+        inbound_name: &NameRow,
+        item: &ItemRow,
+    ) -> Self {
+        let outbound_invoice = InvoiceRow {
+            id: uuid(),
+            name_link_id: inbound_name.id.clone(),
+            store_id: outbound_store.id.clone(),
+            r#type: InvoiceType::OutboundShipment,
+            status: InvoiceStatus::Allocated,
+            ..Default::default()
+        };
+
+        let stock_line = StockLineRow {
+            id: uuid(),
+            store_id: outbound_store.id.clone(),
+            item_link_id: item.id.clone(),
+            batch: Some("batch1".to_string()),
+            pack_size: 10.0,
+            total_number_of_packs: 100.0,
+            available_number_of_packs: 100.0,
+            ..Default::default()
+        };
+
+        let outbound_line = InvoiceLineRow {
+            id: uuid(),
+            invoice_id: outbound_invoice.id.clone(),
+            item_link_id: item.id.clone(),
+            item_name: item.name.clone(),
+            item_code: item.code.clone(),
+            r#type: InvoiceLineType::StockOut,
+            pack_size: stock_line.pack_size,
+            number_of_packs: 10.0,
+            batch: stock_line.batch.clone(),
+            stock_line_id: Some(stock_line.id.clone()),
+            ..Default::default()
+        };
+
+        Self {
+            outbound_store: outbound_store.clone(),
+            inbound_store: inbound_store.clone(),
+            outbound_invoice,
+            inbound_invoice: None,
+            outbound_line,
+            outbound_line_batch2: None,
+            stock_line: stock_line.clone(),
+            stock_line_batch2: None,
+            extra_mock_data: MockData {
+                stock_lines: vec![stock_line],
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Create tester with two batches of the same item
+    fn new_with_multiple_batches(
+        outbound_store: &StoreRow,
+        inbound_store: &StoreRow,
+        inbound_name: &NameRow,
+        item: &ItemRow,
+    ) -> Self {
+        let outbound_invoice = InvoiceRow {
+            id: uuid(),
+            name_link_id: inbound_name.id.clone(),
+            store_id: outbound_store.id.clone(),
+            r#type: InvoiceType::OutboundShipment,
+            status: InvoiceStatus::Allocated,
+            ..Default::default()
+        };
+
+        // First batch
+        let stock_line_batch1 = StockLineRow {
+            id: uuid(),
+            store_id: outbound_store.id.clone(),
+            item_link_id: item.id.clone(),
+            batch: Some("batch1".to_string()),
+            pack_size: 10.0,
+            total_number_of_packs: 100.0,
+            available_number_of_packs: 100.0,
+            ..Default::default()
+        };
+
+        let outbound_line_batch1 = InvoiceLineRow {
+            id: uuid(),
+            invoice_id: outbound_invoice.id.clone(),
+            item_link_id: item.id.clone(),
+            item_name: item.name.clone(),
+            item_code: item.code.clone(),
+            r#type: InvoiceLineType::StockOut,
+            pack_size: stock_line_batch1.pack_size,
+            number_of_packs: 10.0,
+            batch: stock_line_batch1.batch.clone(),
+            stock_line_id: Some(stock_line_batch1.id.clone()),
+            ..Default::default()
+        };
+
+        // Second batch
+        let stock_line_batch2 = StockLineRow {
+            id: uuid(),
+            store_id: outbound_store.id.clone(),
+            item_link_id: item.id.clone(),
+            batch: Some("batch2".to_string()),
+            pack_size: 10.0,
+            total_number_of_packs: 50.0,
+            available_number_of_packs: 50.0,
+            ..Default::default()
+        };
+
+        let outbound_line_batch2 = InvoiceLineRow {
+            id: uuid(),
+            invoice_id: outbound_invoice.id.clone(),
+            item_link_id: item.id.clone(),
+            item_name: item.name.clone(),
+            item_code: item.code.clone(),
+            r#type: InvoiceLineType::StockOut,
+            pack_size: stock_line_batch2.pack_size,
+            number_of_packs: 5.0,
+            batch: stock_line_batch2.batch.clone(),
+            stock_line_id: Some(stock_line_batch2.id.clone()),
+            ..Default::default()
+        };
+
+        Self {
+            outbound_store: outbound_store.clone(),
+            inbound_store: inbound_store.clone(),
+            outbound_invoice,
+            inbound_invoice: None,
+            outbound_line: outbound_line_batch1,
+            outbound_line_batch2: Some(outbound_line_batch2),
+            stock_line: stock_line_batch1.clone(),
+            stock_line_batch2: Some(stock_line_batch2.clone()),
+            extra_mock_data: MockData {
+                stock_lines: vec![stock_line_batch1, stock_line_batch2],
+                ..Default::default()
+            },
+        }
+    }
+
+    fn insert_outbound_shipment(&self, connection: &StorageConnection) {
+        repository::mock::insert_extra_mock_data(
+            connection,
+            MockData {
+                invoices: vec![self.outbound_invoice.clone()],
+                invoice_lines: vec![self.outbound_line.clone()],
+                ..Default::default()
+            }
+            .join(self.extra_mock_data.clone()),
+        );
+    }
+
+    fn insert_outbound_shipment_with_two_batches(&self, connection: &StorageConnection) {
+        let mut invoice_lines = vec![self.outbound_line.clone()];
+        if let Some(ref line2) = self.outbound_line_batch2 {
+            invoice_lines.push(line2.clone());
+        }
+
+        repository::mock::insert_extra_mock_data(
+            connection,
+            MockData {
+                invoices: vec![self.outbound_invoice.clone()],
+                invoice_lines,
+                ..Default::default()
+            }
+            .join(self.extra_mock_data.clone()),
+        );
+    }
+
+    fn update_outbound_shipment_to_picked(&mut self, service_provider: &ServiceProvider) {
+        let ctx = service_provider
+            .context(self.outbound_store.id.clone(), "".to_string())
+            .unwrap();
+
+        self.outbound_invoice = service_provider
+            .invoice_service
+            .update_outbound_shipment(
+                &ctx,
+                UpdateOutboundShipment {
+                    id: self.outbound_invoice.id.clone(),
+                    status: Some(UpdateOutboundShipmentStatus::Picked),
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+            .invoice_row;
+    }
+
+    fn check_inbound_shipment_created(&mut self, connection: &StorageConnection) {
+        let inbound_invoice = InvoiceRepository::new(connection)
+            .query_one(InvoiceFilter::new_match_linked_invoice_id(
+                &self.outbound_invoice.id,
+            ))
+            .unwrap();
+
+        assert!(inbound_invoice.is_some());
+        self.inbound_invoice = Some(inbound_invoice.unwrap().invoice_row);
+    }
+
+    fn add_outbound_line(&mut self, service_provider: &ServiceProvider) {
+        let ctx = service_provider
+            .context(self.outbound_store.id.clone(), "".to_string())
+            .unwrap();
+
+        let stock_line_batch2 = StockLineRow {
+            id: uuid(),
+            store_id: self.outbound_store.id.clone(),
+            item_link_id: self.outbound_line.item_link_id.clone(),
+            batch: Some("batch2".to_string()),
+            pack_size: 10.0,
+            total_number_of_packs: 50.0,
+            available_number_of_packs: 50.0,
+            ..Default::default()
+        };
+
+        StockLineRowRepository::new(&ctx.connection)
+            .upsert_one(&stock_line_batch2)
+            .unwrap();
+
+        let new_line = service_provider
+            .invoice_line_service
+            .insert_stock_out_line(
+                &ctx,
+                InsertStockOutLine {
+                    id: uuid(),
+                    invoice_id: self.outbound_invoice.id.clone(),
+                    stock_line_id: stock_line_batch2.id.clone(),
+                    number_of_packs: 5.0,
+                    r#type: StockOutType::OutboundShipment,
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+            .invoice_line_row;
+
+        self.outbound_line_batch2 = Some(new_line);
+        self.stock_line_batch2 = Some(stock_line_batch2);
+    }
+
+    fn check_two_inbound_lines_created(&self, connection: &StorageConnection) {
+        let inbound_lines = InvoiceLineRepository::new(connection)
+            .query_by_filter(InvoiceLineFilter::new().invoice_id(EqualFilter::equal_to(
+                &self.inbound_invoice.as_ref().unwrap().id,
+            )))
+            .unwrap();
+
+        assert_eq!(inbound_lines.len(), 2);
+
+        let batch1 = inbound_lines
+            .iter()
+            .find(|l| l.invoice_line_row.batch == Some("batch1".to_string()));
+        assert!(batch1.is_some());
+        assert_eq!(batch1.unwrap().invoice_line_row.number_of_packs, 10.0);
+
+        let batch2 = inbound_lines
+            .iter()
+            .find(|l| l.invoice_line_row.batch == Some("batch2".to_string()));
+        assert!(batch2.is_some());
+        assert_eq!(batch2.unwrap().invoice_line_row.number_of_packs, 5.0);
+    }
+
+    fn update_outbound_line(&mut self, service_provider: &ServiceProvider) {
+        let ctx = service_provider
+            .context(self.outbound_store.id.clone(), "".to_string())
+            .unwrap();
+
+        self.outbound_line = service_provider
+            .invoice_line_service
+            .update_stock_out_line(
+                &ctx,
+                UpdateStockOutLine {
+                    id: self.outbound_line.id.clone(),
+                    number_of_packs: Some(20.0),
+                    r#type: Some(StockOutType::OutboundShipment),
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+            .invoice_line_row;
+    }
+
+    fn check_inbound_line_updated(&self, connection: &StorageConnection) {
+        let inbound_lines = InvoiceLineRepository::new(connection)
+            .query_by_filter(
+                InvoiceLineFilter::new()
+                    .invoice_id(EqualFilter::equal_to(
+                        &self.inbound_invoice.as_ref().unwrap().id,
+                    ))
+                    .item_id(EqualFilter::equal_to(&self.outbound_line.item_link_id)),
+            )
+            .unwrap();
+
+        assert_eq!(inbound_lines.len(), 2);
+        let batch1 = inbound_lines
+            .iter()
+            .find(|l| l.invoice_line_row.batch == Some("batch1".to_string()));
+        assert!(batch1.is_some(), "Batch1 should exist");
+        assert_eq!(batch1.unwrap().invoice_line_row.number_of_packs, 20.0);
+
+        // Check batch2 is unchanged
+        let batch2 = inbound_lines
+            .iter()
+            .find(|l| l.invoice_line_row.batch == Some("batch2".to_string()));
+        assert!(batch2.is_some(), "Batch2 should still exist");
+        assert_eq!(batch2.unwrap().invoice_line_row.number_of_packs, 5.0,);
+    }
+
+    fn delete_outbound_line(&self, service_provider: &ServiceProvider) {
+        let ctx = service_provider
+            .context(self.outbound_store.id.clone(), "".to_string())
+            .unwrap();
+
+        service_provider
+            .invoice_line_service
+            .delete_stock_out_line(
+                &ctx,
+                DeleteStockOutLine {
+                    id: self.outbound_line.id.clone(),
+                    r#type: Some(StockOutType::OutboundShipment),
+                },
+            )
+            .unwrap();
+    }
+
+    fn delete_first_batch(&self, service_provider: &ServiceProvider) {
+        let ctx = service_provider
+            .context(self.outbound_store.id.clone(), "".to_string())
+            .unwrap();
+
+        service_provider
+            .invoice_line_service
+            .delete_stock_out_line(
+                &ctx,
+                DeleteStockOutLine {
+                    id: self.outbound_line.id.clone(),
+                    r#type: Some(StockOutType::OutboundShipment),
+                },
+            )
+            .unwrap();
+    }
+
+    fn check_inbound_line_deleted(&self, connection: &StorageConnection) {
+        let inbound_lines = InvoiceLineRepository::new(connection)
+            .query_by_filter(
+                InvoiceLineFilter::new()
+                    .invoice_id(EqualFilter::equal_to(
+                        &self.inbound_invoice.as_ref().unwrap().id,
+                    ))
+                    .item_id(EqualFilter::equal_to(&self.outbound_line.item_link_id)),
+            )
+            .unwrap();
+
+        assert_eq!(inbound_lines.len(), 1);
+
+        let remaining = &inbound_lines[0].invoice_line_row;
+        assert_eq!(remaining.batch, Some("batch2".to_string()));
+        assert_eq!(remaining.number_of_packs, 5.0);
+    }
+
+    fn check_first_batch_deleted_second_remains(&self, connection: &StorageConnection) {
+        let inbound_lines = InvoiceLineRepository::new(connection)
+            .query_by_filter(InvoiceLineFilter::new().invoice_id(EqualFilter::equal_to(
+                &self.inbound_invoice.as_ref().unwrap().id,
+            )))
+            .unwrap();
+
+        assert_eq!(inbound_lines.len(), 1);
+
+        let remaining = &inbound_lines[0].invoice_line_row;
+        assert_eq!(remaining.batch, Some("batch2".to_string()));
+        assert_eq!(remaining.number_of_packs, 5.0);
+    }
+}

--- a/server/service/src/processors/transfer/invoice_line/update_inbound_invoice_line.rs
+++ b/server/service/src/processors/transfer/invoice_line/update_inbound_invoice_line.rs
@@ -117,8 +117,6 @@ impl UpdateInboundInvoiceLineProcessor {
         outbound_line: &InvoiceLine,
         inbound_invoice: &Invoice,
     ) -> Result<InvoiceLineTransferOutput, RepositoryError> {
-        let repo = InvoiceLineRowRepository::new(connection);
-
         // Find corresponding inbound line by linked_invoice_id
         let existing_inbound_lines = InvoiceLineRepository::new(connection).query_by_filter(
             InvoiceLineFilter::new()
@@ -141,7 +139,7 @@ impl UpdateInboundInvoiceLineProcessor {
             inbound_line_row.id = existing_inbound_line.invoice_line_row.id.clone();
         }
 
-        repo.upsert_one(&inbound_line_row)?;
+        InvoiceLineRowRepository::new(connection).upsert_one(&inbound_line_row)?;
 
         Ok(InvoiceLineTransferOutput::Processed(format!(
             "Upserted inbound line {} for invoice {}",

--- a/server/service/src/processors/transfer/invoice_line/update_inbound_invoice_line.rs
+++ b/server/service/src/processors/transfer/invoice_line/update_inbound_invoice_line.rs
@@ -1,0 +1,279 @@
+use repository::{
+    EqualFilter, Invoice, InvoiceFilter, InvoiceLine, InvoiceLineFilter, InvoiceLineRepository,
+    InvoiceLineRow, InvoiceLineRowRepository, InvoiceLineType, InvoiceRepository, InvoiceRow,
+    InvoiceRowRepository, InvoiceStatus, InvoiceType, ItemStoreJoinRowRepository,
+    ItemStoreJoinRowRepositoryTrait, RepositoryError, RowActionType, StorageConnection,
+};
+
+use super::{
+    InvoiceLineTransferOutput, InvoiceLineTransferProcessor, InvoiceLineTransferProcessorRecord,
+};
+use crate::invoice::common::{calculate_foreign_currency_total, calculate_total_after_tax};
+use util::uuid::uuid;
+
+const DESCRIPTION: &str = "Update inbound invoice line from outbound invoice line (PICKED status)";
+
+pub(crate) struct UpdateInboundInvoiceLineProcessor;
+
+impl InvoiceLineTransferProcessor for UpdateInboundInvoiceLineProcessor {
+    fn get_description(&self) -> String {
+        DESCRIPTION.to_string()
+    }
+
+    /// Process individual invoice line changes when:
+    /// 1. Source invoice is Outbound Shipment or Supplier Return  
+    /// 2. Source invoice status is PICKED (editable state)
+    /// 3. Linked inbound invoice exists and is also PICKED
+    /// 4. Action is UPSERT or DELETE
+    fn try_process_record(
+        &self,
+        connection: &StorageConnection,
+        record: &InvoiceLineTransferProcessorRecord,
+    ) -> Result<InvoiceLineTransferOutput, RepositoryError> {
+        if !matches!(
+            record.operation,
+            RowActionType::Upsert | RowActionType::Delete
+        ) {
+            return Ok(InvoiceLineTransferOutput::WrongOperation);
+        }
+
+        // Get the outbound line (may not exist if deleted)
+        let outbound_line = InvoiceLineRepository::new(connection).query_one(
+            InvoiceLineFilter::new().id(EqualFilter::equal_to(&record.invoice_line_id)),
+        )?;
+
+        let outbound_invoice = match &outbound_line {
+            Some(line) => line.invoice_row.clone(),
+            None => {
+                // If outbound line doesn't exist (must be DELETE operation), then try to get the outbound invoice by ID
+                let invoice = InvoiceRowRepository::new(connection)
+                    .find_one_by_id(&record.invoice_id)?
+                    .ok_or(RepositoryError::NotFound)?;
+
+                if invoice.store_id != record.invoice_store_id {
+                    return Ok(InvoiceLineTransferOutput::WrongStoreInvoice(
+                        "Outbound invoice store ID does not match record".to_string(),
+                    ));
+                }
+                invoice
+            }
+        };
+
+        // Check invoice type
+        if !matches!(
+            outbound_invoice.r#type,
+            InvoiceType::OutboundShipment | InvoiceType::SupplierReturn
+        ) {
+            return Ok(InvoiceLineTransferOutput::WrongInvoiceType);
+        }
+
+        // Only process if outbound invoice is PICKED
+        if outbound_invoice.status != InvoiceStatus::Picked {
+            return Ok(InvoiceLineTransferOutput::WrongInvoiceStatus);
+        }
+
+        // Get linked inbound invoice
+        let inbound_invoice = match &outbound_invoice.linked_invoice_id {
+            Some(linked_id) => InvoiceRepository::new(connection)
+                .query_by_filter(InvoiceFilter::new().id(EqualFilter::equal_to(linked_id)))?
+                .pop(),
+            None => None,
+        };
+
+        let inbound_invoice = match inbound_invoice {
+            Some(inv) => inv,
+            None => return Ok(InvoiceLineTransferOutput::NoLinkedInvoice),
+        };
+
+        if inbound_invoice.invoice_row.store_id != record.other_party_store_id {
+            return Ok(InvoiceLineTransferOutput::WrongStoreInvoice(
+                "Inbound invoice store ID does not match record".to_string(),
+            ));
+        }
+
+        // Only process if inbound invoice is PICKED (editable)
+        if inbound_invoice.invoice_row.status != InvoiceStatus::Picked {
+            return Ok(InvoiceLineTransferOutput::InboundNotEditable);
+        }
+
+        let result = match &record.operation {
+            RowActionType::Upsert => {
+                let outbound_line = outbound_line.ok_or(RepositoryError::NotFound)?;
+                self.upsert_line(connection, &outbound_line, &inbound_invoice)?
+            }
+            RowActionType::Delete => {
+                self.delete_line(connection, &outbound_invoice, &inbound_invoice.invoice_row)?
+            }
+        };
+
+        Ok(result)
+    }
+}
+
+impl UpdateInboundInvoiceLineProcessor {
+    fn upsert_line(
+        &self,
+        connection: &StorageConnection,
+        outbound_line: &InvoiceLine,
+        inbound_invoice: &Invoice,
+    ) -> Result<InvoiceLineTransferOutput, RepositoryError> {
+        let repo = InvoiceLineRowRepository::new(connection);
+
+        // Find corresponding inbound line by linked_invoice_id
+        let existing_inbound_lines = InvoiceLineRepository::new(connection).query_by_filter(
+            InvoiceLineFilter::new()
+                .invoice_id(EqualFilter::equal_to(&inbound_invoice.invoice_row.id))
+                .linked_invoice_id(EqualFilter::equal_to(&outbound_line.invoice_row.id)),
+        )?;
+
+        // Find the specific matching line based on business key (item, batch, expiry)
+        let existing_inbound_line = existing_inbound_lines.into_iter().find(|inbound_line| {
+            self.lines_match(
+                &outbound_line.invoice_line_row,
+                &inbound_line.invoice_line_row,
+            )
+        });
+
+        let mut inbound_line_row =
+            self.generate_inbound_line(connection, outbound_line, inbound_invoice);
+
+        if let Some(existing_inbound_line) = &existing_inbound_line {
+            inbound_line_row.id = existing_inbound_line.invoice_line_row.id.clone();
+        }
+
+        repo.upsert_one(&inbound_line_row)?;
+
+        Ok(InvoiceLineTransferOutput::Processed(format!(
+            "Upserted inbound line {} for invoice {}",
+            inbound_line_row.id, inbound_line_row.invoice_id
+        )))
+    }
+
+    fn generate_inbound_line(
+        &self,
+        connection: &StorageConnection,
+        outbound_line: &InvoiceLine,
+        inbound_invoice: &Invoice,
+    ) -> InvoiceLineRow {
+        let item_properties_repo = ItemStoreJoinRowRepository::new(connection);
+        let item = &outbound_line.item_row;
+        let mut new_line = outbound_line.invoice_line_row.clone();
+
+        let item_properties = item_properties_repo
+            .find_one_by_item_and_store_id(&item.id, &inbound_invoice.invoice_row.store_id)
+            .unwrap_or(None);
+
+        let default_sell_price_per_pack = match (
+            item_properties,
+            item.default_pack_size == new_line.pack_size,
+        ) {
+            (Some(p), true) => p.default_sell_price_per_pack,
+            _ => 0.0,
+        };
+
+        let total_before_tax = match new_line.r#type {
+            // Service lines don't work in packs
+            InvoiceLineType::Service => new_line.total_before_tax,
+            _ => new_line.cost_price_per_pack * new_line.number_of_packs,
+        };
+
+        new_line.id = uuid();
+        new_line.invoice_id = inbound_invoice.invoice_row.id.clone();
+        new_line.r#type = match new_line.r#type {
+            InvoiceLineType::StockOut => InvoiceLineType::StockIn,
+            _ => new_line.r#type,
+        };
+        new_line.stock_line_id = None; // Inbound creates its own stock lines
+        new_line.location_id = None;
+        new_line.reason_option_id = None;
+        new_line.cost_price_per_pack = new_line.sell_price_per_pack; // Cost price on inbound is sell price from outbound
+        new_line.linked_invoice_id = Some(outbound_line.invoice_row.id.clone());
+        new_line.total_before_tax = total_before_tax;
+        new_line.total_after_tax =
+            calculate_total_after_tax(new_line.total_before_tax, new_line.tax_percentage);
+        new_line.sell_price_per_pack = default_sell_price_per_pack;
+        new_line.foreign_currency_price_before_tax = calculate_foreign_currency_total(
+            connection,
+            new_line.total_before_tax,
+            inbound_invoice.invoice_row.currency_id.clone(),
+            &inbound_invoice.invoice_row.currency_rate,
+        )
+        .unwrap_or_default();
+
+        new_line
+    }
+
+    fn delete_line(
+        &self,
+        connection: &StorageConnection,
+        outbound_invoice: &InvoiceRow,
+        inbound_invoice: &InvoiceRow,
+    ) -> Result<InvoiceLineTransferOutput, RepositoryError> {
+        // Get current outbound lines
+        let outbound_lines = InvoiceLineRepository::new(connection).query_by_filter(
+            InvoiceLineFilter::new().invoice_id(EqualFilter::equal_to(&outbound_invoice.id)),
+        )?;
+
+        // Get inbound lines linked to this outbound invoice
+        let inbound_lines = InvoiceLineRepository::new(connection).query_by_filter(
+            InvoiceLineFilter::new()
+                .invoice_id(EqualFilter::equal_to(&inbound_invoice.id))
+                .linked_invoice_id(EqualFilter::equal_to(&outbound_invoice.id)),
+        )?;
+
+        let mut deleted_count = 0;
+
+        // Find and delete orphaned inbound lines
+        for inbound_line in &inbound_lines {
+            let has_match = outbound_lines.iter().any(|outbound_line| {
+                self.lines_match_for_delete(
+                    &outbound_line.invoice_line_row,
+                    &inbound_line.invoice_line_row,
+                )
+            });
+
+            if !has_match {
+                InvoiceLineRowRepository::new(connection)
+                    .delete(&inbound_line.invoice_line_row.id)?;
+                deleted_count += 1;
+            }
+        }
+
+        Ok(InvoiceLineTransferOutput::Processed(format!(
+            "Deleted {} orphaned inbound lines for outbound invoice {}",
+            deleted_count, outbound_invoice.id
+        )))
+    }
+
+    /// Check if two lines match based on business key (item, batch, expiry)
+    fn lines_match(
+        &self,
+        outbound_line_row: &InvoiceLineRow,
+        inbound_line_row: &InvoiceLineRow,
+    ) -> bool {
+        outbound_line_row.item_link_id == inbound_line_row.item_link_id
+            && outbound_line_row.batch == inbound_line_row.batch
+            && outbound_line_row.expiry_date == inbound_line_row.expiry_date
+    }
+
+    /// Check if two lines match for deletion purposes, considering (item, batch, expiry) with quantity tolerance
+    fn lines_match_for_delete(
+        &self,
+        outbound_line_row: &InvoiceLineRow,
+        inbound_line_row: &InvoiceLineRow,
+    ) -> bool {
+        let same_batch = self.lines_match(outbound_line_row, inbound_line_row);
+
+        if !same_batch {
+            return false;
+        }
+
+        // Compare total quantity (number_of_packs * pack_size),
+        // since inbound invoice may convert pack-to-one based on store preferences
+        let outbound_line_total = outbound_line_row.number_of_packs * outbound_line_row.pack_size;
+        let inbound_line_total = inbound_line_row.number_of_packs * inbound_line_row.pack_size;
+        let diff = (outbound_line_total - inbound_line_total).abs();
+
+        diff < 0.001 // Tolerance for floating point comparison
+    }
+}

--- a/server/service/src/processors/transfer/mod.rs
+++ b/server/service/src/processors/transfer/mod.rs
@@ -5,6 +5,7 @@ use repository::{
 use thiserror::Error;
 
 pub(crate) mod invoice;
+pub(crate) mod invoice_line;
 pub(crate) mod requisition;
 
 #[derive(Error, Debug)]

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -310,6 +310,10 @@ impl Synchroniser {
 
         ctx.processors_trigger
             .trigger_requisition_transfer_processors();
+
+        ctx.processors_trigger
+            .trigger_invoice_line_transfer_processors();
+
         ctx.processors_trigger.trigger_invoice_transfer_processors();
 
         ctx.processors_trigger

--- a/server/service/src/sync/translations/contact_form.rs
+++ b/server/service/src/sync/translations/contact_form.rs
@@ -137,6 +137,7 @@ mod tests {
             store_id: None,
             is_sync_update: false,
             source_site_id: None,
+            ..Default::default()
         };
 
         let translator = ContactFormTranslation {};


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9666 

# 👩🏻‍💻 What does this PR do?
This PR introduces line-level transfer processing for invoice lines in stock transfers, separating concerns between invoice-level and line-level synchronization between sites.

## Key Changes
- Added `invoice_line` transfer processor module which handle individual line changes of picked outbound shipment.
- Refactored the `invoice` transfer processor module to remove line generation logic from `update_inbound_invoice.rs`
  - Invoice processor now only updates invoice metadata (status, dates, references)
  - Lines are no longer regenerated when invoice status changes to SHIPPED
- Added 2.13.0 migration code to add `invoice_id` field in `changelog` to track invoice_line's invoice id
- Added 2.13.0 migration code for `INVOICE_LINE_TRANSFER_PROCESSOR_CURSOR` pg enum

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create stock transfer outbound
- [ ] Add a single line and then picked or shipped the shipment
- [ ] Sync it to the central server
- [ ] In the other remote site, do force sync and then open inbound shipment
- [ ] You'll have that single item appeared in the shipment
- [ ] Now again go back to that outbound shipment and then add new line to it and then just sync
- [ ] In the inbound shipment, do force sync and see error

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

