### PR TITLE
Add Claude commands for PR creation and review

### DIFF
--- a/.claude/commands/pr-create.md
+++ b/.claude/commands/pr-create.md
@@ -1,0 +1,56 @@
+Create a branch, commit changes, and open a PR.
+
+Arguments: `<issue-number> [claude-warning]`
+- First argument (REQUIRED): the issue number (e.g. `1234` or `#1234`). If not provided, ask for it before proceeding.
+- Base branch (optional): request this if it's not very clear what branch should be used
+- Second argument (optional): `warn` — if present, add a Claude AI warning box at the very top of the PR body (before `Fixes #`). See Step 3 for details.
+
+## Step 1: Create a branch
+
+1. Parse the issue number from the argument (e.g. `1234` or `#1234`)
+2. Run `git diff --staged` and `git diff` to understand the current changes
+3. Read the key changed files to understand context and pick a short descriptive branch name
+4. Create and switch to a new branch named `<issue-number>-short-description` (e.g. `1234-fix-login-redirect`). Use lowercase kebab-case for the description portion, keep it under 5 words.
+5. If the branch already exists (e.g. you're already on it), skip creation and continue
+
+## Step 2: Commit changes (if any uncommitted changes exist)
+
+1. Run `git status` to check for uncommitted changes. If the working tree is clean, skip to Step 3.
+2. Run `git log --oneline -20` to see recent commit message style
+3. Run `git diff --staged` and `git diff` to understand the changes
+4. If changes span multiple files, read the key changed files to understand context
+5. Stage all relevant changes (prefer specific files over `git add -A`)
+6. Craft a commit message following the repo's style:
+   - First line MUST be under 72 characters
+   - First line should be a concise summary
+   - Add a blank line after the first line if a body is needed
+   - Body can elaborate on what and why (not how)
+7. Commit the changes (use HEREDOC for the message)
+
+## Step 3: Push and create the PR
+
+1. Read the PR template at `.github/pull_request_template.md`
+2. Determine the base branch: check upstream tracking or fall back to default branch (`git remote show origin | grep 'HEAD branch'`)
+3. Run `git log <base>..HEAD --oneline` and `git diff <base>...HEAD --stat` to understand all committed changes on this branch
+4. Read relevant changed files to understand what was done and why
+5. **Fetch the related issue** using `gh issue view <issue-number>` to read the issue description and requirements
+6. **Compare implementation to the issue**: identify any differences between what the issue asked for and what was actually implemented. Note:
+   - Requirements from the issue that were NOT implemented or were deferred
+   - Implementation choices that differ from what the issue described
+   - Extra changes made that weren't explicitly requested in the issue
+   - Use these findings to inform the PR description and reviewer notes
+7. Push the branch to origin with `-u` flag
+8. Fill out the PR template with real content:
+   - If the `warn` argument was provided, add the following block at the very top of the PR body (before `Fixes #`):
+     ```
+     > [!WARNING]
+     > This PR was largely authored by Claude
+     ```
+   - Set `Fixes #<issue-number>` using the provided issue number
+   - Write a clear description of what the PR does
+   - In the reviewer notes section, highlight any **implementation differences** from the issue (from step 6). Be transparent about what diverged and why.
+   - Add reviewer notes highlighting key changes or risks
+   - Fill in realistic testing steps specific to the changes
+   - Check the appropriate documentation boxes
+9. Create the PR using `gh pr create` with the filled-out template as the body (use HEREDOC for formatting). The title format MUST be `#<issue-number> <concise summary>` (e.g. `#1234 Fix login redirect on expired sessions`). Keep the total title under 70 characters.
+10. Return the PR URL when done

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,0 +1,59 @@
+Review code changes against a GitHub issue or PR./
+
+Arguments: $ARGUMENTS (optional: issue/PR number or URL)
+
+Steps:
+
+1. **Determine what to review:**
+   - If a PR number/URL is given, fetch it with `gh pr view <number> --json body,title,baseRefName,headRefName,files,comments` and use the PR's base branch for the diff.
+   - If an issue number/URL is given, use it for requirements context. Determine the diff to review (see step 2).
+   - If no argument is given, try to infer the issue from the current branch name (e.g. `1234-some-description` → issue #1234).
+
+2. **Determine the diff scope** (in priority order):
+   - If a PR was provided, use its base branch: `git diff <base>...HEAD`
+   - Otherwise, detect the upstream tracking branch (`git rev-parse --abbrev-ref @{upstream}`).
+   - If no upstream, find the best base by checking `git merge-base HEAD origin/<branch>` against likely candidates: check which remote branches the current branch was forked from using `git log --oneline --decorate --first-parent HEAD | grep -m1 'origin/'` or `git branch -r --contains $(git log --reverse --ancestry-path --format=%H HEAD | head -1)`. As a fallback, try common base branches in order: the repo's default branch, `main`, `master`, `develop`, and any `v*-RC` or release branches.
+   - **Only review commits unique to this branch** — use `git diff <merge-base>...HEAD` (three-dot diff), NOT `git diff <branch>...HEAD` which can include unrelated commits from the base.
+   - If there are only staged/unstaged local changes and no branch commits, review those instead.
+   - **If it's still ambiguous, ask the user** what base branch to diff against before proceeding.
+
+3. **Gather context:**
+   - Fetch the issue thread with `gh issue view <number> --json body,title,comments` to understand requirements, acceptance criteria, and discussion.
+   - Run `git diff <base>...HEAD --stat` and `git diff <base>...HEAD` to get the full diff.
+   - Include any uncommitted changes (`git diff`, `git diff --staged`) if present.
+   - Read the relevant changed files in full (not just the diff) to understand surrounding code and existing patterns.
+
+4. **Review the changes against the issue:**
+   - **Requirements coverage:** Go through each requirement/acceptance criterion in the issue and confirm whether the changes address it. Flag anything missing.
+   - **Unmentioned changes:** Note any changes in the diff that aren't described or motivated by the issue thread — they may be fine (refactors, necessary prep) but should be called out.
+
+5. **Code quality review:**
+   - **Correctness:** Logic errors, off-by-one, missing error handling at system boundaries, race conditions.
+   - **Consistency with existing patterns:** Check how similar features are implemented nearby and flag deviations. Look at naming conventions, module structure, error handling style, and API patterns already in use.
+   - **Security:** SQL injection, XSS, command injection, auth/authz gaps, secrets in code.
+   - **Performance:** Unnecessary allocations, N+1 queries, missing indexes, blocking in async contexts.
+   - **Testing:** Are new/changed code paths tested? Are edge cases covered?
+   - **Types & schemas:** For GraphQL/DB changes, are types, migrations, and generated code consistent?
+
+6. **Output the review** in this format:
+
+   ## Review: <PR/issue title>
+
+   ### Requirements Coverage
+   For each requirement in the issue:
+   - ✅ Requirement — how it's addressed
+   - ❌ Requirement — what's missing
+
+   ### Changes Not in Issue
+   List any changes that aren't covered by the issue description/discussion.
+
+   ### Findings
+   Group by severity:
+   - 🔴 **Must fix** — bugs, security issues, data loss risks
+   - 🟡 **Should fix** — code quality, consistency, maintainability
+   - 🟢 **Nit** — style, naming, minor suggestions
+
+   For each finding, reference the specific file and line.
+
+   ### Summary
+   Brief overall assessment — is this ready to merge, or what needs to change first?


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Adds to claude commands to the claude directory for everyone to use. One for creating a PR using our standard formatting and another for reviewing PR's with an emphasis on issue coverage. Usage:

```bash
/pr-create <issue-num> [base-branch] [warn:bool] # warn adds a message at top of commit warning about claude usage
/pr-review [pr-num] # if pr-num is excluded review current branch, working directory or latest commit
```

## 💌 Any notes for the reviewer?

I found both commands quite useful. Sometimes on the RC branch claude struggles to figure out the base branch so need to specify it manually.

# 🧪 Testing

Just run the commands in your workspace and see what happens ¯\_(ツ)_/¯

# 📃 Documentation

- [x] Self documenting
