### PR TITLE
10459 fix portal components rendering once actual DOM is available

### DIFF
--- a/client/packages/common/src/ui/components/portals/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/common/src/ui/components/portals/AppBarButtons/AppBarButtons.tsx
@@ -26,7 +26,7 @@ export const AppBarButtons: FC = () => {
 export const AppBarButtonsPortal: FC<BoxProps> = props => {
   const { appBarButtonsRef } = useHostContext();
 
-  if (!appBarButtonsRef) return null;
+  if (!appBarButtonsRef?.current) return null;
 
   return (
     <Portal container={appBarButtonsRef.current}>

--- a/client/packages/common/src/ui/components/portals/AppBarContent/AppBarContent.tsx
+++ b/client/packages/common/src/ui/components/portals/AppBarContent/AppBarContent.tsx
@@ -37,7 +37,7 @@ export const AppBarContent: FC = () => {
 export const AppBarContentPortal: FC<BoxProps> = props => {
   const { appBarContentRef } = useHostContext();
 
-  if (!appBarContentRef) return null;
+  if (!appBarContentRef?.current) return null;
 
   return (
     <Portal container={appBarContentRef.current}>

--- a/client/packages/common/src/ui/components/portals/AppBarTabs/AppBarTabs.tsx
+++ b/client/packages/common/src/ui/components/portals/AppBarTabs/AppBarTabs.tsx
@@ -23,7 +23,7 @@ export const AppBarTabs: FC = () => {
 export const AppBarTabsPortal: FC<BoxProps> = props => {
   const { appBarTabsRef } = useHostContext();
 
-  if (!appBarTabsRef) return null;
+  if (!appBarTabsRef?.current) return null;
 
   return (
     <Portal container={appBarTabsRef.current}>

--- a/client/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
@@ -11,7 +11,6 @@ import {
   usePaginatedMaterialTable,
   MaterialTable,
   ColumnType,
-  BasicSpinner,
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
@@ -60,8 +59,7 @@ export const ListView = () => {
     ],
   });
   const queryParams = { ...filter, sortBy, page, first, offset };
-  const { data, isError, isFetching, isLoading } =
-    useResponse.document.list(queryParams);
+  const { data, isError, isFetching } = useResponse.document.list(queryParams);
   const { authoriseResponseRequisitions } = useResponse.utils.preferences();
   const program =
     data?.nodes.some(row => row.programName) ||
@@ -156,7 +154,7 @@ export const ListView = () => {
         includeColumn: authoriseResponseRequisitions,
       },
     ],
-    [t, program, authoriseResponseRequisitions, onUpdate]
+    []
   );
 
   const { table, selectedRows } = usePaginatedMaterialTable({
@@ -176,34 +174,13 @@ export const ListView = () => {
     ),
   });
 
-  // Memoize toolbar and app bar buttons to prevent re-render during sync
-  const toolbarComponent = useMemo(() => <Toolbar />, []);
-
-  const appBarComponent = useMemo(
-    () => (
+  return (
+    <>
+      <Toolbar />
       <AppBarButtons
         requisitionModalController={requisitionModalController}
         createOrderModalController={createOrderModalController}
       />
-    ),
-    [requisitionModalController, createOrderModalController]
-  );
-
-  // Show spinner on initial load only
-  if (isLoading && !data) {
-    return (
-      <>
-        {toolbarComponent}
-        {appBarComponent}
-        <BasicSpinner messageKey="loading" />
-      </>
-    );
-  }
-
-  return (
-    <>
-      {toolbarComponent}
-      {appBarComponent}
       <MaterialTable table={table} />
       <Footer
         selectedRows={selectedRows as ResponseFragment[]}

--- a/client/packages/requisitions/src/ResponseRequisition/ListView/Toolbar.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/ListView/Toolbar.tsx
@@ -11,7 +11,14 @@ const ToolbarComponent = () => {
   const t = useTranslation();
 
   return (
-    <AppBarContentPortal>
+    <AppBarContentPortal
+      sx={{
+        paddingBottom: '16px',
+        flex: 1,
+        justifyContent: 'space-between',
+        display: 'flex',
+      }}
+    >
       <Box display="flex" gap={1}>
         <FilterMenu
           filters={[


### PR DESCRIPTION

<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10459

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

