### PR TITLE
10183 Fix login in APK issue

### DIFF
--- a/client/packages/common/src/authentication/AuthContext.tsx
+++ b/client/packages/common/src/authentication/AuthContext.tsx
@@ -124,10 +124,10 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
     setCookie(undefined);
     setError(AuthError.Timeout);
   });
-  const { setHeader } = useGql();
+  const { client } = useGql();
   const mostRecentUsername = mostRecentCredentials[0]?.username ?? undefined;
   // initialise the auth header with the cookie value i.e. on page refresh
-  setHeader('Authorization', `Bearer ${authCookie?.token}`);
+  client.setHeader('Authorization', `Bearer ${authCookie?.token}`);
   const setStore = async (store: UserStoreNodeFragment) => {
     if (!cookie?.token) return;
 

--- a/client/packages/common/src/authentication/api/hooks/useLogin.ts
+++ b/client/packages/common/src/authentication/api/hooks/useLogin.ts
@@ -87,7 +87,7 @@ export const useLogin = (
 ) => {
   const { mutateAsync, isLoading: isLoggingIn } = useGetAuthToken();
   const { changeLanguage, getLocaleCode, getUserLocale } = useIntlUtils();
-  const { setHeader, setSkipRequest } = useGql();
+  const { client, setSkipRequest } = useGql();
   const { mutateAsync: getUserDetails } = useGetUserDetails();
   const queryClient = useQueryClient();
   const api = useAuthApi();
@@ -133,7 +133,7 @@ export const useLogin = (
 
   const login = async (username: string, password: string) => {
     const { token, error } = await mutateAsync({ username, password });
-    setHeader('Authorization', `Bearer ${token}`);
+    client.setHeader('Authorization', `Bearer ${token}`);
     const userDetails = await getUserDetails(token);
     queryClient.setQueryData(api.keys.me(token), userDetails);
     const store = await getStore(userDetails, mostRecentCredentials);

--- a/client/packages/common/src/authentication/api/hooks/useRefreshToken.ts
+++ b/client/packages/common/src/authentication/api/hooks/useRefreshToken.ts
@@ -9,10 +9,7 @@ import { useGetRefreshToken } from './useGetRefreshToken';
 
 export const useRefreshToken = (onTimeout: () => void) => {
   const { mutateAsync } = useGetRefreshToken();
-  const {
-    setHeader,
-    client: { getLastRequestTime },
-  } = useGql();
+  const { client } = useGql();
 
   const refreshToken = () => {
     const authCookie = getAuthCookie();
@@ -27,7 +24,7 @@ export const useRefreshToken = (onTimeout: () => void) => {
 
     const minutesSinceLastRequest = DateUtils.differenceInMinutes(
       Date.now(),
-      getLastRequestTime()
+      client.getLastRequestTime()
     );
 
     const expiresSoon = expiresIn === 1 || expiresIn === 2;
@@ -42,7 +39,7 @@ export const useRefreshToken = (onTimeout: () => void) => {
         const token = data?.token ?? '';
         const newCookie = { ...authCookie, token };
         setAuthCookie(newCookie);
-        setHeader('Authorization', `Bearer ${token}`);
+        client.setHeader('Authorization', `Bearer ${token}`);
       });
     }
   };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10183

# 👩🏻‍💻 What does this PR do?

In an attempt to fix #10183 and while reviewing related PRs, I wanted to fix this at the root.

I found that a preference and another query is using previous token in the authorisation header, after login, while other queries before it and after are using new token. 

It looks like our wrapper around graphql client is loosing this somehow, I've changed to:

* When extending use extend rather then composition 
* Use setHeader directly from client, otherwise we are loosing this binding

## 💌 Any notes for the reviewer?


# 🧪 Testing

In APK (seems to work fine in normal browser ¯\_(ツ)_/¯).

Login. The close app, then try login again (should see error without this fix)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

