### PR TITLE
9979 remove unwrap in sync

### DIFF
--- a/server/service/src/sync/mod.rs
+++ b/server/service/src/sync/mod.rs
@@ -177,6 +177,9 @@ impl CentralServerConfig {
     }
 }
 pub(crate) fn is_initialised(service_provider: &ServiceProvider) -> bool {
+    // We cache the initialised state to avoid having to check the database every time. This stops
+    // unnecessary database queries and avoids having to unwrap the database connection. We still
+    // unwrap on the first check as there's no point starting up without the database.
     if IS_INITIALISED.read().unwrap().clone() {
         return true;
     } else {


### PR DESCRIPTION
Fixes #9979

# 👩🏻‍💻 What does this PR do?

With this unwrap removed I'm no longer able to crash the server even with a low number of database connection pool connections.

<details>

<summary>Server logs showing the server rejecting requests when overloaded instead of crashing</summary>

```
2025-12-12 17:12:35.394744000 [INFO ] <actix_server::server:197>:starting service: "actix-web-service-0.0.0.0:8001", workers: 12, listening on: 0.0.0.0:8001
2025-12-12 17:12:35.398513000 [INFO ] <actix_server::server:191>:Actix runtime found; starting in Actix runtime
2025-12-12 17:12:35.398532000 [INFO ] <actix_server::server:197>:starting service: "actix-web-service-0.0.0.0:8000", workers: 12, listening on: 0.0.0.0:8000
2025-12-12 17:13:06.803223000 [INFO ] <graphql::logger:108>:[QueryID: 628863413] query: authToken  - variables: Object {"password": String("****"), "username": String("admin")}
2025-12-12 17:13:06.811506000 [INFO ] <service::login:138>:ConnectionError("Failed to reach the central server to fetch data for admin: ConnectionError(reqwest::Error { kind: Request, url: \"http://0.0.0.0:0/api/v4/login\", source: hyper_util::client::legacy::Error(Connect, ConnectError(\"tcp connect error\", 0.0.0.0:0, Os { code: 49, kind: AddrNotAvailable, message: \"Can't assign requested address\" })) })")
2025-12-12 17:13:06.820726000 [INFO ] <graphql::logger:108>:[QueryID: 326865201] query: authToken  - variables: Object {"password": String("****"), "username": String("admin")}
2025-12-12 17:13:06.820929000 [INFO ] <graphql::logger:108>:[QueryID: 628142086] query: authToken  - variables: Object {"password": String("****"), "username": String("admin")}
2025-12-12 17:13:06.821049000 [INFO ] <graphql::logger:108>:[QueryID: 160291663] query: authToken  - variables: Object {"password": String("****"), "username": String("admin")}
2025-12-12 17:13:06.821164000 [INFO ] <graphql::logger:108>:[QueryID: 436356541] query: authToken  - variables: Object {"password": String("****"), "username": String("admin")}
2025-12-12 17:13:06.821275000 [INFO ] <graphql::logger:108>:[QueryID: 894333669] query: authToken  - variables: Object {"password": String("****"), "username": String("admin")}
2025-12-12 17:13:06.821446000 [INFO ] <graphql::logger:108>:[QueryID: 275677557] query: authToken  - variables: Object {"password": String("****"), "username": String("admin")}
2025-12-12 17:13:06.821512000 [INFO ] <graphql::logger:108>:[QueryID: 833575669] query: authToken  - variables: Object {"password": String("****"), "username": String("admin")}
2025-12-12 17:13:06.821579000 [INFO ] <graphql::logger:108>:[QueryID: 609756631] query: authToken  - variables: Object {"password": String("****"), "username": String("admin")}
2025-12-12 17:13:06.821645000 [INFO ] <graphql::logger:108>:[QueryID: 332544332] query: authToken  - variables: Object {"password": String("****"), "username": String("admin")}
2025-12-12 17:13:07.540228000 [INFO ] <graphql::logger:108>:[QueryID: 946591910] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:07.540416000 [INFO ] <graphql::logger:108>:[QueryID: 905822710] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:07.540598000 [INFO ] <graphql::logger:108>:[QueryID: 948683456] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:07.827245000 [INFO ] <graphql::logger:144>:[QueryID: 332544332] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:07.828293000 [INFO ] <graphql::logger:108>:[QueryID: 133485651] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:07.828974000 [INFO ] <service::login:141>:InternalError("Failed to get service context: Failed to open Connection (Error(None))")
2025-12-12 17:13:07.829012000 [INFO ] <service::login:141>:InternalError("Failed to get service context: Failed to open Connection (Error(None))")
2025-12-12 17:13:07.829857000 [INFO ] <service::login:141>:InternalError("Failed to get service context: Failed to open Connection (Error(None))")
2025-12-12 17:13:07.829877000 [INFO ] <service::login:141>:InternalError("Failed to get service context: Failed to open Connection (Error(None))")
2025-12-12 17:13:07.831587000 [INFO ] <service::login:141>:InternalError("Failed to get service context: Failed to open Connection (Error(None))")
2025-12-12 17:13:07.831607000 [INFO ] <service::login:141>:InternalError("Failed to get service context: Failed to open Connection (Error(None))")
2025-12-12 17:13:08.542534000 [INFO ] <service::login:141>:InternalError("Failed to get service context: Failed to open Connection (Error(None))")
2025-12-12 17:13:08.542897000 [INFO ] <service::login:141>:InternalError("Failed to get service context: Failed to open Connection (Error(None))")
2025-12-12 17:13:08.543098000 [INFO ] <graphql::logger:144>:[QueryID: 948683456] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:08.546596000 [INFO ] <graphql::logger:144>:[QueryID: 946591910] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:08.546831000 [INFO ] <graphql::logger:144>:[QueryID: 905822710] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:08.546977000 [INFO ] <graphql::logger:108>:[QueryID: 811151658] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:08.549676000 [INFO ] <graphql::logger:108>:[QueryID: 434854224] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:08.549875000 [INFO ] <graphql::logger:108>:[QueryID: 520372179] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:08.832385000 [INFO ] <graphql::logger:144>:[QueryID: 133485651] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:08.833648000 [INFO ] <graphql::logger:108>:[QueryID: 995791722] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:08.833688000 [INFO ] <graphql::logger:108>:[QueryID: 105062729] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:08.834894000 [INFO ] <graphql::logger:108>:[QueryID: 969561445] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:08.834942000 [INFO ] <graphql::logger:108>:[QueryID: 455947161] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:08.835044000 [INFO ] <graphql::logger:108>:[QueryID: 614127880] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:08.835344000 [INFO ] <graphql::logger:108>:[QueryID: 691327789] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:08.836072000 [INFO ] <graphql::logger:108>:[QueryID: 859245525] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:09.548850000 [INFO ] <graphql::logger:108>:[QueryID: 332149603] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:09.549147000 [INFO ] <graphql::logger:108>:[QueryID: 841179919] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:09.554821000 [INFO ] <graphql::logger:144>:[QueryID: 811151658] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:09.554903000 [INFO ] <graphql::logger:144>:[QueryID: 434854224] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:09.556023000 [INFO ] <graphql::logger:108>:[QueryID: 735452675] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:09.556067000 [INFO ] <graphql::logger:108>:[QueryID: 723947579] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:09.556713000 [INFO ] <graphql::logger:144>:[QueryID: 520372179] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:09.557647000 [INFO ] <graphql::logger:108>:[QueryID: 186042044] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:09.840042000 [INFO ] <graphql::logger:144>:[QueryID: 995791722] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:09.840397000 [INFO ] <graphql::logger:144>:[QueryID: 105062729] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:09.840673000 [INFO ] <graphql::logger:144>:[QueryID: 969561445] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:09.840871000 [INFO ] <graphql::logger:144>:[QueryID: 455947161] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:09.841209000 [INFO ] <graphql::logger:144>:[QueryID: 614127880] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:09.841742000 [INFO ] <graphql::logger:144>:[QueryID: 691327789] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:09.843501000 [INFO ] <graphql::logger:108>:[QueryID: 279920511] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:09.843947000 [INFO ] <graphql::logger:108>:[QueryID: 905943853] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:09.844175000 [INFO ] <graphql::logger:108>:[QueryID: 845511646] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:09.844622000 [INFO ] <graphql::logger:108>:[QueryID: 313197588] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:09.844758000 [INFO ] <graphql::logger:108>:[QueryID: 530519770] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:09.844983000 [INFO ] <graphql::logger:144>:[QueryID: 859245525] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:09.847448000 [INFO ] <graphql::logger:108>:[QueryID: 113166643] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:10.553496000 [INFO ] <graphql::logger:144>:[QueryID: 841179919] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:10.555539000 [INFO ] <graphql::logger:144>:[QueryID: 332149603] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:10.556309000 [INFO ] <graphql::logger:108>:[QueryID: 959929279] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:10.558119000 [INFO ] <graphql::logger:108>:[QueryID: 554629494] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:10.559075000 [INFO ] <graphql::logger:144>:[QueryID: 735452675] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:10.562288000 [INFO ] <graphql::logger:144>:[QueryID: 723947579] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:10.563646000 [INFO ] <graphql::logger:144>:[QueryID: 186042044] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:10.847869000 [INFO ] <graphql::logger:144>:[QueryID: 530519770] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:10.849688000 [INFO ] <graphql::logger:144>:[QueryID: 313197588] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:10.849919000 [INFO ] <graphql::logger:144>:[QueryID: 279920511] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:10.851651000 [INFO ] <graphql::logger:144>:[QueryID: 113166643] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:10.851886000 [INFO ] <graphql::logger:144>:[QueryID: 905943853] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:10.852316000 [INFO ] <graphql::logger:144>:[QueryID: 845511646] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:10.852949000 [INFO ] <graphql::logger:108>:[QueryID: 161601214] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:10.854919000 [INFO ] <graphql::logger:108>:[QueryID: 483896738] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:10.855100000 [INFO ] <graphql::logger:108>:[QueryID: 490375496] query: requisitions  - variables: Object {"filter": Object {"type": Object {"equalTo": String("REQUEST")}}, "page": Object {"first": Number(500), "offset": Number(0)}, "sort": Object {"desc": Bool(true), "key": String("createdDatetime")}, "storeId": String("8D967C2618BE4D78B3A6FAD6C1C8FF25")}
2025-12-12 17:13:11.560652000 [INFO ] <graphql::logger:144>:[QueryID: 959929279] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:11.565915000 [INFO ] <graphql::logger:144>:[QueryID: 554629494] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:11.857083000 [INFO ] <graphql::logger:144>:[QueryID: 161601214] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:11.861489000 [INFO ] <graphql::logger:144>:[QueryID: 490375496] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:11.862283000 [INFO ] <graphql::logger:144>:[QueryID: 483896738] [Error] Failed to open Connection (Error(None))
2025-12-12 17:13:12.829432000 [INFO ] <graphql::logger:144>:[QueryID: 326865201] [Error] Internal error
2025-12-12 17:13:12.830029000 [INFO ] <graphql::logger:144>:[QueryID: 160291663] [Error] Internal error
2025-12-12 17:13:12.830175000 [INFO ] <graphql::logger:144>:[QueryID: 436356541] [Error] Internal error
2025-12-12 17:13:12.830308000 [INFO ] <graphql::logger:144>:[QueryID: 275677557] [Error] Internal error
2025-12-12 17:13:12.830509000 [INFO ] <graphql::logger:144>:[QueryID: 894333669] [Error] Internal error
2025-12-12 17:13:12.830694000 [INFO ] <graphql::logger:144>:[QueryID: 628142086] [Error] Internal error
2025-12-12 17:13:13.539267000 [INFO ] <graphql::logger:144>:[QueryID: 833575669] [Error] Internal error
2025-12-12 17:13:13.540077000 [INFO ] <graphql::logger:144>:[QueryID: 609756631] [Error] Internal error
```

</details>

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Set `connection_pool_max_connections` in `local.yaml` to 3
- [ ] Load the server using the `Bench-server` branch and multiple processes `seq 10 | parallel -j 10 cargo run`

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

