### PR TITLE
9959 Can add batch & edit volume @ shipped status in customer returns

### DIFF
--- a/client/packages/invoices/src/Returns/modals/CustomerReturn/AddBatch.tsx
+++ b/client/packages/invoices/src/Returns/modals/CustomerReturn/AddBatch.tsx
@@ -20,7 +20,7 @@ export const AddBatchButton = ({
   return (
     <Box flex={1} justifyContent="flex-end" display="flex">
       <ButtonWithIcon
-        disabled={disabled ?? returnIsDisabled}
+        disabled={disabled || returnIsDisabled}
         color="primary"
         variant="outlined"
         onClick={addDraftLine}

--- a/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnQuantitiesTable.tsx
@@ -127,6 +127,7 @@ export const QuantityReturnedTableComponent = ({
         width: 100,
         accessor: ({ rowData }) => rowData?.volumePerPack,
         setter: updateLine,
+        getIsDisabled: () => isDisabled,
       }
     );
     return columnDefinitions;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9959

# 👩🏻‍💻 What does this PR do?
Disable add batch and volume per pack input for customer returns

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a finalised or shipped customer return 
- [ ] Go into a line
- [ ] Nothing should be editable

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

