### PR TITLE
10894 store pref can't set decimal values for under overstock thresholds

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -2838,6 +2838,11 @@ export type FinalisedRequisition = DeleteResponseRequisitionErrorInterface & {
   description: Scalars['String']['output'];
 };
 
+export type FloatStorePrefInput = {
+  storeId: Scalars['String']['input'];
+  value: Scalars['Float']['input'];
+};
+
 export enum ForeignKey {
   InvoiceId = 'invoiceId',
   ItemId = 'itemId',
@@ -6801,6 +6806,7 @@ export enum PreferenceValueNodeType {
   Boolean = 'BOOLEAN',
   Colour = 'COLOUR',
   CustomTranslations = 'CUSTOM_TRANSLATIONS',
+  Float = 'FLOAT',
   Integer = 'INTEGER',
   MultiChoice = 'MULTI_CHOICE',
   String = 'STRING',
@@ -6829,8 +6835,8 @@ export type PreferencesNode = {
   itemMarginOverridesSupplierMargin: Scalars['Boolean']['output'];
   manageVaccinesInDoses: Scalars['Boolean']['output'];
   manageVvmStatusForStock: Scalars['Boolean']['output'];
-  numberOfMonthsThresholdToShowLowStockAlertsForProducts: Scalars['Int']['output'];
-  numberOfMonthsThresholdToShowOverStockAlertsForProducts: Scalars['Int']['output'];
+  numberOfMonthsThresholdToShowLowStockAlertsForProducts: Scalars['Float']['output'];
+  numberOfMonthsThresholdToShowOverStockAlertsForProducts: Scalars['Float']['output'];
   numberOfMonthsToCheckForConsumptionWhenCalculatingOutOfStockProducts: Scalars['Int']['output'];
   orderInPacks: Scalars['Boolean']['output'];
   preventTransfersMonthsBeforeInitialisation: Scalars['Int']['output'];
@@ -10655,6 +10661,8 @@ export type UpdateRequestRequisitionInput = {
   id: Scalars['String']['input'];
   maxMonthsOfStock?: InputMaybe<Scalars['Float']['input']>;
   minMonthsOfStock?: InputMaybe<Scalars['Float']['input']>;
+  /** @deprecated Since 2.17.0. Use destination_customer_id */
+  originalCustomerId?: InputMaybe<NullableStringUpdate>;
   otherPartyId?: InputMaybe<Scalars['String']['input']>;
   status?: InputMaybe<UpdateRequestRequisitionStatusInput>;
   theirReference?: InputMaybe<Scalars['String']['input']>;
@@ -11156,10 +11164,10 @@ export type UpsertPreferencesInput = {
   manageVaccinesInDoses?: InputMaybe<Array<BoolStorePrefInput>>;
   manageVvmStatusForStock?: InputMaybe<Array<BoolStorePrefInput>>;
   numberOfMonthsThresholdToShowLowStockAlertsForProducts?: InputMaybe<
-    Array<IntegerStorePrefInput>
+    Array<FloatStorePrefInput>
   >;
   numberOfMonthsThresholdToShowOverStockAlertsForProducts?: InputMaybe<
-    Array<IntegerStorePrefInput>
+    Array<FloatStorePrefInput>
   >;
   numberOfMonthsToCheckForConsumptionWhenCalculatingOutOfStockProducts?: InputMaybe<
     Array<IntegerStorePrefInput>

--- a/client/packages/system/src/Manage/Preferences/EditPage/EditPreference.tsx
+++ b/client/packages/system/src/Manage/Preferences/EditPage/EditPreference.tsx
@@ -94,6 +94,7 @@ export const EditPreference = ({
       );
 
     case PreferenceValueNodeType.Integer:
+    case PreferenceValueNodeType.Float:
       if (!isNumber(preference.value)) {
         return t('error.something-wrong');
       }
@@ -106,6 +107,11 @@ export const EditPreference = ({
               onChange={handleChange}
               onBlur={() => {}}
               disabled={disabled}
+              decimalLimit={
+                preference.valueType === PreferenceValueNodeType.Float
+                  ? 2
+                  : 0
+              }
             />
           }
           isLast={isLast}

--- a/client/packages/system/src/Name/ListView/Stores/EditStorePreferences.tsx
+++ b/client/packages/system/src/Name/ListView/Stores/EditStorePreferences.tsx
@@ -41,8 +41,8 @@ export const EditStorePreferences = ({
               preference={pref}
               update={value => {
                 const finalValue =
-                  pref.valueType === PreferenceValueNodeType.Integer &&
-                  value === undefined
+                  ((pref.valueType === PreferenceValueNodeType.Integer || pref.valueType === PreferenceValueNodeType.Float) &&
+                    value === undefined)
                     ? 0
                     : value;
                 return update({

--- a/server/graphql/preference/src/upsert.rs
+++ b/server/graphql/preference/src/upsert.rs
@@ -22,6 +22,12 @@ pub struct IntegerStorePrefInput {
 }
 
 #[derive(InputObject)]
+pub struct FloatStorePrefInput {
+    pub store_id: String,
+    pub value: f64,
+}
+
+#[derive(InputObject)]
 pub struct StringStorePrefInput {
     pub store_id: String,
     pub value: String,
@@ -266,6 +272,15 @@ impl BoolStorePrefInput {
 
 impl IntegerStorePrefInput {
     pub fn to_domain(&self) -> StorePrefUpdate<i32> {
+        StorePrefUpdate {
+            store_id: self.store_id.clone(),
+            value: self.value,
+        }
+    }
+}
+
+impl FloatStorePrefInput {
+    pub fn to_domain(&self) -> StorePrefUpdate<f64> {
         StorePrefUpdate {
             store_id: self.store_id.clone(),
             value: self.value,

--- a/server/graphql/preference/src/upsert.rs
+++ b/server/graphql/preference/src/upsert.rs
@@ -88,9 +88,9 @@ pub struct UpsertPreferencesInput {
     pub number_of_months_to_check_for_consumption_when_calculating_out_of_stock_products:
         Option<Vec<IntegerStorePrefInput>>,
     pub number_of_months_threshold_to_show_low_stock_alerts_for_products:
-        Option<Vec<IntegerStorePrefInput>>,
+        Option<Vec<FloatStorePrefInput>>,
     pub number_of_months_threshold_to_show_over_stock_alerts_for_products:
-        Option<Vec<IntegerStorePrefInput>>,
+        Option<Vec<FloatStorePrefInput>>,
     pub first_threshold_for_expiring_items: Option<Vec<IntegerStorePrefInput>>,
     pub second_threshold_for_expiring_items: Option<Vec<IntegerStorePrefInput>>,
     pub warn_when_missing_recent_stocktake: Option<Vec<WarnWhenMissingRecentStocktakeInput>>,

--- a/server/graphql/types/src/types/preferences.rs
+++ b/server/graphql/types/src/types/preferences.rs
@@ -167,7 +167,7 @@ impl PreferencesNode {
 
     pub async fn number_of_months_threshold_to_show_low_stock_alerts_for_products(
         &self,
-    ) -> Result<i32> {
+    ) -> Result<f64> {
         self.load_preference(
             &self
                 .preferences
@@ -177,7 +177,7 @@ impl PreferencesNode {
 
     pub async fn number_of_months_threshold_to_show_over_stock_alerts_for_products(
         &self,
-    ) -> Result<i32> {
+    ) -> Result<f64> {
         self.load_preference(
             &self
                 .preferences
@@ -314,6 +314,7 @@ pub enum PreferenceNodeType {
 pub enum PreferenceValueNodeType {
     Boolean,
     Integer,
+    Float,
     MultiChoice,
     CustomTranslations, // Specific type for CustomTranslations preference
     WarnWhenMissingRecentStocktakeData,

--- a/server/service/src/dashboard/item_count.rs
+++ b/server/service/src/dashboard/item_count.rs
@@ -169,11 +169,11 @@ impl ItemCountServiceTrait for ItemServiceCount {
         let products_at_risk_of_being_out_of_stock = self
             .get_products_at_risk_of_being_out_of_stock_count(
                 &item_stats,
-                show_low_stock_alerts as f64,
+                show_low_stock_alerts,
             );
 
         let products_overstocked =
-            self.get_products_overstocked_count(&item_stats, show_over_stock_alerts as f64);
+            self.get_products_overstocked_count(&item_stats, show_over_stock_alerts);
 
         Ok(ItemCounts {
             total: total_count,

--- a/server/service/src/item/item.rs
+++ b/server/service/src/item/item.rs
@@ -195,7 +195,7 @@ pub fn get_products_at_risk_item_ids(
                 return None;
             }
             let months_of_stock = stats.total_stock_on_hand / stats.average_monthly_consumption;
-            let is_at_risk = months_of_stock < show_low_stock_alerts as f64;
+            let is_at_risk = months_of_stock < show_low_stock_alerts;
 
             (is_at_risk == product_at_risk).then_some(id)
         })

--- a/server/service/src/preference/preferences/days_in_month.rs
+++ b/server/service/src/preference/preferences/days_in_month.rs
@@ -14,6 +14,6 @@ impl Preference for DaysInMonth {
     }
 
     fn value_type(&self) -> PreferenceValueType {
-        PreferenceValueType::Integer
+        PreferenceValueType::Float
     }
 }

--- a/server/service/src/preference/preferences/number_of_months_threshold_to_show_low_stock_alerts_for_products.rs
+++ b/server/service/src/preference/preferences/number_of_months_threshold_to_show_low_stock_alerts_for_products.rs
@@ -3,7 +3,7 @@ use crate::preference::{PrefKey, Preference, PreferenceType, PreferenceValueType
 pub struct NumberOfMonthsThresholdToShowLowStockAlertsForProducts;
 
 impl Preference for NumberOfMonthsThresholdToShowLowStockAlertsForProducts {
-    type Value = i32;
+    type Value = f64;
 
     fn key(&self) -> PrefKey {
         PrefKey::NumberOfMonthsThresholdToShowLowStockAlertsForProducts
@@ -14,6 +14,6 @@ impl Preference for NumberOfMonthsThresholdToShowLowStockAlertsForProducts {
     }
 
     fn value_type(&self) -> PreferenceValueType {
-        PreferenceValueType::Integer
+        PreferenceValueType::Float
     }
 }

--- a/server/service/src/preference/preferences/number_of_months_threshold_to_show_over_stock_alerts_for_products.rs
+++ b/server/service/src/preference/preferences/number_of_months_threshold_to_show_over_stock_alerts_for_products.rs
@@ -3,7 +3,7 @@ use crate::preference::{PrefKey, Preference, PreferenceType, PreferenceValueType
 pub struct NumberOfMonthsThresholdToShowOverStockAlertsForProducts;
 
 impl Preference for NumberOfMonthsThresholdToShowOverStockAlertsForProducts {
-    type Value = i32;
+    type Value = f64;
 
     fn key(&self) -> PrefKey {
         PrefKey::NumberOfMonthsThresholdToShowOverStockAlertsForProducts
@@ -14,6 +14,6 @@ impl Preference for NumberOfMonthsThresholdToShowOverStockAlertsForProducts {
     }
 
     fn value_type(&self) -> PreferenceValueType {
-        PreferenceValueType::Integer
+        PreferenceValueType::Float
     }
 }

--- a/server/service/src/preference/types.rs
+++ b/server/service/src/preference/types.rs
@@ -67,6 +67,7 @@ pub enum PreferenceType {
 pub enum PreferenceValueType {
     Boolean,
     Integer,
+    Float,
     MultiChoice,
     // specific type to CustomTranslations preference
     CustomTranslations,

--- a/server/service/src/preference/upsert.rs
+++ b/server/service/src/preference/upsert.rs
@@ -46,9 +46,9 @@ pub struct UpsertPreferences {
     pub number_of_months_to_check_for_consumption_when_calculating_out_of_stock_products:
         Option<Vec<StorePrefUpdate<i32>>>,
     pub number_of_months_threshold_to_show_low_stock_alerts_for_products:
-        Option<Vec<StorePrefUpdate<i32>>>,
+        Option<Vec<StorePrefUpdate<f64>>>,
     pub number_of_months_threshold_to_show_over_stock_alerts_for_products:
-        Option<Vec<StorePrefUpdate<i32>>>,
+        Option<Vec<StorePrefUpdate<f64>>>,
     pub first_threshold_for_expiring_items: Option<Vec<StorePrefUpdate<i32>>>,
     pub second_threshold_for_expiring_items: Option<Vec<StorePrefUpdate<i32>>>,
     pub warn_when_missing_recent_stocktake:


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10894

# 👩🏻‍💻 What does this PR do?
- Adds float preference to support decimal places
- Changed under/overstock MOS threshold preferences to allow floats
- Days in months pref was already f64 value, so have changed that to float type too

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Login to store and edit store preferences: under / over stock alerts with some number to 2 decimal places
- [ ] Click save -> Should save
- [ ] Validate dashboard widgets still load and show correct values

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

