### PR TITLE
7751 Unable to create CCE when Category is selected

### DIFF
--- a/client/packages/coldchain/src/Equipment/ListView/CreateAssetModal.tsx
+++ b/client/packages/coldchain/src/Equipment/ListView/CreateAssetModal.tsx
@@ -203,7 +203,10 @@ export const CreateAssetModal = ({
         <Box>
           <Box display="flex" justifyContent="flex-end">
             <Switch
-              onChange={() => setIsCatalogueAsset(!isCatalogueAsset)}
+              onChange={() => {
+                setIsCatalogueAsset(!isCatalogueAsset);
+                updateDraft({ catalogueItemId: undefined, typeId: undefined });
+              }}
               checked={isCatalogueAsset}
               label={t('label.use-catalogue')}
             />
@@ -230,12 +233,11 @@ export const CreateAssetModal = ({
                 fullWidth
                 onChange={e => {
                   updateDraft({
-                    catalogueItemId: undefined,
                     categoryId: e.target.value,
-                    typeId: '',
                   });
                 }}
                 value={draft.categoryId ?? ''}
+                clearable
               />
             }
           />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7751

# 👩🏻‍💻 What does this PR do?
Allow user to save even if they select category last. clear category item id / type when switch is pressed and allow clearing of category.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an equipment 
- [ ] Enter details in this order: Store, category item, asset number
- [ ] Now enter category. Ok button should still be enabled
- [ ] Use toggle, category item / type should be cleared when switched
- [ ] Category should have a clear selection button now at the end of the list

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

