### PR TITLE
Now that base dir is required, better to make it non-optional

### DIFF
--- a/server/android/src/android.rs
+++ b/server/android/src/android.rs
@@ -45,7 +45,7 @@ pub mod android {
                 discovery: DiscoveryMode::Disabled,
                 debug_no_access_control: false,
                 cors_origins: vec!["http://localhost".to_string()],
-                base_dir: Some(files_dir.to_str().unwrap().to_string()),
+                base_dir: files_dir.to_str().unwrap().to_string(),
                 machine_uid: Some(android_id),
                 override_is_central_server: false,
             },

--- a/server/cli/src/backup/mod.rs
+++ b/server/cli/src/backup/mod.rs
@@ -31,8 +31,6 @@ pub(super) enum BackupError {
     CannotCreateBackupFolder(#[source] io::Error, PathBuf),
     #[error("Problem create folder at path: {1}")]
     CannotCreateBaseDirFolder(#[source] io::Error, PathBuf),
-    #[error("base_dir must be configured in configuration files")]
-    BaseDirNotSet,
     #[error("Invalid path specified: {0}")]
     InvalidPath(String),
     #[error("Problem copying folder, from: {0} to {1}")]
@@ -102,13 +100,8 @@ fn get_dirs_from_settings(settings: &Settings) -> Result<DirSettings, BackupErro
 }
 
 fn get_base_dir(settings: &Settings) -> Result<PathBuf, BackupError> {
-    let base_dir = settings
-        .server
-        .base_dir
-        .as_ref()
-        .map(|dir| PathBuf::from_str(dir).map_err(|_| BackupError::InvalidPath(dir.to_string())))
-        .transpose()?
-        .ok_or(BackupError::BaseDirNotSet)?;
+    let base_dir = PathBuf::from_str(&settings.server.base_dir)
+        .map_err(|_| BackupError::InvalidPath(settings.server.base_dir.clone()))?;
 
     // Create the app base directory if it does not exist
     if !base_dir.exists() {

--- a/server/server/src/certs.rs
+++ b/server/server/src/certs.rs
@@ -21,7 +21,7 @@ pub const PUBLIC_CERT_FILE: &str = "cert.pem";
 
 pub fn find_certs(server_settings: &ServerSettings) -> Option<CertFiles> {
     let cert_dir = PathBuf::new()
-        .join(server_settings.base_dir.clone().unwrap_or(".".to_string()))
+        .join(&server_settings.base_dir)
         .join(CERTS_PATH);
 
     let key_file = PathBuf::new().join(&cert_dir).join(PRIVATE_CERT_FILE);
@@ -95,16 +95,13 @@ impl Certificates {
                     None
                 } else {
                     warn!("No certificates found: Generating self signed certificates");
-                    let base_dir = &settings.base_dir.clone().unwrap_or(".".to_string());
-                    let cert_path = PathBuf::from(base_dir).join(CERTS_PATH);
+                    let cert_path = PathBuf::from(&settings.base_dir).join(CERTS_PATH);
                     let cert_files = match Self::generate_certs(&cert_path) {
                         Ok(cert_files) => cert_files,
                         Err(e) => {
                             warn!("Error generating self signed certificates: {e}");
                             error!("No certificates found");
-                            return Err(std::io::Error::other(
-                                "Certificate required",
-                            ));
+                            return Err(std::io::Error::other("Certificate required"));
                         }
                     };
                     Some(load_certs_rustls(cert_files).expect("Invalid self signed certificates"))

--- a/server/server/src/cold_chain/temperature_log.rs
+++ b/server/server/src/cold_chain/temperature_log.rs
@@ -146,9 +146,7 @@ fn upsert_temperature_log(
                 service_provider
                     .cold_chain_service
                     .insert_temperature_breach(ctx, breach)
-                    .map_err(|e| {
-                        anyhow::anyhow!("Unable to insert temperature breach {e:?}")
-                    })?;
+                    .map_err(|e| anyhow::anyhow!("Unable to insert temperature breach {e:?}"))?;
             }
             Err(e) => {
                 return Err(anyhow::anyhow!(

--- a/server/server/src/configuration.rs
+++ b/server/server/src/configuration.rs
@@ -158,7 +158,7 @@ fn derive_file_paths(config_file: Option<PathBuf>) -> Result<ConfigFilePaths, Se
         None => ConfigFilePaths {
             base: get_configuration_base_file()?,
             app: get_configuration_app_file()?,
-        }
+        },
     };
 
     Ok(file_paths)

--- a/server/server/src/discovery.rs
+++ b/server/server/src/discovery.rs
@@ -21,8 +21,6 @@ pub(crate) fn start_discovery(protocol: Protocol, port: u16, hardware_id: String
         // To avoid crashing the server, we catch the panic here and log the error.
         // Longer term, we should fix the unwrap in the Astro DNS code.
         let result = panic::catch_unwind(|| {
-            
-
             // This code is to test the panic handling. Uncomment the following lines to test.
             // let x: Option<String> = None;
             // let _y = x.unwrap();

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -107,9 +107,9 @@ pub async fn start_server(
     }
 
     // CREATE BASE DIRECTORY IF IT DOESN'T EXIST
-    let base_dir = settings.server.base_dir.clone().unwrap_or(".".to_string());
+    let base_dir = &settings.server.base_dir;
     info!("Creating base directory if needed: {}", base_dir);
-    std::fs::create_dir_all(&base_dir)?;
+    std::fs::create_dir_all(base_dir)?;
 
     // INITIALISE DATABASE AND CONNECTION
     let connection_manager = get_storage_connection_manager(&settings.database);

--- a/server/server/src/upload.rs
+++ b/server/server/src/upload.rs
@@ -18,10 +18,7 @@ use service::{
 use crate::authentication::validate_cookie_auth;
 
 pub fn get_default_directory(settings: &Settings) -> TempFileConfig {
-    match settings.server.base_dir.as_ref() {
-        Some(base_dir) => TempFileConfig::default().directory(base_dir),
-        None => TempFileConfig::default(),
-    }
+    TempFileConfig::default().directory(&settings.server.base_dir)
 }
 
 pub fn config_upload(cfg: &mut web::ServiceConfig) {

--- a/server/service/src/plugin/plugin_files.rs
+++ b/server/service/src/plugin/plugin_files.rs
@@ -30,7 +30,7 @@ impl PluginFileService {
     /// Returns the path to the file
     pub fn find_file(
         plugin_bucket: &Mutex<ValidatedPluginBucket>,
-        base_dir: &Option<String>,
+        base_dir: &str,
         PluginInfo { plugin, filename }: &PluginInfo,
     ) -> anyhow::Result<Option<PathBuf>> {
         let plugin_base_dir = get_plugin_dir(base_dir)?;
@@ -46,7 +46,7 @@ impl PluginFileService {
 
     pub fn plugin_files(
         plugin_bucket: &Mutex<ValidatedPluginBucket>,
-        base_dir: &Option<String>,
+        base_dir: &str,
     ) -> anyhow::Result<Vec<PluginFile>> {
         let mut files = Vec::new();
         let plugin_base_dir = get_plugin_dir(base_dir)?;
@@ -88,11 +88,8 @@ impl PluginFileService {
     }
 }
 
-fn get_plugin_dir(base_dir: &Option<String>) -> Result<PathBuf, anyhow::Error> {
-    Ok(match base_dir {
-        Some(file_dir) => PathBuf::from_str(file_dir)?.join(PLUGIN_FILE_DIR),
-        None => PathBuf::from_str(PLUGIN_FILE_DIR)?,
-    })
+fn get_plugin_dir(base_dir: &str) -> Result<PathBuf, anyhow::Error> {
+    Ok(PathBuf::from_str(base_dir)?.join(PLUGIN_FILE_DIR))
 }
 
 fn read_plugin_file(

--- a/server/service/src/plugin/validation.rs
+++ b/server/service/src/plugin/validation.rs
@@ -41,15 +41,9 @@ pub struct ValidatedPluginBucket {
 }
 
 impl ValidatedPluginBucket {
-    pub fn new(base_dir: &Option<String>) -> anyhow::Result<Self> {
-        let plugin_dir = match base_dir {
-            Some(base_dir) => PathBuf::from_str(base_dir)?.join(PLUGIN_FILE_DIR),
-            None => PathBuf::from_str(PLUGIN_FILE_DIR)?,
-        };
-        let trusted_cert_path = match base_dir {
-            Some(base_dir) => PathBuf::from_str(base_dir)?.join(PLUGIN_CERT_DIR),
-            None => PathBuf::from_str(PLUGIN_CERT_DIR)?,
-        };
+    pub fn new(base_dir: &str) -> anyhow::Result<Self> {
+        let plugin_dir = PathBuf::from_str(base_dir)?.join(PLUGIN_FILE_DIR);
+        let trusted_cert_path = PathBuf::from_str(base_dir)?.join(PLUGIN_CERT_DIR);
 
         Ok(ValidatedPluginBucket {
             plugin_dir,

--- a/server/service/src/report/convert_to_excel.rs
+++ b/server/service/src/report/convert_to_excel.rs
@@ -10,11 +10,7 @@ use umya_spreadsheet::{
     Cell, FontSize, Spreadsheet, Worksheet,
 };
 
-pub fn csv_to_excel(
-    base_dir: &Option<String>,
-    csv_data: &str,
-    filename: &str,
-) -> Result<String, ReportError> {
+pub fn csv_to_excel(base_dir: &str, csv_data: &str, filename: &str) -> Result<String, ReportError> {
     // Parse CSV data
     let mut reader = Reader::from_reader(csv_data.as_bytes());
     let headers = reader
@@ -58,7 +54,7 @@ pub fn csv_to_excel(
 
 /// Converts the report to an Excel file and returns the file id
 pub fn export_html_report_to_excel(
-    base_dir: &Option<String>,
+    base_dir: &str,
     report: GeneratedReport,
     report_name: String,
     template_as_buffer: &Option<Vec<u8>>,
@@ -84,7 +80,7 @@ pub fn export_html_report_to_excel(
 }
 
 /// Hold a file in the temporary directory
-fn reserve_file(base_dir: &Option<String>, report_name: &str) -> Result<StaticFile, ReportError> {
+fn reserve_file(base_dir: &str, report_name: &str) -> Result<StaticFile, ReportError> {
     let now: DateTime<Utc> = SystemTime::now().into();
     let file_service = StaticFileService::new(base_dir)
         .map_err(|err| ReportError::DocGenerationError(format!("{err}")))?;
@@ -718,13 +714,13 @@ mod report_to_excel_test {
     fn test_csv_to_excel() {
         let csv_data = "Name,Status,Invoice Number\nHarry Potter,Picked,2\nHermione Granger,New,3\nRon Weasley,New,4\n";
 
-        let result = csv_to_excel(&None, csv_data, "test_csv_export");
+        let result = csv_to_excel(".", csv_data, "test_csv_export");
         assert!(result.is_ok(), "CSV to Excel conversion should succeed");
 
         let file_id = result.unwrap();
         assert!(!file_id.is_empty(), "File ID should not be empty");
 
-        let file_service = StaticFileService::new(&None).unwrap();
+        let file_service = StaticFileService::new(".").unwrap();
         let generated_file = file_service
             .find_file(&file_id, StaticFileCategory::Temporary)
             .unwrap()
@@ -835,7 +831,7 @@ mod report_to_excel_test {
 
         // Test the full export function with template
         let result = export_html_report_to_excel(
-            &None, // base_dir
+            ".", // base_dir
             report,
             "test_with_template".to_string(),
             &Some(template_bytes),
@@ -845,7 +841,7 @@ mod report_to_excel_test {
         let file_id = result.unwrap();
 
         // Read back the generated file to verify content
-        let file_service = StaticFileService::new(&None).unwrap();
+        let file_service = StaticFileService::new(".").unwrap();
         let generated_file = file_service
             .find_file(&file_id, StaticFileCategory::Temporary)
             .unwrap()

--- a/server/service/src/report/html_printing.rs
+++ b/server/service/src/report/html_printing.rs
@@ -3,7 +3,7 @@ use std::{fs, path::PathBuf, str::FromStr};
 use headless_chrome::{types::PrintToPdfOptions, Browser, LaunchOptionsBuilder};
 
 pub fn html_to_pdf(
-    temp_dir: &Option<String>,
+    temp_dir: &str,
     document: &str,
     document_id: &str,
 ) -> Result<Vec<u8>, anyhow::Error> {
@@ -29,11 +29,7 @@ pub fn html_to_pdf(
         generate_tagged_pdf: None,
     });
 
-    let temp_dir = match temp_dir {
-        Some(temp_dir) => PathBuf::from_str(temp_dir)?,
-        None => std::env::current_dir()?,
-    }
-    .join("report_printing_tmp");
+    let temp_dir = PathBuf::from_str(temp_dir)?.join("report_printing_tmp");
     // headless chrome needs an absolute path
     let temp_dir = if !temp_dir.is_absolute() {
         std::env::current_dir()?.join(temp_dir)

--- a/server/service/src/report/report_service.rs
+++ b/server/service/src/report/report_service.rs
@@ -163,7 +163,7 @@ pub trait ReportServiceTrait: Sync + Send {
     /// Converts a HTML report to a file for the target PrintFormat and returns file id
     fn generate_html_report(
         &self,
-        base_dir: &Option<String>,
+        base_dir: &str,
         report: &ResolvedReportDefinition,
         report_data: serde_json::Value,
         arguments: Option<serde_json::Value>,
@@ -224,7 +224,7 @@ pub trait ReportServiceTrait: Sync + Send {
 
     fn csv_to_excel(
         &self,
-        base_dir: &Option<String>,
+        base_dir: &str,
         csv_data: &str,
         filename: &str,
     ) -> Result<String, ReportError> {
@@ -234,7 +234,7 @@ pub trait ReportServiceTrait: Sync + Send {
 
 /// Converts a HTML report to a pdf file and returns the file id
 fn generate_html_report_to_pdf(
-    base_dir: &Option<String>,
+    base_dir: &str,
     document: GeneratedReport,
     report_name: String,
 ) -> Result<String, ReportError> {
@@ -258,7 +258,7 @@ fn generate_html_report_to_pdf(
 
 /// Converts the report to a HTML file and returns the file id
 fn generate_html_report_to_html(
-    base_dir: &Option<String>,
+    base_dir: &str,
     document: GeneratedReport,
     report_name: String,
 ) -> Result<String, ReportError> {
@@ -1055,7 +1055,8 @@ mod report_filter_test {
         assert_eq!(result.len(), 1);
         let mut report = reports
             .clone()
-            .into_iter().find(|r| r.id == result.clone().into_iter().next().unwrap())
+            .into_iter()
+            .find(|r| r.id == result.clone().into_iter().next().unwrap())
             .unwrap();
         assert_eq!(report.version, Version::from_str("2.3.5"));
 
@@ -1064,7 +1065,8 @@ mod report_filter_test {
         assert_eq!(result.len(), 1);
         report = reports
             .clone()
-            .into_iter().find(|r| r.id == result.clone().into_iter().next().unwrap())
+            .into_iter()
+            .find(|r| r.id == result.clone().into_iter().next().unwrap())
             .unwrap();
         assert_eq!(report.version, Version::from_str("2.3.5"));
 
@@ -1073,7 +1075,8 @@ mod report_filter_test {
         assert_eq!(result.len(), 1);
         report = reports
             .clone()
-            .into_iter().find(|r| r.id == result.clone().into_iter().next().unwrap())
+            .into_iter()
+            .find(|r| r.id == result.clone().into_iter().next().unwrap())
             .unwrap();
         assert_eq!(report.version, Version::from_str("2.8.3"));
 
@@ -1082,7 +1085,8 @@ mod report_filter_test {
         assert_eq!(result.len(), 1);
         report = reports
             .clone()
-            .into_iter().find(|r| r.id == result.clone().into_iter().next().unwrap())
+            .into_iter()
+            .find(|r| r.id == result.clone().into_iter().next().unwrap())
             .unwrap();
         assert_eq!(report.version, Version::from_str("3.0.1"));
 
@@ -1091,7 +1095,8 @@ mod report_filter_test {
         assert_eq!(result.len(), 1);
         report = reports
             .clone()
-            .into_iter().find(|r| r.id == result.clone().into_iter().next().unwrap())
+            .into_iter()
+            .find(|r| r.id == result.clone().into_iter().next().unwrap())
             .unwrap();
         assert_eq!(report.version, Version::from_str("3.5.1"));
     }
@@ -1120,7 +1125,8 @@ mod report_filter_test {
         assert_eq!(result.len(), 1);
         let mut report = reports
             .clone()
-            .into_iter().find(|r| r.id == result.clone().into_iter().next().unwrap())
+            .into_iter()
+            .find(|r| r.id == result.clone().into_iter().next().unwrap())
             .unwrap();
         assert_eq!(report.version, Version::from_str("2.3.0"));
 
@@ -1129,7 +1135,8 @@ mod report_filter_test {
         assert_eq!(result.len(), 1);
         report = reports
             .clone()
-            .into_iter().find(|r| r.id == result.clone().into_iter().next().unwrap())
+            .into_iter()
+            .find(|r| r.id == result.clone().into_iter().next().unwrap())
             .unwrap();
         assert_eq!(report.version, Version::from_str("2.3.0"));
 
@@ -1138,7 +1145,8 @@ mod report_filter_test {
         assert_eq!(result.len(), 1);
         report = reports
             .clone()
-            .into_iter().find(|r| r.id == result.clone().into_iter().next().unwrap())
+            .into_iter()
+            .find(|r| r.id == result.clone().into_iter().next().unwrap())
             .unwrap();
         assert_eq!(report.version, Version::from_str("2.8.2"));
 
@@ -1147,7 +1155,8 @@ mod report_filter_test {
         assert_eq!(result.len(), 1);
         report = reports
             .clone()
-            .into_iter().find(|r| r.id == result.clone().into_iter().next().unwrap())
+            .into_iter()
+            .find(|r| r.id == result.clone().into_iter().next().unwrap())
             .unwrap();
         assert_eq!(report.version, Version::from_str("2.8.2"));
 
@@ -1156,7 +1165,8 @@ mod report_filter_test {
         assert_eq!(result.len(), 1);
         report = reports
             .clone()
-            .into_iter().find(|r| r.id == result.clone().into_iter().next().unwrap())
+            .into_iter()
+            .find(|r| r.id == result.clone().into_iter().next().unwrap())
             .unwrap();
         assert_eq!(report.version, Version::from_str("2.8.2"));
     }

--- a/server/service/src/settings.rs
+++ b/server/service/src/settings.rs
@@ -34,12 +34,17 @@ pub struct ServerSettings {
     /// Sets the allowed origin for cors requests
     pub cors_origins: Vec<String>,
     /// Directory where the server stores its data, e.g. sqlite DB file or certs
-    pub base_dir: Option<String>,
+    #[serde(default = "default_base_dir")]
+    pub base_dir: String,
     /// Option to set the machine id of the device for an OS that isn't supported by machine_uid
     pub machine_uid: Option<String>,
     // Option to set server mode as central server, should only be used in testing, demo and development
     #[serde(default)]
     pub override_is_central_server: bool,
+}
+
+fn default_base_dir() -> String {
+    "app_data".to_string()
 }
 
 impl ServerSettings {

--- a/server/service/src/static_files.rs
+++ b/server/service/src/static_files.rs
@@ -55,11 +55,8 @@ pub struct StaticFileService {
     pub max_lifetime_millis: u64,
 }
 impl StaticFileService {
-    pub fn new(base_dir: &Option<String>) -> anyhow::Result<Self> {
-        let file_dir = match base_dir {
-            Some(file_dir) => PathBuf::from_str(file_dir)?.join(STATIC_FILE_DIR),
-            None => std::env::current_dir()?.join(STATIC_FILE_DIR),
-        };
+    pub fn new(base_dir: &str) -> anyhow::Result<Self> {
+        let file_dir = PathBuf::from_str(base_dir)?.join(STATIC_FILE_DIR);
         Ok(StaticFileService {
             dir: file_dir,
             max_lifetime_millis: 60 * 60 * 1000, // 1 hours
@@ -97,7 +94,7 @@ impl StaticFileService {
     /// use std::io::Write;
     /// use std::fs::File;
     ///
-    /// let static_file_service = StaticFileService::new(&Some("/tmp/".to_string())).unwrap();
+    /// let static_file_service = StaticFileService::new("/tmp/").unwrap();
     ///
     /// let static_file = static_file_service.reserve_file("test.txt", StaticFileCategory::Temporary).unwrap();
     /// let mut file = File::create(static_file.path).unwrap();
@@ -275,7 +272,7 @@ mod test {
 
     #[test]
     fn test_static_file_storage() {
-        let mut service = StaticFileService::new(&None).unwrap();
+        let mut service = StaticFileService::new(".").unwrap();
         service.dir = PathBuf::from_str(TEST_DIR).unwrap();
         service.max_lifetime_millis = 100;
         let test_dir = std::env::current_dir().unwrap().join(TEST_DIR);

--- a/server/service/src/test_helpers.rs
+++ b/server/service/src/test_helpers.rs
@@ -44,7 +44,7 @@ pub(crate) async fn setup_all_with_data_and_service_provider(
             danger_allow_http: false,
             debug_no_access_control: false,
             cors_origins: vec![],
-            base_dir: Some("test_output".to_string()),
+            base_dir: "test_output".to_string(),
             machine_uid: None,
             override_is_central_server: false,
         },


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10498 

# 👩🏻‍💻 What does this PR do?

Now that we're treating base dir as required, we should make the code require it too and clean up the usages.

## 💌 Any notes for the reviewer?

Generated with Copilot + Claude Sonnet 4.6

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Check android still works
- [ ] Try starting the open-mSupply app on Windows with a `base_dir` folder defined in `local.yaml` that doesn't exist (It should be created automatically)


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

