### PR TITLE
9760 Avoid addition of blank campaign and trim the spaces at end

### DIFF
--- a/client/packages/system/src/Manage/Campaigns/ListView/CampaignEditModal.tsx
+++ b/client/packages/system/src/Manage/Campaigns/ListView/CampaignEditModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React from 'react';
 import {
   useTranslation,
   DetailContainer,
@@ -19,18 +19,18 @@ interface CampaignEditModalProps {
   upsert: () => Promise<void>;
 }
 
-export const CampaignEditModal: FC<CampaignEditModalProps> = ({
+export const CampaignEditModal = ({
   campaign,
   isOpen,
   onClose,
   updateDraft,
   upsert,
-}) => {
+}: CampaignEditModalProps) => {
   const t = useTranslation();
-
   const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
 
   const { name, startDate, endDate, id } = campaign;
+  const isValidName = name?.trim().length > 0;
 
   return (
     <Modal
@@ -44,7 +44,9 @@ export const CampaignEditModal: FC<CampaignEditModalProps> = ({
           }}
         />
       }
-      okButton={<DialogButton variant="ok" onClick={upsert} />}
+      okButton={
+        <DialogButton variant="ok" onClick={upsert} disabled={!isValidName} />
+      }
     >
       <DetailContainer>
         <Box display="flex" flexDirection="column" gap={2}>
@@ -56,6 +58,7 @@ export const CampaignEditModal: FC<CampaignEditModalProps> = ({
                 sx={{ width: 250 }}
                 value={name}
                 onChange={e => updateDraft({ name: e.target.value })}
+                onBlur={e => updateDraft({ name: e.target.value.trim() })}
               />
             }
           />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9760

# 👩🏻‍💻 What does this PR do?
Trim whitespaces from campaign name and don't allow saving of empty campaign names

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Be on central server
- [ ] Go to manage -> Campaign 
- [ ] Try add campaign with whitespaced name (empty name)
- [ ] Ok button should be disabled
- [ ] Now add name with whitespace at the end (E.g. December 2025              )
- [ ] Whitespaces at end should be trimmed

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

