### PR TITLE
Fixes #9695: disable editing for cancelled prescriptions

### DIFF
--- a/client/packages/invoices/src/Prescriptions/LineEditView/AllocationSection.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/AllocationSection.tsx
@@ -25,7 +25,9 @@ export const AllocationSection = ({
 
   return (
     <>
-      {showPrescribedQuantity && <AutoAllocatePrescribedQuantityField />}
+      {showPrescribedQuantity && (
+        <AutoAllocatePrescribedQuantityField disabled={disabled} />
+      )}
       <Grid display="flex" alignItems="center" gap={1}>
         <AutoAllocateField
           inputColor="white"
@@ -33,7 +35,7 @@ export const AllocationSection = ({
           autoFocus={!showPrescribedQuantity}
           disabled={disabled}
         />
-        <AllocateInSelector />
+        <AllocateInSelector disabled={disabled} />
       </Grid>
       {hasLines ? (
         <AccordionPanelSection

--- a/client/packages/invoices/src/Prescriptions/LineEditView/AutoAllocatePrescribedQuantityField.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/AutoAllocatePrescribedQuantityField.tsx
@@ -9,7 +9,11 @@ import {
 
 import { AllocateInType, useAllocationContext } from '../../StockOut';
 
-export const AutoAllocatePrescribedQuantityField = () => {
+export const AutoAllocatePrescribedQuantityField = ({
+  disabled = false,
+}: {
+  disabled?: boolean;
+}) => {
   const t = useTranslation();
   const { format } = useFormatNumber();
 
@@ -38,6 +42,8 @@ export const AutoAllocatePrescribedQuantityField = () => {
   );
 
   const handlePrescribedQuantityChange = (quantity: number | undefined) => {
+    if (disabled) return;
+
     // this method is also called onBlur... check that there actually has been a change
     // in quantity (to prevent triggering auto allocation if only focus has moved)
     if (quantity === prescribedQuantity) return;
@@ -54,7 +60,8 @@ export const AutoAllocatePrescribedQuantityField = () => {
         {t('label.prescribed-quantity')}
       </InputLabel>
       <NumericTextInput
-        autoFocus
+        autoFocus={!disabled}
+        disabled={disabled}
         value={prescribedQuantity ?? 0}
         onChange={handlePrescribedQuantityChange}
         slotProps={{ htmlInput: { sx: { backgroundColor: 'white' } } }}

--- a/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
@@ -111,6 +111,8 @@ export const PrescriptionLineEditView = () => {
   }, [allocationIsDirty]);
 
   const onSave = async () => {
+    if (isDisabled) return;
+
     // Save should only be enabled if we have an item anyway...
     const contextItemId = item?.id ?? itemId;
     if (!contextItemId) {
@@ -148,7 +150,12 @@ export const PrescriptionLineEditView = () => {
   if (!data) return <NothingHere />;
 
   const itemIdList = items.map(item => item.id);
-  if (status !== InvoiceNodeStatus.Verified) itemIdList.push('new');
+  if (
+    status !== InvoiceNodeStatus.Verified &&
+    status !== InvoiceNodeStatus.Cancelled
+  ) {
+    itemIdList.push('new');
+  }
 
   return (
     <>
@@ -197,6 +204,7 @@ export const PrescriptionLineEditView = () => {
       <Footer
         isSaving={isSavingLines}
         disabled={
+          isDisabled ||
           !item?.id ||
           !allocationIsDirty ||
           (allocatedQuantity === 0 && prescribedUnits === 0)

--- a/client/packages/invoices/src/StockOut/Components/AllocateInSelector.tsx
+++ b/client/packages/invoices/src/StockOut/Components/AllocateInSelector.tsx
@@ -12,8 +12,10 @@ import { canAutoAllocate } from '../utils';
 
 export const AllocateInSelector = ({
   includePackSizeOptions = false,
+  disabled = false,
 }: {
   includePackSizeOptions?: boolean;
+  disabled?: boolean;
 }) => {
   const t = useTranslation();
   const { format } = useFormatNumber();
@@ -102,6 +104,7 @@ export const AllocateInSelector = ({
         handleAllocateInChange(e.target.value as AllocateInType | number)
       }
       sx={{ width: '150px' }}
+      disabled={disabled}
     />
   );
 };


### PR DESCRIPTION
Fixes #9695

Cancelling a prescription could leave a brief window where the UI still allowed editing (quantity/directions), enabling Save and leading to a console error when attempting to persist changes.

- Update the cached prescription on successful update so the cancelled status (and `isDisabled`) is reflected immediately
- Ensure all LineEditView inputs respect the disabled state (including allocate-in + prescribed quantity)
- Disable Save (and creation via nav) when the prescription is cancelled/disabled

Tests:
- `docker run --rm -v "$PWD":/work -w /work/client node:20-bullseye bash -lc "yarn lint-and-format"`
- `docker run --rm -v "$PWD":/work -w /work/client node:20-bullseye bash -lc "yarn test"`
