### PR TITLE
#9841 Fix bug when changing skipped dose from Not Given to Given

### DIFF
--- a/server/service/src/vaccination/update/validate.rs
+++ b/server/service/src/vaccination/update/validate.rs
@@ -242,12 +242,14 @@ fn validate_change_to_given(
             "Vaccine course dose not found".to_string(),
         ))?;
 
-    // If doses can be skipped, allow changing to given regardless of previous doses
+    // If doses can be skipped, allow changing to given regardless of previous
+    // doses
     if vaccine_course_dose.vaccine_course_row.can_skip_dose {
         return Ok(());
     }
 
-    // Should only be able to change to given if all previous doses in the course are given
+    // If doses CAN'T be skipped, should only be able to change to given if all
+    // previous doses in the course are given
     if let Some(previous_vaccination) = previous_vaccination {
         if !previous_vaccination.vaccination_row.given {
             return Err(UpdateVaccinationError::NotNextDose);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9841

> [!NOTE]
> **Re-make of [this PR](https://github.com/msupply-foundation/open-msupply/pull/9859) which was auto-closed when the base branch was deleted**

# 👩🏻‍💻 What does this PR do?

A bit of an edge case, but the back-end checks were only letting a vaccination be changed from "Not Given" to "Given" when no doses had been skipped. We missed this when changing the logic recently, as now it's possible to skip a dose and therefore this check doesn't need to be quite as strict.

Have relaxed the validation logic to only consider this check when the course is NOT skippable (i.e. as it was previously).

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Repeat steps described in the issue -- confirm can mark as "Given" with no error.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

