### PR TITLE
#10942 Group IS(e) detail view tabs by PO line

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1124,6 +1124,7 @@
   "label.global-preference": "Global preference",
   "label.gps-coordinates": "GPS coordinates",
   "label.group-by-item": "Group by Item",
+  "label.group-by-po-line": "Group by PO Line",
   "label.growth-on-previous-year": "Growth on previous year",
   "label.gtin": "GTIN",
   "label.have-not-shipped": "Have not been shipped",

--- a/client/packages/common/src/ui/layout/tables/useBaseMaterialTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/useBaseMaterialTable.tsx
@@ -45,6 +45,7 @@ export interface BaseTableConfig<T extends MRT_RowData> extends Omit<
   grouping?: {
     field: string;
     groupedByDefault?: boolean;
+    label?: string;
   };
   columns: ColumnDef<T>[];
   noUrlFiltering?: boolean;
@@ -160,6 +161,7 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
     onRowClick,
     isGrouped: !!grouping.state.length,
     toggleGrouped: grouping.enabled ? grouping.toggle : undefined,
+    groupByLabel: groupingInput?.label,
     getIsPlaceholderRow,
     getIsRestrictedRow,
     muiTableBodyRowProps,

--- a/client/packages/common/src/ui/layout/tables/useTableDisplayOptions.tsx
+++ b/client/packages/common/src/ui/layout/tables/useTableDisplayOptions.tsx
@@ -41,6 +41,7 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
   isGrouped,
   toggleGrouped,
   hasColumnFilters,
+  groupByLabel,
   getIsPlaceholderRow = () => false,
   getIsRestrictedRow = () => false,
   muiTableBodyRowProps = {},
@@ -59,6 +60,7 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
   isGrouped: boolean;
   hasColumnFilters: boolean;
   toggleGrouped?: () => void;
+  groupByLabel?: string;
   getIsPlaceholderRow?: (row: MRT_Row<T>) => boolean;
   getIsRestrictedRow?: (row: MRT_Row<T>) => boolean;
   isMobile?: boolean;
@@ -124,7 +126,7 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
           <IconButton
             icon={isGrouped ? <ExpandIcon /> : <CollapseIcon />}
             onClick={toggleGrouped}
-            label={t('label.group-by-item')}
+            label={groupByLabel ?? t('label.group-by-item')}
             sx={iconButtonProps}
           />
         )}

--- a/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -33,6 +33,7 @@ import {
 } from '@openmsupply-client/system';
 
 const TABLE_ID = 'inbound-shipment-detail-view';
+const EXTERNAL_TABLE_ID = 'inbound-shipment-detail-view-external';
 import { Toolbar } from './Toolbar';
 import { Footer } from './Footer';
 import { AppBarButtons } from './AppBarButtons';
@@ -95,6 +96,7 @@ const DetailViewInner = () => {
 
   const {
     query: { data, loading },
+    isExternal,
     isDisabled,
     invalidateQuery,
   } = useInboundShipment();
@@ -165,19 +167,17 @@ const DetailViewInner = () => {
       updateQuery({ tab: InboundShipmentDetailTabs.Documents });
   }, [toggleUploadModal, urlQuery, updateQuery]);
 
-  const external = data?.purchaseOrder !== null;
   const showLineStatus =
     data?.lines.nodes.some(line => line.status != null) ?? false;
-  const columns = useInboundShipmentColumns(external, showLineStatus);
+  const columns = useInboundShipmentColumns(isExternal, showLineStatus);
 
   const { table, selectedRows } =
     useNonPaginatedMaterialTable<InboundLineFragment>({
-      tableId: TABLE_ID,
+      tableId: isExternal ? EXTERNAL_TABLE_ID : TABLE_ID,
       columns,
       data: lines,
-      // REVIEW: could be confusing as there isn't any feedback for what field is being grouped by and we normally only group by item. However grouping by item doesn't really make sense for external IS while grouping by purchase order line number does make sense.
-      grouping: external
-        ? { field: 'purchaseOrderLine.lineNumber' }
+      grouping: isExternal
+        ? { field: 'purchaseOrderLine.lineNumber', label: t('label.group-by-po-line') }
         : { field: 'item.code' },
       isLoading: false,
       initialSort: { key: 'itemName', dir: 'asc' },
@@ -252,7 +252,7 @@ const DetailViewInner = () => {
       ),
       value: InboundShipmentDetailTabs.Details,
     },
-    ...external ? [
+    ...isExternal ? [
       {
         Component: <FinancialTab />,
         value: InboundShipmentDetailTabs.Financial,

--- a/client/packages/invoices/src/InboundShipment/DetailView/Tabs/DeliveryStatus.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Tabs/DeliveryStatus.tsx
@@ -19,6 +19,7 @@ export const DeliveryTab = ({
   const t = useTranslation();
   const {
     query: { data, loading: isLoading },
+    isExternal,
   } = useInboundShipment();
   const statusMap = useInvoiceLineStatusMap();
 
@@ -47,6 +48,12 @@ export const DeliveryTab = ({
         filterVariant: 'select',
         includeColumn: showLineStatus,
         Cell: ({ cell }) => <StatusCell cell={cell} statusMap={statusMap} />,
+      },
+      {
+        accessorKey: 'purchaseOrderLine.lineNumber',
+        header: t('label.purchase-order-line-number'),
+        columnType: ColumnType.Number,
+        size: 70,
       },
       {
         accessorKey: 'item.code',
@@ -117,7 +124,9 @@ export const DeliveryTab = ({
     data: data?.lines.nodes,
     columns,
     isLoading,
-    grouping: { field: 'item.code' },
+    grouping: isExternal
+      ? { field: 'purchaseOrderLine.lineNumber', label: t('label.group-by-po-line') }
+      : { field: 'item.code' },
     enableRowSelection: false,
   });
 

--- a/client/packages/invoices/src/InboundShipment/DetailView/Tabs/Financial.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Tabs/Financial.tsx
@@ -12,6 +12,7 @@ export const FinancialTab = () => {
   const t = useTranslation();
   const {
     query: { data, loading: isLoading },
+    isExternal,
   } = useInboundShipment();
 
   const columns = useMemo(
@@ -19,6 +20,12 @@ export const FinancialTab = () => {
       {
         accessorKey: 'item.name',
         header: t('label.name'),
+      },
+      {
+        accessorKey: 'purchaseOrderLine.lineNumber',
+        header: t('label.purchase-order-line-number'),
+        columnType: ColumnType.Number,
+        size: 70,
       },
       {
         accessorKey: 'numberOfPacks',
@@ -74,7 +81,9 @@ export const FinancialTab = () => {
     data: data?.lines.nodes,
     columns,
     isLoading,
-    grouping: { field: 'item.code' },
+    grouping: isExternal
+      ? { field: 'purchaseOrderLine.lineNumber', label: t('label.group-by-po-line') }
+      : { field: 'item.code' },
     enableRowSelection: false,
   });
 


### PR DESCRIPTION
Fixes #10942

# 👩🏻‍💻 What does this PR do?

Groups all inbound shipment (external) detail view tabs — Details, Financial, and Delivery — by purchase order line number instead of item code. Internal inbound shipments continue to group by item code.

**Changes:**
- Details, Financial, and Delivery tabs all group by `purchaseOrderLine.lineNumber` for external IS
- Added PO line number column to the Financial and Delivery tabs
- Added configurable `label` to the grouping config so the group-by tooltip reflects the actual grouping field ("Group by PO Line" for external, "Group by Item" for internal)
- Uses a separate table ID (`inbound-shipment-detail-view-external`) for external IS to avoid persisted table state conflicts

> **Note:** Mark suggested the tooltip say "Group by item / PO line". I implemented it as separate context-aware labels instead — "Group by Item" for internal and "Group by PO Line" for external — which is more precise since only one grouping applies at a time.

## 💌 Any notes for the reviewer?

- The `groupByLabel` prop is a generic addition to the table framework (`useBaseMaterialTable` / `useTableDisplayOptions`) so other tables can customise their group-by tooltip too
- Financial and Delivery tabs are only rendered for external IS, so they don't need conditional table IDs

# 🧪 Testing

- [ ] Open a PO linked inbound shipment
- [ ] Verify the Details tab groups lines by PO line number
- [ ] Switch to Financial tab — verify grouping is by PO line number and PO line number column is visible
- [ ] Switch to Delivery tab — verify grouping is by PO line number and PO line number column is visible
- [ ] Hover over the group-by toggle icon — tooltip should say "Group by PO Line"
- [ ] Open an **internal** inbound shipment (no purchase order)
- [ ] Verify all tabs group by item code
- [ ] Hover over the group-by toggle — tooltip should say "Group by Item"

# 📃 Documentation

- [ ] **These areas should be updated or checked**:
  1. IS(e) detail view now groups by PO line instead of item