### PR TITLE
10347 Default inbound shipment filter to not include verified on mobile

### DIFF
--- a/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
+++ b/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
@@ -30,6 +30,7 @@ interface Filter {
 }
 interface UrlQueryParams {
   initialSort?: UrlQuerySort;
+  initialFilter?: { id: string; value: string }[];
   filters?: Filter[];
 }
 
@@ -42,6 +43,7 @@ export type ListParams<T> = {
 
 export const useUrlQueryParams = ({
   initialSort,
+  initialFilter,
   filters = [],
 }: UrlQueryParams = {}) => {
   const initialMount = useRef(true);
@@ -62,16 +64,26 @@ export const useUrlQueryParams = ({
     skipParse,
   });
 
-  // Set initial sort on mount
+  // Set initial sort and filter on mount
   useEffect(() => {
     initialMount.current = false;
-    if (!initialSort) return;
 
-    // Don't want to override existing sort
-    if (urlQuery['sort']) return;
+    if (initialSort) {
+      // Don't want to override existing sort
+      if (urlQuery['sort']) return;
 
-    const { key: sort, dir } = initialSort;
-    updateQuery({ sort, dir: dir === 'desc' ? 'desc' : '' });
+      const { key: sort, dir } = initialSort;
+      updateQuery({ sort, dir: dir === 'desc' ? 'desc' : '' });
+    }
+
+    if (initialFilter) {
+      initialFilter.forEach(({ id, value }) => {
+        // Don't want to override existing filter
+        if (urlQuery[id]) return;
+
+        updateQuery({ [id]: value });
+      });
+    }
   }, []);
 
   const updateSortQuery = useCallback(

--- a/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
@@ -38,6 +38,7 @@ export const InboundListView = () => {
     queryParams: { first, offset, sortBy, filterBy },
   } = useUrlQueryParams({
     initialSort: { key: 'invoiceNumber', dir: 'desc' },
+    ...isMobile && { initialFilter: [{ id: 'status', value: 'NEW,DELIVERED,RECEIVED' }] },
     filters: [
       { key: 'invoiceNumber', condition: 'equalTo', isNumber: true },
       { key: 'otherPartyName' },
@@ -45,7 +46,7 @@ export const InboundListView = () => {
         key: 'createdDatetime',
         condition: 'between',
       },
-      { key: 'status', condition: 'equalTo' },
+      { key: 'status', condition: 'equalAny' },
     ],
   });
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10347

# 👩🏻‍💻 What does this PR do?

Adds an initial filter option to `useUrlQueryParams`. Uses this to hide verified shipments on mobile by default.

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] On mobile go to inbound shipments
- [ ] Check there are no verified shipments in the list view

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [x] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [x] Frontend

