### PR TITLE
fix(#10914): increase sync status polling interval to 2 seconds

### DIFF
--- a/client/packages/host/src/components/Sync/SyncModal.tsx
+++ b/client/packages/host/src/components/Sync/SyncModal.tsx
@@ -33,7 +33,7 @@ import {
 } from '@common/components';
 import { AppRoute } from '@openmsupply-client/config';
 
-const STATUS_POLLING_INTERVAL = 1000;
+const STATUS_POLLING_INTERVAL = 2000;
 
 interface SyncModalProps {
   open: boolean;


### PR DESCRIPTION
## Summary
- Increases `STATUS_POLLING_INTERVAL` from 1000ms to 2000ms in `SyncModal.tsx`
- Halves the polling load when many users have the sync modal open simultaneously
- With 53+ concurrent users, this reduces sync status requests from 53/s to ~27/s

Closes part of #10914 (root cause 4)

## Changes
- `SyncModal.tsx` — change `STATUS_POLLING_INTERVAL` from `1000` to `2000`

## Test plan
- [ ] Open sync modal and verify sync progress still updates smoothly
- [ ] Check Network tab to confirm polling interval is ~2 seconds
- [ ] Trigger a manual sync and verify progress bar updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)