### PR TITLE
Translations update from mSupply Foundation Translation Server

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1519,7 +1519,7 @@
   "label.rows-per-page": "Rows per page:",
   "label.rtmd": "mSupply",
   "label.save-log": "Save log to file",
-  "label.save-table-config-as-global-default": "Save table config as global default",
+  "label.save-table-config-as-global-default": "Save table changes as global default",
   "label.schedule": "Schedule",
   "label.schedule-next-encounter": "Schedule next encounter",
   "label.search-results": "Search results",


### PR DESCRIPTION
Translations update from [mSupply Foundation Translation Server](https://translate.msupply.org) for [Open mSupply/Common](https://translate.msupply.org/projects/open-msupply/common/).


It also includes following components:

* [Open mSupply/Desktop](https://translate.msupply.org/projects/open-msupply/desktop/)



Current translation status:

![Weblate translation status](https://translate.msupply.org/widget/open-msupply/common/horizontal-auto.svg)