### PR TITLE
10166 fix sql subquery alias runtime error in items stats query

### DIFF
--- a/server/repository/src/db_diesel/days_out_of_stock.rs
+++ b/server/repository/src/db_diesel/days_out_of_stock.rs
@@ -68,10 +68,12 @@ impl<'a> DaysOutOfStockRepository<'a> {
         } = filter;
 
         // Build filter_helper query for any present fields
-        let mut filter_helper_query = dos_filter_helper::table.into_boxed();
+        let mut filter_helper_query = dos_filter_helper::table
+            .select((dos_filter_helper::item_id, dos_filter_helper::store_id))
+            .distinct()
+            .into_boxed();
 
         apply_equal_filter!(filter_helper_query, item_id, dos_filter_helper::item_id);
-
         apply_equal_filter!(filter_helper_query, store_id, dos_filter_helper::store_id);
 
         let dos_query = Dos {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10166 

# 👩🏻‍💻 What does this PR do?
Fix sql subquery alias runtime error in the items stats query.
<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing
**Should be using Postrges database**
<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Catalogue
- [ ] Click `Items`
- [ ] Should show all items list
- [ ] Create a prescription and add items
- [ ] Should show item list and be able to add to the prescription
- [ ] Regression: try adding item(s) in both outbound/inbound, requisition, etc
- [ ] Should be working as usual.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

