### PR TITLE
10433 Hide AMC if population forecast is shown

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ModalContentPanels.ts
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ModalContentPanels.ts
@@ -8,33 +8,46 @@ import { DraftRequestLine } from '.';
 export const getLeftPanel = (
   t: TypedTFunction<LocaleKey>,
   draft?: DraftRequestLine | null,
-  showExtraFields: boolean = false
+  showExtraFields: boolean = false,
+  displayForecasting: boolean = false
 ): ValueInfo[] => {
-  const base: ValueInfo[] = [
+  const rows: ValueInfo[] = [
     {
       label: t('label.our-soh'),
       value: draft?.itemStats.availableStockOnHand,
     },
-    {
-      label: t('label.amc/amd'),
-      value: draft?.itemStats.averageMonthlyConsumption,
-    },
+    ...(displayForecasting
+      ? [
+          {
+            label: t('label.target-stock-population'),
+            value: draft?.forecastTotalUnits
+              ? Math.ceil(draft.forecastTotalUnits)
+              : undefined,
+          },
+        ]
+      : [
+          {
+            label: t('label.amc/amd'),
+            value: draft?.itemStats.averageMonthlyConsumption,
+          },
+        ]),
     {
       label: t('label.months-of-stock'),
       value: draft?.itemStats.availableMonthsOfStockOnHand,
       endAdornmentOverride: t('label.months'),
       displayVaccinesInDoses: false,
     },
+    ...(showExtraFields
+      ? [
+          {
+            label: t('label.short-expiry'),
+            value: draft?.expiringUnits,
+          },
+        ]
+      : []),
   ];
 
-  const extraPanel: ValueInfo[] = [
-    {
-      label: t('label.short-expiry'),
-      value: draft?.expiringUnits,
-    },
-  ];
-
-  return showExtraFields ? [...base, ...extraPanel] : base;
+  return rows;
 };
 
 export const getExtraMiddlePanels = (

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -268,16 +268,9 @@ export const RequestLineEdit = ({
                   value={currentItem?.doses}
                 />
               ) : null}
-              {renderValueInfoRows(getLeftPanel(t, draft, showExtraFields))}
-              {displayForecasting &&
-                renderValueInfoRows([
-                  {
-                    label: t('label.target-stock-population'),
-                    value: line?.forecastTotalUnits
-                      ? Math.ceil(line.forecastTotalUnits)
-                      : undefined,
-                  },
-                ])}
+              {renderValueInfoRows(
+                getLeftPanel(t, draft, showExtraFields, displayForecasting)
+              )}
               {line &&
                 plugins.requestRequisitionLine?.editViewField?.map(
                   (Field, index) => (

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -330,15 +330,24 @@ export const ResponseLineEdit = ({
         </ModalPanelArea>
         {!!requisition.linkedRequisition || showExtraFields ? (
           <>
-            <ResponseNumInputRow
-              label={t('label.amc/amd')}
-              value={draft?.averageMonthlyConsumption}
-              onChange={value => update({ averageMonthlyConsumption: value })}
-              sx={{
-                pt: 1,
-              }}
-              {...commonProps}
-            />
+            {displayForecasting ? (
+              <ResponseNumInputRow
+                label={t('label.target-stock-population')}
+                value={draft?.forecastTotalUnits ?? 0}
+                disabledOverride={true}
+                {...commonProps}
+              />
+            ) : (
+              <ResponseNumInputRow
+                label={t('label.amc/amd')}
+                value={draft?.averageMonthlyConsumption}
+                onChange={value => update({ averageMonthlyConsumption: value })}
+                sx={{
+                  pt: 1,
+                }}
+                {...commonProps}
+              />
+            )}
             <ResponseNumInputRow
               label={t('label.months-of-stock')}
               value={mos() ?? 0}
@@ -349,14 +358,6 @@ export const ResponseLineEdit = ({
               }}
               {...commonProps}
             />
-            {displayForecasting && (
-              <ResponseNumInputRow
-                label={t('label.target-stock-population')}
-                value={draft?.forecastTotalUnits ?? 0}
-                disabledOverride={true}
-                {...commonProps}
-              />
-            )}
           </>
         ) : null}
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10433

# 👩🏻‍💻 What does this PR do?
Hide AMC if population forecast preference is on for vaccine items

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have global preference on for population forecasting
- [ ] Have population forecast settings set up
- [ ] Create Internal Order with vaccine item -> shouldn't see AMC

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

