### PR TITLE
10205 add store preference for 'Inbound shipment (external) lines must be authorised'

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2244,6 +2244,7 @@
   "preference.disableManualReturns": "Disable manual returns",
   "preference.expiredStockIssueThreshold": "Expired stock issue threshold (days)",
   "preference.expiredStockPreventIssue": "Prevent issuing expired stock",
+  "preference.externalInboundShipmentLinesMustBeAuthorised": "Inbound shipment (external) lines must be authorised",
   "preference.firstThresholdForExpiringItems": "First threshold for expiring items (days)",
   "preference.genderOptions": "Gender options",
   "preference.inboundShipmentAutoVerify": "Automatically verify inbound shipments",

--- a/server/graphql/preference/src/upsert.rs
+++ b/server/graphql/preference/src/upsert.rs
@@ -78,6 +78,7 @@ pub struct UpsertPreferencesInput {
     pub inbound_shipment_auto_verify: Option<Vec<BoolStorePrefInput>>,
     pub can_create_internal_order_from_a_requisition: Option<Vec<BoolStorePrefInput>>,
     pub select_destination_store_for_an_internal_order: Option<Vec<BoolStorePrefInput>>,
+    pub external_inbound_shipment_lines_must_be_authorised: Option<Vec<BoolStorePrefInput>>,
     pub number_of_months_to_check_for_consumption_when_calculating_out_of_stock_products:
         Option<Vec<IntegerStorePrefInput>>,
     pub number_of_months_threshold_to_show_low_stock_alerts_for_products:
@@ -153,6 +154,7 @@ impl UpsertPreferencesInput {
             warn_when_missing_recent_stocktake,
             store_custom_colour,
             invoice_status_options,
+            external_inbound_shipment_lines_must_be_authorised,
         } = self;
 
         UpsertPreferences {
@@ -240,6 +242,10 @@ impl UpsertPreferencesInput {
             invoice_status_options: invoice_status_options
                 .as_ref()
                 .map(|i| i.iter().map(|i| i.to_domain()).collect()),
+            external_inbound_shipment_lines_must_be_authorised:
+                external_inbound_shipment_lines_must_be_authorised
+                    .as_ref()
+                    .map(|i| i.iter().map(|i| i.to_domain()).collect()),
         }
     }
 }

--- a/server/graphql/types/src/types/preferences.rs
+++ b/server/graphql/types/src/types/preferences.rs
@@ -276,6 +276,7 @@ pub enum PreferenceKey {
     WarningForExcessRequest,
     CanCreateInternalOrderFromARequisition,
     SelectDestinationStoreForAnInternalOrder,
+    ExternalInboundShipmentLinesMustBeAuthorised,
     NumberOfMonthsToCheckForConsumptionWhenCalculatingOutOfStockProducts,
     NumberOfMonthsThresholdToShowLowStockAlertsForProducts,
     NumberOfMonthsThresholdToShowOverStockAlertsForProducts,

--- a/server/service/src/preference/mod.rs
+++ b/server/service/src/preference/mod.rs
@@ -54,6 +54,7 @@ pub trait PreferenceServiceTrait: Sync + Send {
             inbound_shipment_auto_verify,
             can_create_internal_order_from_a_requisition,
             select_destination_store_for_an_internal_order,
+            external_inbound_shipment_lines_must_be_authorised,
             number_of_months_to_check_for_consumption_when_calculating_out_of_stock_products,
             number_of_months_threshold_to_show_low_stock_alerts_for_products,
             number_of_months_threshold_to_show_over_stock_alerts_for_products,
@@ -111,6 +112,11 @@ pub trait PreferenceServiceTrait: Sync + Send {
         )?;
         append_if_type(
             select_destination_store_for_an_internal_order,
+            &mut prefs,
+            &input,
+        )?;
+        append_if_type(
+            external_inbound_shipment_lines_must_be_authorised,
             &mut prefs,
             &input,
         )?;

--- a/server/service/src/preference/preferences/external_inbound_shipment_lines_must_be_authorised.rs
+++ b/server/service/src/preference/preferences/external_inbound_shipment_lines_must_be_authorised.rs
@@ -1,0 +1,19 @@
+use crate::preference::{PrefKey, Preference, PreferenceType, PreferenceValueType};
+
+pub struct ExternalInboundShipmentLinesMustBeAuthorised;
+
+impl Preference for ExternalInboundShipmentLinesMustBeAuthorised {
+    type Value = bool;
+
+    fn key(&self) -> PrefKey {
+        PrefKey::ExternalInboundShipmentLinesMustBeAuthorised
+    }
+
+    fn preference_type(&self) -> PreferenceType {
+        PreferenceType::Store
+    }
+
+    fn value_type(&self) -> PreferenceValueType {
+        PreferenceValueType::Boolean
+    }
+}

--- a/server/service/src/preference/preferences/mod.rs
+++ b/server/service/src/preference/preferences/mod.rs
@@ -32,6 +32,8 @@ pub mod disable_manual_returns;
 pub use disable_manual_returns::*;
 pub mod requisition_auto_finalise;
 pub use requisition_auto_finalise::*;
+pub mod external_inbound_shipment_lines_must_be_authorised;
+pub use external_inbound_shipment_lines_must_be_authorised::*;
 pub mod inbound_shipment_auto_verify;
 pub use inbound_shipment_auto_verify::*;
 pub mod warning_for_excess_request;
@@ -98,6 +100,8 @@ pub struct PreferenceProvider {
     pub disable_manual_returns: DisableManualReturns,
     pub can_create_internal_order_from_a_requisition: CanCreateInternalOrderFromARequisition,
     pub select_destination_store_for_an_internal_order: SelectDestinationStoreForAnInternalOrder,
+    pub external_inbound_shipment_lines_must_be_authorised:
+        ExternalInboundShipmentLinesMustBeAuthorised,
     pub number_of_months_to_check_for_consumption_when_calculating_out_of_stock_products:
         NumberOfMonthsToCheckForConsumptionWhenCalculatingOutOfStockProducts,
     pub number_of_months_threshold_to_show_low_stock_alerts_for_products:
@@ -143,6 +147,8 @@ pub fn get_preference_provider() -> PreferenceProvider {
         inbound_shipment_auto_verify: InboundShipmentAutoVerify,
         can_create_internal_order_from_a_requisition: CanCreateInternalOrderFromARequisition,
         select_destination_store_for_an_internal_order: SelectDestinationStoreForAnInternalOrder,
+        external_inbound_shipment_lines_must_be_authorised:
+            ExternalInboundShipmentLinesMustBeAuthorised,
         number_of_months_to_check_for_consumption_when_calculating_out_of_stock_products:
             NumberOfMonthsToCheckForConsumptionWhenCalculatingOutOfStockProducts,
         number_of_months_threshold_to_show_low_stock_alerts_for_products:

--- a/server/service/src/preference/types.rs
+++ b/server/service/src/preference/types.rs
@@ -41,6 +41,7 @@ pub enum PrefKey {
     InboundShipmentAutoVerify,
     CanCreateInternalOrderFromARequisition,
     SelectDestinationStoreForAnInternalOrder,
+    ExternalInboundShipmentLinesMustBeAuthorised,
     NumberOfMonthsToCheckForConsumptionWhenCalculatingOutOfStockProducts,
     NumberOfMonthsThresholdToShowLowStockAlertsForProducts,
     NumberOfMonthsThresholdToShowOverStockAlertsForProducts,

--- a/server/service/src/preference/upsert.rs
+++ b/server/service/src/preference/upsert.rs
@@ -43,6 +43,7 @@ pub struct UpsertPreferences {
     pub inbound_shipment_auto_verify: Option<Vec<StorePrefUpdate<bool>>>,
     pub can_create_internal_order_from_a_requisition: Option<Vec<StorePrefUpdate<bool>>>,
     pub select_destination_store_for_an_internal_order: Option<Vec<StorePrefUpdate<bool>>>,
+    pub external_inbound_shipment_lines_must_be_authorised: Option<Vec<StorePrefUpdate<bool>>>,
     pub number_of_months_to_check_for_consumption_when_calculating_out_of_stock_products:
         Option<Vec<StorePrefUpdate<i32>>>,
     pub number_of_months_threshold_to_show_low_stock_alerts_for_products:
@@ -92,6 +93,7 @@ pub fn upsert_preferences(
             can_create_internal_order_from_a_requisition_input,
         select_destination_store_for_an_internal_order:
             select_destination_store_for_an_internal_order_input,
+        external_inbound_shipment_lines_must_be_authorised: external_inbound_shipment_lines_must_be_authorised_input,
         number_of_months_to_check_for_consumption_when_calculating_out_of_stock_products:
             number_of_months_to_check_for_consumption_when_calculating_out_of_stock_products_input,
         number_of_months_threshold_to_show_low_stock_alerts_for_products:
@@ -144,6 +146,7 @@ pub fn upsert_preferences(
         warn_when_missing_recent_stocktake,
         store_custom_colour,
         invoice_status_options,
+        external_inbound_shipment_lines_must_be_authorised,
     }: PreferenceProvider = get_preference_provider();
 
     ctx.connection
@@ -265,8 +268,12 @@ pub fn upsert_preferences(
                 )?;
             }
 
+            if let Some(input) = external_inbound_shipment_lines_must_be_authorised_input {
+                upsert_store_input(connection, external_inbound_shipment_lines_must_be_authorised, input)?;
+            }
+
             if let Some(input) = number_of_months_to_check_for_consumption_when_calculating_out_of_stock_products_input {
-                           upsert_store_input(
+                upsert_store_input(
                     connection,
                     number_of_months_to_check_for_consumption_when_calculating_out_of_stock_products,
                     input,
@@ -274,7 +281,7 @@ pub fn upsert_preferences(
             }
 
              if let Some(input) = number_of_months_threshold_to_show_low_stock_alerts_for_products_input {
-                           upsert_store_input(
+                upsert_store_input(
                     connection,
                     number_of_months_threshold_to_show_low_stock_alerts_for_products,
                     input,
@@ -282,7 +289,7 @@ pub fn upsert_preferences(
             }
 
             if let Some(input) = number_of_months_threshold_to_show_over_stock_alerts_for_products_input {
-                           upsert_store_input(
+                upsert_store_input(
                     connection,
                     number_of_months_threshold_to_show_over_stock_alerts_for_products,
                     input,
@@ -290,7 +297,7 @@ pub fn upsert_preferences(
             }
             
             if let Some(input) = first_threshold_for_expiring_items_input {
-                           upsert_store_input(
+                upsert_store_input(
                     connection,
                     first_threshold_for_expiring_items,
                     input,
@@ -298,7 +305,7 @@ pub fn upsert_preferences(
             }
 
             if let Some(input) = second_threshold_for_expiring_items_input {
-                           upsert_store_input(
+                upsert_store_input(
                     connection,
                     second_threshold_for_expiring_items,
                     input,
@@ -306,7 +313,7 @@ pub fn upsert_preferences(
             }
 
             if let Some(input) = warn_when_missing_recent_stocktake_input {
-                           upsert_store_input(
+                upsert_store_input(
                     connection,
                     warn_when_missing_recent_stocktake,
                     input,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10205

# 👩🏻‍💻 What does this PR do?

Add store preference for 'Inbound shipment (external) lines must be authorised'. To be used later.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to store preferences
- [ ] See new preference

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

