### PR TITLE
10918 Stores show instead of manufacturers when selecting in Inbound Shipments

### DIFF
--- a/client/packages/system/src/Name/api/hooks/document/useManufacturers.ts
+++ b/client/packages/system/src/Name/api/hooks/document/useManufacturers.ts
@@ -6,7 +6,7 @@ export const useManufacturers = () => {
   const queryParams = useQueryParamsStore();
   const params = queryParams?.paramList ? queryParams.paramList() : {};
 
-  return useQuery(api.keys.paramList(params), () =>
+  return useQuery([...api.keys.paramList(params), 'manufacturers'], () =>
     api.get.manufacturers(params)
   );
 };

--- a/client/packages/system/src/Name/api/hooks/document/useSuppliers.ts
+++ b/client/packages/system/src/Name/api/hooks/document/useSuppliers.ts
@@ -6,7 +6,7 @@ export const useSuppliers = (external?: boolean) => {
   const queryParams = useQueryParamsStore();
 
   const params = queryParams?.paramList ? queryParams.paramList() : {};
-  return useQuery(api.keys.paramList(params), () =>
+  return useQuery([...api.keys.paramList(params), 'suppliers'], () =>
     api.get.suppliers({
       ...params,
       external,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10918 & #10961

# 👩🏻‍💻 What does this PR do?
Use different invalidation keys for manufacturer & supplier since it was causing the manufacturer input to load the wrong thing. Sorry, wasn't happening for me but this should fix it

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have manufacturers set up in OG
- [ ] Create inbound shipment and add a line
- [ ] Try assigning manufacturer
- [ ] Shouldn't see suppliers instead

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

