### PR TITLE
Add cancel method to debounce utility and cleanup on unmount

### DIFF
--- a/client/packages/common/src/hooks/useDebounce/useDebouncedValueCallback.ts
+++ b/client/packages/common/src/hooks/useDebounce/useDebouncedValueCallback.ts
@@ -1,4 +1,4 @@
-import { useCallback, DependencyList } from 'react';
+import { useCallback, useEffect, DependencyList } from 'react';
 import { FnUtils } from '@common/utils';
 
 /**
@@ -20,6 +20,14 @@ export const useDebouncedValueCallback = <T extends (...args: any[]) => any>(
     ...depsArray,
     memoizedCallback,
   ]);
+
+  // Cancel any pending debounced call on unmount to prevent stale URL updates
+  // after navigation (e.g. clicking a row while a filter input is still debouncing)
+  useEffect(() => {
+    return () => {
+      memoizedCallback.cancel();
+    };
+  }, [memoizedCallback]);
 
   return debounced;
 };

--- a/client/packages/common/src/utils/functions/FnUtils.test.ts
+++ b/client/packages/common/src/utils/functions/FnUtils.test.ts
@@ -29,4 +29,21 @@ describe('debounce', () => {
     expect(result2).resolves.toBe(1);
     expect(result3).resolves.toBe(1);
   });
+
+  it('cancel prevents the pending callback from firing', async () => {
+    jest.useFakeTimers();
+    let callCount = 0;
+    const fn = FnUtils.debounce(() => {
+      callCount += 1;
+    }, 300);
+
+    fn();
+    fn();
+    fn.cancel();
+
+    jest.advanceTimersByTime(500);
+    expect(callCount).toBe(0);
+
+    jest.useRealTimers();
+  });
 });

--- a/client/packages/common/src/utils/functions/FnUtils.ts
+++ b/client/packages/common/src/utils/functions/FnUtils.ts
@@ -7,10 +7,12 @@ export const FnUtils = {
   debounce: <T extends (...args: any[]) => any>(
     callback: T,
     wait = 500
-  ): ((...args: Parameters<T>) => Promise<ReturnType<T>>) => {
+  ): ((...args: Parameters<T>) => Promise<ReturnType<T>>) & {
+    cancel: () => void;
+  } => {
     let timer: NodeJS.Timeout | undefined;
 
-    return (...args: Parameters<T>) => {
+    const debounced = (...args: Parameters<T>) => {
       if (timer) {
         clearTimeout(timer);
       }
@@ -21,5 +23,14 @@ export const FnUtils = {
         }, wait);
       });
     };
+
+    debounced.cancel = () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+    };
+
+    return debounced;
   },
 };


### PR DESCRIPTION
Fixes #10677

# 👩🏻‍💻 What does this PR do?

This PR adds a `cancel()` method to the `FnUtils.debounce` utility function, allowing pending debounced callbacks to be explicitly cancelled before they fire. Additionally, the `useDebouncedValueCallback` hook now automatically cancels any pending debounced calls on component unmount.

## Why these changes are needed

When a debounced callback is still pending and a component unmounts (e.g., user navigates away while a filter input is still debouncing), the callback would still fire after unmount, potentially causing stale state updates or unintended side effects. This is particularly problematic for URL updates triggered by filter changes.

By providing a `cancel()` method and calling it on unmount, we prevent these stale callbacks from executing.

## 💌 Any notes for the reviewer?

- The `debounce` function signature now returns a function with an attached `cancel` method rather than a plain function
- The cleanup in `useDebouncedValueCallback` is added to the dependency array with `memoizedCallback` to ensure proper cleanup when the callback changes
- This is a non-breaking change for existing code that doesn't use the `cancel()` method

# 🧪 Testing

- [x] Added unit test covering the `cancel()` method behavior in `FnUtils.test.ts`
- [x] Existing debounce tests continue to pass

# 📃 Documentation

- [ ] **No documentation required**: This is an internal utility enhancement with no user-facing changes

https://claude.ai/code/session_01NxgyZffasVfzxxdumojQhr