### PR TITLE
fix: add debounce to units-received input to prevent premature rounding during typing

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -271,6 +271,7 @@ export const QuantityTable = ({
         Cell: ({ row, cell }) => (
           <NumberInputCell
             cell={cell}
+            debounceTime={300}
             updateFn={(value: number) => {
               const { packSize } = row.original;
               if (packSize !== undefined) {


### PR DESCRIPTION
## Summary
- Cherry-picked from #10680 onto `v2.16.0-RC`
- Adds debounce to units-received input to prevent premature rounding during typing

## Test plan
- [ ] Open an inbound shipment and edit a line
- [ ] Type a number into the units-received input
- [ ] Verify the input doesn't round prematurely while typing

🤖 Generated with [Claude Code](https://claude.com/claude-code)