### PR TITLE
Statically link windows binaries

### DIFF
--- a/server/.cargo/config.toml
+++ b/server/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #6655

# 👩🏻‍💻 What does this PR do?
Adds the static linking to the windows build

<!-- Explain the changes you made -->
Tested on the demo server (windows server 2019) and the minisforum (windows 10) both of which had the vcruntime installed. 

Only uninstalling the runtime wasn't sufficient though.. I also renamed the file `c:\windows\system32\vcruntime140.dll`. After that the service wouldn't start. Copied the statically linked binary instead (the two versions are available for download from [mega](https://mega.nz/fm/Rc51XJZL)) and the service started successfully despite the missing file. 

tested that the site was functional using the new binary.

New file size is 172kb larger for the windows service, acceptable I think:

<img width="614" height="44" alt="Screenshot 2025-12-30 at 12 07 14 PM" src="https://github.com/user-attachments/assets/65cf1b05-7c79-43c9-8f20-fa65bc55e3c7" />

Side note: the postgres install actually installed the vcruntime as a preliminary step. uninstalling vcruntime stops the postgres service from running, which in turn stops open mSupply. The full testing was done on a sqlite installation.

<!-- why are the changes needed -->

Removes a potential runtime issue due to a missing dll

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] rename the vcruntime140.dll file and run the service

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

