### PR TITLE
Added improved check for comparison

### DIFF
--- a/server/service/src/invoice_line/stock_in_line/update/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/mod.rs
@@ -683,4 +683,103 @@ mod test {
         )
         .is_ok());
     }
+
+    #[actix_rt::test]
+    async fn update_stock_in_line_cannot_edit_cost_price() {
+        fn internal_supplier_inbound() -> InvoiceRow {
+            InvoiceRow {
+                id: "internal_supplier_inbound".to_string(),
+                store_id: mock_store_b().id,
+                name_id: mock_name_store_b().id,
+                name_store_id: Some(mock_store_b().id),
+                r#type: InvoiceType::InboundShipment,
+                status: InvoiceStatus::New,
+                ..Default::default()
+            }
+        }
+
+        fn internal_supplier_line() -> InvoiceLineRow {
+            InvoiceLineRow {
+                id: "internal_supplier_line".to_string(),
+                invoice_id: internal_supplier_inbound().id,
+                item_link_id: mock_item_a().id,
+                r#type: InvoiceLineType::StockIn,
+                cost_price_per_pack: 100_000.0,
+                number_of_packs: 1.0,
+                pack_size: 1.0,
+                ..Default::default()
+            }
+        }
+
+        let (_, _, connection_manager, _) = setup_all_with_data(
+            "update_stock_in_line_cannot_edit_cost_price",
+            MockDataInserts::all(),
+            MockData {
+                invoices: vec![internal_supplier_inbound()],
+                invoice_lines: vec![internal_supplier_line()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context(mock_store_b().id, mock_user_account_a().id)
+            .unwrap();
+
+        // CannotEditCostPrice: changing cost price on internal supplier invoice
+        assert_eq!(
+            update_stock_in_line(
+                &context,
+                UpdateStockInLine {
+                    id: internal_supplier_line().id,
+                    r#type: StockInType::InboundShipment,
+                    cost_price_per_pack: Some(999.0),
+                    ..Default::default()
+                },
+                None
+            ),
+            Err(ServiceError::CannotEditCostPrice)
+        );
+
+        // Submitting the same cost price should succeed (not a real change)
+        assert!(update_stock_in_line(
+            &context,
+            UpdateStockInLine {
+                id: internal_supplier_line().id,
+                r#type: StockInType::InboundShipment,
+                cost_price_per_pack: Some(100_000.0),
+                ..Default::default()
+            },
+            None
+        )
+        .is_ok());
+
+        // A value within floating-point tolerance of the original should also succeed
+        // (simulates round-trip through JSON serialization)
+        let nearly_same = 100_000.0 + (f64::EPSILON * 100_000.0 * 5.0);
+        assert!(update_stock_in_line(
+            &context,
+            UpdateStockInLine {
+                id: internal_supplier_line().id,
+                r#type: StockInType::InboundShipment,
+                cost_price_per_pack: Some(nearly_same),
+                ..Default::default()
+            },
+            None
+        )
+        .is_ok());
+
+        // No cost_price_per_pack in input should skip the check entirely
+        assert!(update_stock_in_line(
+            &context,
+            UpdateStockInLine {
+                id: internal_supplier_line().id,
+                r#type: StockInType::InboundShipment,
+                ..Default::default()
+            },
+            None
+        )
+        .is_ok());
+    }
 }

--- a/server/service/src/invoice_line/stock_in_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/validate.rs
@@ -139,7 +139,7 @@ pub fn validate(
     // through floating point serialization (Rust f64 → JSON → JS Number → JSON → f64).
     if let Some(new_cost_price) = input.cost_price_per_pack {
         if (invoice.name_store_id.is_some() || invoice.purchase_order_id.is_some())
-            && (new_cost_price - line_row.cost_price_per_pack).abs() > f64::EPSILON
+            && !f64_approx_eq(new_cost_price, line_row.cost_price_per_pack)
         {
             return Err(CannotEditCostPrice);
         }
@@ -161,6 +161,14 @@ pub fn validate(
     Ok((line, item, invoice))
 }
 
+/// Compare two f64 values for approximate equality using a relative tolerance.
+/// Uses a minimum absolute tolerance of 1e-8 to handle values near zero,
+/// scaled by the magnitude of the larger operand for large values.
+fn f64_approx_eq(a: f64, b: f64) -> bool {
+    let tolerance = f64::EPSILON * a.abs().max(b.abs()) * 10.0;
+    (a - b).abs() <= tolerance.max(1e-8)
+}
+
 fn check_item_option(
     item_id_option: &Option<String>,
     connection: &StorageConnection,
@@ -171,5 +179,33 @@ fn check_item_option(
         ))
     } else {
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::f64_approx_eq;
+
+    #[test]
+    fn test_f64_approx_eq() {
+        // Identical values
+        assert!(f64_approx_eq(1.0, 1.0));
+        assert!(f64_approx_eq(0.0, 0.0));
+
+        // Clearly different values
+        assert!(!f64_approx_eq(1.0, 2.0));
+        assert!(!f64_approx_eq(100.0, 100.01));
+
+        // Large values: difference within relative tolerance should be equal
+        let large = 1_000_000.0;
+        let drift = f64::EPSILON * large * 5.0;
+        assert!(f64_approx_eq(large, large + drift));
+
+        // Large values: meaningful difference should not be equal
+        assert!(!f64_approx_eq(large, large + 0.01));
+
+        // Near zero: uses minimum absolute tolerance of 1e-8
+        assert!(f64_approx_eq(0.0, 1e-9));
+        assert!(!f64_approx_eq(0.0, 1e-7));
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11126 (I think)

# 👩🏻‍💻 What does this PR do?

Makes the can't edit cost price more robust with large number

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a PO witha very high and hard to represent cost in f64
- [ ] Try to edit a line in and inbound shipment without changing cost price

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

