### PR TITLE
#11311 Add cancel button to item variant select panel

### DIFF
--- a/client/packages/system/src/Item/Components/ItemVariantSelector/ItemVariantSelectPanel.tsx
+++ b/client/packages/system/src/Item/Components/ItemVariantSelector/ItemVariantSelectPanel.tsx
@@ -5,6 +5,7 @@ import {
   SlidePanel,
   Box,
   Typography,
+  DialogButton,
 } from '@openmsupply-client/common';
 import { ItemVariantFragment, useItemVariants } from '../../api';
 
@@ -86,6 +87,7 @@ export const ItemVariantSelectPanel = ({
       open={open}
       onClose={onClose}
       title={t('label.select-item-variant')}
+      cancelButton={<DialogButton variant="cancel" onClick={onClose} />}
     >
       <Box display="flex" flexDirection="column" gap={2} padding={2}>
         <VariantCard onClick={onManual ?? onClose}>


### PR DESCRIPTION
Closes #11311

## Summary
- Adds a cancel button to the "Select item variant" modal (`ItemVariantSelectPanel`) so users can close it without selecting a variant
- Uses the existing `cancelButton` prop on `SlidePanel` with `DialogButton`, consistent with all other modals in the codebase

<img width="1881" height="1020" alt="image" src="https://github.com/user-attachments/assets/1a97d649-f7ff-4527-aaf3-54909d4cdd31" />


## Test plan
- [ ] Open a stocktake 
- [ ] Add an item which has variants configured for it
- [ ] Click add batch -> see the select item variant panel
- [ ] Verify a cancel button appears at the bottom of the panel
- [ ] Click cancel and confirm the panel closes and you see the list of existing batches of the item again

🤖 Generated with [Claude Code](https://claude.com/claude-code)