### PR TITLE
Replace electron preferences

### DIFF
--- a/client/packages/electron/src/electron.ts
+++ b/client/packages/electron/src/electron.ts
@@ -25,6 +25,7 @@ import { KeyboardScanner } from './keyboardScanner/keyboardScanner';
 import https from 'https';
 import http from 'http';
 import defaultTranslations from '../../common/src/intl/locales/en/desktop.json';
+import fs from 'fs-extra';
 
 // We'll lazy load, once we have the locale available
 const importDesktopTranslations = async (locale: string) =>
@@ -492,11 +493,10 @@ function configureMenus(
                 return;
               }
               store.clear();
-              const contents = webContents.getFocusedWebContents();
-              if (contents) {
-                contents.executeJavaScript(`localStorage.clear();`);
-              }
-              app.exit();
+              const userDataPath = app.getPath('userData');
+              fs.removeSync(userDataPath);
+
+              app.quit();
             });
         },
       },


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10032

# 👩🏻‍💻 What does this PR do?
In the desktop version we were using the Capacitor preferences plugin to store the previously connected server.

There is a menu item to `Clear data` in the desktop app and this clears `localStorage` and the ElectronStore - neither of which are storing the previous server.

This means that calling `Clear data` did not clear the previous server. If the app was restarted it tried to reconnect to the previous server again

<!-- Explain the changes you made -->
I've removed the preferences capacitor plugin. It couldn't be cleared from electron and isn't necessary.
Instead I've exposed the ElectronStore when running as electron and saved the previous server there. This can be cleared by the `Clear data` action.

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Open the desktop app and connect to a server
- [ ] Restart and verify that you are connected to that server automatically
- [ ] Clear data and restart the app: you should not be connected to the server

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

