### PR TITLE
#10936 Clamp negative received quantity in PO lines

### DIFF
--- a/server/service/src/invoice/inbound_shipment/add_from_purchase_order.rs
+++ b/server/service/src/invoice/inbound_shipment/add_from_purchase_order.rs
@@ -45,8 +45,8 @@ pub fn add_from_purchase_order(
             .unwrap_or(purchase_order_line.requested_number_of_units);
         let shipped_number_of_units = purchase_order_line_stats.shipped_number_of_units;
         let pack_size = purchase_order_line.requested_pack_size;
-        let number_of_packs =
-            (purchase_order_number_of_units - shipped_number_of_units) / pack_size;
+        let remaining_units = (purchase_order_number_of_units - shipped_number_of_units).max(0.0);
+        let number_of_packs = remaining_units / pack_size;
 
         invoice_line_row_repository.upsert_one(&InvoiceLineRow {
             id: uuid(),


### PR DESCRIPTION
Fixes #10936

# 👩🏻‍💻 What does this PR do?

When creating inbound shipment lines from a purchase order, if shipped units exceed ordered units, the `number_of_packs` could go negative. This clamps `remaining_units` to a minimum of `0.0` so that `number_of_packs` is never negative.

## 💌 Any notes for the reviewer?

Single line change in `add_from_purchase_order.rs` — adds `.max(0.0)` to the remaining units calculation.

# 🧪 Testing

- [ ] Create a purchase order with lines
- [ ] Ship more units than ordered for a PO line (e.g. via another inbound shipment)
- [ ] Create a new inbound shipment from that purchase order with add all lines
- [ ] Verify the generated line has 0 packs instead of a negative number

# 📃 Documentation

- [x] **No documentation required**: bug fix which isn't a change in behaviour