### PR TITLE
filter the PO table when creating an external inbound shipment

### DIFF
--- a/client/packages/invoices/src/InboundShipment/ListView/LinkPurchaseOrderModal.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/LinkPurchaseOrderModal.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { InboundShipmentPurchaseOrderLineFragment } from '../api';
 import {
   useWindowDimensions,
@@ -11,7 +11,6 @@ import {
   PurchaseOrderNodeStatus,
   useNonPaginatedMaterialTable,
 } from '@openmsupply-client/common';
-import { MRT_RowSelectionState } from 'material-react-table';
 import { useListSentPurchaseOrders } from '../api/hooks/document/useListSentPurchaseOrders';
 
 interface LinkInternalOrderModalProps {
@@ -61,14 +60,11 @@ export const LinkPurchaseOrderModal = ({
         accessorKey: 'comment',
         header: t('label.comment'),
         columnType: ColumnType.Comment,
-        enableColumnFilter: false,
         size: 80,
       },
     ],
     []
   );
-
-  const [rowSelection, setRowSelection] = useState<MRT_RowSelectionState>({});
 
   const { table, selectedRows } =
     useNonPaginatedMaterialTable<InboundShipmentPurchaseOrderLineFragment>({
@@ -84,8 +80,7 @@ export const LinkPurchaseOrderModal = ({
         onClick: row.getToggleSelectedHandler(),
         sx: { cursor: 'pointer' },
       }),
-      onRowSelectionChange: setRowSelection,
-      state: { rowSelection, showColumnFilters: true },
+      state: { showColumnFilters: true },
       isLoading,
     });
 
@@ -94,7 +89,7 @@ export const LinkPurchaseOrderModal = ({
       selectedRows[0] as InboundShipmentPurchaseOrderLineFragment,
       addLines
     );
-    setRowSelection({});
+    table.resetRowSelection();
   };
 
   const disabled = selectedRows.length == 0;


### PR DESCRIPTION
Fixes #10647 

# 👩🏻‍💻 What does this PR do?

This PR adds filters to each of the supplier, PO number and reference columns on the table of purchase orders when choosing a PO to link a new external inbound shipment to.
This is necessary to find the correct PO when the list is longer

<img width="1899" height="1021" alt="image" src="https://github.com/user-attachments/assets/c7c822d9-a540-49d4-821a-96840811ee07" />


## 💌 Any notes for the reviewer?
The table is unpaginated and I have applied client side filtering so it does not need to reload as you type
If the table were especially large, then we should transition to server side filtering


# 🧪 Testing

Clic new inbound shipment external
See the PO mtable
Test out the filters together and apart, including no resolts
Ensure no problem with realistically large numbers of POs

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

