### PR TITLE
#10915 Fix external inbound shipment deletion

### DIFF
--- a/client/packages/invoices/src/InboundShipment/api/hooks/document/useInboundList.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/document/useInboundList.ts
@@ -106,20 +106,41 @@ const useDelete = () => {
   const mutationFn = async (
     invoices: InboundRowFragment[]
   ): Promise<string[]> => {
-    const result =
-      (await inboundApi.deleteInboundShipments({
-        storeId,
-        deleteInboundShipments: invoices.map(invoice => ({ id: invoice.id })),
-      })) || {};
+    const internal = invoices.filter(inv => !inv.purchaseOrder);
+    const external = invoices.filter(inv => !!inv.purchaseOrder);
+    const deletedIds: string[] = [];
 
-    const { batchInboundShipment } = result;
-    if (batchInboundShipment?.deleteInboundShipments) {
-      return batchInboundShipment.deleteInboundShipments.map(
-        ({ id }: { id: string }) => id
-      );
+    const extractIds = (
+      result: { deleteInboundShipments?: { id: string }[] | null } | undefined
+    ) =>
+      result?.deleteInboundShipments?.map(({ id }: { id: string }) => id) ?? [];
+
+    if (internal.length > 0) {
+      const variables = {
+        storeId,
+        deleteInboundShipments: internal.map(inv => ({ id: inv.id })),
+      };
+      const result = (await inboundApi.deleteInboundShipments(variables))
+        ?.batchInboundShipment;
+      deletedIds.push(...extractIds(result));
     }
 
-    throw new Error('Could not delete invoices');
+    if (external.length > 0) {
+      const variables = {
+        storeId,
+        deleteInboundShipments: external.map(inv => ({ id: inv.id })),
+      };
+      const result = (
+        await inboundApi.deleteInboundShipmentsExternal(variables)
+      )?.batchInboundShipmentExternal;
+      deletedIds.push(...extractIds(result));
+    }
+
+    if (deletedIds.length === 0) {
+      throw new Error('Could not delete invoices');
+    }
+
+    return deletedIds;
   };
 
   return useMutation({


### PR DESCRIPTION
Fixes #10915

Replaces #10960 - Trying to fix the apis is probably too much for this release. This PR takes a simpler route by just making frontend changes (now I'm not sure why I didn't just do this in the first place...)

# 👩🏻‍💻 What does this PR do?

When deleting inbound shipments from the list view, the batch API (`batchInboundShipment`) fails with `WrongInboundShipmentType` for external shipments (those linked to a purchase order).

This PR groups the selected shipments by type and calls the correct batch API for each group:
- **Internal shipments**: `batchInboundShipment`
- **External shipments** (with `purchaseOrder`): `batchInboundShipmentExternal`

At most 2 API calls are made (one per type), rather than one per shipment.

## 💌 Any notes for the reviewer?

- Single file change in `useInboundList.ts`
- The existing `useInboundDelete` hook (used elsewhere) already handled this distinction — this brings the list view delete in line with that approach

# 🧪 Testing

- [ ] Create an external inbound shipment (linked to a purchase order)
- [ ] Create a regular inbound shipment
- [ ] From the inbound shipment list view, select both shipments
- [ ] Delete them — both should delete successfully without `WrongInboundShipmentType` error
- [ ] Also test deleting only external and only internal shipments individually

# 📃 Documentation

- [x] **No documentation required**: bug fix, no change in user-facing behaviour

# 📃 Reviewer Checklist

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API

**Issue Review**
- [ ] All requirements in original issue have been covered

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend