### PR TITLE
Windows service tweaks

### DIFF
--- a/build/windows/omsupply_server.suf
+++ b/build/windows/omsupply_server.suf
@@ -4446,9 +4446,6 @@ if ((queryResult == SERVICE_PAUSED) or (queryResult == SERVICE_STOPPED)) then
 	bServiceExists = true;
 end
 
-if (bServiceExists) then
-	Service.Delete("Open mSupply Server", "omsupply-server");
-end
 				</Script>
 <BookMarks count="0">
 </BookMarks>
@@ -4566,17 +4563,26 @@ else
 	end
 end
 
--- Delete unchoosen app file (.exe) by a user
-if (omSupplyServerDatabase == "sqlite") then
-	Service.Create(SessionVar.Expand("%AppFolder%\\omSupply-sqlite.exe"), "Open mSupply Server", "omsupply-server", SERVICE_WIN32_OWN_PROCESS, false, SERVICE_AUTO_START, SERVICE_ERROR_NORMAL, "", nil, nil, "", "");
-	File.Delete(SessionVar.Expand("%AppFolder%\\omSupply-postgres.exe"));
-	File.Delete(SessionVar.Expand("%AppFolder%\\omSupply-cli-postgres.exe"));
-	File.Delete(SessionVar.Expand("%AppFolder%\\test-connection-postgres.exe"));
-else
-	Service.Create(SessionVar.Expand("%AppFolder%\\omSupply-postgres.exe"), "Open mSupply Server", "omsupply-server", SERVICE_WIN32_OWN_PROCESS, false, SERVICE_AUTO_START, SERVICE_ERROR_NORMAL, "", nil, nil, "", "");
-	File.Delete(SessionVar.Expand("%AppFolder%\\omSupply-sqlite.exe"));
-	File.Delete(SessionVar.Expand("%AppFolder%\\omSupply-cli-sqlite.exe"));
-	File.Delete(SessionVar.Expand("%AppFolder%\\test-connection-sqlite.exe"));
+queryResult = Service.Query("Open mSupply Server", "omsupply-server");
+if (queryResult == SERVICE_NOT_FOUND) then
+	-- Delete unchoosen app file (.exe) by a user
+	if (omSupplyServerDatabase == "sqlite") then
+		Service.Create(SessionVar.Expand("%AppFolder%\\omSupply-sqlite.exe"), "Open mSupply Server", "omsupply-server", SERVICE_WIN32_OWN_PROCESS, false, SERVICE_AUTO_START, SERVICE_ERROR_NORMAL, "", nil, nil, "", "");
+		File.Delete(SessionVar.Expand("%AppFolder%\\omSupply-postgres.exe"));
+		File.Delete(SessionVar.Expand("%AppFolder%\\omSupply-cli-postgres.exe"));
+		File.Delete(SessionVar.Expand("%AppFolder%\\test-connection-postgres.exe"));
+	else
+		Service.Create(SessionVar.Expand("%AppFolder%\\omSupply-postgres.exe"), "Open mSupply Server", "omsupply-server", SERVICE_WIN32_OWN_PROCESS, false, SERVICE_AUTO_START, SERVICE_ERROR_NORMAL, "", nil, nil, "", "");
+		File.Delete(SessionVar.Expand("%AppFolder%\\omSupply-sqlite.exe"));
+		File.Delete(SessionVar.Expand("%AppFolder%\\omSupply-cli-sqlite.exe"));
+		File.Delete(SessionVar.Expand("%AppFolder%\\test-connection-sqlite.exe"));
+	end
+end
+
+-- set the startup to Automatic (Delayed Start) (not possible with a service startup type enum, it requires the flag to be set)
+local serviceKey = "SYSTEM\\CurrentControlSet\\Services\\omsupply-server";
+if (Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, serviceKey)) then
+	Registry.SetValue(HKEY_LOCAL_MACHINE, serviceKey, "DelayedAutoStart", 1, REG_DWORD);
 end
 
 -- Add a firewall rule to allow incoming requests

--- a/build/windows/omsupply_standalone.suf
+++ b/build/windows/omsupply_standalone.suf
@@ -3320,9 +3320,6 @@ if ((queryResult == SERVICE_PAUSED) or (queryResult == SERVICE_STOPPED)) then
 	bServiceExists = true;
 end
 
-if (bServiceExists) then
-	Service.Delete("Open mSupply Server", "omsupply-server");
-end
 </Script>
 <BookMarks count="0">
 </BookMarks>
@@ -3392,7 +3389,16 @@ if (Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, firewallRuleKey)) then
 	end
 end
 
-Service.Create(SessionVar.Expand("%AppFolder%\\server\\omSupply-sqlite.exe"), "Open mSupply Server", "omsupply-server", SERVICE_WIN32_OWN_PROCESS, false, SERVICE_AUTO_START, SERVICE_ERROR_NORMAL, "", nil, nil, "", "");
+queryResult = Service.Query("Open mSupply Server", "omsupply-server");
+if (queryResult == SERVICE_NOT_FOUND) then
+	Service.Create(SessionVar.Expand("%AppFolder%\\server\\omSupply-sqlite.exe"), "Open mSupply Server", "omsupply-server", SERVICE_WIN32_OWN_PROCESS, false, SERVICE_AUTO_START, SERVICE_ERROR_NORMAL, "", nil, nil, "", "");
+end
+
+-- set the startup to Automatic (Delayed Start) (not possible with a service startup type enum, it requires the flag to be set)
+local serviceKey = "SYSTEM\\CurrentControlSet\\Services\\omsupply-server";
+if (Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, serviceKey)) then
+	Registry.SetValue(HKEY_LOCAL_MACHINE, serviceKey, "DelayedAutoStart", 1, REG_DWORD);
+end
 
 Service.Start("Open mSupply Server", "omsupply-server", nil);
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8156

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
Three small changes
* Does not delete the service if it is already existing
* Only creates the service if the service doesn't already exist
* Sets the startup type to be `Automatic (Delayed start)`

The changes apply to the server and standalone versions as both of these install a windows service.

Note: the delayed start only showed up after restarting the server 😉 The option is configured but is not displayed immediately

<!-- why are the changes needed -->
The delete and recreate of the windows service has meant that any changes to the service (e.g. login or recovery settings) are not retained when upgrading open mSupply.

The startup type being delayed is preferable in environments where we should wait for a database service to start on server startup.

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Install a prior version, alter the service in some way
- [ ] Upgrade to this version: service changes should remain
- [ ] Install on a machine without open mSupply installed - will create a service with delayed start

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

