### PR TITLE
#10966: Hide add item button on mobile in inbound shipment

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -121,6 +121,7 @@ const DetailViewInner = () => {
   const simplifiedTabletView = useSimplifiedTabletUI();
 
   const isExtraSmallScreen = useIsExtraSmallScreen();
+  const canAddItem = !isDisabled && !isExtraSmallScreen;
 
   const [editPurchaseOrderLineId, setEditPurchaseOrderLineId] = useState<
     string | null
@@ -192,12 +193,12 @@ const DetailViewInner = () => {
         : { field: 'item.code' },
       isLoading: false,
       initialSort: { key: 'itemName', dir: 'asc' },
-      onRowClick: !isDisabled && !isExtraSmallScreen ? onRowClick : undefined,
+      onRowClick: canAddItem ? onRowClick : undefined,
       getIsPlaceholderRow: row => isInboundPlaceholderRow(row.original),
       noDataElement: (
         <NothingHere
           body={t('error.no-inbound-items')}
-          onCreate={isDisabled ? undefined : () => onAddItem()}
+          onCreate={canAddItem ? () => onAddItem() : undefined}
           buttonText={t('button.add-item')}
         />
       ),


### PR DESCRIPTION
Fixes https://github.com/msupply-foundation/open-msupply/issues/10966

# 👩🏻‍💻 What does this PR do?

Hides the "Add item" button in the `NothingHere` component on mobile for the inbound shipment detail view.

On mobile, line-by-line editing is not supported — users should use the scanner approach instead. The `AppBarButtons` component already hid the add button on small screens, but the empty state (`NothingHere`) still showed it.

Extracts a shared `canAddItem` variable that combines `!isDisabled && !isExtraSmallScreen`, used by both `onRowClick` and the `NothingHere` `onCreate` prop.

<img width="723" height="521" alt="image" src="https://github.com/user-attachments/assets/85f16118-f391-45ec-ab4e-33cd8dd76e74" />


## 💌 Any notes for the reviewer?

Small change — only touches `DetailView.tsx`. The `AppBarButtons` component already had its own mobile guard; this brings the empty-state button in line with that behaviour.

# 🧪 Testing

- [ ] Open an inbound shipment detail view on a mobile/extra-small screen
- [ ] Verify the "Add item" button does not appear in the empty state
- [ ] Verify the scanner button still appears in the app bar
- [ ] Open the same view on desktop and verify the "Add item" button still works as before

# 📃 Documentation

- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend