### PR TITLE
10889: Fix CannotEditCostPrice error on inbound shipment line edit

### DIFF
--- a/server/service/src/invoice_line/stock_in_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/validate.rs
@@ -128,10 +128,12 @@ pub fn validate(
     }
 
     // Cost price is read-only for internal suppliers and external suppliers linked to a PO
-    if input.cost_price_per_pack.is_some()
-        && (invoice.name_store_id.is_some() || invoice.purchase_order_id.is_some())
-    {
-        return Err(CannotEditCostPrice);
+    if let Some(new_cost_price) = input.cost_price_per_pack {
+        if (invoice.name_store_id.is_some() || invoice.purchase_order_id.is_some())
+            && new_cost_price != line_row.cost_price_per_pack
+        {
+            return Err(CannotEditCostPrice);
+        }
     }
 
     if input


### PR DESCRIPTION
Fixes #10889 (well resolves the bug from there)

## Summary

- Fixes a bug introduced in #10906 where editing **any** field on an inbound shipment line (e.g. packs received) linked to a purchase order or internal supplier would fail with a `CannotEditCostPrice` error
- The backend validation rejected the update whenever `cost_price_per_pack` was present in the input, even if the value was unchanged — the frontend always sends the current price back as part of the update payload
- The fix changes the validation to only reject when the price value **actually differs** from the existing line, allowing unchanged prices to pass through

## Test plan

- [ ] Open an inbound shipment (external) linked to a purchase order
- [ ] Edit a line and change packs received (without touching cost price)
- [ ] Confirm the update saves without error
- [ ] Edit a line and attempt to change the cost price — confirm it is still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)