### PR TITLE
11281: prevent double login bug

### DIFF
--- a/client/packages/host/src/Host.tsx
+++ b/client/packages/host/src/Host.tsx
@@ -182,7 +182,9 @@ const Host = () => (
                   <MigrationInfoProvider>
                     <AuthProvider>
                       <PreInit>
-                        <Init />
+                        <React.Suspense fallback={null}>
+                          <Init />
+                        </React.Suspense>
                       </PreInit>
                       <ConfirmationModalProvider>
                         <AlertModalProvider>

--- a/client/packages/host/src/Host.tsx
+++ b/client/packages/host/src/Host.tsx
@@ -182,9 +182,7 @@ const Host = () => (
                   <MigrationInfoProvider>
                     <AuthProvider>
                       <PreInit>
-                        <React.Suspense fallback={null}>
-                          <Init />
-                        </React.Suspense>
+                        <Init />
                       </PreInit>
                       <ConfirmationModalProvider>
                         <AlertModalProvider>

--- a/client/packages/host/src/Host.tsx
+++ b/client/packages/host/src/Host.tsx
@@ -188,8 +188,7 @@ const Host = () => (
                       </PreInit>
                       <ConfirmationModalProvider>
                         <AlertModalProvider>
-                          {/* eslint-disable-next-line camelcase */}
-                          <RouterProvider router={router} future={{ v7_startTransition: true }} />
+                          <RouterProvider router={router} />
                         </AlertModalProvider>
                       </ConfirmationModalProvider>
                     </AuthProvider>

--- a/client/playwright/e2e/smoke-all-sections.spec.ts
+++ b/client/playwright/e2e/smoke-all-sections.spec.ts
@@ -62,7 +62,11 @@ function setupErrorTracking(page: Page): ErrorTracker {
         tracker.hasInfiniteLoop = true;
       }
     } else if (msg.type() === 'warning') {
-      tracker.warnings.push(text);
+      // React Router v6 emits deprecation warnings about v7 future flags;
+      // these are informational and not actionable bugs.
+      if (!text.includes('React Router Future Flag Warning')) {
+        tracker.warnings.push(text);
+      }
     }
   });
   page.on('pageerror', err => {


### PR DESCRIPTION
## Summary
- Fixes #11281
- Removes the `v7_startTransition` future flag from `RouterProvider`, which was the root cause of the double-login bug
- Suppresses the React Router v6 deprecation warning in smoke tests instead

## Root cause
Commit `b508bb0c9e` added `future={{ v7_startTransition: true }}` to `RouterProvider` to suppress a React Router deprecation warning that was failing the smoke tests. This flag wraps all router state updates in `React.startTransition()`, which keeps the old route (Login) mounted while React prepares the new route after navigation. During this transition, the Login component's mount-time `logout()` effect can re-fire and wipe the auth cookie that was just set by `login()` — sending the user back to the login page.

## Fix
- **Remove `v7_startTransition`** — restores synchronous navigation state updates, eliminating the race condition. The flag was only added to silence a console warning, not for any functional benefit. We're on react-router-dom v6 and don't need to opt into v7 concurrent behaviour.
- **Filter the deprecation warning in the smoke test** — the `"React Router Future Flag Warning"` only fires in dev mode and is informational, not an actionable bug.

## Test plan
- [ ] Clear cookies / use incognito
- [ ] Log in with valid credentials — should navigate to the app on the **first** attempt
- [ ] Verify preferences and isCentralServer data still load correctly after login
- [ ] Run smoke tests — should pass without v7 deprecation warnings causing failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)