### PR TITLE
10354 - line total display issue in inbound shipment

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -415,6 +415,7 @@ export const PricingTableComponent = ({
         header: t('label.fc-cost-price', {
           currency: currency?.code,
         }),
+        columnType: ColumnType.Currency,
         size: 100,
         accessorFn: row => {
           if (currency) {
@@ -441,6 +442,7 @@ export const PricingTableComponent = ({
       {
         id: 'foreignCurrencySellPricePerPack',
         header: t('label.fc-sell-price'),
+        columnType: ColumnType.Currency,
         size: 100,
         accessorFn: row => {
           if (currency) {
@@ -454,12 +456,14 @@ export const PricingTableComponent = ({
       {
         accessorKey: 'lineTotal',
         header: t('label.line-total'),
+        columnType: ColumnType.Currency,
         size: 100,
         accessorFn: row => row.costPricePerPack * row.numberOfPacks,
       },
       {
         id: 'foreignCurrencyLineTotal',
         header: t('label.fc-line-total'),
+        columnType: ColumnType.Currency,
         size: 100,
         accessorFn: row => {
           if (currency) {


### PR DESCRIPTION

Fixes #10354 

# 👩🏻‍💻 What does this PR do?

This PR corrects the line total cells to use currency value cells, which already apply the relevant rounding

Before this PR:
<img width="1668" height="695" alt="image" src="https://github.com/user-attachments/assets/bd3c1f8b-df99-4d56-b22a-3fa2981b6b53" />


After this PR:
<img width="1820" height="721" alt="image" src="https://github.com/user-attachments/assets/78aec37a-bf78-4c68-a876-7c753494e740" />


## 💌 Any notes for the reviewer?


Note that it will use up to 2 dp regardless of the currency as it uses the currency value cell which is used elsewhere throughout the app. Better support for currencies without 2dp should be split out into another ticket -> feeding this back onn. the ticket

# 🧪 Testing

Steps to reproduce the behaviour:

- Go to Inbound shipment and add an item
- Enter number of packs 24800 and pack cost price 4.6 --> see result 114079.99999999999.. -> now it should be 114080.00 and show the dollar symbol too

Would be good to test with other currencies as well, and when using foreign currency in addition


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

