### PR TITLE
UI updates

### DIFF
--- a/client/packages/common/src/intl/utils/IntlUtils.ts
+++ b/client/packages/common/src/intl/utils/IntlUtils.ts
@@ -160,6 +160,8 @@ const locales = [
 
 const rtlLocales = ['ar', 'prs', 'ps'];
 
+const pluralExceptions = ['each'];
+
 export type SupportedLocales = (typeof locales)[number];
 export const isRtlLocale = (locale: string) => rtlLocales.includes(locale);
 
@@ -213,9 +215,13 @@ export const useIntlUtils = () => {
     [language]
   );
 
-  // pluralize only works for English words. Any other language strings are returned unchanged
   const getPlural = (word: string, count: number) => {
+    // pluralize only works for English words. Any other language strings are returned unchanged
     if (language !== 'en') return word;
+
+    // pick up any known failures in the pluralization library and return the original word in that case
+    if (pluralExceptions.includes(word.toLowerCase())) return word;
+
     return pluralize(word, count);
   };
 

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestedSelection/RequestedSelection.tsx
@@ -162,6 +162,7 @@ export const RequestedSelection = ({
               )}
               dosesPerUnit={dosesPerUnit}
               dosesSelected={representation === Representation.DOSES}
+              unitsLabel={unitName}
             />
           )}
         </Box>

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemPackagingVariantsTable.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemPackagingVariantsTable.tsx
@@ -77,7 +77,7 @@ export const ItemPackagingVariantsTable = ({
                   updatePackaging({ id: row.id, volumePerUnit: value })
                 }
                 error={cell.getValue() === 0}
-                decimalLimit={3}
+                decimalLimit={4}
               />
             )
           : TextWithTooltipCell,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10983 

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
Three minor UI updates
* No longer pluralising 'each'
* Show the unit name in the internal order edit modal when viewing doses
* Allow 4dp when editing variant volumes

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Edit a vaccine row in an internal order. change the required quantity entry to be in doses. observe that the number of units is shown below the input field and displays the unit name
- [ ] Edit an item variant and observe that the entry allows up to 4 decimal places
- [ ] Add an item which has the unit name of 'each' to the internal order. observe that 'each' is shown rather than 'eaches'

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

