### PR TITLE
fix(#11255): remove master list visibility check from stock line search

### DIFF
--- a/server/repository/src/db_diesel/stock_line.rs
+++ b/server/repository/src/db_diesel/stock_line.rs
@@ -230,7 +230,7 @@ impl<'a> StockLineRepository<'a> {
                     if search_for_item.is_some() || item_code_or_name.is_some() {
                         let item_filter = ItemFilter {
                             code_or_name: search_for_item.or(item_code_or_name),
-                            ..ItemFilter::new().is_visible(true).is_active(true)
+                            ..ItemFilter::new().is_active(true)
                         };
                         let item_query = ItemRepository::create_filtered_query(
                             store_id.clone(),


### PR DESCRIPTION
## Summary
- Stock line search by item name was failing for items not on the store's master list
- The item subquery used `is_visible(true)` which gates on master list membership — unnecessary since the stock already exists in the store
- Removed `is_visible(true)`, keeping only `is_active(true)`

Closes #11255

## Test plan
- [ ] Search stock lines with a term matching an item name that is **not** on any master list for the store — verify results now appear
- [ ] Search stock lines with a term matching an item name on a master list — verify still works
- [ ] Search stock lines by batch number — verify still works
- [ ] Verify inactive items are still excluded from search results

🤖 Generated with [Claude Code](https://claude.com/claude-code)