### PR TITLE
10355 Right after an item runs out of doses to issue in an encounter, user runs into an error instead of being able to proceed without selecting a batch

### DIFF
--- a/client/packages/system/src/Vaccination/Components/SelectBatch.tsx
+++ b/client/packages/system/src/Vaccination/Components/SelectBatch.tsx
@@ -29,10 +29,21 @@ export const SelectBatch = ({
     stockLinesFromItem: { data, isLoading },
   } = useItem(itemId);
 
-  // Auto-select if there is only one stock line (and not already selected)
+  const availableDoses = (data?.nodes ?? []).filter(
+    n => getRemainingDoses(n) >= 1
+  );
+  const selectedIsAvailable = availableDoses.some(
+    n => n.id === stockLine?.id
+  );
+
+  // Auto-select the only available batch, or clear selection if the previously selected batch is no longer available
   useEffect(() => {
-    if (data?.nodes?.length === 1 && !stockLine && isNewlyGiven) {
-      setStockLine(data.nodes[0]!);
+    if (!selectedIsAvailable) {
+      const autoSelect =
+        availableDoses.length === 1 && isNewlyGiven
+          ? availableDoses[0]!
+          : null;
+      setStockLine(autoSelect);
     }
   }, [data, isNewlyGiven, stockLine]);
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10355

# 👩🏻‍💻 What does this PR do?
Allow vaccinations to be given with no batch if all doses have been given

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Load vaccination schema from [here](https://github.com/msupply-foundation/programschemas) to OG. 
- [ ] Make sure vaccine course is set up for some vaccine item (make sure stock is low 1/2 doses in same batch left)
- [ ] Enrol patient in program & create encounter 
- [ ] Give vaccination and see only batch selected
- [ ] Give vaccination again after giving all doses
- [ ] Should be able to give vaccination with no batch

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

