### PR TITLE
10242: move the cancel btn to the right on warning msg for no stockta…

### DIFF
--- a/client/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.tsx
+++ b/client/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.tsx
@@ -19,6 +19,7 @@ interface ConfirmationModalProps {
   buttonLabel?: string | undefined;
   cancelButtonLabel?: string | undefined;
   otherButtons?: Array<React.ReactNode>;
+  placeCancelButtonLast?: boolean;
 }
 
 const iconLookup = {
@@ -40,10 +41,22 @@ export const ConfirmationModal = ({
   buttonLabel,
   cancelButtonLabel,
   otherButtons,
+  placeCancelButtonLast = false,
 }: ConfirmationModalProps) => {
   const [loading, setLoading] = useState(false);
   const Icon = iconLookup[iconType];
   const t = useTranslation();
+
+  const cancelButton = (
+    <Grid>
+      <DialogButton
+        variant="cancel"
+        customLabel={cancelButtonLabel}
+        disabled={loading}
+        onClick={onCancel}
+      />
+    </Grid>
+  );
 
   return (
     <BasicModal width={width} height={height} open={open} onClose={onCancel}>
@@ -75,17 +88,9 @@ export const ConfirmationModal = ({
           flex={1}
           display="flex"
         >
-          {otherButtons && otherButtons.map((button, idx) => (
-            <Grid key={idx}>{button}</Grid>
-          ))}
-          <Grid>
-            <DialogButton
-              variant="cancel"
-              customLabel={cancelButtonLabel}
-              disabled={loading}
-              onClick={onCancel}
-            />
-          </Grid>
+          {otherButtons &&
+            otherButtons.map((button, idx) => <Grid key={idx}>{button}</Grid>)}
+          {!placeCancelButtonLast && cancelButton}
           <Grid>
             <LoadingButton
               autoFocus
@@ -103,6 +108,7 @@ export const ConfirmationModal = ({
               label={buttonLabel ? buttonLabel : t('button.ok')}
             />
           </Grid>
+          {placeCancelButtonLast && cancelButton}
         </Grid>
       </Grid>
     </BasicModal>

--- a/client/packages/requisitions/src/RequestRequisition/ListView/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/ListView/AppBarButtons.tsx
@@ -98,18 +98,28 @@ export const AppBarButtons: FC<{
         })}
         buttonLabel={t('button.continue-without-stocktake')}
         width={700}
-        onConfirm={() => { setConfirmationState(false); modalController.toggleOn(); }}
-        onCancel={() => { setConfirmationState(false); }}
-        otherButtons={[<DialogButton
-          key='go-to-stocktakes'
-          variant='back'
-          customLabel={t('button.go-to-stocktakes')}
-          onClick={() => navigate(
-            RouteBuilder.create(AppRoute.Inventory)
-              .addPart(AppRoute.Stocktakes)
-              .build()
-          )}
-        />]}
+        onConfirm={() => {
+          setConfirmationState(false);
+          modalController.toggleOn();
+        }}
+        onCancel={() => {
+          setConfirmationState(false);
+        }}
+        placeCancelButtonLast={true}
+        otherButtons={[
+          <DialogButton
+            key="go-to-stocktakes"
+            variant="back"
+            customLabel={t('button.go-to-stocktakes')}
+            onClick={() =>
+              navigate(
+                RouteBuilder.create(AppRoute.Inventory)
+                  .addPart(AppRoute.Stocktakes)
+                  .build()
+              )
+            }
+          />,
+        ]}
       />
       <CreateRequisitionModal
         isOpen={modalController.isOn}


### PR DESCRIPTION
Addresses point 4 of #10242 , as raised in UIUX testing of release v2.16

# 👩🏻‍💻 What does this PR do?

When there has been no recent internal stocktake, when you try to create an internal order, a warning message shows.
The cancel button was in the wrong place - it was betwen two other buttons. This PR moves it to the correct place, on the right.
That modal uses the resuable component `ConfirmationModal` and so I have added a setting to that modal to configure the position of the cancel button (prop `placeCancelButtonLast` which defaults to false)

Before this PR:
<img width="3024" height="1824" alt="image" src="https://github.com/user-attachments/assets/f874430f-4542-4b88-b447-5be51cecc54e" />

After this PR:
<img width="1423" height="828" alt="image" src="https://github.com/user-attachments/assets/ef146097-f096-4744-aed3-0c2b633fb01b" />


Other instances of the ConfirmationModal are unaffected, eg the order of these buttons is unchanged
<img width="1023" height="588" alt="image" src="https://github.com/user-attachments/assets/b44fc0f2-c133-4416-b6ca-d58f5b694f4e" />


## 💌 Any notes for the reviewer?

I was surprised by the formatting changes in this file and it made me question if I have prettier set up properly. There are two things here:
- for the line break I cannot see a line length specified for the formatter 
- it changed single -> double quotes for jsx props with strings which I believe is standard convention and isnt overriden by the single quote setting in .prettierrc which only applies to regular strings
Please let me know if this is ok, or if I should look into my formatting more!

# 🧪 Testing

Testing locally, I set showOldStocktakeWarning to true within the code and so forced the warning to come up
Hoping QA know the exact steps to trigger it - as a minimum you need to not have a recent stocktake

- [ ] Navigate to replenishments -> internal orders
- [ ] Click "New Order"
- [ ] Observe the order of the buttons on the warning modal

Other instances of this confirmation modal (eg when logging out) should also be tested to ensure they are not impacted by the change

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

