### PR TITLE
7729 discrepancies between view stock (line) and view stock (detailed)

### DIFF
--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -311,18 +311,6 @@ export const StockLineForm = ({
                   }
                 />
                 <StyledInputRow
-                  label={t('label.expiry')}
-                  Input={
-                    <ExpiryDateInput
-                      value={DateUtils.getNaiveDate(draft.expiryDate)}
-                      onChange={date =>
-                        onUpdate({ expiryDate: Formatter.naiveDate(date) })
-                      }
-                      width={160}
-                    />
-                  }
-                />
-                <StyledInputRow
                   label={t('label.batch')}
                   Input={
                     <BufferedTextInput
@@ -407,6 +395,18 @@ export const StockLineForm = ({
                             : draft.sellPricePerPack,
                         });
                       }}
+                    />
+                  }
+                />
+                <StyledInputRow
+                  label={t('label.expiry')}
+                  Input={
+                    <ExpiryDateInput
+                      value={DateUtils.getNaiveDate(draft.expiryDate)}
+                      onChange={date =>
+                        onUpdate({ expiryDate: Formatter.naiveDate(date) })
+                      }
+                      width={160}
                     />
                   }
                 />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7729

# 👩🏻‍💻 What does this PR do?
- Adds missing unit, total and available in units to detail view
- Move expiry date so that both sides are balanced

<img width="677" height="451" alt="Screenshot 2026-01-09 at 9 08 58 AM" src="https://github.com/user-attachments/assets/9f4e3658-e004-473e-a6e9-6af3db3b1275" />

I didn't do the rename suggested in the issue since we use the same terminology everywhere... Do we want to show what master list it is in? OG doesn't but OMS...

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Check detail view matches list view (minus master list)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

