### PR TITLE
fix: add validation for test database names

### DIFF
--- a/server/repository/src/test_db/mod.rs
+++ b/server/repository/src/test_db/mod.rs
@@ -115,3 +115,30 @@ pub async fn setup_test(
         db_settings,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[should_panic(expected = "contains spaces")]
+    async fn test_db_name_validation_panics_with_spaces() {
+        setup_test(SetupOption {
+            db_name: "test db with spaces",
+            ..Default::default()
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_db_name_validation_succeeds_when_valid() {
+        let db_name = "test_db_without_spaces";
+        let result = setup_test(SetupOption {
+            db_name,
+            ..Default::default()
+        })
+        .await;
+
+        assert!(result.db_settings.database_name.contains(db_name));
+    }
+}


### PR DESCRIPTION
Fixes #10264 

# 👩🏻‍💻 What does this PR do?

Adds db name validation for tests.
Panics if spaces are found in the db name.

## 💌 Any notes for the reviewer?

# 🧪 Testing

- [ ] Checkout this branch
- [ ] run `cargo test`
- [ ] See that some tests panic

# 📃 Documentation

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

