### PR TITLE
fix(#10914): remove cartesian product from consumption/adjustments/replenishment views

### DIFF
--- a/server/repository/src/migrations/views/adjustments.rs
+++ b/server/repository/src/migrations/views/adjustments.rs
@@ -22,15 +22,11 @@ impl ViewMigrationFragment for ViewMigration {
             CREATE VIEW adjustments AS
     SELECT
         'n/a' as id,
-        items_and_stores.item_id AS item_id,
-        items_and_stores.store_id AS store_id,
+        stock_movement.item_id AS item_id,
+        stock_movement.store_id AS store_id,
         stock_movement.quantity AS quantity,
         date(stock_movement.datetime) AS date
-    FROM
-        (SELECT item.id AS item_id, store.id AS store_id FROM item, store) as items_and_stores
-    LEFT OUTER JOIN stock_movement
-        ON stock_movement.item_id = items_and_stores.item_id
-            AND stock_movement.store_id = items_and_stores.store_id
+    FROM stock_movement
     WHERE invoice_type='CUSTOMER_RETURN'
       OR invoice_type='SUPPLIER_RETURN'
       OR invoice_type='INVENTORY_ADDITION'

--- a/server/repository/src/migrations/views/consumption.rs
+++ b/server/repository/src/migrations/views/consumption.rs
@@ -36,17 +36,14 @@ impl ViewMigrationFragment for ViewMigration {
             CREATE VIEW consumption AS
                 SELECT
                     'n/a' as id,
-                    items_and_stores.item_id AS item_id,
-                    items_and_stores.store_id AS store_id,
+                    stock_movement.item_id AS item_id,
+                    stock_movement.store_id AS store_id,
                     {absolute}(COALESCE(stock_movement.quantity, 0)) AS quantity,
                     {utc_datetime_to_local_date} AS date,
                     stock_movement.invoice_type AS invoice_type,
                     stock_movement.name_id AS name_id,
                     stock_movement.name_properties AS name_properties
-            FROM (SELECT item.id AS item_id, store.id AS store_id FROM item, store) as items_and_stores
-                LEFT OUTER JOIN stock_movement
-                ON stock_movement.item_id = items_and_stores.item_id
-                AND stock_movement.store_id = items_and_stores.store_id
+            FROM stock_movement
             WHERE invoice_type='OUTBOUND_SHIPMENT' OR invoice_type='PRESCRIPTION';
             "#
         )?;

--- a/server/repository/src/migrations/views/replenishment.rs
+++ b/server/repository/src/migrations/views/replenishment.rs
@@ -28,15 +28,11 @@ impl ViewMigrationFragment for ViewMigration {
                 CREATE VIEW replenishment AS
     SELECT
         'n/a' as id,
-        items_and_stores.item_id AS item_id,
-        items_and_stores.store_id AS store_id,
+        stock_movement.item_id AS item_id,
+        stock_movement.store_id AS store_id,
         {absolute}(COALESCE(stock_movement.quantity, 0)) AS quantity,
         date(stock_movement.datetime) AS date
-    FROM
-        (SELECT item.id AS item_id, store.id AS store_id FROM item, store) as items_and_stores
-    LEFT OUTER JOIN stock_movement
-        ON stock_movement.item_id = items_and_stores.item_id
-            AND stock_movement.store_id = items_and_stores.store_id
+    FROM stock_movement
     WHERE invoice_type='INBOUND_SHIPMENT';            "#
         )?;
 


### PR DESCRIPTION
Fixes #10914

## Summary

- Removes `FROM item, store` cross join from the `consumption`, `adjustments`, and `replenishment` SQL views
- These views now query `stock_movement` directly, since the `WHERE invoice_type = ...` clause already eliminated all NULL LEFT JOIN rows (making the cross join + LEFT JOIN equivalent to a direct SELECT)
- On large datasets (5,311 items x 279 stores) this eliminates 1.5M intermediate rows generated per query execution

Closes #10914 (root cause 1 of 5)

## Context

The `consumption`, `adjustments`, and `replenishment` views all used:
```sql
FROM (SELECT item.id AS item_id, store.id AS store_id FROM item, store) as items_and_stores
LEFT OUTER JOIN stock_movement ON ...
WHERE invoice_type = '...'
```

The cartesian product generated `count(items) × count(stores)` rows before any filtering. With 53+ concurrent users each triggering these views via the dashboard `itemCounts` query, this caused 100% CPU.

The `stock_on_hand` view also uses a cross join but legitimately needs it (returns zero-stock rows for items with no stock lines) and was not changed.

## Benchmark (local, 3 VUs x 10 iterations)

| Query | p95 before | p95 after | Change |
|---|---|---|---|
| itemCounts (hits consumption view) | 655ms | 221ms | **-66%** |
| Total dashboard (all 6 queries parallel) | 658ms | 228ms | **-65%** |

On the production dataset the improvement will be dramatically larger due to the multiplicative nature of the cross join.

## MFHRC Report
On my mac
15s (before cross join change)
6s (after cross join change)

<img width="1507" height="919" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/e8cced22-c395-4845-890d-0a2729a9ccf9" />


<img width="1507" height="919" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/befefe91-2dec-4c86-873b-4d659541e934" />



## Test plan

- [x] All dashboard tests pass (9/9)
- [x] All item_stats tests pass (2/2)
- [x] All RnR form tests pass (21/21) — RnR forms are the primary consumer of all three views
- [x] k6 dashboard benchmark confirms improvement
- [x] Verified no reports (standard or external) depend on the cross join behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)