### PR TITLE
Fix minor sync UI bug

### DIFF
--- a/client/packages/common/src/api/hooks/useSubscription.ts
+++ b/client/packages/common/src/api/hooks/useSubscription.ts
@@ -59,6 +59,7 @@ export const useSubscription = <TSubscription, TData>({
   useEffect(() => {
     if (!enabled || (requireAuth && !token)) {
       setIsSubscribed(false);
+      setData(undefined);
       return;
     }
 
@@ -105,6 +106,7 @@ export const useSubscription = <TSubscription, TData>({
     return () => {
       disposed = true;
       setIsSubscribed(false);
+      setData(undefined);
       if (unsubscribeRef.current) {
         unsubscribeRef.current();
         unsubscribeRef.current = null;

--- a/client/packages/system/src/Sync/api/hooks/utils/useSyncApi.ts
+++ b/client/packages/system/src/Sync/api/hooks/utils/useSyncApi.ts
@@ -7,7 +7,7 @@ export const useSyncApi = () => {
     base: () => ['sync'] as const,
     syncSettings: () => [...keys.base(), 'syncSettings'] as const,
     syncStatus: () => [...keys.base(), 'syncStatus'] as const,
-    syncInfo: () => [...keys.base(), 'syncStatus'] as const,
+    syncInfo: () => [...keys.base(), 'syncInfo'] as const,
   };
 
   const { client } = useGql();

--- a/client/packages/system/src/Sync/api/hooks/utils/useSyncInfo.ts
+++ b/client/packages/system/src/Sync/api/hooks/utils/useSyncInfo.ts
@@ -30,9 +30,6 @@ export const useSyncInfo = (
     () => api.get.syncInfo(token),
     {
       refetchInterval: isSubscribed ? false : refetchInterval,
-      // Everytime a new consumer mounts, they need to get the latest sync info, so we always want to refetch on mount
-      // Any updates, will be handled by the subscription if it's working, otherwise we'll just get the latest info on the next poll
-      refetchOnMount: 'always',
       enabled: isEnabled,
     }
   );

--- a/client/packages/system/src/Sync/api/hooks/utils/useSyncInfo.ts
+++ b/client/packages/system/src/Sync/api/hooks/utils/useSyncInfo.ts
@@ -30,6 +30,9 @@ export const useSyncInfo = (
     () => api.get.syncInfo(token),
     {
       refetchInterval: isSubscribed ? false : refetchInterval,
+      // Everytime a new consumer mounts, they need to get the latest sync info, so we always want to refetch on mount
+      // Any updates, will be handled by the subscription if it's working, otherwise we'll just get the latest info on the next poll
+      refetchOnMount: 'always',
       enabled: isEnabled,
     }
   );

--- a/client/packages/system/src/Sync/api/hooks/utils/useSyncStatus.ts
+++ b/client/packages/system/src/Sync/api/hooks/utils/useSyncStatus.ts
@@ -31,9 +31,6 @@ export const useSyncStatus = (
     {
       cacheTime: 0,
       refetchInterval: isSubscribed ? false : refetchInterval,
-      // Everytime a new consumer mounts, they need to get the latest sync info, so we always want to refetch on mount
-      // Any updates, will be handled by the subscription if it's working, otherwise we'll just get the latest info on the next poll
-      refetchOnMount: 'always',
       enabled,
     }
   );

--- a/client/packages/system/src/Sync/api/hooks/utils/useSyncStatus.ts
+++ b/client/packages/system/src/Sync/api/hooks/utils/useSyncStatus.ts
@@ -1,4 +1,8 @@
-import { useMutation, useQuery, useSubscription } from '@openmsupply-client/common';
+import {
+  useMutation,
+  useQuery,
+  useSubscription,
+} from '@openmsupply-client/common';
 import { useSyncApi } from './useSyncApi';
 import {
   SyncInfoUpdatedDocument,
@@ -27,6 +31,9 @@ export const useSyncStatus = (
     {
       cacheTime: 0,
       refetchInterval: isSubscribed ? false : refetchInterval,
+      // Everytime a new consumer mounts, they need to get the latest sync info, so we always want to refetch on mount
+      // Any updates, will be handled by the subscription if it's working, otherwise we'll just get the latest info on the next poll
+      refetchOnMount: 'always',
       enabled,
     }
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10934

# 👩🏻‍💻 What does this PR do?

Cleans up a minor bug regarding showing stale data in the subscription modal.

Sync badge used to show the correct info eg. '5' but the sync modal would show 'there are no records to push'. After the change both modal and badge show the correct info:
<img width="1430" height="783" alt="image" src="https://github.com/user-attachments/assets/6121267e-eeed-4e82-805e-431e32b9c9bb" />



## 💌 Any notes for the reviewer?
In `useSubscrition` - the hook for graphql subscriptions this change adds changes for cleaning up data so when a component mounts/un-mounts or toggles the enabled flag it will always refetch fresh data

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Make changes that trigger the sync badge to show number of records to push (e.g adding stock)
- [ ] Open sync modal
- [ ] Verify Modal is showing up-to-date info

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

