### PR TITLE
#10544 Allow existing items when scanning in Outbounds

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import {
   DialogButton,
   Grid,
@@ -41,6 +41,13 @@ export const OutboundLineEdit = ({
   const t = useTranslation();
   const { info, warning } = useNotification();
   const [itemId, setItemId] = useState(openedWith?.itemId);
+
+  // Used to determine if the item selector should be disabled. We want to allow
+  // changing the item if we opened with a barcode and haven't selected an item
+  // yet (e.g. if the barcode didn't match any items), but once an item is
+  // selected, we want to disable changing it to avoid complications with
+  // changing the allocation when the item changes.
+  const hasInitialItem = useRef(!!itemId);
 
   const onClose = () => {
     clear();
@@ -167,7 +174,7 @@ export const OutboundLineEdit = ({
         <SelectItem
           itemId={itemId}
           onChangeItem={setItemId}
-          disabled={mode === ModalMode.Update}
+          disabled={mode === ModalMode.Update || hasInitialItem.current}
           openedWithBarcode={!!asBarcodeOrNull(openedWith)}
         />
 

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/SelectItem.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/SelectItem.tsx
@@ -12,20 +12,23 @@ interface SelectItemProps {
   itemId: string | undefined;
   onChangeItem: (newItemId?: string) => void;
   disabled: boolean;
-  openedWithBarcode: boolean;
+  openedWithBarcode?: boolean;
 }
 
 export const SelectItem = ({
   itemId,
   onChangeItem,
   disabled,
-  openedWithBarcode,
+  openedWithBarcode = false,
 }: SelectItemProps) => {
   const t = useTranslation();
   const { data: items } = useOutboundItems();
 
   const existingItemIds = items?.map(item => item.id);
 
+  // Normally we exclude items already in the invoice from the search, but if we
+  // opened the modal with a barcode, we want to allow selecting the same item
+  // again (e.g. to add another line with the same item)
   const existingItemFilter = openedWithBarcode
     ? {}
     : { id: { notEqualAll: existingItemIds } };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10544

# 👩🏻‍💻 What does this PR do?

Normally, the Item Select component doesn't show items that are already in the invoice in its list of options. However, when adding from a barcode scan, this is necessary when the scanned code is not already in the database.

I've also made the `disabled` behaviour consistent -- when the modal opens up with an item already matching, it will be disabled. But if there's no item yet (from clicking "Add" or scanning a barcode that doesn't match and item), you will be able to edit it (and keep editing it after initial selection).


## 💌 Any notes for the reviewer?

See comments

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Follow procedure defined in the issue -- confirm that item can be selected even if it already exists in the system
- [ ] When adding an item manually (not through barcode scan), confirm that existing items are *not* available
- [ ] Scanning a new item, the item selector is active, and item selector remains active even after initial selection
- [ ] When scanning a matching item, or when clicking on the line in the invoice, confirm that item selector is *disabled*

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

