### PR TITLE
Update migration to fix issues with pref re-initalisation

### DIFF
--- a/server/repository/src/migrations/v2_15_00/remove_skip_immediate_statuses_in_outbound_pref.rs
+++ b/server/repository/src/migrations/v2_15_00/remove_skip_immediate_statuses_in_outbound_pref.rs
@@ -8,6 +8,8 @@ impl MigrationFragment for Migrate {
     }
 
     fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        // Note: even though we're removing the old preference, if a client has the old preference set, we'll keep the legacy record around incase the re-initialise on an old version.
+        // This should only affect a very small number of clients
         sql!(
             connection,
             r#"


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10159 

# 👩🏻‍💻 What does this PR do?

The migration now creates a new pref record for the new pref, old records for old sites will still exist (probably only affecting a few customers, and some devs)

Any broken 2.15 upgrades should be fixes as we delete any invalid changelogs for `skip_intermediate_statuses_in_outbound`

## 💌 Any notes for the reviewer?

This was missed in code review, it's not clear if any `real` customers will be affected but definitely would affect some Demo, QA, and dev enviroments

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Install 2.14.3 on central & on remote
- [ ] Set the skip_intermediate_statuses_in_outbound pref in Central server and sync to remote
- [ ] Update central to 2.15
- [ ] Re-inititalise the 2.14 remote
- [ ] Check skip_intermediate_statuses_in_outbound is still set
- [ ] Upgrade remote to 2.15
- [ ] Make sure the outbound status are unticked
- [ ] Re-initialise remote on 2.15
- [ ] Make sure the outbound status are unticked

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [X] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [X] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

