### PR TITLE
9979 add database connection configuration

### DIFF
--- a/server/android/src/android.rs
+++ b/server/android/src/android.rs
@@ -56,8 +56,8 @@ pub mod android {
                 host: "n/a".to_string(),
                 database_name: db_path.to_string_lossy().to_string(),
                 database_path: None,
-                connection_pool_max_connections: 10,
-                connection_pool_timeout: 30,
+                connection_pool_max_connections: None,
+                connection_pool_timeout_seconds: None,
                 // See https://github.com/openmsupply/remote-server/issues/1076
                 init_sql: Some(format!("PRAGMA temp_store_directory = '{}';", cache_dir)),
             },

--- a/server/configuration/base.yaml
+++ b/server/configuration/base.yaml
@@ -17,7 +17,7 @@ database:
   password: "password"
   database_name: "omsupply-database"
   connection_pool_max_connections: 10
-  connection_pool_timeout: 30
+  connection_pool_timeout_seconds: 30
 logging:
   #   one of: All | Console | File
   mode: File

--- a/server/configuration/example.yaml
+++ b/server/configuration/example.yaml
@@ -31,7 +31,7 @@
 #   password: "password"
 #   database_name: "omsupply-database"
 #   connection_pool_max_connections: 10
-#   connection_pool_timeout: 30
+#   connection_pool_timeout_seconds: 30
 # logging:
 ##   one of: All | Console | File
 #   mode: Console

--- a/server/repository/src/database_settings.rs
+++ b/server/repository/src/database_settings.rs
@@ -13,6 +13,9 @@ const SQLITE_LOCKWAIT_MS: u32 = 30 * 1000;
 #[cfg(all(not(feature = "postgres"), not(feature = "memory")))]
 const SQLITE_WAL_PRAGMA: &str = "PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;";
 
+const DEFUALT_CONNECTION_POOL_MAX_CONNECTIONS: u32 = 10;
+const DEFAULT_CONNECTION_POOL_TIMEOUT_SECONDS: u64 = 30;
+
 #[derive(Deserialize, Serialize, Clone)]
 pub struct DatabaseSettings {
     pub username: String,
@@ -21,8 +24,8 @@ pub struct DatabaseSettings {
     pub host: String,
     pub database_name: String,
     pub database_path: Option<String>,
-    pub connection_pool_max_connections: u32,
-    pub connection_pool_timeout: u64,
+    pub connection_pool_max_connections: Option<u32>,
+    pub connection_pool_timeout_seconds: Option<u64>,
     /// SQL run once at startup. For example, to run pragma statements
     pub init_sql: Option<String>,
 }
@@ -182,8 +185,16 @@ pub fn get_storage_connection_manager(settings: &DatabaseSettings) -> StorageCon
     }
     info!("Connecting to database '{}'", settings.database_name);
     let pool = Pool::builder()
-        .max_size(settings.connection_pool_max_connections)
-        .connection_timeout(Duration::from_secs(settings.connection_pool_timeout))
+        .max_size(
+            settings
+                .connection_pool_max_connections
+                .unwrap_or(DEFUALT_CONNECTION_POOL_MAX_CONNECTIONS),
+        )
+        .connection_timeout(Duration::from_secs(
+            settings
+                .connection_pool_timeout_seconds
+                .unwrap_or(DEFAULT_CONNECTION_POOL_TIMEOUT_SECONDS),
+        ))
         .build(connection_manager)
         .expect("Failed to connect to database");
     StorageConnectionManager::new(pool)
@@ -199,8 +210,16 @@ pub fn get_storage_connection_manager(settings: &DatabaseSettings) -> StorageCon
         .connection_customizer(Box::new(SqliteConnectionOptions {
             busy_timeout_ms: Some(SQLITE_LOCKWAIT_MS),
         }))
-        .max_size(settings.connection_pool_max_connections)
-        .connection_timeout(Duration::from_secs(settings.connection_pool_timeout))
+        .max_size(
+            settings
+                .connection_pool_max_connections
+                .unwrap_or(DEFUALT_CONNECTION_POOL_MAX_CONNECTIONS),
+        )
+        .connection_timeout(Duration::from_secs(
+            settings
+                .connection_pool_timeout_seconds
+                .unwrap_or(DEFAULT_CONNECTION_POOL_TIMEOUT_SECONDS),
+        ))
         .build(connection_manager)
         .expect("Failed to connect to database");
     StorageConnectionManager::new(pool)
@@ -220,8 +239,8 @@ mod database_setting_test {
             database_name: "".to_string(),
             init_sql,
             database_path: None,
-            connection_pool_max_connections: 10,
-            connection_pool_timeout: 30,
+            connection_pool_max_connections: None,
+            connection_pool_timeout_seconds: None,
         }
     }
 

--- a/server/repository/src/test_db/postgres.rs
+++ b/server/repository/src/test_db/postgres.rs
@@ -24,8 +24,8 @@ pub fn get_test_db_settings(db_name: &str) -> DatabaseSettings {
         database_name: db_name.to_string(),
         init_sql: None,
         database_path: None,
-        connection_pool_max_connections: 10,
-        connection_pool_timeout: 30,
+        connection_pool_max_connections: None,
+        connection_pool_timeout_seconds: None,
     }
 }
 

--- a/server/repository/src/test_db/sqlite.rs
+++ b/server/repository/src/test_db/sqlite.rs
@@ -35,8 +35,8 @@ fn get_test_db_settings_etc(db_name: &str, is_template: bool) -> DatabaseSetting
         },
         init_sql: None,
         database_path: None,
-        connection_pool_max_connections: 10,
-        connection_pool_timeout: 30,
+        connection_pool_max_connections: None,
+        connection_pool_timeout_seconds: None,
     }
 }
 


### PR DESCRIPTION
Fixes #9979

# 👩🏻‍💻 What does this PR do?

Allows for configuration of the database connection pool settings. In particular the max connections the pool will manage and the timeout before the pool will close the connection. These settings can be used to stop the server crashing under load when too many connections are opened.

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Use the [Bench-server](/msupply-foundation/open-msupply/tree/Bench-server) branch to make many requests to the server. If one instance isn't enough to crash the server you can run multiple instances using gnu `parallel`: `seq 50 | parallel -j 50 cargo run`
- [ ] If you still can't crash the server you can decrease `connection_pool_max_connections` or `connection_pool_timeout` to make it easier
- [ ] Once you're able to crash the server you can increase the `connection_pool_max_connections` or the `connection_pool_timeout` to stop the server crashing.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ x] **These areas should be updated or checked**: The configuration file and environment variable documentation should be updated

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

