### PR TITLE
#11175 Fix infinite rerender on purchase order detail view

### DIFF
--- a/client/packages/common/src/intl/currency/currency.ts
+++ b/client/packages/common/src/intl/currency/currency.ts
@@ -1,3 +1,4 @@
+import { useCallback, useMemo } from 'react';
 import currency from 'currency.js';
 import { useAuthContext } from '../../authentication';
 import { MAX_FRACTION_DIGITS, useIntlUtils } from '../utils';
@@ -273,19 +274,27 @@ export const useCurrency = (code?: Currencies) => {
   const { currentLanguage: language } = useIntlUtils();
   const currencyCode = code ? code : (store?.homeCurrencyCode as Currencies);
 
-  const options = currencyOptions(language, currencyCode);
-  return {
-    c: (value: currency.Any, precision?: number) =>
+  const options = useMemo(
+    () => currencyOptions(language, currencyCode),
+    [language, currencyCode]
+  );
+
+  const c = useCallback(
+    (value: currency.Any, precision?: number) =>
       currency(value, {
         ...options,
         precision: precision ?? options.precision,
       }),
-    options,
-    currencyCode,
-  };
+    [options]
+  );
+
+  return { c, options, currencyCode };
 };
 
 export const useFormatCurrency = (code?: Currencies) => {
   const { c } = useCurrency(code);
-  return (value: currency.Any) => c(value).format();
+  return useCallback(
+    (value: currency.Any) => c(value).format(),
+    [c]
+  );
 };

--- a/client/packages/common/src/ui/layout/tables/tableState/useColumnOrder.ts
+++ b/client/packages/common/src/ui/layout/tables/tableState/useColumnOrder.ts
@@ -6,6 +6,7 @@ import {
   MRT_StatefulTableOptions,
   MRT_TableOptions,
 } from 'material-react-table';
+import { isEqual } from '@common/utils';
 import { getSavedState, updateSavedState, differentOrUndefined } from './utils';
 import { ColumnDef } from '../types';
 import { useGlobalTableDefaults } from './useGlobalTableConfig';
@@ -46,10 +47,13 @@ export const useColumnOrder = <T extends MRT_RowData>(
 
   // If initial state changes (due to plugin column loading, for example) and no
   // custom column order has been saved, update the column order to the new
-  // default
+  // default. Use functional updater to avoid rerender when content is unchanged.
   useEffect(() => {
     if (!getSavedState(tableId)?.columnOrder)
-      setState(globalDefaults?.columnOrder ?? initial);
+      setState(prev => {
+        const next = globalDefaults?.columnOrder ?? initial;
+        return isEqual(prev, next) ? prev : next;
+      });
   }, [initial, enableExpanding]);
 
   const update = useCallback<

--- a/client/packages/common/src/ui/layout/tables/tableState/useColumnOrder.ts
+++ b/client/packages/common/src/ui/layout/tables/tableState/useColumnOrder.ts
@@ -6,7 +6,6 @@ import {
   MRT_StatefulTableOptions,
   MRT_TableOptions,
 } from 'material-react-table';
-import { isEqual } from '@common/utils';
 import { getSavedState, updateSavedState, differentOrUndefined } from './utils';
 import { ColumnDef } from '../types';
 import { useGlobalTableDefaults } from './useGlobalTableConfig';
@@ -47,13 +46,10 @@ export const useColumnOrder = <T extends MRT_RowData>(
 
   // If initial state changes (due to plugin column loading, for example) and no
   // custom column order has been saved, update the column order to the new
-  // default. Use functional updater to avoid rerender when content is unchanged.
+  // default
   useEffect(() => {
     if (!getSavedState(tableId)?.columnOrder)
-      setState(prev => {
-        const next = globalDefaults?.columnOrder ?? initial;
-        return isEqual(prev, next) ? prev : next;
-      });
+      setState(globalDefaults?.columnOrder ?? initial);
   }, [initial, enableExpanding]);
 
   const update = useCallback<

--- a/client/packages/purchasing/src/purchase_order/context/purchaseOrderLineError.tsx
+++ b/client/packages/purchasing/src/purchase_order/context/purchaseOrderLineError.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useCallback, useContext, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
 import { PropsWithChildrenOnly, RecordWithId } from '@common/types';
 import { ItemCannotBeOrderedFragment } from '../api';
 
@@ -31,7 +37,10 @@ const usePurchaseOrderLineErrors = () => {
     setErrors({});
   }, []);
 
-  return { errors, setError, setErrors, getError, unsetError, unsetAll };
+  return useMemo(
+    () => ({ errors, setError, setErrors, getError, unsetError, unsetAll }),
+    [errors, setError, setErrors, getError, unsetError, unsetAll]
+  );
 };
 
 export type UsePurchaseOrderLineErrors = ReturnType<

--- a/client/packages/purchasing/src/purchase_order/context/purchaseOrderLineError.tsx
+++ b/client/packages/purchasing/src/purchase_order/context/purchaseOrderLineError.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useCallback, useContext, useState } from 'react';
 import { PropsWithChildrenOnly, RecordWithId } from '@common/types';
 import { ItemCannotBeOrderedFragment } from '../api';
 
@@ -9,23 +9,27 @@ const usePurchaseOrderLineErrors = () => {
     [purchaseOrderLineId: string]: PurchaseOrderLineError | undefined;
   }>({});
 
-  const getError = ({
-    id,
-  }: RecordWithId): PurchaseOrderLineError | undefined => {
-    return errors[id];
-  };
+  const getError = useCallback(
+    ({ id }: RecordWithId): PurchaseOrderLineError | undefined => {
+      return errors[id];
+    },
+    [errors]
+  );
 
-  const setError = (id: string, error: PurchaseOrderLineError) => {
-    setErrors(errors => ({ ...errors, [id]: error }));
-  };
+  const setError = useCallback(
+    (id: string, error: PurchaseOrderLineError) => {
+      setErrors(prev => ({ ...prev, [id]: error }));
+    },
+    []
+  );
 
-  const unsetError = (id: string) => {
-    setErrors(errors => ({ ...errors, [id]: undefined }));
-  };
+  const unsetError = useCallback((id: string) => {
+    setErrors(prev => ({ ...prev, [id]: undefined }));
+  }, []);
 
-  const unsetAll = () => {
+  const unsetAll = useCallback(() => {
     setErrors({});
-  };
+  }, []);
 
   return { errors, setError, setErrors, getError, unsetError, unsetAll };
 };


### PR DESCRIPTION
## Summary
- `useFormatCurrency` returned a new function reference on every render, cascading through `usePurchaseOrderColumns` → `useColumnOrder`, triggering a `setState` → rerender loop when no column order was saved in localStorage
- Memoized currency options and `formatCurrency` with `useMemo`/`useCallback` in `useCurrency`/`useFormatCurrency`
- Memoized error context callbacks and provider value in `usePurchaseOrderLineErrors` to prevent unnecessary consumer rerenders

Closes #11175

## Test plan
- [ ] Navigate to a purchase order detail view — confirm no infinite rerender / frozen UI
- [ ] Clear localStorage for the table (`@openmsupply-client/tables/purchase-order-detail-view`) and reload — confirm no infinite rerender
- [ ] Verify currency formatting still works correctly on PO line costs
- [ ] Verify column reordering and persistence still works
- [ ] Verify PO line error highlighting still works after a failed status change

🤖 Generated with [Claude Code](https://claude.com/claude-code)