### PR TITLE
Use plain text dropdown for status in line edit cards

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
@@ -24,7 +24,6 @@ import {
   Typography,
   CopyIcon,
   StockIcon,
-  StatusChip,
   InvoiceLineStatusType,
   InvoiceNodeStatus,
   InfoIcon,
@@ -216,8 +215,8 @@ export const InboundLineEditCards = ({
                 helperText={
                   isPlaceholder
                     ? t('error.field-must-be-specified', {
-                      field: t('label.packs-received'),
-                    })
+                        field: t('label.packs-received'),
+                      })
                     : undefined
                 }
               />
@@ -265,7 +264,7 @@ export const InboundLineEditCards = ({
                   const shouldClearSellPrice =
                     item?.defaultPackSize !== line.packSize &&
                     item?.itemStoreProperties?.defaultSellPricePerPack ===
-                    line.sellPricePerPack;
+                      line.sellPricePerPack;
 
                   updateDraftLine({
                     volumePerPack:
@@ -311,7 +310,7 @@ export const InboundLineEditCards = ({
           if (isStatusDisabled) {
             const entry = status ? statusMapRef.current[status] : undefined;
             return entry ? (
-              <StatusChip label={entry.label} colour={entry.colour} />
+              <Typography variant="body2">{entry.label}</Typography>
             ) : null;
           }
 
@@ -335,12 +334,6 @@ export const InboundLineEditCards = ({
                   status: e.target.value as InvoiceLineStatusType,
                 });
               }}
-              renderValue={() => {
-                const entry = status ? statusMapRef.current[status] : undefined;
-                return entry ? (
-                  <StatusChip label={entry.label} colour={entry.colour} />
-                ) : null;
-              }}
             >
               {Object.entries(statusMapRef.current)
                 .filter(
@@ -348,9 +341,9 @@ export const InboundLineEditCards = ({
                     hasAuthorisePermission ||
                     key === InvoiceLineStatusType.Pending
                 )
-                .map(([key, { label, colour }]) => (
+                .map(([key, { label }]) => (
                   <MenuItem key={key} value={key}>
-                    <StatusChip label={label} colour={colour} />
+                    {label}
                   </MenuItem>
                 ))}
             </Select>
@@ -819,9 +812,9 @@ export const InboundLineEditCards = ({
   const groupIcons = simplified
     ? undefined
     : {
-      stockLineDetails: <StockIcon />,
-      moreInfo: <InfoIcon />,
-    };
+        stockLineDetails: <StockIcon />,
+        moreInfo: <InfoIcon />,
+      };
 
   return (
     <>

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
@@ -307,19 +307,13 @@ export const InboundLineEditCards = ({
             inboundData?.status === InvoiceNodeStatus.Received ||
             inboundData?.status === InvoiceNodeStatus.Verified;
 
-          if (isStatusDisabled) {
-            const entry = status ? statusMapRef.current[status] : undefined;
-            return entry ? (
-              <Typography variant="body2">{entry.label}</Typography>
-            ) : null;
-          }
-
           return (
             <Select
               value={status ?? ''}
               variant="standard"
               size="small"
               fullWidth
+              disabled={isStatusDisabled}
               sx={{
                 backgroundColor: theme => theme.palette.background.input.main,
                 borderRadius: 2,

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
@@ -321,6 +321,9 @@ export const InboundLineEditCards = ({
                 '& .MuiSelect-select': {
                   py: 0.5,
                 },
+                '&::before, &::after': {
+                  display: 'none',
+                },
               }}
               onChange={e => {
                 updateDraftLine({


### PR DESCRIPTION
## Summary
- Closes point 4 of #9711
- Replaced `StatusChip` pill with a plain text dropdown for the auth status field in the inbound line edit card view
- The table view continues to use the pill/chip style as before

<img width="1279" height="650" alt="image" src="https://github.com/user-attachments/assets/e99789d6-a726-4461-bdce-90ad821ff3a2" />

<img width="1283" height="496" alt="image" src="https://github.com/user-attachments/assets/f5b4152e-796a-41a0-b3dd-3b78eeec9dd1" />


## Test plan
- [ ] Open an inbound shipment with line-level authorisation enabled
- [ ] Verify the status dropdown in the line edit card shows plain text options (not pills)
- [ ] Verify the status column in the table view still shows pills

🤖 Generated with [Claude Code](https://claude.com/claude-code)