### PR TITLE
#10802 cleanup orphaned goods received chagnelog entries

### DIFF
--- a/server/repository/src/migrations/v2_17_00/mod.rs
+++ b/server/repository/src/migrations/v2_17_00/mod.rs
@@ -6,6 +6,7 @@ mod add_purchase_order_id_to_invoice;
 mod invoice_line_add_status;
 mod item_category_join_add_item_link_id;
 mod remove_goods_received;
+mod remove_goods_received_cleanup;
 
 pub(crate) struct V2_17_00;
 impl Migration for V2_17_00 {
@@ -21,6 +22,7 @@ impl Migration for V2_17_00 {
         vec![
             Box::new(add_forecasting_fields_to_requisition_line::Migrate),
             Box::new(remove_goods_received::Migrate),
+            Box::new(remove_goods_received_cleanup::Migrate),
             Box::new(add_purchase_order_id_to_invoice::Migrate),
             Box::new(invoice_line_add_status::Migrate),
             Box::new(item_category_join_add_item_link_id::Migrate),

--- a/server/repository/src/migrations/v2_17_00/remove_goods_received_cleanup.rs
+++ b/server/repository/src/migrations/v2_17_00/remove_goods_received_cleanup.rs
@@ -1,0 +1,20 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "remove_goods_received_cleanup"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        sql!(
+            connection,
+            r#"
+                DELETE FROM changelog WHERE table_name = 'report' AND record_id NOT IN (SELECT id FROM report);
+            "#
+        )?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10802

# 👩🏻‍💻 What does this PR do?

Adds a migration to remove changelog entries related to the goods received report that was removed in the 'remove_goods_received' migration.

## 💌 Any notes for the reviewer?

Considered alternatives:

- Adding this to the migration before deleting the reports:
  `DELETE FROM changelog WHERE table_name = 'report' AND record_id IN (SELECT id FROM report WHERE context = 'GOODS_RECEIVED');`
  But this won't help people who've already run the migration (only devs and I haven't heard them complaining yet so maybe doesn't matter?)
- Add back the GOODS_RECEIVED report context even though it'll never be used...

# 🧪 Testing

See issue

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

