### PR TITLE
10242 - fix unacknowledged toggle showing correctly. point 3 of UXUI issues for release v2.16

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Filters/BooleanFilter.tsx
+++ b/client/packages/common/src/ui/components/inputs/Filters/BooleanFilter.tsx
@@ -1,7 +1,8 @@
 import React, { FC, useState } from 'react';
 import { useUrlQuery } from '@common/hooks';
 import { Switch } from '@common/components';
-import { FilterDefinitionCommon } from './FilterMenu';
+import { Box } from '@mui/material';
+import { FilterDefinitionCommon, FILTER_WIDTH } from './FilterMenu';
 
 export interface BooleanFilterDefinition extends FilterDefinitionCommon {
   type: 'boolean';
@@ -24,17 +25,19 @@ export const BooleanFilter: FC<{
   };
 
   return (
-    <Switch
-      switchSx={{
-        marginTop: 0.2,
-      }}
-      labelSx={{
-        marginTop: 1.5,
-      }}
-      label={name}
-      checked={value}
-      onChange={handleChange}
-      size="medium"
-    />
+    <Box sx={{ minWidth: FILTER_WIDTH }}>
+      <Switch
+        switchSx={{
+          marginTop: 0.2,
+        }}
+        labelSx={{
+          marginTop: 1.5,
+        }}
+        label={name}
+        checked={value}
+        onChange={handleChange}
+        size="medium"
+      />
+    </Box>
   );
 };

--- a/client/packages/common/src/ui/components/inputs/Filters/FilterMenu.tsx
+++ b/client/packages/common/src/ui/components/inputs/Filters/FilterMenu.tsx
@@ -98,7 +98,7 @@ export const FilterMenu = ({ filters }: FilterDefinitions) => {
   return (
     <Box
       display="flex"
-      gap={2}
+      gap={3}
       sx={theme => ({
         [theme.breakpoints.down('sm')]: {
           flexDirection: 'column',


### PR DESCRIPTION
Addresses point 3 of #10242 which was raised while testing release v2.16

# 👩🏻‍💻 What does this PR do?

On the cold chain monitory chart tab, stops the unacknowledged toggle from overlapping with the expiry date to the left of it

Before this PR: it overlapped
<img width="2862" height="662" alt="image" src="https://github.com/user-attachments/assets/92fbc318-b4c9-4391-b4ab-7b6ce0832c43" />

After this PR it is appropriately spaced:
<img width="2872" height="758" alt="image" src="https://github.com/user-attachments/assets/e70683cc-2a24-4f0b-87a5-3bdd9f233ed2" />

On a small screen eg tablet, it moves below when there's inadequate space to the right
<img width="668" height="272" alt="image" src="https://github.com/user-attachments/assets/840ba4ad-c175-4db9-bf61-4d4fa429f51c" />



The change is to the boolean filter component and so will also ensure no overlap when that component is used elsewhere. Currently it is only used in replenishments and so I have ensured it looks ok there too:
<img width="890" height="342" alt="image" src="https://github.com/user-attachments/assets/23f41da0-7074-4e87-8899-0c1d27bf2ee8" />



## 💌 Any notes for the reviewer?

Visual change only

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to /cold-chain/monitoring?datetime=2026-01-27+13%3A09_2026-01-28+13%3A09&sort=datetime&tab=Chart
- [ ] Look at the unacknowledged box and observes its position / no overlap 

I would recommend checking boolean filters elsewhere in the app to ensure they are still as expected

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

