### PR TITLE
Set explicit column widths in Outstanding Lines table

### DIFF
--- a/client/packages/purchasing/src/purchase_order/ListView/OutstandingLines/OutstandingLines.tsx
+++ b/client/packages/purchasing/src/purchase_order/ListView/OutstandingLines/OutstandingLines.tsx
@@ -47,6 +47,7 @@ export const OutstandingLinesListView = () => {
         accessorFn: row => row?.purchaseOrder?.number,
         enableSorting: true,
         columnType: ColumnType.Number,
+        size: 90,
       },
       {
         header: t('label.purchase-order-reference'),
@@ -61,6 +62,7 @@ export const OutstandingLinesListView = () => {
         header: t('label.supplier-code'),
         accessorKey: 'supplierCode',
         accessorFn: row => row?.purchaseOrder?.supplier?.code,
+        size: 100,
       },
       {
         header: t('label.supplier-name'),
@@ -77,26 +79,31 @@ export const OutstandingLinesListView = () => {
         header: t('label.purchase-order-confirmed'),
         accessorKey: 'purchaseOrder.confirmedDatetime',
         columnType: ColumnType.Date,
+        size: 100,
       },
       {
         header: t('label.expected-delivery-date'),
         accessorKey: 'purchaseOrder.expectedDeliveryDate',
         columnType: ColumnType.Date,
+        size: 100,
       },
       {
         header: t('label.adjusted-units-expected'),
         accessorKey: 'adjustedNumberOfUnits',
         columnType: ColumnType.Number,
+        size: 90,
       },
       {
         header: t('label.shipped-units'),
         accessorKey: 'shippedNumberOfUnits',
         columnType: ColumnType.Number,
+        size: 90,
       },
       {
         header: t('label.outstanding-units'),
         accessorKey: 'outstandingQuantity',
         columnType: ColumnType.Number,
+        size: 90,
         accessorFn: row => {
           const adjusted = row?.adjustedNumberOfUnits ?? 0;
           const shipped = row?.shippedNumberOfUnits ?? 0;


### PR DESCRIPTION
Fixes #

# 👩🏻‍💻 What does this PR do?

This PR adds explicit `size` properties to column definitions in the Outstanding Lines list view table. The following columns now have defined widths:

- Purchase Order Number: 90px
- Supplier Code: 100px
- Purchase Order Confirmed: 100px
- Expected Delivery Date: 100px
- Adjusted Units Expected: 90px
- Shipped Units: 90px
- Outstanding Units: 90px

These changes ensure consistent and predictable column sizing in the table layout, improving the visual presentation and user experience.

## 💌 Any notes for the reviewer?

This is a straightforward UI layout improvement with no functional changes. The column widths were chosen to accommodate typical content while maintaining a balanced table appearance.

# 🧪 Testing

- [ ] Verify the Outstanding Lines table displays with the new column widths
- [ ] Confirm columns are appropriately sized for their content
- [ ] Check that the table layout remains responsive and visually balanced

# 📃 Documentation

- [ ] **No documentation required**: UI layout adjustment with no user-facing behavior changes

https://claude.ai/code/session_01YaDY8TrPJxS7K49f3QSugy