### PR TITLE
Add created date filters for internal orders and supplier returns

### DIFF
--- a/client/packages/invoices/src/Returns/SupplierListView/ListView.tsx
+++ b/client/packages/invoices/src/Returns/SupplierListView/ListView.tsx
@@ -33,6 +33,7 @@ export const SupplierReturnListView = () => {
     filters: [
       { key: 'otherPartyName' },
       { key: 'status', condition: 'equalTo' },
+      { key: 'createdDatetime', condition: 'between' },
     ],
   });
   const navigate = useNavigate();
@@ -114,6 +115,7 @@ export const SupplierReturnListView = () => {
       {
         accessorKey: 'createdDatetime',
         header: t('label.created-datetime'),
+        enableColumnFilter: true,
         enableSorting: true,
         columnType: ColumnType.Date,
       },

--- a/client/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
@@ -40,6 +40,7 @@ export const ListView = () => {
     filters: [
       { key: 'otherPartyName' },
       { key: 'status', condition: 'equalTo' },
+      { key: 'createdDatetime', condition: 'between' },
     ],
   });
   const queryParams = { ...filter, sortBy, first, offset };
@@ -77,6 +78,7 @@ export const ListView = () => {
       {
         accessorKey: 'createdDatetime',
         header: t('label.created'),
+        enableColumnFilter: true,
         enableSorting: true,
         columnType: ColumnType.Date,
       },


### PR DESCRIPTION
Adds a created date (range) filter to:
- Replenishment → Internal Orders list
- Distribution → Supplier Returns list

Fixes #9687
Fixes #9688

Tests (CI-like):
- cd client && yarn re-compile
- cd client && yarn eslint
- cd client && yarn test
