### PR TITLE
Translations update from mSupply Foundation Translation Server

### DIFF
--- a/client/packages/common/src/intl/locales/fr/common.json
+++ b/client/packages/common/src/intl/locales/fr/common.json
@@ -1517,7 +1517,7 @@
   "label.status-late": "En retard",
   "label.status-not-given": "Non administré(e)",
   "label.status-pending": "En attente",
-  "label.statushistory": "Historique du statut",
+  "label.statushistory": "Historique PCV",
   "label.stock-level": "Niveau de stock",
   "label.stock-lines-found": "Lignes de stock trouvées",
   "label.stock-on-hand": "Stock total",


### PR DESCRIPTION
Translations update from [mSupply Foundation Translation Server](https://translate.msupply.org) for [Open mSupply/Common](https://translate.msupply.org/projects/open-msupply/common/).


It also includes following components:

* [Open mSupply/Desktop](https://translate.msupply.org/projects/open-msupply/desktop/)



Current translation status:

![Weblate translation status](https://translate.msupply.org/widget/open-msupply/common/horizontal-auto.svg)