### PR TITLE
#11310 Fix Autocomplete width prop not applied to root element

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
@@ -239,10 +239,14 @@ export function Autocomplete<T>({
       slotProps={{
         ...restOfAutocompleteProps.slotProps,
         popper: popperMinWidth
-          ? { placement: 'bottom-start', style: { minWidth: popperMinWidth, width: 'auto' } }
+          ? {
+              placement: 'bottom-start',
+              style: { minWidth: popperMinWidth, width: 'auto' },
+            }
           : undefined,
       }}
       sx={{
+        width,
         ...restOfAutocompleteProps.sx,
       }}
     />


### PR DESCRIPTION
Closes #11310 

## Summary
- The `Autocomplete` component's `width` prop was only applied as `minWidth` on the inner `BasicTextInput`, but not on the outer `MuiAutocomplete` root element
- This caused dropdowns like Campaign/Program in the stocktake edit item modal to appear too narrow instead of filling the column width
- Apply `width` to the `MuiAutocomplete` root `sx` so the component correctly respects the `width` prop

Campaign / porogram dropdown resolved:
<img width="1895" height="1017" alt="image" src="https://github.com/user-attachments/assets/0ac25c50-8ac4-45e5-b6ba-de7532573f6e" />

And on tablet:
<img width="919" height="835" alt="image" src="https://github.com/user-attachments/assets/94f8da8a-b897-4eea-8bc7-94b340e2f915" />



## Test plan
- [ ] Open a stocktake, edit an item, go to the "Other" tab — verify the Campaign/Program dropdown fills its column width
- [ ] Check the Donor Edit modal on inbound shipments (passes a `width` prop to Autocomplete)
- [ ] Check the PO line selector in inbound shipment line edit (`width="100%"`)
- [ ] Check any Autocomplete without an explicit `width` prop still renders correctly (default `width='auto'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)