### PR TITLE
#11167 Add New status transitions for external inbound shipments

### DIFF
--- a/client/packages/invoices/src/statuses.ts
+++ b/client/packages/invoices/src/statuses.ts
@@ -129,6 +129,12 @@ const INBOUND_INTERNAL_NEXT: NextStatusMap = {
 };
 
 const INBOUND_EXTERNAL_NEXT: NextStatusMap = {
+  [InvoiceNodeStatus.New]: [
+    InvoiceNodeStatus.Shipped,
+    InvoiceNodeStatus.Delivered,
+    InvoiceNodeStatus.Received,
+    InvoiceNodeStatus.Verified,
+  ],
   [InvoiceNodeStatus.Shipped]: [
     InvoiceNodeStatus.Delivered,
     InvoiceNodeStatus.Received,


### PR DESCRIPTION
Fixes #11167

# 👩🏻‍💻 What does this PR do?

Adds the missing `New` status entry to `INBOUND_EXTERNAL_NEXT` in `statuses.ts`, so that PO-linked (external) inbound shipments can transition from `New` → `Shipped` / `Delivered` / `Received` / `Verified`.

Previously, the next-status button didn't render at all for external inbound shipments in `New` status because `getNextValidStatuses()` returned an empty array.

## 💌 Any notes for the reviewer?

One-line fix in the status transition map. `INBOUND_MANUAL_NEXT` already had a `New` entry; `INBOUND_EXTERNAL_NEXT` was simply missing one. `INBOUND_INTERNAL_NEXT` is left unchanged since internal inbound shipment status is driven by the supplying store's outbound shipment.

# 🧪 Testing

- [ ] Create a purchase order and send it
- [ ] Create an inbound shipment from that purchase order
- [ ] Open the new inbound shipment
- [ ] Verify the status change button appears in the footer
- [ ] Confirm you can transition through `New` → `Shipped` → `Delivered` → `Received` → `Verified`

# 📃 Documentation

- [x] **No documentation required**: bug fix restoring expected behaviour