### PR TITLE
9795 - Use todays date if threshold date is 0

### DIFF
--- a/client/packages/common/src/intl/utils/DateUtils.test.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.test.ts
@@ -61,3 +61,29 @@ describe('getDisplayAge', () => {
     jest.useRealTimers();
   });
 });
+
+describe('formatDaysFromToday', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-10-01'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  const hookResult = renderHookWithProvider(() => useFormatDateTime());
+  const { formatDaysFromToday } = hookResult.result.current;
+
+  it('returns today when days is undefined', () => {
+    expect(formatDaysFromToday(undefined)).toBe('2025-10-01');
+  });
+
+  it('returns today when days is 0', () => {
+    expect(formatDaysFromToday(0)).toBe('2025-10-01');
+  });
+
+  it('returns (days) after today when days is defined ', () => {
+    expect(formatDaysFromToday(5)).toBe('2025-10-06');
+  });
+});

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -280,8 +280,7 @@ export const useFormatDateTime = () => {
   };
 
   const formatDaysFromToday = (days?: number): string => {
-    if (!days) return '';
-    const date = DateUtils.addDays(new Date(), days);
+    const date = days ? DateUtils.addDays(new Date(), days) : new Date();
     return customDate(date, URL_QUERY_DATE);
   };
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9795 

# 👩🏻‍💻 What does this PR do?

When a threshold for expiring items is 0, the filter will use todays date -> as both dates exist for the filter results will only include items expiring within the range, rather than leaving it open-ended (to all past expirys for example)

<img width="367" height="215" alt="Screenshot 2025-11-19 at 3 46 18 PM" src="https://github.com/user-attachments/assets/0480e981-445d-4735-983a-3c4661357be0" />

<img width="852" height="257" alt="Screenshot 2025-11-19 at 3 46 05 PM" src="https://github.com/user-attachments/assets/cc5322f4-9c91-4794-aa72-086b72510feb" />


<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Edit -> Preferences -> keep first threshold as 0 and set the second one to something like 1 or 2 days for easy testing
- [ ] Have an item that expired prior to today
- [ ] Have an item that has an expiry that falls on or between today - second threshold days away
- [ ] Go to Dashboard -> click on Batches expiring in 0 days to 2 days
- [ ] It will bring you to stock page -> check the filters have the correct days, 'from' being todays date
- [ ] See the item expiring today/within the range shows in the list, but the item in the past does not

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

