### PR TITLE
Improve token refresh error handling and expiry detection

### DIFF
--- a/client/packages/common/src/authentication/api/hooks/useRefreshToken.ts
+++ b/client/packages/common/src/authentication/api/hooks/useRefreshToken.ts
@@ -29,7 +29,7 @@ export const useRefreshToken = (onTimeout: () => void) => {
       getLastRequestTime()
     );
 
-    const expiresSoon = expiresIn === 1 || expiresIn === 2;
+    const expiresSoon = expiresIn > 0 && expiresIn <= 5;
 
     if (minutesSinceLastRequest >= INACTIVITY_TIMEOUT_MINUTES) {
       onTimeout();
@@ -37,11 +37,23 @@ export const useRefreshToken = (onTimeout: () => void) => {
     }
 
     if (expiresSoon && minutesSinceLastRequest < INACTIVITY_TIMEOUT_MINUTES) {
-      mutateAsync().then(data => {
-        const token = data?.token ?? '';
-        const newCookie = { ...authCookie, token };
-        setAuthCookie(newCookie);
-      });
+      mutateAsync()
+        .then(data => {
+          const token = data?.token ?? '';
+          // Only update the cookie if the server returned a valid token.
+          // A failed refresh (e.g. expired refresh token) returns an empty
+          // string which would cause the next interval check to log the user
+          // out immediately.
+          if (token) {
+            const newCookie = { ...authCookie, token };
+            setAuthCookie(newCookie);
+          }
+        })
+        .catch(() => {
+          // Silently ignore network errors during refresh. The next interval
+          // tick will retry. If the cookie expires before a successful refresh,
+          // the normal expiry/inactivity logic in AuthContext will handle logout.
+        });
     }
   };
   return { refreshToken };


### PR DESCRIPTION
Fixes #

# 👩🏻‍💻 What does this PR do?

This PR improves the token refresh logic in `useRefreshToken` hook with two key changes:

1. **Expanded expiry detection window**: Changed `expiresSoon` condition from checking if token expires in 1-2 minutes to 0-5 minutes, providing a larger buffer for token refresh before expiration.

2. **Added error handling for token refresh**: 
   - Added validation to only update the auth cookie if the server returns a valid token, preventing empty tokens from being stored
   - Added `.catch()` handler to silently ignore network errors during refresh, allowing the next interval check to retry rather than immediately logging the user out
   - Added explanatory comments documenting the rationale for these checks

## Why these changes are needed

The previous implementation could cause premature logout in two scenarios:
- If a token refresh request failed due to network issues, the error would propagate and potentially trigger logout logic
- If the server returned an empty token (e.g., due to expired refresh token), it would be stored in the cookie, causing immediate logout on the next interval check

These changes make the refresh logic more resilient by deferring logout decisions to the normal expiry/inactivity logic in AuthContext.

# 💌 Any notes for the reviewer?

The error handling is intentionally silent - network errors during refresh are expected to be transient and will be retried on the next interval tick. If the refresh token itself is invalid, the cookie will eventually expire and the normal logout flow will handle it.

# 🧪 Testing

- [ ] Verify token refresh succeeds with valid refresh token
- [ ] Verify empty token responses are not stored in cookie
- [ ] Verify network errors during refresh don't cause immediate logout

# 📃 Documentation

- [ ] **No documentation required**: This is a bug fix improving error resilience without changing user-facing behavior

https://claude.ai/code/session_01SZMDTKgaHxRvKKeKP8iX7B