### PR TITLE
10133 User item id rather then item_link_id in stocktake generation of stoc…

### DIFF
--- a/server/service/src/stocktake/update/generate.rs
+++ b/server/service/src/stocktake/update/generate.rs
@@ -81,6 +81,7 @@ fn generate_stock_in_out_or_update(
     stocktake_number: &i64,
 ) -> Result<StockLineJob, UpdateStocktakeError> {
     let stocktake_line_row = stocktake_line.line.to_owned();
+    let item = &stocktake_line.item;
     let counted_number_of_packs = match stocktake_line_row.counted_number_of_packs {
         Some(counted_number_of_packs) => counted_number_of_packs,
         None => {
@@ -202,7 +203,7 @@ fn generate_stock_in_out_or_update(
             item_variant_id,
             // From existing stock line
             stock_line_id: Some(stock_line_row.id),
-            item_id: stock_line_row.item_link_id,
+            item_id: item.id.clone(),
             stock_on_hold: stock_line_row.on_hold,
             barcode: stock_line_row.barcode_id,
             // Default


### PR DESCRIPTION

<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10133

# 👩🏻‍💻 What does this PR do?

As per commit message

## 💌 Any notes for the reviewer?

See issue for more details of item link (and direction to deal with this in the future)

# 🧪 Testing

As per issue

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

