### PR TITLE
9744 Reason from return not visible in supplying store (customer return) when created by customer (using supplier return)

### DIFF
--- a/server/service/src/processors/transfer/invoice/common.rs
+++ b/server/service/src/processors/transfer/invoice/common.rs
@@ -43,7 +43,7 @@ pub(crate) fn generate_inbound_lines(
                     cost_price_per_pack: _,
                     total_after_tax: _,
                     linked_invoice_id: _,
-                    reason_option_id: _,
+                    reason_option_id,
                     item_link_id,
                     item_name,
                     item_code,
@@ -141,10 +141,10 @@ pub(crate) fn generate_inbound_lines(
                     volume_per_pack,
                     sell_price_per_pack: adjusted_sell_price_per_pack,
                     shipped_pack_size,
+                    reason_option_id,
                     // Default
                     stock_line_id: None,
                     location_id: None,
-                    reason_option_id: None,
                 }
             },
         )
@@ -214,7 +214,7 @@ pub(crate) fn auto_verify_if_store_preference(
             Some(&inbound_shipment.store_id),
         )
         .map_err(|e| {
-            log::error!("{:?}", e);
+            log::error!("{e:?}");
             RepositoryError::as_db_error("Error attempting to verify inbound shipment", e)
         })?;
     }

--- a/server/service/src/processors/transfer/invoice/create_inbound_invoice.rs
+++ b/server/service/src/processors/transfer/invoice/create_inbound_invoice.rs
@@ -42,7 +42,7 @@ impl InvoiceTransferProcessor for CreateInboundInvoiceProcessor {
     /// 2. Source invoice is either Outbound shipment or Supplier Return
     /// 3. Source outbound invoice is either Shipped or Picked
     ///    (outbounds can also be New or Allocated, but we only want to generate transfer when it's Shipped or Picked, as per
-    ///     ./doc/omSupply_shipment_transfer_workflow.png)
+    ///    ./doc/omSupply_shipment_transfer_workflow.png)
     /// 4. The outbound_invoice.linked_invoice_id is None. This check rather than looking for the Some inbound invoice gives us an escape hatch to prevent transfers being generated.
     /// 5. Source invoice was not created a month before receiving store was created.
     /// 6. Source invoice was not picked more than 3 months before initialisation of the site that we skip generating the transfer
@@ -136,7 +136,7 @@ impl InvoiceTransferProcessor for CreateInboundInvoiceProcessor {
                         .and_then(|initialisation_date| {
                             initialisation_date.checked_sub_months(Months::new(pref_months as u32))
                         })
-                        .map_or(false, |cutoff_date| picked_date < cutoff_date)
+                        .is_some_and(|cutoff_date| picked_date < cutoff_date)
                     {
                         return Ok(InvoiceTransferOutput::BeforeInitialisationMonths);
                     }
@@ -243,11 +243,11 @@ fn generate_inbound_invoice(
 
     let formatted_comment = match r#type {
         InboundInvoiceType::InboundShipment => match &outbound_invoice_row.comment {
-            Some(comment) => format!("Stock transfer ({})", comment),
+            Some(comment) => format!("Stock transfer ({comment})"),
             None => "Stock transfer".to_string(),
         },
         InboundInvoiceType::CustomerReturn => match &outbound_invoice_row.comment {
-            Some(comment) => format!("Stock return ({})", comment),
+            Some(comment) => format!("Stock return ({comment})"),
             None => "Stock return".to_string(),
         },
     };
@@ -324,7 +324,7 @@ mod test {
         let log_1 = SyncLogRow {
             id: "sync_log_1".to_string(),
             integration_finished_datetime: Some(
-                NaiveDate::from_ymd_opt(2025, 01, 01)
+                NaiveDate::from_ymd_opt(2025, 1, 1)
                     .unwrap()
                     .and_hms_opt(0, 0, 0)
                     .unwrap(),
@@ -335,7 +335,7 @@ mod test {
         let log_2 = SyncLogRow {
             id: "sync_log_2".to_string(),
             integration_finished_datetime: Some(
-                NaiveDate::from_ymd_opt(2024, 01, 01)
+                NaiveDate::from_ymd_opt(2024, 1, 1)
                     .unwrap()
                     .and_hms_opt(0, 0, 0)
                     .unwrap(),
@@ -518,7 +518,7 @@ mod test {
         }
 
         CreateInboundInvoiceProcessor {}
-            .try_process_record(&ctx, &new_status_invoice_input)
+            .try_process_record(ctx, &new_status_invoice_input)
             .unwrap();
 
         let invoice = get_linked_invoice(&ctx.connection, new_invoice_row.id.to_string());
@@ -528,7 +528,7 @@ mod test {
         );
 
         CreateInboundInvoiceProcessor {}
-            .try_process_record(&ctx, &picked_status_invoice_input)
+            .try_process_record(ctx, &picked_status_invoice_input)
             .unwrap();
         let invoice_status = get_linked_invoice(&ctx.connection, picked_invoice_row.id.to_string())
             .unwrap()
@@ -541,7 +541,7 @@ mod test {
         );
 
         CreateInboundInvoiceProcessor {}
-            .try_process_record(&ctx, &shipped_status_invoice_input)
+            .try_process_record(ctx, &shipped_status_invoice_input)
             .unwrap();
         let invoice_status =
             get_linked_invoice(&ctx.connection, shipped_invoice_row.id.to_string())
@@ -580,7 +580,7 @@ mod test {
             .unwrap();
 
         CreateInboundInvoiceProcessor {}
-            .try_process_record(&ctx, &picked_status_invoice_input)
+            .try_process_record(ctx, &picked_status_invoice_input)
             .unwrap();
         let invoice_status = get_linked_invoice(&ctx.connection, picked_invoice_row.id.to_string())
             .unwrap()
@@ -593,7 +593,7 @@ mod test {
         );
 
         CreateInboundInvoiceProcessor {}
-            .try_process_record(&ctx, &shipped_status_invoice_input)
+            .try_process_record(ctx, &shipped_status_invoice_input)
             .unwrap();
         let invoice_status =
             get_linked_invoice(&ctx.connection, shipped_invoice_row.id.to_string())
@@ -607,7 +607,7 @@ mod test {
         );
 
         CreateInboundInvoiceProcessor {}
-            .try_process_record(&ctx, &supplier_return_shipped)
+            .try_process_record(ctx, &supplier_return_shipped)
             .unwrap();
 
         let invoice_status =


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9744

# 👩🏻‍💻 What does this PR do?
Transfer return reason to customer return so that the supplier can see why the customer returned stock

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have return reasons set up in OG under pref -> options
- [ ] Create a supplier return to a supplier and add reason 
- [ ] Finalise
- [ ] Go to customer store -> see reason has been transferred over

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

