### PR TITLE
#10645 fix migration error for item_category_join

### DIFF
--- a/server/repository/src/migrations/v2_17_00/item_category_join_add_item_link_id.rs
+++ b/server/repository/src/migrations/v2_17_00/item_category_join_add_item_link_id.rs
@@ -26,14 +26,25 @@ impl MigrationFragment for Migrate {
         sql!(
             connection,
             r#"
-                PRAGMA foreign_keys = OFF;
-                ALTER TABLE item_category_join
-                ADD COLUMN item_link_id TEXT NOT NULL REFERENCES item_link (id) DEFAULT 'temp_for_migration'; 
-                UPDATE item_category_join SET item_link_id = item_id;
-                PRAGMA foreign_keys = ON;
+                CREATE TABLE item_category_join_new (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    item_link_id TEXT NOT NULL REFERENCES item_link(id),
+                    category_id TEXT NOT NULL REFERENCES category(id),
+                    deleted_datetime TEXT
+                );
+
+                INSERT INTO item_category_join_new (id, item_link_id, category_id, deleted_datetime)
+                SELECT id, item_id, category_id, deleted_datetime
+                FROM item_category_join;
+
+                DROP TABLE item_category_join;
+                ALTER TABLE item_category_join_new RENAME TO item_category_join;
+
+                CREATE INDEX "index_item_category_join_item_link_id_fkey" ON "item_category_join" ("item_link_id");
          "#,
         )?;
 
+        #[cfg(feature = "postgres")]
         sql!(
             connection,
             r#"


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10645

# 👩🏻‍💻 What does this PR do?

Recreates the item_category_join in the sqlite migration to get around sqlite limitations. Could possibly be done with `PRAGMA foreign_keys = OFF;` but the only way to delete the item_link column is to rebuild the table anyway.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Run 2.16-2.17-develop migration in sqlite with populated database

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

