### PR TITLE
8792 Where multiple stores on a OMS central server site - controlling global preferences is confusing

### DIFF
--- a/client/packages/system/src/Manage/Preferences/EditPage/EditPreference.tsx
+++ b/client/packages/system/src/Manage/Preferences/EditPage/EditPreference.tsx
@@ -16,6 +16,7 @@ import {
   isString,
   useAuthContext,
   UserPermission,
+  useIsCentralServerApi,
 } from '@openmsupply-client/common';
 import { MultiChoice, getMultiChoiceOptions } from '../Components/MultiChoice';
 import { EditCustomTranslations } from '../Components/CustomTranslations/CustomTranslationsModal';
@@ -27,7 +28,6 @@ interface EditPreferenceProps {
   update: (
     input: UpsertPreferencesInput[keyof UpsertPreferencesInput]
   ) => Promise<boolean>;
-  disabled?: boolean;
   label?: string;
   isLast?: boolean;
 }
@@ -35,15 +35,16 @@ interface EditPreferenceProps {
 export const EditPreference = ({
   preference,
   update,
-  disabled = false,
   label,
   isLast = false,
 }: EditPreferenceProps) => {
   const t = useTranslation();
   const { error } = useNotification();
   const { userHasPermission } = useAuthContext();
-  const isDisabled =
-    disabled || !userHasPermission(UserPermission.EditCentralData);
+  const isCentralServer = useIsCentralServerApi();
+
+  const disabled =
+    isCentralServer || !userHasPermission(UserPermission.EditCentralData);
 
   const preferenceLabel =
     label ?? t(`preference.${preference.key}` as LocaleKey);
@@ -82,7 +83,7 @@ export const EditPreference = ({
           label={preferenceLabel}
           Input={
             <Switch
-              disabled={isDisabled}
+              disabled={disabled}
               checked={value}
               onChange={(_, checked) => handleChange(checked)}
             />
@@ -103,7 +104,7 @@ export const EditPreference = ({
               value={value}
               onChange={handleChange}
               onBlur={() => {}}
-              disabled={isDisabled}
+              disabled={disabled}
             />
           }
           isLast={isLast}
@@ -122,7 +123,7 @@ export const EditPreference = ({
               value={value}
               onChange={e => handleChange(e.target.value)}
               onBlur={() => {}}
-              disabled={isDisabled}
+              disabled={disabled}
               sx={
                 hasError
                   ? {
@@ -150,7 +151,7 @@ export const EditPreference = ({
           label={preferenceLabel}
           Input={
             <MultiChoice
-              disabled={isDisabled}
+              disabled={disabled}
               options={options}
               value={value}
               onChange={handleChange}
@@ -178,7 +179,7 @@ export const EditPreference = ({
         <EditWarningWhenMissingRecentStocktakeData
           value={value}
           update={handleChange}
-          disabled={isDisabled}
+          disabled={disabled}
           label={preferenceLabel}
         />
       );

--- a/client/packages/system/src/Name/ListView/Stores/EditStorePreferences.tsx
+++ b/client/packages/system/src/Name/ListView/Stores/EditStorePreferences.tsx
@@ -3,7 +3,6 @@ import {
   NothingHere,
   PreferenceNodeType,
   PreferenceValueNodeType,
-  useIsCentralServerApi,
 } from '@openmsupply-client/common';
 import {
   EditPreference,
@@ -19,7 +18,6 @@ interface EditStorePreferencesProps {
 export const EditStorePreferences = ({
   storeId,
 }: EditStorePreferencesProps) => {
-  const isCentralServer = useIsCentralServerApi();
   const { update, preferences } = useEditPreferences(
     PreferenceNodeType.Store,
     storeId
@@ -40,7 +38,6 @@ export const EditStorePreferences = ({
           return (
             <EditPreference
               key={pref.key}
-              disabled={!isCentralServer}
               preference={pref}
               update={value => {
                 const finalValue =


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8792

# 👩🏻‍💻 What does this PR do?
Disable global preferences if user doesn't have edit central permission. Also should custom translations only be editable by those with edit permissions??

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a user without edit central permission
- [ ] Go to global preferences
- [ ] Editing should be disabled

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

