### PR TITLE
5747 Stop logout soft lock

### DIFF
--- a/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.ts
+++ b/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.ts
@@ -94,8 +94,12 @@ export const useBlockNavigation = () => {
       customConfirmation
         ? customConfirmation(blocker.proceed)
         : showConfirmation({
-            onConfirm: blocker.proceed,
+            onConfirm: () => {
+              if (blocker.state === 'blocked') blocker.proceed();
+            },
           });
+    } else {
+      // ideally we would close the modal here if the blocker is no longer active but useConfirmationModal doesn't currently support this
     }
   }, [blocker]);
 };
@@ -132,9 +136,10 @@ interface BlockNavigationControl {
     options?: BlockerOptions
   ) => void;
   clearKey: (key: string) => void;
+  clearAll: () => void;
 }
 
-const useBlockNavigationState = create<BlockNavigationControl>(set => {
+export const useBlockNavigationState = create<BlockNavigationControl>(set => {
   return {
     blocking: new Map(),
     setBlocking: (key, blocking, options) => {
@@ -156,6 +161,12 @@ const useBlockNavigationState = create<BlockNavigationControl>(set => {
           blocking: blockingState,
         };
       });
+    },
+    clearAll: () => {
+      set(state => ({
+        ...state,
+        blocking: new Map(),
+      }));
     },
   };
 });

--- a/client/packages/host/src/components/ErrorAlert.tsx
+++ b/client/packages/host/src/components/ErrorAlert.tsx
@@ -1,4 +1,4 @@
-import { useToggle } from '@common/hooks';
+import { useBlockNavigationState, useToggle } from '@common/hooks';
 import { AppRoute } from '@openmsupply-client/config';
 import React, { useEffect } from 'react';
 import {
@@ -21,11 +21,19 @@ export const ErrorAlert = () => {
   const t = useTranslation();
   const location = useLocation();
   const [error, , removeError] = useLocalStorage('/error/auth');
+  const { clearAll: clearAllBlockers } = useBlockNavigationState();
 
   useEffect(() => {
     if (!!error) toggleOn();
     return () => toggleOff();
   }, [error, toggleOff, toggleOn]);
+
+  useEffect(() => {
+    if (isOn) {
+      // clear blockers to ensure the user can navigate to the login page, otherwise they will be stuck on the error modal
+      clearAllBlockers();
+    }
+  }, [isOn, clearAllBlockers]);
 
   // no need to alert if you are on the login screen
   if (

--- a/client/packages/system/src/Manage/Preferences/Components/MultiChoice.test.tsx
+++ b/client/packages/system/src/Manage/Preferences/Components/MultiChoice.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import {
-  MultiChoice,
-  getMultiChoiceOptions,
-} from './MultiChoice';
+import { MultiChoice } from './MultiChoice';
 import {
   InvoiceNodeStatus,
   PreferenceKey,


### PR DESCRIPTION
Fixes #5747

# 👩🏻‍💻 What does this PR do?

Allows the user to go back to the login page from the 'you are not currently logged in' modal even when there is a navigation blocker from a dirty form. If the 'your work will be lost' modal was open this will need to be closed once on the login page as `useConfirmationModal` doesn't have an api for closing the modal programatically.

## 💌 Any notes for the reviewer?

Data in the blocking form is lost as trying to recover it would require a change in the login flow or changing all the forms that can block navigation. Could possibly have a better user experience by putting the 'your work will be lost' modal on top of the error modal after pressing OK but given the relative rarity of this problem this wasn't implemented. Let me know if it's worth implementing either of these.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go a page that blocks navigation (e.g. Patient Encounter or Cold Chain Equipment edit)
- [ ] Make an edit on that page
- [ ] Try to navigate away - should come up with a 'your work will be lost' modal
- [ ] Wait an hour or clear cookies from application tab in dev tools and wait like 2 mins
- [ ] Should get 'you are not currently logged in' modal
- [ ] Can navigate back to the login page by pressing OK

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

