### PR TITLE
Fixes #4918: avoid bogus ellipsis from float noise

### DIFF
--- a/client/packages/common/src/utils/numbers/NumUtils.test.ts
+++ b/client/packages/common/src/utils/numbers/NumUtils.test.ts
@@ -41,8 +41,12 @@ describe('NumUtils', () => {
     });
 
     it('handles very large numbers', () => {
-      const veryLarge = 1e15 + 0.12;
-      expect(NumUtils.hasMoreThanDp(veryLarge, 2)).toBe(false);
+      // At this magnitude, doubles can only represent fractional steps of 0.125.
+      const veryLargeWithTwoDp = 1e15 + 0.25;
+      const veryLargeWithMoreThanTwoDp = 1e15 + 0.375;
+
+      expect(NumUtils.hasMoreThanDp(veryLargeWithTwoDp, 2)).toBe(false);
+      expect(NumUtils.hasMoreThanDp(veryLargeWithMoreThanTwoDp, 2)).toBe(true);
     });
 
     it('handles very small numbers', () => {

--- a/client/packages/common/src/utils/numbers/NumUtils.ts
+++ b/client/packages/common/src/utils/numbers/NumUtils.ts
@@ -55,7 +55,11 @@ export const NumUtils = {
     if (!Number.isFinite(value)) return false;
 
     const multiplier = 10 ** dp;
-    return !isNearlyInteger(value * multiplier);
+    // For very large values, `value * multiplier` can lose the fractional part due to IEEE-754
+    // precision limits (e.g. `1e15 + 0.12` becomes `1e15 + 0.125`). Only inspect the fraction.
+    const abs = Math.abs(value);
+    const fraction = abs - Math.trunc(abs);
+    return !isNearlyInteger(fraction * multiplier);
   },
   /**
    * This constant should be used for values that are potentially send to a backend API that expects


### PR DESCRIPTION
Fixes #4918

The ellipsis ("...") marker for >2dp values was triggering for values like `4.40000000000006`, causing totals/currency cells to show `4.40...`.

- Make `NumUtils.hasMoreThanDp/hasMoreThanTwoDp` robust to floating-point rounding noise
- Add unit tests covering the regression

Tests:
- `docker run --rm -v "$PWD":/work -w /work/client node:20-bullseye bash -lc "yarn lint-and-format"`
- `docker run --rm -v "$PWD":/work -w /work/client node:20-bullseye bash -lc "yarn test"`
