### PR TITLE
#11094 Move auth token to HttpOnly cookie

### DIFF
--- a/client/packages/common/src/api/GqlContext.tsx
+++ b/client/packages/common/src/api/GqlContext.tsx
@@ -5,7 +5,7 @@ import {
   RequestOptions,
   Variables,
 } from 'graphql-request';
-import { AuthError, getAuthCookie } from '../authentication/AuthContext';
+import { AuthError } from '../authentication/AuthContext';
 import { LocalStorage } from '../localStorage';
 import { DocumentNode } from 'graphql';
 import { RequestConfig } from 'graphql-request/build/esm/types';
@@ -103,7 +103,8 @@ class GQLClient extends GraphQLClient {
       return new Promise(() => this.emptyData);
     }
 
-    super.setHeader('Authorization', `Bearer ${getAuthCookie().token}`);
+    // Auth token is in an HttpOnly cookie — sent automatically by the browser
+    // via credentials: 'include'. No need to set an Authorization header.
     const response = options.document
       ? super.request(options)
       : super.request(

--- a/client/packages/common/src/authentication/AuthContext.tsx
+++ b/client/packages/common/src/authentication/AuthContext.tsx
@@ -2,9 +2,8 @@
 import React, { useMemo, useState, useEffect, FC } from 'react';
 import { AppRoute } from '@openmsupply-client/config';
 import { useLocalStorage } from '../localStorage';
-import Cookies from 'js-cookie';
-import { addMinutes } from 'date-fns/addMinutes';
 import { useLogin, useGetUserPermissions, useRefreshToken } from './api/hooks';
+import { clearTokenExpiry } from './api/hooks/useRefreshToken';
 import { AuthenticationResponse } from './api';
 import { UserStoreNodeFragment } from './api/operations.generated';
 import { PropsWithChildrenOnly, UserPermission } from '@common/types';
@@ -14,8 +13,8 @@ import { createRegisteredContext } from 'react-singleton-context';
 import { useUpdateUserInfo } from './hooks/useUpdateUserInfo';
 import { useUserActivity } from './hooks/useUserActivity';
 
-const AUTH_TOKEN_LIFETIME_MINUTES = 60;
 const TOKEN_CHECK_INTERVAL = 60 * 1000;
+const AUTH_STATE_KEY = 'auth_state';
 
 export enum AuthError {
   NoStoreAssigned = 'NoStoreAssigned',
@@ -25,10 +24,8 @@ export enum AuthError {
   Timeout = 'Timeout',
 }
 
-export interface AuthCookie {
-  expires?: Date;
+export interface AuthState {
   store?: UserStoreNodeFragment;
-  token: string;
   user?: User;
 }
 
@@ -56,7 +53,7 @@ interface AuthControl {
   setStore: (store: UserStoreNodeFragment) => Promise<void>;
   store?: UserStoreNodeFragment;
   storeId: string;
-  token: string;
+  isAuthenticated: boolean;
   user?: User;
   userHasPermission: (permission: UserPermission) => boolean;
   updateUserIsLoading: boolean;
@@ -65,25 +62,26 @@ interface AuthControl {
   updateUser: () => Promise<void>;
 }
 
-export const getAuthCookie = (): AuthCookie => {
-  const authString = Cookies.get('auth');
-  const emptyCookie = { token: '' };
-  if (!!authString) {
-    try {
-      const parsed = JSON.parse(authString) as AuthCookie;
-      return parsed;
-    } catch {
-      return emptyCookie;
-    }
+/**
+ * Persist auth state (user info, store) to localStorage.
+ * The actual JWT is in an HttpOnly cookie — only metadata is stored here.
+ */
+const saveAuthState = (state: AuthState | undefined) => {
+  if (state) {
+    localStorage.setItem(AUTH_STATE_KEY, JSON.stringify(state));
+  } else {
+    localStorage.removeItem(AUTH_STATE_KEY);
   }
-  return emptyCookie;
 };
 
-export const setAuthCookie = (cookie: AuthCookie) => {
-  const expires = addMinutes(new Date(), AUTH_TOKEN_LIFETIME_MINUTES); // Decide when to refresh
-  const authCookie = { ...cookie, expires };
-
-  Cookies.set('auth', JSON.stringify(authCookie), { expires });
+const loadAuthState = (): AuthState | undefined => {
+  try {
+    const stored = localStorage.getItem(AUTH_STATE_KEY);
+    if (!stored) return undefined;
+    return JSON.parse(stored) as AuthState;
+  } catch {
+    return undefined;
+  }
 };
 
 const authControl = {
@@ -93,7 +91,7 @@ const authControl = {
   logout: () => { },
   setStore: (_store: UserStoreNodeFragment) => new Promise<void>(() => ({})),
   storeId: 'store-id',
-  token: '',
+  isAuthenticated: false,
   userHasPermission: (_permission: UserPermission) => false,
   updateUserIsLoading: false,
   updateUser: () => new Promise<void>(() => { }),
@@ -106,44 +104,48 @@ const AuthContext = createRegisteredContext<AuthControl>(
 const { Provider } = AuthContext;
 
 export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
-  const authCookie = getAuthCookie();
-  const [cookie, setCookie] = useState<AuthCookie | undefined>(authCookie);
+  const savedState = loadAuthState();
+  const [authState, setAuthState] = useState<AuthState | undefined>(
+    savedState
+  );
   const [error, setError] = useLocalStorage('/error/auth');
-  const storeId = cookie?.store?.id ?? '';
+  const storeId = authState?.store?.id ?? '';
   const {
     login,
     isLoggingIn,
     upsertMostRecentCredential,
     mostRecentCredentials,
-  } = useLogin(setCookie);
+  } = useLogin(setAuthState);
   const getUserPermissions = useGetUserPermissions();
   const { isActive } = useUserActivity();
-  const { refreshToken } = useRefreshToken(
-    () => {
-      Cookies.remove('auth');
-      setCookie(undefined);
-      setError(AuthError.Timeout);
-    },
-  );
+  const { refreshToken } = useRefreshToken(() => {
+    setAuthState(undefined);
+    saveAuthState(undefined);
+    clearTokenExpiry();
+    setError(AuthError.Timeout);
+  });
 
   const mostRecentUsername = mostRecentCredentials[0]?.username ?? undefined;
 
+  // Persist auth state to localStorage whenever it changes
+  useEffect(() => {
+    saveAuthState(authState);
+  }, [authState]);
+
   const setStore = async (store: UserStoreNodeFragment) => {
-    if (!cookie?.token) return;
+    if (!authState) return;
 
     upsertMostRecentCredential(mostRecentUsername ?? '', store);
 
-    const permissions = await getUserPermissions(cookie?.token, store);
+    const permissions = await getUserPermissions(store);
     const user = {
-      id: cookie.user?.id ?? '',
-      name: cookie.user?.name ?? '',
+      id: authState.user?.id ?? '',
+      name: authState.user?.name ?? '',
       permissions,
-      email: cookie.user?.email,
-      jobTitle: cookie.user?.jobTitle,
+      email: authState.user?.email,
+      jobTitle: authState.user?.jobTitle,
     };
-    const newCookie = { ...cookie, store, user };
-    setAuthCookie(newCookie);
-    setCookie(newCookie);
+    setAuthState({ ...authState, store, user });
   };
 
   const {
@@ -151,16 +153,17 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
     lastSuccessfulSync,
     updateUser,
     error: updateUserError,
-  } = useUpdateUserInfo(setCookie, cookie, mostRecentCredentials);
+  } = useUpdateUserInfo(setAuthState, authState, mostRecentCredentials);
 
   const logout = () => {
-    Cookies.remove('auth');
     setError(undefined);
-    setCookie(undefined);
+    setAuthState(undefined);
+    saveAuthState(undefined);
+    clearTokenExpiry();
   };
 
   const userHasPermission = (permission: UserPermission) =>
-    cookie?.user?.permissions.some(p => p === permission) || false;
+    authState?.user?.permissions.some(p => p === permission) || false;
 
   const val = useMemo(
     () => ({
@@ -169,9 +172,9 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
       login,
       logout,
       storeId,
-      token: cookie?.token || '',
-      user: cookie?.user,
-      store: cookie?.store,
+      isAuthenticated: !!authState,
+      user: authState?.user,
+      store: authState?.store,
       mostRecentUsername,
       setStore,
       setError,
@@ -183,7 +186,7 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
     }),
     [
       login,
-      cookie,
+      authState,
       error,
       mostRecentUsername,
       isLoggingIn,
@@ -194,11 +197,8 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
   );
 
   useEffect(() => {
-    // check every minute for a valid token
-    // if the cookie has expired, raise an auth error
+    // check every minute for a valid session
     const timer = window.setInterval(() => {
-      const authCookie = getAuthCookie();
-      const { token } = authCookie;
       const isInitScreen = matchPath(
         RouteBuilder.create(AppRoute.Initialise).addWildCard().build(),
         location.pathname
@@ -212,7 +212,7 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
       const isNotAuthPath = isDiscoveryScreen || isInitScreen;
       if (isNotAuthPath) return;
 
-      if (!token) {
+      if (!authState) {
         setError(AuthError.Timeout);
         window.clearInterval(timer);
         return;
@@ -223,7 +223,7 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
       }
     }, TOKEN_CHECK_INTERVAL);
     return () => window.clearInterval(timer);
-  }, [cookie?.token, isActive, refreshToken, setError]);
+  }, [authState, isActive, refreshToken, setError]);
 
   return <Provider value={val}>{children}</Provider>;
 };

--- a/client/packages/common/src/authentication/api/api.ts
+++ b/client/packages/common/src/authentication/api/api.ts
@@ -102,14 +102,9 @@ export const getAuthQueries = (sdk: Sdk, t: TypedTFunction<LocaleKey>) => ({
       const result = await sdk.isCentralServer();
       return result.isCentralServer;
     },
-    me: async (token?: string) => {
+    me: async () => {
       try {
-        const result = await sdk.me(
-          {},
-          {
-            Authorization: `Bearer ${token}`,
-          }
-        );
+        const result = await sdk.me();
         return result.me;
       } catch (e) {
         console.error(e);
@@ -117,20 +112,9 @@ export const getAuthQueries = (sdk: Sdk, t: TypedTFunction<LocaleKey>) => ({
         LocalStorage.setItem('/error/server', (e as Error).message);
       }
     },
-    permissions: async ({
-      storeId,
-      token,
-    }: {
-      storeId: string;
-      token?: string;
-    }) => {
+    permissions: async ({ storeId }: { storeId: string }) => {
       try {
-        const result = await sdk.permissions(
-          { storeId },
-          {
-            Authorization: `Bearer ${token}`,
-          }
-        );
+        const result = await sdk.permissions({ storeId });
         return result?.me?.permissions;
       } catch (e) {
         console.error(e);

--- a/client/packages/common/src/authentication/api/hooks/useAuthApi.ts
+++ b/client/packages/common/src/authentication/api/hooks/useAuthApi.ts
@@ -10,9 +10,9 @@ export const useAuthApi = () => {
   const queries = getAuthQueries(sdk, t);
 
   const keys = {
-    me: (token: string) => ['me', token] as const,
+    me: () => ['me'] as const,
     isCentralServer: ['isCentralServer'] as const,
-    refresh: (token: string) => ['refresh', token] as const,
+    refresh: () => ['refresh'] as const,
     userSync: () => ['userSync'] as const,
   };
 

--- a/client/packages/common/src/authentication/api/hooks/useGetUserPermissions.ts
+++ b/client/packages/common/src/authentication/api/hooks/useGetUserPermissions.ts
@@ -6,12 +6,10 @@ export const useGetUserPermissions = () => {
   const { mutateAsync: getPermissions } = useUserPermissions();
 
   const getUserPermissions = async (
-    token?: string,
     store?: UserStoreNodeFragment
   ): Promise<UserPermission[]> => {
     const permissions = await getPermissions({
       storeId: store?.id || '',
-      token,
     });
     return permissions?.nodes?.[0]?.permissions || [];
   };

--- a/client/packages/common/src/authentication/api/hooks/useLogin.ts
+++ b/client/packages/common/src/authentication/api/hooks/useLogin.ts
@@ -1,7 +1,9 @@
-import { AuthCookie, AuthError, setAuthCookie } from '../../AuthContext';
+import { AuthState, AuthError } from '../../AuthContext';
+import { setTokenExpiry } from './useRefreshToken';
 import { useGetAuthToken } from './useGetAuthToken';
 import {
   AuthenticationCredentials,
+  DateUtils,
   LocalStorage,
   useAuthApi,
   useGetUserDetails,
@@ -83,7 +85,7 @@ export const getStore = async (
 };
 
 export const useLogin = (
-  setCookie: React.Dispatch<React.SetStateAction<AuthCookie | undefined>>
+  setAuthState: React.Dispatch<React.SetStateAction<AuthState | undefined>>
 ) => {
   const { mutateAsync, isLoading: isLoggingIn } = useGetAuthToken();
   const { changeLanguage, getLocaleCode, getUserLocale } = useIntlUtils();
@@ -133,17 +135,19 @@ export const useLogin = (
 
   const login = async (username: string, password: string) => {
     const { token, error } = await mutateAsync({ username, password });
-    const userDetails = await getUserDetails(token);
-    queryClient.setQueryData(api.keys.me(token), userDetails);
+    // token is only used to check if login succeeded — we don't store it
+    const loggedIn = !!token;
+    const userDetails = await getUserDetails();
+    const userId = userDetails?.userId ?? '';
+    queryClient.setQueryData(api.keys.me(), userDetails);
     const store = await getStore(userDetails, mostRecentCredentials);
-    const permissions = await getUserPermissions(token, store);
+    const permissions = await getUserPermissions(store);
     setSkipRequest(skipNoStoreRequests);
 
-    const authCookie = {
+    const authState = {
       store,
-      token,
       user: {
-        id: userDetails?.userId ?? '',
+        id: userId,
         name: username,
         permissions,
         firstName: userDetails?.firstName,
@@ -154,7 +158,7 @@ export const useLogin = (
       },
     };
 
-    if (token) {
+    if (loggedIn) {
       const userLocale = getUserLocale(username);
       if (userLocale === undefined) {
         changeLanguage(
@@ -162,10 +166,10 @@ export const useLogin = (
         );
       }
       upsertMostRecentCredential(username, store);
-      setAuthCookie(authCookie);
-      setCookie(authCookie);
+      setTokenExpiry(DateUtils.addMinutes(new Date(), 60));
+      setAuthState(authState);
     }
-    setLoginError(!!token, !!store);
+    setLoginError(loggedIn, !!store);
     setSkipRequest(
       () => LocalStorage.getItem('/error/auth') === AuthError.NoStoreAssigned
     );

--- a/client/packages/common/src/authentication/api/hooks/useRefreshToken.ts
+++ b/client/packages/common/src/authentication/api/hooks/useRefreshToken.ts
@@ -1,46 +1,59 @@
-import {
-  DateUtils,
-  getAuthCookie,
-  setAuthCookie,
-} from '@openmsupply-client/common';
+import { DateUtils } from '@openmsupply-client/common';
 import { useGetRefreshToken } from './useGetRefreshToken';
 
-export const TOKEN_REFRESH_BUFFER_MINUTES = 5;
-export type RefreshAction = 'refresh' | 'none';
+const TOKEN_LIFETIME_MINUTES = 60;
+const TOKEN_REFRESH_BUFFER_MINUTES = 5;
+const TOKEN_EXPIRY_KEY = 'token_expiry';
 
-export const getRefreshAction = (expiresInMinutes: number): RefreshAction =>
-  expiresInMinutes <= TOKEN_REFRESH_BUFFER_MINUTES ? 'refresh' : 'none';
+// Track token expiry in module scope, persisted to localStorage so it
+// survives page refresh. The actual JWT is in an HttpOnly cookie — we
+// only need to know *when* to trigger a refresh.
+let tokenExpiry: Date | null = (() => {
+  const stored = localStorage.getItem(TOKEN_EXPIRY_KEY);
+  return stored ? new Date(stored) : null;
+})();
+
+export const setTokenExpiry = (expires: Date) => {
+  tokenExpiry = expires;
+  localStorage.setItem(TOKEN_EXPIRY_KEY, expires.toISOString());
+};
+
+export const clearTokenExpiry = () => {
+  tokenExpiry = null;
+  localStorage.removeItem(TOKEN_EXPIRY_KEY);
+};
 
 export const useRefreshToken = (onTimeout: () => void) => {
   const { mutateAsync } = useGetRefreshToken();
 
+  const doRefresh = () => {
+    mutateAsync()
+      .then(data => {
+        if (data?.token) {
+          setTokenExpiry(
+            DateUtils.addMinutes(new Date(), TOKEN_LIFETIME_MINUTES)
+          );
+        } else {
+          onTimeout();
+        }
+      })
+      .catch(() => onTimeout());
+  };
+
   const refreshToken = () => {
-    const authCookie = getAuthCookie();
-    // authCookie.expires reports as Date but is actually a string
-    const expires = DateUtils.getDateOrNull(authCookie?.expires?.toString());
+    if (!tokenExpiry) {
+      doRefresh();
+      return;
+    }
 
-    const expiresIn = expires
-      ? DateUtils.differenceInMinutes(expires, Date.now(), {
-          roundingMethod: 'ceil',
-        })
-      : 0;
+    const minutesLeft = DateUtils.differenceInMinutes(
+      tokenExpiry,
+      Date.now(),
+      { roundingMethod: 'ceil' }
+    );
 
-    const action = getRefreshAction(expiresIn);
-
-    if (action === 'refresh') {
-      mutateAsync()
-        .then(data => {
-          const token = data?.token ?? '';
-          if (token) {
-            const newCookie = { ...authCookie, token };
-            setAuthCookie(newCookie);
-          } else {
-            onTimeout(); // token expired -> logout
-          }
-        })
-        .catch(() => {
-          onTimeout(); // token expired/invalid -> logout
-        });
+    if (minutesLeft <= TOKEN_REFRESH_BUFFER_MINUTES) {
+      doRefresh();
     }
   };
 

--- a/client/packages/common/src/authentication/api/hooks/useUserDetails.ts
+++ b/client/packages/common/src/authentication/api/hooks/useUserDetails.ts
@@ -6,11 +6,9 @@ export const useGetUserDetails = () => {
   return useMutation(api.get.me);
 };
 
-export const useUserDetails = (token: string) => {
+export const useUserDetails = () => {
   const api = useAuthApi();
-  return useQuery(api.keys.me(token), () => api.get.me(token), {
-    enabled: !!token,
-  });
+  return useQuery(api.keys.me(), () => api.get.me());
 };
 
 export const useUserPermissions = () => {

--- a/client/packages/common/src/authentication/hooks/useUpdateUserInfo.ts
+++ b/client/packages/common/src/authentication/hooks/useUpdateUserInfo.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from '@common/intl';
-import { AuthCookie } from '../AuthContext';
+import { AuthState } from '../AuthContext';
 import {
   useGetUserPermissions,
   useLastSuccessfulUserSync,
@@ -12,8 +12,8 @@ import { noOtherVariants } from '../../utils/types';
 import { AuthenticationCredentials } from '../../localStorage';
 
 export const useUpdateUserInfo = (
-  setCookie: React.Dispatch<React.SetStateAction<AuthCookie | undefined>>,
-  cookie?: AuthCookie,
+  setAuthState: React.Dispatch<React.SetStateAction<AuthState | undefined>>,
+  authState?: AuthState,
   mostRecentCredentials?: AuthenticationCredentials[]
 ) => {
   const t = useTranslation();
@@ -33,26 +33,21 @@ export const useUpdateUserInfo = (
         const update = await updateUser();
 
         if (update.__typename === 'UpdateUserNode') {
-          const permissions = await getUserPermissions(
-            cookie?.token,
-            cookie?.store
-          );
-          const userDetails = await getUserDetails(cookie?.token);
+          const permissions = await getUserPermissions(authState?.store);
+          const userDetails = await getUserDetails();
           const store = await getStore(userDetails, mostRecentCredentials);
 
-          const authCookie = {
-            ...cookie,
+          setAuthState({
+            ...authState,
             store,
-            token: cookie?.token ?? '',
             user: {
               id: userDetails?.userId ?? '',
-              name: cookie?.user?.name ?? '',
+              name: authState?.user?.name ?? '',
               permissions,
               email: userDetails?.email,
               jobTitle: userDetails?.jobTitle,
             },
-          };
-          setCookie(authCookie);
+          });
           return;
         }
 

--- a/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
+++ b/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
@@ -43,7 +43,7 @@ export const useNativeClient = ({
   discovery,
 }: { discovery?: boolean; autoconnect?: boolean } = {}) => {
   const nativeAPI = getNativeAPI();
-  const { token } = useAuthContext();
+  const { isAuthenticated } = useAuthContext();
 
   const setMode = (mode: NativeMode) =>
     setPreference('mode', mode).then(() =>
@@ -165,8 +165,7 @@ export const useNativeClient = ({
     advertiseService();
     // on first load, the login status is not checked correctly in the native app
     // and users are shown the dashboard even if they are not logged in
-    // here we check the token and if invalid redirect to login
-    const path = !token ? 'login' : '';
+    const path = !isAuthenticated ? 'login' : '';
     connectToServer({ ...DEFAULT_LOCAL_SERVER, path })
       .then(handleConnectionResult)
       .catch(e => handleConnectionResult({ success: false, error: e.message }));

--- a/client/packages/host/src/Host.tsx
+++ b/client/packages/host/src/Host.tsx
@@ -78,7 +78,6 @@ const PreInit: React.FC<React.PropsWithChildren> = ({ children }) => {
   if (data?.data?.status == InitialisationStatusType.Initialised)
     return children;
 
-  // Clear token
   logout();
 
   return null;

--- a/client/packages/host/src/components/Footer/StoreSelector.tsx
+++ b/client/packages/host/src/components/Footer/StoreSelector.tsx
@@ -17,8 +17,8 @@ import { PropsWithChildrenOnly, UserStoreNodeFragment } from '@common/types';
 export const StoreSelector: FC<PropsWithChildrenOnly> = ({ children }) => {
   const t = useTranslation();
   const navigate = useNavigate();
-  const { store, setStore, token } = useAuthContext();
-  const { data, isLoading } = useUserDetails(token);
+  const { store, setStore } = useAuthContext();
+  const { data, isLoading } = useUserDetails();
   const [popoverAnchor, setPopoverAnchor] = useState<HTMLElement | null>(null);
 
   const rootNavigationPath = useRootNavigationPath();

--- a/client/packages/host/src/components/Footer/UserDetails.tsx
+++ b/client/packages/host/src/components/Footer/UserDetails.tsx
@@ -20,10 +20,10 @@ import { AppRoute } from '@openmsupply-client/config';
 import { PropsWithChildrenOnly } from '@common/types';
 
 export const UserDetails: FC<PropsWithChildrenOnly> = ({ children }) => {
-  const { user, token } = useAuthContext();
+  const { user } = useAuthContext();
   const navigate = useNavigate();
   const [popoverAnchor, setPopoverAnchor] = useState<HTMLElement | null>(null);
-  const { isLoading } = useUserDetails(token);
+  const { isLoading } = useUserDetails();
   const t = useTranslation();
   const { getLocalisedFullName } = useIntlUtils();
   const LABEL_WIDTH = 150;

--- a/client/packages/host/src/components/Navigation/RequireAuthentication.tsx
+++ b/client/packages/host/src/components/Navigation/RequireAuthentication.tsx
@@ -10,12 +10,12 @@ import { PropsWithChildrenOnly } from '@common/types';
 export const RequireAuthentication: FC<PropsWithChildrenOnly> = ({
   children,
 }) => {
-  const { token } = useAuthContext();
+  const { isAuthenticated } = useAuthContext();
   const location = useLocation();
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!token) {
+    if (!isAuthenticated) {
       navigate(`/${AppRoute.Login}`, {
         replace: true,
         state: { from: location },

--- a/client/packages/system/src/Sync/api/api.ts
+++ b/client/packages/system/src/Sync/api/api.ts
@@ -18,8 +18,9 @@ export const getSyncQueries = (sdk: Sdk) => ({
       const result = await sdk.syncStatus();
       return result?.syncStatus;
     },
-    syncInfo: (token?: string) =>
-      sdk.syncInfo({}, { Authorization: `Bearer ${token}` }),
+    syncInfo: () =>
+      // Auth is handled by the HttpOnly cookie sent automatically by the browser
+      sdk.syncInfo(),
   },
   // manualSync is a trigger that returns a string result (don't need to capture it)
   manualSync: async (fetchPatientId?: string) =>

--- a/client/packages/system/src/Sync/api/hooks/utils/useSyncInfo.ts
+++ b/client/packages/system/src/Sync/api/hooks/utils/useSyncInfo.ts
@@ -1,4 +1,4 @@
-import { getAuthCookie, useQuery } from '@openmsupply-client/common';
+import { useAuthContext, useQuery } from '@openmsupply-client/common';
 import { useSyncApi } from './useSyncApi';
 
 export const useSyncInfo = (
@@ -6,19 +6,14 @@ export const useSyncInfo = (
   enabled: boolean = true
 ) => {
   const api = useSyncApi();
-  const { token } = getAuthCookie();
+  const { isAuthenticated } = useAuthContext();
 
-  // manually adding the token and setting the authorization header
-  // there were instances where the token was not included in the request
-  // even though the auth cookie existed with a valid token
-  // the query is only enabled if there's a token -
-  // no need to check the sync status if there's no token
   const { data, ...rest } = useQuery(
     api.keys.syncInfo(),
-    () => api.get.syncInfo(token),
+    () => api.get.syncInfo(),
     {
       refetchInterval,
-      enabled: !!token && enabled,
+      enabled: isAuthenticated && enabled,
     }
   );
 

--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -279,6 +279,7 @@ async fn initialise_from_central(
         token_bucket: Arc::new(RwLock::new(TokenBucket::new())),
         no_ssl: true,
         debug_no_access_control: false,
+        cookie_suffix: settings.server.port.to_string(),
     };
 
     let service_context = service_provider.basic_context()?;

--- a/server/graphql/core/src/lib.rs
+++ b/server/graphql/core/src/lib.rs
@@ -106,10 +106,16 @@ pub struct RequestUserData {
     pub refresh_token: Option<String>,
 }
 
-pub fn auth_data_from_request(http_req: &HttpRequest) -> RequestUserData {
+pub fn auth_data_from_request(
+    http_req: &HttpRequest,
+    cookie_suffix: &str,
+) -> RequestUserData {
     let headers = http_req.headers();
-    // retrieve auth token
-    let auth_token = headers.get("Authorization").and_then(|header_value| {
+    let auth_cookie_name = format!("auth_{cookie_suffix}");
+    let refresh_cookie_name = format!("refresh_token_{cookie_suffix}");
+
+    // retrieve auth token from Authorization header first
+    let auth_token_from_header = headers.get("Authorization").and_then(|header_value| {
         header_value.to_str().ok().and_then(|header| {
             if header.starts_with("Bearer ") {
                 return Some(header["Bearer ".len()..header.len()].to_string());
@@ -118,24 +124,30 @@ pub fn auth_data_from_request(http_req: &HttpRequest) -> RequestUserData {
         })
     });
 
-    // retrieve refresh token
-    let refresh_token = headers.get(COOKIE).and_then(|header_value| {
-        header_value
-            .to_str()
-            .ok()
-            .and_then(|header| {
-                let cookies = header.split(' ').collect::<Vec<&str>>();
-                cookies
-                    .into_iter()
-                    .map(|raw_cookie| Cookie::parse(raw_cookie).ok())
-                    .find(|cookie_option| match &cookie_option {
-                        Some(cookie) => cookie.name() == "refresh_token",
-                        None => false,
-                    })
-                    .flatten()
-            })
+    // parse cookies once for both auth and refresh_token lookups
+    let parsed_cookies: Vec<Cookie> = headers
+        .get(COOKIE)
+        .and_then(|header_value| header_value.to_str().ok())
+        .map(|header| {
+            header
+                .split(' ')
+                .filter_map(|raw_cookie| Cookie::parse(raw_cookie).ok())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // fall back to HttpOnly auth cookie when no Authorization header
+    let auth_token = auth_token_from_header.or_else(|| {
+        parsed_cookies
+            .iter()
+            .find(|cookie| cookie.name() == auth_cookie_name)
             .map(|cookie| cookie.value().to_owned())
     });
+
+    let refresh_token = parsed_cookies
+        .iter()
+        .find(|cookie| cookie.name() == refresh_cookie_name)
+        .map(|cookie| cookie.value().to_owned());
 
     RequestUserData {
         auth_token,

--- a/server/graphql/core/src/test_helpers.rs
+++ b/server/graphql/core/src/test_helpers.rs
@@ -52,6 +52,7 @@ pub async fn run_test_gql_query<
         // TODO: configure ssl
         no_ssl: true,
         debug_no_access_control: true,
+        cookie_suffix: "test".to_string(),
     });
 
     let app = actix_web::test::init_service(
@@ -97,7 +98,7 @@ async fn graphql<Q: 'static + ObjectType + Clone, M: 'static + ObjectType + Clon
     http_req: HttpRequest,
     req: GraphQLRequest,
 ) -> GraphQLResponse {
-    let user_data = auth_data_from_request(&http_req);
+    let user_data = auth_data_from_request(&http_req, "test");
     let query = req.into_inner().data(user_data);
     schema.execute(query).await.into()
 }

--- a/server/graphql/general/src/queries/login.rs
+++ b/server/graphql/general/src/queries/login.rs
@@ -17,7 +17,9 @@ pub struct AuthToken {
 
 #[Object]
 impl AuthToken {
-    /// Bearer token
+    /// Bearer token. The web client uses the HttpOnly cookie instead, but
+    /// the token is still returned here for backward compatibility and
+    /// external integrations that use the Authorization header directly.
     pub async fn token(&self) -> &str {
         &self.pair.token
     }
@@ -160,34 +162,39 @@ pub async fn login(ctx: &Context<'_>, username: &str, password: &str) -> Result<
     };
 
     let now = Utc::now().timestamp() as usize;
-    set_refresh_token_cookie(
-        ctx,
-        &pair.refresh,
-        pair.refresh_expiry_date - now,
-        auth_data.no_ssl,
-    );
+    let suffix = &auth_data.cookie_suffix;
+
+    set_refresh_token_cookie(ctx, &pair.refresh, pair.refresh_expiry_date - now, auth_data.no_ssl, suffix);
+    set_auth_token_cookie(ctx, &pair.token, pair.expiry_date - now, auth_data.no_ssl, suffix);
 
     Ok(AuthTokenResponse::Response(AuthToken { pair }))
 }
 
-/// Store refresh token in a cookie:
-/// - HttpOnly cookie (not readable from js).
-/// - Secure (https only)
-/// - SameSite (only attached to request originating from the same site)
-///
-/// Also see:
-///     https://hasura.io/blog/best-practices-of-using-jwt-with-graphql/
+fn set_cookie(ctx: &Context<'_>, name: &str, value: &str, max_age: usize, no_ssl: bool) {
+    let secure = if no_ssl { "" } else { "; Secure" };
+    // Use append so multiple Set-Cookie headers are sent (one per cookie)
+    ctx.append_http_header(
+        SET_COOKIE,
+        format!("{name}={value}; Max-Age={max_age}{secure}; HttpOnly; SameSite=Strict; Path=/"),
+    );
+}
+
 pub fn set_refresh_token_cookie(
     ctx: &Context<'_>,
     refresh_token: &str,
     max_age: usize,
     no_ssl: bool,
+    suffix: &str,
 ) {
-    let secure = if no_ssl { "" } else { "; Secure" };
-    ctx.insert_http_header(
-        SET_COOKIE,
-        format!(
-            "refresh_token={refresh_token}; Max-Age={max_age}{secure}; HttpOnly; SameSite=Strict"
-        ),
-    );
+    set_cookie(ctx, &format!("refresh_token_{suffix}"), refresh_token, max_age, no_ssl);
+}
+
+pub fn set_auth_token_cookie(
+    ctx: &Context<'_>,
+    token: &str,
+    max_age: usize,
+    no_ssl: bool,
+    suffix: &str,
+) {
+    set_cookie(ctx, &format!("auth_{suffix}"), token, max_age, no_ssl);
 }

--- a/server/graphql/general/src/queries/logout.rs
+++ b/server/graphql/general/src/queries/logout.rs
@@ -5,7 +5,7 @@ use service::auth::{validate_auth, AuthError};
 use service::settings::is_develop;
 use service::token::TokenService;
 
-use super::set_refresh_token_cookie;
+use super::{set_auth_token_cookie, set_refresh_token_cookie};
 
 pub struct Logout {
     pub user_id: String,
@@ -26,8 +26,10 @@ pub enum LogoutResponse {
 
 pub fn logout(ctx: &Context<'_>) -> Result<LogoutResponse> {
     let auth_data = ctx.get_auth_data();
-    // invalid the refresh token cookie first (just in case an error happens before we do so)
-    set_refresh_token_cookie(ctx, "logged out", 0, auth_data.no_ssl);
+    let suffix = &auth_data.cookie_suffix;
+    // invalidate auth cookies first (just in case an error happens before we do so)
+    set_refresh_token_cookie(ctx, "logged out", 0, auth_data.no_ssl, suffix);
+    set_auth_token_cookie(ctx, "logged out", 0, auth_data.no_ssl, suffix);
 
     let user_auth = match validate_auth(auth_data, &ctx.get_auth_token()) {
         Ok(value) => value,

--- a/server/graphql/general/src/queries/refresh_token.rs
+++ b/server/graphql/general/src/queries/refresh_token.rs
@@ -9,7 +9,7 @@ use service::{
     token::{JWTRefreshError, TokenPair, TokenService},
 };
 
-use crate::set_refresh_token_cookie;
+use crate::{set_auth_token_cookie, set_refresh_token_cookie};
 
 pub struct RefreshToken {
     pub pair: TokenPair,
@@ -17,7 +17,8 @@ pub struct RefreshToken {
 
 #[Object]
 impl RefreshToken {
-    /// New Bearer token
+    /// New Bearer token. Returned for backward compatibility and external
+    /// integrations — the web client uses the HttpOnly cookie instead.
     pub async fn token(&self) -> &str {
         &self.pair.token
     }
@@ -130,7 +131,9 @@ pub fn refresh_token(ctx: &Context<'_>) -> RefreshTokenResponse {
         }
     };
 
-    set_refresh_token_cookie(ctx, &pair.refresh, max_age_refresh, auth_data.no_ssl);
+    let suffix = &auth_data.cookie_suffix;
+    set_refresh_token_cookie(ctx, &pair.refresh, max_age_refresh, auth_data.no_ssl, suffix);
+    set_auth_token_cookie(ctx, &pair.token, max_age_token, auth_data.no_ssl, suffix);
 
     RefreshTokenResponse::Response(RefreshToken { pair })
 }

--- a/server/graphql/lib.rs
+++ b/server/graphql/lib.rs
@@ -303,6 +303,8 @@ pub struct GraphqlSchema {
     migration: MigrationSchema,
     /// Set on startup based on InitialisationStatus and then updated via SiteIsInitialisedCallback after initialisation
     operational_status: Data<RwLock<OperationalStatus>>,
+    /// Port-derived cookie suffix for auth cookies (e.g. "8000")
+    cookie_suffix: String,
 }
 
 pub struct GraphSchemaData {
@@ -377,6 +379,7 @@ impl GraphqlSchema {
             initialisation: initialisation_builder.finish(),
             migration: migration_builder.finish(),
             operational_status: operational_status_ref.clone(),
+            cookie_suffix: auth.cookie_suffix.clone(),
         }
     }
 
@@ -395,7 +398,7 @@ impl GraphqlSchema {
         match &*self.operational_status.read().await {
             OperationalStatus::Operational => {
                 // auth_data is only available in schema in operational mode
-                let user_data = auth_data_from_request(&http_req);
+                let user_data = auth_data_from_request(&http_req, &self.cookie_suffix);
                 self.operational.execute(req.data(user_data)).await
             }
             OperationalStatus::MigratingDatabase => self.migration.execute(req).await,

--- a/server/server/src/authentication.rs
+++ b/server/server/src/authentication.rs
@@ -1,34 +1,19 @@
 use actix_web::HttpRequest;
 use service::{
-    auth::{validate_auth, AuthDeniedKind, AuthError, ValidatedUserAuth},
+    auth::{validate_auth, ValidatedUserAuth},
     auth_data::AuthData,
 };
 
-const COOKIE_NAME: &str = "auth";
-
-#[derive(serde::Deserialize)]
-struct AuthCookie {
-    token: String,
-}
-
+/// Validate auth from the HttpOnly auth cookie.
+/// The cookie contains the raw JWT token (set by set_auth_token_cookie).
 pub(crate) fn validate_cookie_auth(
     request: HttpRequest,
     auth_data: &AuthData,
-) -> Result<ValidatedUserAuth, AuthError> {
-    let token = match request.cookie(COOKIE_NAME) {
-        Some(cookie) => {
-            let auth_cookie: AuthCookie = match serde_json::from_str(cookie.value()) {
-                Ok(auth_cookie) => auth_cookie,
-                Err(err) => {
-                    return Err(AuthError::Denied(AuthDeniedKind::NotAuthenticated(
-                        err.to_string(),
-                    )))
-                }
-            };
-            Some(auth_cookie.token)
-        }
-        None => None,
-    };
+) -> Result<ValidatedUserAuth, service::auth::AuthError> {
+    let name = format!("auth_{}", auth_data.cookie_suffix);
+    let token = request
+        .cookie(&name)
+        .map(|cookie| cookie.value().to_owned());
 
     validate_auth(auth_data, &token)
 }

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -483,5 +483,6 @@ fn auth_data(
         token_bucket,
         no_ssl: !certificates.is_https(),
         debug_no_access_control: is_develop() && server_settings.debug_no_access_control,
+        cookie_suffix: server_settings.port.to_string(),
     })
 }

--- a/server/service/src/auth.rs
+++ b/server/service/src/auth.rs
@@ -1464,6 +1464,7 @@ mod permission_validation_test {
             token_bucket: Arc::new(RwLock::new(TokenBucket::new())),
             no_ssl: true,
             debug_no_access_control: false,
+            cookie_suffix: "test".to_string(),
         };
         let user_id = "test_user_id";
         let password = "pass";
@@ -1661,6 +1662,7 @@ mod permission_validation_test {
             token_bucket: Arc::new(RwLock::new(TokenBucket::new())),
             no_ssl: true,
             debug_no_access_control: false,
+            cookie_suffix: "test".to_string(),
         };
 
         let token = TokenService::new(

--- a/server/service/src/auth_data.rs
+++ b/server/service/src/auth_data.rs
@@ -15,6 +15,10 @@ pub struct AuthData {
     /// testing).
     /// However, if a token is provided this token is fully evaluate.
     pub debug_no_access_control: bool,
+    /// Suffix for cookie names, derived from the server port.
+    /// Cookies are named `auth_{port}` / `refresh_token_{port}` to prevent
+    /// collisions between instances on the same domain.
+    pub cookie_suffix: String,
 }
 
 #[cfg(test)]

--- a/server/service/src/login.rs
+++ b/server/service/src/login.rs
@@ -594,6 +594,7 @@ mod test {
             token_bucket: Arc::new(RwLock::new(TokenBucket::new())),
             no_ssl: true,
             debug_no_access_control: false,
+            cookie_suffix: "test".to_string(),
         };
 
         let expected: LoginResponseV4 = serde_json::from_str(LOGIN_V4_RESPONSE_1).unwrap();


### PR DESCRIPTION
> [!WARNING]
> This PR was largely authored by Claude

Fixes #11094, #11173
Related: #2832, #11072

# 👩🏻‍💻 What does this PR do?

Replaces the JS-accessible `auth` cookie with an **HttpOnly server-set cookie**, and scopes cookie names by port to prevent collisions between instances on the same domain.

This addresses three issues from a single root cause (auth data stored in a JS-accessible cookie):

1. **Cookie collision (#11094)** — Two instances on `localhost` overwrite each other's `auth` and `refresh_token` cookies because cookies are domain-scoped, not port-scoped. Now cookies are suffixed by port: `auth_8000`, `refresh_token_3003`, etc.

2. **Cookie size limit (#2832)** — The old `auth` cookie stored JWT + user info + permissions as JSON (~2KB, approaching 4KB limit). Now the cookie contains only the raw JWT (~0.5KB). User/store/permissions state is stored in React state backed by localStorage.

3. **XSS token exfiltration (#11072 weakness #<!-- -->2)** — The old cookie was readable by JavaScript, meaning any XSS could steal the access token. Now it's HttpOnly — invisible to JS.

### Potentially fixes mysterious unexpected logouts (#11072)

The old auth flow had several fragile points that could silently lose the auth cookie:
- **Cookie size overflow**: if permissions grew past 4KB, the browser would silently drop the cookie
- **JSON parse failure**: `getAuthCookie()` did `JSON.parse(Cookies.get('auth'))` — any corruption → empty token → logout
- **Read/write race**: the 60-second timer calling `getAuthCookie()` could race with `setAuthCookie()` during store change or refresh
- **Cross-instance overwrite**: two instances sharing the same `auth` cookie name

All of these go away because the client never touches the cookie.

### How it works

- **Login**: Server sets two HttpOnly cookies (`auth_{port}` and `refresh_token_{port}`) via `Set-Cookie` headers. Client stores user metadata in React state (persisted to localStorage). Client does NOT store the JWT anywhere JS can reach.
- **Requests**: Browser sends HttpOnly cookies automatically (`credentials: 'include'`). Server reads auth token from cookie, falling back to `Authorization: Bearer` header for API clients/plugins.
- **Refresh**: Client tracks token expiry in memory (persisted to localStorage). When approaching expiry, calls `refreshToken` query — server reads refresh cookie and issues new token pair.
- **Logout**: Server clears both cookies (Max-Age=0). Client clears localStorage.
- **Token in response body**: Still returned by `authToken` and `refreshToken` queries for backward compatibility with external integrations that use the `Authorization` header directly.

### What changed vs the original PR (#11095)

The original PR used a configurable `cookie_suffix` server setting that the client had to fetch via GraphQL before auth could work. This approach:
- Derives the suffix from the server port automatically — zero configuration
- Removes all client-side cookie naming logic (no `CookieConfigProvider`, no `setAuthCookieSuffix`)
- Removes the `cookie_suffix` field from the GraphQL schema
- The client never touches cookies at all

## Changes

**Server:**
- `auth_data.rs` — Added `cookie_suffix: String` field to `AuthData`
- `login.rs` — Added `set_auth_token_cookie()`, both cookie helpers use port suffix, use `append_http_header` for multiple `Set-Cookie` headers
- `refresh_token.rs` — Sets auth token HttpOnly cookie on refresh
- `logout.rs` — Clears auth token cookie on logout
- `core/lib.rs` — `auth_data_from_request` reads auth from HttpOnly cookie (fallback from Authorization header)
- `graphql/lib.rs` — `GraphqlSchema` stores cookie suffix, passes to request handler
- `authentication.rs` — `validate_cookie_auth` reads raw JWT from HttpOnly cookie (no more JSON parsing)

**Client:**
- `AuthContext.tsx` — Removed `js-cookie`. Renamed `AuthCookie` → `AuthState`, `token` → `isAuthenticated`. State in React + localStorage.
- `GqlContext.tsx` — Removed `Authorization: Bearer` header setting
- `useRefreshToken.ts` — Tracks expiry in module scope + localStorage
- `useLogin.ts` — No cookie write, sets token expiry
- `api.ts` — Removed explicit Authorization headers from `me()` and `permissions()`
- `useGetUserPermissions.ts`, `useUpdateUserInfo.ts` — Removed dead token params
- `useUserDetails.ts`, `useAuthApi.ts` — Simplified cache keys (no token/userId param needed)
- `useSyncInfo.ts`, `sync/api.ts` — Uses `isAuthenticated` instead of explicit token
- `RequireAuthentication.tsx`, `StoreSelector.tsx`, `UserDetails.tsx`, `useNativeClient.ts` — Use `isAuthenticated` instead of `token`

## 💌 Any notes for the reviewer?

- The GraphQL schema still returns the token in `authToken` and `refreshToken` responses — this is intentional for backward compatibility with external integrations. The web client ignores it.
- `append_http_header` (not `insert_http_header`) is used for `Set-Cookie` — `insert` replaces, `append` adds another header. This was a bug in the original PR approach.
- The `auth` cookie includes `Path=/` to ensure it's sent for all routes (file upload/download endpoints, not just `/graphql`).
- Cookie splitting in `auth_data_from_request` splits on space `' '` — this is pre-existing code and `Cookie::parse` handles edge cases, but worth noting as a code smell for a future cleanup.

# 🧪 Testing

### Multi-instance isolation (the main fix)
- [ ] Run two server instances on different ports (e.g. 8000 and 9000)
- [ ] Open both in the same browser, log in to both
- [ ] Verify both sessions remain active independently
- [ ] Log out of one — confirm the other remains logged in
- [ ] Inspect cookies: should see `auth_8000`/`refresh_token_8000` and `auth_3003`/`refresh_token_3003`

### HttpOnly verification
- [ ] After logging in, open browser dev tools console
- [ ] `document.cookie` should NOT contain `auth_` or `refresh_token_` (HttpOnly cookies are invisible to JS)
- [ ] Cookie inspector should show both cookies with the HttpOnly flag checked

### Single instance
- [ ] Run on default port (8000)
- [ ] Full login → select store → navigate → logout cycle
- [ ] Wait 2+ minutes to confirm token refresh works (no unexpected logout)
- [ ] Inspect cookies: should see `auth_8000` and `refresh_token_8000`

### Page refresh
- [ ] Log in, select a store, refresh the page (F5)
- [ ] Should restore session without re-login
- [ ] Verify no unnecessary refresh token call (check network tab — should NOT see a `refreshToken` query immediately after page load if token isn't expiring soon)

### File upload/download
- [ ] Log in on a non-default port
- [ ] Upload and download a file
- [ ] Confirm both succeed without auth errors

### Token refresh
- [ ] Log in and wait ~55 minutes (or temporarily lower TOKEN_LIFETIME_SEC)
- [ ] Confirm automatic refresh (new cookies set, no logout)

# 📃 Documentation

- [x] **No documentation required**: security improvement and bug fix, no user-facing behavior change