### PR TITLE
#10474 Fix confusion with simultaneous modals

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2641,6 +2641,7 @@
   "warning.high-number-records-to-sync": "A high number of records are being synced. This may take longer than usual.",
   "warning.insufficient-recent-stocktake-items": "You have not completed stocktake(s) containing at least {{ minItems }} items within the last {{maxAge}} days. Your stock levels may not be accurate. Are you sure that you want to continue?",
   "warning.manual-store-requisition": "Entering a requisition for this store may result in duplicates if the store also submits an Internal Order.",
+  "warning.no-scanning-while-line-editing": "Please save or cancel the line edit modal before scanning",
   "warning.nothing-to-supply": "Nothing left to supply!",
   "warning.requested-exceeds-suggested": "Your requested quantity is higher than the suggested",
   "settings.enable-mock-barcode-scanner": "Enable manual barcode input (for testing purposes only)",

--- a/client/packages/common/src/utils/BarcodeScannerContext.tsx
+++ b/client/packages/common/src/utils/BarcodeScannerContext.tsx
@@ -66,6 +66,7 @@ interface BarcodeScannerControl {
   setMockScannerEnabled: (enabled: boolean) => void;
   supportsContinuousScanning: boolean;
   registerCallback: (callback: ScanCallback) => void;
+  revertCallback: () => void;
   handleScanResult: (barcode: ScanResult) => void;
 }
 
@@ -136,6 +137,7 @@ export const BarcodeScannerProvider: FC<PropsWithChildrenOnly> = ({
     useState<boolean>(false);
   const { error } = useNotification();
   const callbackRef = useRef<ScanCallback | null>(null);
+  const previousCallbackRef = useRef<ScanCallback | null>(null);
   const { electronNativeAPI } = window;
   const [scanner, setScanner] = useState<BarcodeScanner | null>(null);
   const [localScannerType, setLocalScannerType] =
@@ -367,8 +369,9 @@ export const BarcodeScannerProvider: FC<PropsWithChildrenOnly> = ({
             return;
           }
           if (data && 'barcode' in data) {
-            if (callbackRef.current) {
-              callbackRef.current(parseResult(data.barcode));
+            const currentCallback = callbackRef.current;
+            if (currentCallback) {
+              currentCallback(parseResult(data.barcode));
             } else {
               console.error(
                 'No scan callback registered to handle barcode:',
@@ -394,8 +397,9 @@ export const BarcodeScannerProvider: FC<PropsWithChildrenOnly> = ({
         await startBarcodeScan();
         electronNativeAPI.onBarcodeScan((_event, data) => {
           const barcode = BarcodeUtils.parseBarcodeFromBytes(data);
-          if (callbackRef.current) {
-            callbackRef.current(parseResult(barcode));
+          const currentCallback = callbackRef.current;
+          if (currentCallback) {
+            currentCallback(parseResult(barcode));
           } else {
             console.error(
               'No scan callback registered to handle barcode:',
@@ -418,8 +422,9 @@ export const BarcodeScannerProvider: FC<PropsWithChildrenOnly> = ({
       setIsListening(true);
       const scanHandler = async (barcode: string) => {
         const result = parseResult(barcode);
-        if (callbackRef.current) {
-          callbackRef.current(result);
+        const currentCallback = callbackRef.current;
+        if (currentCallback) {
+          currentCallback(result);
         } else {
           console.error(
             'No scan callback registered to handle barcode:',
@@ -479,11 +484,18 @@ export const BarcodeScannerProvider: FC<PropsWithChildrenOnly> = ({
       setMockScannerEnabled,
       supportsContinuousScanning:
         hasHoneywellScanner || hasElectronApi || mockScannerEnabled,
-      registerCallback: (callback: ScanCallback) =>
-        (callbackRef.current = callback),
+      registerCallback: (callback: ScanCallback) => {
+        previousCallbackRef.current = callbackRef.current;
+        callbackRef.current = callback;
+      },
+      revertCallback: () => {
+        callbackRef.current = previousCallbackRef.current;
+        previousCallbackRef.current = null;
+      },
       handleScanResult: (barcode: ScanResult) => {
-        if (callbackRef.current) {
-          callbackRef.current(barcode);
+        const currentCallback = callbackRef.current;
+        if (currentCallback) {
+          currentCallback(barcode);
         } else {
           console.error(
             'No scan callback registered to handle barcode:',

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
@@ -12,7 +12,6 @@ import {
   ButtonWithIcon,
   PlusCircleIcon,
   useBarcodeScannerContext,
-  ScanResult,
   Alert,
 } from '@openmsupply-client/common';
 import { InboundLineEditForm } from './InboundLineEditForm';
@@ -85,11 +84,17 @@ export const InboundLineEdit = ({
     setCurrentItem(item);
   }, [item]);
 
-  // Temporarily suppress new scanning while edit modal is open. Once this
-  // closes, the Scan modal automatically re-registers its handler
-  useBarcodeScannerContext(() => setShowScanWarning(() => true));
-
-  // console.log('handleScanResult', handleScanResult);
+  // Temporarily suppress scanning while edit modal is open. Once this
+  // closes (component unmounts), the callback is reverted to allow scanning
+  // again.
+  const { revertCallback } = useBarcodeScannerContext(() =>
+    setShowScanWarning(() => true)
+  );
+  useEffect(() => {
+    return () => {
+      revertCallback();
+    };
+  }, []);
 
   const tableContent = simplifiedTabletView ? (
     <>

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
@@ -11,6 +11,9 @@ import {
   Box,
   ButtonWithIcon,
   PlusCircleIcon,
+  useBarcodeScannerContext,
+  ScanResult,
+  Alert,
 } from '@openmsupply-client/common';
 import { InboundLineEditForm } from './InboundLineEditForm';
 import { InboundLineFragment, useDraftInboundLines } from '../../../api';
@@ -59,6 +62,7 @@ export const InboundLineEdit = ({
     getSortedItems,
     currentItem?.id ?? ''
   );
+  const [showScanWarning, setShowScanWarning] = useState(false);
 
   const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
   const {
@@ -80,6 +84,12 @@ export const InboundLineEdit = ({
   useEffect(() => {
     setCurrentItem(item);
   }, [item]);
+
+  // Temporarily suppress new scanning while edit modal is open. Once this
+  // closes, the Scan modal automatically re-registers its handler
+  useBarcodeScannerContext(() => setShowScanWarning(() => true));
+
+  // console.log('handleScanResult', handleScanResult);
 
   const tableContent = simplifiedTabletView ? (
     <>
@@ -168,6 +178,11 @@ export const InboundLineEdit = ({
             item={currentItem}
             onChangeItem={setCurrentItem}
           />
+          {showScanWarning && (
+            <Alert severity="warning">
+              {t('warning.no-scanning-while-line-editing')}
+            </Alert>
+          )}
           <Divider margin={5} />
           {tableContent}
         </>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10474

# 👩🏻‍💻 What does this PR do?

The LineEdit modal didn't really have any proper `isDirty` tracking, so just went with the simpler option here -- if the Line Edit modal is open, we simply suppress any scanning until it's closed. If the user attempts to scan, they'll get a warning like so:

<img width="1036" height="715" alt="Screenshot 2026-02-16 at 3 29 38 PM" src="https://github.com/user-attachments/assets/24d96262-cad5-4855-80f4-28ea1887211a" />

## 💌 Any notes for the reviewer?

Was a bit tricky since these two modals don't have any knowledge of each other's state. There was a convoluted approach suggested by Co-pilot, but it had way to much interdependence between the modals and was quite hard to follow. So I've just updated the BarcodeScannerContext so it can temporarily change the scan handler callback. 

So the Edit modal registers a new callback when it opens (which toggles on the warning), and calls `revertCallback()` on dismount so the original callback becomes active again.

I'm not 100% convinced this is rock solid, so we should check it on different devices.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Scan items as normal
- [ ] Click on an item line and bring up the Edit modal
- [ ] Now try scanning again (can just click button on mock scanner, but try with real scanner if possible)
- [ ] Should see the warning shown above
- [ ] Close the modal (either save or cancel)
- [ ] Now scan again, the normal scan input modal should come back

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

