### PR TITLE
9115 User is not redirected when changing suppliers in a supplier return

### DIFF
--- a/client/packages/host/src/components/MobileNavBar/MobileNavBar.tsx
+++ b/client/packages/host/src/components/MobileNavBar/MobileNavBar.tsx
@@ -31,7 +31,7 @@ import {
   AppRoute,
   ExternalURL,
   useExternalUrl,
-} from 'packages/config/src/routes';
+} from '@openmsupply-client/config';
 import { SyncNavLink } from '../AppDrawer/SyncNavLink';
 import { ColdChainNav } from '../Navigation/ColdChainNav';
 const commonListContainerStyles = {

--- a/client/packages/invoices/src/Returns/SupplierDetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Returns/SupplierDetailView/Toolbar.tsx
@@ -13,7 +13,7 @@ import {
 } from '@openmsupply-client/common';
 import { SupplierReturnFragment, useReturns } from '../api';
 import { SupplierSearchInput } from '@openmsupply-client/system';
-import { AppRoute } from 'packages/config/src';
+import { AppRoute } from '@openmsupply-client/config';
 
 export const Toolbar: FC = () => {
   const t = useTranslation();
@@ -62,6 +62,7 @@ export const Toolbar: FC = () => {
                         id,
                         otherPartyId,
                       });
+                      if (!newId) return;
                       navigate(
                         RouteBuilder.create(AppRoute.Replenishment)
                           .addPart(AppRoute.SupplierReturn)

--- a/client/packages/system/src/Manage/Reports/ListView/ReportUploadModal.tsx
+++ b/client/packages/system/src/Manage/Reports/ListView/ReportUploadModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { FileList } from '../../../../../coldchain/src/Equipment/Components';
-import { Environment } from 'packages/config/src';
+import { Environment } from '@openmsupply-client/config';
 import {
   useTranslation,
   Box,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9115

# 👩🏻‍💻 What does this PR do?
Add redirect when updating name so user isn't kicked to listview

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create supplier return
- [ ] Change name
- [ ] Should still be in the same supplier return 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

