### PR TITLE
Better error message when failed to fetch errror on login

### DIFF
--- a/client/packages/host/src/components/Login/Login.tsx
+++ b/client/packages/host/src/components/Login/Login.tsx
@@ -98,7 +98,10 @@ export const Login = () => {
     }
 
     // Treat failed to fetch error as a connection error as this is the most likely cause, and provides a more helpful message to the user
-    if (error?.detail?.includes('Failed to fetch')) {
+    if (
+      error?.detail?.includes('Failed to fetch') || // Chrome
+      error?.detail?.includes('NetworkError') // Firefox
+    ) {
       return {
         error: t('error.connection-error'),
         hint: t('error.connection-error-hint'),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10492

# 👩🏻‍💻 What does this PR do?

Show connection error when we get a `failed to fetch` error on login. There is supposed to be a `ConnectionError` response that can be triggered but I'm not sure how that is meant to work. From reading up it seems like failed to fetch is a generic error from the browser and deliberately is lacking information about exactly what is going wrong. I think it's fair to say we can't connect to the server though, and the technical information (which is very limited, is still available from the `more information` button)
https://dev.to/toddhgardner/understanding-failed-to-fetch-javascript-errors-and-how-to-fix-them-14io

Chrome:
<img width="389" height="675" alt="image" src="https://github.com/user-attachments/assets/44ea42b4-0257-487e-b7a7-cef1815ff06d" />

Firefox:
<img width="389" height="675" alt="image" src="https://github.com/user-attachments/assets/7da83ab7-0da5-4fd9-9387-ddab267b4158" />


## 💌 Any notes for the reviewer?

This shows nicer errors for the login screen but we have a lot of `Failed to fetch` errors that pop up when the server isn't available. 

`useInitialisationStatus.ts` triggers this frequently 

<img width="389" height="675" alt="image" src="https://github.com/user-attachments/assets/6b5487c7-ecda-4edc-9e0c-bff23c402d25" />

<img width="310" height="319" alt="image" src="https://github.com/user-attachments/assets/89cb7929-1b48-44b8-a135-775b247ce9cb" />


So this is really only a partial fix for that problem. I thought there was another issue for this problem but couldn't find it ina quick search.
Maybe we need to look at a better error handler at a high level (server unavailable page that's triggered from GQL context)

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] I haven't tested on android so would be good to check that!
- [ ] Try navigating to the login screen, then turn off your server.
- [ ] Try to login
- [ ] Make sure the error says `connection error`

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

