### PR TITLE
#11059 Add Claude auto-review and general-purpose workflows

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -7,7 +7,15 @@ jobs:
   review:
     if: |
       contains(github.event.comment.body, '@review') &&
-      github.event.issue.pull_request != null
+      github.event.issue.pull_request != null &&
+      contains(
+        fromJson('["OWNER","MEMBER","COLLABORATOR"]'),
+        github.event.comment.author_association
+      )
+    # Don't run multiple reviews at the same time on the same PR
+    concurrency:
+      group: claude-review-${{ github.event.issue.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -23,8 +31,8 @@ jobs:
             repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
             --method POST \
             -f content="eyes"
-    
-      - uses: actions/checkout@v6
+
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -34,10 +42,11 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          base_branch: develop # Restores .claude, .mcp.json, .claude.json, .gitmodules, .ripgreprc from develop (PR head is untrusted)
+          # Restores .claude, .mcp.json, .claude.json, .gitmodules, .ripgreprc from develop (PR head is untrusted)
+          base_branch: develop
           claude_args: |
-            --allowedTools "mcp__github__pull_request_read,mcp__github__issue_read,mcp__github__pull_request_review_write,mcp__github__add_comment_to_pending_review"
-            --mcp-config '{"mcpServers":{"github":{"command":"docker","args":["run","-i","--rm","-e","GITHUB_PERSONAL_ACCESS_TOKEN","ghcr.io/github/github-mcp-server"],"env":{"GITHUB_PERSONAL_ACCESS_TOKEN":"${{ secrets.GITHUB_TOKEN }}"}}}}' 
+            --allowedTools "Read,Glob,Grep,mcp__github__pull_request_read,mcp__github__search_pull_requests,mcp__github__list_commits,mcp__github__get_commit,mcp__github__get_file_contents,mcp__github__issue_read,mcp__github__search_issues,mcp__github__pull_request_review_write,mcp__github__add_comment_to_pending_review"
+            --mcp-config '{"mcpServers":{"github":{"command":"docker","args":["run","-i","--rm","-e","GITHUB_PERSONAL_ACCESS_TOKEN","ghcr.io/github/github-mcp-server"],"env":{"GITHUB_PERSONAL_ACCESS_TOKEN":"${{ secrets.GITHUB_TOKEN }}"}}}}'
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.issue.number }}
@@ -83,7 +92,7 @@ jobs:
             repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
             --method POST \
             -f content="confused"
-      
+
           gh api \
             repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments \
             --method POST \

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -1,0 +1,90 @@
+name: Claude Auto Review
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    if: |
+      contains(github.event.comment.body, '@review') &&
+      github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      actions: read
+    steps:
+      - name: React with eyes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            --method POST \
+            -f content="eyes"
+    
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Claude Code Review
+        id: claude_review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          base_branch: develop # Restores .claude, .mcp.json, .claude.json, .gitmodules, .ripgreprc from develop (PR head is untrusted)
+          claude_args: |
+            --allowedTools "mcp__github__pull_request_read,mcp__github__issue_read,mcp__github__pull_request_review_write,mcp__github__add_comment_to_pending_review"
+            --mcp-config '{"mcpServers":{"github":{"command":"docker","args":["run","-i","--rm","-e","GITHUB_PERSONAL_ACCESS_TOKEN","ghcr.io/github/github-mcp-server"],"env":{"GITHUB_PERSONAL_ACCESS_TOKEN":"${{ secrets.GITHUB_TOKEN }}"}}}}' 
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.issue.number }}
+
+            Review this pull request and submit a single unified GitHub review using the MCP tools.
+            Note: The PR branch is already checked out in the current working directory.
+
+            Steps:
+            1. Use `mcp__github__pull_request_read` with method `get_diff` to read the diff
+            2. Use `mcp__github__pull_request_review_write` with method `create_pending` to open a pending review
+            3. For each file-specific finding, use `mcp__github__add_comment_to_pending_review`
+               with owner, repo, pullNumber, path, line, side ("RIGHT"), subjectType ("LINE"), and body
+            4. Use `mcp__github__pull_request_review_write` to submit with:
+               - event: "REQUEST_CHANGES" if any must fix severity findings exist
+               - event: "COMMENT" if only should fix/nit findings
+               - body: a summary of all findings grouped by severity
+
+            Make sure to find any associated issue(s) and compare the features implemented by the PR with the associated issue(s).
+            Make sure there is complete coverage of the issue and note anything added by the PR that isn't in the issue.
+            Note any tests that would be important to add not already in the PR.
+            Note this in the main summary body.
+
+            Severity guide:
+            - 🔴 **Must fix** — bugs, security issues, data loss risks
+            - 🟡 **Should fix** — code quality, consistency, maintainability
+            - 🟢 **Nit** — style, naming, minor suggestions
+
+            If you run into a critical permission issue or other error stopping you from completing the review, abort the review and simply post a review comment on the PR detailing what went wrong, what permission you need and why you need it.
+
+      - name: Upload Claude logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-logs
+          path: /home/runner/work/_temp/claude-execution-output.json
+
+      - name: React with failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            --method POST \
+            -f content="confused"
+      
+          gh api \
+            repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments \
+            --method POST \
+            -f body="❌ Claude review failed — check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -1,0 +1,39 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -13,10 +13,18 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      ) &&
+      contains(
+        fromJson('["OWNER","MEMBER","COLLABORATOR"]'),
+        github.event.comment.author_association ||
+        github.event.review.author_association ||
+        github.event.issue.author_association
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -26,7 +34,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -36,4 +44,5 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          base_branch: develop
           track_progress: true


### PR DESCRIPTION
Fixes #11059

# 👩🏻‍💻 What does this PR do?

Adds two GitHub Actions workflows for automated Claude Code integration:

1. **`claude-review.yaml`** — Triggered by `@review` comments on PRs. Runs a structured Claude code review that:
   - Reads the PR diff via MCP GitHub tools
   - Compares implementation against the linked issue for coverage
   - Submits a unified GitHub review with inline comments
   - Uses severity levels (🔴 Must fix / 🟡 Should fix / 🟢 Nit)
   - Posts failure notifications if the review errors out

2. **`claude.yaml`** — General-purpose Claude Code action triggered by `@claude` mentions in issue comments, PR review comments, PR reviews, and new issues. Enables conversational AI assistance directly in GitHub.

Both workflows use the `anthropics/claude-code-action@v1` action with API key or OAuth token secrets. The review workflow restricts Claude to read-only + review tools via `--allowedTools`, while the general-purpose workflow has broader permissions (contents write, PRs, issues).

## 💌 Any notes for the reviewer?

- **Secrets required**: `ANTHROPIC_API_KEY` **or** `CLAUDE_CODE_OAUTH_TOKEN` must be configured in the repo settings
- The both workflows use `base_branch: develop` to restore trusted config files (`.claude`, `.mcp.json`, etc.) from develop rather than the PR branch
- The review workflow uses Docker to run the GitHub MCP server — ensure GitHub Actions runners have Docker available (they do by default on `ubuntu-latest`)
- The general-purpose workflow has `contents: write` permission, so Claude can push commits when asked

**Implementation vs issue notes:**
- The issue mentioned "compare with the issue for coverage" — the review workflow prompt explicitly instructs Claude to find associated issues and compare feature coverage
- The issue was a general cooldown/exploration task; this PR delivers a concrete first implementation of both review and general-purpose workflows

# 🧪 Testing

- [ ] Open a test PR against this branch
- [ ] Comment `@review` on the test PR and verify Claude submits a review with inline comments and severity ratings
- [ ] Comment `@claude <question>` on an issue or PR and verify Claude responds
- [ ] Verify the "eyes" reaction appears on the triggering comment for reviews
- [ ] Verify failure handling: if review fails, confirm "confused" reaction and error comment are posted

# 📃 Documentation

- [x] **No documentation required**: internal CI/workflow tooling, no user-facing changes