### PR TITLE
#10937 Inbound shipment external date field

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1450,6 +1450,7 @@
   "label.repack": "Repack",
   "label.replacement-date": "Replacement due",
   "label.report-filters": "Report Filters",
+  "label.reporting-date": "Reporting date",
   "label.requested": "Requested",
   "label.requested-delivery-date": "Requested delivery date",
   "label.requested-number-packs": "Requested number of packs (approx)",

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -4448,6 +4448,7 @@ export type InvoiceNode = {
   programId?: Maybe<Scalars['String']['output']>;
   purchaseOrder?: Maybe<PurchaseOrderNode>;
   receivedDatetime?: Maybe<Scalars['DateTime']['output']>;
+  reportingDate?: Maybe<Scalars['NaiveDate']['output']>;
   /**
    * Response Requisition that is the origin of this Outbound Shipment
    * Or Request Requisition for Inbound Shipment that Originated from Outbound Shipment (linked through Response Requisition)
@@ -9986,10 +9987,10 @@ export type UpdateInboundShipmentInput = {
   currencyId?: InputMaybe<Scalars['String']['input']>;
   currencyRate?: InputMaybe<Scalars['Float']['input']>;
   defaultDonor?: InputMaybe<UpdateDonorInput>;
-  deliveredDatetime?: InputMaybe<Scalars['NaiveDate']['input']>;
   id: Scalars['String']['input'];
   onHold?: InputMaybe<Scalars['Boolean']['input']>;
   otherPartyId?: InputMaybe<Scalars['String']['input']>;
+  reportingDate?: InputMaybe<Scalars['NaiveDate']['input']>;
   status?: InputMaybe<UpdateInboundShipmentStatusInput>;
   tax?: InputMaybe<TaxInput>;
   theirReference?: InputMaybe<Scalars['String']['input']>;

--- a/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
@@ -49,7 +49,7 @@ export const Toolbar = () => {
     update: { update },
   } = useInboundShipment();
 
-  const { deliveredDatetime, otherParty, theirReference, purchaseOrder } =
+  const { reportingDate, otherParty, theirReference, purchaseOrder } =
     shipment || {};
 
   const isTransfer = !!shipment?.linkedShipment?.id;
@@ -134,23 +134,17 @@ export const Toolbar = () => {
             </Grid>
             <Grid>
               <InputWithLabelRow
-                label={t('label.delivered-date')}
+                label={t('label.reporting-date')}
                 Input={
                   <DateTimePickerInput
-                    value={DateUtils.getDateOrNull(deliveredDatetime)}
+                    value={DateUtils.getDateOrNull(reportingDate)}
                     onChange={date =>
                       update({
-                        deliveredDatetime:
+                        reportingDate:
                           Formatter.naiveDate(date) ?? undefined,
                       })
                     }
-                    // Max now or received date, whichever is earlier
-                    maxDate={
-                      shipment?.receivedDatetime
-                        ? (DateUtils.getDateOrNull(shipment.receivedDatetime) ??
-                          new Date())
-                        : new Date()
-                    }
+                    maxDate={new Date()}
                   />
                 }
               />

--- a/client/packages/invoices/src/InboundShipment/api/api.ts
+++ b/client/packages/invoices/src/InboundShipment/api/api.ts
@@ -92,8 +92,8 @@ export const inboundParsers = {
       id: patch.id,
       colour: 'colour' in patch ? patch.colour : undefined,
       comment: 'comment' in patch ? patch.comment : undefined,
-      deliveredDatetime:
-        'deliveredDatetime' in patch ? patch.deliveredDatetime : undefined,
+      reportingDate:
+        'reportingDate' in patch ? patch.reportingDate : undefined,
       status: inboundParsers.toStatus(patch),
       onHold: 'onHold' in patch ? patch.onHold : undefined,
       otherPartyId: 'otherParty' in patch ? patch.otherParty?.id : undefined,

--- a/client/packages/invoices/src/InboundShipment/api/operations.generated.ts
+++ b/client/packages/invoices/src/InboundShipment/api/operations.generated.ts
@@ -120,6 +120,7 @@ export type InboundFragment = {
   createdDatetime: string;
   allocatedDatetime?: string | null;
   deliveredDatetime?: string | null;
+  reportingDate?: string | null;
   receivedDatetime?: string | null;
   pickedDatetime?: string | null;
   shippedDatetime?: string | null;
@@ -329,6 +330,7 @@ export type InboundRowFragment = {
   comment?: string | null;
   createdDatetime: string;
   deliveredDatetime?: string | null;
+  reportingDate?: string | null;
   receivedDatetime?: string | null;
   id: string;
   invoiceNumber: number;
@@ -379,6 +381,7 @@ export type InvoicesQuery = {
       comment?: string | null;
       createdDatetime: string;
       deliveredDatetime?: string | null;
+      reportingDate?: string | null;
       receivedDatetime?: string | null;
       id: string;
       invoiceNumber: number;
@@ -427,6 +430,7 @@ export type InvoiceQuery = {
         createdDatetime: string;
         allocatedDatetime?: string | null;
         deliveredDatetime?: string | null;
+        reportingDate?: string | null;
         receivedDatetime?: string | null;
         pickedDatetime?: string | null;
         shippedDatetime?: string | null;
@@ -669,6 +673,7 @@ export type InboundByNumberQuery = {
         createdDatetime: string;
         allocatedDatetime?: string | null;
         deliveredDatetime?: string | null;
+        reportingDate?: string | null;
         receivedDatetime?: string | null;
         pickedDatetime?: string | null;
         shippedDatetime?: string | null;
@@ -1478,6 +1483,7 @@ export const InboundFragmentDoc = gql`
     createdDatetime
     allocatedDatetime
     deliveredDatetime
+    reportingDate
     receivedDatetime
     pickedDatetime
     shippedDatetime
@@ -1586,6 +1592,7 @@ export const InboundRowFragmentDoc = gql`
     comment
     createdDatetime
     deliveredDatetime
+    reportingDate
     receivedDatetime
     id
     invoiceNumber

--- a/client/packages/invoices/src/InboundShipment/api/operations.graphql
+++ b/client/packages/invoices/src/InboundShipment/api/operations.graphql
@@ -123,6 +123,7 @@ fragment Inbound on InvoiceNode {
   createdDatetime
   allocatedDatetime
   deliveredDatetime
+  reportingDate
   receivedDatetime
   pickedDatetime
   shippedDatetime
@@ -241,6 +242,7 @@ fragment InboundRow on InvoiceNode {
   comment
   createdDatetime
   deliveredDatetime
+  reportingDate
   receivedDatetime
   id
   invoiceNumber

--- a/server/graphql/invoice/src/mutations/inbound_shipment/update.rs
+++ b/server/graphql/invoice/src/mutations/inbound_shipment/update.rs
@@ -49,7 +49,7 @@ pub struct UpdateInput {
     pub currency_id: Option<String>,
     pub currency_rate: Option<f64>,
     pub default_donor: Option<UpdateDonorInput>,
-    pub delivered_datetime: Option<NaiveDate>,
+    pub reporting_date: Option<NaiveDate>,
 }
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq, Debug)]
@@ -120,7 +120,7 @@ impl UpdateInput {
             currency_id,
             currency_rate,
             default_donor,
-            delivered_datetime,
+            reporting_date,
         } = self;
 
         ServiceInput {
@@ -140,7 +140,7 @@ impl UpdateInput {
                 donor_id: donor.donor_id,
                 apply_to_lines: donor.apply_to_lines.to_domain(),
             }),
-            delivered_datetime,
+            reporting_date,
         }
     }
 }
@@ -208,8 +208,7 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
         | ServiceError::NotAnInboundShipment
         | ServiceError::OtherPartyDoesNotExist
         | ServiceError::CanOnlyChangeDateOfExternalInboundShipments
-        | ServiceError::CannotPutDeliveredDateAfterReceivedDate
-        | ServiceError::CannotSetDeliveredDateInFuture
+        | ServiceError::CannotSetReportingDateInFuture
         | ServiceError::CannotSetShippedStatusOnManualInboundShipment => {
             BadUserInput(formatted_error)
         }
@@ -553,7 +552,7 @@ mod test {
                     currency_id: None,
                     currency_rate: None,
                     default_donor: None,
-                    delivered_datetime: None,
+                    reporting_date: None,
                 }
             );
             Ok(Invoice {

--- a/server/graphql/types/src/types/invoice_query.rs
+++ b/server/graphql/types/src/types/invoice_query.rs
@@ -203,6 +203,10 @@ impl InvoiceNode {
             .map(|v| DateTime::<Utc>::from_naive_utc_and_offset(v, Utc))
     }
 
+    pub async fn reporting_date(&self) -> Option<NaiveDate> {
+        self.row().reporting_date
+    }
+
     pub async fn received_datetime(&self) -> Option<DateTime<Utc>> {
         self.row()
             .received_datetime

--- a/server/repository/src/db_diesel/invoice_row.rs
+++ b/server/repository/src/db_diesel/invoice_row.rs
@@ -57,6 +57,7 @@ define_linked_tables! {
         expected_delivery_date -> Nullable<Date>,
         purchase_order_id -> Nullable<Text>,
         shipping_method_id -> Nullable<Text>,
+        reporting_date -> Nullable<Date>,
     },
     links:{
          name_link_id -> name_id,
@@ -153,6 +154,7 @@ pub struct InvoiceRow {
     pub expected_delivery_date: Option<NaiveDate>,
     pub purchase_order_id: Option<String>,
     pub shipping_method_id: Option<String>,
+    pub reporting_date: Option<NaiveDate>,
     // Resolved from name_link - must be last to match view column order
     pub name_id: String,
     pub default_donor_id: Option<String>,

--- a/server/repository/src/migrations/v2_17_00/add_reporting_date_to_invoice.rs
+++ b/server/repository/src/migrations/v2_17_00/add_reporting_date_to_invoice.rs
@@ -1,0 +1,20 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_reporting_date_to_invoice"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        sql!(
+            connection,
+            r#"
+                ALTER TABLE invoice ADD COLUMN reporting_date TEXT;
+            "#
+        )?;
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_17_00/mod.rs
+++ b/server/repository/src/migrations/v2_17_00/mod.rs
@@ -5,14 +5,15 @@ mod add_forecasting_fields_to_requisition_line;
 mod add_manufacture_date_to_stock_and_invoice_lines;
 mod add_manufacturer_link_id_to_lines;
 mod add_purchase_order_id_to_invoice;
+mod add_reporting_date_to_invoice;
 mod import_goods_received;
 mod invoice_line_add_status;
 mod item_category_join_add_item_link_id;
 mod item_store_join_add_default_location_id;
 mod remove_goods_received;
 mod remove_goods_received_cleanup;
-mod vaccine_course_store_config;
 mod requisition_add_destination_customer_link_id;
+mod vaccine_course_store_config;
 
 pub(crate) struct V2_17_00;
 impl Migration for V2_17_00 {
@@ -38,6 +39,7 @@ impl Migration for V2_17_00 {
             Box::new(import_goods_received::Migrate),
             Box::new(vaccine_course_store_config::Migrate),
             Box::new(requisition_add_destination_customer_link_id::Migrate),
+            Box::new(add_reporting_date_to_invoice::Migrate),
         ]
     }
 }

--- a/server/service/src/invoice/customer_return/insert/generate.rs
+++ b/server/service/src/invoice/customer_return/insert/generate.rs
@@ -80,6 +80,7 @@ pub fn generate(
         default_donor_id: None,
         purchase_order_id: None,
         shipping_method_id: None,
+        reporting_date: None,
     };
 
     let lines_with_packs: Vec<CustomerReturnLineInput> = customer_return_lines

--- a/server/service/src/invoice/inbound_shipment/insert/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/insert/generate.rs
@@ -43,6 +43,11 @@ pub fn generate(
         invoice_number: next_number(connection, &NumberRowType::InboundShipment, store_id)?,
         store_id: store_id.to_string(),
         created_datetime: current_datetime,
+        reporting_date: if purchase_order_id.is_some() {
+            Some(current_datetime.date())
+        } else {
+            None
+        },
         status: InvoiceStatus::New,
         on_hold: on_hold.unwrap_or(false),
         colour,

--- a/server/service/src/invoice/inbound_shipment/update/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/update/generate.rs
@@ -1,4 +1,4 @@
-use chrono::{NaiveDateTime, Utc};
+use chrono::Utc;
 
 use repository::vvm_status::vvm_status_log_row::VVMStatusLogRow;
 use repository::{
@@ -80,8 +80,8 @@ pub(crate) fn generate(
     update_invoice.currency_rate = patch.currency_rate.unwrap_or(update_invoice.currency_rate);
 
     // Already validated in validate
-    if let Some(delivered_datetime) = patch.delivered_datetime {
-        update_invoice.delivered_datetime = Some(NaiveDateTime::from(delivered_datetime));
+    if let Some(reporting_date) = patch.reporting_date {
+        update_invoice.reporting_date = Some(reporting_date);
     }
 
     let batches_to_update = if should_create_batches {

--- a/server/service/src/invoice/inbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/update/mod.rs
@@ -53,7 +53,7 @@ pub struct UpdateInboundShipment {
     pub currency_id: Option<String>,
     pub currency_rate: Option<f64>,
     pub default_donor: Option<UpdateDefaultDonor>,
-    pub delivered_datetime: Option<NaiveDate>,
+    pub reporting_date: Option<NaiveDate>,
 }
 
 type OutError = UpdateInboundShipmentError;
@@ -175,8 +175,7 @@ pub enum UpdateInboundShipmentError {
     CannotIssueForeignCurrencyForInternalSuppliers,
     CannotUpdateStatusAndDonorAtTheSameTime,
     CanOnlyChangeDateOfExternalInboundShipments,
-    CannotSetDeliveredDateInFuture,
-    CannotPutDeliveredDateAfterReceivedDate,
+    CannotSetReportingDateInFuture,
     CannotReceiveWithPendingLines,
     CannotSetShippedStatusOnManualInboundShipment,
     // Name validation

--- a/server/service/src/invoice/inbound_shipment/update/validate.rs
+++ b/server/service/src/invoice/inbound_shipment/update/validate.rs
@@ -4,7 +4,7 @@ use crate::invoice::{
     inbound_shipment::UpdateInboundShipmentStatus, InvoiceRowStatusError,
 };
 use crate::validate::{check_other_party, CheckOtherPartyType, OtherPartyErrors};
-use chrono::{NaiveDateTime, Utc};
+use chrono::Utc;
 use repository::{
     InvoiceLineRowRepository, InvoiceLineStatus, InvoiceRow, InvoiceType, Name, StorageConnection,
 };
@@ -58,23 +58,15 @@ pub fn validate(
         }
     }
 
-    // Delivered datetime is only editable for external inbound shipments (those created from a
-    // purchase order). It must not be in the future and must not be after the received datetime,
-    // as the goods can't have been delivered after they were received.
-    if let Some(delivered_datetime) = patch.delivered_datetime {
+    // Reporting date is only editable for external inbound shipments (those created from a
+    // purchase order). It must not be in the future.
+    if let Some(reporting_date) = patch.reporting_date {
         if invoice.purchase_order_id.is_none() {
             return Err(CanOnlyChangeDateOfExternalInboundShipments);
         }
 
-        let delivered_datetime = NaiveDateTime::from(delivered_datetime);
-        if delivered_datetime > Utc::now().naive_utc() {
-            return Err(CannotSetDeliveredDateInFuture);
-        }
-
-        if let Some(received_datetime) = invoice.received_datetime {
-            if delivered_datetime > received_datetime {
-                return Err(CannotPutDeliveredDateAfterReceivedDate);
-            }
+        if reporting_date > Utc::now().naive_utc().date() {
+            return Err(CannotSetReportingDateInFuture);
         }
     }
 

--- a/server/service/src/invoice/inventory_adjustment/add_new_stock_line/generate.rs
+++ b/server/service/src/invoice/inventory_adjustment/add_new_stock_line/generate.rs
@@ -97,6 +97,7 @@ pub fn generate(
         default_donor_id: None,
         purchase_order_id: None,
         shipping_method_id: None,
+        reporting_date: None,
     };
 
     let invoice_line_id = uuid();

--- a/server/service/src/invoice/inventory_adjustment/adjust_existing_stock/generate.rs
+++ b/server/service/src/invoice/inventory_adjustment/adjust_existing_stock/generate.rs
@@ -97,6 +97,7 @@ pub fn generate(
         default_donor_id: None,
         purchase_order_id: None,
         shipping_method_id: None,
+        reporting_date: None,
     };
 
     let StockLineRow {

--- a/server/service/src/invoice/outbound_shipment/insert/generate.rs
+++ b/server/service/src/invoice/outbound_shipment/insert/generate.rs
@@ -63,6 +63,7 @@ pub fn generate(
         default_donor_id: None,
         purchase_order_id: None,
         shipping_method_id: None,
+        reporting_date: None,
     };
 
     Ok(result)

--- a/server/service/src/invoice/prescription/insert/generate.rs
+++ b/server/service/src/invoice/prescription/insert/generate.rs
@@ -70,6 +70,7 @@ pub fn generate(
         default_donor_id: None,
         purchase_order_id: None,
         shipping_method_id: None,
+        reporting_date: None,
     };
 
     if let Some(date) = prescription_date {

--- a/server/service/src/invoice/supplier_return/insert/generate.rs
+++ b/server/service/src/invoice/supplier_return/insert/generate.rs
@@ -78,6 +78,7 @@ pub fn generate(
         default_donor_id: None,
         purchase_order_id: None,
         shipping_method_id: None,
+        reporting_date: None,
     };
 
     let lines_with_packs: Vec<&SupplierReturnLineInput> = supplier_return_lines

--- a/server/service/src/processors/transfer/invoice/create_inbound_invoice.rs
+++ b/server/service/src/processors/transfer/invoice/create_inbound_invoice.rs
@@ -304,6 +304,7 @@ fn generate_inbound_invoice(
         is_cancellation: false,
         default_donor_id: None,
         purchase_order_id: None,
+        reporting_date: None,
     };
 
     Ok(result)

--- a/server/service/src/requisition/response_requisition/create_requisition_shipment/generate.rs
+++ b/server/service/src/requisition/response_requisition/create_requisition_shipment/generate.rs
@@ -81,6 +81,7 @@ pub fn generate(
         default_donor_id: None,
         purchase_order_id: None,
         shipping_method_id: None,
+        reporting_date: None,
     };
 
     let invoice_line_rows = generate_invoice_lines(connection, &new_invoice.id, fulfillments)?;

--- a/server/service/src/stocktake/update/generate.rs
+++ b/server/service/src/stocktake/update/generate.rs
@@ -677,6 +677,7 @@ pub fn generate(
         default_donor_id: None,
         purchase_order_id: None,
         shipping_method_id: None,
+        reporting_date: None,
     };
 
     let inventory_addition = if !inventory_addition_lines.is_empty() {

--- a/server/service/src/sync/test/test_data/invoice.rs
+++ b/server/service/src/sync/test/test_data/invoice.rs
@@ -2,6 +2,7 @@ use crate::sync::{
     test::TestSyncIncomingRecord,
     translations::invoice::{
         LegacyOmStatus, LegacyTransactRow, LegacyTransactStatus, LegacyTransactType, TransactMode,
+        TransactRowOmsFields,
     },
 };
 use chrono::{Duration, NaiveDate, NaiveTime};
@@ -233,7 +234,9 @@ fn transact_1_push_legacy_row() -> LegacyTransactRow {
         goods_received_ID: None,
         purchase_order_id: Some("test_purchase_order_a".to_string()),
         shipping_method_id: Some("SHIPPING_METHOD_1_ID".to_string()),
-        oms_fields: None,
+        oms_fields: Some(TransactRowOmsFields {
+            reporting_date: None,
+        }),
     }
 }
 
@@ -438,7 +441,9 @@ fn transact_2_push_record() -> TestSyncOutgoingRecord {
             goods_received_ID: None,
             purchase_order_id: None,
             shipping_method_id: None,
-            oms_fields: None,
+            oms_fields: Some(TransactRowOmsFields {
+                reporting_date: None,
+            }),
         }),
     }
 }
@@ -704,7 +709,9 @@ fn transact_om_fields_push_record() -> TestSyncOutgoingRecord {
             goods_received_ID: None,
             purchase_order_id: None,
             shipping_method_id: None,
-            oms_fields: None,
+            oms_fields: Some(TransactRowOmsFields {
+                reporting_date: None,
+            }),
         }),
     }
 }
@@ -922,7 +929,9 @@ fn inventory_addition_push_record() -> TestSyncOutgoingRecord {
             goods_received_ID: None,
             purchase_order_id: None,
             shipping_method_id: None,
-            oms_fields: None,
+            oms_fields: Some(TransactRowOmsFields {
+                reporting_date: None,
+            }),
         }),
     }
 }
@@ -1139,7 +1148,9 @@ fn inventory_reduction_push_record() -> TestSyncOutgoingRecord {
             goods_received_ID: None,
             purchase_order_id: None,
             shipping_method_id: None,
-            oms_fields: None,
+            oms_fields: Some(TransactRowOmsFields {
+                reporting_date: None,
+            }),
         }),
     }
 }
@@ -1353,7 +1364,9 @@ fn prescription_1_push_record() -> TestSyncOutgoingRecord {
             goods_received_ID: None,
             purchase_order_id: None,
             shipping_method_id: None,
-            oms_fields: None,
+            oms_fields: Some(TransactRowOmsFields {
+                reporting_date: None,
+            }),
         }),
     }
 }
@@ -1578,7 +1591,9 @@ fn cancelled_prescription_push_record() -> TestSyncOutgoingRecord {
             goods_received_ID: None,
             purchase_order_id: None,
             shipping_method_id: None,
-            oms_fields: None,
+            oms_fields: Some(TransactRowOmsFields {
+                reporting_date: None,
+            }),
         }),
     }
 }

--- a/server/service/src/sync/test/test_data/invoice.rs
+++ b/server/service/src/sync/test/test_data/invoice.rs
@@ -158,6 +158,7 @@ fn transact_1_pull_row() -> InvoiceRow {
         default_donor_id: Some("donor_a".to_string()),
         purchase_order_id: Some("test_purchase_order_a".to_string()),
         shipping_method_id: Some("SHIPPING_METHOD_1_ID".to_string()),
+        reporting_date: None,
     }
 }
 
@@ -232,6 +233,7 @@ fn transact_1_push_legacy_row() -> LegacyTransactRow {
         goods_received_ID: None,
         purchase_order_id: Some("test_purchase_order_a".to_string()),
         shipping_method_id: Some("SHIPPING_METHOD_1_ID".to_string()),
+        oms_fields: None,
     }
 }
 
@@ -373,6 +375,7 @@ fn transact_2_pull_record() -> TestSyncIncomingRecord {
             default_donor_id: None,
             purchase_order_id: None,
             shipping_method_id: None,
+            reporting_date: None,
         },
     )
 }
@@ -435,6 +438,7 @@ fn transact_2_push_record() -> TestSyncOutgoingRecord {
             goods_received_ID: None,
             purchase_order_id: None,
             shipping_method_id: None,
+            oms_fields: None,
         }),
     }
 }
@@ -608,6 +612,7 @@ fn transact_om_fields_pull_record() -> TestSyncIncomingRecord {
             default_donor_id: None,
             purchase_order_id: None,
             shipping_method_id: None,
+            reporting_date: None,
         },
     )
 }
@@ -699,6 +704,7 @@ fn transact_om_fields_push_record() -> TestSyncOutgoingRecord {
             goods_received_ID: None,
             purchase_order_id: None,
             shipping_method_id: None,
+            oms_fields: None,
         }),
     }
 }
@@ -847,6 +853,7 @@ fn inventory_addition_pull_record() -> TestSyncIncomingRecord {
             default_donor_id: None,
             purchase_order_id: None,
             shipping_method_id: None,
+            reporting_date: None,
         },
     )
 }
@@ -915,6 +922,7 @@ fn inventory_addition_push_record() -> TestSyncOutgoingRecord {
             goods_received_ID: None,
             purchase_order_id: None,
             shipping_method_id: None,
+            oms_fields: None,
         }),
     }
 }
@@ -1063,6 +1071,7 @@ fn inventory_reduction_pull_record() -> TestSyncIncomingRecord {
             default_donor_id: None,
             purchase_order_id: None,
             shipping_method_id: None,
+            reporting_date: None,
         },
     )
 }
@@ -1130,6 +1139,7 @@ fn inventory_reduction_push_record() -> TestSyncOutgoingRecord {
             goods_received_ID: None,
             purchase_order_id: None,
             shipping_method_id: None,
+            oms_fields: None,
         }),
     }
 }
@@ -1275,6 +1285,7 @@ fn prescription_1_pull_record() -> TestSyncIncomingRecord {
             default_donor_id: None,
             purchase_order_id: None,
             shipping_method_id: None,
+            reporting_date: None,
         },
     )
 }
@@ -1342,6 +1353,7 @@ fn prescription_1_push_record() -> TestSyncOutgoingRecord {
             goods_received_ID: None,
             purchase_order_id: None,
             shipping_method_id: None,
+            oms_fields: None,
         }),
     }
 }
@@ -1493,6 +1505,7 @@ fn cancelled_prescription_pull_record() -> TestSyncIncomingRecord {
             default_donor_id: None,
             purchase_order_id: None,
             shipping_method_id: None,
+            reporting_date: None,
         },
     )
 }
@@ -1565,6 +1578,7 @@ fn cancelled_prescription_push_record() -> TestSyncOutgoingRecord {
             goods_received_ID: None,
             purchase_order_id: None,
             shipping_method_id: None,
+            oms_fields: None,
         }),
     }
 }

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use util::constants::INVENTORY_ADJUSTMENT_NAME_CODE;
 use util::sync_serde::{
     date_option_to_isostring, date_to_isostring, empty_str_as_option, empty_str_as_option_string,
-    naive_time, zero_date_as_option, zero_f64_as_none,
+    naive_time, object_fields_as_option, zero_date_as_option, zero_f64_as_none,
 };
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
@@ -119,6 +119,13 @@ pub enum TransactMode {
     #[serde(other)]
     Others,
 }
+
+#[derive(Deserialize, Serialize, Default)]
+pub struct TransactRowOmsFields {
+    #[serde(default)]
+    pub reporting_date: Option<NaiveDate>,
+}
+
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
 pub struct LegacyTransactRow {
@@ -280,6 +287,10 @@ pub struct LegacyTransactRow {
     #[serde(rename = "ship_method_ID")]
     #[serde(deserialize_with = "empty_str_as_option_string")]
     pub shipping_method_id: Option<String>,
+
+    #[serde(default)]
+    #[serde(deserialize_with = "object_fields_as_option")]
+    pub oms_fields: Option<TransactRowOmsFields>,
 }
 
 /// The mSupply central server will map outbound invoices from omSupply to "si" invoices for the
@@ -457,6 +468,7 @@ impl SyncTranslation for InvoiceTranslation {
             expected_delivery_date: data.expected_delivery_date,
             purchase_order_id: data.purchase_order_id,
             shipping_method_id: data.shipping_method_id,
+            reporting_date: data.oms_fields.and_then(|f| f.reporting_date),
         };
 
         // HACK...
@@ -547,6 +559,7 @@ impl SyncTranslation for InvoiceTranslation {
                     default_donor_id,
                     purchase_order_id,
                     shipping_method_id,
+                    reporting_date,
                 },
             name_row,
             clinician_row,
@@ -623,6 +636,7 @@ impl SyncTranslation for InvoiceTranslation {
             goods_received_ID: None,
             purchase_order_id,
             shipping_method_id,
+            oms_fields: Some(TransactRowOmsFields { reporting_date }),
         };
 
         let json_record = serde_json::to_value(legacy_row)?;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10937

# 👩🏻‍💻 What does this PR do?

Changes the inbound shipment external delivered date in the toolbar to reporting date. Adds a new column to the invoice table to store reporting date and syncs through `oms_fields`.

<img width="1657" height="435" alt="Screenshot 2026-03-23 at 10 42 32 am" src="https://github.com/user-attachments/assets/014cb774-97dc-43b3-866c-9a7f6cbf1711" />

## 💌 Any notes for the reviewer?

Can still change the name if anyone thinks of a better one.

# 🧪 Testing

- [ ] Go to an external inbound shipment
- [ ] Change the reporting date in the toolbar
- [ ] Sync then check reporting date is kept upon reinitialisation (or move store to different site or something)

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

