### PR TITLE
Warn users they can't scan in an inbound shipment if the edit line modal is open.

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2644,5 +2644,6 @@
   "button.scanning": "Scanning…",
   "button.listening-for-scans": "Ready to scan…",
   "label.listening": "Listening for scans",
-  "label.enter-barcode": "Enter barcode"
+  "label.enter-barcode": "Enter barcode",
+  "messages.scan-disabled-warning": "Unable to scan, please close the item edit window modal to continue"
 }

--- a/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -249,7 +249,11 @@ const DetailViewInner = () => {
           )}
           <SidePanel />
 
-          <ScanInputModal lines={lines ?? []} invoiceId={data?.id ?? ''} />
+          <ScanInputModal
+            lines={lines ?? []}
+            invoiceId={data?.id ?? ''}
+            shouldOpen={!isOpen}
+          />
 
           {isOpen && (
             <InboundLineEdit

--- a/client/packages/invoices/src/InboundShipment/DetailView/ScanInputModal.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ScanInputModal.tsx
@@ -11,6 +11,7 @@ import {
   Box,
   TypedTFunction,
   LocaleKey,
+  useNotification,
 } from '@openmsupply-client/common';
 import { FnUtils, ScanResult, useBarcodeScannerContext } from '@common/utils';
 import React, { useCallback, useState } from 'react';
@@ -31,6 +32,7 @@ interface Message {
 interface ScanInputModalProps {
   lines: InboundLineFragment[];
   invoiceId: string;
+  shouldOpen?: boolean;
 }
 
 interface FormDraftState {
@@ -60,9 +62,14 @@ const defaultDraftState: FormDraftState = {
   barcodeContent: '',
 };
 
-export const ScanInputModal = ({ lines, invoiceId }: ScanInputModalProps) => {
+export const ScanInputModal = ({
+  lines,
+  invoiceId,
+  shouldOpen = false,
+}: ScanInputModalProps) => {
   const t = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
+  const { warning } = useNotification();
 
   const [barcodeData, setBarcodeData] = useState<BarcodeNode | null>(null);
   const [draftState, setDraftState] =
@@ -84,6 +91,14 @@ export const ScanInputModal = ({ lines, invoiceId }: ScanInputModalProps) => {
 
   const handleScan = useCallback(
     async (barcode: ScanResult) => {
+      if (!shouldOpen) {
+        console.warn(
+          'Scan received but shouldOpen is false, not opening modal to show scan result'
+        );
+        warning(t('messages.scan-disabled-warning'))();
+        return;
+      }
+
       if (!isOpen) {
         setIsOpen(true);
       }
@@ -142,7 +157,7 @@ export const ScanInputModal = ({ lines, invoiceId }: ScanInputModalProps) => {
         return newState;
       });
     },
-    [isOpen, getBarcode]
+    [isOpen, shouldOpen, getBarcode]
   );
 
   // Register the scan handler so it runs on scan events when context is


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10527

# 👩🏻‍💻 What does this PR do?

Shows a snackbar message when scanning at the edit line window is open. Note the risk of allowing this is that lines in that modal might not be saved and adding lines via scanning could cause the user to loose data.

<img width="953" height="963" alt="image" src="https://github.com/user-attachments/assets/a82b33f9-7bf2-4889-885c-886b0ac860d8" />

## 💌 Any notes for the reviewer?

To me this is less risky that the reverting callback solution....

https://github.com/msupply-foundation/open-msupply/pull/10527


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

