### PR TITLE
#10963 Expose user in ledger tabs

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -4716,6 +4716,7 @@ export type ItemLedgerNode = {
   sellPricePerPack: Scalars['Float']['output'];
   storeId: Scalars['String']['output'];
   totalBeforeTax?: Maybe<Scalars['Float']['output']>;
+  user?: Maybe<UserNode>;
 };
 
 export type ItemLedgerResponse = ItemLedgerConnector;
@@ -4951,6 +4952,7 @@ export type LedgerNode = {
   stockLine?: Maybe<StockLineNode>;
   stockLineId?: Maybe<Scalars['String']['output']>;
   storeId: Scalars['String']['output'];
+  user?: Maybe<UserNode>;
 };
 
 export type LedgerResponse = LedgerConnector;
@@ -8806,10 +8808,14 @@ export enum RequisitionNodeStatus {
 }
 
 export enum RequisitionNodeType {
+  /** Imprest requisition where each item has a pre-determined max/target quantity */
+  Imprest = 'IMPREST',
   /** Requisition created by store that is ordering stock */
   Request = 'REQUEST',
-  /** Supplying store requisition in response to request requisition */
+  /** Supplying store requisition in response to request requisition, or manual requisition for a customer */
   Response = 'RESPONSE',
+  /** Stock history requisition where facility submits stock on hand */
+  StockHistory = 'STOCK_HISTORY',
 }
 
 export type RequisitionReasonNotProvided =

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
@@ -141,6 +141,11 @@ const ItemLedgerTable = ({
         accessorKey: 'reason',
         header: t('label.reason'),
       },
+      {
+        id: 'user',
+        header: t('label.user'),
+        accessorFn: row => row.user?.username,
+      },
     ],
     [localisedTime, t]
   );

--- a/client/packages/system/src/Item/api/operations.generated.ts
+++ b/client/packages/system/src/Item/api/operations.generated.ts
@@ -1470,6 +1470,7 @@ export type ItemLedgerFragment = {
   sellPricePerPack: number;
   totalBeforeTax?: number | null;
   numberOfPacks: number;
+  user?: { __typename: 'UserNode'; username: string } | null;
 };
 
 export type ItemLedgerQueryVariables = Types.Exact<{
@@ -1503,6 +1504,7 @@ export type ItemLedgerQuery = {
       sellPricePerPack: number;
       totalBeforeTax?: number | null;
       numberOfPacks: number;
+      user?: { __typename: 'UserNode'; username: string } | null;
     }>;
   };
 };
@@ -1825,6 +1827,9 @@ export const ItemLedgerFragmentDoc = gql`
     sellPricePerPack
     totalBeforeTax
     numberOfPacks
+    user {
+      username
+    }
   }
 `;
 export const ItemsWithStockLinesDocument = gql`

--- a/client/packages/system/src/Item/api/operations.graphql
+++ b/client/packages/system/src/Item/api/operations.graphql
@@ -523,6 +523,9 @@ fragment ItemLedger on ItemLedgerNode {
   sellPricePerPack
   totalBeforeTax
   numberOfPacks
+  user {
+    username
+  }
 }
 
 query itemLedger(

--- a/client/packages/system/src/Stock/Components/Ledger/useLedgerColumns.ts
+++ b/client/packages/system/src/Stock/Components/Ledger/useLedgerColumns.ts
@@ -20,6 +20,7 @@ export enum ColumnKey {
   Reason = 'reason',
   Number = 'number',
   Balance = 'runningBalance',
+  User = 'user',
 }
 
 export const useLedgerColumns = () => {
@@ -71,6 +72,11 @@ export const useLedgerColumns = () => {
         accessorKey: ColumnKey.Reason,
         header: t('label.reason'),
         enableSorting: true,
+      },
+      {
+        accessorKey: ColumnKey.User,
+        header: t('label.user'),
+        accessorFn: row => row.user?.username,
       },
     ],
     [getInvoiceLocalisationKey]

--- a/client/packages/system/src/Stock/api/operations.generated.ts
+++ b/client/packages/system/src/Stock/api/operations.generated.ts
@@ -215,6 +215,7 @@ export type LedgerRowFragment = {
   stockLineId?: string | null;
   storeId: string;
   runningBalance: number;
+  user?: { __typename: 'UserNode'; username: string } | null;
 };
 
 export type VvmStatusLogRowFragment = {
@@ -528,6 +529,7 @@ export type LedgerQuery = {
       stockLineId?: string | null;
       storeId: string;
       runningBalance: number;
+      user?: { __typename: 'UserNode'; username: string } | null;
     }>;
   };
 };
@@ -1200,6 +1202,9 @@ export const LedgerRowFragmentDoc = gql`
     stockLineId
     storeId
     runningBalance
+    user {
+      username
+    }
   }
 `;
 export const VvmStatusFragmentDoc = gql`

--- a/client/packages/system/src/Stock/api/operations.graphql
+++ b/client/packages/system/src/Stock/api/operations.graphql
@@ -122,6 +122,9 @@ fragment LedgerRow on LedgerNode {
   stockLineId
   storeId
   runningBalance
+  user {
+    username
+  }
 }
 
 fragment VVMStatusLogRow on VvmstatusLogNode {

--- a/server/graphql/general/src/queries/item_ledger.rs
+++ b/server/graphql/general/src/queries/item_ledger.rs
@@ -1,7 +1,8 @@
-use async_graphql::*;
+use async_graphql::{dataloader::DataLoader, *};
 use chrono::{DateTime, NaiveDate, Utc};
 use graphql_core::{
     generic_filters::{DatetimeFilterInput, EqualFilterStringInput},
+    loader::UserLoader,
     map_filter,
     pagination::PaginationInput,
     standard_graphql_error::{validate_auth, StandardGraphqlError},
@@ -10,6 +11,7 @@ use graphql_core::{
 
 use graphql_types::types::{
     EqualFilterInvoiceStatusInput, EqualFilterInvoiceTypeInput, InvoiceNodeStatus, InvoiceNodeType,
+    UserNode,
 };
 use repository::{
     DatetimeFilter, EqualFilter, InvoiceStatus, InvoiceType, ItemLedgerFilter, ItemLedgerRow,
@@ -102,6 +104,22 @@ impl ItemLedgerNode {
 
     pub async fn number_of_packs(&self) -> &f64 {
         &self.item_ledger.number_of_packs
+    }
+
+    pub async fn user(&self, ctx: &Context<'_>) -> Result<Option<UserNode>> {
+        let loader = ctx.get_loader::<DataLoader<UserLoader>>();
+
+        let user_id = match &self.item_ledger.user_id {
+            Some(user_id) => user_id,
+            None => return Ok(None),
+        };
+
+        let result = loader
+            .load_one(user_id.clone())
+            .await?
+            .map(UserNode::from_domain);
+
+        Ok(result)
     }
 }
 

--- a/server/graphql/general/src/queries/ledger.rs
+++ b/server/graphql/general/src/queries/ledger.rs
@@ -2,12 +2,12 @@ use async_graphql::{dataloader::DataLoader, *};
 use chrono::{DateTime, Utc};
 use graphql_core::{
     generic_filters::{DatetimeFilterInput, EqualFilterStringInput},
-    loader::StockLineByIdLoader,
+    loader::{StockLineByIdLoader, UserLoader},
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
 
-use graphql_types::types::{InvoiceNodeType, StockLineNode};
+use graphql_types::types::{InvoiceNodeType, StockLineNode, UserNode};
 use repository::{
     stock_line_ledger::{
         StockLineLedgerFilter, StockLineLedgerRow, StockLineLedgerSort, StockLineLedgerSortField,
@@ -89,6 +89,21 @@ impl LedgerNode {
     }
     pub async fn running_balance(&self) -> &f64 {
         &self.ledger.running_balance
+    }
+    pub async fn user(&self, ctx: &Context<'_>) -> Result<Option<UserNode>> {
+        let loader = ctx.get_loader::<DataLoader<UserLoader>>();
+
+        let user_id = match &self.ledger.user_id {
+            Some(user_id) => user_id,
+            None => return Ok(None),
+        };
+
+        let result = loader
+            .load_one(user_id.clone())
+            .await?
+            .map(UserNode::from_domain);
+
+        Ok(result)
     }
 
     pub async fn stock_line(&self, ctx: &Context<'_>) -> Result<Option<StockLineNode>> {

--- a/server/repository/src/db_diesel/item_ledger.rs
+++ b/server/repository/src/db_diesel/item_ledger.rs
@@ -41,6 +41,7 @@ table! {
         sell_price_per_pack -> Double,
         total_before_tax -> Nullable<Double>,
         number_of_packs -> Double,
+        user_id -> Nullable<Text>,
         type_precedence -> Integer,
         running_balance -> Double,
     }
@@ -66,6 +67,7 @@ pub struct ItemLedgerRow {
     pub sell_price_per_pack: f64,
     pub total_before_tax: Option<f64>,
     pub number_of_packs: f64,
+    pub user_id: Option<String>,
     pub type_precedence: i32,
     pub running_balance: f64,
 }

--- a/server/repository/src/db_diesel/stock_line_ledger.rs
+++ b/server/repository/src/db_diesel/stock_line_ledger.rs
@@ -43,6 +43,7 @@ table! {
         sell_price_per_pack -> Double,
         total_before_tax -> Nullable<Double>,
         number_of_packs -> Double,
+        user_id -> Nullable<Text>,
         running_balance -> Double,
     }
 }
@@ -68,6 +69,7 @@ pub struct StockLineLedgerRow {
     pub sell_price_per_pack: f64,
     pub total_before_tax: Option<f64>,
     pub number_of_packs: f64,
+    pub user_id: Option<String>,
     /// The running balance for the stock line at the time of this ledger entry
     pub running_balance: f64,
 }

--- a/server/repository/src/migrations/views/item_ledger.rs
+++ b/server/repository/src/migrations/views/item_ledger.rs
@@ -52,6 +52,7 @@ impl ViewMigrationFragment for ViewMigration {
         invoice_line_stock_movement.total_before_tax AS total_before_tax,
         invoice_line_stock_movement.pack_size as pack_size,
         invoice_line_stock_movement.number_of_packs as number_of_packs,
+        invoice.user_id as user_id,
         CASE
           WHEN invoice.type IN ('INBOUND_SHIPMENT', 'CUSTOMER_RETURN', 'INVENTORY_ADDITION') THEN 1
           WHEN invoice.type IN ('OUTBOUND_SHIPMENT', 'SUPPLIER_RETURN', 'PRESCRIPTION', 'INVENTORY_REDUCTION') THEN 2

--- a/server/repository/src/migrations/views/stock_movement.rs
+++ b/server/repository/src/migrations/views/stock_movement.rs
@@ -53,7 +53,8 @@ impl ViewMigrationFragment for ViewMigration {
         invoice.status AS invoice_status,
         invoice_line_stock_movement.total_before_tax AS total_before_tax,
         invoice_line_stock_movement.pack_size as pack_size,
-        invoice_line_stock_movement.number_of_packs as number_of_packs
+        invoice_line_stock_movement.number_of_packs as number_of_packs,
+        invoice.user_id as user_id
     FROM
         invoice_line_stock_movement
         LEFT JOIN reason_option ON invoice_line_stock_movement.reason_option_id = reason_option.id

--- a/server/service/src/invoice/inventory_adjustment/add_new_stock_line/insert.rs
+++ b/server/service/src/invoice/inventory_adjustment/add_new_stock_line/insert.rs
@@ -99,6 +99,15 @@ pub fn add_new_stock_line(
                 None,
             )?;
 
+            // Also log against the stock line so it appears in the stock line's Log tab
+            activity_log_entry(
+                ctx,
+                ActivityLogType::InventoryAdjustment,
+                Some(stock_line_id.clone()),
+                None,
+                None,
+            )?;
+
             match get_stock_line(ctx, stock_line_id) {
                 Ok(stock_line) => Ok(stock_line),
                 Err(SingleRecordError::NotFound(_)) => {

--- a/server/service/src/invoice/inventory_adjustment/adjust_existing_stock/insert.rs
+++ b/server/service/src/invoice/inventory_adjustment/adjust_existing_stock/insert.rs
@@ -52,6 +52,7 @@ pub fn insert_inventory_adjustment(
         .connection
         .transaction_sync(|connection| {
             let stock_line = validate(connection, &ctx.store_id, &input)?;
+            let stock_line_id = stock_line.stock_line_row.id.clone();
             let GenerateResult {
                 invoice,
                 insert_stock_in_or_out_line,
@@ -95,6 +96,15 @@ pub fn insert_inventory_adjustment(
                 ctx,
                 ActivityLogType::InventoryAdjustment,
                 Some(verified_invoice.id.to_string()),
+                None,
+                None,
+            )?;
+
+            // Also log against the stock line so it appears in the stock line's Log tab
+            activity_log_entry(
+                ctx,
+                ActivityLogType::InventoryAdjustment,
+                Some(stock_line_id),
                 None,
                 None,
             )?;


### PR DESCRIPTION
> [!WARNING]
> This PR was largely authored by Claude

Fixes #10963

# 👩🏻‍💻 What does this PR do?

<img width="1722" height="830" alt="image" src="https://github.com/user-attachments/assets/cafd72a0-16cb-4e90-b967-9c180d3a7a76" />
<img width="1710" height="635" alt="image" src="https://github.com/user-attachments/assets/3e534a77-ef05-4b9f-8878-d8b9f131aa6e" />
<img width="1727" height="730" alt="image" src="https://github.com/user-attachments/assets/f1832d8c-b299-44b0-9de2-57fca72313b6" />


Exposes the user who created/last edited each stock movement in both the **Item Ledger** and **Stock Line Ledger** tabs, addressing the auditability gap for inventory adjustments.

**Server:**
- `stock_movement` SQL view: added `invoice.user_id`
- `item_ledger` SQL view: added `invoice.user_id`
- `StockLineLedgerRow` / `ItemLedgerRow` (Diesel): added `user_id` field
- `LedgerNode` / `ItemLedgerNode` (GraphQL): added `user` resolver using existing `UserLoader` DataLoader (same pattern as `InvoiceNode`, `StocktakeNode`, `ActivityLogNode`)

**Client:**
- `LedgerRow` / `ItemLedger` fragments: added `user { username }`
- Stock line ledger + Item ledger tables: added User column at end

**Activity Log fix:**
- Inventory adjustments now also log against the stock line ID (in addition to the invoice ID), so they appear in the stock line's **Log** tab

## 💌 Any notes for the reviewer?

- The `user` field represents the **last user who edited the invoice**, not necessarily the user who created it. For inventory adjustments this is always the creating user (since they're immediately verified). For inbound/outbound shipments, it's whoever last updated the invoice (e.g. the user who received it).
- Uses the existing `UserLoader` DataLoader to resolve user info efficiently (avoids N+1). Rows with no `user_id` (e.g. synced legacy data) return `null` gracefully.
- The activity log fix only applies to **new** inventory adjustments going forward — existing ones won't retroactively appear in the stock line Log tab.
- PR #10964 (Copilot) covers the item ledger only; this PR covers both item and stock line ledgers plus the Log tab fix.

# 🧪 Testing

- [ ] Open an item detail → Ledger tab → verify "User" column appears as the last column
- [ ] Open a stock line detail → Ledger tab → verify "User" column appears as the last column
- [ ] Create an inventory adjustment → verify the username appears on the new ledger entry in both tabs
- [ ] Verify inbound/outbound shipments also show the user (or blank if none set)
- [ ] Open a stock line detail → Log tab → create an inventory adjustment → verify it appears in the log
- [ ] Test with SQLite and Postgres

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend