### PR TITLE
Fix external inbound shipment save using wrong mutation

### DIFF
--- a/client/packages/invoices/src/InboundShipment/api/hooks/useDraftPurchaseOrderInboundLines.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/useDraftPurchaseOrderInboundLines.ts
@@ -75,6 +75,7 @@ export const useDraftPurchaseOrderInboundLines = (
 
   const {
     query: { data },
+    isExternal,
   } = useInboundShipment();
   const invoiceId = data?.id ?? '';
 
@@ -87,9 +88,8 @@ export const useDraftPurchaseOrderInboundLines = (
         line.purchaseOrderLine?.id === purchaseOrderLine.id
     );
   }, [data, purchaseOrderLine]);
-
-  const { mutateAsync, isLoading } = useSaveInboundLines();
-  const { mutateAsync: deleteMutation } = useDeleteInboundLines();
+  const { mutateAsync, isLoading } = useSaveInboundLines(isExternal);
+  const { mutateAsync: deleteMutation } = useDeleteInboundLines(isExternal);
 
   const { isDirty, setIsDirty } = useConfirmOnLeaving(
     'external-inbound-line-edit'


### PR DESCRIPTION

Closes https://github.com/msupply-foundation/open-msupply/issues/10338 (fxies bug produced by original PR to close this)

## Summary
- Fixes saving/deleting lines on external inbound shipments (ISE) failing with a `ForeignKeyError` on `invoiceId`
- `useDraftPurchaseOrderInboundLines` was calling `useSaveInboundLines()` and `useDeleteInboundLines()` without passing the `isExternal` flag, so the regular (non-external) `batchInboundShipment` mutation was used instead of `batchInboundShipmentExternal`

## Bug introduced in
#10900

## Test plan
- [ ] Open an external inbound shipment linked to a purchase order
- [ ] Edit a line item, fill in values, and click OK
- [ ] Verify the save succeeds without error
- [ ] Verify deleting a line also works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)