### PR TITLE
#10065 Fix auto-allocation bug for auto-created shipments

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/Allocation.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/Allocation.tsx
@@ -42,7 +42,12 @@ export const Allocation = ({
 }: AllocationProps) => {
   const t = useTranslation();
   const { format } = useFormatNumber();
-  const { manageVaccinesInDoses, sortByVvmStatusThenExpiry } = usePreferences();
+  const {
+    manageVaccinesInDoses,
+    sortByVvmStatusThenExpiry,
+    expiredStockPreventIssue,
+    expiredStockIssueThreshold,
+  } = usePreferences();
 
   const { initialise, item } = useAllocationContext(({ initialise, item }) => ({
     initialise,
@@ -86,6 +91,9 @@ export const Allocation = ({
             manageVaccinesInDoses && data.item.isVaccine
               ? { type: AllocateInType.Doses }
               : allocateInPacksize,
+          expiryThresholdDays: expiredStockPreventIssue
+            ? (expiredStockIssueThreshold ?? 0)
+            : 0,
         },
         format,
         t

--- a/client/packages/invoices/src/Prescriptions/LineEditView/AutoAllocatePrescribedQuantityField.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/AutoAllocatePrescribedQuantityField.tsx
@@ -5,7 +5,6 @@ import {
   useFormatNumber,
   useDebounceCallback,
   InputLabel,
-  usePreferences,
 } from '@openmsupply-client/common';
 
 import { AllocateInType, useAllocationContext } from '../../StockOut';
@@ -13,8 +12,6 @@ import { AllocateInType, useAllocationContext } from '../../StockOut';
 export const AutoAllocatePrescribedQuantityField = () => {
   const t = useTranslation();
   const { format } = useFormatNumber();
-  const { expiredStockPreventIssue, expiredStockIssueThreshold } =
-    usePreferences();
 
   const { autoAllocate, prescribedQuantity, setPrescribedQuantity } =
     useAllocationContext(state => ({
@@ -34,13 +31,7 @@ export const AutoAllocatePrescribedQuantityField = () => {
   // and https://github.com/msupply-foundation/open-msupply/issues/3532
   const debouncedAllocate = useDebounceCallback(
     quantity => {
-      autoAllocate(
-        quantity,
-        format,
-        t,
-        expiredStockPreventIssue ? (expiredStockIssueThreshold ?? 0) : 0,
-        true
-      );
+      autoAllocate(quantity, format, t, true);
     },
     [],
     500

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEdit.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEdit.tsx
@@ -33,7 +33,12 @@ export const PrescriptionLineEdit = ({
 
   const t = useTranslation();
   const { format } = useFormatNumber();
-  const { manageVaccinesInDoses, sortByVvmStatusThenExpiry } = usePreferences();
+  const {
+    manageVaccinesInDoses,
+    sortByVvmStatusThenExpiry,
+    expiredStockPreventIssue,
+    expiredStockIssueThreshold,
+  } = usePreferences();
 
   // Needs to update when user clicks on different item in the list, or when
   // changing item with the selector
@@ -80,6 +85,9 @@ export const PrescriptionLineEdit = ({
             manageVaccinesInDoses && data.item.isVaccine
               ? { type: AllocateInType.Doses }
               : undefined,
+          expiryThresholdDays: expiredStockPreventIssue
+            ? (expiredStockIssueThreshold ?? 0)
+            : 0,
         },
         format,
         t

--- a/client/packages/invoices/src/StockOut/Components/AutoAllocateIssueField.tsx
+++ b/client/packages/invoices/src/StockOut/Components/AutoAllocateIssueField.tsx
@@ -6,7 +6,6 @@ import {
   useFormatNumber,
   useBufferState,
   useDebounceCallback,
-  usePreferences,
 } from '@openmsupply-client/common';
 import { useAllocationContext } from '../useAllocationContext';
 import { getAllocatedQuantity } from '../utils';
@@ -24,8 +23,6 @@ export const AutoAllocateField = ({
 }) => {
   const t = useTranslation();
   const { format } = useFormatNumber();
-  const { expiredStockPreventIssue, expiredStockIssueThreshold } =
-    usePreferences();
 
   const { autoAllocate, allocatedQuantity } = useAllocationContext(state => ({
     autoAllocate: state.autoAllocate,
@@ -36,13 +33,7 @@ export const AutoAllocateField = ({
 
   const debouncedAllocate = useDebounceCallback(
     quantity => {
-      const allocated = autoAllocate(
-        quantity,
-        format,
-        t,
-        expiredStockPreventIssue ? (expiredStockIssueThreshold ?? 0) : 0,
-        allowPartialPacks
-      );
+      const allocated = autoAllocate(quantity, format, t, allowPartialPacks);
       setIssueQuantity(allocated);
     },
     [],


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10065 

# 👩🏻‍💻 What does this PR do?

Turns out it wasn't actually a back-end issue, as the allocation logic for the new shipment lines is still in the front-end. It's just that when I did #10051 I missed this case as the initial values of the auto-created shipments are called separately to when you put the issue amounts in by the user.

I've refactored the `useAllocationContext` to take the expiry threshold value in its `initalise` method, so it's always available to all other methods in the context. Now *all* auto-allocation logic should have the correct value for this threshold.


<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] See steps in issue - confirm that stock within the expiry threshold is not auto-allocated (if pref is on)
- [ ] Confirm that changing the issue quanity yourself (in the UI) still behaves correctly (i.e. respects this threshold)
- [ ] Maybe check a prescription too, to confirm the change applies everywhere?

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

