### PR TITLE
9160 Location types only show if they have temperatures defined

### DIFF
--- a/server/repository/src/db_diesel/location_type.rs
+++ b/server/repository/src/db_diesel/location_type.rs
@@ -91,11 +91,6 @@ impl<'a> LocationTypeRepository<'a> {
 
     pub fn create_filtered_query(filter: Option<LocationTypeFilter>) -> BoxedLocationTypeQuery {
         let mut query = location_type::table.into_boxed();
-        // Any cold storage types that don't have temperature set (OdegC to 0degC default value) are invalid => filter out
-
-        query = query.filter(not(location_type::min_temperature
-            .eq(0.0)
-            .and(location_type::max_temperature.eq(0.0))));
 
         if let Some(f) = filter {
             let LocationTypeFilter { id, name } = f;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9160

# 👩🏻‍💻 What does this PR do?
Removes filtering of 0 temps since location types are being used throughout the app. Maybe training to improve inputting of bad location types for CCEI?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create 0 min/max temp location types in OG
- [ ] Sync
- [ ] Go to location -> click on a location and try assign a location type
- [ ] Should see 0/0 temp location types

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

