### PR TITLE
Fix Status History dates in timezones ahead of UTC

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/Tabs/StatusLogs.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/Tabs/StatusLogs.tsx
@@ -174,7 +174,7 @@ const StatusLog = ({
                 lineHeight: 2,
               })}
             >
-              {localisedDate(log.logDatetime + 'Z')}
+              {localisedDate(log.logDatetime)}
             </Typography>
             <StatusChip
               label={status ? t(status.label) : undefined}

--- a/client/packages/coldchain/src/Equipment/DetailView/Tabs/StatusLogs.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/Tabs/StatusLogs.tsx
@@ -174,7 +174,7 @@ const StatusLog = ({
                 lineHeight: 2,
               })}
             >
-              {localisedDate(log.logDatetime)}
+              {localisedDate(log.logDatetime + 'Z')}
             </Typography>
             <StatusChip
               label={status ? t(status.label) : undefined}

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -53,7 +53,20 @@ const URL_QUERY_DATE_TIME = 'yyyy-MM-dd HH:mm';
 
 const dateInputHandler = (date: Date | string | number): Date => {
   // Assume a string is an ISO date-time string
-  if (typeof date === 'string') return parseISO(date);
+  if (typeof date === 'string') {
+    // NaiveDateTime strings from the server have no timezone suffix but are
+    // stored as UTC. Without the 'Z', parseISO treats them as local time,
+    // which shifts dates in timezones ahead of UTC. Appending 'Z' ensures
+    // they are parsed as UTC. Date-only strings (no 'T') are left as-is.
+    const tIndex = date.indexOf('T');
+    if (
+      tIndex !== -1 &&
+      !date.endsWith('Z') &&
+      !/[+-]/.test(date.substring(tIndex))
+    )
+      return parseISO(date + 'Z');
+    return parseISO(date);
+  }
   // Assume a number is a UNIX timestamp
   if (typeof date === 'number') return fromUnixTime(date);
   return date as Date;

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -57,14 +57,11 @@ const dateInputHandler = (date: Date | string | number): Date => {
     // Any dates we receive from the server without timezone information are
     // assumed to be in UTC time
     const tIndex = date.indexOf('T');
-    if (
+    const needsUtcSuffix =
       tIndex !== -1 &&
       !date.endsWith('Z') &&
-      !/[+-]/.test(date.substring(tIndex))
-    ) {
-      return parseISO(date + 'Z');
-    }
-    return parseISO(date);
+      !/[+-]/.test(date.substring(tIndex));
+    return parseISO(needsUtcSuffix ? date + 'Z' : date);
   }
   // Assume a number is a UNIX timestamp
   if (typeof date === 'number') return fromUnixTime(date);

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -54,17 +54,16 @@ const URL_QUERY_DATE_TIME = 'yyyy-MM-dd HH:mm';
 const dateInputHandler = (date: Date | string | number): Date => {
   // Assume a string is an ISO date-time string
   if (typeof date === 'string') {
-    // NaiveDateTime strings from the server have no timezone suffix but are
-    // stored as UTC. Without the 'Z', parseISO treats them as local time,
-    // which shifts dates in timezones ahead of UTC. Appending 'Z' ensures
-    // they are parsed as UTC. Date-only strings (no 'T') are left as-is.
+    // Any dates we receive from the server without timezone information are
+    // assumed to be in UTC time
     const tIndex = date.indexOf('T');
     if (
       tIndex !== -1 &&
       !date.endsWith('Z') &&
       !/[+-]/.test(date.substring(tIndex))
-    )
+    ) {
       return parseISO(date + 'Z');
+    }
     return parseISO(date);
   }
   // Assume a number is a UNIX timestamp

--- a/server/graphql/asset/src/types/asset.rs
+++ b/server/graphql/asset/src/types/asset.rs
@@ -2,7 +2,7 @@ use std::vec;
 
 use async_graphql::dataloader::DataLoader;
 use async_graphql::*;
-use chrono::NaiveDate;
+use chrono::{DateTime, NaiveDate, Utc};
 use repository::asset_log_row::AssetLogStatus;
 use serde_json;
 
@@ -147,12 +147,12 @@ impl AssetNode {
         self.row().replacement_date
     }
 
-    pub async fn created_datetime(&self) -> &chrono::NaiveDateTime {
-        &self.row().created_datetime
+    pub async fn created_datetime(&self) -> DateTime<Utc> {
+        DateTime::<Utc>::from_naive_utc_and_offset(self.row().created_datetime, Utc)
     }
 
-    pub async fn modified_datetime(&self) -> &chrono::NaiveDateTime {
-        &self.row().modified_datetime
+    pub async fn modified_datetime(&self) -> DateTime<Utc> {
+        DateTime::<Utc>::from_naive_utc_and_offset(self.row().modified_datetime, Utc)
     }
 
     pub async fn store(&self, ctx: &Context<'_>) -> Result<Option<StoreNode>> {

--- a/server/graphql/asset/src/types/asset_log.rs
+++ b/server/graphql/asset/src/types/asset_log.rs
@@ -2,6 +2,7 @@ use std::vec;
 
 use async_graphql::dataloader::DataLoader;
 use async_graphql::*;
+use chrono::{DateTime, Utc};
 use graphql_core::generic_filters::{
     DatetimeFilterInput, EqualFilterStringInput, StringFilterInput,
 };
@@ -141,8 +142,8 @@ impl AssetLogNode {
         }
     }
 
-    pub async fn log_datetime(&self) -> &chrono::NaiveDateTime {
-        &self.row().log_datetime
+    pub async fn log_datetime(&self) -> DateTime<Utc> {
+        DateTime::<Utc>::from_naive_utc_and_offset(self.row().log_datetime, Utc)
     }
 
     pub async fn documents(&self, ctx: &Context<'_>) -> Result<SyncFileReferenceConnector> {

--- a/server/graphql/types/src/types/sync_file_reference.rs
+++ b/server/graphql/types/src/types/sync_file_reference.rs
@@ -1,5 +1,5 @@
 use async_graphql::*;
-use chrono::NaiveDateTime;
+use chrono::{DateTime, Utc};
 use graphql_core::simple_generic_errors::NodeError;
 use repository::sync_file_reference::SyncFileReference;
 use service::{usize_to_u32, ListResult};
@@ -37,8 +37,11 @@ impl SyncFileReferenceNode {
         &self.row().sync_file_reference_row.mime_type
     }
 
-    pub async fn created_datetime(&self) -> &NaiveDateTime {
-        &self.row().sync_file_reference_row.created_datetime
+    pub async fn created_datetime(&self) -> DateTime<Utc> {
+        DateTime::<Utc>::from_naive_utc_and_offset(
+            self.row().sync_file_reference_row.created_datetime,
+            Utc,
+        )
     }
 }
 


### PR DESCRIPTION
Closes #11206 

## Summary
- The Status History tab on assets shows incorrect dates for users in timezones ahead of UTC (e.g. a status update made on April 10 NZST shows as April 9)
- Root cause: `NaiveDateTime` fields from the server (e.g. `log_datetime`) have no timezone suffix, so `parseISO` treats them as local time instead of UTC
- This PR implements both a backend fix (root cause) and a frontend safety net

### Backend fix
Converts the 3 remaining GraphQL files that still returned raw `NaiveDateTime` to use `DateTime<Utc>`, matching the pattern used throughout the rest of the codebase:
- `asset_log.rs` — `log_datetime`
- `asset.rs` — `created_datetime`, `modified_datetime`
- `sync_file_reference.rs` — `created_datetime`

This ensures the server always includes a `Z` suffix on these datetime fields.

### Frontend safety net
Adds a guard in `dateInputHandler` (`DateUtils.ts`) that detects datetime strings with a time component (`T`) but no timezone suffix and appends `Z` before parsing. This protects against any future `NaiveDateTime` fields that might be missed on the backend, and covers all ~20 formatting call sites in a single change.

### Affected areas
- **coldchain**: asset status logs, asset summary, mobile log cards, temperature breach cells/modals, breach popovers, notifications
- **invoices**: inbound/outbound shipment side panels, prescription details
- **requisitions**: side bar components, RnR form side panel
- **system**: activity log list, item ledger, encounter detail/side panel, vaccination modal, name details
- **inventory**: stocktake side panel
- **programs**: encounter line chart, historic encounter data, program events
- **common**: column defaults for date/datetime columns, StatusCrumbs

## Test plan
- [ ] Set system timezone to UTC+12 (e.g. NZST)
- [ ] Create or update an asset status before noon local time (so the UTC date is the previous day)
- [ ] Open the asset's Status History tab and verify the date shows **today**, not yesterday
- [ ] Verify date-only fields (e.g. date of birth, vaccination date) still display correctly
- [ ] Verify datetimes that already have `Z` suffix (e.g. invoice created dates) still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)