### PR TITLE
#10056 add args for date and store ids to CLI refresh dates command

### DIFF
--- a/server/cli/src/refresh_dates.rs
+++ b/server/cli/src/refresh_dates.rs
@@ -293,6 +293,7 @@ impl<'a> RefreshDatesRepository<'a> {
         // the program_event table is using `9999-09-09 09:09:09` as a max timestamp value
         // we don't want to update this datetime value
         let query = if let Some(store_ids) = store_ids {
+            // It'd be good to filter changelog by table name too, however dealing with pg enums here is too annoying.
             format!(
             "select id, {field_name} as dt from {table_name} t join changelog cl on cl.record_id = t.id where cl.store_id in {store_ids} and {field_name} is not null and {field_name} <> '9999-09-09 09:09:09'")
         } else {
@@ -335,6 +336,7 @@ impl<'a> RefreshDatesRepository<'a> {
         store_ids: Option<String>,
     ) -> Result<Vec<IdAndDate>, RepositoryError> {
         let query = if let Some(store_ids) = store_ids {
+            // It'd be good to filter changelog by table name too, however dealing with pg enums here is too annoying.
             format!("select id, {field_name} as d from {table_name} t join changelog cl on cl.record_id = t.id where cl.store_id in {store_ids} and {field_name} is not null")
         } else {
             format!("select id, {field_name} as d from {table_name} where {field_name} is not null")


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10056 

# 👩🏻‍💻 What does this PR do?

Changes the CLI `refresh-dates` sub command to allows specifying the date to shift data to and what stores to affect.

## 💌 Any notes for the reviewer?

changelog should have store ID of just about all records that we'd care about. There may be more fringe things out side of invoices/requisitions/stocktakes that I haven't thought through, or non-store data.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] `./target/debug/remote_server_cli refresh-dates` works as before
- [ ] `./target/debug/remote_server_cli refresh-dates -r 2024-05-19` moves dates back to 2024-05-19
- [ ] `./target/debug/remote_server_cli refresh-dates -r 2024-05-19 -s STORE-ID-1,STORE-ID-2` moves dates back to 2024-05-19 just for the two specified stores (if they exist in your datafile)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

