### PR TITLE
9540 Can't view transactions that involve a disabled Store 

### DIFF
--- a/server/repository/src/db_diesel/name.rs
+++ b/server/repository/src/db_diesel/name.rs
@@ -179,11 +179,6 @@ impl<'a> NameRepository<'a> {
             )
             .inner_join(name_oms_fields_alias)
             .filter(name::type_.ne(NameRowType::Patient))
-            .filter(
-                store::is_disabled
-                    .is_null()
-                    .or(store::is_disabled.eq(false)),
-            ) // Filter out disabled stores, these are usually due to store merge, and should not be visible
             .into_boxed();
 
         if let Some(f) = filter {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9540

# 👩🏻‍💻 What does this PR do?
Filtering code was added because of name merging, but I'm not having the name merging problem in my store. I've had transactions for both names and merged and went back and the names now point to the kept name. Also merged name removed from search, so have removed the problematic code.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a disabled store with transactions in another store
- [ ] Try click on an invoice / requisition / whatever to that store
- [ ] Should be able to see invoice / requisition / whatever

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

