### PR TITLE
Bundle android barcode scanner dependancy with the App

### DIFF
--- a/client/packages/android/app/build.gradle
+++ b/client/packages/android/app/build.gradle
@@ -86,6 +86,12 @@ repositories {
     }
 }
 
+// Exclude the unbundled Play Services barcode scanning dependency
+// to avoid conflicts with the bundled version
+configurations.all {
+    exclude group: 'com.google.android.gms', module: 'play-services-mlkit-barcode-scanning'
+}
+
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation(name: 'HoneywellScanner', ext: 'aar')
@@ -98,6 +104,10 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation project(':capacitor-cordova-android-plugins')
     implementation "com.google.android.gms:play-services-location:$playServicesLocationVersion"
+    
+    // Use bundled MLKit barcode scanning instead of unbundled Play Services version
+    // This bundles the model with the app, avoiding runtime downloads
+    implementation 'com.google.mlkit:barcode-scanning:17.3.0'
 }
 
 apply from: 'capacitor.build.gradle'

--- a/client/packages/android/app/src/main/AndroidManifest.xml
+++ b/client/packages/android/app/src/main/AndroidManifest.xml
@@ -25,7 +25,6 @@
             </intent-filter>
 
         </activity>
-        <meta-data android:name="com.google.mlkit.vision.DEPENDENCIES" android:value="barcode_ui"/>
 
         <provider
             android:name="androidx.core.content.FileProvider"


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?
Fixes #10521

Note this is a cherry pick of this copilot PR: https://github.com/msupply-foundation/open-msupply/pull/10565

Want to do this approach with out the additional changes in this PR: https://github.com/msupply-foundation/open-msupply/pull/10560

Replaces the unbundled Play Services barcode scanner (which requires runtime model downloads) with the bundled MLKit version. The previous implementation failed on devices installed via MDM or manual APK in low-bandwidth/offline environments.

**Changes:**
- Removed AndroidManifest.xml meta-data tag that triggers Play Services download
- Added bundled dependency: `com.google.mlkit:barcode-scanning:17.3.0` 
- Excluded unbundled Play Services dependency to prevent conflicts

**Impact:**
- Barcode model (~3MB) now embedded in APK
- No runtime download required
- Works with MDM/manual installations

## 💌 Any notes for the reviewer?

This addresses the limitation discovered where the unbundled approach only downloads models for Play Store installations, not MDM/manual APK deployments.

# 🧪 Testing

- [ ] On Android tablet/Honeywell CK65 device installed via MDM or manual APK
- [ ] First-time launch should not trigger any download prompts
- [ ] Scan GS1 barcode from "Scan" button on Inbound/Outbound shipment screen
- [ ] Camera scanner opens immediately without delay
- [ ] GS1 barcode reads with correct data

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour