### PR TITLE
Update docker docs for production

### DIFF
--- a/docker/docker-hub.md
+++ b/docker/docker-hub.md
@@ -72,6 +72,17 @@ Or with FAKETIME, which will set server time at particular date, this does not w
 docker run -e LOAD_REFERENCE_FILE=reference1 -e FAKETIME="@2023-05-20 11:30:00" -p 9000:8000 msupplyfoundation/omsupply:v2.7.3
 ```
 
+## Production
+
+If used in production, it's important to persist database and to give each instance a unique UUID (hardware_id). Persisting database for sqlite flavour is done by mounting database folder (it's important to do this before initialising omSupply instance): `"$(pwd)/mydatabase":/database`. Default [test-uuid](https://github.com/msupply-foundation/open-msupply/blob/1f066619137959131866d291516d4b39e958b819/Dockerfile#L26) can be overwritten through `/etc/machine-id`. 
+
+Example command for mac:
+
+```bash
+echo $(ioreg -rd1 -c IOPlatformExpertDevice | awk '/IOPlatformUUID/ { print $3 }') > machine-id
+docker run -v "$(pwd)/mydatabase":/database -v "$(pwd)/machine-id":/etc/machine-id -p 9000:8000 msupplyfoundation/omsupply:v2.17.0
+```
+
 ## Dev 
 
 You can work on front end using the 'dev' flavour of omSupply image, it comes with all dependencies pre-installed (make sure clientdev folder is empty).

--- a/docker/docker-hub.md
+++ b/docker/docker-hub.md
@@ -14,7 +14,7 @@ Open mSupply is an open source logistic management system for medicine distribut
 
 # Image flavours
 
-Image comes with two flavours base, and dev (with -dev prefix). Dev image comes with client folder ready for development, with dependencies pre-installed
+Image comes with two flavours base, and dev (with -dev suffix). Dev image comes with client folder ready for development, with dependencies pre-installed
 
 # How to use this image
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

First part of #11182

# 👩🏻‍💻 What does this PR do?

A quick work around for hardware id protection for docker instance in production

I've updated docker hub docks with this change

# 🧪 Testing

Use docker image without mounting machine-id (still mount database), sync a site, run command in the doc (with same database), it should fail on syncing with hardware id problems (remember when testing on mac, local host won't be mounted to container's network and you'll need to use `host.docker.internal`)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

