### PR TITLE
9924 Status filter in Prescriptions showing irrelevant options

### DIFF
--- a/client/packages/invoices/src/Prescriptions/ListView/ListView.tsx
+++ b/client/packages/invoices/src/Prescriptions/ListView/ListView.tsx
@@ -12,7 +12,11 @@ import {
   ColumnType,
   NameAndColorSetterCell,
 } from '@openmsupply-client/common';
-import { getStatusTranslator, isPrescriptionDisabled } from '../../utils';
+import {
+  getStatusTranslator,
+  isPrescriptionDisabled,
+  prescriptionStatuses,
+} from '../../utils';
 import { usePrescriptionList, usePrescription } from '../api';
 import { PrescriptionRowFragment } from '../api/operations.generated';
 import { AppBarButtons } from './AppBarButtons';
@@ -74,7 +78,7 @@ export const PrescriptionListView = () => {
         enableSorting: true,
         enableColumnFilter: true,
         filterVariant: 'select',
-        filterSelectOptions: Object.values(InvoiceNodeStatus).map(status => ({
+        filterSelectOptions: prescriptionStatuses.map(status => ({
           value: status,
           label: getStatusTranslator(t)(status),
         })),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9924

# 👩🏻‍💻 What does this PR do?
Only show prescription statuses in status filter

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to prescription
- [ ] Click on statuses
- [ ] Filter by statuses
- [ ] Should only see statuses relevant to prescriptions

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

