### PR TITLE
Clarify the treat `None` as `Null` with define_linked_tables! 

### DIFF
--- a/server/repository/src/diesel_macros.rs
+++ b/server/repository/src/diesel_macros.rs
@@ -385,6 +385,17 @@ macro_rules! apply_sort_asc_nulls_first {
 /// 2. **View table** definition (with resolved `id` columns for queries)
 /// 3. **Repository `_upsert` method** that translates between resolved IDs and link IDs
 ///
+/// # `treat_none_as_null` Semantics
+///
+/// The generated `_upsert` method always explicitly sets every field value, including `None`
+/// values for `Option<T>` fields. This is equivalent to Diesel's `#[diesel(treat_none_as_null = true)]`
+/// behavior — `None` is written as SQL `NULL`, never skipped.
+///
+/// **Important:** If a database column has a `NOT NULL DEFAULT` constraint, the corresponding
+/// Rust field must NOT be `Option<T>` / `Nullable<...>`. Use the non-optional type instead
+/// (e.g., `f64` / `Double`) and set a matching default in the Rust `Default` impl. Otherwise,
+/// inserting a default-constructed row will attempt to write `NULL` and violate the constraint.
+///
 /// # Entity Linking Pattern
 ///
 /// The pattern hides internal `*_link_id` columns from the public API, exposing only resolved IDs.


### PR DESCRIPTION
## Summary

This change just clarifies the change in behaviour for the application, that now that we have define_linked_tables! macro for tables that link to name_link, we've also changed the behaviour of the interest to treat `None` as `Null`

The PR mainly exists for awareness as there's no code changes now (test issue that exposed this problem has been resolved in `develop` already

## Context

The `define_linked_tables!` macro generates explicit `.eq(&record.field)` calls for every field in its `_upsert` method. This is equivalent to Diesel's `treat_none_as_null = true` — `None` always sends SQL `NULL`, never skips the column.

This differs from Diesel's default `Insertable` behavior where `Option<T>` with `None` omits the column from INSERT, allowing the DB `DEFAULT` to apply (on SQLite, the column is dropped entirely from the INSERT statement).

`purchase_order.foreign_exchange_rate` was the only column across all 24 tables using the macro where this caused a real breakage: `NOT NULL DEFAULT 1.0` in SQL but `Nullable<Double>` in Rust → inserting a default-constructed row sends `NULL` → constraint violation.

## Analysis of affected tables

**24 tables** use `define_linked_tables!`. On `develop`:

| Category | Count | Impact |
|---|---|---|
| Had `treat_none_as_null = true` | 15 | **No behavioral change** — macro matches old behavior exactly |
| Did NOT have `treat_none_as_null` | 9 | **Behavioral difference on UPDATE path** — old: `None` skips column (preserves existing value); new: `None` sends `NULL`. However, all 9 tables have zero `NOT NULL DEFAULT` mismatches, and upserts use fully-populated row structs, so this is safe in practice. |

**Tables without `treat_none_as_null` on develop:** `program_event_row`, `name_insurance_join_row`, `master_list_name_join`, `indicator_value_row`, `name_tag_join`, `document`, `program_enrolment_row`, `name_store_join`, `store_row`

### Options considered

1. **Fix the one type mismatch** (chosen) — minimal change, correct modeling
2. **Add skip-if-none to the macro** — very difficult due to Diesel's static query typing for `.values()` tuples
3. **Fix + document convention** (chosen) — adopt `treat_none_as_null = true` as standard
4. **Use Diesel's DEFAULT expression** — requires raw SQL fragments, fragile

## Test plan

- [x] `cargo check` — clean compilation
- [x] `cargo test` (SQLite) — 608 passed, 0 failed
- [x] `cargo test --features=postgres` — 608 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)