### PR TITLE
CI: make PR workflows fork-friendly

### DIFF
--- a/.github/workflows/client-bundle-size-diff.yaml
+++ b/.github/workflows/client-bundle-size-diff.yaml
@@ -102,6 +102,8 @@ jobs:
           pr_path: "./pr/stats.json"
 
       - name: Comment
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        continue-on-error: true
         uses: NejcZdovc/comment-pr@v1
         with:
           file: "comment.md"

--- a/.github/workflows/pr-issue-label-sync.yaml
+++ b/.github/workflows/pr-issue-label-sync.yaml
@@ -12,7 +12,6 @@ jobs:
         with:
           script: |
             core.debug(`where the PR? ${context.repo.repo} ${context.repo.owner} ${context.issue.number}`);
-            let x = 1
             const pullRequestResult = await github.graphql(`
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(name: $repo, owner: $owner) {
@@ -53,10 +52,12 @@ jobs:
 
             if (!issue) {
               const regex = new RegExp(/#(\d+)/);
-              const issueNumber = Number(pullRequest.body.match(regex)[1])
+              const match = pullRequest.body?.match(regex)
+              const issueNumber = match ? Number(match[1]) : undefined
 
-              if  (!issueNumber) {
-                throw new Error('No associated issue found for this pull request. Not even in the body!')
+              if (!issueNumber) {
+                core.notice('No associated issue found for this pull request. Skipping label sync.')
+                return
               }
 
               const issueResult = await github.graphql(`
@@ -84,23 +85,17 @@ jobs:
               issue = issueResult.repository.issue
 
               if (!issue) {
-                throw new Error('No associated issue found for this pull request. There was a match in the description, but not to an issue: ${issueNumber}')
+                throw new Error(`No associated issue found for this pull request. There was a match in the description, but not to an issue: ${issueNumber}`)
               }
             }
 
             core.debug(issue)
 
-            core.debug(x++)
             const pullRequestId = pullRequest.id
-            core.debug(x++)
             const pullRequestLabelIds = pullRequest.labels.nodes.map(label => label.id)
-            core.debug(x++)
             const issueLabelIds = issue.labels.nodes.map(label => label.id)
-            core.debug(x++)
-            const labelIds = issueLabelIds.concat(pullRequestLabelIds)
-            core.debug(x++)
+            const labelIds = [...new Set(issueLabelIds.concat(pullRequestLabelIds))]
             const milestoneId = issue.milestone && issue.milestone.id // Linked issue might not have a milestone
-            core.debug(x++)
 
             const mutationResult = await github.graphql(`
               mutation($labelIds: [ID!] = "", $pullRequestId: ID!, $milestoneId: ID = "") {


### PR DESCRIPTION
This makes two contributor-facing PR workflows more robust:

- **Label sync**: avoid hard-failing when a PR has no linked/mentioned issue (skip with a notice instead).
- **Bundle size diff**: skip the PR comment step on fork PRs (token permissions), and don't fail the workflow if commenting fails.

Motivation: fork PRs currently show failing checks even when builds/tests pass, which adds friction for external contributors and reviewers.

Fixes #10226