### PR TITLE
#11316 Disable reason edit for supplier on linked requisitions

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEdit.tsx
@@ -71,7 +71,7 @@ export const ResponseLineEdit = ({
   const isDisabled = disabled || !!requisition.linkedRequisition;
   const disableItemSelection = disabled || isUpdateMode;
   const disableReasons =
-    draft?.requestedQuantity === draft?.suggestedQuantity || disabled;
+    draft?.requestedQuantity === draft?.suggestedQuantity || isDisabled;
 
   const unitName = currentItem?.unitName || t('label.unit');
   const defaultPackSize = currentItem?.defaultPackSize || 1;


### PR DESCRIPTION
Closes #11316 

## Summary
- Fixes the reason field on the response requisition line edit modal being editable by the supplier when the requisition is linked to a customer request
eg in the requisition listed in the issue (linked to a customer's internal order)
<img width="1664" height="970" alt="image" src="https://github.com/user-attachments/assets/bff4c4b2-539b-4119-8ef5-420b339ac357" />

- Changed `disableReasons` to use `isDisabled` (which includes the `linkedRequisition` check) instead of the base `disabled` prop
- The reason field remains editable for supplier-created response requisitions (no linked requisition)
eg this one I made manually 
<img width="1803" height="1008" alt="image" src="https://github.com/user-attachments/assets/a58dbdde-24c7-47a4-bfb1-7a9a94a13a1f" />


The bug is in core functionality - not related to CIV plugin

## Test plan
- [ ] Open a linked customer requisition (Distribution > Requisitions) with extra fields enabled
- [ ] Verify the reason field is read-only / disabled on the supplier side
- [ ] Verify the reason field is still editable on the customer side (Request Requisition)
- [ ] Verify the reason field is still editable on a supplier-created (non-linked) response requisition

Edit Brian: Enable useConsumptionAndStockFromCustomersForInternalOrders in mSupply for the store and it needs to be a program requisition

## GTo run with CIV plugin
- In client folder, git submodule add https://github.com/msupply-foundation/civ-plugins ./packages/plugins/civ-plugins
- Then run FE normally
- To run BE: export RUST_MIN_STACK=8388608;cargo run --features=postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)