### PR TITLE
10769: total cost -> line cost in PO detail view (simple copy change)

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1203,6 +1203,7 @@
   "label.ledger": "Ledger",
   "label.level": "Level",
   "label.line": "Line {{line, number}}",
+  "label.line-cost": "Line cost",
   "label.line-number": "Line",
   "label.line-total": "Line total",
   "label.line-total-local": "Line total (local)",

--- a/client/packages/purchasing/src/purchase_order/DetailView/columns.tsx
+++ b/client/packages/purchasing/src/purchase_order/DetailView/columns.tsx
@@ -106,7 +106,7 @@ export const usePurchaseOrderColumns = () => {
       },
       {
         accessorKey: 'totalCost',
-        header: t('label.total-cost'),
+        header: t('label.line-cost'),
         columnType: ColumnType.Currency,
         accessorFn: row => {
           const units =


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Towards #10769 (other points already in pother open PRs)

# 👩🏻‍💻 What does this PR do?
This is a simple copy change - from total cost (ambigious as per line and also got a PO total cost in the total footer row) to `Line cost`
<img width="1892" height="947" alt="image" src="https://github.com/user-attachments/assets/c6e1bb29-afa2-4d58-8579-6ee31293cbfe" />
## 💌 Any notes for the reviewer?
Simple copy change - unusure if you need to check it out?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

