### PR TITLE
disable / enable pack cost price for ise

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
@@ -439,7 +439,7 @@ export const InboundLineEditCards = ({
         Cell: ({ cell, row }) => (
           <CurrencyInputCell
             cell={cell}
-            disabled={isDisabled}
+            disabled={isDisabled || !isExternalSupplier || !!purchaseOrderId}
             updateFn={value =>
               updateDraftLine({ id: row.original.id, costPricePerPack: value })
             }

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
@@ -224,6 +224,7 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
         | ServiceError::ManufacturerIsNotAManufacturer
         | ServiceError::ProgramNotVisible
         | ServiceError::CampaignDoesNotExist
+        | ServiceError::CannotEditCostPrice
         | ServiceError::ItemNotFound => BadUserInput(formatted_error),
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
         ServiceError::UpdatedLineDoesNotExist => InternalError(formatted_error),

--- a/server/service/src/invoice_line/stock_in_line/update/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/mod.rs
@@ -115,6 +115,7 @@ pub enum UpdateStockInLineError {
     ProgramNotVisible,
     IncorrectLocationType,
     CampaignDoesNotExist,
+    CannotEditCostPrice,
 }
 
 impl From<RepositoryError> for UpdateStockInLineError {

--- a/server/service/src/invoice_line/stock_in_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/validate.rs
@@ -127,6 +127,13 @@ pub fn validate(
         }
     }
 
+    // Cost price is read-only for internal suppliers and external suppliers linked to a PO
+    if input.cost_price_per_pack.is_some()
+        && (invoice.name_store_id.is_some() || invoice.purchase_order_id.is_some())
+    {
+        return Err(CannotEditCostPrice);
+    }
+
     if input
         .status
         .as_ref()


### PR DESCRIPTION

Fixes #10889 

# 👩🏻‍💻 What does this PR do?

Makes pack cost price uneditable for internal suppliers and external suppliers linked to a PO (external inbound shipments)
Ensures pack cost price is still editable for external supplier not linked to a PO

Not editable:
<img width="1249" height="715" alt="image" src="https://github.com/user-attachments/assets/5da6b39b-7655-4f68-b168-984cdd279646" />
Editable:
<img width="1259" height="775" alt="image" src="https://github.com/user-attachments/assets/5680a594-5301-4332-88c9-8c0a7d580718" />

## 💌 Any notes for the reviewer?

...

# 🧪 Testing

Test that you can edit the pack cost price for inbound shipments when from an iexternal supplier but not attached to a PO
Test you cannot edit the pack cost price when from an internal supplier
Test you cannot edit the pack cost price when from an external supplier and linked to a PO

The permissions is out of the scope of this PR so should be tested with relevant user permissions on


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

