### PR TITLE
FIx issue where out of stock is ignored due to conflicting item_filte…

### DIFF
--- a/server/service/src/dashboard/item_count.rs
+++ b/server/service/src/dashboard/item_count.rs
@@ -117,7 +117,7 @@ impl ItemCountServiceTrait for ItemServiceCount {
     ) -> Result<ItemCounts, PluginOrRepositoryError> {
         let item_filter = ItemFilter::new().is_active(true).visible_or_on_hand(true);
         let visible_or_on_hand_items = ItemRepository::new(&ctx.connection)
-            .query_by_filter(item_filter.clone(), Some(store_id.to_string()))?;
+            .query_by_filter(item_filter, Some(store_id.to_string()))?;
 
         let total_count = visible_or_on_hand_items.len() as i64;
 
@@ -135,8 +135,11 @@ impl ItemCountServiceTrait for ItemServiceCount {
         let more_than_six_months_stock =
             Self::get_more_than_six_months_stock_count(self, &item_stats);
 
-        let out_of_stock_products =
-            self.get_out_of_stock_products_count(ctx, store_id, item_filter)?;
+        let out_of_stock_products = self.get_out_of_stock_products_count(
+            ctx,
+            store_id,
+            ItemFilter::new().is_active(true).has_stock_on_hand(false),
+        )?;
 
         let show_low_stock_alerts = NumberOfMonthsThresholdToShowLowStockAlertsForProducts
             .load(&ctx.connection, Some(store_id.to_string()))


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10553 Part 1

# 👩🏻‍💻 What does this PR do?

This PR fixes the issue where Out of stock Products showed the opposite of what it said, showing instead the number of instock items with recent consumption....

<img width="563" height="251" alt="image" src="https://github.com/user-attachments/assets/4f2d5ed1-260d-4f23-bcc2-e701514d494a" />


## 💌 Any notes for the reviewer?

This was a bit knarly to find. The problem was due to re-using an item filter for other queries, which contained `visible_or_on_hand=true` the item query filter definitions explicitly states that `has_stock_on_hand` will be ignored in this case, but it's not obvious that this will happen at call time. It does actually make sense that this is an invalid combination but I wonder if we should log an error at least in this scenario so that we don't accidentally ignore a parameter rather than see the resulting null set for conflicted sql...

<img width="880" height="80" alt="image" src="https://github.com/user-attachments/assets/234ed795-9d92-4272-86e7-b9aa5c264568" />

Might be some more fixes coming for other issues but thought this deserves it's own PR.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] You need products with recent consumption (see the store pref:  `Number of months to check for consumption when calculating out of stock products:`
- [ ] Make sure at least 1 product is out of stock
- [ ] Check that the dashboard out of stock product count matches what you expect from both recent consumption and actually being out of stock
- [ ] Check that the linked List view displays the same number of items.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [X] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

