### PR TITLE
fix: crate recompilation

### DIFF
--- a/server/repository/build.rs
+++ b/server/repository/build.rs
@@ -28,7 +28,6 @@ fn main() {
         }
     }
 
-    println!("cargo:rerun-if-changed=migrations");
     println!("cargo:rerun-if-changed=src/migrations");
     println!("cargo:rerun-if-changed=src/mock");
 }


### PR DESCRIPTION
Fixes # 10259

# 👩🏻‍💻 What does this PR do?

Repository crate always triggers recompilation due to missing migrations folder. This fix, removes the rerun-if-changed command for said folder

## 💌 Any notes for the reviewer?

# 🧪 Testing

run `cargo build` multiple times to check if recompilation is no longer triggered without changes

# 📃 Documentation

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [x] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [x] Postgres
- [x] SQLite
- [x] Frontend

