### PR TITLE
5525 item_variants_configured is inefficient

### DIFF
--- a/server/graphql/item_variant/src/lib.rs
+++ b/server/graphql/item_variant/src/lib.rs
@@ -3,6 +3,7 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
+use repository::PaginationOption;
 use service::auth::{Resource, ResourceAccessRequest};
 
 mod mutations;
@@ -31,7 +32,15 @@ impl ItemVariantQueries {
 
         let item_variants = service_provider
             .item_service
-            .get_item_variants(&service_context, None, None, None)
+            .get_item_variants(
+                &service_context,
+                Some(PaginationOption {
+                    limit: Some(1),
+                    offset: None,
+                }),
+                None,
+                None,
+            )
             .map_err(StandardGraphqlError::from_list_error)?;
 
         Ok(item_variants.count > 0)

--- a/server/service/src/item/item_variant/query.rs
+++ b/server/service/src/item/item_variant/query.rs
@@ -1,12 +1,10 @@
+use crate::{get_pagination_or_default, i64_to_u32, ListError, ListResult};
 use repository::{
     item_variant::item_variant::{
         ItemVariant, ItemVariantFilter, ItemVariantRepository, ItemVariantSort,
     },
     PaginationOption, StorageConnection,
 };
-
-use crate::{get_pagination_or_default, i64_to_u32, ListError, ListResult};
- 
 
 pub fn get_item_variants(
     connection: &StorageConnection,
@@ -16,6 +14,7 @@ pub fn get_item_variants(
 ) -> Result<ListResult<ItemVariant>, ListError> {
     let pagination = get_pagination_or_default(pagination)?;
     let repository = ItemVariantRepository::new(connection);
+
     Ok(ListResult {
         rows: repository.query(pagination, filter.clone(), sort)?,
         count: i64_to_u32(repository.count(filter)?),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5525

# 👩🏻‍💻 What does this PR do?
Only query for first variant if it doesn't exist then item variants aren't configured

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Don't have item variants set up 
- [ ] Go add an item in inbound shipment -> Shouldn't see variants selection
- [ ] If you have variants then you should see the selection
- [ ] Set up 300 + variants and try loading inbound shipment (check before and after loading times.. should be faster)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

