### PR TITLE
10583 Logging of initialise process logs password in plain text

### DIFF
--- a/server/graphql/logger.rs
+++ b/server/graphql/logger.rs
@@ -10,14 +10,18 @@ use rand::Rng;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+fn mask_password_entry(key: &str, value: &mut async_graphql::Value) {
+    if key == "password" {
+        *value = "****".into();
+    } else {
+        mask_passwords(value);
+    }
+}
+
 fn mask_passwords(value: &mut async_graphql::Value) {
     if let async_graphql::Value::Object(map) = value {
-        for (key, val) in map.iter_mut() {
-            if key.as_str() == "password" {
-                *val = "****".into();
-            } else {
-                mask_passwords(val);
-            }
+        for (key, value) in map.iter_mut() {
+            mask_password_entry(key.as_str(), value);
         }
     }
 }
@@ -98,11 +102,7 @@ impl Extension for LoggerExtension {
 
             let mut variables = variables.clone();
             for (key, value) in variables.iter_mut() {
-                if key.as_str() == "password" {
-                    *value = "****".into();
-                } else {
-                    mask_passwords(value);
-                }
+                mask_password_entry(key.as_str(), value);
             }
 
             for (_, operation) in document.operations.iter() {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10583

# 👩🏻‍💻 What does this PR do?
Recursion to mask passwords that are deeper than top layer
<img width="512" height="85" alt="Screenshot 2026-03-06 at 10 41 46 AM" src="https://github.com/user-attachments/assets/43b7e245-f778-4f93-bab3-34cc8700cf45" />
<img width="522" height="65" alt="Screenshot 2026-03-06 at 10 41 41 AM" src="https://github.com/user-attachments/assets/d3b8037c-aad9-4d74-8e55-373267d63a0f" />


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Login
- [ ] Look at logs -> Password should be masked
- [ ] Change sync settings password for site
- [ ] Look at logs -> Password should be masked

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

