### PR TITLE
5519 View Stock > Stock line details: item code is missing / not displayed

### DIFF
--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -27,7 +27,6 @@ import {
   Alert,
   RouteBuilder,
   Link,
-  FormLabel,
 } from '@openmsupply-client/common';
 import { DraftStockLine, StockLineRowFragment } from '../api';
 import { LocationSearchInput } from '../../Location/Components/LocationSearchInput';
@@ -161,47 +160,40 @@ export const StockLineForm = ({
         >
           {!isNewModal && (
             <Box paddingBottom={1}>
-              <Box display="flex" alignItems="center">
-                <Box style={{ textAlign: 'end', whiteSpace: 'nowrap' }}>
-                  <FormLabel
-                    sx={{
-                      fontWeight: 'bold',
-                      display: 'inline-block',
-                      width: '100px',
-                    }}
-                  >
-                    {t('label.item')}:
-                  </FormLabel>
-                </Box>
-                <Box paddingLeft={1} paddingRight={1.5}>
-                  <Box>
-                    <Link
-                      to={RouteBuilder.create(AppRoute.Catalogue)
-                        .addPart(AppRoute.Items)
-                        .addPart(draft.itemId)
-                        .build()}
-                    >
-                      {draft.item.name}
-                    </Link>
-                  </Box>
-                </Box>
+              <TextWithLabelRow
+                label={`${t('label.item')}`}
+                text={''}
+                labelProps={{ sx: { fontWeight: 'bold', width: '100px' } }}
+                textProps={{ sx: { pl: 1 } }}
+              />
+              <Box
+                sx={{
+                  paddingLeft: '110px',
+                  marginTop: '-24px',
+                  marginBottom: '8px',
+                }}
+              >
+                <Link
+                  to={RouteBuilder.create(AppRoute.Catalogue)
+                    .addPart(AppRoute.Items)
+                    .addPart(draft.itemId)
+                    .build()}
+                >
+                  {draft.item.name}
+                </Link>
               </Box>
-              <Box display="flex" alignItems="center">
-                <Box style={{ textAlign: 'end', whiteSpace: 'nowrap' }}>
-                  <FormLabel
-                    sx={{
-                      fontWeight: 'bold',
-                      display: 'inline-block',
-                      width: '100px',
-                    }}
-                  >
-                    {t('label.unit')}:
-                  </FormLabel>
-                </Box>
-                <Box paddingLeft={1} paddingRight={1.5}>
-                  <Box>{draft.item.unitName}</Box>
-                </Box>
-              </Box>
+              <TextWithLabelRow
+                label={`${t('label.code')}`}
+                text={draft.item.code}
+                labelProps={{ sx: { fontWeight: 'bold', width: '100px' } }}
+                textProps={{ sx: { pl: 1 } }}
+              />
+              <TextWithLabelRow
+                label={`${t('label.unit')}`}
+                text={draft.item.unitName ?? ''}
+                labelProps={{ sx: { fontWeight: 'bold', width: '100px' } }}
+                textProps={{ sx: { pl: 1 } }}
+              />
             </Box>
           )}
           <Box>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5519

# 👩🏻‍💻 What does this PR do?
Show item code in stock view

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to stock
- [ ] Click stock line
- [ ] Should see item code

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

