### PR TITLE
7699 Location font size as other columns, when add item to outbound shipment

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.tsx
@@ -288,7 +288,8 @@ export const useOutboundLineEditColumns = ({
 const LocationCell = ({ row }: { row: MRT_Row<DraftStockOutLineFragment> }) => {
   const t = useTranslation();
 
-  const { code = '', onHold = false } = row.original.location || {};
+  const { code = UNDEFINED_STRING_VALUE, onHold = false } =
+    row.original.location || {};
 
   const onHoldText = onHold ? ` (${t('label.on-hold')})` : '';
 


### PR DESCRIPTION
Fixes #7699 

# 👩🏻‍💻 What does this PR do?

This PR makes the font size consistent in the location column as the other columns, when adding an item to an outbound shipment

Before this PR the font size was larger in the location column:
<img width="2828" height="1474" alt="image" src="https://github.com/user-attachments/assets/c1b48e89-a5b6-42b0-8b05-01f276adddcd" />


After this PR it is consistent across all columns
<img width="2764" height="1484" alt="image" src="https://github.com/user-attachments/assets/1ba80b71-0222-4620-8dd0-136cfafcb70c" />



In addition, small improvement that when there is no location for the item then it shows a dash like how it does for no donor (previously no location was blank)
<img width="2798" height="1642" alt="image" src="https://github.com/user-attachments/assets/5a715d71-6ef8-4969-9e93-4aa2b474bbf5" />


## 💌 Any notes for the reviewer?

Low risk

# 🧪 Testing

To test:
- Go to /distribution/outbound-shipment
- Create a new outboundshipment
- Click add item
- Select an item which has a location
- Observe the font size in the location column compared to other columns

# 📃 Documentation


- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour



# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

