### PR TITLE
10173 reduce needless log entries

### DIFF
--- a/server/service/src/sync/sync_status/logger.rs
+++ b/server/service/src/sync/sync_status/logger.rs
@@ -1,4 +1,4 @@
-use log::{error, info};
+use log::{debug, error, info};
 use repository::{
     RepositoryError, StorageConnection, SyncApiErrorCode, SyncLogRow, SyncLogRowRepository,
 };
@@ -62,6 +62,14 @@ impl SyncLoggerError {
 }
 
 impl<'a> SyncLogger<'a> {
+    fn log(count: i32, action: &str) {
+        if count > 0 {
+            info!("{action} ({count}) records");
+        } else {
+            debug!("{action} step finished with no progress recorded")
+        }
+    }
+
     pub fn start(connection: &'a StorageConnection) -> Result<SyncLogger<'a>, SyncLoggerError> {
         info!("Sync started");
         let row = SyncLogRow {
@@ -134,30 +142,27 @@ impl<'a> SyncLogger<'a> {
                 ..self.row.clone()
             },
             SyncStep::Push => {
-                let count = *self.row.push_progress_done.as_ref().unwrap_or(&0);
-                if count > 0 {
-                    info!("Pushed ({count}) records");
-                }
+                Self::log(self.row.push_progress_done.unwrap_or(0), "Pushed");
                 SyncLogRow {
                     push_finished_datetime: Some(chrono::Utc::now().naive_utc()),
                     ..self.row.clone()
                 }
             }
             SyncStep::PullCentral => {
-                let count = *self.row.pull_central_progress_done.as_ref().unwrap_or(&0);
-                if count > 0 {
-                    info!("Pulled ({count}) central records");
-                }
+                Self::log(
+                    self.row.pull_central_progress_done.unwrap_or(0),
+                    "Pulled central",
+                );
                 SyncLogRow {
                     pull_central_finished_datetime: Some(chrono::Utc::now().naive_utc()),
                     ..self.row.clone()
                 }
             }
             SyncStep::PullRemote => {
-                let count = *self.row.pull_remote_progress_done.as_ref().unwrap_or(&0);
-                if count > 0 {
-                    info!("Pulled ({count}) remote records");
-                }
+                Self::log(
+                    self.row.pull_remote_progress_done.unwrap_or(0),
+                    "Pulled remote",
+                );
                 SyncLogRow {
                     pull_remote_finished_datetime: Some(chrono::Utc::now().naive_utc()),
                     ..self.row.clone()
@@ -168,20 +173,20 @@ impl<'a> SyncLogger<'a> {
                 ..self.row.clone()
             },
             SyncStep::PullCentralV6 => {
-                let count = *self.row.pull_v6_progress_done.as_ref().unwrap_or(&0);
-                if count > 0 {
-                    info!("Pulled ({count}) central v6 records");
-                }
+                Self::log(
+                    self.row.pull_v6_progress_done.unwrap_or(0),
+                    "Pulled central v6",
+                );
                 SyncLogRow {
                     pull_v6_finished_datetime: Some(chrono::Utc::now().naive_utc()),
                     ..self.row.clone()
                 }
             }
             SyncStep::PushCentralV6 => {
-                let count = *self.row.push_v6_progress_done.as_ref().unwrap_or(&0);
-                if count > 0 {
-                    info!("Pushed ({count}) central v6 records");
-                }
+                Self::log(
+                    self.row.push_v6_progress_done.unwrap_or(0),
+                    "Pushed central v6",
+                );
                 SyncLogRow {
                     push_v6_finished_datetime: Some(chrono::Utc::now().naive_utc()),
                     ..self.row.clone()

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -292,9 +292,9 @@ impl Synchroniser {
         )
         .map_err(SyncError::IntegrationError)?;
 
-        upserts.log_if_has_results("Upsert");
-        deletes.log_if_has_results("Delete");
-        merges.log_if_has_results("Merge");
+        upserts.log("Upsert");
+        deletes.log("Delete");
+        merges.log("Merge");
 
         logger.done_step(SyncStep::Integrate)?;
 

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -247,7 +247,7 @@ impl TranslationAndIntegrationResults {
         Default::default()
     }
 
-    pub(crate) fn log_if_has_results(&self, operation_name: &str) {
+    pub(crate) fn log(&self, operation_name: &str) {
         let has_results = !self.0.is_empty()
             && self
                 .0
@@ -261,6 +261,11 @@ impl TranslationAndIntegrationResults {
                     log::info!("{operation_name} Integration result for {table_name}: {result:?}");
                 }
             }
+        } else {
+            log::debug!(
+                "{operation_name} Integration result: No records integrated or errored {:?}",
+                self.0
+            );
         }
     }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10173

# 👩🏻‍💻 What does this PR do?
Reduces number of logs from sync. Results should only log if there is a result, and warning is separated from info logs.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Run server
- [ ] Don't see endless integration result logs
- [ ] Don't see countless push / pull logs

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

