### PR TITLE
9597 Opening properties modal refetch supplies and display suppliers that are not visible to the store

### DIFF
--- a/client/packages/system/src/Name/api/hooks/document/useStores.ts
+++ b/client/packages/system/src/Name/api/hooks/document/useStores.ts
@@ -9,7 +9,7 @@ export const useStores = () => {
   });
 
   return useQuery(
-    api.keys.paramList(queryParams),
+    api.keys.storesList(queryParams),
     () => api.get.stores(queryParams),
     {
       keepPreviousData: true,

--- a/client/packages/system/src/Name/api/hooks/utils/useNameApi.ts
+++ b/client/packages/system/src/Name/api/hooks/utils/useNameApi.ts
@@ -10,6 +10,8 @@ export const useNameApi = () => {
     detail: (id: string) => [...keys.base(), storeId, id] as const,
     list: () => [...keys.base(), storeId, 'list'] as const,
     paramList: (params?: ListParams) => [...keys.list(), params] as const,
+    storesList: (params?: ListParams) =>
+      [...keys.base(), 'stores-list', params] as const,
     donors: () => [...keys.base(), storeId, 'donors'] as const,
     properties: () => [NAME_PROPERTIES_KEY] as const,
   };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9597

# 👩🏻‍💻 What does this PR do?
Use separate invalidation keys so doesn't refresh the supplier / customer list view

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Supplier / Customer list view
- [ ] Click on `Edit` button in the footer
- [ ] List view should not change

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

