### PR TITLE
[DOC] Sanity check and validation for v7

### DIFF
--- a/syncdoc/content/v7.md
+++ b/syncdoc/content/v7.md
@@ -527,20 +527,18 @@ For 2, it would be a hard and would impact performance to
 
 Therefore an approach to reduce a chance of impersonation of remote site is taken, using a token based authentication, after initial authentication.
 
-- Initial login is done via configured site credentials
+- Initial login is done via a separate endpoint using configured site credentials
 - During initial login, a token is allocated and shared with sync client
 - Further communication is done using the token
 - Site credentials cannot be used to authenticate if token is already allocated
 - Token can be cleared by admin user, if site needs to be re-initialised
 - Hardware id check remains as is, to prevent accidental sync of dev clones of sync client
 
-<details>
+<details> <summary> **Other authentication approaches and considerations** </summary>
 
-<summary>
+#### Would hardware_id be enough ?
 
-Other authentication approaches and considerations
-
-</summary>
+Yes technically hardware_id is similar to token, but it originates at remote site. And with hardware_id we would still need to send credentials and store credential as SHA, but we want to move away to bcrypt and there is some overhead with constant validation of bcrypt hash, lastly with user login there would be token associated with site, and it's easier to do it now for future migration (see below about user login)
 
 #### Symmetric Authentication
 
@@ -550,7 +548,30 @@ This approach uses a secret, rather then a token. This secret is used to encrypt
 
 Token can be exposed whenever there is access to database, at which point the system is compromised beyond concerns of sync site authentication.
 
+#### User based login
+
+There was a brief discussion of user based auth where user credentials are used, and OMS central will return possible unallocated sites, then site is chosen and token allocated (or with active stores for user ?), we liked this for future and thus opted to do token auth in V7 mvp, for ease of transition in the future. TODO this discussion needs to take place
+
+#### What about direct database edits
+
+Even though we consider that at the point of direct access to database there would be worse problems then just sync record validation, there is still a real use case of admin users modifying data (unfinalising invoices etc..), for now the strategy to deal with this is sync buffer archiving/recording might help capture these changes (if the record was previously synced and being changed now manually). Potentially could implement a check at night for things like record was finalised and now unfinalised, or invoice_line was changed for finalised record (some business rule sanity check TODO discuss further)
+
+Alternatively some sort of signing of records (potentially with a key stored in binary during build etc..) and then validation of this ether during sync or after sync by checking sync buffer etc.. TODO to discuss further.
+
+#### Backup issue
+
+Due to accidental backup restore we could have 'lacking' on remote or central site, we can deal with this by using cursors (OMS central should also record what cursor remote site is up to in terms of push, and then a request could be made in the future to ask remote site to go back to that cursor for next push TODO)
+
+#### Why is manual data manipulation and support/admin user SOP related mishaps here ?
+
+Above are not entirely sync issue, but we've wished before that sync had ability to protect use from these, thus they are at least captured here
+
+#### Multiple places for sanity check
+
+Is it worth having a sanity check at the time of push ? There is a potential of database being edited to send a record for another site from this site but with different store_id on changelog and then sync record, doing another sanity check to confirm that actual data is reflective of the metadata in changelog would be benificial in this case, however it seem like record signing might be a better way and deals with more use cases.
+
 </details>
+
 
 
 ### **de-duplication** {#de-duplication}
@@ -905,6 +926,8 @@ When a store is moved to a remote site, we need to re-sync all of its data, this
 We have to be careful to not try to integrate part of the sync\_buffer populated by the other sync operation.
 
 Draft: A bit more thought required here, can see edge cases where some of the sync buffer is from normal and some are from store or patient specific sync, we may need to flag sync\_buffer rows as ‘from particular site’ or make sure we fully sync one before the other. 
+
+TODO also mention somewhere about sanity check on central and remote data not being integrated if store was moved (i.e. store is not active anymore for the site that is pushing it, which would protect from multiple sites having the same store active and ledger issues etc..)
 
 ### **Patient re-syncs** {#patient-re-syncs}
 

--- a/syncdoc/content/v7.md
+++ b/syncdoc/content/v7.md
@@ -525,11 +525,33 @@ For 2, it would be a hard and would impact performance to
 - To differentiate between a valid data state and something malicious (for example price updates)
 - To stop sensitive data being accessed, pulled.
 
-Therefore an approach to reduce a chance of impersonation of remote site is taken, which is using symmetric authentication. When a ROMS initially authenticates with COMS a secret is generate (for that site only) which is then sent to ROMS, this secret is used to encrypt hardware_id in all future authentications, COMS will use this secret to decrypt hardware_id and validate that it matches hardware_id stored for the site (if no hardware_id is yet set it will be updated to match the first hardware_id sent by the site).
+Therefore an approach to reduce a chance of impersonation of remote site is taken, using a token based authentication, after initial authentication.
 
-An admin user can re-set both the secret and hardware_id for the site. In this way you can have simpler credentials for site authentication (username and password), but if they are stolen you are still protected by the shared secret.
+- Initial login is done via configured site credentials
+- During initial login, a token is allocated and shared with sync client
+- Further communication is done using the token
+- Site credentials cannot be used to authenticate if token is already allocated
+- Token can be cleared by admin user, if site needs to be re-initialised
+- Hardware id check remains as is, to prevent accidental sync of dev clones of sync client
 
-The only way for the shared secret to leak is to have access to the database, at which point data can be manipulated and examines by a bad actor in any case
+<details>
+
+<summary>
+
+Other authentication approaches and considerations
+
+</summary>
+
+#### Symmetric Authentication
+
+This approach uses a secret, rather then a token. This secret is used to encrypt hardware id, which in turn will be descrypted by COMS. This is redundant layer of cryptography, even if we add HMAC, TLS already guarantees protection at transport layer, and leakage of token has the same attack vectors as leakage of secret.
+
+#### Leakage of secret
+
+Token can be exposed whenever there is access to database, at which point the system is compromised beyond concerns of sync site authentication.
+
+</details>
+
 
 ### **de-duplication** {#de-duplication}
 
@@ -1030,11 +1052,13 @@ Key tables used in v7 sync
 
 ### **Site** {#site}
 
-| id | number | primary key |
+| field | type | constraints |
 | :---- | :---- | :---- |
+| id | number | primary key |
 | name | text |  |
 | passwordHash | text |  |
 | hardwareId | text | nullable |
+| token | text | nullable |
 
 ### **Store** {#store}
 

--- a/syncdoc/content/v7.md
+++ b/syncdoc/content/v7.md
@@ -505,9 +505,31 @@ When pushing records to central, the remote site will know its own **site\_id**,
 
 WHERE (source\_site\_id \== site\_id) AND (cursor \< SyncPushCursor)
 
-##### Sanity check {#sanity-check}
 
-There is a check on central and remote for data ownership, to protect against errors or unauthorised editing of data, there is a separate section for this in the document
+### Sanity check and record validation
+
+We want to deal with these use cases when considering validation and sanity check
+
+1. A bug in our code where sync record are sent to the wrong site
+2. A bad actor that has acquired sync site credentials
+
+`note:` at the time of this writing, we are not intending to support bespoke sync clients, thus a mechanism for making sure data is consistent with our business rules is not planned 
+
+For 1, there is a basic sanity check to examine sync_buffer record and make sure it can be integrated based on it's sync type, store_id, transfer_store_id and patient_id
+
+TODO: Implementer to update this doc with all of the rules ([examples in the prototype](https://github.com/msupply-foundation/open-msupply/blob/v7-prototype/server/service/src/sync_v7/validate.rs))
+
+For 2, it would be a hard and would impact performance to
+
+- To check all incoming records for consistency
+- To differentiate between a valid data state and something malicious (for example price updates)
+- To stop sensitive data being accessed, pulled.
+
+Therefore an approach to reduce a chance of impersonation of remote site is taken, which is using symmetric authentication. When a ROMS initially authenticates with COMS a secret is generate (for that site only) which is then sent to ROMS, this secret is used to encrypt hardware_id in all future authentications, COMS will use this secret to decrypt hardware_id and validate that it matches hardware_id stored for the site (if no hardware_id is yet set it will be updated to match the first hardware_id sent by the site).
+
+An admin user can re-set both the secret and hardware_id for the site. In this way you can have simpler credentials for site authentication (username and password), but if they are stolen you are still protected by the shared secret.
+
+The only way for the shared secret to leak is to have access to the database, at which point data can be manipulated and examines by a bad actor in any case
 
 ### **de-duplication** {#de-duplication}
 


### PR DESCRIPTION
As per [README.md](https://github.com/msupply-foundation/open-msupply/blob/1f066619137959131866d291516d4b39e958b819/syncdoc/README.md), I still like v7 spec to be about how v7 works, not so much about 'why', the 'why' should 100% still be documented but I think in separate sub sections ? (or maybe in 'drop down' detail sections, food for thought.