### PR TITLE
7120 Inventory -> View Stock: buttons disappear when switching languages

### DIFF
--- a/client/packages/system/src/Stock/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Stock/DetailView/DetailView.tsx
@@ -27,6 +27,13 @@ import { RepackModal } from '../Components';
 import { InventoryAdjustmentModal } from '../Components';
 import { StatusHistory } from '../Components/StatusHistory';
 
+enum StockLineDetailTabs {
+  Details = 'details',
+  StatusHistory = 'statushistory',
+  Log = 'log',
+  Ledger = 'ledger',
+}
+
 export const StockLineDetailView: React.FC = () => {
   const t = useTranslation();
   const { id } = useParams();
@@ -109,23 +116,23 @@ export const StockLineDetailView: React.FC = () => {
           existingStockLine={data}
         />
       ),
-      value: t('label.details'),
+      value: StockLineDetailTabs.Details,
     },
     ...(isVaccine && manageVvmStatusForStock
       ? [
           {
             Component: <StatusHistory draft={draft} isLoading={isLoading} />,
-            value: t('label.statushistory'),
+            value: StockLineDetailTabs.StatusHistory,
           },
         ]
       : []),
     {
       Component: <ActivityLogList recordId={data?.id ?? ''} />,
-      value: t('label.log'),
+      value: StockLineDetailTabs.Log,
     },
     {
       Component: <LedgerTable stockLine={draft} />,
-      value: t('label.ledger'),
+      value: StockLineDetailTabs.Ledger,
     },
   ];
 
@@ -164,9 +171,9 @@ export const StockLineDetailView: React.FC = () => {
       />
       <TableProvider createStore={createTableStore}>
         <DetailTabs tabs={tabs} />
-        {(tab === t('label.details') || !tab || simplifiedTabletView) && (
-          <Footer {...footerProps} />
-        )}
+        {(tab === StockLineDetailTabs.Details ||
+          !tab ||
+          simplifiedTabletView) && <Footer {...footerProps} />}
       </TableProvider>
     </>
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7120

# 👩🏻‍💻 What does this PR do?
Tab values are already being translated in DetailTabs.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Click on a stock line
- [ ] Change tab
- [ ] Change back to detail tab
- [ ] Change language
- [ ] Footer shouldn't disappear

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

