### PR TITLE
10317 No alert when switching tab without saving in demographics (lost data)

### DIFF
--- a/client/packages/system/src/Manage/IndicatorsDemographics/DetailView/IndicatorsDemographics.tsx
+++ b/client/packages/system/src/Manage/IndicatorsDemographics/DetailView/IndicatorsDemographics.tsx
@@ -4,6 +4,7 @@ import {
   Box,
   MaterialTable,
   RecordPatch,
+  useConfirmOnLeaving,
   useIntlUtils,
   useNotification,
   useSimpleMaterialTable,
@@ -26,7 +27,9 @@ export const IndicatorsDemographics = () => {
   useUrlQueryParams({ initialSort: { key: 'name', dir: 'asc' } });
   const [headerDraft, setHeaderDraft] = useState<HeaderData>();
   const [indexPopulation, setIndexPopulation] = useState(0);
-  const [isDirty, setIsDirty] = useState(false);
+  const { isDirty, setIsDirty } = useConfirmOnLeaving(
+    'indicators-demographics'
+  );
 
   const { error, success } = useNotification();
   const t = useTranslation();


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10317

# 👩🏻‍💻 What does this PR do?
Use confirm on leaving to alert the user they might be losing data

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [x] Go to manage -> demographics
- [x] Enter some data
- [x] Try navigate away to somewhere else without saving
- [x] Should see confirmation

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

