### PR TITLE
10341 Able to zero out pack size in customer returns, running into an error when saving 

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -177,6 +177,7 @@ export const QuantityTable = ({
               updateDraftLine({ shippedPackSize: value, id: row.original.id });
             }}
             disabled={isDisabled}
+            min={1}
           />
         ),
         defaultHideOnMobile: true,
@@ -195,7 +196,7 @@ export const QuantityTable = ({
               });
             }}
             disabled={isDisabled}
-            min={1}
+            min={0}
           />
         ),
       },

--- a/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnQuantitiesTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnQuantitiesTable.tsx
@@ -65,7 +65,7 @@ export const QuantityReturnedTableComponent = ({
             selectedId={row.itemVariantId}
             itemId={row.item.id}
             disabled={isDisabled}
-            width={"100%"}
+            width={'100%'}
             onChange={variant =>
               updateLine({
                 ...row,
@@ -87,18 +87,20 @@ export const QuantityReturnedTableComponent = ({
         size: 130,
         Cell: ({ cell, row: { original: row } }) => {
           const value = cell.getValue<Date | null>();
-          return <ExpiryDateInput
-            value={value}
-            onChange={newValue =>
-              updateLine({
-                ...row,
-                expiryDate: newValue
-                  ? Formatter.naiveDate(new Date(newValue))
-                  : null,
-              })
-            }
-            disabled={isDisabled}
-          />
+          return (
+            <ExpiryDateInput
+              value={value}
+              onChange={newValue =>
+                updateLine({
+                  ...row,
+                  expiryDate: newValue
+                    ? Formatter.naiveDate(new Date(newValue))
+                    : null,
+                })
+              }
+              disabled={isDisabled}
+            />
+          );
         },
       },
       {
@@ -117,14 +119,18 @@ export const QuantityReturnedTableComponent = ({
             cell={cell}
             disabled={isDisabled}
             defaultValue={0}
-            updateFn={packSize => updateLine({
-              ...row,
-              packSize,
-              volumePerPack: getVolumePerPackFromVariant({
+            updateFn={packSize =>
+              updateLine({
                 ...row,
                 packSize,
-              }) ?? 0,
-            })}
+                volumePerPack:
+                  getVolumePerPackFromVariant({
+                    ...row,
+                    packSize,
+                  }) ?? 0,
+              })
+            }
+            min={1}
           />
         ),
       },
@@ -160,7 +166,7 @@ export const QuantityReturnedTableComponent = ({
             decimalLimit={10}
           />
         ),
-      }
+      },
     ],
     [lines, showItemVariantsColumn]
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10341

# 👩🏻‍💻 What does this PR do?
Min packs size should be 1 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a customer return with some pack size > 1 
- [ ] Save line
- [ ] Go back edit line ... shouldn't be able to enter 0, so should not get error in issue

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

