### PR TITLE
Cherry-pick: add log messages for failing/slow db connections

### DIFF
--- a/server/repository/src/db_diesel/mod.rs
+++ b/server/repository/src/db_diesel/mod.rs
@@ -408,9 +408,47 @@ impl From<DieselError> for RepositoryError {
 fn get_connection(
     pool: &Pool<ConnectionManager<DBBackendConnection>>,
 ) -> Result<DBConnection, RepositoryError> {
-    pool.get().map_err(|error| RepositoryError::DBError {
-        msg: "Failed to open Connection".to_string(),
-        extra: format!("{:?}", error),
+    let state = pool.state();
+    let available = state.idle_connections;
+    let total = state.connections;
+    let max = pool.max_size();
+
+    if available == 0 {
+        log::warn!(
+            "DB pool exhausted: {}/{} connections in use, max={}",
+            total - available,
+            total,
+            max,
+        );
+    }
+
+    let start = std::time::Instant::now();
+    let result = pool.get();
+    let wait_ms = start.elapsed().as_millis();
+
+    if wait_ms > 500 {
+        log::warn!(
+            "DB pool: waited {}ms for connection (available={}, total={}, max={})",
+            wait_ms,
+            available,
+            total,
+            max,
+        );
+    }
+
+    result.map_err(|error| {
+        log::error!(
+            "DB pool: failed to get connection after {}ms (available={}, total={}, max={}): {:?}",
+            wait_ms,
+            available,
+            total,
+            max,
+            error,
+        );
+        RepositoryError::DBError {
+            msg: "Failed to open Connection".to_string(),
+            extra: format!("{:?}", error),
+        }
     })
 }
 


### PR DESCRIPTION
Fixes #11041

# 👩🏻‍💻 What does this PR do?

Cherry-picks commit 44beafef from the `2.16.1-sl-hotfix-db-connection-logging` branch (PR #11041) into `v2.16.1-RC`.

Adds diagnostic logging around the database connection pool in `get_connection()`:

- **Pool exhaustion warning**: logs a `warn` when all idle connections are consumed (`available == 0`)
- **Slow connection wait warning**: logs a `warn` when acquiring a connection takes longer than 500ms
- **Failure error log**: logs an `error` with full pool state and timing when connection acquisition fails entirely

These logs help diagnose connection pool exhaustion issues in production.

## 💌 Any notes for the reviewer?

This is a direct cherry-pick of 44beafef with no conflicts. The change is low-risk — it only adds logging to an existing code path and does not change any control flow or error handling behaviour.

# 🧪 Testing

- [ ] Verify the server compiles and starts correctly with both Postgres and SQLite backends
- [ ] Under normal load, no new warnings should appear in logs
- [ ] Under heavy load or with a small pool size, verify the pool exhaustion and slow wait warnings are emitted

# 📃 Documentation

- [x] **No documentation required**: no user facing changes — adds server-side diagnostic logging only

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend