### PR TITLE
5847 User information disappears from new user popup when switching stores

### DIFF
--- a/client/packages/common/src/authentication/AuthContext.tsx
+++ b/client/packages/common/src/authentication/AuthContext.tsx
@@ -136,6 +136,8 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
       id: cookie.user?.id ?? '',
       name: cookie.user?.name ?? '',
       permissions,
+      email: cookie.user?.email,
+      jobTitle: cookie.user?.jobTitle,
     };
     const newCookie = { ...cookie, store, user };
     setAuthCookie(newCookie);

--- a/client/packages/common/src/authentication/hooks/useUpdateUserInfo.ts
+++ b/client/packages/common/src/authentication/hooks/useUpdateUserInfo.ts
@@ -45,9 +45,11 @@ export const useUpdateUserInfo = (
             store,
             token: cookie?.token ?? '',
             user: {
-              id: cookie?.user?.id ?? '',
+              id: userDetails?.userId ?? '',
               name: cookie?.user?.name ?? '',
               permissions,
+              email: userDetails?.email,
+              jobTitle: userDetails?.jobTitle,
             },
           };
           setCookie(authCookie);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5847

# 👩🏻‍💻 What does this PR do?
Saves email and job title in cookie so that it persists even when swapping store since we return the cookie user in auth

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Click on the username in the footer
- [ ] If you have email & job title set up should see those
- [ ] Swap stores
- [ ] Email & job title should persist

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

