### PR TITLE
11066: reset column default order

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/columns.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/columns.tsx
@@ -79,17 +79,6 @@ export const useInboundShipmentColumns = (
         enableSorting: true,
       },
       {
-        id: 'manufactureDate',
-        accessorFn: row =>
-          row.manufactureDate ? new Date(row.manufactureDate) : null,
-        header: t('label.manufacture-date'),
-        columnType: ColumnType.Date,
-        size: 120,
-        defaultHideOnMobile: true,
-        enableColumnFilter: true,
-        enableSorting: true,
-      },
-      {
         id: 'vvmStatus',
         accessorFn: row => row.vvmStatus?.description ?? '',
         header: t('label.vvm-status'),
@@ -148,14 +137,6 @@ export const useInboundShipmentColumns = (
         includeColumn: !external,
       },
       {
-        accessorKey: 'status',
-        header: t('label.auth-status'),
-        enableColumnFilter: true,
-        filterVariant: 'select',
-        includeColumn: showLineStatus,
-        Cell: ({ cell }) => <StatusCell cell={cell} statusMap={statusMap} />,
-      },
-      {
         id: 'doseQuantity',
         accessorFn: row => {
           if (!row.item.isVaccine) return null;
@@ -167,6 +148,14 @@ export const useInboundShipmentColumns = (
         defaultHideOnMobile: true,
         includeColumn: manageVaccinesInDoses,
         size: 120,
+      },
+      {
+        accessorKey: 'status',
+        header: t('label.auth-status'),
+        enableColumnFilter: true,
+        filterVariant: 'select',
+        includeColumn: showLineStatus,
+        Cell: ({ cell }) => <StatusCell cell={cell} statusMap={statusMap} />,
       },
       {
         id: 'costPricePerUnit',
@@ -206,6 +195,17 @@ export const useInboundShipmentColumns = (
         header: t('label.manufacturer'),
         defaultHideOnMobile: true,
         accessorFn: row => row.manufacturer?.name ?? '',
+      },
+      {
+        id: 'manufactureDate',
+        accessorFn: row =>
+          row.manufactureDate ? new Date(row.manufactureDate) : null,
+        header: t('label.manufacture-date'),
+        columnType: ColumnType.Date,
+        size: 120,
+        defaultHideOnMobile: true,
+        enableColumnFilter: true,
+        enableSorting: true,
       },
       {
         id: 'campaign',


### PR DESCRIPTION


Fixes #11066 

# 👩🏻‍💻 What does this PR do?

Changes the default column order to:

1. Comment
2. Code
3. Name
4. Purchase order line number (if applicable)
5. Batch
6. Expiry Date
7. VVM status
8. Location
9. Unit Name
10. Pack Size
11. Doses per unit (if applicable)
12. Pack Qty
13. Unit Qty
14. Doses (if applicable)
15. Authorisation status (if applicable)
16. Cost per unit
17. Total
18. Donor
19. Manufacturer
20. Manufature date
21. Campaign / Program

Note that if you've ran this before, you need to reset the column order to see the change.
But this will apply for new people going forwards
Considered changing the table id so it would apply, however then people would loose their personalised ordering so have left as is

Screenshot:
<img width="1660" height="540" alt="image" src="https://github.com/user-attachments/assets/002bd987-1081-4c71-9073-95fbcfc4960d" />

Note how manufacturer has gone towards the end - it used to be less relevantly near the beginningf

## 💌 Any notes for the reviewer?

Simples

# 🧪 Testing

You will need to reset column order to see the change
Please test with some of the conditional columns in place

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  3.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

