### PR TITLE
9970 fix bug with moving asset between stores on remote site

### DIFF
--- a/server/repository/src/db_diesel/assets/asset_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_row.rs
@@ -99,10 +99,12 @@ impl<'a> AssetRowRepository<'a> {
         )?;
 
         if let Some(original_store) = original_store_id {
-            // Insert "delete" changelog for the original store
+            // Insert upsert changelog for original store
+            // if store is on different site it should be synced there
+            // with new store_id, making it invisible in that store
             self.insert_changelog(
                 asset_row.id.to_string(),
-                RowActionType::Delete,
+                RowActionType::Upsert,
                 Some(original_store),
             )?;
         }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Closing #9970 

# 👩🏻‍💻 What does this PR do?

Changes change log that is created when store is changed for asset, from 'Delete' to 'Upsert', which has the same functional effect (asset is hidden from previous store), and avoids asset being marked as deleted when it's being transferred on from to store on another site

## 💌 Any notes for the reviewer?

I had a look at original PR just to make sure nothing else needs to change, looks good.

# 🧪 Testing

Setup assets with one central and two remote OMS stores, try combination of changing asset to different stores on different sites, including central. Make sure to test transferring store to a store on the same site

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

