### PR TITLE
#11214 Aggregate customer indicators across elmis_code-linked programs

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/IndicatorEdit/IndicatorLineEdit.tsx
@@ -135,7 +135,7 @@ export const IndicatorLineEdit = ({
   const showInfo =
     store?.preferences.useConsumptionAndStockFromCustomersForInternalOrders &&
     store?.preferences?.extraFieldsInRequisition &&
-    !!currentLine?.customerIndicatorInfo;
+    !!currentLine?.customerIndicatorInfo?.length;
   const { width } = useWindowDimensions();
   const t = useTranslation();
 

--- a/server/graphql/core/src/loader/program_indicator_value.rs
+++ b/server/graphql/core/src/loader/program_indicator_value.rs
@@ -6,7 +6,7 @@ use repository::{
     EqualFilter, IndicatorValueRow,
 };
 use service::service_provider::ServiceProvider;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub struct IndicatorValueLoaderInput {
@@ -48,44 +48,43 @@ impl Loader<IndicatorValueLoaderInput> for IndicatorValueLoader {
         loader_inputs: &[IndicatorValueLoaderInput],
     ) -> Result<HashMap<IndicatorValueLoaderInput, Self::Value>, Self::Error> {
         let service_context = self.service_provider.basic_context()?;
+        let repo = IndicatorValueRepository::new(&service_context.connection);
 
-        let (period_id, store_id, customer_name_id) =
-            // TODO replace with logic to not assume only one combination queried at any time.
-            if let Some(loader_input) = loader_inputs.first() {
-                (
-                    loader_input.period_id.clone(),
-                    loader_input.store_id.clone(),
-                    loader_input.customer_name_id.clone(),
-                )
-            } else {
-                return Ok(HashMap::new());
-            };
-        if loader_inputs.len() > 1 {
-            log::error!("Multiple loader inputs provided to IndicatorValueLoader, but only one combination of period_id, store_id, and customer_name_id is supported. Only the first input will be used.");
+        // Group inputs by (period_id, store_id, customer_name_id) to handle
+        // batched requests with different filter combinations
+        let mut groups: HashSet<(String, String, String)> = HashSet::new();
+        for input in loader_inputs {
+            groups.insert((
+                input.period_id.clone(),
+                input.store_id.clone(),
+                input.customer_name_id.clone(),
+            ));
         }
 
-        let filter = IndicatorValueFilter::new()
-            .store_id(EqualFilter::equal_to(store_id.to_string()))
-            .customer_name_id(EqualFilter::equal_to(customer_name_id.to_string()))
-            .period_id(EqualFilter::equal_to(period_id.to_string()));
+        let mut result = HashMap::new();
 
-        let values =
-            IndicatorValueRepository::new(&service_context.connection).query_by_filter(filter)?;
+        for (period_id, store_id, customer_name_id) in &groups {
+            let filter = IndicatorValueFilter::new()
+                .store_id(EqualFilter::equal_to(store_id.clone()))
+                .customer_name_id(EqualFilter::equal_to(customer_name_id.clone()))
+                .period_id(EqualFilter::equal_to(period_id.clone()));
 
-        Ok(values
-            .into_iter()
-            .map(|value| {
-                (
+            let values = repo.query_by_filter(filter)?;
+
+            for value in values {
+                result.insert(
                     IndicatorValueLoaderInput::new(
                         &value.indicator_value_row.indicator_line_id,
                         &value.indicator_value_row.indicator_column_id,
-                        &period_id,
-                        &store_id,
-                        &customer_name_id,
+                        period_id,
+                        store_id,
+                        customer_name_id,
                     ),
                     value.indicator_value_row,
-                )
-            })
-            .collect())
+                );
+            }
+        }
+
+        Ok(result)
     }
 }

--- a/server/repository/src/db_diesel/indicator_line_row.rs
+++ b/server/repository/src/db_diesel/indicator_line_row.rs
@@ -74,6 +74,16 @@ impl<'a> IndicatorLineRowRepository<'a> {
         Ok(result)
     }
 
+    pub fn find_many_by_ids(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<IndicatorLineRow>, RepositoryError> {
+        let result = indicator_line::table
+            .filter(indicator_line::id.eq_any(ids))
+            .load(self.connection.lock().connection())?;
+        Ok(result)
+    }
+
     pub fn find_many_by_indicator_ids(
         &self,
         ids: &[String],

--- a/server/service/src/requisition/common.rs
+++ b/server/service/src/requisition/common.rs
@@ -420,7 +420,7 @@ mod test_related_program_indicators {
     async fn related_program_indicator_ids_empty_input() {
         let (_, connection, _, _) = setup_all_with_data(
             "related_program_indicator_ids_empty_input",
-            MockDataInserts::none().contexts().programs(),
+            MockDataInserts::none().contexts(),
             test_mock_data(),
         )
         .await;
@@ -433,7 +433,7 @@ mod test_related_program_indicators {
     async fn related_program_indicator_ids_expands_via_elmis_code() {
         let (_, connection, _, _) = setup_all_with_data(
             "related_program_indicator_ids_expands_via_elmis_code",
-            MockDataInserts::none().contexts().programs(),
+            MockDataInserts::none().contexts(),
             test_mock_data(),
         )
         .await;
@@ -468,7 +468,7 @@ mod test_related_program_indicators {
 
         let (_, connection, _, _) = setup_all_with_data(
             "related_program_indicator_ids_no_elmis_code_fallback",
-            MockDataInserts::none().contexts().programs(),
+            MockDataInserts::none().contexts(),
             MockData {
                 programs: vec![bare_program],
                 program_indicators: vec![bare_pi.clone()],
@@ -486,7 +486,7 @@ mod test_related_program_indicators {
     async fn related_indicator_schema_returns_cross_program_rows_and_mappings() {
         let (_, connection, _, _) = setup_all_with_data(
             "related_indicator_schema_returns_cross_program",
-            MockDataInserts::none().contexts().programs(),
+            MockDataInserts::none().contexts(),
             test_mock_data(),
         )
         .await;

--- a/server/service/src/requisition/common.rs
+++ b/server/service/src/requisition/common.rs
@@ -1,11 +1,14 @@
+use std::collections::{HashMap, HashSet};
+
 use repository::{
     requisition_row::RequisitionRow, RepositoryError, RequisitionLine, RequisitionLineFilter,
     RequisitionLineRepository, RequisitionRowRepository, StorageConnection,
 };
 use repository::{
-    ApprovalStatusType, EqualFilter, IndicatorColumnRow, IndicatorLineRow, IndicatorValueType,
-    MasterList, MasterListFilter, MasterListRepository, ProgramFilter,
-    ProgramRequisitionOrderTypeRowRepository, ProgramRequisitionSettingsFilter,
+    ApprovalStatusType, EqualFilter, IndicatorColumnRow, IndicatorColumnRowRepository,
+    IndicatorLineRow, IndicatorLineRowRepository, IndicatorValueType, MasterList, MasterListFilter,
+    MasterListRepository, ProgramFilter, ProgramIndicatorFilter, ProgramIndicatorRepository,
+    ProgramRepository, ProgramRequisitionOrderTypeRowRepository, ProgramRequisitionSettingsFilter,
     ProgramRequisitionSettingsRepository, Requisition, RequisitionFilter, RequisitionRepository,
     RequisitionType,
 };
@@ -139,6 +142,100 @@ pub fn check_exceeded_max_orders_for_period(
     }
 }
 
+/// Expand `program_indicator_ids` to include indicators from all programs
+/// sharing the same `elmis_code`. Deployments can split a single
+/// logical program across multiple programs per facility level (customer vs
+/// district) sharing an `elmis_code`; indicators need to aggregate across
+/// them. Falls back to the input IDs when no `elmis_code` is set.
+pub(crate) fn related_program_indicator_ids(
+    connection: &StorageConnection,
+    program_indicator_ids: &[String],
+) -> Result<Vec<String>, RepositoryError> {
+    if program_indicator_ids.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let own_pis = ProgramIndicatorRepository::new(connection).query_by_filter(
+        ProgramIndicatorFilter::new().id(EqualFilter::equal_any(program_indicator_ids.to_vec())),
+    )?;
+    let program_ids: Vec<String> = own_pis
+        .iter()
+        .map(|pi| pi.program_id.clone())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    let elmis_codes: Vec<String> = ProgramRepository::new(connection)
+        .query_by_filter(ProgramFilter::new().id(EqualFilter::equal_any(program_ids)))?
+        .into_iter()
+        .filter_map(|p| p.elmis_code.filter(|c| !c.is_empty()))
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    if elmis_codes.is_empty() {
+        return Ok(program_indicator_ids.to_vec());
+    }
+
+    let related_program_ids: Vec<String> = ProgramRepository::new(connection)
+        .query_by_filter(ProgramFilter::new().elmis_code(EqualFilter::equal_any(elmis_codes)))?
+        .into_iter()
+        .map(|p| p.id)
+        .collect();
+
+    let related_pi_ids: Vec<String> = ProgramIndicatorRepository::new(connection)
+        .query_by_filter(
+            ProgramIndicatorFilter::new().program_id(EqualFilter::equal_any(related_program_ids)),
+        )?
+        .into_iter()
+        .map(|pi| pi.id)
+        .collect();
+
+    Ok(if related_pi_ids.is_empty() {
+        program_indicator_ids.to_vec()
+    } else {
+        related_pi_ids
+    })
+}
+
+/// Lines and columns across all program indicators related (by `elmis_code`)
+/// to the given starting program_indicator_ids, with mappings from any matched
+/// row's `id` back to its identity key (`code` for lines, `(header, column_number)`
+/// for columns). Used to match customer indicator values across programs.
+pub(crate) struct RelatedIndicatorSchema {
+    pub lines: Vec<IndicatorLineRow>,
+    pub columns: Vec<IndicatorColumnRow>,
+    pub line_id_to_code: HashMap<String, String>,
+    pub column_id_to_key: HashMap<String, (String, i32)>,
+}
+
+pub(crate) fn related_indicator_schema(
+    connection: &StorageConnection,
+    program_indicator_ids: &[String],
+) -> Result<RelatedIndicatorSchema, RepositoryError> {
+    let expanded_pi_ids = related_program_indicator_ids(connection, program_indicator_ids)?;
+    let lines =
+        IndicatorLineRowRepository::new(connection).find_many_by_indicator_ids(&expanded_pi_ids)?;
+    let columns = IndicatorColumnRowRepository::new(connection)
+        .find_many_by_indicator_ids(&expanded_pi_ids)?;
+
+    let line_id_to_code = lines
+        .iter()
+        .map(|l| (l.id.clone(), l.code.clone()))
+        .collect();
+    let column_id_to_key = columns
+        .iter()
+        .map(|c| (c.id.clone(), (c.header.clone(), c.column_number)))
+        .collect();
+
+    Ok(RelatedIndicatorSchema {
+        lines,
+        columns,
+        line_id_to_code,
+        column_id_to_key,
+    })
+}
+
 pub(crate) fn indicator_value_type<'a>(
     line: &'a IndicatorLineRow,
     column: &'a IndicatorColumnRow,
@@ -190,4 +287,240 @@ pub(crate) fn get_indicative_price_pref(
             msg: "Could not load showIndicativePriceInRequisitions store preference".to_string(),
             extra: e.to_string(),
         })
+}
+
+#[cfg(test)]
+mod test_related_program_indicators {
+    use super::*;
+    use repository::{
+        mock::{context_program_a, MockData, MockDataInserts},
+        test_db::setup_all_with_data,
+        IndicatorColumnRow, IndicatorLineRow, ProgramIndicatorRow, ProgramRow,
+    };
+
+    // Two programs that share an elmis_code (e.g. CS + DISTRICT facility levels
+    // of the same logical program), each with its own program_indicator.
+    fn program_cs() -> ProgramRow {
+        ProgramRow {
+            id: "elmis_program_cs".to_string(),
+            master_list_id: None,
+            name: "elmis_program_cs".to_string(),
+            context_id: context_program_a().id,
+            is_immunisation: false,
+            elmis_code: Some("SHARED_ELMIS".to_string()),
+            deleted_datetime: None,
+        }
+    }
+    fn program_district() -> ProgramRow {
+        ProgramRow {
+            id: "elmis_program_district".to_string(),
+            master_list_id: None,
+            name: "elmis_program_district".to_string(),
+            context_id: context_program_a().id,
+            is_immunisation: false,
+            elmis_code: Some("SHARED_ELMIS".to_string()),
+            deleted_datetime: None,
+        }
+    }
+    fn program_unrelated() -> ProgramRow {
+        ProgramRow {
+            id: "elmis_program_unrelated".to_string(),
+            master_list_id: None,
+            name: "elmis_program_unrelated".to_string(),
+            context_id: context_program_a().id,
+            is_immunisation: false,
+            elmis_code: Some("OTHER_ELMIS".to_string()),
+            deleted_datetime: None,
+        }
+    }
+    fn pi_cs() -> ProgramIndicatorRow {
+        ProgramIndicatorRow {
+            id: "pi_cs".to_string(),
+            program_id: program_cs().id,
+            code: Some("pi_cs".to_string()),
+            is_active: true,
+        }
+    }
+    fn pi_district() -> ProgramIndicatorRow {
+        ProgramIndicatorRow {
+            id: "pi_district".to_string(),
+            program_id: program_district().id,
+            code: Some("pi_district".to_string()),
+            is_active: true,
+        }
+    }
+    fn pi_unrelated() -> ProgramIndicatorRow {
+        ProgramIndicatorRow {
+            id: "pi_unrelated".to_string(),
+            program_id: program_unrelated().id,
+            code: Some("pi_unrelated".to_string()),
+            is_active: true,
+        }
+    }
+    fn line_cs() -> IndicatorLineRow {
+        IndicatorLineRow {
+            id: "line_cs".to_string(),
+            code: "SHARED_CODE".to_string(),
+            program_indicator_id: pi_cs().id,
+            line_number: 0,
+            description: "CS line".to_string(),
+            value_type: Some(repository::IndicatorValueType::Number),
+            default_value: "0".to_string(),
+            is_required: false,
+            is_active: true,
+        }
+    }
+    fn line_district() -> IndicatorLineRow {
+        IndicatorLineRow {
+            id: "line_district".to_string(),
+            code: "SHARED_CODE".to_string(),
+            program_indicator_id: pi_district().id,
+            line_number: 0,
+            description: "District line".to_string(),
+            value_type: Some(repository::IndicatorValueType::Number),
+            default_value: "0".to_string(),
+            is_required: false,
+            is_active: true,
+        }
+    }
+    fn col_cs() -> IndicatorColumnRow {
+        IndicatorColumnRow {
+            id: "col_cs".to_string(),
+            program_indicator_id: pi_cs().id,
+            column_number: 0,
+            header: "SHARED_HEADER".to_string(),
+            value_type: Some(repository::IndicatorValueType::Number),
+            default_value: "0".to_string(),
+            is_active: true,
+        }
+    }
+    fn col_district() -> IndicatorColumnRow {
+        IndicatorColumnRow {
+            id: "col_district".to_string(),
+            program_indicator_id: pi_district().id,
+            column_number: 0,
+            header: "SHARED_HEADER".to_string(),
+            value_type: Some(repository::IndicatorValueType::Number),
+            default_value: "0".to_string(),
+            is_active: true,
+        }
+    }
+
+    fn test_mock_data() -> MockData {
+        MockData {
+            programs: vec![program_cs(), program_district(), program_unrelated()],
+            program_indicators: vec![pi_cs(), pi_district(), pi_unrelated()],
+            indicator_lines: vec![line_cs(), line_district()],
+            indicator_columns: vec![col_cs(), col_district()],
+            ..Default::default()
+        }
+    }
+
+    #[actix_rt::test]
+    async fn related_program_indicator_ids_empty_input() {
+        let (_, connection, _, _) = setup_all_with_data(
+            "related_program_indicator_ids_empty_input",
+            MockDataInserts::none().contexts().programs(),
+            test_mock_data(),
+        )
+        .await;
+
+        let result = related_program_indicator_ids(&connection, &[]).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[actix_rt::test]
+    async fn related_program_indicator_ids_expands_via_elmis_code() {
+        let (_, connection, _, _) = setup_all_with_data(
+            "related_program_indicator_ids_expands_via_elmis_code",
+            MockDataInserts::none().contexts().programs(),
+            test_mock_data(),
+        )
+        .await;
+
+        let mut result =
+            related_program_indicator_ids(&connection, &[pi_cs().id]).unwrap();
+        result.sort();
+        assert_eq!(result, vec![pi_cs().id, pi_district().id]);
+
+        // Unrelated PI (different elmis_code) is not pulled in.
+        assert!(!result.contains(&pi_unrelated().id));
+    }
+
+    #[actix_rt::test]
+    async fn related_program_indicator_ids_no_elmis_code_fallback() {
+        // Program with no elmis_code should fall back to returning the input ids.
+        let bare_program = ProgramRow {
+            id: "bare_program".to_string(),
+            master_list_id: None,
+            name: "bare_program".to_string(),
+            context_id: context_program_a().id,
+            is_immunisation: false,
+            elmis_code: None,
+            deleted_datetime: None,
+        };
+        let bare_pi = ProgramIndicatorRow {
+            id: "bare_pi".to_string(),
+            program_id: bare_program.id.clone(),
+            code: None,
+            is_active: true,
+        };
+
+        let (_, connection, _, _) = setup_all_with_data(
+            "related_program_indicator_ids_no_elmis_code_fallback",
+            MockDataInserts::none().contexts().programs(),
+            MockData {
+                programs: vec![bare_program],
+                program_indicators: vec![bare_pi.clone()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let result =
+            related_program_indicator_ids(&connection, &[bare_pi.id.clone()]).unwrap();
+        assert_eq!(result, vec![bare_pi.id]);
+    }
+
+    #[actix_rt::test]
+    async fn related_indicator_schema_returns_cross_program_rows_and_mappings() {
+        let (_, connection, _, _) = setup_all_with_data(
+            "related_indicator_schema_returns_cross_program",
+            MockDataInserts::none().contexts().programs(),
+            test_mock_data(),
+        )
+        .await;
+
+        let schema = related_indicator_schema(&connection, &[pi_cs().id]).unwrap();
+
+        // Lines from both CS and DISTRICT PIs.
+        let mut line_ids: Vec<String> = schema.lines.iter().map(|l| l.id.clone()).collect();
+        line_ids.sort();
+        assert_eq!(line_ids, vec![line_cs().id, line_district().id]);
+
+        // Columns from both PIs.
+        let mut col_ids: Vec<String> = schema.columns.iter().map(|c| c.id.clone()).collect();
+        col_ids.sort();
+        assert_eq!(col_ids, vec![col_cs().id, col_district().id]);
+
+        // line_id → code mapping covers both programs; both share the same code.
+        assert_eq!(
+            schema.line_id_to_code.get(&line_cs().id),
+            Some(&"SHARED_CODE".to_string())
+        );
+        assert_eq!(
+            schema.line_id_to_code.get(&line_district().id),
+            Some(&"SHARED_CODE".to_string())
+        );
+
+        // column_id → (header, column_number) mapping covers both programs.
+        assert_eq!(
+            schema.column_id_to_key.get(&col_cs().id),
+            Some(&("SHARED_HEADER".to_string(), 0))
+        );
+        assert_eq!(
+            schema.column_id_to_key.get(&col_district().id),
+            Some(&("SHARED_HEADER".to_string(), 0))
+        );
+    }
 }

--- a/server/service/src/requisition/request_requisition/indicator_information.rs
+++ b/server/service/src/requisition/request_requisition/indicator_information.rs
@@ -3,25 +3,19 @@ use std::collections::HashMap;
 use chrono::NaiveDateTime;
 use repository::{
     indicator_value::{IndicatorValueFilter, IndicatorValueRepository},
-    EqualFilter, IndicatorValueRow, NameFilter, NameRepository, Pagination, PeriodRowRepository,
-    RepositoryError,
+    EqualFilter, IndicatorLineRowRepository, NameFilter, NameRepository, Pagination,
+    PeriodRowRepository, RepositoryError,
 };
 
-use crate::{service_provider::ServiceContext, store_preference::get_store_preferences};
+use crate::{
+    requisition::common::related_indicator_schema, service_provider::ServiceContext,
+    store_preference::get_store_preferences,
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct IndicatorInformation {
     pub column_id: String,
     pub value: String,
-}
-
-impl IndicatorInformation {
-    fn from_value(value: &IndicatorValueRow) -> Self {
-        Self {
-            column_id: value.indicator_column_id.clone(),
-            value: value.value.clone(),
-        }
-    }
 }
 #[derive(Debug, Clone, PartialEq)]
 pub struct CustomerIndicatorInformation {
@@ -67,25 +61,70 @@ pub fn get_indicator_information(
         None => return Ok(vec![]),
     };
 
+    // Expand to indicator lines in all programs sharing the same elmis_code so
+    // cross-program aggregation works (e.g. CIV CS vs DISTRICT programs).
+    let requested_lines =
+        IndicatorLineRowRepository::new(connection).find_many_by_ids(&line_ids)?;
+    let own_pi_ids: Vec<String> = requested_lines
+        .iter()
+        .map(|l| l.program_indicator_id.clone())
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
+    let schema = related_indicator_schema(connection, &own_pi_ids)?;
+    let expanded_line_ids: Vec<String> = schema.lines.iter().map(|l| l.id.clone()).collect();
+
+    // Map (header, column_number) -> requested column_id. The frontend joins
+    // column values by the requested (district) column_id, so values from
+    // customer programs need to be remapped onto the requested IDs.
+    let own_pi_id_set: std::collections::HashSet<&str> =
+        own_pi_ids.iter().map(String::as_str).collect();
+    let requested_column_key_to_id: HashMap<(String, i32), String> = schema
+        .columns
+        .iter()
+        .filter(|c| own_pi_id_set.contains(c.program_indicator_id.as_str()))
+        .map(|c| ((c.header.clone(), c.column_number), c.id.clone()))
+        .collect();
+
     let values = IndicatorValueRepository::new(connection).query_by_filter(
         IndicatorValueFilter::new()
             .store_id(EqualFilter::equal_to(store_id.to_string()))
             .period_id(EqualFilter::equal_to(period_id.to_string()))
-            .indicator_line_id(EqualFilter::equal_any(line_ids.clone()))
+            .indicator_line_id(EqualFilter::equal_any(expanded_line_ids))
             .customer_name_id(EqualFilter::equal_any(customer_ids.clone())),
     )?;
 
     let mut result: Vec<CustomerIndicatorInformation> = vec![];
 
+    let requested_line_code: HashMap<String, String> = requested_lines
+        .iter()
+        .map(|l| (l.id.clone(), l.code.clone()))
+        .collect();
+
     for line_id in line_ids {
-        let line_values = values
-            .iter()
-            .filter(|v| v.indicator_value_row.indicator_line_id == line_id);
+        let Some(line_code) = requested_line_code.get(&line_id) else {
+            continue;
+        };
+        let line_values = values.iter().filter(|v| {
+            schema
+                .line_id_to_code
+                .get(&v.indicator_value_row.indicator_line_id)
+                == Some(line_code)
+        });
         for customer_id in customer_ids.clone() {
-            let customer_line_values = line_values
+            let customer_line_values: Vec<IndicatorInformation> = line_values
                 .clone()
                 .filter(|v| v.name_row.id == *customer_id)
-                .map(|v| IndicatorInformation::from_value(&v.indicator_value_row))
+                .filter_map(|v| {
+                    let key = schema
+                        .column_id_to_key
+                        .get(&v.indicator_value_row.indicator_column_id)?;
+                    let requested_column_id = requested_column_key_to_id.get(key)?.clone();
+                    Some(IndicatorInformation {
+                        column_id: requested_column_id,
+                        value: v.indicator_value_row.value.clone(),
+                    })
+                })
                 .collect();
 
             result.push(CustomerIndicatorInformation {

--- a/server/service/src/requisition/request_requisition/insert_program.rs
+++ b/server/service/src/requisition/request_requisition/insert_program.rs
@@ -8,7 +8,8 @@ use crate::{
     requisition::{
         common::{
             check_exceeded_max_orders_for_period, check_requisition_row_exists,
-            default_indicator_value, indicator_value_type, CheckExceededOrdersForPeriod,
+            default_indicator_value, indicator_value_type, related_indicator_schema,
+            CheckExceededOrdersForPeriod,
         },
         program_indicator::query::{program_indicators, ProgramIndicator},
         program_settings::get_supplier_program_requisition_settings,
@@ -23,8 +24,8 @@ use repository::{
     indicator_value::{IndicatorValueFilter, IndicatorValueRepository},
     requisition_row::{RequisitionRow, RequisitionStatus, RequisitionType},
     ActivityLogType, EqualFilter, IndicatorValueRow, IndicatorValueRowRepository,
-    IndicatorValueType, MasterListLineFilter, MasterListLineRepository, NameFilter, NameRepository,
-    NumberRowType, Pagination, PeriodRowRepository, PluginDataRowRepository,
+    IndicatorValueType, MasterListLineFilter, MasterListLineRepository, NameFilter,
+    NameRepository, NumberRowType, Pagination, PeriodRowRepository, PluginDataRowRepository,
     ProgramIndicatorFilter, ProgramRequisitionOrderTypeRow, ProgramRow, RepositoryError,
     Requisition, RequisitionLineRow, RequisitionLineRowRepository, RequisitionRowRepository,
     StorageConnection, StoreFilter, StoreRepository,
@@ -314,30 +315,20 @@ fn generate_program_indicator_values(
         .map(|name| name.name_row.id)
         .collect();
 
-    let indicator_line_ids = program_indicators
+    let own_pi_ids: Vec<String> = program_indicators
         .iter()
-        .flat_map(|program_indicator| {
-            program_indicator
-                .lines
-                .iter()
-                .map(|line| line.line.id.clone())
-        })
-        .collect::<Vec<String>>();
-    let indicator_column_ids = program_indicators
-        .iter()
-        .flat_map(|program_indicator| {
-            program_indicator
-                .lines
-                .iter()
-                .flat_map(|line| line.columns.iter().map(|column| column.id.clone()))
-        })
-        .collect::<Vec<String>>();
+        .map(|pi| pi.program_indicator.id.clone())
+        .collect();
+    let schema = related_indicator_schema(connection, &own_pi_ids)?;
+    let expanded_line_ids: Vec<String> = schema.lines.iter().map(|l| l.id.clone()).collect();
+    let expanded_column_ids: Vec<String> = schema.columns.iter().map(|c| c.id.clone()).collect();
 
     let customer_values = IndicatorValueRepository::new(connection).query_by_filter(
         IndicatorValueFilter::new()
+            .store_id(EqualFilter::equal_to(store_id.to_string()))
             .period_id(EqualFilter::equal_to(period_id.to_string()))
-            .indicator_line_id(EqualFilter::equal_any(indicator_line_ids))
-            .indicator_column_id(EqualFilter::equal_any(indicator_column_ids))
+            .indicator_line_id(EqualFilter::equal_any(expanded_line_ids))
+            .indicator_column_id(EqualFilter::equal_any(expanded_column_ids))
             .customer_name_id(EqualFilter::equal_any(customer_name_ids.clone())),
     )?;
 
@@ -353,11 +344,21 @@ fn generate_program_indicator_values(
                     && value_type == &Some(IndicatorValueType::Number)
                     && !customer_name_ids.is_empty()
                 {
+                    // Match customer values by code (lines) and header (columns)
+                    // instead of by ID, to support cross-program aggregation
                     customer_values
                         .iter()
                         .filter(|v| {
-                            v.indicator_value_row.indicator_line_id == line.line.id
-                                && v.indicator_value_row.indicator_column_id == column.id
+                            let code_matches = schema
+                                .line_id_to_code
+                                .get(&v.indicator_value_row.indicator_line_id)
+                                == Some(&line.line.code);
+                            let col_matches = schema
+                                .column_id_to_key
+                                .get(&v.indicator_value_row.indicator_column_id)
+                                .map(|(h, n)| h == &column.header && *n == column.column_number)
+                                .unwrap_or(false);
+                            code_matches && col_matches
                         })
                         .map(|v| {
                             v.indicator_value_row


### PR DESCRIPTION
Fixes #11214

# 👩🏻‍💻 What does this PR do?

When a district store creates a program internal order, the indicators tab aggregates values from finalised customer requisitions for the same period. The aggregation was scoped to the current program only, so deployments that split a single logical program across multiple `program` rows per facility level (e.g. CIV's `CS` vs `DISTRICT` variants sharing an `elmis_code`) saw `-0` in the main values and an empty per-customer breakdown.

Changes:
- New `related_program_indicator_ids` / `related_indicator_schema` helpers in `requisition/common.rs` expand starting `program_indicator_ids` to include all indicators from programs sharing the same `elmis_code`. Falls back to the input IDs when no `elmis_code` is set.
- `generate_program_indicator_values` (on request requisition creation) and `get_indicator_information` (per-customer breakdown query) now match customer indicator values by line `code` and column `(header, column_number)` across related programs, not by raw IDs. This mirrors Legacy mSupply's `elmisCode`-based lookup in `indicatorSetValuesFromReponse.4dm`.
- `get_indicator_information` remaps customer column IDs onto the requested (district) column IDs so the frontend `CustomerIndicatorInfo` table — which joins values by `columnId` — renders them under the correct columns.
- Aggregation query gains a `store_id` filter to stop double-counting customer rows + the district's transferred copies when both exist in the same DB.
- Frontend: `IndicatorLineEdit` now checks `customerIndicatorInfo?.length` instead of truthy, so the breakdown box hides when there are no customers with store-type accounts (covers #11226).
- Tangentially, `IndicatorValueLoader` was rewritten to group inputs by `(period, store, customer)` so batched GraphQL requests with different filter combinations no longer silently drop all but the first.

## 💌 Any notes for the reviewer?

- The `elmis_code` approach matches how Legacy does cross-level aggregation; see `Project/Sources/Methods/indicatorSetValuesFromReponse.4dm` in the legacy repo.
- `indicator_information.rs` builds `requested_column_key_to_id` from only the requesting program's columns (filtered by `own_pi_id_set`) to ensure the remap targets the district-side column IDs, not any other program's.
- New tests in `requisition/common.rs` cover the three behaviours of `related_program_indicator_ids` (empty input, elmis_code expansion, no-elmis_code fallback) and the `related_indicator_schema` mapping output.
- Also closes the frontend side of #11226 (empty aggregation box visible on stores with no store-type customers), which the issue author has also confirmed is a related symptom of the same CIV setup.

# 🧪 Testing

- [ ] Two customer stores (e.g. CIV CS-level) sharing a district supplier, plus the district creating its own internal order to a central supplier
- [ ] Customer programs use a different `program_id` from the district program but share the same `elmis_code`
- [ ] Both prefs enabled on the district store: `useConsumptionAndStockFromCustomersForInternalOrders`, `extraFieldsInRequisition`
- [ ] Create request requisitions from two customer stores with indicator values, send and finalise at the district
- [ ] Create a new district internal order for the same period → main indicator values should be the sum of the two customers' values, per-customer breakdown box should show each customer with their individual values under the correct columns
- [ ] Repeat on a deployment with a single program (no `elmis_code` split) to confirm fallback path still aggregates correctly

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**:
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend