### PR TITLE
#11349 Add code filter to Location list view

### DIFF
--- a/client/packages/system/src/Location/ListView/ListView.tsx
+++ b/client/packages/system/src/Location/ListView/ListView.tsx
@@ -28,6 +28,9 @@ export const LocationListView = () => {
         key: 'name',
       },
       {
+        key: 'code',
+      },
+      {
         key: 'onHold',
         condition: '=',
       },
@@ -49,6 +52,7 @@ export const LocationListView = () => {
         accessorKey: 'code',
         header: t('label.code'),
         enableSorting: true,
+        enableColumnFilter: true,
       },
       {
         accessorKey: 'name',

--- a/client/packages/system/src/Location/ListView/Toolbar.tsx
+++ b/client/packages/system/src/Location/ListView/Toolbar.tsx
@@ -27,6 +27,11 @@ export const Toolbar = () => {
               urlParameter: 'name',
             },
             {
+              type: 'text',
+              name: t('label.code'),
+              urlParameter: 'code',
+            },
+            {
               type: 'boolean',
               name: t('label.on-hold'),
               urlParameter: 'onHold',


### PR DESCRIPTION
Closes #11349 


## Summary
- Adds a "Code" text filter to the Location list toolbar filter menu and enables column filtering on the code column
- Closes #11349 (child of #11348, point 3)
- Frontend-only change — the backend `LocationFilterInput` already supports `code` with `StringFilterInput`
<img width="1489" height="490" alt="image" src="https://github.com/user-attachments/assets/aaf30cc5-e000-4ab5-97f5-623a8ce55643" />
<img width="1454" height="660" alt="image" src="https://github.com/user-attachments/assets/40cb8d31-1afd-4c79-8dd9-db58ab958fa4" />
<img width="1493" height="637" alt="image" src="https://github.com/user-attachments/assets/0fe83bcb-e568-46b4-a994-ad477da74fc0" />

Name and code fitlers together:
<img width="1494" height="803" alt="image" src="https://github.com/user-attachments/assets/043c1a76-180f-407a-94e9-d03a2469cea9" />


## Test plan
- [ ] Go to Location list view
- [ ] Open the filter menu — verify "Code" appears as a filter option
- [ ] Apply a code filter — verify only locations matching the code substring are shown
- [ ] Verify the code column header also has an inline filter option

🤖 Generated with [Claude Code](https://claude.com/claude-code)