### PR TITLE
9801 [CCEI / GAPS] CCE asset catalogue item import fails to import numerical values

### DIFF
--- a/client/packages/system/src/Asset/ImportCatalogueItem/CatalogueItemImportModal.tsx
+++ b/client/packages/system/src/Asset/ImportCatalogueItem/CatalogueItemImportModal.tsx
@@ -49,7 +49,7 @@ export type ImportRow = {
   type: string;
   typeId?: string;
   errorMessage?: string;
-  properties: Record<string, string>;
+  properties: Record<string, string | number>;
 };
 
 export type LineNumber = {

--- a/client/packages/system/src/Asset/utils.ts
+++ b/client/packages/system/src/Asset/utils.ts
@@ -90,7 +90,7 @@ export const importRowToCsv = (
       node.model,
       node.class,
       node.category,
-    ].concat(props.map(key => node.properties?.[key] ?? ''));
+    ].concat(props.map(key => String(node.properties?.[key] ?? '')));
     row.push(node.errorMessage);
     return row;
   });

--- a/client/packages/system/src/utils.ts
+++ b/client/packages/system/src/utils.ts
@@ -92,7 +92,7 @@ interface ParsedRow {
 }
 
 export const processProperties = <
-  T extends { properties: Record<string, string> },
+  T extends { properties: Record<string, string | number> },
 >(
   properties: AssetPropertyFragment[] | PropertyNode[],
   row: ParsedRow,
@@ -125,7 +125,7 @@ export const processProperties = <
               })
             );
           }
-          importRow.properties[property.key] = value;
+          importRow.properties[property.key] = Number(value);
           break;
         case 'BOOLEAN':
           const isTrue =


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9801

# 👩🏻‍💻 What does this PR do?
Properties was only allow string, so have added number to save floats as numbers.
<img width="622" height="1014" alt="Screenshot 2025-12-09 at 10 12 00 AM" src="https://github.com/user-attachments/assets/95f3eeef-1d32-439b-9d2c-4eadf68a174b" />

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

[Example.Asset.Item.Import_2025-11-18.csv](https://github.com/user-attachments/files/24050991/Example.Asset.Item.Import_2025-11-18.csv)

- [ ] Using example above, go to Asset > Import
- [ ] Then go to Equipment and create one from one of the assets you imported from the above example
- [ ] Go to details
- [ ] Should see numbers matching example for properties that are populated

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

