### PR TITLE
#11064 Fix: Default requested qty to 0 in internal orders

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
@@ -35,7 +35,7 @@ const createDraftFromItem = (
     id: FnUtils.generateUUID(),
     requisitionId: request.id,
     itemId: item.id,
-    requestedQuantity: suggested,
+    requestedQuantity: 0,
     suggestedQuantity: suggested,
     isCreated: true,
     itemStats: item.stats,


### PR DESCRIPTION
## Summary
- Fixes #11064 — when adding a new line to an internal order, the requested quantity was pre-filled with the suggested quantity but never sent to the backend on insert, silently resetting to 0
- Defaults `requestedQuantity` to `0` instead of pre-filling with `suggestedQuantity`, so the user must explicitly enter a value
- The suggested quantity is still calculated and displayed for reference

## Test plan
- [ ] Create an internal order, add a line where suggested qty > 0
- [ ] Confirm the requested qty field shows 0 (not the suggested qty)
- [ ] The suggested qty should still be visible separately
- [ ] Type a requested qty value, click OK — confirm it saves correctly
- [ ] Existing lines with previously saved requested qty should be unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)