### PR TITLE
Fix barcode scanning imports and Electron API null-safety

### DIFF
--- a/client/packages/coldchain/src/Equipment/ListView/AddFromScannerButton.tsx
+++ b/client/packages/coldchain/src/Equipment/ListView/AddFromScannerButton.tsx
@@ -21,7 +21,7 @@ import {
 import { AppRoute } from '@openmsupply-client/config';
 import { useAssets } from '../api';
 import { DraftAsset } from '../types';
-import { BarcodeFormat } from '@capacitor-mlkit/barcode-scanning/dist/esm/definitions';
+import { BarcodeFormat } from '@capacitor-mlkit/barcode-scanning';
 
 export const AddFromScannerButtonComponent = () => {
   const t = useTranslation();

--- a/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
+++ b/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
@@ -23,7 +23,7 @@ import { useAuthContext } from '../../authentication';
 
 declare global {
   interface Window {
-    electronNativeAPI: NativeAPI;
+    electronNativeAPI?: NativeAPI;
   }
 }
 

--- a/client/packages/common/src/utils/BarcodeScannerContext.tsx
+++ b/client/packages/common/src/utils/BarcodeScannerContext.tsx
@@ -255,9 +255,12 @@ export const BarcodeScannerProvider: FC<PropsWithChildrenOnly> = ({
   };
 
   const setScannerType = (type: ScannerType) => {
-    electronNativeAPI.setScannerType(type);
-    electronNativeAPI?.linkedBarcodeScannerDevice().then(setScanner);
     setLocalScannerType(type);
+
+    if (!electronNativeAPI) return;
+
+    electronNativeAPI.setScannerType(type);
+    electronNativeAPI.linkedBarcodeScannerDevice().then(setScanner);
   };
   // calling this outside of a useEffect so that it will detect when a new scanner is added
   useEffect(() => {

--- a/client/packages/host/src/Admin/ElectronSettings.tsx
+++ b/client/packages/host/src/Admin/ElectronSettings.tsx
@@ -85,12 +85,14 @@ export const ElectronSettings = () => {
 
     const getDevicePromise = () =>
       new Promise<BarcodeScanner | undefined>(async resolve => {
-        const { startDeviceScan } = electronNativeAPI;
-        await startDeviceScan();
+        if (!electronNativeAPI) {
+          resolve(undefined);
+          return;
+        }
 
-        electronNativeAPI.onDeviceMatched((_event, scanner) =>
-          resolve(scanner)
-        );
+        await electronNativeAPI.startDeviceScan();
+
+        electronNativeAPI.onDeviceMatched((_event, scanner) => resolve(scanner));
       });
 
     try {


### PR DESCRIPTION
This PR makes barcode scanning code more robust across web/Electron/native.

Changes:
- Avoid deep-importing `BarcodeFormat` from `@capacitor-mlkit/barcode-scanning/dist/...`.
- Treat `window.electronNativeAPI` as optional for web builds.
- Guard `setScannerType` against missing Electron API.
- Keep React hooks usage valid in Electron settings while handling optional API.

Checks run:
- `cd client && yarn lint-and-format`
- `cd client && yarn test`

Fixes #10223