### PR TITLE
10060 [CCEI / GAPS] Data matrix scan doesn't give users enough time

### DIFF
--- a/client/packages/common/src/utils/BarcodeScannerContext.tsx
+++ b/client/packages/common/src/utils/BarcodeScannerContext.tsx
@@ -9,7 +9,7 @@ import { Gs1Barcode, parseBarcode } from 'gs1-barcode-parser-mod';
 import { Formatter } from './formatters';
 import { BarcodeScanner, ScannerType } from '@openmsupply-client/common';
 
-const SCAN_TIMEOUT_IN_MS = 5000;
+const SCAN_TIMEOUT_IN_MS = 10000;
 
 export interface ScanResult {
   gs1?: Gs1Barcode;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10060

# 👩🏻‍💻 What does this PR do?
Up timeout of scan to 10 secs

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have assets in store
- [ ] Print asset data matrix to scan
- [ ] Install OMS on your phone
- [ ] Try scan data matrix, and let it timeout, should be 10 secs

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

