### PR TITLE
#11307 Cache-bust frontend plugin JS via content hash

### DIFF
--- a/client/packages/common/src/plugins/api/operations.generated.ts
+++ b/client/packages/common/src/plugins/api/operations.generated.ts
@@ -13,6 +13,7 @@ export type FrontendPluginMetadataQuery = {
     __typename: 'FrontendPluginMetadataNode';
     code: string;
     path: string;
+    hash: string;
   }>;
 };
 
@@ -32,6 +33,7 @@ export const FrontendPluginMetadataDocument = gql`
     frontendPluginMetadata {
       code
       path
+      hash
     }
   }
 `;

--- a/client/packages/common/src/plugins/api/operations.graphql
+++ b/client/packages/common/src/plugins/api/operations.graphql
@@ -2,6 +2,7 @@ query frontendPluginMetadata {
   frontendPluginMetadata {
     code
     path
+    hash
   }
 }
 

--- a/client/packages/common/src/plugins/pluginProvider.ts
+++ b/client/packages/common/src/plugins/pluginProvider.ts
@@ -59,9 +59,11 @@ export const fetchPlugin = (
   pluginNode: FrontendPluginMetadataNode
 ): Promise<Container> =>
   new Promise((resolve, reject) => {
-    // We define a script tag to use the browser for fetching the plugin js file
+    // We define a script tag to use the browser for fetching the plugin js file.
+    // ?v=<hash> makes the URL change whenever the bundle's bytes change, so the
+    // browser can safely cache the response with `immutable, max-age=1y`.
     const script = document.createElement('script');
-    script.src = `${Environment.API_HOST}/frontend_plugins/${pluginNode.path}`;
+    script.src = `${Environment.API_HOST}/frontend_plugins/${pluginNode.path}?v=${pluginNode.hash}`;
     script.onerror = err => {
       const message = typeof err === 'string' ? err : 'unknown';
       reject(

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -2916,6 +2916,12 @@ export type FormSchemaSortInput = {
 export type FrontendPluginMetadataNode = {
   __typename: 'FrontendPluginMetadataNode';
   code: Scalars['String']['output'];
+  /**
+   * Hash of the plugin's bundled file contents — clients append this as a
+   * cache-busting URL token (?v=...) so the browser only refetches when the
+   * bundle's bytes change.
+   */
+  hash: Scalars['String']['output'];
   path: Scalars['String']['output'];
 };
 

--- a/server/graphql/general/src/queries/plugin.rs
+++ b/server/graphql/general/src/queries/plugin.rs
@@ -6,6 +6,10 @@ use service::plugin::FrontendPluginMetadata;
 pub struct FrontendPluginMetadataNode {
     pub code: String,
     pub path: String,
+    /// Hash of the plugin's bundled file contents — clients append this as a
+    /// cache-busting URL token (?v=...) so the browser only refetches when the
+    /// bundle's bytes change.
+    pub hash: String,
 }
 
 pub fn frontend_plugin_metadata(
@@ -27,12 +31,16 @@ pub fn frontend_plugin_metadata(
 impl FrontendPluginMetadataNode {
     fn from_domain(
         FrontendPluginMetadata {
-            code, entry_point, ..
+            code,
+            entry_point,
+            hash,
+            ..
         }: FrontendPluginMetadata,
     ) -> Self {
         Self {
             path: format!("{code}/{entry_point}"),
             code,
+            hash,
         }
     }
 }

--- a/server/server/src/serve_frontend_plugins.rs
+++ b/server/server/src/serve_frontend_plugins.rs
@@ -1,5 +1,6 @@
 use actix_web::{
     error, get,
+    http::header,
     web::{self, Data},
     Error, HttpResponse,
 };
@@ -24,6 +25,11 @@ impl error::ResponseError for DatabaseError {}
 struct FetchFileError(FrontendPluginFileRequestError);
 impl error::ResponseError for FetchFileError {}
 
+// The client appends ?v=<plugin_hash> to the URL — when the bundle changes the
+// hash changes, producing a new URL and a fresh cache entry. The bytes at any
+// given URL are therefore safe to mark immutable.
+const CACHE_CONTROL_VALUE: &str = "public, max-age=31536000, immutable";
+
 #[get(r#"/frontend_plugins/{plugin_code}/{filename:.*\..+$}"#)]
 async fn serve(
     service_provider: Data<ServiceProvider>,
@@ -38,5 +44,6 @@ async fn serve(
 
     Ok(HttpResponse::Ok()
         .content_type("application/javascript; charset=utf-8")
+        .insert_header((header::CACHE_CONTROL, CACHE_CONTROL_VALUE))
         .body(file_content))
 }

--- a/server/service/src/plugin/mod.rs
+++ b/server/service/src/plugin/mod.rs
@@ -1,14 +1,17 @@
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
+    time::Instant,
 };
 
 use base64::{prelude::BASE64_STANDARD, Engine};
+use log::info;
 use repository::{
     migrations::Version, BackendPluginRowRepository, FrontendPluginFile, FrontendPluginRow,
     FrontendPluginRowRepository, PluginType, RepositoryError,
 };
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use thiserror::Error;
 
 use crate::{
@@ -59,6 +62,10 @@ pub struct FrontendPluginMetadata {
     pub code: String,
     pub version: Version,
     pub entry_point: String,
+    /// Hex-encoded SHA-256 of the concatenated file contents — used as a
+    /// cache-busting URL token so the browser only refetches when the bundle
+    /// actually changes.
+    pub hash: String,
 }
 
 #[derive(Debug)]
@@ -150,6 +157,10 @@ pub trait PluginServiceTrait: Sync + Send {
             ..
         }: FrontendPluginRow,
     ) {
+        let started = Instant::now();
+        let file_count = files.0.len();
+        let total_bytes: usize = files.0.iter().map(|f| f.file_content_base64.len()).sum();
+
         let version = Version::from_str(&version);
         let app_version = Version::from_package_json();
 
@@ -182,11 +193,23 @@ pub trait PluginServiceTrait: Sync + Send {
             );
         }
 
+        // Hash all files (sorted by name for stability) so the URL token only
+        // changes when the bundle's bytes change.
+        let mut hasher = Sha256::new();
+        let mut file_names: Vec<&String> = files_content.keys().collect();
+        file_names.sort();
+        for name in file_names {
+            hasher.update(name.as_bytes());
+            hasher.update(&files_content[name]);
+        }
+        let hash = hex::encode(hasher.finalize());
+
         let mut plugins = ctx.frontend_plugins_cache.0.write().unwrap();
         // Remove all plugins with this code
         (*plugins).remove(&code);
 
         // Add plugin with this code
+        let code_for_log = code.clone();
         (*plugins).insert(
             code.clone(),
             FrontendPlugin {
@@ -194,9 +217,18 @@ pub trait PluginServiceTrait: Sync + Send {
                     code,
                     version,
                     entry_point,
+                    hash,
                 },
                 files_content,
             },
+        );
+
+        info!(
+            "Loaded frontend plugin '{}' ({} files, {} base64 bytes) in {:?}",
+            code_for_log,
+            file_count,
+            total_bytes,
+            started.elapsed(),
         );
     }
 


### PR DESCRIPTION
Fixes #11307

# 👩🏻‍💻 What does this PR do?

Makes frontend plugin JS bundles cacheable in the browser by appending a content hash to the URL and serving the response with `Cache-Control: public, max-age=31536000, immutable`.

**The mechanism**

- `server/service/src/plugin/mod.rs` — in `bind_frontend_plugin`, compute a SHA-256 over the plugin's files (sorted by name, filename + bytes into the hasher) and store the hex digest on `FrontendPluginMetadata.hash`.
- `server/graphql/general/src/queries/plugin.rs` — expose `hash` on `FrontendPluginMetadataNode`.
- `server/server/src/serve_frontend_plugins.rs` — set `Cache-Control: public, max-age=31536000, immutable` on the JS response.
- `client/packages/common/src/plugins/pluginProvider.ts` — client reads `pluginNode.hash` from the metadata query and appends `?v=<hash>` to the `<script src>`.

Because the URL changes any time the bundle's bytes change, the response is genuinely immutable and the browser can cache it for a year without risk of serving stale code.

**Why this matters (from the issue)**

On high-latency / low-throughput links (satellite, rural mobile), a 3.8 MB plugin transfer is bounded by bandwidth-delay-product, not raw bandwidth. Today the browser refetches the bundle on every load. After this PR, first load is the same, every subsequent load is served from local disk cache with zero network traffic until the plugin genuinely changes.

**Also included**

`bind_frontend_plugin` now emits an INFO-level log with file count, byte size, and elapsed time each time a plugin binds (startup, upload, reload). Measured ~175 ms for `civ_plugins` (1 file, ~5 MB base64) on my machine — useful baseline for future work.

## 💌 Any notes for the reviewer?

- The hash is computed with no length-prefix between filename and content bytes in the hasher. That's theoretically ambiguous (`{"a":"bc"}` and `{"ab":"c"}` concatenate to the same bytes), but within a single plugin's file map it can't actually collide. Left as-is for simplicity; easy to tighten later.
- The server does not validate the incoming `?v=` token against the current hash — it simply serves whatever bytes are cached. A client requesting a stale hash would get current bytes (cached as `immutable` under that stale URL), which is harmless because clients always request the current hash returned by the metadata query. Worth knowing if debugging.
- `yarn generate` surfaced an unrelated drift in `schema.ts` (four `NaiveDateTime` → `DateTime` fields on `AssetLogNode` / `AssetNode` / `SyncFileReferenceNode`) that had not been regenerated on the client. **I intentionally excluded those from this PR** so it stays scoped to the cache-headers work — they should be regenerated in their own PR by whoever made the corresponding server schema change.
- Uses `sha2` + `hex` crates which were already workspace dependencies of `service`.

# 🧪 Testing

- [ ] Run server with at least one frontend plugin installed (I tested with `civ_plugins` locally against a Postgres `demoivory` datafile).
- [ ] Query GraphQL `{ frontendPluginMetadata { code path hash } }` — `hash` should be a 64-char hex string and should be identical across server restarts for the same bundle.
- [ ] `curl -I http://localhost:8000/frontend_plugins/<code>/<entry>.js?v=<hash>` — response should include `cache-control: public, max-age=31536000, immutable`.
- [ ] Open the client in a browser, load a page that uses a plugin, verify the `<script>` tag's `src` includes `?v=<hash>` matching the GraphQL metadata.
- [ ] Reload the page — verify the plugin JS is served from (disk) cache in devtools Network tab, not re-requested from the server.
- [ ] Upload a new plugin bundle (or bump version) — verify the hash changes, the client URL changes, and the new bundle is fetched exactly once.
- [ ] Check server INFO logs at startup — should see `Loaded frontend plugin '<code>' (<n> files, <bytes> base64 bytes) in <duration>` once per installed plugin.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**:
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend