### PR TITLE
Upgrade docs to Zola 0.22.1

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -18,8 +18,10 @@ search_placeholder = "Search docs..."
 internal_level = "warn"
 
 [markdown]
-highlight_code = true
 insert_anchor_links = "none"
+
+[markdown.highlighting]
+theme = "one-dark-pro"
 
 [search]
 include_title = true

--- a/docs/content/tools/zola-docs/_index.md
+++ b/docs/content/tools/zola-docs/_index.md
@@ -56,24 +56,28 @@ docs/
 
 ### Install Zola for macOS
 
-Zola v0.17.2 is required (later versions have breaking changes).
+Zola v0.22.1 is required (later versions might work but haven't been tested).
 
-**Option 1 - download binary:**
+**Option 1 — install via [cargo-binstall](https://github.com/cargo-bins/cargo-binstall)** (fetches the prebuilt binary, no compile):
 
-1. Download `zola-v0.17.2-x86_64-apple-darwin.tar.gz` from the [v0.17.2 release](https://github.com/getzola/zola/releases/tag/v0.17.2)
+```bash
+cargo binstall zola@0.22.1
+zola --version
+```
+
+**Option 2 — install via cargo** (requires [Rust](https://www.rust-lang.org/tools/install)):
+
+```bash
+cargo install --locked --version 0.22.1 zola
+zola --version
+```
+
+**Option 3 - download binary:**
+
+1. Download `zola-v0.22.1-x86_64-apple-darwin.tar.gz` from the [v0.22.1 release](https://github.com/getzola/zola/releases/tag/v0.22.1)
 2. Extract and move the `zola` binary to `/usr/local/bin/`
 3. In a terminal try run zola. macOS will flag it as unverified — approve it in **System Settings → Privacy & Security**
 4. Verify: `zola --version`
-
-**Option 2 — build from source** (requires [Rust](https://www.rust-lang.org/tools/install)):
-
-```bash
-git clone https://github.com/getzola/zola.git
-cd zola
-git checkout v0.17.2
-cargo install --path . --locked
-zola --version
-```
 
 ### Serve locally
 


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Upgrades the docs site to Zola 0.22.1.

Zola 0.22 swapped out the syntax highlighter (syntect → giallo), which renamed the config keys and retired the old theme names. The old `docs/config.toml` no longer parses:

```
ERROR TOML parse error at line 21, column 1
21 | highlight_code = true
unknown field `highlight_code`
```

Changes:
- `docs/config.toml`: replaced the top-level `highlight_code`/`highlight_theme` with a `[markdown.highlighting]` section using the new `one-dark-pro` theme.
- `docs/content/tools/zola-docs/_index.md`: bumped the required version from v0.17.2 → v0.22.1, replaced the "build from source" instructions with simpler `cargo install` / `cargo binstall` options (both pinned to 0.22.1), and reordered the install options with `cargo binstall` first.

## 💌 Any notes for the reviewer?

Small, docs-only change. Verified locally with `zola check` — config parses and the site builds; the remaining "broken external link" warnings are pre-existing and unrelated.

Theme choice (`one-dark-pro`) is arbitrary — happy to swap for any other [giallo theme](https://textmate-grammars-themes.netlify.app/) if there's a preference.

# 🧪 Testing

- [ ] Install Zola 0.22.1 (`cargo binstall zola@0.22.1` or download)
- [ ] From `docs/`, run `zola serve`
- [ ] Confirm the site builds and renders, and that code blocks have syntax highlighting

# 📃 Documentation

- [x] **No documentation required**: this PR _is_ the documentation update