### PR TITLE
#10790 (purchase orders) Supplier discount amount 

### DIFF
--- a/client/packages/purchasing/src/purchase_order/DetailView/SidePanel/PricingSection.tsx
+++ b/client/packages/purchasing/src/purchase_order/DetailView/SidePanel/PricingSection.tsx
@@ -39,7 +39,7 @@ export const PricingSection = ({
   disabled,
 }: PricingSectionProps) => {
   const t = useTranslation();
-  const { c } = useCurrency(draft?.currency?.code as Currencies);
+  const { c, options } = useCurrency(draft?.currency?.code as Currencies);
 
   if (!draft) return null;
 
@@ -100,6 +100,8 @@ export const PricingSection = ({
             slotProps={slotProps}
             onChange={handleSupplierDiscountAmountChange}
             disabled={disabled}
+            decimalLimit={options.precision}
+            endAdornment={options.symbol}
           />
         </PanelRow>
         <PanelRow>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10790

# 👩🏻‍💻 What does this PR do?

Makes the purchase order supplier discount amount display using the currency's symbol and precision.

<img width="289" height="285" alt="Screenshot 2026-03-23 at 3 58 30 pm" src="https://github.com/user-attachments/assets/8e00bab5-3262-4575-8d29-f618b40a7ab5" />

## 💌 Any notes for the reviewer?

> Should display decimals, up to 5 digits

I figure it is better to use the currency's config instead of a hard coded value.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to purchase order with prices set
- [ ] Open sidebar
- [ ] Check supplier discount amount is shown using the right symbol and precision for the set currency

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

