### PR TITLE
10282 VVM Type for Vaccine's Items variants is not visible in shipments

### DIFF
--- a/client/packages/system/src/Item/Components/ItemVariantSelector/columns.tsx
+++ b/client/packages/system/src/Item/Components/ItemVariantSelector/columns.tsx
@@ -52,8 +52,8 @@ export const useItemVariantSelectorColumns = ({
         Cell: TextWithTooltipCell,
       },
       {
-        accessorKey: 'vvmStatus',
-        header: t('label.vvm-status'),
+        accessorKey: 'vvmType',
+        header: t('label.vvm-type'),
         Cell: TextWithTooltipCell,
         includeColumn: isVaccine,
       },


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10282

# 👩🏻‍💻 What does this PR do?
Item variants don't save the vvm status, they save type... 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have item variants set up on vaccine item and type something for vvm type
- [ ] Go to inbound and add vaccine to inbound, click item variant
- [ ] Should see vvm type

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

