### PR TITLE
Docs: fix CONTRIBUTING and README links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ It's generally best if you get confirmation of your bug or approval for your fea
 
 Note that the issue tracker is only for bugs and feature requests. If you have a general question, please ask elsewhere.
 
-The best place to start are the issues which have the label [good first issue](https://github.com/openmsupply/open-msupply/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+The best place to start are the issues which have the label [good first issue](https://github.com/msupply-foundation/open-msupply/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 
 Working on your first Pull Request? You might find http://makeapullrequest.com/ and http://www.firsttimersonly.com/ helpful.
 
@@ -63,14 +63,19 @@ everyone is a beginner at first :smile_cat:
 
 ### View your changes in the client application
 
-To see the application running, you can get up and running quickly by running this from the client folder:
+To see the application running, you can get up and running quickly in one of two ways:
 
 ```sh
+# Option 1: run server + client locally (requires Rust + Node)
 yarn start
+
+# Option 2: run client against the demo server API (no Rust required)
+cd ./client
+yarn start-remote
 ```
 
-This will compile the react app and launch a browser on <http://localhost:3003>. We're using mostly chrome and firefox.. but you be you!
-Running `yarn start` will connect you to our [demo server](https://demo-open.msupply.org/)
+This will compile the React app and launch a browser on <http://localhost:3003>. We're using mostly chrome and firefox.. but you be you!
+Running `yarn start-remote` will connect you to our [demo server](https://demo-open.msupply.org/)
 You can log in using:
 
 *User*: developer
@@ -82,7 +87,8 @@ Your patch should follow the same conventions & pass the same code quality check
 The valdiation is running 
 
 ```sh
-yarn pre-commit-lint
+cd ./client
+yarn lint-and-format
 ```
 
 and you can run that yourself to test!
@@ -93,7 +99,7 @@ At this point, you should switch back to your main branch and make sure it's
 up to date with open mSupply's develop branch:
 
 ```sh
-git remote add upstream git@github.com:openmsupply/open-msupply.git
+git remote add upstream git@github.com:msupply-foundation/open-msupply.git
 git checkout develop
 git pull upstream develop
 ```
@@ -123,12 +129,12 @@ To learn more about rebasing in Git, there are a lot of [good][git rebasing] [re
 ```sh
 git checkout 325-fix-a-bug
 git pull --rebase upstream develop
-git push --force-with-lease fix-a-bug
+git push --force-with-lease origin 325-fix-a-bug
 ```
 
 [Stack Overflow]: http://stackoverflow.com/questions/tagged/activeadmin
-[new issue]: https://github.com//openmsupply/open-msupply/issues/new
-[fork Active Admin]: https://help.github.com/articles/fork-a-repo
+[new issue]: https://github.com/msupply-foundation/open-msupply/issues/new/choose
+[fork Open mSupply]: https://github.com/msupply-foundation/open-msupply/fork
 [make a pull request]: https://help.github.com/articles/creating-a-pull-request
 [git rebasing]: http://git-scm.com/book/en/Git-Branching-Rebasing
 [interactive rebase]: https://help.github.com/en/github/using-git/about-git-rebase

--- a/README.md
+++ b/README.md
@@ -33,26 +33,26 @@ There are also several ancilliary applications as noted, which are available to 
 
 We have some automations to build windows installers based on git tags. To create a build:
 
-1. Update the package version in `client/package.json` appropriately and commit it. [v1.0.4 example](https://github.com/openmsupply/open-msupply/blob/18b193ae0ecd16a5c48190a2a346cb459eeed30d/client/package.json#L3)
-2. Create a tag on your commit stating the version/build you're doing, but add `v` to the start. [v1.0.4 example](https://github.com/openmsupply/open-msupply/tree/v1.0.4)
-3. Our [Jenkins server](<[url](https://jenkins.msupply.org/)>) will pickup this tag and start the build process against the repo for the tagged commit
-4. A TMF staff member can download the generated executables from the Jenkins server and share them on the [releases](https://github.com/openmsupply/open-msupply/releases) page.
+1. Update the package version in `client/package.json` appropriately and commit it.
+2. Create a tag on your commit stating the version/build you're doing, but add `v` to the start (e.g. `v2.16.0`).
+3. Our [Jenkins server](https://jenkins.msupply.org/) will pickup this tag and start the build process against the repo for the tagged commit.
+4. A TMF staff member can download the generated executables from the Jenkins server and share them on the [releases](https://github.com/msupply-foundation/open-msupply/releases) page.
 
 #### Test builds
 
 For test builds feel welcome to just create the tag based off the current version of your base branch.
-For example a test build of `develop` might be [v1.0.4-test1](https://github.com/openmsupply/open-msupply/releases/tag/v1.0.3-test3).
+For example a test build of `develop` might be `v2.16.0-test1`.
 Continue incrementing the test version as builds are done.
 
 If you want to build your own branch, anything such as `v1.0.4-PR123-t1` will work great.
 
 #### Demo builds
 
-You can build a demo app for MacOS through actions: Run new workflow [from here](https://github.com/openmsupply/open-msupply/actions/workflows/build-mac-demo.yaml), this can take up to an hour
+You can build a demo app for MacOS through actions: Run new workflow [from here](https://github.com/msupply-foundation/open-msupply/actions/workflows/build-mac-demo.yaml), this can take up to an hour
 
 ![Mac Buid Dispatch](./doc/mac_demo_workflow_dispatch.png)
 
-Once the binary is compiled it should be available in the Artifacts of the action run: Find the [workflow run here](https://github.com/openmsupply/open-msupply/actions), then look at the Artifacts for that workflow run
+Once the binary is compiled it should be available in the Artifacts of the action run: Find the [workflow run here](https://github.com/msupply-foundation/open-msupply/actions), then look at the Artifacts for that workflow run
 
 ![Mac Build Artifact](./doc/mac_demo_artifact.png)
 


### PR DESCRIPTION
Fixes a handful of stale/broken links and commands in contributor docs:

- README: update Jenkins + GitHub URLs (org changed) and remove stale example links
- CONTRIBUTING: update good-first-issue/new-issue/fork URLs, fix upstream remote URL, and align dev/lint commands with current scripts (yarn start/start-remote, client lint-and-format)

No functional changes.

Fixes #10191
