### PR TITLE
fix(shipments): campaign-program not showing in inbound shipments

### DIFF
--- a/server/service/src/invoice_line/stock_out_line/insert/generate.rs
+++ b/server/service/src/invoice_line/stock_out_line/insert/generate.rs
@@ -205,6 +205,7 @@ fn generate_line(
         tax_percentage,
         currency_id,
         currency_rate,
+        program_id: invoice_program_id,
         ..
     }: InvoiceRow,
     default_pricing: ItemPrice,
@@ -250,7 +251,7 @@ fn generate_line(
         vvm_status_id,
         item_variant_id,
         campaign_id,
-        program_id,
+        program_id: program_id.or(invoice_program_id),
         volume_per_pack,
         shipped_number_of_packs: (r#type == StockOutType::OutboundShipment)
             .then_some(number_of_packs),


### PR DESCRIPTION
Fixes #10825

# 👩🏻‍💻 What does this PR do?

Shows the correct Campaign/Program in Inbound Shipments

<img width="2472" height="926" alt="image" src="https://github.com/user-attachments/assets/4778f564-13ff-4a2b-b74b-3f64c953cfa6" />

When generating stock out lines it previously would only pull `program_id` from the `stock_line`. Now it will use the program_id from the `invoice` if `stock_line` does not `have program_id`

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an internal order for a program (new order -> program tab)
- [ ] From the supplier store confirm the requisition
- [ ] From the supplier store confirm outbound shipment
- [ ] From the customer store view inbound shipments and see if correct program is shown in the campaign/program column

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

