### PR TITLE
move the border of vax card groups

### DIFF
--- a/client/packages/common/src/ui/layout/tables/useTableDisplayOptions.tsx
+++ b/client/packages/common/src/ui/layout/tables/useTableDisplayOptions.tsx
@@ -295,7 +295,8 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
                 borderRadius: '8px',
               }
             : {
-                borderBottom: '1px solid rgba(224, 224, 224, 1)',
+                borderBottom: '1px solid',
+                borderColor: 'border',
               }),
         },
       };

--- a/client/packages/system/src/Vaccination/Components/VaccineCardTable.tsx
+++ b/client/packages/system/src/Vaccination/Components/VaccineCardTable.tsx
@@ -74,6 +74,13 @@ export const VaccineCardTable = ({
     const index = data?.items.findIndex(item => item.id === row.id) ?? 0;
     return row.minAgeMonths === data?.items?.[index - 1]?.minAgeMonths;
   };
+  const isAgeSameAsNextRow = (row: VaccinationCardItemFragment) => {
+    const index = data?.items.findIndex(item => item.id === row.id) ?? 0;
+    return (
+      data?.items?.length === index ||
+      row.minAgeMonths === data?.items?.[index + 1]?.minAgeMonths
+    );
+  };
 
   const columns = useMemo(
     (): ColumnDef<VaccinationCardItemFragment>[] => [
@@ -88,7 +95,7 @@ export const VaccineCardTable = ({
           sx: {
             fontWeight: 'bold',
             paddingLeft: 2,
-            ...(isAgeSameAsPreviousRow(row.original)
+            ...(isAgeSameAsNextRow(row.original)
               ? { borderBottom: 'none' }
               : {}),
           },


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10402

# 👩🏻‍💻 What does this PR do?
The table cell bottom border was previously hidden if the row's Age is the same as the previous row's Age.
This will show ages grouped incorrectly though - the bottom border should be hidden if the next row is the same Age value / part of the current group. It should show if the next row is a new group. when the next row differs, we want to show a border which indicates that a new group is coming up.

Note that in the table display options, we add a bottom border only - so the adjustment in this table does have to be for the bottom border

This PR moves the border hiding to group correctly - like this:

<img width="630" height="550" alt="Screenshot 2026-02-09 at 4 35 19 PM" src="https://github.com/user-attachments/assets/98d8d666-9e71-4b37-8356-1eeb900ecf22" />


<!-- Explain the changes you made -->


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create more than one vaccine course and create Doses for these courses which are the same. check the grouping is correct

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

