### PR TITLE
#10995 Move remaining qty to PO line selector header

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1486,6 +1486,7 @@
   "label.rejected": "Rejected",
   "label.relationship": "Relationship",
   "label.remaining": "Remaining",
+  "label.remaining-quantity-to-receive": "Remaining quantity to receive: {{count}}",
   "label.remaining-to-supply": "Remaining",
   "label.remove": "Remove",
   "label.remove-all-filters": "Remove all filters",

--- a/client/packages/common/src/ui/forms/Modal/ModalLabel.tsx
+++ b/client/packages/common/src/ui/forms/Modal/ModalLabel.tsx
@@ -5,6 +5,7 @@ import { Property } from 'csstype';
 export interface ModalLabelProps {
   label: string;
   justifyContent?: Property.JustifyContent;
+  minWidth?: string;
 }
 
 const labelStyle = {
@@ -15,6 +16,7 @@ const labelStyle = {
 export const ModalLabel: React.FC<ModalLabelProps> = ({
   label,
   justifyContent = 'flex-start',
+  minWidth = '80px',
 }) => (
   <Grid
     item
@@ -24,7 +26,7 @@ export const ModalLabel: React.FC<ModalLabelProps> = ({
     sx={{
       alignItems: 'center',
       display: 'flex',
-      minWidth: '80px',
+      minWidth,
       '&.MuiGrid-root': { flexBasis: 0 },
     }}
   >

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
@@ -46,7 +46,6 @@ import { PatchDraftLineInput } from '../../../api';
 import { useInboundShipment } from '../../../api/hooks/document/useInboundShipment';
 import { isInboundPlaceholderRow } from '../../../../utils';
 import { useInvoiceLineStatusMap } from '../../..';
-import { usePurchaseOrder } from '@openmsupply-client/purchasing/src/purchase_order/api';
 
 interface CardProps {
   lines: DraftInboundLine[];
@@ -108,29 +107,8 @@ export const InboundLineEditCards = ({
     hasAuthorisePermission,
     isExternal,
   } = useInboundShipment();
-  const purchaseOrderId = inboundData?.purchaseOrder?.id;
   const isManualShipment =
     !inboundData?.purchaseOrder && !inboundData?.linkedShipment;
-  const { query: poQuery } = usePurchaseOrder(purchaseOrderId);
-
-  // Calculate outstanding packs for the current item from PO lines
-  // Outstanding = ordered packs - shipped packs, calculated per-line using requestedPackSize
-  const poOutstandingPacks = useMemo(() => {
-    if (!purchaseOrderId || !item?.id || !poQuery.data) return null;
-    let totalOutstandingPacks = 0;
-    for (const line of poQuery.data.lines.nodes) {
-      if (line.item.id === item.id) {
-        const orderedUnits =
-          line.adjustedNumberOfUnits ?? line.requestedNumberOfUnits;
-        const shippedUnits = line.shippedNumberOfUnits ?? 0;
-        const packSize = line.requestedPackSize || 1;
-        const orderedPacks = Math.ceil(orderedUnits / packSize);
-        const shippedPacks = Math.ceil(shippedUnits / packSize);
-        totalOutstandingPacks += orderedPacks - shippedPacks;
-      }
-    }
-    return totalOutstandingPacks;
-  }, [purchaseOrderId, item?.id, poQuery.data]);
 
   const showLineStatus =
     lines.some(line => line.status != null) ||
@@ -227,15 +205,6 @@ export const InboundLineEditCards = ({
                   sx={{ mt: 0.5, display: 'block' }}
                 >
                   {`${t('label.shipped-number-of-packs')}: ${shippedPacks}`}
-                </Typography>
-              )}
-              {!!purchaseOrderId && poOutstandingPacks != null && (
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  sx={{ mt: 0.5, display: 'block' }}
-                >
-                  {`${t('label.outstanding-packs')}: ${poOutstandingPacks}`}
                 </Typography>
               )}
             </Box>
@@ -788,7 +757,6 @@ export const InboundLineEditCards = ({
     isManualShipment,
     item?.isVaccine,
     pluralisedUnitName,
-    poOutstandingPacks,
     removeDraftLine,
     restrictedToLocationTypeId,
     setPackRoundingMessage,

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
@@ -108,12 +108,9 @@ export const InboundLineEditForm = ({
                 disabled={disabled}
                 options={availablePOLines}
                 value={selectedPOLine}
-                getOptionLabel={(option: PurchaseOrderLineFragment) => {
-                  const qty =
-                    option.adjustedNumberOfUnits ??
-                    option.requestedNumberOfUnits;
-                  return `#${option.lineNumber} ${option.item.name} (${option.item.code}) - ${qty} units`;
-                }}
+                getOptionLabel={(option: PurchaseOrderLineFragment) =>
+                  `#${option.lineNumber} ${option.item.name} (${option.item.code}) - ${t('label.pack-size')} ${option.requestedPackSize}`
+                }
                 isOptionEqualToValue={(a, b) => a.id === b.id}
                 onChange={(_, line) => onChangePOLine(line ?? null)}
                 width="100%"

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
@@ -4,6 +4,7 @@ import {
   ModalLabel,
   Grid,
   Box,
+  Typography,
   useTranslation,
   BasicTextInput,
   PurchaseOrderLineStatusNode,
@@ -78,48 +79,69 @@ export const InboundLineEditForm = ({
     );
   }, [query.data, data, selectedPOLine?.id, hasPurchaseOrder]);
 
+  const remainingUnits =
+    hasPurchaseOrder && selectedPOLine
+      ? (selectedPOLine.adjustedNumberOfUnits ??
+          selectedPOLine.requestedNumberOfUnits) -
+        (selectedPOLine.shippedNumberOfUnits ?? 0)
+      : null;
+
   if (hasPurchaseOrder) {
     return (
-      <Box display="flex" flexWrap="wrap" alignItems="center" gap={1}>
-        <Box
-          display="flex"
-          alignItems="center"
-          flex={1}
-          minWidth={300}
-          gap={1}
-        >
-          <ModalLabel
-            label={t('label.purchase-order-line')}
-            justifyContent="flex-end"
-          />
-          <Grid flex={1}>
-            <Autocomplete
-              autoFocus={!selectedPOLine}
-              disabled={disabled}
-              options={availablePOLines}
-              value={selectedPOLine}
-              getOptionLabel={(option: PurchaseOrderLineFragment) => {
-                const qty =
-                  option.adjustedNumberOfUnits ?? option.requestedNumberOfUnits;
-                return `#${option.lineNumber} ${option.item.name} (${option.item.code}) - ${qty} units`;
-              }}
-              isOptionEqualToValue={(a, b) => a.id === b.id}
-              onChange={(_, line) => onChangePOLine(line ?? null)}
-              width="100%"
+      <Box>
+        <Box display="flex" flexWrap="wrap" alignItems="center" gap={1}>
+          <Box
+            display="flex"
+            alignItems="center"
+            flex={1}
+            minWidth={300}
+            gap={1}
+          >
+            <ModalLabel
+              label={t('label.purchase-order-line')}
+              justifyContent="flex-end"
             />
-          </Grid>
-        </Box>
-        {selectedPOLine && (
-          <Box display="flex" alignItems="center" gap={1}>
-            <ModalLabel label={t('label.unit')} justifyContent="flex-end" />
-            <BasicTextInput
-              disabled
-              sx={{ width: 150 }}
-              value={
-                selectedPOLine.unit ?? selectedPOLine.item.unitName ?? ''
-              }
-            />
+            <Grid flex={1}>
+              <Autocomplete
+                autoFocus={!selectedPOLine}
+                disabled={disabled}
+                options={availablePOLines}
+                value={selectedPOLine}
+                getOptionLabel={(option: PurchaseOrderLineFragment) => {
+                  const qty =
+                    option.adjustedNumberOfUnits ??
+                    option.requestedNumberOfUnits;
+                  return `#${option.lineNumber} ${option.item.name} (${option.item.code}) - ${qty} units`;
+                }}
+                isOptionEqualToValue={(a, b) => a.id === b.id}
+                onChange={(_, line) => onChangePOLine(line ?? null)}
+                width="100%"
+              />
+            </Grid>
           </Box>
+          {selectedPOLine && (
+            <Box display="flex" alignItems="center" gap={1}>
+              <ModalLabel label={t('label.unit')} justifyContent="flex-end" />
+              <BasicTextInput
+                disabled
+                sx={{ width: 150 }}
+                value={
+                  selectedPOLine.unit ?? selectedPOLine.item.unitName ?? ''
+                }
+              />
+            </Box>
+          )}
+        </Box>
+        {remainingUnits != null && (
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ mt: 1, ml: 1 }}
+          >
+            {t('label.remaining-quantity-to-receive', {
+              count: remainingUnits,
+            })}
+          </Typography>
         )}
       </Box>
     );

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
@@ -88,7 +88,7 @@ export const InboundLineEditForm = ({
 
   if (hasPurchaseOrder) {
     return (
-      <Box>
+      <>
         <Box display="flex" flexWrap="wrap" alignItems="center" gap={1}>
           <Box
             display="flex"
@@ -100,6 +100,7 @@ export const InboundLineEditForm = ({
             <ModalLabel
               label={t('label.purchase-order-line')}
               justifyContent="flex-end"
+              minWidth="fit-content"
             />
             <Grid flex={1}>
               <Autocomplete
@@ -143,7 +144,7 @@ export const InboundLineEditForm = ({
             })}
           </Typography>
         )}
-      </Box>
+      </>
     );
   }
 

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
@@ -120,29 +120,20 @@ export const InboundLineEditForm = ({
               />
             </Grid>
           </Box>
-          {selectedPOLine && (
-            <Box display="flex" alignItems="center" gap={1}>
-              <ModalLabel label={t('label.unit')} justifyContent="flex-end" />
-              <BasicTextInput
-                disabled
-                sx={{ width: 150 }}
-                value={
-                  selectedPOLine.unit ?? selectedPOLine.item.unitName ?? ''
-                }
-              />
-            </Box>
-          )}
         </Box>
-        {remainingUnits != null && (
-          <Typography
-            variant="body2"
-            color="text.secondary"
-            sx={{ mt: 1, ml: 1 }}
-          >
-            {t('label.remaining-quantity-to-receive', {
-              count: remainingUnits,
-            })}
-          </Typography>
+        {selectedPOLine && (
+          <Box display="flex" justifyContent="space-between" sx={{ mt: 1, ml: 1 }}>
+            {remainingUnits != null && (
+              <Typography variant="body2" color="text.secondary">
+                {t('label.remaining-quantity-to-receive', {
+                  count: remainingUnits,
+                })}
+              </Typography>
+            )}
+            <Typography variant="body2" color="text.secondary">
+              {`${t('label.unit')}: ${selectedPOLine.unit ?? selectedPOLine.item.unitName ?? ''}`}
+            </Typography>
+          </Box>
         )}
       </>
     );


### PR DESCRIPTION
Fixes #10995

# 👩🏻‍💻 What does this PR do?

Moves the "remaining quantity to receive" display from individual batch cards up to the PO line selector header area, and makes several related improvements to the inbound shipment line edit modal:

- **Moved remaining quantity**: Relocated from per-batch display to a text line below the PO line selector, matching OG mSupply's `Remaining quantity to receive: {{count}}` format
- **Fixed label truncation**: The "Purchase Order Line" label was being truncated to "Purchas..." — added `minWidth="fit-content"` support to `ModalLabel`
- **Moved unit display**: Unit name now shows alongside the remaining quantity below the selector, instead of as a separate disabled input field in IS(E) (left as is for IS(I) for now)
- **PO line selector label**: Changed from showing ordered/adjusted unit quantity (e.g. `- 1000 units`) to showing the requested pack size (e.g. `- Pack size 1000`)
- **Added translation key**: New `label.remaining-quantity-to-receive` for the remaining quantity text

External Inobund shipments
<img width="1294" height="814" alt="image" src="https://github.com/user-attachments/assets/5ee67598-a138-47d7-ac26-968e9eecf826" />

French on portrait tablet:
<img width="836" height="638" alt="image" src="https://github.com/user-attachments/assets/21a1170f-fbdc-410e-b91b-c1deffadb9fc" />


## 💌 Any notes for the reviewer?

- The remaining quantity calculation uses `adjustedNumberOfUnits ?? requestedNumberOfUnits` minus `shippedNumberOfUnits`, calculated per PO line rather than aggregated across all PO lines for the item (which was the previous batch-card approach)
- The issue mentioned renaming the label to "PO line" to save space — instead, the fix uses `minWidth="fit-content"` on the ModalLabel so the full "Purchase Order Line" text displays without truncation - tested across languages and on portrait tablets
- The last commit changes the PO line selector dropdown to show `Pack size` instead of the unit quantity — this wasn't explicitly in the issue but was discussed with Mark as it is a better differentiator between PO lines than units

# 🧪 Testing

- [ ] Create a Purchase Order with lines and confirm it
- [ ] Create an Inbound Shipment linked to the PO
- [ ] Open the "Add Item" modal and verify:
  - [ ] "Purchase Order Line" label is fully visible (not truncated)
  - [ ] PO line dropdown shows `#N ItemName (Code) - Pack size X`
  - [ ] After selecting a PO line, "Remaining quantity to receive: X" appears below the selector
  - [ ] Unit name displays next to the remaining quantity
  - [ ] Remaining quantity is NOT shown on individual batch cards
- [ ] Ship some stock against a PO line, then check remaining quantity updates correctly

# 📃 Documentation

- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour