### PR TITLE
fix: postgres markers being deleted during template recreation

### DIFF
--- a/server/repository/src/test_db/sqlite.rs
+++ b/server/repository/src/test_db/sqlite.rs
@@ -14,7 +14,8 @@ use crate::{
 };
 
 use super::constants::{
-    env_msupply_no_test_db_template, find_workspace_root, TEMPLATE_MARKER_FILE_SQLITE, TEST_OUTPUT_DIR,
+    env_msupply_no_test_db_template, find_workspace_root, TEMPLATE_MARKER_FILE_POSTGRES,
+    TEMPLATE_MARKER_FILE_SQLITE, TEST_OUTPUT_DIR,
 };
 
 pub fn get_test_db_settings(db_name: &str) -> DatabaseSettings {
@@ -102,16 +103,16 @@ pub(crate) async fn setup_with_version(
             // remove all DB templates
             for entry in fs::read_dir(&template_output_dir).unwrap() {
                 let entry = entry.unwrap();
-                if entry.file_name().to_string_lossy() == TEMPLATE_MARKER_FILE_SQLITE {
-                    // delete marker after all template DBs to ensure we deleted all DBs, e.g. if
-                    // this loop is interrupted
+                let file_name = entry.file_name().to_string_lossy().to_string();
+
+                // delete marker after all template DBs to ensure we deleted all DBs, e.g. if
+                // this loop is interrupted by user
+                if file_name == TEMPLATE_MARKER_FILE_SQLITE || file_name == TEMPLATE_MARKER_FILE_POSTGRES {
                     continue;
                 }
-                if entry
-                    .file_name()
-                    .to_string_lossy()
-                    .starts_with("___template_")
-                {
+
+                // Only delete sqlite template database files
+                if file_name.starts_with("___template_") && file_name.ends_with(".sqlite") {
                     fs::remove_file(entry.path()).unwrap();
                 }
             }


### PR DESCRIPTION
Fixes #10304 

# 👩🏻‍💻 What does this PR do?

Fixes a bug with how template regeneration for sqlite tests deletes postgres marker files.

## 💌 Any notes for the reviewer?

# 🧪 Testing

- [ ] Run unit tests for sqlite and postgres
- [ ] Add a test migration
- [ ] Build the project with `cargo build`
- [ ] Check `server/repository/test_output` for marker files (ending with .marker and .pg.marker)
- [ ] Run `cargo nextest run` from `server` directory
- [ ] Check `server/repository/test_output` for marker files (only .pg.marker file should remain)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

