### PR TITLE
10197 Assets - Import: can go to Review steps without uploading anything

### DIFF
--- a/client/packages/coldchain/src/Equipment/ImportAsset/EquipmentImportModal.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/EquipmentImportModal.tsx
@@ -253,7 +253,7 @@ export const EquipmentImportModal = ({
     {
       label: t('label.review'),
       description: '',
-      clickable: true,
+      clickable: bufferedEquipment.length > 0,
       tab: Tabs.Review,
     },
     {

--- a/client/packages/purchasing/src/purchase_order/DetailView/ImportLines/LineImportModal.tsx
+++ b/client/packages/purchasing/src/purchase_order/DetailView/ImportLines/LineImportModal.tsx
@@ -89,13 +89,13 @@ export const LineImportModal = ({ isOpen, onClose }: LineImportModalProps) => {
     {
       label: t('label.review'),
       description: '',
-      clickable: true,
+      clickable: bufferedLines.length > 0,
       tab: Tabs.Review,
     },
     {
       label: t('label.import'),
       description: '',
-      clickable: true,
+      clickable: false,
       tab: Tabs.Import,
     },
   ];

--- a/client/packages/system/src/Asset/ImportCatalogueItem/CatalogueItemImportModal.tsx
+++ b/client/packages/system/src/Asset/ImportCatalogueItem/CatalogueItemImportModal.tsx
@@ -273,7 +273,7 @@ export const AssetCatalogueItemImportModal: FC<AssetItemImportModalProps> = ({
     {
       label: t('label.review'),
       description: '',
-      clickable: true,
+      clickable: bufferedAssetItem.length > 0,
       tab: Tabs.Review,
     },
     {

--- a/client/packages/system/src/Name/ListView/ImportProperties/PropertiesImportModal.tsx
+++ b/client/packages/system/src/Name/ListView/ImportProperties/PropertiesImportModal.tsx
@@ -162,7 +162,7 @@ export const PropertiesImportModal: FC<PropertiesImportModalProps> = ({
     {
       label: t('label.review'),
       description: '',
-      clickable: false,
+      clickable: bufferedFacilityProperties.length > 0,
       tab: Tabs.Review,
     },
     {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10197

# 👩🏻‍💻 What does this PR do?
Don't make review tab clickable if there's nothing to review

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to anywhere where you can upload document and review e.g. asset
- [ ] Download template, fill out and upload
- [ ] Get to review tab
- [ ] Click back to upload tab -> review tab should be disabled

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

