### PR TITLE
fix(#10914): guard dashboard queries until storeId is available

### DIFF
--- a/client/packages/dashboard/src/api/hooks/useInboundCounts.ts
+++ b/client/packages/dashboard/src/api/hooks/useInboundCounts.ts
@@ -12,6 +12,7 @@ export const useInboundCounts = () => {
         storeId,
       }),
     {
+      enabled: !!storeId,
       retry: false,
     }
   );

--- a/client/packages/dashboard/src/api/hooks/useInternalOrderCounts.ts
+++ b/client/packages/dashboard/src/api/hooks/useInternalOrderCounts.ts
@@ -12,6 +12,7 @@ export const useInternalOrderCounts = () => {
         storeId,
       }),
     {
+      enabled: !!storeId,
       retry: false,
     }
   );

--- a/client/packages/dashboard/src/api/hooks/useItemCounts.ts
+++ b/client/packages/dashboard/src/api/hooks/useItemCounts.ts
@@ -13,6 +13,7 @@ export const useItemCounts = (lowStockThreshold: number) => {
         lowStockThreshold,
       }),
     {
+      enabled: !!storeId,
       retry: false,
     }
   );

--- a/client/packages/dashboard/src/api/hooks/useOutboundCounts.ts
+++ b/client/packages/dashboard/src/api/hooks/useOutboundCounts.ts
@@ -12,6 +12,7 @@ export const useOutboundCounts = () => {
         storeId,
       }),
     {
+      enabled: !!storeId,
       retry: false,
     }
   );

--- a/client/packages/dashboard/src/api/hooks/useRequisitionCounts.ts
+++ b/client/packages/dashboard/src/api/hooks/useRequisitionCounts.ts
@@ -12,6 +12,7 @@ export const useRequisitionCounts = () => {
         storeId,
       }),
     {
+      enabled: !!storeId,
       retry: false,
     }
   );

--- a/client/packages/dashboard/src/api/hooks/useStockCounts.ts
+++ b/client/packages/dashboard/src/api/hooks/useStockCounts.ts
@@ -13,6 +13,7 @@ export const useStockCounts = (daysTillExpired: number) => {
         daysTillExpired,
       }),
     {
+      enabled: !!storeId,
       retry: false,
     }
   );


### PR DESCRIPTION
## Summary
- Adds `enabled: !!storeId` to all 6 dashboard `useQuery` hooks to prevent queries firing before auth context resolves
- Eliminates ~23 Forbidden (403) errors per user login that waste backend resources
- Follows existing pattern used in `useIsCentralServer` and `usePreferences`

Closes part of #10914 (root cause 3)

## Changes
- `useItemCounts.ts` — add `enabled: !!storeId`
- `useStockCounts.ts` — add `enabled: !!storeId`
- `useRequisitionCounts.ts` — add `enabled: !!storeId`
- `useInboundCounts.ts` — add `enabled: !!storeId`
- `useOutboundCounts.ts` — add `enabled: !!storeId`
- `useInternalOrderCounts.ts` — add `enabled: !!storeId`

## Test plan
- [ ] Log in to the app and open browser dev tools Network tab
- [ ] Confirm no 403 Forbidden errors on dashboard load
- [ ] Confirm all dashboard widgets load correctly after storeId resolves
- [ ] Verify queries include storeId in the request payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)