### PR TITLE
11273: Settings logs and stock logs

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -7603,6 +7603,7 @@ export type QueriesActivityLogsArgs = {
   filter?: InputMaybe<ActivityLogFilterInput>;
   page?: InputMaybe<PaginationInput>;
   sort?: InputMaybe<Array<ActivityLogSortInput>>;
+  storeId: Scalars['String']['input'];
 };
 
 export type QueriesAllReportVersionsArgs = {

--- a/client/packages/host/src/Admin/ServerSettings.tsx
+++ b/client/packages/host/src/Admin/ServerSettings.tsx
@@ -83,7 +83,7 @@ export const ServerSettings = () => {
         title={t('label.server-log')}
         component={
           <>
-            <LogFileModal onClose={hideLog} isOpen={isLogShown} />
+            {isLogShown && <LogFileModal onClose={hideLog} isOpen={isLogShown} />}
             <BaseButton onClick={showLog}>{t('button.view')}</BaseButton>
           </>
         }
@@ -135,7 +135,7 @@ export const ServerSettings = () => {
         title={t('label.server-log')}
         component={
           <>
-            <LogFileModal onClose={hideLog} isOpen={isLogShown} />
+            {isLogShown && <LogFileModal onClose={hideLog} isOpen={isLogShown} />}
             <BaseButton onClick={showLog}>{t('button.view')}</BaseButton>
           </>
         }

--- a/client/packages/system/src/ActivityLog/api/hooks/useActivityLog.ts
+++ b/client/packages/system/src/ActivityLog/api/hooks/useActivityLog.ts
@@ -5,6 +5,7 @@ import {
   ActivityLogSortFieldInput,
   ActivityLogNodeType,
   isEnumValue,
+  useAuthContext,
 } from '@openmsupply-client/common';
 import { ActivityLogRowFragment } from '../operations.generated';
 import { useActivityLogGraphQL } from '../useActivityLogGraphQL';
@@ -17,6 +18,7 @@ export function useActivityLog(
   sortBy?: SortBy<ActivityLogRowFragment>
 ) {
   const { activityLogApi } = useActivityLogGraphQL();
+  const { storeId } = useAuthContext();
 
   const queryKey = [ACTIVITY_LOG, recordId, sortBy];
   const queryFn = async (): Promise<{
@@ -29,6 +31,7 @@ export function useActivityLog(
     };
 
     const query = await activityLogApi.activityLogs({
+      storeId,
       offset: 0,
       first: 1000,
       sort: sortBy ? getSortInput(sortBy) : undefined,

--- a/client/packages/system/src/ActivityLog/api/operations.generated.ts
+++ b/client/packages/system/src/ActivityLog/api/operations.generated.ts
@@ -16,6 +16,7 @@ export type ActivityLogRowFragment = {
 };
 
 export type ActivityLogsQueryVariables = Types.Exact<{
+  storeId: Types.Scalars['String']['input'];
   first?: Types.InputMaybe<Types.Scalars['Int']['input']>;
   offset?: Types.InputMaybe<Types.Scalars['Int']['input']>;
   sort?: Types.InputMaybe<
@@ -59,12 +60,14 @@ export const ActivityLogRowFragmentDoc = gql`
 `;
 export const ActivityLogsDocument = gql`
   query activityLogs(
+    $storeId: String!
     $first: Int
     $offset: Int
     $sort: [ActivityLogSortInput!]
     $filter: ActivityLogFilterInput
   ) {
     activityLogs(
+      storeId: $storeId
       filter: $filter
       page: { first: $first, offset: $offset }
       sort: $sort

--- a/client/packages/system/src/ActivityLog/api/operations.generated.ts
+++ b/client/packages/system/src/ActivityLog/api/operations.generated.ts
@@ -103,7 +103,7 @@ export function getSdk(
 ) {
   return {
     activityLogs(
-      variables?: ActivityLogsQueryVariables,
+      variables: ActivityLogsQueryVariables,
       requestHeaders?: GraphQLClientRequestHeaders,
       signal?: RequestInit['signal']
     ): Promise<ActivityLogsQuery> {

--- a/client/packages/system/src/ActivityLog/api/operations.graphql
+++ b/client/packages/system/src/ActivityLog/api/operations.graphql
@@ -12,12 +12,14 @@ fragment ActivityLogRow on ActivityLogNode {
 }
 
 query activityLogs(
+  $storeId: String!
   $first: Int
   $offset: Int
   $sort: [ActivityLogSortInput!]
   $filter: ActivityLogFilterInput
 ) {
   activityLogs(
+    storeId: $storeId
     filter: $filter
     page: { first: $first, offset: $offset }
     sort: $sort

--- a/server/graphql/general/src/lib.rs
+++ b/server/graphql/general/src/lib.rs
@@ -266,12 +266,13 @@ impl GeneralQueries {
     pub async fn activity_logs(
         &self,
         ctx: &Context<'_>,
+        store_id: String,
         #[graphql(desc = "Pagination option (first and offset)")] page: Option<PaginationInput>,
         #[graphql(desc = "Filter option")] filter: Option<ActivityLogFilterInput>,
         #[graphql(desc = "Sort options (only first sort input is evaluated for this endpoint)")]
         sort: Option<Vec<ActivityLogSortInput>>,
     ) -> Result<ActivityLogResponse> {
-        activity_logs(ctx, page, filter, sort)
+        activity_logs(ctx, store_id, page, filter, sort)
     }
 
     /// Available without authorisation in operational and initialisation states

--- a/server/graphql/general/src/queries/activity_log.rs
+++ b/server/graphql/general/src/queries/activity_log.rs
@@ -60,6 +60,7 @@ pub enum ActivityLogResponse {
 
 pub fn activity_logs(
     ctx: &Context<'_>,
+    store_id: String,
     page: Option<PaginationInput>,
     filter: Option<ActivityLogFilterInput>,
     sort: Option<Vec<ActivityLogSortInput>>,
@@ -68,7 +69,7 @@ pub fn activity_logs(
         ctx,
         &ResourceAccessRequest {
             resource: Resource::QueryLog,
-            store_id: None,
+            store_id: Some(store_id),
         },
     )?;
 

--- a/server/graphql/general/src/queries/log.rs
+++ b/server/graphql/general/src/queries/log.rs
@@ -36,7 +36,7 @@ pub fn log_file_names(ctx: &Context<'_>) -> Result<LogNode> {
     validate_auth(
         ctx,
         &ResourceAccessRequest {
-            resource: Resource::QueryLog,
+            resource: Resource::ServerAdmin,
             store_id: None,
         },
     )?;
@@ -53,7 +53,7 @@ pub fn log_content(ctx: &Context<'_>, file_name: Option<String>) -> Result<LogNo
     validate_auth(
         ctx,
         &ResourceAccessRequest {
-            resource: Resource::QueryLog,
+            resource: Resource::ServerAdmin,
             store_id: None,
         },
     )?;
@@ -70,7 +70,7 @@ pub fn log_level(ctx: &Context<'_>) -> Result<LogLevelNode> {
     validate_auth(
         ctx,
         &ResourceAccessRequest {
-            resource: Resource::QueryLog,
+            resource: Resource::ServerAdmin,
             store_id: None,
         },
     )?;

--- a/server/graphql/general/src/queries/tests/activity_log.rs
+++ b/server/graphql/general/src/queries/tests/activity_log.rs
@@ -16,8 +16,8 @@ mod graphql {
         )
         .await;
 
-        let query = r#"query activityLogs {
-            activityLogs {
+        let query = r#"query activityLogs($storeId: String!) {
+            activityLogs(storeId: $storeId) {
                 ... on ActivityLogConnector {
                     nodes {
                         datetime
@@ -29,6 +29,10 @@ mod graphql {
                 }
             }
         }"#;
+
+        let variables = json!({
+            "storeId": "store_a"
+        });
 
         let expected = json!({
             "activityLogs": {
@@ -58,7 +62,7 @@ mod graphql {
             }
         });
 
-        assert_graphql_query!(&settings, query, &None, Some(&expected), None);
+        assert_graphql_query!(&settings, query, &Some(variables), Some(&expected), None);
     }
 
     #[actix_rt::test]
@@ -71,8 +75,8 @@ mod graphql {
         )
         .await;
 
-        let query = r#"query activityLogs($activityLogFilter: ActivityLogFilterInput!) {
-            activityLogs(filter: $activityLogFilter) {
+        let query = r#"query activityLogs($storeId: String!, $activityLogFilter: ActivityLogFilterInput!) {
+            activityLogs(storeId: $storeId, filter: $activityLogFilter) {
                 ... on ActivityLogConnector {
                     nodes {
                         datetime
@@ -92,6 +96,7 @@ mod graphql {
         }"#;
 
         let variables = json!({
+            "storeId": "store_a",
             "activityLogFilter": {
                 "type": {
                     "equalTo": "INVOICE_CREATED"


### PR DESCRIPTION
Closes #11273

## Root cause

PR #11189 tightened the permission check for `Resource::QueryLog` by adding `HasStoreAccess` alongside `HasPermission(LogQuery)`. This broke all callers that were passing `store_id: None` — which included both the server log file queries and the activity log query.

## Changes

Three categories:

### 1. Server log file queries (`log_file_names`, `log_content`, `log_level`)

Changed from `Resource::QueryLog` to `Resource::ServerAdmin`.

These read files from the server filesystem (not store-scoped data), so `HasStoreAccess` was never appropriate. `Resource::ServerAdmin` matches the existing UI behaviour — the log viewer is only rendered for `ServerAdmin` users.

### 2. Activity log query (`activity_logs`)

Added a `storeId` parameter and passes it to the auth check. Activity logs ARE store-scoped, so passing `store_id` is the correct fix to satisfy the `HasStoreAccess` check.

### 3. Client

- Only mount `LogFileModal` when the modal is actually open (prevents the `logFileNames` query from firing on Settings page load).
- Pass `storeId` from the auth context in the `useActivityLog` hook.

## Test plan

- [ ] Open Settings page as a ServerAdmin user — no auth error
- [ ] Open the log file modal from Settings — logs load correctly
- [ ] View activity logs on stock lines, invoices, stocktakes — logs load correctly
- [ ] Non-ServerAdmin users should not see log file queries firing