### PR TITLE
Check for name store join when checking other party

### DIFF
--- a/server/service/src/validate.rs
+++ b/server/service/src/validate.rs
@@ -48,6 +48,7 @@ pub fn get_other_party(
     }
 
     // If names have been merged, there could be multiple results, if so we need to return the one with the name_store_join if it exists
+    // Revist this code in https://github.com/msupply-foundation/open-msupply/issues/9824
     let name_with_join = results
         .iter()
         .find(|name| name.name_store_join_row.is_some());


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9780

# 👩🏻‍💻 What does this PR do?

This is a quick and dirty? solution for the reported problem.
The issue occurs when a name (normal customer) is merged with a store.
In this situation the `name_store_join` records for the store get removed but the `name_link` join causes us to get 2 records back when querying for the name.

The `correct` solution might be to fix the query so only one row is returned but that's more complex that I'd hoped.
We need to work on that solution for the underlying issue too, but will do this as a hot fix and come back to the bigger problem as I think it applies to item_link and other future merge/unmerge situations too. so worth finding a good pattern,.

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a store and a customer
- [ ] Merge the customer into the store
- [ ] Try to raise an outbound shipment to the store.
- [ ] PLS replicate the issue before upgrading 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

