### PR TITLE
update workspace resolver to 2

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -6,10 +6,7 @@ strip = true
 # Warning don't add anything above this lines as auto patch is applied during docker build
 async-graphql = { version = "7.0.17", features = ["dataloader", "chrono"] }
 async-graphql-actix-web = "7.0.17"
-actix-web = { version = "4.11.0", default-features = false, features = [
-  "macros",
-  "rustls",
-] }
+actix-web = { version = "4.11.0", default-features = false, features = ["macros", "rustls"] }
 actix-multipart = "0.7.2"
 anymap = "0.12.1"
 async-trait = "0.1.88"
@@ -64,6 +61,7 @@ enum_variant_names = "allow"
 too_many_arguments = "allow"
 
 [workspace]
+resolver = "2"
 members = [
   "android",
   "report_builder",


### PR DESCRIPTION
Fixes #1

Stops terminal complaining about:
```
❯ cargo run --features postgres
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
```