### PR TITLE
10097 Excel report ignore html table headers

### DIFF
--- a/server/service/src/report/convert_to_excel.rs
+++ b/server/service/src/report/convert_to_excel.rs
@@ -194,7 +194,7 @@ fn apply_data_rows(
     // Insert new rows below the first row. We'll copy the styles and formulae from the first row down.
     // Formulae cell references will be adjusted by umya i.e "=A2*3" will be adjusted to "=A3*3"
     // Any footer in the excel will be pushed down appropriately.
-    sheet.insert_new_row(&(row_idx + 1), &(rows_len - 1));
+    sheet.insert_new_row(&(row_idx + 1), &rows_len);
 
     for row in body_rows.into_iter() {
         // Duplicate any formulae/formatting to the next row before populating


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10097 

# 👩🏻‍💻 What does this PR do?

Ignores the table header when populating the excel template if you include `excel-ignore-table-header` in any element.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a report with an excel template with no table headers in it, but there are headers in the html
- [ ] Add `excel-ignore-table-header` in an element of the html template (presumably the `<table>` element)
- [ ] Report to excel
- [ ] The excel has no table headers

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

