### PR TITLE
Fix Android APK size regression (138 MB → ~54 MB)

### DIFF
--- a/client/packages/android/app/build.gradle
+++ b/client/packages/android/app/build.gradle
@@ -61,6 +61,12 @@ android {
             signingConfig signingConfigs.release
         }
     }
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging = true
+        }
+    }
+
     flavorDimensions "abi"
     productFlavors {
         arm64 {


### PR DESCRIPTION
## Summary

Fixes #10636 — the ARM64 release APK ballooned from ~43.8 MB (v2.15.05) to ~138 MB (v2.16.0-RC).

Sets `useLegacyPackaging = true` in `app/build.gradle` to restore compression of native `.so` libraries within the APK.

**Measured size impact (arm64 debug build, same machine, same `.so`):**

| Build | APK size |
|---|---|
| Without fix (current default) | **132 MB** |
| With `useLegacyPackaging = true` | **54 MB** |

The remaining difference from v2.15.05 (~43.8 MB) reflects the new MLKit barcode scanner library added during the Capacitor v8 upgrade.

## Root cause

### 1. AGP default changed — `.so` files now stored uncompressed

The app's `minSdkVersion = 24` (≥ 23), which triggers a new Android Gradle Plugin default: native libraries are stored **uncompressed** in the APK. This allows the OS to memory-map them directly without extraction at install time — a performance benefit for Play Store installs — but significantly increases the raw APK download size for our direct APK distribution model.

The dominant file is the Rust server binary (`libremote_server_android.so`), which is **114 MB** stripped. Uncompressed in the APK it contributes ~114 MB; compressed (with `useLegacyPackaging = true`) it compresses down to ~40 MB, consistent with the v2.15.05 size.

### 2. Barcode scanner library switch added ~10 MB

The Capacitor v6 → v8 upgrade (commit `7055f6c2fe`) switched from `@capacitor-community/barcode-scanner` (ZXing-based, no ML model) to `@capacitor-mlkit/barcode-scanning` (MLKit bundled, includes `libbarhopper_v3.so` + TFLite models). This added ~10 MB on top, explaining why the fixed APK (~54 MB) is larger than v2.15.05 (~43.8 MB).

## Why `useLegacyPackaging = true` is appropriate here

The "uncompressed = better" argument from Google assumes Play Store delivery with Android App Bundle splits. This app is distributed as a **direct APK download**, so:
- Users download the full raw APK size
- The ~78 MB saving on download is a direct UX improvement for low-bandwidth sites
- The install-time extraction overhead (the downside of `useLegacyPackaging = true`) is a one-time cost measured in seconds

## Why not `minifyEnabled true`?

`minifyEnabled true` (ProGuard/R8) only affects Java/Kotlin DEX code — it has no effect on the Rust `.so`, the JS bundle, or the MLKit native libs. The Java layer here is thin (Capacitor boilerplate + plugin wrappers), so the size saving would be at most 2–5 MB. The risk is meaningful: Capacitor plugins use reflection, and the Rust JNI bridge calls Java methods by name — both require correct `-keep` rules in `proguard-rules.pro` which are not currently maintained. Runtime crashes from mangled names are hard to debug in the field. Not worth the risk for the marginal gain.