### PR TITLE
10568 Schedule form input for reports - part 2 date time fix

### DIFF
--- a/client/packages/programs/src/JsonForms/components/ScheduleForm.tsx
+++ b/client/packages/programs/src/JsonForms/components/ScheduleForm.tsx
@@ -9,6 +9,7 @@ import {
   PeriodScheduleNode,
   DateTimePickerInput,
   useTranslation,
+  DateUtils,
 } from '@openmsupply-client/common';
 import { DefaultFormRowSx, FORM_LABEL_WIDTH } from '../common';
 import { ProgramFragment, useProgramList } from '../../api';
@@ -80,19 +81,17 @@ const UIComponent = (props: ControlProps) => {
     handleChange('before', undefined);
   };
 
-  const onPeriodChange = (period: PeriodNode | null) => {
-    const after = period ? new Date(period.startDate) : null;
-    const before = period ? new Date(period.endDate) : null;
-
-    setForm(prev => ({ ...prev, periodId: period?.id ?? null, after, before }));
-    handleChange('periodId', period?.id);
-    handleChange('after', after?.toISOString());
-    handleChange('before', before?.toISOString());
+  const onDateChange = (path: 'after' | 'before', date: Date | null) => {
+    const value = path === 'before' && date ? DateUtils.endOfDay(date) : date;
+    setForm(prev => ({ ...prev, [path]: value }));
+    handleChange(path, value?.toISOString());
   };
 
-  const onDateChange = (path: 'after' | 'before', date: Date | null) => {
-    setForm(prev => ({ ...prev, [path]: date }));
-    handleChange(path, date?.toISOString());
+  const onPeriodChange = (period: PeriodNode | null) => {
+    setForm(prev => ({ ...prev, periodId: period?.id ?? null }));
+    handleChange('periodId', period?.id);
+    onDateChange('after', period ? new Date(period.startDate) : null);
+    onDateChange('before', period ? new Date(period.endDate) : null);
   };
 
   return (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10568 part 2

# 👩🏻‍💻 What does this PR do?

Use date at end of day for `before` date time 

When a before date is set - either by period selection or manually-  the date sent as the argument will be the time in utc at the local end of day - eg 30-01-2026 will use the argument as 2026-01-30T10%3A59%3A59.999Z

Can see the argument in the url after generating the report
<img width="386" height="38" alt="Screenshot 2026-03-13 at 4 26 03 PM" src="https://github.com/user-attachments/assets/93f954a0-8224-4d9b-aa42-fee68f6d5dd3" />


<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

This keeps the same functionality other reports use for end of day, though this is added to the date handle change instead of the date picker so that it also works when period selection fills in the date

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Test with Rapport FOSA from reports repo 
- [ ] Have programs and set up and transactions for items in the program - both outbound shipments and prescriptions
- [ ]  Should see CMM calculation and DMM calculation - CMM is prescription AMC and DMM is distribution AMC. The two of these should add to total AMC in the items list
- [ ]  Have transactions where the local date is different to the UTC date (eg in the morning NZT). Verify that transactions appear on the correct date eg:
-  transaction at 11AM 4/03 NZT, is at 10PM 3/3 UTC
-  report run with from/to dates 4/03 will include the transaction
-  report run to date 3/03 will not include the transaction

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

