### PR TITLE
#10993 clear invalid location_id on item_store_join integration

### DIFF
--- a/server/service/src/sync/test/test_data/item_store_join.rs
+++ b/server/service/src/sync/test/test_data/item_store_join.rs
@@ -3,6 +3,44 @@ use repository::ItemStoreJoinRow;
 
 const TABLE_NAME: &str = "item_store_join";
 
+const ITEM_STORE_JOIN_INVALID_LOCATION: (&str, &str) = (
+    "item_store_join_invalid_location",
+    r#"{
+        "AMC_modification_factor": 0,
+        "ID": "item_store_join_invalid_location",
+        "bulk_replenish_at_packs": 0,
+        "bulk_replenish_up_to_packs": 0,
+        "custom_data": null,
+        "default_location_ID": "non_existent_location",
+        "default_price": 5.0,
+        "estimated_AMC": 0,
+        "forecast_method": 0,
+        "hold_for_issue": false,
+        "hold_for_receive": false,
+        "ignore_for_orders": true,
+        "inactive": false,
+        "include_on_price_list": false,
+        "indic_price": 0,
+        "item_ID": "item_a",
+        "location_bulk_ID": "",
+        "margin": 0.0,
+        "maximum_stock": 0,
+        "minimum_stock": 0,
+        "non_stock": false,
+        "non_stock_name_ID": "",
+        "pack_to_one": true,
+        "pack_to_one_allow": true,
+        "pickface_location_ID": "",
+        "pickface_pack_size": 0,
+        "pickface_replenish_at_packs": 0,
+        "pickface_replenish_up_to_packs": 0,
+        "projection_for_calcs": "",
+        "report_quantity": 0,
+        "restricted_location_type_id": "",
+        "store_ID": "store_b"
+    }"#,
+);
+
 const ITEM_STORE_JOIN_1: (&str, &str) = (
     "item_store_join_1",
     r#"{
@@ -42,17 +80,32 @@ const ITEM_STORE_JOIN_1: (&str, &str) = (
 );
 
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
-    vec![TestSyncIncomingRecord::new_pull_upsert(
-        TABLE_NAME,
-        ITEM_STORE_JOIN_1,
-        ItemStoreJoinRow {
-            id: ITEM_STORE_JOIN_1.0.to_owned(),
-            item_link_id: "item_a".to_string(),
-            store_id: "store_b".to_string(),
-            default_sell_price_per_pack: 10.0,
-            ignore_for_orders: false,
-            margin: 10.0,
-            default_location_id: None,
-        },
-    )]
+    vec![
+        TestSyncIncomingRecord::new_pull_upsert(
+            TABLE_NAME,
+            ITEM_STORE_JOIN_INVALID_LOCATION,
+            ItemStoreJoinRow {
+                id: ITEM_STORE_JOIN_INVALID_LOCATION.0.to_owned(),
+                item_link_id: "item_a".to_string(),
+                store_id: "store_b".to_string(),
+                default_sell_price_per_pack: 5.0,
+                ignore_for_orders: true,
+                margin: 0.0,
+                default_location_id: None, // Invalid location cleared
+            },
+        ),
+        TestSyncIncomingRecord::new_pull_upsert(
+            TABLE_NAME,
+            ITEM_STORE_JOIN_1,
+            ItemStoreJoinRow {
+                id: ITEM_STORE_JOIN_1.0.to_owned(),
+                item_link_id: "item_a".to_string(),
+                store_id: "store_b".to_string(),
+                default_sell_price_per_pack: 10.0,
+                ignore_for_orders: false,
+                margin: 10.0,
+                default_location_id: None,
+            },
+        ),
+    ]
 }

--- a/server/service/src/sync/translations/item_store_join.rs
+++ b/server/service/src/sync/translations/item_store_join.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
 
-use super::{PullTranslateResult, SyncTranslation};
-use crate::sync::translations::{item::ItemTranslation, store::StoreTranslation};
+use super::{utils::clear_invalid_location_id, PullTranslateResult, SyncTranslation};
+use crate::sync::translations::{
+    item::ItemTranslation, location::LocationTranslation, store::StoreTranslation,
+};
 use repository::{ItemStoreJoinRow, StorageConnection, SyncBufferRow};
 use util::sync_serde::empty_str_as_option_string;
 
@@ -37,15 +39,21 @@ impl SyncTranslation for ItemStoreJoinTranslation {
     }
 
     fn pull_dependencies(&self) -> Vec<&str> {
-        vec![ItemTranslation.table_name(), StoreTranslation.table_name()]
+        vec![
+            ItemTranslation.table_name(),
+            StoreTranslation.table_name(),
+            LocationTranslation.table_name(),
+        ]
     }
 
     fn try_translate_from_upsert_sync_record(
         &self,
-        _: &StorageConnection,
+        connection: &StorageConnection,
         sync_record: &SyncBufferRow,
     ) -> Result<PullTranslateResult, anyhow::Error> {
         let data = serde_json::from_str::<LegacyItemStoreJoinRow>(&sync_record.data)?;
+
+        let default_location_id = clear_invalid_location_id(connection, data.default_location_id)?;
 
         let result = ItemStoreJoinRow {
             id: data.id,
@@ -54,7 +62,7 @@ impl SyncTranslation for ItemStoreJoinTranslation {
             default_sell_price_per_pack: data.default_sell_price_per_pack,
             ignore_for_orders: data.ignore_for_orders,
             margin: data.margin,
-            default_location_id: data.default_location_id,
+            default_location_id,
         };
         Ok(PullTranslateResult::upsert(result))
     }


### PR DESCRIPTION
Fixes #10993

# 👩🏻‍💻 What does this PR do?

When migrating stores from OG to OMS, some `item_store_join` records reference `location_ID` values that don't exist in the OMS database, causing FK constraint violations during sync integration.

This PR adds location validation to the `item_store_join` sync translator — matching the existing pattern used by `invoice_line`, `stock_line`, and `stocktake_line`:

- Uses the existing `clear_invalid_location_id()` utility to check if the referenced location exists
- Clears the FK to `None` if the location is missing
- Adds `LocationTranslation` as a pull dependency so locations are synced before item_store_joins

## 💌 Any notes for the reviewer?

This follows the exact same pattern as `invoice_line` (line 287), `stock_line` (line 141), and `stocktake_line` (line 177) which all call `clear_invalid_location_id()` during translation. The only trade-off is a DB query per record during integration, which is consistent with what other translators already do.

# 🧪 Testing

[demo_data.zip](https://github.com/user-attachments/files/26231363/demo_data.zip)

- [ ] Initialise OMS and see if there are any item_store_joins in the sync buffer that have an integration error.

Curiously when I this I get one which I can't explain to you. There are no locations in this datafile. The changes work for all the other item_store_joins. Yet this one somehow isn't addressed by this change?

<img width="438" height="94" alt="image" src="https://github.com/user-attachments/assets/5b3bea71-bec6-4cfe-8f01-8cf6345495b9" />

```
ForeignKeyViolation("insert or update on table \"item_store_join\" violates foreign key constraint \"item_store_join_default_location_id_fkey\" Key (default_location_id)=(154DE0DCA05E497AA6CBF57D1C537DB5) is not present in table \"location\".  item_store_join  item_store_join_default_location_id_fkey 0")
```

```json
{
  "AMC_modification_factor": 0,
  "ID": "2E26C7390AD1409DB81A10F8D736EC79",
  "bulk_replenish_at_packs": 0,
  "bulk_replenish_up_to_packs": 0,
  "custom_data": null,
  "default_location_ID": "154DE0DCA05E497AA6CBF57D1C537DB5",
  "default_price": 0,
  "estimated_AMC": 0,
  "forecast_method": 1,
  "hold_for_issue": false,
  "hold_for_receive": false,
  "ignore_for_orders": false,
  "inactive": true,
  "include_on_price_list": false,
  "indic_price": 0,
  "item_ID": "25A40B07650F404EAF520E1FCC601390",
  "location_bulk_ID": "",
  "margin": 0,
  "maximum_stock": 0,
  "minimum_stock": 0,
  "non_stock": false,
  "non_stock_name_ID": "",
  "pack_to_one": false,
  "pack_to_one_allow": false,
  "pickface_location_ID": "",
  "pickface_pack_size": 0,
  "pickface_replenish_at_packs": 0,
  "pickface_replenish_up_to_packs": 0,
  "projection_for_calcs": "",
  "report_quantity": 0,
  "restricted_location_type_id": "",
  "store_ID": "34660F1A61E249DF9777FCC6588FE98C"
}
```

# 📃 Documentation

- [x] **No documentation required**: bug fix for sync integration, no user facing changes

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend