### PR TITLE
9892 congo] stock lines with soh=0 should not appear in some reports (alerts on the oms homepage)

### DIFF
--- a/server/service/src/dashboard/item_count.rs
+++ b/server/service/src/dashboard/item_count.rs
@@ -44,7 +44,7 @@ pub trait ItemCountServiceTrait: Send + Sync {
     fn get_low_stock_count(&self, item_stats: &Vec<ItemStats>, low_stock_threshold: i32) -> i64 {
         item_stats
             .iter()
-            .filter(|&i| i.average_monthly_consumption > 0.0 && i.total_stock_on_hand > 0.0)
+            .filter(|&i| i.average_monthly_consumption > 0.0) // exclude items with 0 amc from count, because we assume that means there's no consumption data so we cannot tell how many months of stock there might be.
             .map(|i| i.total_stock_on_hand / i.average_monthly_consumption)
             .filter(|months_of_stock| *months_of_stock < low_stock_threshold as f64)
             .count() as i64

--- a/server/service/src/item/item.rs
+++ b/server/service/src/item/item.rs
@@ -116,8 +116,8 @@ pub fn get_items_ids_for_months_of_stock(
     item_stats
         .into_iter()
         .filter_map(|(k, v)| {
-            // Exclude items with zero consumption or stock
-            if v.average_monthly_consumption == 0.0 || v.total_stock_on_hand == 0.0 {
+            // Exclude items with zero consumption
+            if v.average_monthly_consumption == 0.0 {
                 return None;
             }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9892

# 👩🏻‍💻 What does this PR do?
`Items with less than 3 months of stock` should not show items with stock on hand = 0

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Changes have been removed this is just a refactor

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

