### PR TITLE
Convert asset_log.type to AssetLogType enum

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/RecordMappingButton.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/RecordMappingButton.tsx
@@ -15,16 +15,16 @@ import {
   DateUtils,
   BasicTextInput,
   useDebounceCallback,
+  AssetLogTypeNodeType,
 } from '@openmsupply-client/common';
 import { useAssets } from '../api';
-import { TEMPERATURE_MAPPING_TYPE } from '../utils';
 
 type Draft = Partial<InsertAssetLogInput> & { files?: File[] };
 
 const getEmptyDraft = (assetId: string): Draft => ({
   id: FnUtils.generateUUID(),
   assetId,
-  type: TEMPERATURE_MAPPING_TYPE,
+  type: AssetLogTypeNodeType.TemperatureMapping,
   logDatetime: new Date().toISOString(),
 });
 

--- a/client/packages/coldchain/src/Equipment/DetailView/Tabs/StatusLogs.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/Tabs/StatusLogs.tsx
@@ -24,11 +24,8 @@ import {
 } from '@common/intl';
 import { ColdchainAssetLogFragment, useAssets } from '../../api';
 import { FileList } from '../../Components';
-import {
-  statusColourMap,
-  TEMPERATURE_MAPPING_TYPE,
-  useIsColdRoom,
-} from '../../utils';
+import { statusColourMap, useIsColdRoom } from '../../utils';
+import { AssetLogTypeNodeType } from '@openmsupply-client/common';
 
 const Divider = () => (
   <Box
@@ -199,13 +196,9 @@ const StatusLog = ({
                 colour={status.colour}
               />
             )}
-            {log.type && (
+            {log.type === AssetLogTypeNodeType.TemperatureMapping && (
               <StatusChip
-                label={
-                  log.type === TEMPERATURE_MAPPING_TYPE
-                    ? t('label.temperature-mapping')
-                    : log.type
-                }
+                label={t('label.temperature-mapping')}
                 colour="gray.main"
               />
             )}
@@ -370,7 +363,9 @@ export const StatusLogs = ({ assetId }: { assetId: string }) => {
         equalAny: Object.values(AssetLogStatusNodeType),
       };
     } else {
-      additionalFilter.type = { equalTo: TEMPERATURE_MAPPING_TYPE };
+      additionalFilter.type = {
+        equalTo: AssetLogTypeNodeType.TemperatureMapping,
+      };
     }
   }
 

--- a/client/packages/coldchain/src/Equipment/api/operations.generated.ts
+++ b/client/packages/coldchain/src/Equipment/api/operations.generated.ts
@@ -132,10 +132,11 @@ export type AssetFragment = {
 export type ColdchainAssetLogFragment = {
   __typename: 'AssetLogNode';
   comment?: string | null;
+  createdDatetime: string;
   id: string;
   logDatetime: string;
   status?: Types.AssetLogStatusNodeType | null;
-  type?: string | null;
+  type: Types.AssetLogTypeNodeType;
   reason?: { __typename: 'AssetLogReasonNode'; reason: string } | null;
   user?: {
     __typename: 'UserNode';
@@ -425,10 +426,11 @@ export type AssetLogsQuery = {
     nodes: Array<{
       __typename: 'AssetLogNode';
       comment?: string | null;
+      createdDatetime: string;
       id: string;
       logDatetime: string;
       status?: Types.AssetLogStatusNodeType | null;
-      type?: string | null;
+      type: Types.AssetLogTypeNodeType;
       reason?: { __typename: 'AssetLogReasonNode'; reason: string } | null;
       user?: {
         __typename: 'UserNode';
@@ -672,6 +674,7 @@ export const AssetFragmentDoc = gql`
 export const ColdchainAssetLogFragmentDoc = gql`
   fragment ColdchainAssetLog on AssetLogNode {
     comment
+    createdDatetime
     id
     logDatetime
     reason {

--- a/client/packages/coldchain/src/Equipment/utils.ts
+++ b/client/packages/coldchain/src/Equipment/utils.ts
@@ -19,9 +19,6 @@ export const useIsColdRoom = (): boolean => {
   return data?.assetCategory?.id === COLD_ROOMS_AND_FREEZER_ROOMS_CATEGORY_ID;
 };
 
-// DB value for the log type field — must match the backend constant
-export const TEMPERATURE_MAPPING_TYPE = 'Temperature Mapping';
-
 const statusTranslation: Record<AssetLogStatusNodeType, LocaleKey> = {
   [AssetLogStatusNodeType.Decommissioned]: 'status.decommissioned',
   [AssetLogStatusNodeType.Functioning]: 'status.functioning',

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -514,7 +514,7 @@ export type AssetLogFilterInput = {
   logDatetime?: InputMaybe<DatetimeFilterInput>;
   reasonId?: InputMaybe<EqualFilterStringInput>;
   status?: InputMaybe<EqualFilterStatusInput>;
-  type?: InputMaybe<StringFilterInput>;
+  type?: InputMaybe<EqualFilterAssetLogTypeInput>;
   user?: InputMaybe<StringFilterInput>;
 };
 
@@ -528,7 +528,7 @@ export type AssetLogNode = {
   logDatetime: Scalars['NaiveDateTime']['output'];
   reason?: Maybe<AssetLogReasonNode>;
   status?: Maybe<AssetLogStatusNodeType>;
-  type?: Maybe<Scalars['String']['output']>;
+  type: AssetLogTypeNodeType;
   user?: Maybe<UserNode>;
 };
 
@@ -604,6 +604,11 @@ export enum AssetLogStatusNodeType {
   NotFunctioning = 'NOT_FUNCTIONING',
   NotInUse = 'NOT_IN_USE',
   Unserviceable = 'UNSERVICEABLE',
+}
+
+export enum AssetLogTypeNodeType {
+  StatusUpdate = 'STATUS_UPDATE',
+  TemperatureMapping = 'TEMPERATURE_MAPPING',
 }
 
 export type AssetLogsResponse = AssetLogConnector;
@@ -2666,6 +2671,13 @@ export type EqualFilterActivityLogTypeInput = {
   notEqualTo?: InputMaybe<ActivityLogNodeType>;
 };
 
+export type EqualFilterAssetLogTypeInput = {
+  equalAny?: InputMaybe<Array<AssetLogTypeNodeType>>;
+  equalTo?: InputMaybe<AssetLogTypeNodeType>;
+  notEqualAll?: InputMaybe<Array<AssetLogTypeNodeType>>;
+  notEqualTo?: InputMaybe<AssetLogTypeNodeType>;
+};
+
 export type EqualFilterBigFloatingNumberInput = {
   equalAny?: InputMaybe<Array<Scalars['Float']['input']>>;
   equalAnyOrNull?: InputMaybe<Array<Scalars['Float']['input']>>;
@@ -3160,7 +3172,7 @@ export type InsertAssetLogInput = {
   logDatetime?: InputMaybe<Scalars['DateTime']['input']>;
   reasonId?: InputMaybe<Scalars['String']['input']>;
   status?: InputMaybe<AssetLogStatusNodeType>;
-  type?: InputMaybe<Scalars['String']['input']>;
+  type?: InputMaybe<AssetLogTypeNodeType>;
 };
 
 export type InsertAssetLogReasonError = {

--- a/client/packages/system/src/Asset/api/operations.generated.ts
+++ b/client/packages/system/src/Asset/api/operations.generated.ts
@@ -34,7 +34,7 @@ export type AssetLogFragment = {
   id: string;
   logDatetime: string;
   status?: Types.AssetLogStatusNodeType | null;
-  type?: string | null;
+  type: Types.AssetLogTypeNodeType;
   reason?: { __typename: 'AssetLogReasonNode'; reason: string } | null;
   user?: {
     __typename: 'UserNode';

--- a/server/graphql/asset/src/logs/insert.rs
+++ b/server/graphql/asset/src/logs/insert.rs
@@ -1,4 +1,4 @@
-use crate::types::AssetLogStatusNodeType;
+use crate::types::{AssetLogStatusNodeType, AssetLogTypeNodeType};
 use async_graphql::*;
 use graphql_core::{
     simple_generic_errors::{
@@ -51,7 +51,7 @@ pub struct InsertAssetLogInput {
     pub status: Option<AssetLogStatusNodeType>,
     pub reason_id: Option<String>,
     pub comment: Option<String>,
-    pub r#type: Option<String>,
+    pub r#type: Option<AssetLogTypeNodeType>,
     pub log_datetime: Option<chrono::DateTime<chrono::Utc>>,
 }
 
@@ -73,7 +73,7 @@ impl From<InsertAssetLogInput> for InsertAssetLog {
             status: status.map(|s| s.into()),
             reason_id,
             comment,
-            r#type,
+            r#type: r#type.map(|t| t.into()),
             log_datetime,
         }
     }

--- a/server/graphql/asset/src/types/asset_log.rs
+++ b/server/graphql/asset/src/types/asset_log.rs
@@ -22,7 +22,7 @@ use repository::EqualFilter;
 use repository::{DatetimeFilter, StringFilter};
 use service::ListResult;
 
-use repository::asset_log_row::AssetLogStatus;
+use repository::asset_log_row::{AssetLogStatus, AssetLogType};
 use serde::Serialize;
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq, Debug, Serialize)]
@@ -35,6 +35,14 @@ pub enum AssetLogStatusNodeType {
     NotFunctioning,
     Decommissioned,
     Unserviceable,
+}
+
+#[derive(Enum, Copy, Clone, PartialEq, Eq, Debug, Serialize)]
+#[graphql(remote = "repository::db_diesel::assets::asset_log_row
+::AssetLogType")]
+pub enum AssetLogTypeNodeType {
+    StatusUpdate,
+    TemperatureMapping,
 }
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq)]
@@ -63,7 +71,7 @@ pub struct AssetLogFilterInput {
     pub log_datetime: Option<DatetimeFilterInput>,
     pub user: Option<StringFilterInput>,
     pub reason_id: Option<EqualFilterStringInput>,
-    pub r#type: Option<StringFilterInput>,
+    pub r#type: Option<EqualFilterAssetLogTypeInput>,
 }
 
 impl From<AssetLogFilterInput> for AssetLogFilter {
@@ -75,7 +83,7 @@ impl From<AssetLogFilterInput> for AssetLogFilter {
             log_datetime: f.log_datetime.map(DatetimeFilter::from),
             user: f.user.map(StringFilter::from),
             reason_id: f.reason_id.map(EqualFilter::from),
-            r#type: f.r#type.map(StringFilter::from),
+            r#type: f.r#type.map(|s| map_filter!(s, AssetLogType::from)),
         }
     }
 }
@@ -86,6 +94,14 @@ pub struct EqualFilterStatusInput {
     pub equal_any: Option<Vec<AssetLogStatusNodeType>>,
     pub not_equal_to: Option<AssetLogStatusNodeType>,
     pub not_equal_all: Option<Vec<AssetLogStatusNodeType>>,
+}
+
+#[derive(InputObject, Clone)]
+pub struct EqualFilterAssetLogTypeInput {
+    pub equal_to: Option<AssetLogTypeNodeType>,
+    pub equal_any: Option<Vec<AssetLogTypeNodeType>>,
+    pub not_equal_to: Option<AssetLogTypeNodeType>,
+    pub not_equal_all: Option<Vec<AssetLogTypeNodeType>>,
 }
 
 #[derive(PartialEq, Debug)]
@@ -126,8 +142,9 @@ impl AssetLogNode {
         &self.row().comment
     }
 
-    pub async fn r#type(&self) -> &Option<String> {
-        &self.row().r#type
+    pub async fn r#type(&self) -> AssetLogTypeNodeType {
+        // Historical rows may store NULL — expose those as the default StatusUpdate.
+        AssetLogTypeNodeType::from(self.row().r#type.clone().unwrap_or_default())
     }
 
     pub async fn reason(&self, ctx: &Context<'_>) -> Result<Option<AssetLogReasonNode>> {

--- a/server/repository/src/db_diesel/assets/asset_log.rs
+++ b/server/repository/src/db_diesel/assets/asset_log.rs
@@ -2,7 +2,7 @@ use super::super::user_row::user_account;
 use super::asset_log_row::{asset_log, AssetLogRow};
 use diesel::{dsl::IntoBoxed, prelude::*};
 
-use crate::asset_log_row::{latest_asset_log, AssetLogStatus};
+use crate::asset_log_row::{latest_asset_log, AssetLogStatus, AssetLogType};
 use crate::{
     diesel_macros::{
         apply_date_filter, apply_equal_filter, apply_sort, apply_sort_no_case, apply_string_filter,
@@ -28,7 +28,7 @@ pub struct AssetLogFilter {
     pub log_datetime: Option<DatetimeFilter>,
     pub user: Option<StringFilter>,
     pub reason_id: Option<EqualFilter<String>>,
-    pub r#type: Option<StringFilter>,
+    pub r#type: Option<EqualFilter<AssetLogType>>,
 }
 
 impl AssetLogFilter {
@@ -60,7 +60,7 @@ impl AssetLogFilter {
         self.reason_id = Some(filter);
         self
     }
-    pub fn r#type(mut self, filter: StringFilter) -> Self {
+    pub fn r#type(mut self, filter: EqualFilter<AssetLogType>) -> Self {
         self.r#type = Some(filter);
         self
     }
@@ -168,7 +168,7 @@ fn create_filtered_query(filter: Option<AssetLogFilter>) -> BoxedAssetLogQuery {
 
         apply_equal_filter!(query, asset_id, asset_log::asset_id);
         apply_equal_filter!(query, reason_id, asset_log::reason_id);
-        apply_string_filter!(query, r#type, asset_log::type_);
+        apply_equal_filter!(query, r#type, asset_log::type_);
 
         if let Some(user) = user {
             let mut sub_query = user_account::table.select(user_account::id).into_boxed();
@@ -192,6 +192,15 @@ fn create_latest_filtered_query(filter: Option<AssetLogFilter>) -> BoxedLatestAs
 }
 
 impl AssetLogStatus {
+    pub fn equal_to(&self) -> EqualFilter<Self> {
+        EqualFilter {
+            equal_to: Some(self.clone()),
+            ..Default::default()
+        }
+    }
+}
+
+impl AssetLogType {
     pub fn equal_to(&self) -> EqualFilter<Self> {
         EqualFilter {
             equal_to: Some(self.clone()),

--- a/server/repository/src/db_diesel/assets/asset_log_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_log_row.rs
@@ -19,7 +19,7 @@ table! {
         user_id -> Text,
         status -> Nullable<crate::db_diesel::assets::asset_log_row::AssetLogStatusMapping>,
         comment -> Nullable<Text>,
-        #[sql_name = "type"] type_ -> Nullable<Text>,
+        #[sql_name = "type"] type_ -> Nullable<crate::db_diesel::assets::asset_log_row::AssetLogTypeMapping>,
         reason_id -> Nullable<Text>,
         log_datetime -> Timestamp,
         created_datetime -> Timestamp,
@@ -33,7 +33,7 @@ table! {
         user_id -> Text,
         status -> Nullable<crate::db_diesel::assets::asset_log_row::AssetLogStatusMapping>,
         comment -> Nullable<Text>,
-        #[sql_name = "type"] type_ -> Nullable<Text>,
+        #[sql_name = "type"] type_ -> Nullable<crate::db_diesel::assets::asset_log_row::AssetLogTypeMapping>,
         reason_id -> Nullable<Text>,
         log_datetime -> Timestamp,
         created_datetime -> Timestamp,
@@ -55,6 +55,15 @@ pub enum AssetLogStatus {
     Unserviceable,
 }
 
+#[derive(DbEnum, Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[DbValueStyle = "SCREAMING_SNAKE_CASE"]
+pub enum AssetLogType {
+    #[default]
+    StatusUpdate,
+    TemperatureMapping,
+}
+
 #[derive(
     Clone, Insertable, Queryable, Debug, PartialEq, AsChangeset, Eq, Default, Serialize, Deserialize,
 )]
@@ -67,7 +76,8 @@ pub struct AssetLogRow {
     pub status: Option<AssetLogStatus>,
     pub comment: Option<String>,
     #[diesel(column_name = "type_")]
-    pub r#type: Option<String>,
+    #[serde(default)]
+    pub r#type: Option<AssetLogType>,
     pub reason_id: Option<String>,
     pub log_datetime: NaiveDateTime,
     #[serde(default)]

--- a/server/repository/src/migrations/base_migrations/sqlite_latest.sql
+++ b/server/repository/src/migrations/base_migrations/sqlite_latest.sql
@@ -2089,12 +2089,10 @@ CREATE VIEW latest_asset_log AS
     FROM (
       SELECT asset_id, MAX(log_datetime) AS latest_log_datetime
       FROM asset_log
-      WHERE status IS NOT NULL
       GROUP BY asset_id
     ) grouped
     INNER JOIN asset_log al
-      ON al.asset_id = grouped.asset_id AND al.log_datetime = grouped.latest_log_datetime
-      AND al.status IS NOT NULL;
+      ON al.asset_id = grouped.asset_id AND al.log_datetime = grouped.latest_log_datetime;
 CREATE VIEW report_document AS
     SELECT
         d.name,

--- a/server/repository/src/migrations/v2_18_00/change_asset_log_type_to_enum.rs
+++ b/server/repository/src/migrations/v2_18_00/change_asset_log_type_to_enum.rs
@@ -1,0 +1,53 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "change_asset_log_type_to_enum"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        // Normalise existing values to the new enum variants. The column stays nullable
+        // at the DB level (to avoid recreating the table on SQLite), but the service
+        // layer always writes a concrete value from here on.
+        sql!(
+            connection,
+            r#"
+                UPDATE asset_log
+                SET type = 'TEMPERATURE_MAPPING'
+                WHERE type = 'Temperature Mapping';
+            "#
+        )?;
+        sql!(
+            connection,
+            r#"
+                UPDATE asset_log
+                SET type = 'STATUS_UPDATE'
+                WHERE type IS NULL OR type <> 'TEMPERATURE_MAPPING';
+            "#
+        )?;
+
+        if cfg!(feature = "postgres") {
+            sql!(
+                connection,
+                r#"
+                    CREATE TYPE asset_log_type AS ENUM (
+                        'STATUS_UPDATE',
+                        'TEMPERATURE_MAPPING'
+                    );
+                "#
+            )?;
+            sql!(
+                connection,
+                r#"
+                    ALTER TABLE asset_log
+                        ALTER COLUMN type TYPE asset_log_type
+                        USING type::asset_log_type;
+                "#
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_18_00/mod.rs
+++ b/server/repository/src/migrations/v2_18_00/mod.rs
@@ -6,6 +6,7 @@ mod add_cold_room_mapping_properties;
 mod add_created_datetime_to_asset_log;
 mod add_date_property_value_type;
 mod add_invoice_date_backdated_activity_log_type;
+mod change_asset_log_type_to_enum;
 
 pub(crate) struct V2_18_00;
 impl Migration for V2_18_00 {
@@ -23,6 +24,7 @@ impl Migration for V2_18_00 {
             Box::new(add_date_property_value_type::Migrate),
             Box::new(add_cold_room_mapping_properties::Migrate),
             Box::new(add_created_datetime_to_asset_log::Migrate),
+            Box::new(change_asset_log_type_to_enum::Migrate),
             Box::new(add_invoice_date_backdated_activity_log_type::Migrate),
         ]
     }

--- a/server/repository/src/migrations/views/latest_asset_log.rs
+++ b/server/repository/src/migrations/views/latest_asset_log.rs
@@ -16,6 +16,10 @@ impl ViewMigrationFragment for ViewMigration {
     }
 
     fn rebuild_view(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        // Only status-update entries are considered the "latest" for an asset —
+        // TemperatureMapping and other event-type logs leave status NULL. Filtering on
+        // status rather than type keeps the predicate correct for pre-enum historical
+        // rows where type is still NULL.
         sql!(
             connection,
             r#"
@@ -37,7 +41,7 @@ impl ViewMigrationFragment for ViewMigration {
     ) grouped
     INNER JOIN asset_log al
       ON al.asset_id = grouped.asset_id AND al.log_datetime = grouped.latest_log_datetime
-      AND al.status IS NOT NULL;    
+      AND al.status IS NOT NULL;
             "#
         )?;
 

--- a/server/repository/src/mock/asset_log.rs
+++ b/server/repository/src/mock/asset_log.rs
@@ -1,6 +1,9 @@
 use chrono::NaiveDate;
 
-use crate::{asset_log_row::AssetLogStatus, assets::asset_log_row::AssetLogRow};
+use crate::{
+    asset_log_row::{AssetLogStatus, AssetLogType},
+    assets::asset_log_row::AssetLogRow,
+};
 
 pub fn mock_asset_log_a() -> AssetLogRow {
     AssetLogRow {
@@ -9,7 +12,7 @@ pub fn mock_asset_log_a() -> AssetLogRow {
         user_id: String::from("user_account_a"),
         status: None,
         comment: None,
-        r#type: None,
+        r#type: Some(AssetLogType::StatusUpdate),
         reason_id: None,
         log_datetime: NaiveDate::from_ymd_opt(2022, 4, 12)
             .unwrap()
@@ -29,7 +32,7 @@ pub fn mock_asset_log_b() -> AssetLogRow {
         user_id: String::from("user_account_a"),
         status: None,
         comment: None,
-        r#type: None,
+        r#type: Some(AssetLogType::StatusUpdate),
         reason_id: None,
         log_datetime: NaiveDate::from_ymd_opt(2022, 5, 12)
             .unwrap()
@@ -49,7 +52,7 @@ pub fn mock_asset_log_c() -> AssetLogRow {
         user_id: String::from("user_account_a"),
         status: Some(AssetLogStatus::Functioning),
         comment: None,
-        r#type: None,
+        r#type: Some(AssetLogType::StatusUpdate),
         reason_id: None,
         log_datetime: NaiveDate::from_ymd_opt(2021, 6, 12)
             .unwrap()

--- a/server/service/src/asset/insert_log.rs
+++ b/server/service/src/asset/insert_log.rs
@@ -11,16 +11,15 @@ use crate::{
     activity_log::activity_log_entry, service_provider::ServiceContext, SingleRecordError,
 };
 use chrono::Utc;
-pub const TEMPERATURE_MAPPING_TYPE: &str = "Temperature Mapping";
 
 use repository::{
-    asset_log_row::AssetLogStatus,
+    asset_log_row::{AssetLogStatus, AssetLogType},
     assets::{
         asset_log::AssetLogFilter,
         asset_log_row::{AssetLogRow, AssetLogRowRepository},
         asset_row::AssetRowRepository,
     },
-    ActivityLogType, EqualFilter, RepositoryError, StorageConnection, StringFilter,
+    ActivityLogType, EqualFilter, RepositoryError, StorageConnection,
 };
 
 #[derive(PartialEq, Debug)]
@@ -42,7 +41,7 @@ pub struct InsertAssetLog {
     pub asset_id: String,
     pub status: Option<AssetLogStatus>,
     pub comment: Option<String>,
-    pub r#type: Option<String>,
+    pub r#type: Option<AssetLogType>,
     pub reason_id: Option<String>,
     pub log_datetime: Option<chrono::DateTime<chrono::Utc>>,
 }
@@ -58,7 +57,7 @@ pub fn insert_asset_log(
             let new_asset_log = generate(ctx, input);
             AssetLogRowRepository::new(connection).upsert_one(&new_asset_log)?;
 
-            if new_asset_log.r#type.as_deref() == Some(TEMPERATURE_MAPPING_TYPE) {
+            if new_asset_log.r#type == Some(AssetLogType::TemperatureMapping) {
                 recalculate_mapping_dates(connection, &new_asset_log.asset_id)?;
             }
 
@@ -103,8 +102,10 @@ pub fn validate(
         return Err(InsertAssetLogError::AssetLogAlreadyExists);
     }
 
-    // Status is required unless a type is provided (e.g., Temperature Mapping events)
-    if input.status.is_none() && input.r#type.is_none() {
+    // StatusUpdate logs require a status; event-type logs (e.g. TemperatureMapping) don't.
+    // A missing type defaults to StatusUpdate.
+    let effective_type = input.r#type.clone().unwrap_or_default();
+    if effective_type == AssetLogType::StatusUpdate && input.status.is_none() {
         return Err(InsertAssetLogError::StatusNotProvided);
     }
 
@@ -151,7 +152,7 @@ pub fn generate(
         user_id: ctx.user_id.clone(),
         status,
         comment,
-        r#type,
+        r#type: Some(r#type.unwrap_or_default()),
         reason_id,
         log_datetime: log_datetime.map(|d| d.naive_utc()).unwrap_or(now),
         created_datetime: now,
@@ -167,7 +168,7 @@ pub fn recalculate_mapping_dates(
     let logs = AssetLogRepository::new(connection).query_by_filter(
         AssetLogFilter::new()
             .asset_id(EqualFilter::equal_to(asset_id.to_string()))
-            .r#type(StringFilter::equal_to(TEMPERATURE_MAPPING_TYPE)),
+            .r#type(AssetLogType::TemperatureMapping.equal_to()),
     )?;
 
     let min_date = logs.iter().map(|l| l.log_datetime).min();

--- a/server/service/src/asset/tests/insert_log.rs
+++ b/server/service/src/asset/tests/insert_log.rs
@@ -2,14 +2,14 @@
 mod query {
     use crate::{
         asset::{
-            insert_log::{InsertAssetLog, InsertAssetLogError, TEMPERATURE_MAPPING_TYPE},
+            insert_log::{InsertAssetLog, InsertAssetLogError},
             insert_log_reason::InsertAssetLogReason,
         },
         service_provider::ServiceProvider,
     };
     use chrono::{Duration, Utc};
     use repository::{
-        asset_log_row::AssetLogStatus,
+        asset_log_row::{AssetLogStatus, AssetLogType},
         assets::asset_row::AssetRowRepository,
         mock::{mock_asset_a, mock_store_a, mock_user_account_a, MockDataInserts},
         test_db::setup_all,
@@ -359,7 +359,7 @@ mod query {
                     asset_id: mock_asset_a().id,
                     status: None,
                     comment: None,
-                    r#type: Some(TEMPERATURE_MAPPING_TYPE.to_string()),
+                    r#type: Some(AssetLogType::TemperatureMapping),
                     reason_id: None,
                     log_datetime: Some(Utc::now() - Duration::hours(1)),
                 },
@@ -367,7 +367,7 @@ mod query {
             .unwrap();
 
         assert_eq!(asset_log.id, "event_type_log");
-        assert_eq!(asset_log.r#type.as_deref(), Some(TEMPERATURE_MAPPING_TYPE));
+        assert_eq!(asset_log.r#type, Some(AssetLogType::TemperatureMapping));
         assert_eq!(asset_log.status, None);
     }
 
@@ -398,7 +398,7 @@ mod query {
                     asset_id: asset_id.clone(),
                     status: None,
                     comment: None,
-                    r#type: Some(TEMPERATURE_MAPPING_TYPE.to_string()),
+                    r#type: Some(AssetLogType::TemperatureMapping),
                     reason_id: None,
                     log_datetime: Some(earlier_date),
                 },
@@ -432,7 +432,7 @@ mod query {
                     asset_id: asset_id.clone(),
                     status: None,
                     comment: None,
-                    r#type: Some(TEMPERATURE_MAPPING_TYPE.to_string()),
+                    r#type: Some(AssetLogType::TemperatureMapping),
                     reason_id: None,
                     log_datetime: Some(later_date),
                 },

--- a/server/service/src/sync/test/test_data/asset_log.rs
+++ b/server/service/src/sync/test/test_data/asset_log.rs
@@ -1,4 +1,7 @@
-use repository::{asset_log_row::AssetLogStatus, db_diesel::assets::asset_log_row::AssetLogRow};
+use repository::{
+    asset_log_row::{AssetLogStatus, AssetLogType},
+    db_diesel::assets::asset_log_row::AssetLogRow,
+};
 use serde_json::json;
 
 use super::{TestSyncIncomingRecord, TestSyncOutgoingRecord};
@@ -15,7 +18,8 @@ const ASSET_LOG1: (&str, &str) = (
         "comment": "test_comment",
         "reason_id": null,
         "log_datetime": "2020-01-22T15:16:00",
-        "created_datetime": "2020-01-22T15:16:00"
+        "created_datetime": "2020-01-22T15:16:00",
+        "type": "STATUS_UPDATE"
     }"#,
 );
 fn asset_log1() -> AssetLogRow {
@@ -34,7 +38,7 @@ fn asset_log1() -> AssetLogRow {
             .unwrap()
             .and_hms_opt(15, 16, 0)
             .unwrap(),
-        r#type: None,
+        r#type: Some(AssetLogType::StatusUpdate),
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace the free-form `Option<String>` `type` column on `asset_log` with a typed `AssetLogType` enum (`StatusUpdate`, `TemperatureMapping`) so frontend and backend share a single source of truth instead of a stringly-typed `"Temperature Mapping"` constant duplicated on both sides.
- New migration renames legacy `"Temperature Mapping"` values, backfills `NULL` rows to `STATUS_UPDATE`, and on Postgres casts the column to a new `asset_log_type` enum. The column stays nullable to avoid a SQLite table recreation on large datasets; the service layer always writes a concrete value from here on.
- GraphQL exposes `AssetLogTypeNodeType` and `EqualFilterAssetLogTypeInput`. The insert input stays optional and defaults to `StatusUpdate` server-side, so existing clients keep working.
- Frontend drops the `TEMPERATURE_MAPPING_TYPE` constant and uses the generated `AssetLogTypeNodeType` enum directly.
- Also reverts the hand-edit to `sqlite_latest.sql` — the `latest_asset_log` view migration rebuilds the view on every run, so the baseline snapshot doesn't need patching.

Targets #11204 as its base.

## Test plan
- [x] `cargo test -p repository --lib migration_2_18_00` passes
- [x] `cargo test -p repository --lib drop_and_rebuild_views` passes
- [x] `cargo test -p service --lib insert_log` — all 4 tests pass (service_insert, event_type_without_status, recalculate_mapping_dates, future_log_datetime_rejected)
- [x] `cargo check` passes for both sqlite and postgres feature sets
- [x] `yarn generate` regenerates schema cleanly
- [ ] Smoke test: record a mapping on a cold room asset → log stored with `TEMPERATURE_MAPPING` type, Status History tab still filters correctly
- [ ] Smoke test: post-migration, existing `asset_log` rows all have a non-null type (`STATUS_UPDATE` for historical status updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)