### PR TITLE
#11320 Use linked shipment number for supplier return reference default

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2069,7 +2069,7 @@
   "messages.customer-requisition-created-on": "Customer requisition created on {{date}}",
   "messages.customer-return-created-verified": "Customer Return successfully created as Verified",
   "messages.default-customer-return-reference": "From outbound shipment #{{invoiceNumber}}",
-  "messages.default-supplier-return-reference": "From inbound shipment #{{invoiceNumber}}",
+  "messages.default-supplier-return-reference": "From outbound shipment #{{invoiceNumber}}",
   "messages.delete-all-translations-confirm": "Are you sure you want to delete all custom translations?",
   "messages.delete-this-line": "Delete this line",
   "messages.deleted": "Deleted",

--- a/client/packages/common/src/intl/locales/fr/common.json
+++ b/client/packages/common/src/intl/locales/fr/common.json
@@ -2721,6 +2721,7 @@
   "report.ven-category": "Catégorie VEN",
   "label.delete-all-translations": "Supprimer toutes transactions",
   "messages.default-customer-return-reference": "Depuis la livraison sortante #{{invoiceNumber}}",
+  "messages.default-supplier-return-reference": "Depuis la livraison sortante #{{invoiceNumber}}",
   "messages.download-first-warning": "Veuillez d’abord télécharger vos traductions actuelles afin de ne pas les perdre.",
   "label.return-from": "Retour de",
   "messages.cant-change-line-status-on-received-invoice": "Impossible de modifier le statut de la ligne sur une facture reçue",

--- a/client/packages/invoices/src/InboundShipment/api/operations.generated.ts
+++ b/client/packages/invoices/src/InboundShipment/api/operations.generated.ts
@@ -142,7 +142,11 @@ export type InboundFragment = {
   chargesForeignCurrency: number;
   inboundType: Types.InboundNodeType;
   defaultDonor?: { __typename: 'NameNode'; id: string; name: string } | null;
-  linkedShipment?: { __typename: 'InvoiceNode'; id: string } | null;
+  linkedShipment?: {
+    __typename: 'InvoiceNode';
+    id: string;
+    invoiceNumber: number;
+  } | null;
   user?: {
     __typename: 'UserNode';
     username: string;
@@ -483,7 +487,11 @@ export type InvoiceQuery = {
           id: string;
           name: string;
         } | null;
-        linkedShipment?: { __typename: 'InvoiceNode'; id: string } | null;
+        linkedShipment?: {
+          __typename: 'InvoiceNode';
+          id: string;
+          invoiceNumber: number;
+        } | null;
         user?: {
           __typename: 'UserNode';
           username: string;
@@ -739,7 +747,11 @@ export type InboundByNumberQuery = {
           id: string;
           name: string;
         } | null;
-        linkedShipment?: { __typename: 'InvoiceNode'; id: string } | null;
+        linkedShipment?: {
+          __typename: 'InvoiceNode';
+          id: string;
+          invoiceNumber: number;
+        } | null;
         user?: {
           __typename: 'UserNode';
           username: string;
@@ -1870,6 +1882,7 @@ export const InboundFragmentDoc = gql`
     linkedShipment {
       __typename
       id
+      invoiceNumber
     }
     user {
       __typename

--- a/client/packages/invoices/src/InboundShipment/api/operations.graphql
+++ b/client/packages/invoices/src/InboundShipment/api/operations.graphql
@@ -148,6 +148,7 @@ fragment Inbound on InvoiceNode {
   linkedShipment {
     __typename
     id
+    invoiceNumber
   }
 
   user {

--- a/client/packages/invoices/src/Returns/modals/SupplierReturn/SupplierReturn.tsx
+++ b/client/packages/invoices/src/Returns/modals/SupplierReturn/SupplierReturn.tsx
@@ -23,8 +23,9 @@ interface SupplierReturnEditModalProps {
   returnId?: string;
   inboundShipment?: {
     id: string;
-    invoiceNumber: number;
     otherPartyName: string;
+    theirReference?: string | null;
+    linkedShipment?: { invoiceNumber: number } | null;
   };
   initialItemId?: string | null;
   loadNextItem?: () => void;
@@ -59,10 +60,14 @@ export const SupplierReturnEditModal = ({
     AlertColor | undefined
   >();
 
+  const sourceInvoiceNumber =
+    inboundShipment?.linkedShipment?.invoiceNumber ??
+    inboundShipment?.theirReference ??
+    null;
   const defaultReference =
-    isNewReturn && inboundShipment
+    isNewReturn && sourceInvoiceNumber !== null
       ? t('messages.default-supplier-return-reference', {
-          invoiceNumber: inboundShipment.invoiceNumber,
+          invoiceNumber: sourceInvoiceNumber,
         })
       : '';
   const [theirReference, setTheirReference] = useState(defaultReference);


### PR DESCRIPTION
Relates to #11320
Stacks on #11325

# 👩🏻‍💻 What does this PR do?

Improves the default value of the editable "reference" field in the Supplier Return modal (added in #11325) so it contains the **supplier's outbound shipment number** rather than the receiving store's **inbound shipment number**, matching the intent described in the original issue.

### Why

Issue #11320 specifies the default reference text should be `From outbound shipment [invoice number]`, where the invoice number is the supplier's outbound number (shown as `12` in the issue screenshots) — i.e. the number of the shipment that became this inbound.

In #11325 the default was populated from `inboundShipment.invoiceNumber`, which is the **inbound's own** number (e.g. `6` in the screenshots), producing `From inbound shipment #6` rather than the intended `From outbound shipment #12`.

### What changed

- GraphQL: the inbound-shipment detail fragment now also selects `linkedShipment.invoiceNumber` ([`operations.graphql`](../blob/11320-use-linked-shipment-for-supplier-return-reference/client/packages/invoices/src/InboundShipment/api/operations.graphql)) and generated types updated accordingly.
- `SupplierReturnEditModal` accepts `linkedShipment` on the `inboundShipment` prop and computes the default reference from:
  1. `linkedShipment.invoiceNumber` if present (store-to-store transfer inbounds — gives a clean number), else
  2. `inboundShipment.theirReference` (manually-entered inbounds — user typed the supplier's invoice number into the reference field), else
  3. empty.
- Added `messages.default-supplier-return-reference` translations (English + French) — the French text mirrors the existing customer-return translation pattern.

### Behaviour

| Inbound origin | Default reference shown |
|---|---|
| Manual (external supplier), user typed "12" in reference | `From outbound shipment #12` |
| Transfer-created (supplier = another store, outbound #20) | `From outbound shipment #20` |
| No reference / no linked shipment | (empty) |

## 💌 Any notes for the reviewer?

- This is a small follow-up on #11325. Please review that first — this PR targets that branch, so merging it into #11325's branch before merging #11325 into `v2.17.3-RC` keeps the history tidy.
- The `theirReference` fallback is there because for transfer-created inbounds the field contains an auto-generated, English-only string (`From invoice number: 20 (…)`). We prefer `linkedShipment.invoiceNumber` when available so the rendered default is clean and translatable. The fallback only fires for the manual-entry path, where the user typed the supplier's number directly.
- No server changes.

# 🧪 Testing

- [ ] From a **manually-entered** inbound shipment (reference field = the supplier's invoice number, e.g. `12`), select lines → **Return selected lines** → confirm the Returns modal default reads `From outbound shipment #12`
- [ ] From a **transfer-created** inbound shipment (linked to another store's outbound, e.g. outbound #20), select lines → **Return selected lines** → confirm the default reads `From outbound shipment #20`
- [ ] From an inbound shipment with no reference and no linked shipment, confirm the default reference is empty but still editable
- [ ] Switch UI locale to French → confirm default reads `Depuis la livraison sortante #{{n}}`
- [ ] Submit the return and confirm the reference is persisted on the created Supplier Return

# 📃 Documentation

- [x] **No documentation required**: minor refinement of a default value

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend