### PR TITLE
10839 In the Stock Detail Windows, Doses for available stock and stock on hand are not calculated correctly

### DIFF
--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -253,9 +253,7 @@ export const StockLineForm = ({
                             ).toFixed(2)
                           )}
                           onChange={() => {}}
-                          {...getDosesProps(
-                            draft.availableNumberOfPacks * draft.packSize
-                          )}
+                          {...getDosesProps(draft.availableNumberOfPacks)}
                         />
                       }
                     />
@@ -272,9 +270,7 @@ export const StockLineForm = ({
                             )
                           )}
                           onChange={() => {}}
-                          {...getDosesProps(
-                            draft.totalNumberOfPacks * draft.packSize
-                          )}
+                          {...getDosesProps(draft.totalNumberOfPacks)}
                         />
                       }
                     />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10839

# 👩🏻‍💻 What does this PR do?
Packs was being multiplied twice so have just directly passed in values

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have manage in doses store preference on 
- [ ] Go to stock detail view and click on a vaccine item
- [ ] Make sure all dose calculations are correct

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

