### PR TITLE
9870Some manual response/customer requisition fields are enabled when finalised

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
@@ -171,6 +171,7 @@ export const RequestedSelection = ({
                 },
               },
             }}
+            disabled={disabled}
           />
         </Box>
       </Box>

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseNumInputRow.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseNumInputRow.tsx
@@ -22,6 +22,7 @@ interface ResponseNumInputRowProps {
   endAdornmentOverride?: string;
   unitName?: string | null;
   label: string;
+  disabled?: boolean;
   disabledOverride?: boolean;
   sx?: SxProps<Theme>;
   overrideDoseDisplay?: boolean;
@@ -35,6 +36,7 @@ export const ResponseNumInputRow = ({
   defaultPackSize,
   dosesPerUnit = 1,
   endAdornmentOverride,
+  disabled,
   disabledOverride,
   displayVaccinesInDoses = false,
   overrideDoseDisplay,
@@ -91,6 +93,7 @@ export const ResponseNumInputRow = ({
       onChange={handleChange}
       endAdornment={endAdornment}
       label={label}
+      disabled={disabled}
       disabledOverride={disabledOverride}
       sx={sx}
       dosesCaption={dosesCaption}

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/SuppliedSelection/SupplySelection.tsx
@@ -169,6 +169,7 @@ export const SupplySelection = ({
                 },
               },
             }}
+            disabled={disabled}
           />
         </Box>
       </Box>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9870

# 👩🏻‍💻 What does this PR do?
Disable requisitions and internal order input when they are finalised.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have finalised Internal Order / Requisition
- [ ] Shouldn't be able to edit any of the fields

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

