### PR TITLE
Handle empty port number in electron URL

### DIFF
--- a/client/packages/common/src/hooks/useNativeClient/helpers.ts
+++ b/client/packages/common/src/hooks/useNativeClient/helpers.ts
@@ -52,7 +52,7 @@ export const getNativeAPI = (): NativeAPI | null => {
 };
 
 export const frontEndHostUrl = ({ protocol, ip, port }: FrontEndHost) =>
-  `${protocol}://${ip}:${port}`;
+  port === 0 ? `${protocol}://${ip}` : `${protocol}://${ip}:${port}`;
 
 export const frontEndHostDiscoveryGraphql = (server: FrontEndHost) =>
   `${frontEndHostUrl({
@@ -64,9 +64,13 @@ export const frontEndHostDiscoveryGraphql = (server: FrontEndHost) =>
 export const frontEndHostDisplay = ({ protocol, ip, port }: FrontEndHost) => {
   switch (protocol) {
     case 'https':
-      return port === 443 ? `https://${ip}` : `https://${ip}:${port}`;
+      return port === 443 || port === 0
+        ? `https://${ip}`
+        : `https://${ip}:${port}`;
     default:
-      return port === 80 ? `http://${ip}` : `http://${ip}:${port}`;
+      return port === 80 || port === 0
+        ? `http://${ip}`
+        : `http://${ip}:${port}`;
   }
 };
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9938

# 👩🏻‍💻 What does this PR do?
Handles the case of the default port number (0) being specified in the server object. Currently the port is always appended to the URL resulting in `:0` which fails to connect.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Try to connect using electron to a URL which has no port number

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

