### PR TITLE
10364 Store properties playing up when adding supply levels and re-initialising properties

### DIFF
--- a/client/packages/system/src/Name/ListView/Stores/StoreProperties.tsx
+++ b/client/packages/system/src/Name/ListView/Stores/StoreProperties.tsx
@@ -51,6 +51,7 @@ export const StoreProperties = ({
         .filter(
           p => p.property.key !== 'latitude' && p.property.key !== 'longitude'
         )
+        .sort((a, b) => a.property.name.localeCompare(b.property.name))
         .map(p => (
           <Row
             key={p.id}


### PR DESCRIPTION

<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10364

# 👩🏻‍💻 What does this PR do?
Sort store properties before displaying them so they don't jump around

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Initialise store properties 
- [ ] Go view them
- [ ] Re-initialise
- [ ] View again - components shouldn't jump around

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [x] Frontend

