### PR TITLE
9735.1 store users could supply more than the approved qty when creating shipments

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -146,6 +146,8 @@ export enum ActivityLogNodeType {
   ItemVariantUpdateLocationType = 'ITEM_VARIANT_UPDATE_LOCATION_TYPE',
   ItemVariantUpdateManufacturer = 'ITEM_VARIANT_UPDATE_MANUFACTURER',
   ItemVariantUpdateVvmType = 'ITEM_VARIANT_UPDATE_VVM_TYPE',
+  PatientCreated = 'PATIENT_CREATED',
+  PatientUpdated = 'PATIENT_UPDATED',
   PrescriptionCreated = 'PRESCRIPTION_CREATED',
   PrescriptionDeleted = 'PRESCRIPTION_DELETED',
   PrescriptionStatusCancelled = 'PRESCRIPTION_STATUS_CANCELLED',
@@ -153,7 +155,6 @@ export enum ActivityLogNodeType {
   PrescriptionStatusVerified = 'PRESCRIPTION_STATUS_VERIFIED',
   ProgramCreated = 'PROGRAM_CREATED',
   ProgramUpdated = 'PROGRAM_UPDATED',
-  PropertyUpdated = 'PROPERTY_UPDATED',
   PurchaseOrderConfirmed = 'PURCHASE_ORDER_CONFIRMED',
   PurchaseOrderCreated = 'PURCHASE_ORDER_CREATED',
   PurchaseOrderDeleted = 'PURCHASE_ORDER_DELETED',
@@ -1221,6 +1222,21 @@ export type CannotIssueInForeignCurrency = UpdateErrorInterface &
     __typename: 'CannotIssueInForeignCurrency';
     description: Scalars['String']['output'];
   };
+
+export type CannotIssueMoreThanApprovedQuantity =
+  InsertOutboundShipmentLineErrorInterface &
+    InsertPrescriptionLineErrorInterface &
+    UpdateOutboundShipmentLineErrorInterface &
+    UpdatePrescriptionLineErrorInterface & {
+      __typename: 'CannotIssueMoreThanApprovedQuantity';
+      description: Scalars['String']['output'];
+    };
+
+export type CannotIssueMoreThanAuthorised = UpdateErrorInterface & {
+  __typename: 'CannotIssueMoreThanAuthorised';
+  description: Scalars['String']['output'];
+  invoiceLines: InvoiceLineConnector;
+};
 
 export type CannotReverseInvoiceStatus = UpdateErrorInterface &
   UpdateInboundShipmentErrorInterface &
@@ -6866,6 +6882,7 @@ export enum PreferenceKey {
   NumberOfMonthsToCheckForConsumptionWhenCalculatingOutOfStockProducts = 'numberOfMonthsToCheckForConsumptionWhenCalculatingOutOfStockProducts',
   OrderInPacks = 'orderInPacks',
   PreventTransfersMonthsBeforeInitialisation = 'preventTransfersMonthsBeforeInitialisation',
+  RequisitionAutoFinalise = 'requisitionAutoFinalise',
   SecondThresholdForExpiringItems = 'secondThresholdForExpiringItems',
   SelectDestinationStoreForAnInternalOrder = 'selectDestinationStoreForAnInternalOrder',
   ShowContactTracing = 'showContactTracing',
@@ -6918,6 +6935,7 @@ export type PreferencesNode = {
   numberOfMonthsToCheckForConsumptionWhenCalculatingOutOfStockProducts: Scalars['Int']['output'];
   orderInPacks: Scalars['Boolean']['output'];
   preventTransfersMonthsBeforeInitialisation: Scalars['Int']['output'];
+  requisitionAutoFinalise: Scalars['Boolean']['output'];
   secondThresholdForExpiringItems: Scalars['Int']['output'];
   selectDestinationStoreForAnInternalOrder: Scalars['Boolean']['output'];
   showContactTracing: Scalars['Boolean']['output'];
@@ -9307,6 +9325,7 @@ export type StockLineConnector = {
 };
 
 export type StockLineFilterInput = {
+  code?: InputMaybe<StringFilterInput>;
   expiryDate?: InputMaybe<DateFilterInput>;
   hasPacksInStore?: InputMaybe<Scalars['Boolean']['input']>;
   id?: InputMaybe<EqualFilterStringInput>;
@@ -9318,6 +9337,7 @@ export type StockLineFilterInput = {
   location?: InputMaybe<LocationFilterInput>;
   locationId?: InputMaybe<EqualFilterStringInput>;
   masterList?: InputMaybe<MasterListFilterInput>;
+  name?: InputMaybe<StringFilterInput>;
   search?: InputMaybe<StringFilterInput>;
   storeId?: InputMaybe<EqualFilterStringInput>;
   vvmStatusId?: InputMaybe<EqualFilterStringInput>;
@@ -11237,6 +11257,7 @@ export type UpsertPreferencesInput = {
   preventTransfersMonthsBeforeInitialisation?: InputMaybe<
     Scalars['Int']['input']
   >;
+  requisitionAutoFinalise?: InputMaybe<Array<BoolStorePrefInput>>;
   secondThresholdForExpiringItems?: InputMaybe<Array<IntegerStorePrefInput>>;
   selectDestinationStoreForAnInternalOrder?: InputMaybe<
     Array<BoolStorePrefInput>

--- a/client/packages/invoices/src/OutboundShipment/api/operations.generated.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/operations.generated.ts
@@ -635,6 +635,7 @@ export type UpdateOutboundShipmentMutation = {
               description: string;
             }
           | { __typename: 'CannotIssueInForeignCurrency'; description: string }
+          | { __typename: 'CannotIssueMoreThanAuthorised' }
           | { __typename: 'CannotReverseInvoiceStatus'; description: string }
           | { __typename: 'InvoiceIsNotEditable'; description: string }
           | { __typename: 'NotAnOutboundShipmentError'; description: string }
@@ -790,6 +791,10 @@ export type UpsertOutboundShipmentMutation = {
             __typename: 'InsertOutboundShipmentLineError';
             error:
               | { __typename: 'CannotEditInvoice'; description: string }
+              | {
+                  __typename: 'CannotIssueMoreThanApprovedQuantity';
+                  description: string;
+                }
               | { __typename: 'ForeignKeyError'; description: string }
               | { __typename: 'LocationIsOnHold'; description: string }
               | { __typename: 'LocationNotFound'; description: string }
@@ -848,6 +853,10 @@ export type UpsertOutboundShipmentMutation = {
             __typename: 'UpdateOutboundShipmentLineError';
             error:
               | { __typename: 'CannotEditInvoice'; description: string }
+              | {
+                  __typename: 'CannotIssueMoreThanApprovedQuantity';
+                  description: string;
+                }
               | {
                   __typename: 'ForeignKeyError';
                   description: string;
@@ -939,6 +948,10 @@ export type UpsertOutboundShipmentMutation = {
                 }
               | {
                   __typename: 'CannotIssueInForeignCurrency';
+                  description: string;
+                }
+              | {
+                  __typename: 'CannotIssueMoreThanAuthorised';
                   description: string;
                 }
               | {

--- a/client/packages/invoices/src/Prescriptions/api/operations.generated.ts
+++ b/client/packages/invoices/src/Prescriptions/api/operations.generated.ts
@@ -964,6 +964,10 @@ export type UpsertPrescriptionMutation = {
             __typename: 'InsertPrescriptionLineError';
             error:
               | { __typename: 'CannotEditInvoice'; description: string }
+              | {
+                  __typename: 'CannotIssueMoreThanApprovedQuantity';
+                  description: string;
+                }
               | { __typename: 'ForeignKeyError'; description: string }
               | { __typename: 'LocationIsOnHold'; description: string }
               | { __typename: 'LocationNotFound'; description: string }
@@ -992,6 +996,10 @@ export type UpsertPrescriptionMutation = {
             __typename: 'UpdatePrescriptionLineError';
             error:
               | { __typename: 'CannotEditInvoice'; description: string }
+              | {
+                  __typename: 'CannotIssueMoreThanApprovedQuantity';
+                  description: string;
+                }
               | {
                   __typename: 'ForeignKeyError';
                   description: string;

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
@@ -13,6 +13,7 @@ import {
 } from '@openmsupply-client/common';
 import { getCurrentValue, getUpdatedSupply } from './utils';
 import { DraftResponseLine } from '../hooks';
+import { useResponse } from '../../../api';
 
 interface Option {
   label: string;
@@ -48,6 +49,10 @@ export const SupplySelection = ({
 }: SupplySelectionProps) => {
   const t = useTranslation();
   const { getPlural } = useIntlUtils();
+  const { authoriseResponseRequisitions } = useResponse.utils.preferences();
+  const max = authoriseResponseRequisitions
+    ? draft?.approvedQuantity
+    : undefined;
 
   const currentValue = useMemo(
     (): number =>
@@ -133,6 +138,7 @@ export const SupplySelection = ({
                     : theme.palette.background.white,
               },
             }}
+            max={max}
           />
           {displayVaccinesInDoses && !!value && (
             <DosesCaption

--- a/server/graphql/invoice/src/mutations/outbound_shipment/update.rs
+++ b/server/graphql/invoice/src/mutations/outbound_shipment/update.rs
@@ -144,7 +144,7 @@ impl UpdateInput {
 
 fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
     use StandardGraphqlError::*;
-    let formatted_error = format!("{:#?}", error);
+    let formatted_error = format!("{error:#?}");
 
     let graphql_error = match error {
         // Structured Errors

--- a/server/graphql/invoice_line/src/invoice_line_queries.rs
+++ b/server/graphql/invoice_line/src/invoice_line_queries.rs
@@ -164,7 +164,7 @@ pub fn invoice_lines(
         ))
     } else {
         let err = invoice_lines.unwrap_err();
-        let formatted_error = format!("{:#?}", err);
+        let formatted_error = format!("{err:#?}");
         let graphql_error = match err {
             GetInvoiceLinesError::DatabaseError(err) => err.into(),
             GetInvoiceLinesError::InvalidStore => {
@@ -208,8 +208,8 @@ pub fn draft_outbound_lines(
         })
     } else {
         let err = result.unwrap_err();
-        let formatted_error = format!("{:#?}", err);
-        log::error!("Draft outbound lines generation error: {}", formatted_error);
+        let formatted_error = format!("{err:#?}");
+        log::error!("Draft outbound lines generation error: {formatted_error}");
         Err(list_error_to_gql_err(err))
     }
 }

--- a/server/graphql/invoice_line/src/invoice_line_queries.rs
+++ b/server/graphql/invoice_line/src/invoice_line_queries.rs
@@ -59,17 +59,13 @@ impl From<InvoiceLineFilterInput> for InvoiceLineFilter {
             invoice_id: f.invoice_id.map(EqualFilter::from),
             location_id: f.location_id.map(EqualFilter::from),
             item_id: f.item_id.map(EqualFilter::from),
-            r#type: f
-                .r#type
-                .map(|t| map_filter!(t, |r| InvoiceLineType::from(r))),
+            r#type: f.r#type.map(|t| map_filter!(t, InvoiceLineType::from)),
             requisition_id: f.requisition_id.map(EqualFilter::from),
             number_of_packs: f.number_of_packs.map(|t| map_filter!(t, f64::from)),
-            invoice_type: f
-                .invoice_type
-                .map(|t| map_filter!(t, |i| InvoiceType::from(i))),
+            invoice_type: f.invoice_type.map(|t| map_filter!(t, InvoiceType::from)),
             invoice_status: f
                 .invoice_status
-                .map(|t| map_filter!(t, |i| InvoiceStatus::from(i))),
+                .map(|t| map_filter!(t, InvoiceStatus::from)),
             stock_line_id: f.stock_line_id.map(EqualFilter::from),
             verified_datetime: f.verified_datetime.map(DatetimeFilter::from),
             reason_option: f

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/insert.rs
@@ -1,19 +1,16 @@
+use super::{
+    CannotIssueMoreThanApprovedQuantity, LocationIsOnHold, LocationNotFound,
+    NotEnoughStockForReduction, StockLineAlreadyExistsInInvoice, StockLineIsOnHold,
+};
 use async_graphql::*;
-
 use graphql_core::simple_generic_errors::{self, CannotEditInvoice, ForeignKey, ForeignKeyError};
 use graphql_core::standard_graphql_error::{validate_auth, StandardGraphqlError};
 use graphql_core::ContextExt;
 use graphql_types::types::InvoiceLineNode;
-
 use repository::InvoiceLine;
 use service::auth::{Resource, ResourceAccessRequest};
 use service::invoice_line::stock_out_line::{
     InsertStockOutLine as ServiceInput, InsertStockOutLineError as ServiceError, StockOutType,
-};
-
-use super::{
-    LocationIsOnHold, LocationNotFound, NotEnoughStockForReduction,
-    StockLineAlreadyExistsInInvoice, StockLineIsOnHold,
 };
 
 #[derive(InputObject)]
@@ -81,6 +78,7 @@ pub enum InsertErrorInterface {
     LocationIsOnHold(LocationIsOnHold),
     LocationNotFound(LocationNotFound),
     StockLineIsOnHold(StockLineIsOnHold),
+    CannotIssueMoreThanApprovedQuantity(CannotIssueMoreThanApprovedQuantity),
 }
 
 impl InsertInput {
@@ -172,6 +170,11 @@ fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
                     stock_line_id,
                     line_id: None,
                 },
+            ))
+        }
+        CannotIssueMoreThanApprovedQuantity(line_id) => {
+            return Ok(InsertErrorInterface::CannotIssueMoreThanApprovedQuantity(
+                super::CannotIssueMoreThanApprovedQuantity(line_id),
             ))
         }
         // Standard Graphql Errors

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/insert.rs
@@ -172,9 +172,9 @@ fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
                 },
             ))
         }
-        CannotIssueMoreThanApprovedQuantity(line_id) => {
+        CannotIssueMoreThanApprovedQuantity => {
             return Ok(InsertErrorInterface::CannotIssueMoreThanApprovedQuantity(
-                super::CannotIssueMoreThanApprovedQuantity(line_id),
+                super::CannotIssueMoreThanApprovedQuantity {},
             ))
         }
         // Standard Graphql Errors

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/mod.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/mod.rs
@@ -122,3 +122,26 @@ impl ItemDoesNotMatchStockLine {
         "Item does not match stock line"
     }
 }
+
+pub struct CannotIssueMoreThanApprovedQuantity(pub String);
+#[Object]
+impl CannotIssueMoreThanApprovedQuantity {
+    pub async fn description(&self) -> &str {
+        "Cannot issue more than approved quantity"
+    }
+
+    pub async fn line(&self, ctx: &Context<'_>) -> Result<InvoiceLineNode> {
+        let service_provider = ctx.service_provider();
+        let service_context = service_provider.basic_context()?;
+
+        let invoice_line = service_provider
+            .invoice_line_service
+            .get_invoice_line(&service_context, &self.0)?
+            .ok_or(StandardGraphqlError::InternalError(format!(
+                "cannot get invoice_line {}",
+                &self.0
+            )))?;
+
+        Ok(InvoiceLineNode::from_domain(invoice_line))
+    }
+}

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/mod.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/mod.rs
@@ -123,25 +123,10 @@ impl ItemDoesNotMatchStockLine {
     }
 }
 
-pub struct CannotIssueMoreThanApprovedQuantity(pub String);
+pub struct CannotIssueMoreThanApprovedQuantity;
 #[Object]
 impl CannotIssueMoreThanApprovedQuantity {
     pub async fn description(&self) -> &str {
         "Cannot issue more than approved quantity"
-    }
-
-    pub async fn line(&self, ctx: &Context<'_>) -> Result<InvoiceLineNode> {
-        let service_provider = ctx.service_provider();
-        let service_context = service_provider.basic_context()?;
-
-        let invoice_line = service_provider
-            .invoice_line_service
-            .get_invoice_line(&service_context, &self.0)?
-            .ok_or(StandardGraphqlError::InternalError(format!(
-                "cannot get invoice_line {}",
-                &self.0
-            )))?;
-
-        Ok(InvoiceLineNode::from_domain(invoice_line))
     }
 }

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/update.rs
@@ -116,8 +116,8 @@ impl UpdateInput {
 
 fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
     use ServiceError::*;
-    let formatted_error = format!("{:#?}", error);
-    log::error!("Error updating outbound shipment line: {}", formatted_error);
+    let formatted_error = format!("{error:#?}");
+    log::error!("Error updating outbound shipment line: {formatted_error}");
 
     let graphql_error = match error {
         // Structured Errors
@@ -168,9 +168,9 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
                 },
             ))
         }
-        CannotIssueMoreThanApprovedQuantity(line_id) => {
+        CannotIssueMoreThanApprovedQuantity => {
             return Ok(UpdateErrorInterface::CannotIssueMoreThanApprovedQuantity(
-                super::CannotIssueMoreThanApprovedQuantity(line_id),
+                super::CannotIssueMoreThanApprovedQuantity {},
             ))
         }
         // Standard Graphql Errors

--- a/server/graphql/invoice_line/src/mutations/prescription_line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/prescription_line/insert.rs
@@ -9,8 +9,8 @@ use repository::InvoiceLine;
 use service::auth::{Resource, ResourceAccessRequest};
 
 use crate::mutations::outbound_shipment_line::line::{
-    self, LocationIsOnHold, LocationNotFound, NotEnoughStockForReduction,
-    StockLineAlreadyExistsInInvoice, StockLineIsOnHold,
+    self, CannotIssueMoreThanApprovedQuantity, LocationIsOnHold, LocationNotFound,
+    NotEnoughStockForReduction, StockLineAlreadyExistsInInvoice, StockLineIsOnHold,
 };
 use service::invoice_line::stock_out_line::{
     InsertStockOutLine as ServiceInput, InsertStockOutLineError as ServiceError, StockOutType,
@@ -80,6 +80,7 @@ pub enum InsertErrorInterface {
     LocationIsOnHold(LocationIsOnHold),
     LocationNotFound(LocationNotFound),
     StockLineIsOnHold(StockLineIsOnHold),
+    CannotIssueMoreThanApprovedQuantity(CannotIssueMoreThanApprovedQuantity),
 }
 
 fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
@@ -130,6 +131,11 @@ fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
                     stock_line_id,
                     line_id: None,
                 },
+            ))
+        }
+        CannotIssueMoreThanApprovedQuantity(line_id) => {
+            return Ok(InsertErrorInterface::CannotIssueMoreThanApprovedQuantity(
+                line::CannotIssueMoreThanApprovedQuantity(line_id),
             ))
         }
         // Standard Graphql Errors

--- a/server/graphql/invoice_line/src/mutations/prescription_line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/prescription_line/insert.rs
@@ -85,8 +85,8 @@ pub enum InsertErrorInterface {
 
 fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
     use ServiceError::*;
-    let formatted_error = format!("{:#?}", error);
-    log::error!("Error inserting prescription line: {}", formatted_error);
+    let formatted_error = format!("{error:#?}");
+    log::error!("Error inserting prescription line: {formatted_error}");
 
     let graphql_error = match error {
         // Structured Errors
@@ -133,9 +133,9 @@ fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
                 },
             ))
         }
-        CannotIssueMoreThanApprovedQuantity(line_id) => {
+        CannotIssueMoreThanApprovedQuantity => {
             return Ok(InsertErrorInterface::CannotIssueMoreThanApprovedQuantity(
-                line::CannotIssueMoreThanApprovedQuantity(line_id),
+                line::CannotIssueMoreThanApprovedQuantity {},
             ))
         }
         // Standard Graphql Errors

--- a/server/graphql/invoice_line/src/mutations/prescription_line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/prescription_line/update.rs
@@ -1,21 +1,18 @@
+use crate::mutations::outbound_shipment_line::line::{
+    self, CannotIssueMoreThanApprovedQuantity, LocationIsOnHold, LocationNotFound,
+    NotEnoughStockForReduction, StockLineAlreadyExistsInInvoice, StockLineIsOnHold,
+};
 use async_graphql::*;
-
 use graphql_core::standard_graphql_error::{validate_auth, StandardGraphqlError};
 use graphql_core::{
     simple_generic_errors::{CannotEditInvoice, ForeignKey, ForeignKeyError, RecordNotFound},
     ContextExt,
 };
 use graphql_types::types::InvoiceLineNode;
-
 use repository::InvoiceLine;
 use service::auth::{Resource, ResourceAccessRequest};
 use service::invoice_line::stock_out_line::{
     StockOutType, UpdateStockOutLine as ServiceInput, UpdateStockOutLineError as ServiceError,
-};
-
-use crate::mutations::outbound_shipment_line::line::{
-    self, LocationIsOnHold, LocationNotFound, NotEnoughStockForReduction,
-    StockLineAlreadyExistsInInvoice, StockLineIsOnHold,
 };
 
 #[derive(InputObject)]
@@ -82,6 +79,7 @@ pub enum UpdateErrorInterface {
     LocationNotFound(LocationNotFound),
     StockLineIsOnHold(StockLineIsOnHold),
     NotEnoughStockForReduction(NotEnoughStockForReduction),
+    CannotIssueMoreThanApprovedQuantity(CannotIssueMoreThanApprovedQuantity),
 }
 
 impl UpdateInput {
@@ -160,6 +158,11 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
                     stock_line_id,
                     line_id: Some(line_id),
                 },
+            ))
+        }
+        CannotIssueMoreThanApprovedQuantity(line_id) => {
+            return Ok(UpdateErrorInterface::CannotIssueMoreThanApprovedQuantity(
+                line::CannotIssueMoreThanApprovedQuantity(line_id),
             ))
         }
         // Standard Graphql Errors

--- a/server/graphql/invoice_line/src/mutations/prescription_line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/prescription_line/update.rs
@@ -108,8 +108,8 @@ impl UpdateInput {
 
 fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
     use ServiceError::*;
-    let formatted_error = format!("{:#?}", error);
-    log::error!("Error updating prescription line: {}", formatted_error);
+    let formatted_error = format!("{error:#?}");
+    log::error!("Error updating prescription line: {formatted_error}");
 
     let graphql_error = match error {
         // Structured Errors
@@ -160,9 +160,9 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
                 },
             ))
         }
-        CannotIssueMoreThanApprovedQuantity(line_id) => {
+        CannotIssueMoreThanApprovedQuantity => {
             return Ok(UpdateErrorInterface::CannotIssueMoreThanApprovedQuantity(
-                line::CannotIssueMoreThanApprovedQuantity(line_id),
+                line::CannotIssueMoreThanApprovedQuantity {},
             ))
         }
         // Standard Graphql Errors

--- a/server/repository/src/mock/test_requisition_service.rs
+++ b/server/repository/src/mock/test_requisition_service.rs
@@ -245,10 +245,10 @@ pub fn mock_full_new_response_requisition_for_update_test() -> FullMockRequisiti
 
 pub fn mock_request_draft_requisition_calculation_test() -> FullMockRequisition {
     let requisition_id = "mock_request_draft_requisition_calculation_test".to_string();
-    let line1_id = format!("{}1", requisition_id);
-    let line2_id = format!("{}2", requisition_id);
-    let line3_id = format!("{}3", requisition_id);
-    let line4_id = format!("{}4", requisition_id);
+    let line1_id = format!("{requisition_id}1");
+    let line2_id = format!("{requisition_id}2");
+    let line3_id = format!("{requisition_id}3");
+    let line4_id = format!("{requisition_id}4");
     FullMockRequisition {
         requisition: RequisitionRow {
             id: requisition_id.clone(),
@@ -297,7 +297,7 @@ pub fn mock_request_draft_requisition_calculation_test() -> FullMockRequisition 
             },
             RequisitionLineRow {
                 id: line4_id,
-                requisition_id: requisition_id,
+                requisition_id,
                 item_link_id: mock_item_d().id,
                 requested_quantity: 10.0,
                 suggested_quantity: 200.0,
@@ -328,8 +328,8 @@ pub fn mock_test_not_store_a_master_list() -> FullMockMasterList {
 
 pub fn mock_new_response_requisition_test() -> FullMockRequisition {
     let requisition_id = "mock_new_response_requisition_test".to_string();
-    let line1_id = format!("{}1", requisition_id);
-    let line2_id = format!("{}2", requisition_id);
+    let line1_id = format!("{requisition_id}1");
+    let line2_id = format!("{requisition_id}2");
     FullMockRequisition {
         requisition: RequisitionRow {
             id: requisition_id.clone(),
@@ -360,7 +360,7 @@ pub fn mock_new_response_requisition_test() -> FullMockRequisition {
             },
             RequisitionLineRow {
                 id: line2_id,
-                requisition_id: requisition_id,
+                requisition_id,
                 item_link_id: mock_item_b().id,
                 requested_quantity: 11.0,
                 suggested_quantity: 5.0,
@@ -374,8 +374,8 @@ pub fn mock_new_response_requisition_test() -> FullMockRequisition {
 
 pub fn mock_new_response_requisition_test_invoice() -> FullMockInvoice {
     let invoice_id = "mock_new_response_requisition_test_invoice".to_string();
-    let line1_id = format!("{}1", invoice_id);
-    let line2_id = format!("{}2", invoice_id);
+    let line1_id = format!("{invoice_id}1");
+    let line2_id = format!("{invoice_id}2");
 
     FullMockInvoice {
         invoice: InvoiceRow {
@@ -456,7 +456,7 @@ pub fn mock_request_program_requisition() -> RequisitionRow {
 
 pub fn mock_response_program_requisition() -> FullMockRequisition {
     let requisition_id = "mock_response_program_requisition".to_string();
-    let line1_id = format!("{}1", requisition_id);
+    let line1_id = format!("{requisition_id}1");
     FullMockRequisition {
         requisition: RequisitionRow {
             id: requisition_id.clone(),
@@ -477,7 +477,7 @@ pub fn mock_response_program_requisition() -> FullMockRequisition {
         },
         lines: vec![RequisitionLineRow {
             id: line1_id,
-            requisition_id: requisition_id,
+            requisition_id,
             item_link_id: mock_item_a().id,
             requested_quantity: 10.0,
             suggested_quantity: 10.0,
@@ -491,8 +491,8 @@ pub fn mock_response_program_requisition() -> FullMockRequisition {
 
 pub fn mock_new_response_program_requisition() -> FullMockRequisition {
     let requisition_id = "mock_new_response_program_requisition".to_string();
-    let line1_id = format!("{}1", requisition_id);
-    let line2_id = format!("{}2", requisition_id);
+    let line1_id = format!("{requisition_id}1");
+    let line2_id = format!("{requisition_id}2");
 
     FullMockRequisition {
         requisition: RequisitionRow {
@@ -526,7 +526,7 @@ pub fn mock_new_response_program_requisition() -> FullMockRequisition {
             },
             RequisitionLineRow {
                 id: line2_id,
-                requisition_id: requisition_id,
+                requisition_id,
                 item_link_id: mock_item_b().id,
                 requested_quantity: 10.0,
                 suggested_quantity: 10.0,

--- a/server/repository/src/mock/test_requisition_service.rs
+++ b/server/repository/src/mock/test_requisition_service.rs
@@ -1,16 +1,14 @@
-use chrono::NaiveDate;
-
-use crate::{
-    requisition_row::{RequisitionStatus, RequisitionType},
-    ApprovalStatusType, InvoiceLineRow, InvoiceLineType, InvoiceRow, InvoiceStatus, InvoiceType,
-    MasterListRow, RequisitionLineRow, RequisitionRow,
-};
-
 use super::{
     common::{FullMockInvoice, FullMockInvoiceLine, FullMockMasterList, FullMockRequisition},
     mock_item_a, mock_item_b, mock_item_c, mock_item_d, mock_name_a, mock_program_a,
     mock_stock_line_a, mock_store_a, MockData,
 };
+use crate::{
+    requisition_row::{RequisitionStatus, RequisitionType},
+    ApprovalStatusType, InvoiceLineRow, InvoiceLineType, InvoiceRow, InvoiceStatus, InvoiceType,
+    MasterListRow, RequisitionLineRow, RequisitionRow,
+};
+use chrono::NaiveDate;
 
 pub fn mock_test_requisition_service() -> MockData {
     let mut result = MockData::default();

--- a/server/service/src/invoice/common.rs
+++ b/server/service/src/invoice/common.rs
@@ -15,7 +15,7 @@ pub fn generate_invoice_user_id_update(
 ) -> Option<InvoiceRow> {
     let user_id_option = Some(user_id.to_string());
     let user_id_has_changed = existing_invoice_row.user_id != user_id_option;
-    user_id_has_changed.then(|| InvoiceRow {
+    user_id_has_changed.then_some(InvoiceRow {
         user_id: user_id_option,
         ..existing_invoice_row
     })

--- a/server/service/src/invoice/outbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/outbound_shipment/update/mod.rs
@@ -57,6 +57,7 @@ pub enum UpdateOutboundShipmentError {
     DatabaseError(RepositoryError),
     /// Holds the id of the invalid invoice line
     InvoiceLineHasNoStockLine(String),
+    CannotIssueMoreThanAuthorised(Vec<InvoiceLine>),
 }
 
 type OutError = UpdateOutboundShipmentError;

--- a/server/service/src/invoice/outbound_shipment/update/validate.rs
+++ b/server/service/src/invoice/outbound_shipment/update/validate.rs
@@ -148,6 +148,11 @@ fn validate_approved_quantities(
             .item_id(EqualFilter::equal_any(item_ids)),
     )?;
 
+    let requisition = requisition_lines[0].requisition_row.clone();
+    if requisition.program_id.is_none() {
+        return Ok(());
+    }
+
     let approved_quantities: HashMap<String, f64> = requisition_lines
         .into_iter()
         .map(|req_line| {

--- a/server/service/src/invoice_line/stock_out_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_out_line/insert/mod.rs
@@ -61,7 +61,7 @@ pub enum InsertStockOutLineError {
     BatchIsOnHold,
     ReductionBelowZero { stock_line_id: String },
     VVMStatusDoesNotExist,
-    CannotIssueMoreThanApprovedQuantity(String),
+    CannotIssueMoreThanApprovedQuantity,
 }
 
 impl From<RepositoryError> for InsertStockOutLineError {

--- a/server/service/src/invoice_line/stock_out_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_out_line/insert/mod.rs
@@ -61,6 +61,7 @@ pub enum InsertStockOutLineError {
     BatchIsOnHold,
     ReductionBelowZero { stock_line_id: String },
     VVMStatusDoesNotExist,
+    CannotIssueMoreThanApprovedQuantity(String),
 }
 
 impl From<RepositoryError> for InsertStockOutLineError {

--- a/server/service/src/invoice_line/stock_out_line/insert/validate.rs
+++ b/server/service/src/invoice_line/stock_out_line/insert/validate.rs
@@ -99,7 +99,8 @@ pub fn validate(
     }
 
     if store_preferences.response_requisition_requires_authorisation {
-        check_item_approved_quantity(connection, &item.id, invoice.requisition_id.clone())
+        check_item_approved_quantity(connection, &item.id, None,invoice.requisition_id.clone(), Some(input.number_of_packs), batch.stock_line_row.pack_size
+    )
             .map_err(|e| match e {
                 crate::invoice_line::validate::CannotIssueMoreThanApprovedQuantity::CannotIssueMoreThanApprovedQuantity => {
                     InsertStockOutLineError::CannotIssueMoreThanApprovedQuantity

--- a/server/service/src/invoice_line/stock_out_line/update/mod.rs
+++ b/server/service/src/invoice_line/stock_out_line/update/mod.rs
@@ -52,7 +52,7 @@ pub enum UpdateStockOutLineError {
     LineDoesNotReferenceStockLine,
     BatchIsOnHold,
     UpdatedLineDoesNotExist,
-    CannotIssueMoreThanApprovedQuantity(String),
+    CannotIssueMoreThanApprovedQuantity,
     StockLineAlreadyExistsInInvoice(String),
     AutoPickFailed(String),
     ReductionBelowZero {

--- a/server/service/src/invoice_line/stock_out_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_out_line/update/validate.rs
@@ -91,9 +91,10 @@ pub fn validate(
     }
 
     if store_preferences.response_requisition_requires_authorisation {
+        let pack_size: f64 = batch_pair.main_batch.stock_line_row.pack_size;
         check_item_approved_quantity(connection, &item.id, 
             Some(line_row.id.clone()),
-            invoice.requisition_id.clone(), input.number_of_packs, line_row.pack_size)
+            invoice.requisition_id.clone(), input.number_of_packs, pack_size)
             .map_err(|e| match e {
                 crate::invoice_line::validate::CannotIssueMoreThanApprovedQuantity::CannotIssueMoreThanApprovedQuantity => {
                     UpdateStockOutLineError::CannotIssueMoreThanApprovedQuantity

--- a/server/service/src/invoice_line/stock_out_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_out_line/update/validate.rs
@@ -91,7 +91,9 @@ pub fn validate(
     }
 
     if store_preferences.response_requisition_requires_authorisation {
-        check_item_approved_quantity(connection, &item.id, invoice.requisition_id.clone())
+        check_item_approved_quantity(connection, &item.id, 
+            Some(line_row.id.clone()),
+            invoice.requisition_id.clone(), input.number_of_packs, line_row.pack_size)
             .map_err(|e| match e {
                 crate::invoice_line::validate::CannotIssueMoreThanApprovedQuantity::CannotIssueMoreThanApprovedQuantity => {
                     UpdateStockOutLineError::CannotIssueMoreThanApprovedQuantity

--- a/server/service/src/invoice_line/stock_out_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_out_line/update/validate.rs
@@ -14,20 +14,19 @@ use crate::{
 };
 use repository::{InvoiceLineRow, InvoiceRow, InvoiceStatus, ItemRow, StorageConnection};
 
+pub struct UpdateStockOutLineValidationResult {
+    pub line: InvoiceLineRow,
+    pub item: ItemRow,
+    pub batch_pair: BatchPair,
+    pub invoice: InvoiceRow,
+    pub adjusted_input: UpdateStockOutLine,
+}
+
 pub fn validate(
     ctx: &ServiceContext,
     input: UpdateStockOutLine,
     store_id: &str,
-) -> Result<
-    (
-        InvoiceLineRow,
-        ItemRow,
-        BatchPair,
-        InvoiceRow,
-        UpdateStockOutLine,
-    ),
-    UpdateStockOutLineError,
-> {
+) -> Result<UpdateStockOutLineValidationResult, UpdateStockOutLineError> {
     use UpdateStockOutLineError::*;
     let ServiceContext { connection, .. } = ctx;
 
@@ -119,13 +118,13 @@ pub fn validate(
         }
     }
 
-    Ok((
-        line.invoice_line_row,
+    Ok(UpdateStockOutLineValidationResult {
+        line: line.invoice_line_row,
         item,
         batch_pair,
         invoice,
         adjusted_input,
-    ))
+    })
 }
 
 fn check_batch_exists_option(

--- a/server/service/src/invoice_line/validate.rs
+++ b/server/service/src/invoice_line/validate.rs
@@ -95,6 +95,10 @@ pub fn check_item_approved_quantity(
         .pop();
 
     if let Some(requisition_line) = requisition_line {
+        if requisition_line.requisition_row.program_id.is_none() {
+            return Ok(());
+        }
+
         let approved_quantity = requisition_line.requisition_line_row.approved_quantity;
 
         let all_lines_for_item = InvoiceLineRepository::new(connection).query_by_filter(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Part one of #9735

# 👩🏻‍💻 What does this PR do?
Backend part of 9735. Frontend will be coming in part two. 

Implements checks for Outbound Shipment in the backend so that users cannot issue more than what has been approved by an authoriser

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Testing can be done through the API until frontend is implemented. Or you can run tests and make sure they pass
- [ ] Set up authorisation in OG
- [ ] Have store preferences for authorisation on 
- [ ] Create an Internal Order from Store A to Store B
- [ ] Go to Auth app and set approval quantities
- [ ] Go to Store B and create shipments for generated requisition
- [ ] Try to issue more than what was approved
- [ ] Should get error in api.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

