### PR TITLE
#10480 Scanner input -- persist expiry date for existing lines

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/ScanInputModal.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ScanInputModal.tsx
@@ -12,6 +12,8 @@ import {
   TypedTFunction,
   LocaleKey,
   useNotification,
+  LoadingButton,
+  CheckIcon,
 } from '@openmsupply-client/common';
 import { FnUtils, ScanResult, useBarcodeScannerContext } from '@common/utils';
 import React, { useCallback, useState } from 'react';
@@ -73,9 +75,13 @@ export const ScanInputModal = ({ lines, invoiceId }: ScanInputModalProps) => {
 
   const { success } = useNotification();
 
-  const { saveSingleLine } = useDraftInboundLines(barcodeData?.itemId);
-  const { mutateAsync: getBarcode } = useOutbound.utils.barcode();
-  const { mutateAsync: saveBarcode } = useOutbound.utils.barcodeInsert();
+  const { saveSingleLine, isLoading: isSavingLine } = useDraftInboundLines(
+    barcodeData?.itemId
+  );
+  const { mutateAsync: getBarcode, isLoading: isFetchingBarcode } =
+    useOutbound.utils.barcode();
+  const { mutateAsync: saveBarcode, isLoading: isSavingBarcode } =
+    useOutbound.utils.barcodeInsert();
 
   // Helper to update state and pull in expiry date from matching line
   // - Need to add "manufacturer/manufactureDate" to this when support those
@@ -290,7 +296,7 @@ export const ScanInputModal = ({ lines, invoiceId }: ScanInputModalProps) => {
     });
   };
 
-  const message: Message = errorMessage
+  const message: Message | null = errorMessage
     ? { type: 'error', text: errorMessage }
     : getMessage(barcodeData, draftState, existingLine, t);
 
@@ -308,15 +314,21 @@ export const ScanInputModal = ({ lines, invoiceId }: ScanInputModalProps) => {
     }
   };
 
+  const isLoading = isFetchingBarcode || isSavingLine || isSavingBarcode;
+
   return (
     <Modal
       title={t('heading.scan-product')}
       width={500}
       disableEnforceFocus // Prevents input block in Mock barcode scanner element
       okButton={
-        <DialogButton
-          variant="ok"
+        <LoadingButton
+          startIcon={<CheckIcon />}
+          color="secondary"
+          variant="contained"
+          isLoading={isLoading}
           disabled={!canSubmit}
+          label={t('button.ok')}
           onClick={handleSubmit}
         />
       }
@@ -348,13 +360,15 @@ export const ScanInputModal = ({ lines, invoiceId }: ScanInputModalProps) => {
           </Typography>
         )}
 
-        <Alert severity={message.type}>{message.text}</Alert>
+        {message && !isLoading && (
+          <Alert severity={message.type}>{message.text}</Alert>
+        )}
         <InputWithLabelRow
           label={t('label.item')}
           Input={
             <StockItemSearchInput
               autoFocus={!barcodeData}
-              disabled={!!barcodeData}
+              disabled={!!barcodeData || isLoading}
               currentItemId={barcodeData?.itemId || draftState.itemId || null}
               onChange={newItem => onChangeItem(newItem)}
               // A scanned-in item will only have an ID, not a full item object,
@@ -369,6 +383,7 @@ export const ScanInputModal = ({ lines, invoiceId }: ScanInputModalProps) => {
           Input={
             <BasicTextInput
               value={draftState.batch ?? ''}
+              disabled={isLoading}
               onChange={e => {
                 updateStateWithLineMatch({ batch: e.target.value });
               }}
@@ -380,6 +395,7 @@ export const ScanInputModal = ({ lines, invoiceId }: ScanInputModalProps) => {
           Input={
             <DatePicker
               value={draftState.expiryDate}
+              disabled={isLoading}
               onChange={value =>
                 setDraftState(current => ({ ...current, expiryDate: value }))
               }
@@ -396,7 +412,7 @@ export const ScanInputModal = ({ lines, invoiceId }: ScanInputModalProps) => {
               }
               // If a pack size is associated with a particular GTIN, it should
               // not change
-              disabled={!!barcodeData?.packSize}
+              disabled={!!barcodeData?.packSize || isLoading}
             />
           }
         />
@@ -406,6 +422,7 @@ export const ScanInputModal = ({ lines, invoiceId }: ScanInputModalProps) => {
             <NumericTextInput
               inputRef={quantityInputRef}
               value={draftState.quantity ?? ''}
+              disabled={isLoading}
               onChange={value =>
                 setDraftState(current => ({ ...current, quantity: value || 1 }))
               }
@@ -434,8 +451,7 @@ const getMessage = (
   draftState: FormDraftState,
   existingLine: InboundLineFragment | undefined,
   t: TypedTFunction<LocaleKey>
-): Message => {
-  //
+): Message | null => {
   if (!barcodeData && !draftState.gtin && !draftState.itemId)
     return {
       type: 'error',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10480

# 👩🏻‍💻 What does this PR do?

As part of the draft state update, we now also check if the updated draft values match an existing line, and populate draft expiryDate with existing value if it does.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

There's a tiny inefficiency in that `lines.find()` is run both in the update function and in the component itself, but this is preferable to the alternative which is to add `useEffect` to watch for changes to `existingLine` ;) 

# 🧪 Testing

- [ ] Scan a barcode where the batch/item matches an existing line (but without the expiryDate in the barcode itself) -- confirm that the expiry date from the existing line is kept
- [ ] Scan a barcode with a matching item, but no batch. Manually enter the batch number of the existing line -- confirm that the expiry date is immediately populated with the existing value
- [ ] Scan a barcode where the expiry date is in the barcode,  but different to the one in the existing line -- confirm that existing expiry date is overwritten with the new one (I don't think this case should occur IRL, just want to check behaviour is as expected)
- [ ] Check nothing else is broken


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

