### PR TITLE
Dedup before push on changelog instead of dedup on the fly

### DIFF
--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -29,22 +29,22 @@ table! {
     }
 }
 
-table! {
-    changelog_deduped (cursor) {
-        cursor -> BigInt,
-        table_name -> crate::db_diesel::changelog::ChangelogTableNameMapping,
-        record_id -> Text,
-        row_action -> crate::db_diesel::changelog::RowActionTypeMapping,
-        name_link_id -> Nullable<Text>,
-        store_id -> Nullable<Text>,
-        is_sync_update -> Bool,
-        source_site_id -> Nullable<Integer>,
-    }
-}
+// table! {
+//     changelog (cursor) {
+//         cursor -> BigInt,
+//         table_name -> crate::db_diesel::changelog::ChangelogTableNameMapping,
+//         record_id -> Text,
+//         row_action -> crate::db_diesel::changelog::RowActionTypeMapping,
+//         name_link_id -> Nullable<Text>,
+//         store_id -> Nullable<Text>,
+//         is_sync_update -> Bool,
+//         source_site_id -> Nullable<Integer>,
+//     }
+// }
 
-joinable!(changelog_deduped -> name_link (name_link_id));
-allow_tables_to_appear_in_same_query!(changelog_deduped, name_link);
-allow_tables_to_appear_in_same_query!(changelog_deduped, vaccination);
+joinable!(changelog -> name_link (name_link_id));
+allow_tables_to_appear_in_same_query!(changelog, name_link);
+allow_tables_to_appear_in_same_query!(changelog, vaccination);
 
 #[cfg(not(feature = "postgres"))]
 define_sql_function!(
@@ -304,7 +304,7 @@ impl<'a> ChangelogRepository<'a> {
     ) -> Result<Vec<ChangelogRow>, RepositoryError> {
         let result = with_locked_changelog_table(self.connection, |locked_con| {
             let query = create_filtered_query(earliest, filter)
-                .order(changelog_deduped::dsl::cursor.asc())
+                .order(changelog::dsl::cursor.asc())
                 .limit(limit.into());
 
             // // Debug diesel query
@@ -339,7 +339,7 @@ impl<'a> ChangelogRepository<'a> {
     ) -> Result<Vec<ChangelogRow>, RepositoryError> {
         let result = with_locked_changelog_table(self.connection, |locked_con| {
             let query = create_filtered_outgoing_sync_query(earliest, sync_site_id, is_initialized)
-                .order(changelog_deduped::cursor.asc())
+                .order(changelog::cursor.asc())
                 .limit(batch_size.into());
 
             // Debug diesel query
@@ -367,7 +367,7 @@ impl<'a> ChangelogRepository<'a> {
                 sync_site_id,
                 fetch_patient_id,
             )
-            .order(changelog_deduped::cursor.asc())
+            .order(changelog::cursor.asc())
             .limit(batch_size.into());
 
             // Debug diesel query
@@ -479,15 +479,40 @@ impl<'a> ChangelogRepository<'a> {
             .get_result::<i64>(self.connection.lock().connection())?;
         Ok(cursor_id)
     }
+
+    pub fn dedup_from_cursor(&self, cursor: i64) -> Result<(), RepositoryError> {
+        // This method is used to deduplicate the changelog table from a specific cursor, by keeping only the latest change for each record_id
+        // This is needed before pushing changes to remote site, to avoid pushing multiple changes for the same record and potentially pushing deleted records
+
+        const DEDUP_CHANGELOG: &str = r#"
+        DELETE FROM changelog
+        WHERE cursor IN (
+            SELECT c.cursor
+            FROM changelog c
+            WHERE EXISTS (
+                SELECT 1 FROM changelog d
+                WHERE d.table_name = c.table_name
+                    AND d.record_id = c.record_id
+                    AND d.cursor > c.cursor
+            )
+        )
+        AND cursor >= $1
+        "#;
+
+        diesel::sql_query(DEDUP_CHANGELOG)
+            .bind::<diesel::sql_types::BigInt, _>(cursor)
+            .execute(self.connection.lock().connection())?;
+
+        Ok(())
+    }
 }
 
-type BoxedChangelogQuery =
-    IntoBoxed<'static, LeftJoin<changelog_deduped::table, name_link::table>, DBType>;
+type BoxedChangelogQuery = IntoBoxed<'static, LeftJoin<changelog::table, name_link::table>, DBType>;
 
 fn create_base_query(earliest: u64) -> BoxedChangelogQuery {
-    changelog_deduped::table
+    changelog::table
         .left_join(name_link::table)
-        .filter(changelog_deduped::cursor.ge(earliest.try_into().unwrap_or(0)))
+        .filter(changelog::cursor.ge(earliest.try_into().unwrap_or(0)))
         .into_boxed()
 }
 
@@ -505,13 +530,13 @@ fn create_filtered_query(earliest: u64, filter: Option<ChangelogFilter>) -> Boxe
             source_site_id,
         } = f;
 
-        apply_equal_filter!(query, table_name, changelog_deduped::table_name);
+        apply_equal_filter!(query, table_name, changelog::table_name);
         apply_equal_filter!(query, name_id, name_link::name_id);
-        apply_equal_filter!(query, store_id, changelog_deduped::store_id);
-        apply_equal_filter!(query, record_id, changelog_deduped::record_id);
-        apply_equal_filter!(query, action, changelog_deduped::row_action);
-        apply_equal_filter!(query, is_sync_update, changelog_deduped::is_sync_update);
-        apply_equal_filter!(query, source_site_id, changelog_deduped::source_site_id);
+        apply_equal_filter!(query, store_id, changelog::store_id);
+        apply_equal_filter!(query, record_id, changelog::record_id);
+        apply_equal_filter!(query, action, changelog::row_action);
+        apply_equal_filter!(query, is_sync_update, changelog::is_sync_update);
+        apply_equal_filter!(query, source_site_id, changelog::source_site_id);
     }
 
     query
@@ -546,9 +571,9 @@ fn create_filtered_outgoing_sync_query(
     // The rest of the time we want to exclude any records that were created by the site
     if is_initialized {
         query = query.filter(
-            changelog_deduped::source_site_id
+            changelog::source_site_id
                 .ne(Some(sync_site_id))
-                .or(changelog_deduped::source_site_id.is_null()),
+                .or(changelog::source_site_id.is_null()),
         )
     }
 
@@ -583,18 +608,18 @@ fn create_filtered_outgoing_sync_query(
 
     // Filter the query for the matching records for each type
     query = query.filter(
-        changelog_deduped::table_name
+        changelog::table_name
             .eq_any(central_sync_table_names)
-            .or(changelog_deduped::table_name.eq(ChangelogTableName::SyncFileReference)) // All sites get all sync file references (not necessarily files)
-            .or(changelog_deduped::table_name
+            .or(changelog::table_name.eq(ChangelogTableName::SyncFileReference)) // All sites get all sync file references (not necessarily files)
+            .or(changelog::table_name
                 .eq_any(remote_sync_table_names)
-                .and(changelog_deduped::store_id.eq_any(active_stores_for_site.into_boxed())))
-            .or(changelog_deduped::table_name
+                .and(changelog::store_id.eq_any(active_stores_for_site.into_boxed())))
+            .or(changelog::table_name
                 .eq_any(central_by_empty_store_id)
-                .and(changelog_deduped::store_id.is_null()))
+                .and(changelog::store_id.is_null()))
             // Special case: patient Vaccination records
             // where patient is visible, regardless of the store_id in the changelog
-            .or(changelog_deduped::table_name
+            .or(changelog::table_name
                 .eq(ChangelogTableName::Vaccination)
                 .and(name_link::name_id.eq_any(patient_names_visible_on_site))),
         // Any other special cases could be handled here...

--- a/server/service/src/sync/central_data_synchroniser_v6.rs
+++ b/server/service/src/sync/central_data_synchroniser_v6.rs
@@ -1,3 +1,4 @@
+use std::convert::TryInto;
 use std::time::{Duration, SystemTime};
 
 use crate::{
@@ -142,6 +143,10 @@ impl SynchroniserV6 {
         let changelog_repo = ChangelogRepository::new(connection);
         let change_log_filter = get_sync_push_changelogs_filter(connection)?;
         let cursor_controller = CursorController::new(KeyType::SyncPushCursorV6);
+
+        // First deduplicate changelog table so we don't try to push deleted records or duplicates.
+        let starting_cursor: i64 = cursor_controller.get(connection)?.try_into().unwrap_or(0);
+        changelog_repo.dedup_from_cursor(starting_cursor)?;
 
         loop {
             // TODO inside transaction

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -1,4 +1,7 @@
-use std::time::{Duration, SystemTime};
+use std::{
+    convert::TryInto,
+    time::{Duration, SystemTime},
+};
 
 use crate::{
     cursor_controller::CursorController,
@@ -192,6 +195,10 @@ impl RemoteDataSynchroniser {
         let changelog_repo = ChangelogRepository::new(connection);
         let change_log_filter = get_sync_push_changelogs_filter(connection)?;
         let cursor_controller = CursorController::new(KeyType::RemoteSyncPushCursor);
+
+        // First deduplicate changelog table so we don't try to push deleted records or duplicates.
+        let starting_cursor: i64 = cursor_controller.get(connection)?.try_into().unwrap_or(0);
+        changelog_repo.dedup_from_cursor(starting_cursor)?;
 
         loop {
             // TODO inside transaction


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes issues with performance on the changelog deduplication when there's a lot of records in changelog

# 👩🏻‍💻 What does this PR do?

Switched from changelog dedup to a just in time de-duplication that happens just before sync kicks off (pushing to sync v6 or sync v5. This is required because otherwise if a record is added and then deleted before the sync happens, you'll get an error.

## 💌 Any notes for the reviewer?

I'm deduping in both the sync_v6 and sync v5 push as if you are a central server you won't run sync v6 push, but we still need to dedup there too. Can possibly get away without it for this PR as it's only for 1 server for now.
Final PR might need more clean up...

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an invoice and invoice lines
- [ ] Delete the invoice
- [ ] Try to sync, make sure it works
- [ ] test performance?

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

