### PR TITLE
Fix DateTimePicker firing mutation on intermediate year/month selection

### DIFF
--- a/client/packages/common/src/ui/components/inputs/DateTimePickers/DateTimePickerInput/DateTimePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DateTimePickers/DateTimePickerInput/DateTimePickerInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import {
   DateTimePicker,
   DateTimePickerProps,
@@ -72,6 +72,7 @@ export const DateTimePickerInput = ({
   const [internalError, setInternalError] = useState<string | null>(null);
   const [value, setValue] = useBufferState<Date | null>(props.value ?? null);
   const [isInitialEntry, setIsInitialEntry] = useState(true);
+  const pickerOpen = useRef(false);
   const t = useTranslation();
   const format =
     props.format === undefined ? (showTime ? 'P p' : 'P') : props.format;
@@ -105,6 +106,15 @@ export const DateTimePickerInput = ({
       <DateTimePicker
         format={format}
         onChange={(date, context) => {
+          // When the picker is open, intermediate view selections (e.g.
+          // clicking a year) fire onChange before the user has finished
+          // selecting. Only update internal state here; the final value is
+          // propagated via onAccept.
+          if (pickerOpen.current) {
+            setValue(date);
+            return;
+          }
+
           const { validationError } = context;
 
           if (validationError) {
@@ -117,11 +127,9 @@ export const DateTimePickerInput = ({
             setValue(date);
             return;
           }
-          if (!validationError) {
-            setIsInitialEntry(false);
-            setInternalError(null);
-          }
 
+          setIsInitialEntry(false);
+          setInternalError(null);
           handleDateInput(date);
         }}
         label={label}
@@ -164,8 +172,19 @@ export const DateTimePickerInput = ({
         maxDate={maxDate}
         disableFuture={disableFuture}
         closeOnSelect={true}
-        onOpen={() => setIsOpen?.(true)}
-        onClose={() => setIsOpen?.(false)}
+        onOpen={() => {
+          pickerOpen.current = true;
+          setIsOpen?.(true);
+        }}
+        onClose={() => {
+          pickerOpen.current = false;
+          setIsOpen?.(false);
+        }}
+        onAccept={date => {
+          setIsInitialEntry(false);
+          setInternalError(null);
+          handleDateInput(date);
+        }}
         {...props}
         value={value}
       />


### PR DESCRIPTION
Fixes #11179

# 👩🏻‍💻 What does this PR do?

Prevents `DateTimePickerInput` from propagating intermediate date values to the parent `onChange` when the user is still navigating views in the picker popup (e.g. clicking a year before selecting month and day).

MUI's `DateTimePicker` fires `onChange` on each view transition. Previously this propagated immediately, causing mutations with incomplete dates — triggering server validation errors like `CannotPutDeliveredDateAfterReceivedDate`.

Now:
- When the picker is open, `onChange` only updates internal state (`setValue`)
- The final value is propagated via MUI's `onAccept` callback, which fires only when the full selection is complete
- Keyboard input continues to propagate immediately as before
- Validation error state is properly cleared on accept, so stale errors from prior keyboard input don't persist

## 💌 Any notes for the reviewer?

This fixes the issue at the `DateTimePickerInput` component level, so all ~25 consumers benefit — not just the inbound shipment delivered date field.

The `ExpiryDateInput` wrapper already tracked `pickerOpen` via the `setIsOpen` prop for its own logic. That continues to work — `onAccept` fires before `onClose`, so `ExpiryDateInput`'s `pickerOpen` ref is still `true` when its `onChange` callback runs from `onAccept`.

# 🧪 Testing

- [ ] Open an inbound shipment (external) that has a received date
- [ ] Click to the right of the year number in the delivered date picker
- [ ] Confirm no server error fires — picker navigates to month view
- [ ] Complete the full date selection (year → month → day)
- [ ] Confirm the delivered date is updated correctly
- [ ] Test keyboard input still works (type a date directly, confirm it propagates)
- [ ] Test ExpiryDateInput (e.g. in stock line edit) still sets last day of month when using picker

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)