### PR TITLE
10484 - fix auto-populated volume in Inbound shipments

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -216,7 +216,11 @@ export const QuantityTable = ({
                   line.sellPricePerPack;
 
               updateDraftLine({
-                volumePerPack: getVolumePerPackFromVariant(line) ?? 0,
+                volumePerPack:
+                  getVolumePerPackFromVariant({
+                    itemVariant: line.itemVariant,
+                    packSize: value,
+                  }) ?? 0,
                 sellPricePerPack: shouldClearSellPrice
                   ? 0
                   : line.sellPricePerPack,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10484

# 👩🏻‍💻 What does this PR do?

Calculate the correct volume when entering inbound shipment lines: when the pack size is updated (to a value that matches the item variant pack size), the volume is calculated correctly

https://github.com/user-attachments/assets/9d7ab351-41b4-4f35-9815-c206f080d014


<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Set up item variants with pack sizes and volumes. Have a variant where any level pack size = default pack size
- [ ] Add the item to an inbound shipment -> be in line edit view
- [ ] Select a variant for the item -> if the default pack size matches a variant pack size, see a volume per pack calculated
- [ ] If the default pack size does not match any of the variants pack sizes, see volume per pack is not calculated
- [ ] Change the pack size to another level pack size -> see volume per pack calculate correctly
- [ ] Change the variant to another variant with the same pack size (but different volume) -> see volume per pack  calculate correctly
- [ ] Change the pack size to something that does not match the variant pack size -> volume per pack should be 0

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

