### PR TITLE
10158 fix client crash when server down

### DIFF
--- a/client/packages/common/src/api/hooks/useInitialisationStatus.ts
+++ b/client/packages/common/src/api/hooks/useInitialisationStatus.ts
@@ -3,7 +3,6 @@ import { getSdk } from '../operations.generated';
 
 export const useInitialisationStatus = (
   refetchInterval: number | false = false,
-  shouldSuspend?: boolean
 ) => {
   const { client } = useGql();
   const sdk = getSdk(client);
@@ -16,7 +15,6 @@ export const useInitialisationStatus = (
     },
     {
       cacheTime: 0,
-      suspense: shouldSuspend,
       refetchInterval,
     }
   );

--- a/client/packages/common/src/authentication/api/hooks/useIsCentralServer.ts
+++ b/client/packages/common/src/authentication/api/hooks/useIsCentralServer.ts
@@ -15,7 +15,7 @@ export const useIsCentralServerApi = () => {
       refetchOnMount: false,
       cacheTime: Infinity,
       staleTime: Infinity,
-      suspense: true,
+      suspense: false,
       enabled: !!storeId,
     }
   );

--- a/client/packages/common/src/authentication/api/hooks/usePreferences.ts
+++ b/client/packages/common/src/authentication/api/hooks/usePreferences.ts
@@ -23,7 +23,7 @@ export const usePreferences = (): Partial<PreferencesNode> => {
     // Or when switching stores
     cacheTime: Infinity,
     staleTime: Infinity,
-    suspense: true,
+    suspense: false,
     enabled: !!storeId,
   });
 

--- a/client/packages/host/src/Host.tsx
+++ b/client/packages/host/src/Host.tsx
@@ -71,15 +71,17 @@ const skipRequest = () =>
 
 const PreInit: React.FC<React.PropsWithChildren> = ({ children }) => {
   const { logout } = useAuthContext();
-  const data = useInitialisationStatus(false, true);
+  const { data, isLoading } = useInitialisationStatus();
 
-  // Technically this should not fire before query is loaded because we are doing suspense
-  if (data?.data?.status == InitialisationStatusType.Initialised)
+  // If query successful and initialisation complete, render children
+  if (data?.status == InitialisationStatusType.Initialised)
     return children;
 
-  // Clear token
-  logout();
+  // If finished loading and not initialised, log out
+  if (!isLoading)
+    logout();
 
+  // Skip startup hooks, they dont work if not initialised
   return null;
 };
 

--- a/client/packages/host/src/Host.tsx
+++ b/client/packages/host/src/Host.tsx
@@ -27,9 +27,6 @@ import {
   KBarProvider,
   usePreferences,
   useIsCentralServerApi,
-  useInitialisationStatus,
-  InitialisationStatusType,
-  useAuthContext,
 } from '@openmsupply-client/common';
 import { AppRoute, Environment } from '@openmsupply-client/config';
 import { Initialise, Login, Viewport } from './components';
@@ -68,22 +65,6 @@ Bugsnag.start({
 
 const skipRequest = () =>
   LocalStorage.getItem('/error/auth') === AuthError.NoStoreAssigned;
-
-const PreInit: React.FC<React.PropsWithChildren> = ({ children }) => {
-  const { logout } = useAuthContext();
-  const { data, isLoading } = useInitialisationStatus();
-
-  // If query successful and initialisation complete, render children
-  if (data?.status == InitialisationStatusType.Initialised)
-    return children;
-
-  // If finished loading and not initialised, log out
-  if (!isLoading)
-    logout();
-
-  // Skip startup hooks, they dont work if not initialised
-  return null;
-};
 
 /**
  * Empty component which can be used to call startup hooks.
@@ -179,9 +160,7 @@ const Host = () => (
                   skipRequest={skipRequest}
                 >
                   <AuthProvider>
-                    <PreInit>
                       <Init />
-                    </PreInit>
                     <ConfirmationModalProvider>
                       <AlertModalProvider>
                         <RouterProvider router={router} />

--- a/client/packages/host/src/Host.tsx
+++ b/client/packages/host/src/Host.tsx
@@ -160,7 +160,7 @@ const Host = () => (
                   skipRequest={skipRequest}
                 >
                   <AuthProvider>
-                      <Init />
+                    <Init />
                     <ConfirmationModalProvider>
                       <AlertModalProvider>
                         <RouterProvider router={router} />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10158

# 👩🏻‍💻 What does this PR do?

Even before #10116 when there are cookies in the cache and the server is unaccessible the client crashes with a runtime error. This PR fixes #10113 and #10158 by using option 1 of the following:

1. (this pr) remove suspense from initialisation queries. This does mean that preferences and is initialised will have placeholder values to begin with but I haven't been able to find any cases where this causes a problem. While waiting for the queries I return an empty preferences object and return isInitialised as false. Some more rigorous testing would be required to make sure this doesn't cause problems.
2. Add error boundary for initialisation. This would let you see the page but would still freeze the page load until the initialisation queries time out due to the suspense.
3. Just revert #10116. This would at least let the page load when you don't have cookies.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  4.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

