### PR TITLE
7573 Vaccination Card enrolment: compulsory prompt to enter the enrolment code does not come back when the field is cleared

### DIFF
--- a/client/packages/programs/src/JsonForms/common/hooks/useDebouncedTextInput.ts
+++ b/client/packages/programs/src/JsonForms/common/hooks/useDebouncedTextInput.ts
@@ -57,7 +57,7 @@ export const useDebouncedTextInput = (
     if (Date.now() > latestKey.current + 500) setText(data);
   }, [data]);
 
-  const onChange = (value: string) => {
+  const onChange = (value: string | undefined) => {
     latestKey.current = Date.now();
     setText(value);
   };

--- a/client/packages/programs/src/JsonForms/components/IdGenerator.tsx
+++ b/client/packages/programs/src/JsonForms/components/IdGenerator.tsx
@@ -419,7 +419,7 @@ const UIComponent = (props: ControlProps) => {
             value={text}
             style={{ flex: 1 }}
             helperText={zErrors ?? errors}
-            onChange={e => onChange(e.target.value)}
+            onChange={e => onChange(e.target.value || undefined)}
             error={!!zErrors || !!errors}
             FormHelperTextProps={
               errors ? { sx: { color: 'error.main' } } : undefined


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7573

# 👩🏻‍💻 What does this PR do?
e.target.value was saving as empty string which is still string, so have cleared it

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Upload the immunisation program (see programschema repo)
- [ ] Enrol patient into program
- [ ] Generate Numéro
- [ ] Clear Numéro
- [ ] Validation error should prompt back up

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

