### PR TITLE
Only add temperatureBreach if there is a type

### DIFF
--- a/client/packages/coldchain/src/Monitoring/api/TemperatureLog/api.ts
+++ b/client/packages/coldchain/src/Monitoring/api/TemperatureLog/api.ts
@@ -1,6 +1,11 @@
 import { FilterBy, SortBy } from '@common/hooks';
 import { Sdk, TemperatureLogFragment } from './operations.generated';
-import { EqualFilterTemperatureBreachRowTypeInput, TemperatureLogSortFieldInput } from '@common/types';
+import {
+  EqualFilterTemperatureBreachRowTypeInput,
+  InputMaybe,
+  TemperatureLogFilterInput,
+  TemperatureLogSortFieldInput,
+} from '@common/types';
 
 export type ListParams = {
   first: number;
@@ -22,6 +27,19 @@ export const getTemperatureLogQueries = (sdk: Sdk, storeId: string) => ({
         // to make query compatible with breach tab filters we move the type filter into temperatureBreach.type
         const { type: typeFilterBy, ...noTypeFilterBy } = filterBy || {};
 
+        let filter: InputMaybe<TemperatureLogFilterInput> = {
+          ...noTypeFilterBy,
+        };
+
+        if (typeFilterBy) {
+          filter = {
+            ...filter,
+            temperatureBreach: {
+              type: typeFilterBy as EqualFilterTemperatureBreachRowTypeInput,
+            },
+          };
+        }
+
         const result = await sdk.temperatureLogs({
           storeId,
           page: { offset, first },
@@ -29,12 +47,7 @@ export const getTemperatureLogQueries = (sdk: Sdk, storeId: string) => ({
             key,
             desc: !!sortBy.isDesc,
           },
-          filter: {
-            ...noTypeFilterBy,
-            temperatureBreach: {
-              type: typeFilterBy as EqualFilterTemperatureBreachRowTypeInput ?? null,
-            },
-          },
+          filter,
         });
 
         return result?.temperatureLogs;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10537

# 👩🏻‍💻 What does this PR do?

A change made recently to the cold chain monitoring for tables, was subtlely wrong, it was adding in a Temperature Breach Filter with `null`. This sounds like it wouldn't do anything with temperature breaches, however the way it was interpereted in the repository this meant we only saw logs that had breaches attached to them.

The query changes from this (Only shows breaches)...
```
{
    "storeId": "34660F1A61E249DF9777FCC6588FE98C",
    "page": {
        "offset": 0,
        "first": 8640
    },
    "sort": {
        "key": "datetime",
        "desc": false
    },
    "filter": {
        "datetime": {
            "afterOrEqualTo": "2026-02-14T02:22:00.000Z",
            "beforeOrEqualTo": "2026-02-19T02:22:00.000Z"
        },
        "temperatureBreach": {
            "type": null
        }
    }
}
```

To this (shows everything)...

```
{
    "storeId": "34660F1A61E249DF9777FCC6588FE98C",
    "page": {
        "offset": 0,
        "first": 8640
    },
    "sort": {
        "key": "datetime",
        "desc": false
    },
    "filter": {
        "datetime": {
            "afterOrEqualTo": "2026-02-14T02:22:00.000Z",
            "beforeOrEqualTo": "2026-02-19T02:22:00.000Z"
        }
    }
}
```

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Test importing fridge tags
- [ ] Test temperature breach filters

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

