### PR TITLE
Keep deleted line in memory and delete on save

### DIFF
--- a/client/packages/invoices/src/InboundShipment/api/hooks/useDraftInboundLines.tsx
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/useDraftInboundLines.tsx
@@ -92,7 +92,7 @@ export const useDraftInboundLines = (
     [setDraftLines, setIsDirty]
   );
 
-  const removeDraftLine = async (lineId: string) => {
+  const removeDraftLine = (lineId: string) => {
     const batch = draftLines.find(line => line.id === lineId);
     if (!batch) return;
     if (batch.isCreated) {
@@ -104,39 +104,51 @@ export const useDraftInboundLines = (
         return newLines;
       });
     } else {
-      const deletedBatch = { ...batch, isDeleted: true };
-      try {
-        const response = await deleteMutation([deletedBatch]);
-
-        const responseForLine =
-          response.batchInboundShipment.deleteInboundShipmentLines?.[0];
-
-        if (!responseForLine) {
-          error(t('error.something-wrong'))();
-          return;
-        }
-        const errorMessage = mapErrorToMessageAndSetContext(
-          responseForLine,
-          [deletedBatch],
-          t
+      setDraftLines(draftLines => {
+        const updatedLines = draftLines.map(line =>
+          line.id === lineId ? { ...line, isDeleted: true } : line
         );
-        if (errorMessage) error(errorMessage)();
-      } catch {
-        error(t('error.something-wrong'))();
-      }
+        setIsDirty(true);
+        return updatedLines;
+      });
     }
   };
 
   const saveLines = async () => {
     if (isDirty) {
-      const { errorMessage } = await mutateAsync(draftLines);
-      if (errorMessage) throw new Error(errorMessage);
+      const linesToDelete = draftLines.filter(line => line.isDeleted);
+      if (linesToDelete.length > 0) {
+        const response = await deleteMutation(linesToDelete);
+
+        linesToDelete.forEach((lineToDelete, index) => {
+          const responseForLine =
+            response.batchInboundShipment.deleteInboundShipmentLines?.[index];
+          if (!responseForLine) {
+            error(t('error.something-wrong'))();
+            return;
+          }
+
+          const errorMessage = mapErrorToMessageAndSetContext(
+            responseForLine,
+            [lineToDelete],
+            t
+          );
+          if (errorMessage) error(errorMessage)();
+        });
+      }
+
+      const linesToSave = draftLines.filter(line => !line.isDeleted);
+      if (linesToSave.length > 0) {
+        const { errorMessage } = await mutateAsync(linesToSave);
+        if (errorMessage) throw new Error(errorMessage);
+      }
+
       setIsDirty(false);
     }
   };
 
   return {
-    draftLines,
+    draftLines: draftLines.filter(line => !line.isDeleted),
     addDraftLine,
     updateDraftLine,
     removeDraftLine,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8462

# 👩🏻‍💻 What does this PR do?
Keep deleted line in memory with isDeleted flag, and delete when user clicks okay. This ensures that lines are still there when users click cancel

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to inbound shipment. Click on a line
- [ ] Delete a batch
- [ ] Click cancel
- [ ] You line should still be there

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

