### PR TITLE
10916 repack permission denied and yet i can perform the action

### DIFF
--- a/client/packages/system/src/ActivityLog/api/hooks/useActivityLog.ts
+++ b/client/packages/system/src/ActivityLog/api/hooks/useActivityLog.ts
@@ -13,7 +13,8 @@ import { ACTIVITY_LOG } from './keys';
 export function useActivityLog(
   recordId: string,
   logType?: ActivityLogNodeType,
-  sortBy?: SortBy<ActivityLogRowFragment>
+  sortBy?: SortBy<ActivityLogRowFragment>,
+  enabled: boolean = true
 ) {
   const { activityLogApi } = useActivityLogGraphQL();
 
@@ -37,7 +38,11 @@ export function useActivityLog(
     return { nodes, totalCount };
   };
 
-  const query = useQuery({ queryKey, queryFn });
+  const query = useQuery({
+    queryKey,
+    queryFn,
+    enabled,
+  });
   return query;
 }
 

--- a/client/packages/system/src/ActivityLog/api/hooks/useActivityLog.ts
+++ b/client/packages/system/src/ActivityLog/api/hooks/useActivityLog.ts
@@ -12,9 +12,9 @@ import { ACTIVITY_LOG } from './keys';
 
 export function useActivityLog(
   recordId: string,
+  enabled: boolean = true,
   logType?: ActivityLogNodeType,
-  sortBy?: SortBy<ActivityLogRowFragment>,
-  enabled: boolean = true
+  sortBy?: SortBy<ActivityLogRowFragment>
 ) {
   const { activityLogApi } = useActivityLogGraphQL();
 

--- a/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
+++ b/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
@@ -22,6 +22,7 @@ import {
   NothingHere,
   ActivityLogNodeType,
   Link,
+  useAuthContext,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { RepackEditForm } from './RepackEditForm';
@@ -53,9 +54,14 @@ export const RepackModal: FC<RepackModalControlProps> = ({
   const [invoiceId, setInvoiceId] = useState<string | undefined>(undefined);
   const [isNew, setIsNew] = useState<boolean>(false);
 
+  const { userHasPermission } = useAuthContext();
+  const hasLogPermission = userHasPermission(UserPermission.LogQuery);
+
   const { data: logData } = useActivityLog(
     stockLine?.id ?? '',
-    ActivityLogNodeType.Repack
+    ActivityLogNodeType.Repack,
+    undefined,
+    hasLogPermission
   );
   const toLogData = logData?.nodes.find(node => !!node.from);
 

--- a/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
+++ b/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
@@ -59,9 +59,9 @@ export const RepackModal: FC<RepackModalControlProps> = ({
 
   const { data: logData } = useActivityLog(
     stockLine?.id ?? '',
+    hasLogPermission,
     ActivityLogNodeType.Repack,
     undefined,
-    hasLogPermission
   );
   const toLogData = logData?.nodes.find(node => !!node.from);
 

--- a/server/service/src/auth.rs
+++ b/server/service/src/auth.rs
@@ -567,7 +567,10 @@ fn all_permissions() -> HashMap<Resource, PermissionDSL> {
 
     map.insert(
         Resource::QueryLog,
-        PermissionDSL::HasPermission(PermissionType::LogQuery),
+        PermissionDSL::And(vec![
+            PermissionDSL::HasStoreAccess,
+            PermissionDSL::HasPermission(PermissionType::LogQuery),
+        ]),
     );
 
     map.insert(Resource::QueryClinician, PermissionDSL::HasStoreAccess);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10916

# 👩🏻‍💻 What does this PR do?
Some extra information in the repack modal is fetched from the logs, have disabled the log api call if the user doesn't have permission. Also found #11188 while playin' around

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] In OG, take away view log permission for your user
- [ ] Sync. (Log out / Log in just to be sure)
- [ ] Go to repack a stock line 
- [ ] Shouldn't see permission denied

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

