### PR TITLE
#11320 Create supplier return as Verified status

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2357,6 +2357,7 @@
   "messages.stopping-scanner": "Stopping scanner...",
   "messages.success-printing-label": "Label printed successfully.",
   "messages.supplier-return-created-shipped": "Supplier Return successfully created as Shipped",
+  "messages.supplier-return-created-verified": "Supplier Return successfully created as Verified",
   "messages.supply-level-in-use": "Supply level is currently in use and cannot be deleted.",
   "messages.supply-to-approved": "Are you sure you want to set all lines supply quantity to the approved?",
   "messages.supply-to-requested": "Are you sure you want to set all lines supply quantity to the requested?",

--- a/client/packages/invoices/src/Returns/modals/SupplierReturn/SupplierReturn.tsx
+++ b/client/packages/invoices/src/Returns/modals/SupplierReturn/SupplierReturn.tsx
@@ -102,7 +102,7 @@ export const SupplierReturnEditModal = ({
       !!supplierReturn &&
         supplierReturn?.originalShipment?.id &&
         isNewReturn &&
-        success(t('messages.supplier-return-created-shipped'))();
+        success(t('messages.supplier-return-created-verified'))();
       onClose();
     } catch (e) {
       const errorMessage =

--- a/server/graphql/invoice/src/mutations/supplier_return/update.rs
+++ b/server/graphql/invoice/src/mutations/supplier_return/update.rs
@@ -29,6 +29,7 @@ pub struct UpdateInput {
 pub enum UpdateSupplierReturnStatusInput {
     Picked,
     Shipped,
+    Verified,
 }
 
 #[derive(Union)]
@@ -112,6 +113,7 @@ impl UpdateSupplierReturnStatusInput {
         match self {
             UpdateSupplierReturnStatusInput::Picked => Picked,
             UpdateSupplierReturnStatusInput::Shipped => Shipped,
+            UpdateSupplierReturnStatusInput::Verified => Verified,
         }
     }
 }

--- a/server/service/src/invoice/supplier_return/insert/mod.rs
+++ b/server/service/src/invoice/supplier_return/insert/mod.rs
@@ -103,7 +103,7 @@ pub fn insert_supplier_return(
                     ctx,
                     UpdateSupplierReturn {
                         supplier_return_id: supplier_return.id.clone(),
-                        status: Some(UpdateSupplierReturnStatus::Shipped),
+                        status: Some(UpdateSupplierReturnStatus::Verified),
                         ..Default::default()
                     },
                 )
@@ -451,7 +451,7 @@ mod test {
             u.name_id = supplier().id;
             u.user_id = Some(mock_user_account_a().id);
             u.original_shipment_id = Some(mock_inbound_shipment_a().id);
-            u.status = InvoiceStatus::Shipped;
+            u.status = InvoiceStatus::Verified;
             u
         });
 

--- a/server/service/src/invoice/supplier_return/update/generate.rs
+++ b/server/service/src/invoice/supplier_return/update/generate.rs
@@ -92,10 +92,10 @@ fn set_new_status_datetime(
 
     let current_datetime = Utc::now().naive_utc();
 
-    // Status sequence for supplier return: New, Picked, Shipped
+    // Status sequence for supplier return: New, Picked, Shipped, Verified
     match (&supplier_return.status, new_status) {
-        // From Shipped to Any, ignore
-        (InvoiceStatus::Shipped, _) => {}
+        // From Verified to Any, ignore
+        (InvoiceStatus::Verified, _) => {}
 
         // From New to Picked
         (InvoiceStatus::New, UpdateSupplierReturnStatus::Picked) => {
@@ -112,6 +112,24 @@ fn set_new_status_datetime(
         (InvoiceStatus::Picked, UpdateSupplierReturnStatus::Shipped) => {
             supplier_return.shipped_datetime = Some(current_datetime)
         }
+
+        // From New to Verified (skipping Picked and Shipped)
+        (InvoiceStatus::New, UpdateSupplierReturnStatus::Verified) => {
+            supplier_return.picked_datetime = Some(current_datetime);
+            supplier_return.shipped_datetime = Some(current_datetime);
+            supplier_return.verified_datetime = Some(current_datetime);
+        }
+
+        // From Picked to Verified (skipping Shipped)
+        (InvoiceStatus::Picked, UpdateSupplierReturnStatus::Verified) => {
+            supplier_return.shipped_datetime = Some(current_datetime);
+            supplier_return.verified_datetime = Some(current_datetime);
+        }
+
+        // From Shipped to Verified
+        (InvoiceStatus::Shipped, UpdateSupplierReturnStatus::Verified) => {
+            supplier_return.verified_datetime = Some(current_datetime);
+        }
         _ => {}
     }
 }
@@ -127,9 +145,11 @@ fn should_update_stock_lines_total_number_of_packs(
 
     match (existing_status, new_status) {
         (
-            // From New to Picked, or New to Shipped
+            // From New to Picked, Shipped, or Verified
             InvoiceStatus::New,
-            UpdateSupplierReturnStatus::Picked | UpdateSupplierReturnStatus::Shipped,
+            UpdateSupplierReturnStatus::Picked
+            | UpdateSupplierReturnStatus::Shipped
+            | UpdateSupplierReturnStatus::Verified,
         ) => true,
         _ => false,
     }

--- a/server/service/src/invoice/supplier_return/update/mod.rs
+++ b/server/service/src/invoice/supplier_return/update/mod.rs
@@ -19,6 +19,7 @@ use self::generate::GenerateResult;
 pub enum UpdateSupplierReturnStatus {
     Picked,
     Shipped,
+    Verified,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -100,6 +101,7 @@ impl UpdateSupplierReturnStatus {
         match self {
             UpdateSupplierReturnStatus::Picked => InvoiceStatus::Picked,
             UpdateSupplierReturnStatus::Shipped => InvoiceStatus::Shipped,
+            UpdateSupplierReturnStatus::Verified => InvoiceStatus::Verified,
         }
     }
 

--- a/server/service/src/invoice/supplier_return/update/mod.rs
+++ b/server/service/src/invoice/supplier_return/update/mod.rs
@@ -366,4 +366,105 @@ mod test {
             original_stock_line.total_number_of_packs // total has not changed (no stock movements after PICKED status)
         );
     }
+
+    #[actix_rt::test]
+    async fn test_update_supplier_return_success_new_to_verified() {
+        let (_, connection, connection_manager, _) = setup_all(
+            "test_update_supplier_return_success_new_to_verified",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context(mock_store_b().id, mock_user_account_a().id)
+            .unwrap();
+
+        let stock_line_row_repo = StockLineRowRepository::new(&connection);
+        let stock_line_id = mock_supplier_return_b_invoice_line_a()
+            .stock_line_id
+            .unwrap();
+
+        let original_stock_line = stock_line_row_repo
+            .find_one_by_id(&stock_line_id)
+            .unwrap()
+            .unwrap();
+
+        let result = service_provider
+            .invoice_service
+            .update_supplier_return(
+                &context,
+                UpdateSupplierReturn {
+                    supplier_return_id: mock_supplier_return_b().id, // is NEW status
+                    status: Some(UpdateSupplierReturnStatus::Verified),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert_eq!(result.invoice_row.status, InvoiceStatus::Verified);
+        assert!(result.invoice_row.picked_datetime.is_some());
+        assert!(result.invoice_row.shipped_datetime.is_some());
+        assert!(result.invoice_row.verified_datetime.is_some());
+
+        let updated_stock_line = stock_line_row_repo
+            .find_one_by_id(&stock_line_id)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            updated_stock_line.total_number_of_packs,
+            original_stock_line.total_number_of_packs - 5.0 // stock has been reduced by the num of packs in the supplier return line
+        );
+    }
+
+    #[actix_rt::test]
+    async fn test_update_supplier_return_success_picked_to_verified() {
+        let (_, connection, connection_manager, _) = setup_all(
+            "test_update_supplier_return_success_picked_to_verified",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context(mock_store_a().id, mock_user_account_a().id)
+            .unwrap();
+
+        let stock_line_row_repo = StockLineRowRepository::new(&connection);
+        let stock_line_id = mock_supplier_return_a_invoice_line_a()
+            .stock_line_id
+            .unwrap();
+
+        let original_stock_line = stock_line_row_repo
+            .find_one_by_id(&stock_line_id)
+            .unwrap()
+            .unwrap();
+
+        let result = service_provider
+            .invoice_service
+            .update_supplier_return(
+                &context,
+                UpdateSupplierReturn {
+                    supplier_return_id: mock_supplier_return_a().id, // is PICKED status
+                    status: Some(UpdateSupplierReturnStatus::Verified),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert_eq!(result.invoice_row.status, InvoiceStatus::Verified);
+        assert!(result.invoice_row.shipped_datetime.is_some());
+        assert!(result.invoice_row.verified_datetime.is_some());
+
+        let updated_stock_line = stock_line_row_repo
+            .find_one_by_id(&stock_line_id)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            updated_stock_line.total_number_of_packs,
+            original_stock_line.total_number_of_packs // total has not changed (no stock movements after PICKED status)
+        );
+    }
 }


### PR DESCRIPTION
Fix #11320

**Depends on #11325**

**NOTE**:  Done in separate PR cos I wasn't 100% clear on the status change here. Issue says change from Recieved to Verified, but it actually creates a "Shipped" Return not "Received".

# 👩🏻‍💻 What does this PR do?

Changes the auto-created supplier return status from "Shipped" to "Verified" when created from an inbound shipment, as requested in #11320.

Adds `Verified` as a valid status transition for supplier returns throughout the backend:
- `UpdateSupplierReturnStatus` enum (service + GraphQL layers)
- Status datetime transitions (sets picked, shipped, and verified datetimes)
- Stock line total packs update on New → Verified transition
- Updates the existing test to expect `Verified` status
- Updates the frontend success toast message

## 💌 Any notes for the reviewer?

This is the second half of #11320. The reference field changes are in #11325.

# 🧪 Testing

- [ ] From an Inbound shipment, select lines and click "Return selected lines"
- [ ] Submit the return — it should appear in the "Supplier Returns" list in **Verified** status (not Shipped)
- [ ] The success toast should say "Supplier Return successfully created as Verified"
- [ ] Manually created supplier returns (not from an inbound) should still start as "New"

# 📃 Reviewer Checklist

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend