### PR TITLE
10821 Cannot see VVM statuses when issuing prescriptions unless both 'Manage VVM status for stock' and 'Sort available batches by VVM status then expiry' preferences are enabled

### DIFF
--- a/client/packages/invoices/src/Prescriptions/LineEditView/columns.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/columns.tsx
@@ -35,7 +35,7 @@ export const usePrescriptionLineEditColumns = ({
   const { sortByVvmStatusThenExpiry, manageVvmStatusForStock } =
     usePreferences();
   const hasVvmStatusesEnabled =
-    manageVvmStatusForStock && sortByVvmStatusThenExpiry;
+    manageVvmStatusForStock || sortByVvmStatusThenExpiry;
   const pluralisedUnitName = getPlural(unit, 2);
   const displayInDoses = allocateIn === AllocateInType.Doses;
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10821

Allows vvm status to show in prescription if the user has either `manage vvm..`. or `sort available...` statuses

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have either one of the above store preferences on
- [ ] Create a prescription with a vaccine item
- [ ] Should see vvm status column

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

