### PR TITLE
10327 table reset configuration button

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2140,7 +2140,7 @@
   "messages.requested-to-suggested": "This will set requested quantity to the suggested quantity for lines where requested quantity is 0.",
   "messages.requisition-item-information-amc": "Customer's average monthly consumption. For your store it is the sum of the customers' average monthly consumption.",
   "messages.requisition-no-stock": "There is currently no stock available",
-  "messages.reset-table-defaults": "This will reset the table to default configurations",
+  "messages.reset-table-defaults": "The table will be reset to default configurations",
   "messages.results-found": "{{totalCount}} results found",
   "messages.results-over-limit": "Showing the first {{limit}} results only - please refine your search",
   "messages.return-saved": "Return saved 🥳",

--- a/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/material-react-table/useBaseMaterialTable.tsx
@@ -110,7 +110,6 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
     columnVisibility.hasSavedState ||
     columnOrder.hasSavedState;
 
-  /// confirm before this here
   const resetTableState = () => {
     clearSavedState(tableId);
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Part 1 of #10327

# 👩🏻‍💻 What does this PR do?

Add a confirmation modal when the `reset` button in the table toolbar is pressed

Gives the user more understanding that this is not a 'refresh data' button, but resets the table configurations. Also guards against accidental single-click resets

Just getting this in for the patch, will continue with the settings menu for the long term solution


<img width="422" height="218" alt="Screenshot 2026-02-04 at 4 32 42 PM" src="https://github.com/user-attachments/assets/ad1faab0-adda-4d2c-9755-e11a8024125f" />

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to any list or detail view with the MRT table
- [ ] Change some column widths, re-order columns, pin etc
- [ ] Click the reset table button - see confirmation modal
- [ ] Cancel -> modal closes and table is NOT reset
- [ ] Ok -> table is reset to defaults  

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

