### PR TITLE
Default to all statuses

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/Footer/Footer.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Footer/Footer.tsx
@@ -185,7 +185,9 @@ export const FooterComponent = ({
     shipmentType
       ? getInboundStatusesForType(shipmentType)
       : inboundStatuses
-  ).filter(status => invoiceStatusOptions?.includes(status));
+  ).filter(status =>
+    invoiceStatusOptions ? invoiceStatusOptions.includes(status) : true
+  );
 
   return (
     <AppFooterPortal

--- a/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
@@ -79,9 +79,10 @@ const StatusChangeButtonContent = ({
     return statusOptions;
   }, [status, shipmentType, invoiceStatusOptions, t]);
 
-  const currentStatus = invoiceStatusOptions?.includes(status)
-    ? status
-    : getPreviousStatus(status, invoiceStatusOptions ?? [], inboundStatuses);
+  const currentStatus =
+    !invoiceStatusOptions || invoiceStatusOptions.includes(status)
+      ? status
+      : getPreviousStatus(status, invoiceStatusOptions, inboundStatuses);
 
   const [selectedOption, setSelectedOption] =
     useState<SplitButtonOption<InvoiceNodeStatus> | null>(() =>

--- a/client/packages/invoices/src/OutboundShipment/DetailView/Footer/Footer.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Footer/Footer.tsx
@@ -133,7 +133,7 @@ export const FooterComponent: FC<FooterComponentProps> = ({
   ];
 
   const statuses = outboundStatuses.filter(status =>
-    invoiceStatusOptions?.includes(status)
+    invoiceStatusOptions ? invoiceStatusOptions.includes(status) : true
   );
 
   return (

--- a/client/packages/invoices/src/OutboundShipment/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Footer/StatusChangeButton.tsx
@@ -83,9 +83,10 @@ const useStatusChangeButton = () => {
 
   // If the status has already been set, but is not included in the preferences,
   // then use the previous valid status.
-  const currentStatus = invoiceStatusOptions?.includes(status)
-    ? status
-    : getPreviousStatus(status, invoiceStatusOptions ?? [], outboundStatuses);
+  const currentStatus =
+    !invoiceStatusOptions || invoiceStatusOptions.includes(status)
+      ? status
+      : getPreviousStatus(status, invoiceStatusOptions, outboundStatuses);
 
   const [selectedOption, setSelectedOption] =
     useState<SplitButtonOption<InvoiceNodeStatus> | null>(() =>

--- a/client/packages/invoices/src/Returns/CustomerDetailView/Footer/Footer.tsx
+++ b/client/packages/invoices/src/Returns/CustomerDetailView/Footer/Footer.tsx
@@ -86,10 +86,10 @@ export const FooterComponent = ({
 
   const statuses = isManuallyCreated
     ? manualCustomerReturnStatuses.filter(status =>
-        invoiceStatusOptions?.includes(status)
+        invoiceStatusOptions ? invoiceStatusOptions.includes(status) : true
       )
     : customerReturnStatuses.filter(status =>
-        invoiceStatusOptions?.includes(status)
+        invoiceStatusOptions ? invoiceStatusOptions.includes(status) : true
       );
 
   return (

--- a/client/packages/invoices/src/Returns/CustomerDetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/Returns/CustomerDetailView/Footer/StatusChangeButton.tsx
@@ -103,13 +103,14 @@ const useStatusChangeButton = () => {
     return statusOptions;
   }, [status, isManuallyCreated, invoiceStatusOptions]);
 
-  const currentStatus = invoiceStatusOptions?.includes(status)
-    ? status
-    : getPreviousStatus(
-        status,
-        invoiceStatusOptions ?? [],
-        customerReturnStatuses
-      );
+  const currentStatus =
+    !invoiceStatusOptions || invoiceStatusOptions.includes(status)
+      ? status
+      : getPreviousStatus(
+          status,
+          invoiceStatusOptions,
+          customerReturnStatuses
+        );
 
   const [selectedOption, setSelectedOption] =
     useState<SplitButtonOption<InvoiceNodeStatus> | null>(() =>

--- a/client/packages/invoices/src/Returns/SupplierDetailView/Footer/Footer.tsx
+++ b/client/packages/invoices/src/Returns/SupplierDetailView/Footer/Footer.tsx
@@ -84,7 +84,7 @@ export const FooterComponent = ({
   ];
 
   const statuses = supplierReturnStatuses.filter(status =>
-    invoiceStatusOptions?.includes(status)
+    invoiceStatusOptions ? invoiceStatusOptions.includes(status) : true
   );
 
   return (

--- a/client/packages/invoices/src/Returns/SupplierDetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/Returns/SupplierDetailView/Footer/StatusChangeButton.tsx
@@ -71,13 +71,14 @@ const useStatusChangeButton = () => {
     return statusOptions;
   }, [status, invoiceStatusOptions]);
 
-  const currentStatus = invoiceStatusOptions?.includes(status)
-    ? status
-    : getPreviousStatus(
-        status,
-        invoiceStatusOptions ?? [],
-        supplierReturnStatuses
-      );
+  const currentStatus =
+    !invoiceStatusOptions || invoiceStatusOptions.includes(status)
+      ? status
+      : getPreviousStatus(
+          status,
+          invoiceStatusOptions,
+          supplierReturnStatuses
+        );
 
   const [selectedOption, setSelectedOption] =
     useState<SplitButtonOption<InvoiceNodeStatus> | null>(() =>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10803

# 👩🏻‍💻 What does this PR do?
When invoiceStatusOptions returns undefined it breaks the status crumbs and status change button

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [x] Don't use the store preference to have custom statuses
- [x] Create an Outbound Shipment to store b
- [x] Go to store B's Inbound shipment
- [x] The footer should show 
- [x] Status change should respect next status

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

