### PR TITLE
#11028 Change "Return to" to "Return from"

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1502,7 +1502,7 @@
   "label.reset-column-sizes": "Reset column sizes",
   "label.reset-pinned-columns": "Reset pinned columns",
   "label.reset-table-defaults": "Reset table to defaults",
-  "label.return-to": "Return to",
+  "label.return-from": "Return from",
   "label.revert-existing-transaction": "Revert existing stock transaction",
   "label.review": "Review",
   "label.rnr-adjustments": "Adjustments +/-",

--- a/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnSteps.tsx
+++ b/client/packages/invoices/src/Returns/modals/CustomerReturn/ReturnSteps.tsx
@@ -86,7 +86,7 @@ export const ReturnSteps = ({
         }}
       >
         <InputWithLabelRow
-          label={t('label.return-to')}
+          label={t('label.return-from')}
           Input={
             <Typography>
               {returnToStoreName ?? data?.otherPartyName ?? ''}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11028

# 👩🏻‍💻 What does this PR do?

Trivial update here, just changing the string (and the key) to reflect the correct direction as noted by @alainsussol 

Actual French translations will need to be updated in Weblate.

## 💌 Any notes for the reviewer?


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Confirm new return from Outbound shipment says "Return from:" on modal rather than "Return to:"

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

