### PR TITLE
#11197 Date picker: navigate on month/year select

### DIFF
--- a/client/packages/common/src/ui/components/inputs/DateTimePickers/DateTimePickerInput/DateTimePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DateTimePickers/DateTimePickerInput/DateTimePickerInput.tsx
@@ -72,9 +72,14 @@ export const DateTimePickerInput = ({
   const [internalError, setInternalError] = useState<string | null>(null);
   const [value, setValue] = useBufferState<Date | null>(props.value ?? null);
   const [isInitialEntry, setIsInitialEntry] = useState(true);
+  const [currentView, setCurrentView] = useState<string | null>(null);
   const t = useTranslation();
   const format =
     props.format === undefined ? (showTime ? 'P p' : 'P') : props.format;
+
+  // Month/year selections are intermediate only when a day view exists.
+  // Default views always include 'day'; only explicit overrides (e.g. ExpiryDateInput) omit it.
+  const hasDayView = !props.views || (props.views as string[]).includes('day');
 
   const isDesktop = useMediaQuery('(pointer: fine)');
 
@@ -122,6 +127,15 @@ export const DateTimePickerInput = ({
             setInternalError(null);
           }
 
+          // Month/year picks should navigate, not set the date (unless there's no day view)
+          if (
+            date !== null &&
+            hasDayView &&
+            (currentView === 'month' || currentView === 'year')
+          ) {
+            return;
+          }
+
           handleDateInput(date);
         }}
         label={label}
@@ -164,9 +178,13 @@ export const DateTimePickerInput = ({
         maxDate={maxDate}
         disableFuture={disableFuture}
         closeOnSelect={true}
-        onOpen={() => setIsOpen?.(true)}
-        onClose={() => setIsOpen?.(false)}
         {...props}
+        onViewChange={newView => setCurrentView(newView)}
+        onOpen={() => setIsOpen?.(true)}
+        onClose={() => {
+          setCurrentView(null);
+          setIsOpen?.(false);
+        }}
         value={value}
       />
       {required && (


### PR DESCRIPTION
Fixes #11197

# 👩🏻‍💻 What does this PR do?

Prevents the date picker from updating the date value when selecting a month or year from the dropdown. Instead, month/year selections now just navigate the picker (like the month arrows do).

Pickers without a day view (e.g. ExpiryDateInput) still correctly set the date on month selection since month is their final selection step.

**How it works:** Tracks the current picker view via `onViewChange` + `useState`. When `onChange` fires, React's state batching means `currentView` still holds the *previous* view — so we can detect that the change came from a month/year navigation and suppress it.

## 💌 Any notes for the reviewer?

- Only one file changed: `DateTimePickerInput.tsx`
- The `hasDayView` check ensures ExpiryDateInput (and JsonForms Date/DateTime with `noDay`/`monthOnly`) still commit on month selection since they pass `views={['year', 'month']}` which omits `'day'`
- The `date !== null` guard ensures the Clear button still works from any view
- No changes needed to ExpiryDateInput or any other consumers

# 🧪 Testing

- [ ] Open any date picker → click the month/year header → select a different month → should navigate to that month's day view **without** changing the date → select a day → date should update
- [ ] Open an expiry date picker → select a month → date should update to last day of that month (existing behaviour preserved)
- [ ] Type a date via keyboard in any date picker → should update immediately as before
- [ ] Open a date picker, navigate to a different month, then click outside to dismiss → date should not change
- [ ] Click the Clear button while viewing month/year selection → should clear the date

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour