### PR TITLE
10441 Item variant: volume per pack won't allow decimal entry 

### DIFF
--- a/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemPackagingVariantsTable.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemPackagingVariantsTable.tsx
@@ -38,33 +38,49 @@ export const ItemPackagingVariantsTable = ({
       {
         accessorKey: 'name',
         header: t('label.name'),
-        Cell: update ? ({ cell, row: { original: row } }) => <TextInputCell
-          cell={cell}
-          updateFn={value => updatePackaging({ id: row.id, name: value })}
-        /> : TextWithTooltipCell,
+        Cell: update
+          ? ({ cell, row: { original: row } }) => (
+              <TextInputCell
+                cell={cell}
+                updateFn={value => updatePackaging({ id: row.id, name: value })}
+              />
+            )
+          : TextWithTooltipCell,
         size: 150,
       },
       {
         accessorKey: 'packSize',
         header: t('label.pack-size'),
-        Cell: update ? ({ cell, row: { original: row } }) => <NumberInputCell
-          cell={cell}
-          updateFn={value => updatePackaging({ id: row.id, packSize: value })}
-          min={1}
-          decimalLimit={0}
-          error={cell.getValue() === 0}
-        /> : TextWithTooltipCell,
+        Cell: update
+          ? ({ cell, row: { original: row } }) => (
+              <NumberInputCell
+                cell={cell}
+                updateFn={value =>
+                  updatePackaging({ id: row.id, packSize: value })
+                }
+                min={1}
+                decimalLimit={0}
+                error={cell.getValue() === 0}
+              />
+            )
+          : TextWithTooltipCell,
         size: 100,
       },
       {
         accessorKey: 'volumePerUnit',
         header: t('label.volume-per-unit'),
-        Cell: update ? ({ cell, row: { original: row } }) => <NumberInputCell
-          cell={cell}
-          updateFn={value => updatePackaging({ id: row.id, volumePerUnit: value })}
-          min={1}
-          error={cell.getValue() === 0}
-        /> : TextWithTooltipCell,
+        Cell: update
+          ? ({ cell, row: { original: row } }) => (
+              <NumberInputCell
+                cell={cell}
+                updateFn={value =>
+                  updatePackaging({ id: row.id, volumePerUnit: value })
+                }
+                error={cell.getValue() === 0}
+                decimalLimit={3}
+              />
+            )
+          : TextWithTooltipCell,
         size: 100,
       },
     ],


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10441

# 👩🏻‍💻 What does this PR do?
Remove min in volume per pack & have checked other places but this was the only place relevant. Have also made it 3 dp to handle mL

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to item, variant tab
- [ ] Add new variant
- [ ] Edit volume per pack and put < 1 value
- [ ] Should be able to input up to 3 dp

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

