### PR TITLE
10417 Add itemOrCode filter to stocktake detail view

### DIFF
--- a/client/packages/common/src/utils/item/ItemUtils.ts
+++ b/client/packages/common/src/utils/item/ItemUtils.ts
@@ -12,7 +12,10 @@ export const useItemUtils = () => {
   const setItemFilter = (itemFilter: string) =>
     updateQuery({ codeOrName: itemFilter });
 
-  const matchItem = (itemFilter: string, { name, code }: Partial<ItemNode>) => {
+  const matchItem = (
+    itemFilter: string,
+    { name, code }: Pick<ItemNode, 'name' | 'code'>
+  ) => {
     const filter = RegexUtils.escapeChars(itemFilter);
     return (
       RegexUtils.includes(filter, name ?? '') ||

--- a/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
@@ -30,7 +30,10 @@ export const useStocktakeRows = (itemId?: string) => {
     return lines?.filter(item => matchItem(itemFilter, item.item));
   }, [lines, itemFilter]);
 
-  const items = useMemo(() => getStocktakeItems(filteredLines ?? []), [lines]);
+  const items = useMemo(
+    () => getStocktakeItems(filteredLines ?? []),
+    [filteredLines]
+  );
 
   const totalLineCount = lineData?.totalCount ?? 0;
   const isDisabled = !stocktake || isStocktakeDisabled(stocktake);

--- a/client/packages/inventory/src/Stocktake/api/operations.generated.ts
+++ b/client/packages/inventory/src/Stocktake/api/operations.generated.ts
@@ -60,10 +60,7 @@ export type StocktakeLineFragment = {
     restrictedLocationTypeId?: string | null;
     itemStoreProperties?: {
       __typename: 'ItemStorePropertiesNode';
-      id: string;
       defaultSellPricePerPack: number;
-      ignoreForOrders: boolean;
-      margin: number;
     } | null;
   };
   vvmStatus?: {
@@ -159,10 +156,7 @@ export type StocktakeFragment = {
         restrictedLocationTypeId?: string | null;
         itemStoreProperties?: {
           __typename: 'ItemStorePropertiesNode';
-          id: string;
           defaultSellPricePerPack: number;
-          ignoreForOrders: boolean;
-          margin: number;
         } | null;
       };
       vvmStatus?: {
@@ -302,10 +296,7 @@ export type StocktakeQuery = {
               restrictedLocationTypeId?: string | null;
               itemStoreProperties?: {
                 __typename: 'ItemStorePropertiesNode';
-                id: string;
                 defaultSellPricePerPack: number;
-                ignoreForOrders: boolean;
-                margin: number;
               } | null;
             };
             vvmStatus?: {
@@ -421,10 +412,7 @@ export type StocktakeByNumberQuery = {
               restrictedLocationTypeId?: string | null;
               itemStoreProperties?: {
                 __typename: 'ItemStorePropertiesNode';
-                id: string;
                 defaultSellPricePerPack: number;
-                ignoreForOrders: boolean;
-                margin: number;
               } | null;
             };
             vvmStatus?: {
@@ -525,10 +513,7 @@ export type StocktakeLinesQuery = {
         restrictedLocationTypeId?: string | null;
         itemStoreProperties?: {
           __typename: 'ItemStorePropertiesNode';
-          id: string;
           defaultSellPricePerPack: number;
-          ignoreForOrders: boolean;
-          margin: number;
         } | null;
       };
       vvmStatus?: {
@@ -837,10 +822,7 @@ export const StocktakeLineFragmentDoc = gql`
       defaultPackSize
       restrictedLocationTypeId
       itemStoreProperties(storeId: $storeId) {
-        id
         defaultSellPricePerPack
-        ignoreForOrders
-        margin
       }
     }
     itemVariantId

--- a/client/packages/inventory/src/Stocktake/api/operations.graphql
+++ b/client/packages/inventory/src/Stocktake/api/operations.graphql
@@ -58,10 +58,7 @@ fragment StocktakeLine on StocktakeLineNode {
     defaultPackSize
     restrictedLocationTypeId
     itemStoreProperties(storeId: $storeId) {
-      id
       defaultSellPricePerPack
-      ignoreForOrders
-      margin
     }
   }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10417

# 👩🏻‍💻 What does this PR do?

Adds item/code filter to stocktake detail view
<img width="1245" height="466" alt="Screenshot 2026-02-11 at 10 20 18 AM" src="https://github.com/user-attachments/assets/c4a53668-bdc9-4bdf-a692-7ddd21da2372" />
<img width="1248" height="538" alt="Screenshot 2026-02-11 at 10 20 10 AM" src="https://github.com/user-attachments/assets/a1533350-5724-45d9-8350-6151afb0a4e0" />

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Lined this up more with the patterns used in requisition filters than the original stocktake item filter. The original one queried graphql on every keystroke 😓 

Is in useStocktakeRows instead of useStocktakeLines due to the grouping - this will work the same whether grouping is turned on or off

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ]  Search bar appears on the right hand side
- [ ]  Can search by item name or code - if the value is present in either column, the line will appear in the results
- [ ] Get the same results whether grouping is turned on or off
- [ ]  Able to click on lines to access the line edit modal without any errors

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

