### PR TITLE
#9867 Footer colour customisation -- fix edge case inputs and colour for Divider

### DIFF
--- a/client/packages/common/src/ui/components/portals/AppFooter/AppFooter.tsx
+++ b/client/packages/common/src/ui/components/portals/AppFooter/AppFooter.tsx
@@ -1,11 +1,8 @@
 import { Box, BoxProps, Portal } from '@mui/material';
-import { styled, useTheme } from '@mui/material/styles';
-import React, { FC, ReactNode, useEffect, useRef } from 'react';
+import { styled } from '@mui/material/styles';
+import React, { ReactNode, useEffect, useRef } from 'react';
 import { useHostContext, useKeyboard } from '@common/hooks';
-import {
-  useIsCentralServerApi,
-  usePreferences,
-} from '@openmsupply-client/common';
+import { useIsCentralServerApi } from '@openmsupply-client/common';
 
 const Container = styled('div')(() => ({
   display: 'flex',
@@ -17,15 +14,18 @@ const Container = styled('div')(() => ({
   paddingRight: '20px',
 }));
 
-export const AppFooter: FC = () => {
+interface AppFooterProps {
+  backgroundColor?: string;
+  textColor?: string;
+}
+
+export const AppFooter = ({ backgroundColor, textColor }: AppFooterProps) => {
   const { setAppFooterRef, setAppSessionDetailsRef, fullScreen } =
     useHostContext();
   const { keyboardIsOpen } = useKeyboard();
   const appFooterRef = useRef(null);
   const appSessionDetailsRef = useRef(null);
   const isCentralServer = useIsCentralServerApi();
-  const { storeCustomColour } = usePreferences();
-  const theme = useTheme();
 
   useEffect(() => {
     setAppFooterRef(appFooterRef);
@@ -34,31 +34,6 @@ export const AppFooter: FC = () => {
 
   const hideFooter = fullScreen || keyboardIsOpen;
 
-  // Colours for the Footer bar, if specified in Store prefs
-  let customColour: string | undefined;
-  let textColour: string | undefined;
-  if (storeCustomColour) {
-    // Try/catch allows us to validate the colour string, but we have to do two
-    // separate checks to cover all cases:
-    // 1. the `getContrastText` function will throw on most invalid inputs, but
-    //    it does let incomplete HEX values through (e.g. #257A2), which results
-    //    in invalid CSS and a non-contrasting text color
-    // 2. The CSS.supports() function can also check, but it accepts colour
-    //    literals like "red", which the `getContrastText` function does NOT, so
-    //    we have to use a combination of both these to cover all cases
-    //
-    // When either of these checks fail, then neither customColour nor
-    // textColour will be defined
-    try {
-      if (!CSS.supports('color', storeCustomColour))
-        throw new Error('Invalid colour');
-      textColour = theme.palette.getContrastText(storeCustomColour);
-      customColour = storeCustomColour;
-    } catch (e) {
-      console.error('Error parsing footer colours from Store properties', e);
-    }
-  }
-
   return (
     <Box sx={{ display: hideFooter ? 'none' : undefined }}>
       <Container ref={appFooterRef} style={{ flex: 0 }} />
@@ -66,9 +41,9 @@ export const AppFooter: FC = () => {
         ref={appSessionDetailsRef}
         sx={{
           backgroundColor:
-            customColour ??
+            backgroundColor ??
             (isCentralServer ? 'primary.main' : 'background.menu'),
-          color: textColour ?? (isCentralServer ? '#fff' : 'gray.main'),
+          color: textColor ?? (isCentralServer ? '#fff' : 'gray.main'),
         }}
       />
     </Box>
@@ -80,11 +55,11 @@ interface AppFooterPortalProps extends BoxProps {
   Content?: ReactNode;
 }
 
-export const AppFooterPortal: FC<AppFooterPortalProps> = ({
+export const AppFooterPortal = ({
   SessionDetails,
   Content,
   ...boxProps
-}) => {
+}: AppFooterPortalProps) => {
   const { appFooterRef, appSessionDetailsRef } = useHostContext();
 
   if (!(appFooterRef && appSessionDetailsRef)) return null;

--- a/client/packages/host/src/Site.tsx
+++ b/client/packages/host/src/Site.tsx
@@ -20,6 +20,8 @@ import {
   DetailLoadingSkeleton,
   useIsGapsStoreOnly,
   useBlockNavigation,
+  useTheme,
+  usePreferences,
 } from '@openmsupply-client/common';
 import { AppDrawer, AppBar, Footer, NotFound } from './components';
 import { CommandK } from './CommandK';
@@ -74,10 +76,35 @@ export const Site: FC = () => {
   const { setPageTitle } = useHostContext();
   const pageTitle = getPageTitle(location.pathname);
   const isGapsStore = useIsGapsStoreOnly();
+  const { storeCustomColour } = usePreferences();
+  const theme = useTheme();
 
   useEffect(() => {
     setPageTitle(pageTitle);
   }, [location, pageTitle, setPageTitle]);
+
+  // Colours for the Footer bar, if specified in Store prefs
+  let customColour: string | undefined;
+  let textColour: string | undefined;
+  if (storeCustomColour) {
+    // Try/catch allows us to validate the colour string, while also getting the
+    // complementary textColour using the `getContrastText` function. We need
+    // BOTH the CSS.supports() check and try/catch because:
+    // 1. `getContrastText` function will throw on most invalid inputs, but it
+    //    does let incomplete HEX values through (e.g. #257A2), which results in
+    //    invalid CSS and a non-contrasting text color
+    // 2. The CSS.supports() function rejects the above incomplete HEX values,
+    //    but it accepts CSS colour literals like "red", which the
+    //    `getContrastText` function does not
+    try {
+      if (!CSS.supports('color', storeCustomColour))
+        throw new Error('Invalid colour');
+      textColour = theme.palette.getContrastText(storeCustomColour);
+      customColour = storeCustomColour;
+    } catch (e) {
+      console.error('Error parsing footer colours from Store properties', e);
+    }
+  }
 
   return (
     <RequireAuthentication>
@@ -223,8 +250,13 @@ export const Site: FC = () => {
                       <Route path="*" element={<NotFound />} />
                     </Routes>
                   </Box>
-                  <AppFooter />
-                  <AppFooterPortal SessionDetails={<Footer />} />
+                  <AppFooter
+                    backgroundColor={customColour}
+                    textColor={textColour}
+                  />
+                  <AppFooterPortal
+                    SessionDetails={<Footer backgroundColor={textColour} />}
+                  />
                 </Box>
                 <DetailPanel />
                 <QueryErrorHandler />

--- a/client/packages/host/src/components/Footer/Footer.tsx
+++ b/client/packages/host/src/components/Footer/Footer.tsx
@@ -77,7 +77,7 @@ const PaddedCell: FC<PaddedCellProps> = ({
   );
 };
 
-export const Footer = () => {
+export const Footer = ({ backgroundColor }: { backgroundColor?: string }) => {
   const t = useTranslation();
   const theme = useAppTheme();
   const isExtraSmallScreen = useMediaQuery(
@@ -92,7 +92,8 @@ export const Footer = () => {
   const Divider = styled(Box)({
     width: '1px',
     height: '24px',
-    backgroundColor: isCentralServer ? '#fff' : theme.palette.gray.main,
+    backgroundColor:
+      backgroundColor ?? (isCentralServer ? '#fff' : theme.palette.gray.main),
   });
 
   const iconStyles = {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9867

# 👩🏻‍💻 What does this PR do?

Solves two problems overlooked in the [original PR](https://github.com/msupply-foundation/open-msupply/pull/9808), and pointed out in the [follow-up issue](https://github.com/msupply-foundation/open-msupply/issues/9867):
1. While it was correctly ignoring most invalid colour string inputs, it *was* accepting *incomplete* HEX strings (such as `#257A2`), which resulted in the Footer disappearing completely
2. The complementary text colour wasn't being applied to the Dividers `|`, which is apparent when a light background colour was specified

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

1. Turns out the `getContrastText` function accepts incomplete HEX codes as valid input even though they don't work! (it correctly throws on other invalid inputs). So I've had to *also* use the `CSS.supports` function to do an additional check. However, I can't *just* use this check, because it accepts CSS colour literals (e.g. "red"), which the `getContrastText` function does *not*, so have to do both checks for completeness. (Have explained this in code comments)
2. Getting the colour to the Divider was a bit tricky as it's in a different component, so have moved all the colour fetching and validation logic up to the `Site` component and passes the colour values as props to both the Footer components

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Footer falls back to default colour when an incomplete HEX code is entered for the Custom Colour store pref (and any other invalid inputs)
- [ ] The colour of the "Divider" `|` element matches the text colour, for both dark and light backgrounds/text colours.



# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

