### PR TITLE
10350 Clicking 'Ok' after viewing a line in a finalised requisition leads to an error 

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -9,6 +9,7 @@ import {
   UserStoreNodeFragment,
   Representation,
   RepresentationValue,
+  RequisitionNodeStatus,
 } from '@openmsupply-client/common';
 import { ItemWithStatsFragment } from '@openmsupply-client/system';
 import { RequestFragment, useRequest } from '../../api';
@@ -106,8 +107,10 @@ export const RequestLineEditModal = ({
   };
 
   const onNext = async () => {
-    const success = await handleSave();
-    if (!success) return false;
+    if (requisition.status !== RequisitionNodeStatus.Sent) {
+      const success = await handleSave();
+      if (!success) return false;
+    }
     if (mode === ModalMode.Update && next) setCurrentItem(next);
     else if (mode === ModalMode.Create) setCurrentItem(undefined);
     else onClose();
@@ -140,8 +143,12 @@ export const RequestLineEditModal = ({
           variant="ok"
           disabled={!currentItem || isEditingRequested}
           onClick={async () => {
-            const success = await handleSave();
-            if (success) onClose();
+            if (requisition.status === RequisitionNodeStatus.Sent) {
+              onClose();
+            } else {
+              const success = await handleSave();
+              if (success) onClose();
+            }
           }}
         />
       }

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
@@ -10,6 +10,7 @@ import {
   UserStoreNodeFragment,
   Representation,
   RepresentationValue,
+  RequisitionNodeStatus,
 } from '@openmsupply-client/common';
 import { ItemWithStatsFragment } from '@openmsupply-client/system';
 import { ResponseFragment, useResponse } from '../../api';
@@ -103,8 +104,10 @@ export const ResponseLineEditModal = ({
   };
 
   const onSave = async () => {
-    const success = await handleSave();
-    if (!success) return false;
+    if (requisition.status !== RequisitionNodeStatus.Finalised) {
+      const success = await handleSave();
+      if (!success) return false;
+    }
     if (mode === ModalMode.Update && next) setCurrentItem(next);
     else if (mode === ModalMode.Create) setCurrentItem(undefined);
     else onClose();
@@ -186,8 +189,12 @@ export const ResponseLineEditModal = ({
           variant="ok"
           disabled={!currentItem || isEditingSupply}
           onClick={async () => {
-            const success = await handleSave();
-            if (success) onClose();
+            if (requisition.status === RequisitionNodeStatus.Finalised) {
+              onClose();
+            } else {
+              const success = await handleSave();
+              if (success) onClose();
+            }
           }}
         />
       }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10350 

# 👩🏻‍💻 What does this PR do?
Don't call upsert if requisition / internal order is finalised

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have sent internal orders / finalised requisitions
- [ ] Click on a line, click ok / ok & next
- [ ] Shouldn't error

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

