### PR TITLE
Translations update from mSupply Foundation Translation Server

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1516,7 +1516,7 @@
   "label.status-late": "Overdue",
   "label.status-not-given": "Not given",
   "label.status-pending": "Pending",
-  "label.statushistory": "Status History",
+  "label.statushistory": "VVM History",
   "label.stock-level": "Stock level",
   "label.stock-on-hand": "Stock on hand",
   "label.stock-on-hand-remaining": "SoH (Est. remaining)",


### PR DESCRIPTION
Translations update from [mSupply Foundation Translation Server](https://translate.msupply.org) for [Open mSupply/Common](https://translate.msupply.org/projects/open-msupply/common/).


It also includes following components:

* [Open mSupply/Desktop](https://translate.msupply.org/projects/open-msupply/desktop/)



Current translation status:

![Weblate translation status](https://translate.msupply.org/widget/open-msupply/common/horizontal-auto.svg)