### PR TITLE
11228 wait_before_integrating

### DIFF
--- a/server/service/src/sync/api/common_records.rs
+++ b/server/service/src/sync/api/common_records.rs
@@ -34,6 +34,9 @@ pub(crate) struct RemoteSyncBatchV5 {
     pub(crate) queue_length: u64,
     #[serde(default)]
     pub(crate) data: Vec<RemoteSyncRecordV5>,
+    #[serde(rename = "waitBeforeIntegrating")]
+    #[serde(default)]
+    pub(crate) wait_before_integrating: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]

--- a/server/service/src/sync/api/common_records.rs
+++ b/server/service/src/sync/api/common_records.rs
@@ -36,6 +36,7 @@ pub(crate) struct RemoteSyncBatchV5 {
     pub(crate) data: Vec<RemoteSyncRecordV5>,
     #[serde(rename = "waitBeforeIntegrating")]
     #[serde(default)]
+    #[serde(skip_serializing)]
     pub(crate) wait_before_integrating: bool,
 }
 

--- a/server/service/src/sync/api/get_queued_records.rs
+++ b/server/service/src/sync/api/get_queued_records.rs
@@ -72,9 +72,7 @@ mod test {
                             table_name: "test_table_1".to_string(),
                             record_id: "ID2".to_string(),
                             action: SyncAction::Update,
-                            record_data: json!({
-                                "test_key": "test_value"
-                            })
+                            record_data: json!({"test_key":"test_value"})
                         }
                     },
                     RemoteSyncRecordV5 {
@@ -86,7 +84,8 @@ mod test {
                             record_data: json!({})
                         }
                     }
-                ]
+                ],
+                wait_before_integrating: false,
             }
         );
     }

--- a/server/service/src/sync/api/post_queued_records.rs
+++ b/server/service/src/sync/api/post_queued_records.rs
@@ -19,6 +19,7 @@ impl SyncApiV5 {
         let body = RemoteSyncBatchV5 {
             queue_length,
             data: records,
+            wait_before_integrating: false,
         };
 
         let response = self.do_post(route, &body).await?;

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -153,6 +153,7 @@ impl RemoteDataSynchroniser {
             let RemoteSyncBatchV5 {
                 queue_length: remaining,
                 data,
+                wait_before_integrating,
             } = sync_batch;
 
             let sync_buffer_rows = CommonSyncRecord::to_buffer_rows(
@@ -172,7 +173,7 @@ impl RemoteDataSynchroniser {
                     .map_err(|e| e.to_inner_error())?;
 
                 self.sync_api_v5.post_acknowledged_records(sync_ids).await?;
-            } else {
+            } else if !wait_before_integrating {
                 break;
             }
 

--- a/server/service/src/sync/sync_status/test.rs
+++ b/server/service/src/sync/sync_status/test.rs
@@ -303,6 +303,7 @@ fn get_initialisation_sync_status_tester(
                         sync_id: "".to_string(),
                         record: CommonSyncRecord::test(),
                     }],
+                    wait_before_integrating: false,
                 };
                 let pull_remote = current_status.pull_remote.unwrap();
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11228

# 👩🏻‍💻 What does this PR do?

Handles the wait_before_integrating from OG central server, OMS continuing to request queued records until the flag is false.

## 💌 Any notes for the reviewer?

Goes in hand with this PR: https://github.com/msupply-foundation/msupply/pull/18099

# 🧪 Testing

- [ ] I think safe to have this PR just be testing that normal sync works as usual (the OG PR can test the new data migration functionality).

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

