### PR TITLE
Avoid fetching expensive live item.stats on requisition detail

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
 import {
+  ItemWithAvailableStockFragment,
   ItemWithStatsFragment,
   ReasonOptionsSearchInput,
   RequestFragment,
@@ -44,7 +45,7 @@ import ForecastCalculationDisplay from '../../../common/ForecastCalculationDispl
 interface RequestLineEditProps {
   requisition: RequestFragment;
   lines: RequestLineFragment[];
-  currentItem?: ItemWithStatsFragment;
+  currentItem?: ItemWithAvailableStockFragment;
   onChangeItem: (item: ItemWithStatsFragment) => void;
   draft?: DraftRequestLine | null;
   update: (patch: Partial<DraftRequestLine>) => void;

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -11,7 +11,10 @@ import {
   RepresentationValue,
   RequisitionNodeStatus,
 } from '@openmsupply-client/common';
-import { ItemWithStatsFragment } from '@openmsupply-client/system';
+import {
+  ItemWithAvailableStockFragment,
+  ItemWithStatsFragment,
+} from '@openmsupply-client/system';
 import { RequestFragment, useRequest } from '../../api';
 import { useDraftRequisitionLine, useNextRequestLine } from './hooks';
 import { isRequestDisabled, shouldDeleteLine } from '../../../utils';
@@ -47,9 +50,9 @@ export const RequestLineEditModal = ({
     [requisition?.lines.nodes]
   );
 
-  const [currentItem, setCurrentItem] = useState(
-    lines?.find(line => line.item.id === itemId)?.item
-  );
+  const [currentItem, setCurrentItem] = useState<
+    ItemWithAvailableStockFragment | ItemWithStatsFragment | undefined
+  >(lines?.find(line => line.item.id === itemId)?.item);
   const getDefaultRepresentation = (
     item?: { isVaccine?: boolean; doses?: number } | null
   ): RepresentationValue => {
@@ -59,8 +62,9 @@ export const RequestLineEditModal = ({
     return Representation.UNITS;
   };
 
-  const [representation, setRepresentation] =
-    useState<RepresentationValue>(getDefaultRepresentation(currentItem));
+  const [representation, setRepresentation] = useState<RepresentationValue>(
+    getDefaultRepresentation(currentItem)
+  );
 
   const { draft, save, update, isLoading, isReasonsError } =
     useDraftRequisitionLine(currentItem);

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
@@ -66,7 +66,7 @@ const createDraftFromRequestLine = (
 });
 
 export const useDraftRequisitionLine = (
-  item?: ItemWithAvailableStockFragment | null
+  item?: ItemWithAvailableStockFragment | ItemWithStatsFragment | null
 ) => {
   const t = useTranslation();
   const [isReasonsError, setIsReasonsError] = useState(false);
@@ -87,7 +87,7 @@ export const useDraftRequisitionLine = (
       if (existingLine) {
         setDraft(createDraftFromRequestLine(existingLine, data));
       } else if ('stats' in item) {
-        setDraft(createDraftFromItem(item as ItemWithStatsFragment, data));
+        setDraft(createDraftFromItem(item, data));
       }
     } else {
       setDraft(null);

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
@@ -7,6 +7,7 @@ import {
 import {
   useRequest,
   RequestLineFragment,
+  ItemWithAvailableStockFragment,
   ItemWithStatsFragment,
   RequestFragment,
 } from '../../api';
@@ -65,7 +66,7 @@ const createDraftFromRequestLine = (
 });
 
 export const useDraftRequisitionLine = (
-  item?: ItemWithStatsFragment | null
+  item?: ItemWithAvailableStockFragment | null
 ) => {
   const t = useTranslation();
   const [isReasonsError, setIsReasonsError] = useState(false);
@@ -85,8 +86,8 @@ export const useDraftRequisitionLine = (
       );
       if (existingLine) {
         setDraft(createDraftFromRequestLine(existingLine, data));
-      } else {
-        setDraft(createDraftFromItem(item, data));
+      } else if ('stats' in item) {
+        setDraft(createDraftFromItem(item as ItemWithStatsFragment, data));
       }
     } else {
       setDraft(null);
@@ -142,7 +143,7 @@ export const useDraftRequisitionLine = (
 
 export const useNextRequestLine = (
   lines?: RequestLineFragment[],
-  currentItem?: ItemWithStatsFragment | null
+  currentItem?: ItemWithAvailableStockFragment | null
 ) => {
   if (!lines || !currentItem) {
     return { hasNext: false, next: null };
@@ -150,7 +151,7 @@ export const useNextRequestLine = (
 
   const nextState: {
     hasNext: boolean;
-    next: null | ItemWithStatsFragment;
+    next: null | ItemWithAvailableStockFragment;
   } = { hasNext: true, next: null };
   const idx = lines.findIndex(l => l.item.id === currentItem?.id);
   const next = lines[idx + 1];

--- a/client/packages/requisitions/src/RequestRequisition/api/index.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/index.ts
@@ -3,5 +3,6 @@ export * from './operations.generated';
 export {
   RequestLineFragment,
   ItemWithStatsFragment,
+  ItemWithAvailableStockFragment,
   RequestFragment,
 } from '@openmsupply-client/system';

--- a/client/packages/requisitions/src/RequestRequisition/api/operations.generated.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/operations.generated.ts
@@ -156,15 +156,6 @@ export type RequestByNumberQuery = {
               isVaccine: boolean;
               doses: number;
               availableStockOnHand: number;
-              stats: {
-                __typename: 'ItemStatsNode';
-                averageMonthlyConsumption: number;
-                availableStockOnHand: number;
-                availableMonthsOfStockOnHand?: number | null;
-                totalConsumption: number;
-                stockOnHand: number;
-                monthsOfStockOnHand?: number | null;
-              };
             };
             reason?: {
               __typename: 'ReasonOptionNode';
@@ -317,15 +308,6 @@ export type RequestByIdQuery = {
               isVaccine: boolean;
               doses: number;
               availableStockOnHand: number;
-              stats: {
-                __typename: 'ItemStatsNode';
-                averageMonthlyConsumption: number;
-                availableStockOnHand: number;
-                availableMonthsOfStockOnHand?: number | null;
-                totalConsumption: number;
-                stockOnHand: number;
-                monthsOfStockOnHand?: number | null;
-              };
             };
             reason?: {
               __typename: 'ReasonOptionNode';

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -15,6 +15,7 @@ import {
   RepresentationValue,
 } from '@openmsupply-client/common';
 import {
+  ItemWithAvailableStockFragment,
   ItemWithStatsFragment,
   ReasonOptionsSearchInput,
   StockItemSearchInputWithStats,
@@ -28,7 +29,7 @@ import { ResponseNumInputRow } from './ResponseNumInputRow';
 interface ResponseLineEditProps {
   store?: UserStoreNodeFragment;
   requisition: ResponseFragment;
-  currentItem?: ItemWithStatsFragment;
+  currentItem?: ItemWithAvailableStockFragment;
   onChangeItem: (item: ItemWithStatsFragment) => void;
   lines: ResponseLineFragment[];
   draft?: DraftResponseLine | null;

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/hooks.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useResponse, ResponseLineFragment, ResponseFragment } from '../../api';
-import { ItemWithStatsFragment } from '@openmsupply-client/system';
+import { ItemWithAvailableStockFragment } from '@openmsupply-client/system';
 import { FnUtils } from '@common/utils';
 import { useTranslation } from '@common/intl';
 
@@ -13,7 +13,7 @@ export type DraftResponseLine = Omit<
 };
 
 const createDraftFromItem = (
-  item: ItemWithStatsFragment,
+  item: ItemWithAvailableStockFragment,
   requisition: ResponseFragment
 ): DraftResponseLine => {
   return {
@@ -55,7 +55,7 @@ const createDraftFromResponseLine = (
 });
 
 export const useDraftRequisitionLine = (
-  item?: ItemWithStatsFragment | null
+  item?: ItemWithAvailableStockFragment | null
 ) => {
   const t = useTranslation();
   const { lines } = useResponse.line.list();
@@ -127,14 +127,14 @@ export const useDraftRequisitionLine = (
 
 export const useNextResponseLine = (
   lines: ResponseLineFragment[],
-  currentItem?: ItemWithStatsFragment | null
+  currentItem?: ItemWithAvailableStockFragment | null
 ) => {
   if (!lines || !currentItem) {
     return { hasNext: false, next: null };
   }
   const nextState: {
     hasNext: boolean;
-    next: ItemWithStatsFragment | null;
+    next: ItemWithAvailableStockFragment | null;
   } = { hasNext: true, next: null };
   const idx = lines.findIndex(l => l.item.id === currentItem?.id);
   const next = lines[idx + 1];

--- a/client/packages/requisitions/src/ResponseRequisition/api/operations.generated.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/api/operations.generated.ts
@@ -6,7 +6,7 @@ import {
   RequisitionReasonsNotProvidedErrorFragmentDoc,
   ProgramIndicatorFragmentDoc,
 } from '../../RequestRequisition/api/operations.generated';
-import { ItemWithStatsFragmentDoc } from '../../../../system/src/RequestRequisitionLine/operations.generated';
+import { ItemWithAvailableStockFragmentDoc } from '../../../../system/src/RequestRequisitionLine/operations.generated';
 import { ReasonOptionRowFragmentDoc } from '../../../../system/src/ReasonOption/api/operations.generated';
 import { SyncFileReferenceFragmentDoc } from '../../../../system/src/Documents/types.generated';
 type GraphQLClientRequestHeaders = RequestOptions['requestHeaders'];
@@ -116,15 +116,6 @@ export type ResponseLineFragment = {
     isVaccine: boolean;
     doses: number;
     availableStockOnHand: number;
-    stats: {
-      __typename: 'ItemStatsNode';
-      averageMonthlyConsumption: number;
-      availableStockOnHand: number;
-      availableMonthsOfStockOnHand?: number | null;
-      totalConsumption: number;
-      stockOnHand: number;
-      monthsOfStockOnHand?: number | null;
-    };
   };
   linkedRequisitionLine?: {
     __typename: 'RequisitionLineNode';
@@ -255,15 +246,6 @@ export type ResponseFragment = {
         isVaccine: boolean;
         doses: number;
         availableStockOnHand: number;
-        stats: {
-          __typename: 'ItemStatsNode';
-          averageMonthlyConsumption: number;
-          availableStockOnHand: number;
-          availableMonthsOfStockOnHand?: number | null;
-          totalConsumption: number;
-          stockOnHand: number;
-          monthsOfStockOnHand?: number | null;
-        };
       };
       linkedRequisitionLine?: {
         __typename: 'RequisitionLineNode';
@@ -427,15 +409,6 @@ export type ResponseByNumberQuery = {
               isVaccine: boolean;
               doses: number;
               availableStockOnHand: number;
-              stats: {
-                __typename: 'ItemStatsNode';
-                averageMonthlyConsumption: number;
-                availableStockOnHand: number;
-                availableMonthsOfStockOnHand?: number | null;
-                totalConsumption: number;
-                stockOnHand: number;
-                monthsOfStockOnHand?: number | null;
-              };
             };
             linkedRequisitionLine?: {
               __typename: 'RequisitionLineNode';
@@ -607,15 +580,6 @@ export type ResponseByIdQuery = {
               isVaccine: boolean;
               doses: number;
               availableStockOnHand: number;
-              stats: {
-                __typename: 'ItemStatsNode';
-                averageMonthlyConsumption: number;
-                availableStockOnHand: number;
-                availableMonthsOfStockOnHand?: number | null;
-                totalConsumption: number;
-                stockOnHand: number;
-                monthsOfStockOnHand?: number | null;
-              };
             };
             linkedRequisitionLine?: {
               __typename: 'RequisitionLineNode';
@@ -1225,7 +1189,7 @@ export const ResponseLineFragmentDoc = gql`
       averageMonthlyConsumption
     }
     item {
-      ...ItemWithStats
+      ...ItemWithAvailableStock
     }
     approvedQuantity
     approvalComment
@@ -1246,7 +1210,7 @@ export const ResponseLineFragmentDoc = gql`
     forecastTotalDoses
     vaccineCourses
   }
-  ${ItemWithStatsFragmentDoc}
+  ${ItemWithAvailableStockFragmentDoc}
   ${ReasonOptionRowFragmentDoc}
   ${AvailableVolumeAtLocationTypeFragmentDoc}
 `;

--- a/client/packages/requisitions/src/ResponseRequisition/api/operations.graphql
+++ b/client/packages/requisitions/src/ResponseRequisition/api/operations.graphql
@@ -93,7 +93,7 @@ fragment ResponseLine on RequisitionLineNode {
     averageMonthlyConsumption
   }
   item {
-    ...ItemWithStats
+    ...ItemWithAvailableStock
   }
   approvedQuantity
   approvalComment

--- a/client/packages/system/src/RequestRequisitionLine/index.ts
+++ b/client/packages/system/src/RequestRequisitionLine/index.ts
@@ -1,5 +1,6 @@
 export {
   RequestLineFragment,
   ItemWithStatsFragment,
+  ItemWithAvailableStockFragment,
   RequestFragment,
 } from './operations.generated';

--- a/client/packages/system/src/RequestRequisitionLine/operations.generated.ts
+++ b/client/packages/system/src/RequestRequisitionLine/operations.generated.ts
@@ -5,6 +5,18 @@ import gql from 'graphql-tag';
 import { ReasonOptionRowFragmentDoc } from '../ReasonOption/api/operations.generated';
 import { SyncFileReferenceFragmentDoc } from '../Documents/types.generated';
 type GraphQLClientRequestHeaders = RequestOptions['requestHeaders'];
+export type ItemWithAvailableStockFragment = {
+  __typename: 'ItemNode';
+  id: string;
+  name: string;
+  code: string;
+  unitName?: string | null;
+  defaultPackSize: number;
+  isVaccine: boolean;
+  doses: number;
+  availableStockOnHand: number;
+};
+
 export type ItemWithStatsFragment = {
   __typename: 'ItemNode';
   id: string;
@@ -67,15 +79,6 @@ export type RequestLineFragment = {
     isVaccine: boolean;
     doses: number;
     availableStockOnHand: number;
-    stats: {
-      __typename: 'ItemStatsNode';
-      averageMonthlyConsumption: number;
-      availableStockOnHand: number;
-      availableMonthsOfStockOnHand?: number | null;
-      totalConsumption: number;
-      stockOnHand: number;
-      monthsOfStockOnHand?: number | null;
-    };
   };
   reason?: {
     __typename: 'ReasonOptionNode';
@@ -165,15 +168,6 @@ export type RequestFragment = {
         isVaccine: boolean;
         doses: number;
         availableStockOnHand: number;
-        stats: {
-          __typename: 'ItemStatsNode';
-          averageMonthlyConsumption: number;
-          availableStockOnHand: number;
-          availableMonthsOfStockOnHand?: number | null;
-          totalConsumption: number;
-          stockOnHand: number;
-          monthsOfStockOnHand?: number | null;
-        };
       };
       reason?: {
         __typename: 'ReasonOptionNode';
@@ -246,8 +240,8 @@ export type OnlyHereToAvoidUnusedWarningsQuery = {
   me: { __typename: 'UserNode' };
 };
 
-export const ItemWithStatsFragmentDoc = gql`
-  fragment ItemWithStats on ItemNode {
+export const ItemWithAvailableStockFragmentDoc = gql`
+  fragment ItemWithAvailableStock on ItemNode {
     id
     name
     code
@@ -256,6 +250,11 @@ export const ItemWithStatsFragmentDoc = gql`
     isVaccine
     doses
     availableStockOnHand(storeId: $storeId)
+  }
+`;
+export const ItemWithStatsFragmentDoc = gql`
+  fragment ItemWithStats on ItemNode {
+    ...ItemWithAvailableStock
     stats(storeId: $storeId) {
       averageMonthlyConsumption
       availableStockOnHand
@@ -264,8 +263,8 @@ export const ItemWithStatsFragmentDoc = gql`
       stockOnHand
       monthsOfStockOnHand
     }
-    isVaccine
   }
+  ${ItemWithAvailableStockFragmentDoc}
 `;
 export const RequestLineFragmentDoc = gql`
   fragment RequestLine on RequisitionLineNode {
@@ -295,7 +294,7 @@ export const RequestLineFragmentDoc = gql`
       approvalComment
     }
     item {
-      ...ItemWithStats
+      ...ItemWithAvailableStock
     }
     reason {
       ...ReasonOptionRow
@@ -304,7 +303,7 @@ export const RequestLineFragmentDoc = gql`
     forecastTotalDoses
     vaccineCourses
   }
-  ${ItemWithStatsFragmentDoc}
+  ${ItemWithAvailableStockFragmentDoc}
   ${ReasonOptionRowFragmentDoc}
 `;
 export const RequestFragmentDoc = gql`

--- a/client/packages/system/src/RequestRequisitionLine/operations.graphql
+++ b/client/packages/system/src/RequestRequisitionLine/operations.graphql
@@ -1,4 +1,4 @@
-fragment ItemWithStats on ItemNode {
+fragment ItemWithAvailableStock on ItemNode {
   id
   name
   code
@@ -7,6 +7,10 @@ fragment ItemWithStats on ItemNode {
   isVaccine
   doses
   availableStockOnHand(storeId: $storeId)
+}
+
+fragment ItemWithStats on ItemNode {
+  ...ItemWithAvailableStock
   stats(storeId: $storeId) {
     averageMonthlyConsumption
     availableStockOnHand
@@ -15,7 +19,6 @@ fragment ItemWithStats on ItemNode {
     stockOnHand
     monthsOfStockOnHand
   }
-  isVaccine
 }
 
 fragment RequestLine on RequisitionLineNode {
@@ -46,7 +49,7 @@ fragment RequestLine on RequisitionLineNode {
     approvalComment
   }
   item {
-    ...ItemWithStats
+    ...ItemWithAvailableStock
   }
   reason {
     ...ReasonOptionRow


### PR DESCRIPTION
Fixes #11304

# 👩🏻‍💻 What does this PR do?

Stops the request/response requisition detail queries from fetching `item.stats(storeId)` for every line. The frontend never reads those values on these pages — it reads the cheap snapshot `line.itemStats` instead — but each request was paying for a live per-item `ItemsStatsForItemLoader` call.

Why: with civ-plugins a 50-line internal order took ~2.8–3.4s. Dropping `item.stats` from the line fragment brought it down to ~1.5s. The saving scales linearly with line count, so this matters a lot on 1000+ line orders (see #9778).

How:
- Split `ItemWithStats` in `client/packages/system/src/RequestRequisitionLine/operations.graphql` into a lighter `ItemWithAvailableStock` (id, name, code, unitName, defaultPackSize, isVaccine, doses, availableStockOnHand) plus `ItemWithStats` which extends it with the `stats { ... }` block.
- `RequestLine` and `ResponseLine` fragments now spread `ItemWithAvailableStock` instead of `ItemWithStats`.
- Item-picker flows (`StockItemSearchInputWithStats` and the `createDraftFromItem` hook that computes suggested quantity from AMC + SOH) still use `ItemWithStats` and still get live stats — no behaviour change there.
- Propagated the narrower type through `useDraftRequisitionLine`, `useNextRequestLine`, `useNextResponseLine`, `RequestLineEdit`, `ResponseLineEdit`. Added a `'stats' in item` type guard in the Request hook before calling `createDraftFromItem`.

## 💌 Any notes for the reviewer?

- The key question for review: is there anywhere on request/response requisition detail pages that reads `line.item.stats.totalConsumption`, `line.item.stats.stockOnHand`, or `line.item.stats.monthsOfStockOnHand`? Those three fields aren't on `line.itemStats`, so they'd be lost here. A codebase audit found zero readers, and typecheck + eslint are clean, but a second pair of eyes is welcome.
- No server/schema changes — just the client fragment shape. Regenerated schema/types are included in the commit so it's all one consistent snapshot.
- `ItemWithStats` remains available and untouched for the item-picker path and the purchase-order screen that legitimately uses `item.stats.stockOnHand`.

# 🧪 Testing

- [ ] Open an existing request requisition (internal order) with a lot of lines — verify it loads noticeably faster and all the stats columns (SOH, AMC, MOS) still populate correctly
- [ ] Same for a response requisition (customer requisition)
- [ ] Add a new line to a request requisition via the item picker — confirm the suggested quantity is still calculated correctly from live AMC + SOH
- [ ] Edit an existing line in both request and response requisition edit modals — confirm no regressions (drafts, saving, reasons, next-line navigation)
- [ ] Smoke check the purchase-order detail view (still uses `item.stats.stockOnHand` through a different fragment — unaffected, but worth a glance)

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend