### PR TITLE
5209 Vaccine course - unable to fully backspace wastage/coverage rate number

### DIFF
--- a/client/packages/programs/src/VaccineCourseEditModal/VaccineCourseEditModal.tsx
+++ b/client/packages/programs/src/VaccineCourseEditModal/VaccineCourseEditModal.tsx
@@ -105,11 +105,10 @@ export const VaccineCourseEditModal: FC<VaccineCourseEditModalProps> = ({
     isDirty,
     resetDraft,
   } = useVaccineCourse(vaccineCourse?.id ?? undefined);
+  const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
   const doses = draft.vaccineCourseDoses ?? [];
 
   const { data: demographicData } = useDemographicData.demographics.list();
-
-  const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
 
   const options = useMemo(
     () => getDemographicOptions(demographicData?.nodes ?? []),
@@ -165,6 +164,12 @@ export const VaccineCourseEditModal: FC<VaccineCourseEditModalProps> = ({
   const isValid =
     draft.name.trim() &&
     !draft.vaccineCourseDoses?.some(dose => !dose.label.trim());
+  const disable =
+    !isDirty ||
+    !programId ||
+    !isValid ||
+    draft.wastageRate === undefined ||
+    draft.coverageRate === undefined;
 
   const modalContent = isLoading ? (
     <BasicSpinner />
@@ -248,13 +253,7 @@ export const VaccineCourseEditModal: FC<VaccineCourseEditModalProps> = ({
           : t('heading.edit-vaccine-course')
       }
       cancelButton={<DialogButton variant="cancel" onClick={onClose} />}
-      okButton={
-        <DialogButton
-          disabled={!isDirty || !programId || !isValid}
-          variant="ok"
-          onClick={save}
-        />
-      }
+      okButton={<DialogButton disabled={disable} variant="ok" onClick={save} />}
       height={900}
       width={1100}
       slideAnimation={false}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5209

# 👩🏻‍💻 What does this PR do?
Allow clearing of coverage & wastage rates and make the max % 100.. 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to immunisation and create a vaccine course
- [ ] Should be able to clear coverage / wastage rates
- [ ] Shouldn't be able to enter a number > 100

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

