### PR TITLE
[DOC] sync v7 backtrack storing store_id, transfer_store_id and patient_id on records

### DIFF
--- a/syncdoc/content/v7.md
+++ b/syncdoc/content/v7.md
@@ -1125,11 +1125,19 @@ As patients only sync to a remote site if they are visible to that site, without
 
 The remote patient lookup end point used by ROMS is on COGS \- this needs to be moved over to COMS
 
+#### Store merge and creating store from names
+
+TODO: Capturing those two use cases as per the header.
+TODO: The latter case would suggest that changelogs might need to be updated to have transfer_store_id set
+
+
 ##### V7 Specification {#v7-specification}
 
 Draft: The COMS site is configured to have all patients and their data visible via COGS (investigate what this looks like on a large data file with lots of patients, when initialising).
 
 Draft: Normal patient lookup endpoint is used, but ROMS proxies graphql call to COMS (in terms of permissions for user, should just work). To sync patient and their detail, an endpoint/graphql, to add name\_store\_join is called from COMS to ROMS, name\_store\_join is added, and then similar operation to ‘Moving stores between sites’ is called \<- however since patient details need to be available now, we can call sync ‘pull’ and integrate logic (sync buffer to be filtered by patient\_id ?), for data for that patient, outside of sync.
+
+
 
 ### **Assets**  {#assets}
 

--- a/syncdoc/content/v7.md
+++ b/syncdoc/content/v7.md
@@ -379,14 +379,9 @@ Notes on backend handling:
 
 * When records are being mutated by the site itself (graphql mutation, side effect, etc..), current site id is queried from key\_value\_store (cached)
 
-* **store\_id**, **transfer\_store\_id** and **patient\_id** are set based on record sync type, these fields need to be available on the record and sometimes are de-normalised (for example invoice\_line will have store\_id and transfer\_store\_id even though those can be deduced from invoice, also invoice\_line may have patient\_id based on invoice type, if it’s related to a patient)
+* **store_id**, **transfer_store_id** and **patient_id** are set based on record sync type, these fields are not always available on the record itself and will need to be queried based on related record when they are updated during normal operations. However when records are integrated via sync, these fields will be populated from sync_buffer which in turn is populated from sync_record, and sync_record will have these fields populated from changelog (full circle)
 
-* ~~Otherwise, if store\_id and/or name\_id are required for the record sync\_type~~  
-  * ~~Use current record store\_id and/or name\_id if they exist on the record~~  
-  * ~~Query for related record\_store\_id and/or name\_id (i.e. invoice\_line queries invoice)~~  
-* ~~Discuss Propo	sal: add store\_id and name\_id to every record that currently has just store\_id~~  
-  * ~~I.e. It would mean~~   
-    * ~~Migration for existing records and making sure those are set correctly throughout all of the code base, vs as currently, just being separated to just insert changelog/sync. However if they are made compulsory fields it would be easy enough to make sure they are set, and a lot more performant when inserting change log. I think I would rather add them to every record.~~
+(TODO: here a link to all sync types and explanation about how/when they sync, what actual tables relate to what type should really be in code).
 
 ##### store\_id justification for inclusion {#store_id-justification-for-inclusion}
 
@@ -578,7 +573,8 @@ sync\_buffer is essentially a copy of sync\_record, it contains all of the infor
 
 * **table\_name** and **record\_id** identify a record, it’s unique in sync\_buffer by **record\_id**  
 * **row\_action** determines if it’s UPSERT or DELETE  
-* **source\_site\_id** records the origin of the record  
+* **source\_site\_id** records the origin of the record 
+* **transfer_store_id**, **store_id**, **patient_id** to populate changelog record
 * **data** is used to store a json version of the record  
 * **received\_datetime**, **integration\_datetime** and **error** fields keep track of integration status
 
@@ -683,11 +679,7 @@ A common shape in the request of the **push** and response of the **pull**
 
 #### **Sync\_record** {#sync_record}
 
-```ts
-CP: I can't delete this code block help lol
-```
-
-A **cursor** of the current record, coming from the change log. And a serialized version of sync\_buffer row (and can be deserialized straight into sync\_buffer) This sync record can be produced by a common function, built from a changelog and a query for the related record
+A **cursor** of the current record, coming from the change log, and a serialized version of sync\_buffer row (can be deserialized straight into sync\_buffer). This sync record can be produced by a common function, built from a changelog and a query for the related record
 
 #### **Implementation details** {#implementation-details-3}
 


### PR DESCRIPTION
This is basically how prototype implemented them, the doc first had this, then I changed it to having these on the record, now backtracking again.

There is a TODO for sync types, will have to move that from google doc at some point