### PR TITLE
10721 Target demographic not being saved when entered in programs

### DIFF
--- a/client/packages/common/src/hooks/usePatchState/usePatchState.ts
+++ b/client/packages/common/src/hooks/usePatchState/usePatchState.ts
@@ -8,28 +8,23 @@
  */
 
 import { isEqual } from '@openmsupply-client/common';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 export const usePatchState = <T>(referenceData: Record<string, unknown>) => {
   const [patch, setPatch] = useState<Partial<T>>({});
-  const [isDirty, setIsDirty] = useState(false);
 
   const updatePatch = (newData: Partial<T>) => {
-    const newPatch = { ...patch, ...newData };
-    setPatch(newPatch);
-
-    // Ensures that UI doesn't show in "dirty" state if nothing actually
-    // different from the saved data
-    const updatedData = { ...referenceData, ...newPatch };
-    if (isEqual(referenceData, updatedData)) setIsDirty(false);
-    else setIsDirty(true);
-    return;
+    setPatch(prev => ({ ...prev, ...newData }));
   };
 
   const resetDraft = () => {
     setPatch({});
-    setIsDirty(false);
   };
+
+  const isDirty = useMemo(
+    () => !isEqual(referenceData, { ...referenceData, ...patch }),
+    [referenceData, patch]
+  );
 
   return { patch, updatePatch, resetDraft, isDirty };
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10721

# 👩🏻‍💻 What does this PR do?
Refactors the usePatchState to always merge latest changes and use the isEqual to find if data isDirty instead of having a separate state for it

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a vaccine course with doses (don't enter in a demographic)
- [ ] Now go back to edit that vaccine course
- [ ] Enter demographic
- [ ] Enter custom label
- [ ] Save
- [ ] Should update straight away

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

