### PR TITLE
#11352 Fix location code uniqueness check using hardcoded store_a

### DIFF
--- a/client/packages/system/src/Location/ListView/LocationEditModal/LocationEditModal.tsx
+++ b/client/packages/system/src/Location/ListView/LocationEditModal/LocationEditModal.tsx
@@ -11,6 +11,7 @@ import {
   InlineSpinner,
   NumericTextInput,
   Box,
+  useNotification,
 } from '@openmsupply-client/common';
 import { LocationRowFragment, useLocationList, useLocation } from '../../api';
 import { LocationTypeInput } from '@openmsupply-client/system';
@@ -99,9 +100,20 @@ export const LocationEditModal: FC<LocationEditModalProps> = ({
 }) => {
   const { Modal } = useDialog({ isOpen, onClose });
   const t = useTranslation();
+  const { error } = useNotification();
   const { draft, onUpdate, onChangeLocation, onSave, isLoading } =
     useDraftLocation(location, mode);
   const isInvalid = !draft.code.trim() || !draft.name.trim();
+
+  const handleSave = async () => {
+    try {
+      await onSave();
+      return true;
+    } catch (e) {
+      error(e instanceof Error ? e.message : t('error.cant-save'))();
+      return false;
+    }
+  };
 
   return (
     <Modal
@@ -110,8 +122,7 @@ export const LocationEditModal: FC<LocationEditModalProps> = ({
           variant="ok"
           disabled={isInvalid}
           onClick={async () => {
-            await onSave();
-            onClose();
+            if (await handleSave()) onClose();
           }}
         />
       }
@@ -121,8 +132,7 @@ export const LocationEditModal: FC<LocationEditModalProps> = ({
           variant="next-and-ok"
           disabled={isInvalid}
           onClick={async () => {
-            await onSave();
-            onChangeLocation();
+            if (await handleSave()) onChangeLocation();
             return true;
           }}
         />

--- a/client/packages/system/src/Location/api/hooks/useLocation.ts
+++ b/client/packages/system/src/Location/api/hooks/useLocation.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@openmsupply-client/common';
+import { useMutation, useTranslation } from '@openmsupply-client/common';
 import { useLocationGraphQL } from '../useLocationGraphQL';
 import { LOCATION } from './keys';
 import { LocationRowFragment } from '../operations.generated';
@@ -35,11 +35,12 @@ export const useLocation = () => {
 
 const useCreateLocation = () => {
   const { locationApi, queryClient, storeId } = useLocationGraphQL();
+  const t = useTranslation();
 
   const mutationFn = async (input: LocationRowFragment) => {
     const { id, code, name, onHold, locationType, volume } = input;
 
-    await locationApi.insertLocation({
+    const result = await locationApi.insertLocation({
       input: {
         id,
         code,
@@ -50,6 +51,17 @@ const useCreateLocation = () => {
       },
       storeId,
     });
+
+    const { insertLocation } = result;
+    if (insertLocation.__typename === 'InsertLocationError') {
+      const { error } = insertLocation;
+      if (error.__typename === 'UniqueValueViolation') {
+        throw new Error(
+          t('error.unique-value-violation', { field: error.field })
+        );
+      }
+      throw new Error(error.description);
+    }
   };
 
   return useMutation({
@@ -65,11 +77,12 @@ const useCreateLocation = () => {
 
 const useUpdateLocation = () => {
   const { locationApi, queryClient, storeId } = useLocationGraphQL();
+  const t = useTranslation();
 
   const mutationFn = async (input: LocationRowFragment) => {
     const { id, code, name, onHold, locationType, volume } = input;
 
-    await locationApi.updateLocation({
+    const result = await locationApi.updateLocation({
       input: {
         id,
         code,
@@ -80,6 +93,17 @@ const useUpdateLocation = () => {
       },
       storeId,
     });
+
+    const { updateLocation } = result;
+    if (updateLocation.__typename === 'UpdateLocationError') {
+      const { error } = updateLocation;
+      if (error.__typename === 'UniqueValueViolation') {
+        throw new Error(
+          t('error.unique-value-violation', { field: error.field })
+        );
+      }
+      throw new Error(error.description);
+    }
   };
 
   return useMutation({

--- a/server/graphql/location/src/mutations/insert.rs
+++ b/server/graphql/location/src/mutations/insert.rs
@@ -234,7 +234,7 @@ mod test {
             "insertLocation": {
                 "error": {
                     "__typename": "UniqueValueViolation",
-                    "field": "CODE"
+                    "field": "code"
                 }
             }
         });

--- a/server/graphql/location/src/mutations/insert.rs
+++ b/server/graphql/location/src/mutations/insert.rs
@@ -1,7 +1,7 @@
 use async_graphql::*;
 use graphql_core::{
     simple_generic_errors::{
-        DatabaseError, InternalError, RecordAlreadyExist, UniqueValueViolation,
+        DatabaseError, InternalError, RecordAlreadyExist, UniqueValueKey, UniqueValueViolation,
     },
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
@@ -97,9 +97,18 @@ fn map_error(error: ServiceError) -> Result<InsertLocationErrorInterface> {
     let formatted_error = format!("{error:#?}");
 
     let graphql_error = match error {
+        // Structured Errors
+        ServiceError::LocationAlreadyExists => {
+            return Ok(InsertLocationErrorInterface::LocationAlreadyExists(
+                RecordAlreadyExist,
+            ))
+        }
+        ServiceError::LocationWithCodeAlreadyExists => {
+            return Ok(InsertLocationErrorInterface::UniqueValueViolation(
+                UniqueValueViolation(UniqueValueKey::Code),
+            ))
+        }
         // Standard Graphql Errors
-        ServiceError::LocationAlreadyExists => BadUserInput(formatted_error),
-        ServiceError::LocationWithCodeAlreadyExists => BadUserInput(formatted_error),
         ServiceError::CreatedRecordNotFound => InternalError(formatted_error),
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
     };

--- a/server/graphql/location/src/mutations/insert.rs
+++ b/server/graphql/location/src/mutations/insert.rs
@@ -196,13 +196,18 @@ mod test {
         let test_service = TestService(Box::new(|_| {
             Err(InsertLocationError::LocationAlreadyExists)
         }));
-        let expected_message = "Bad user input";
-        assert_standard_graphql_error!(
+        let expected = json!({
+            "insertLocation": {
+                "error": {
+                    "__typename": "RecordAlreadyExist"
+                }
+            }
+        });
+        assert_graphql_query!(
             &settings,
             mutation,
             &variables,
-            &expected_message,
-            None,
+            &expected,
             Some(service_provider(test_service, &connection_manager))
         );
 
@@ -225,13 +230,19 @@ mod test {
         let test_service = TestService(Box::new(|_| {
             Err(InsertLocationError::LocationWithCodeAlreadyExists)
         }));
-        let expected_message = "Bad user input";
-        assert_standard_graphql_error!(
+        let expected = json!({
+            "insertLocation": {
+                "error": {
+                    "__typename": "UniqueValueViolation",
+                    "field": "CODE"
+                }
+            }
+        });
+        assert_graphql_query!(
             &settings,
             mutation,
             &variables,
-            &expected_message,
-            None,
+            &expected,
             Some(service_provider(test_service, &connection_manager))
         );
 

--- a/server/graphql/location/src/mutations/update.rs
+++ b/server/graphql/location/src/mutations/update.rs
@@ -2,7 +2,7 @@ use async_graphql::*;
 
 use graphql_core::{
     simple_generic_errors::{
-        DatabaseError, InternalError, RecordBelongsToAnotherStore, RecordNotFound,
+        DatabaseError, InternalError, RecordBelongsToAnotherStore, RecordNotFound, UniqueValueKey,
         UniqueValueViolation,
     },
     standard_graphql_error::{validate_auth, StandardGraphqlError},
@@ -101,10 +101,25 @@ fn map_error(error: ServiceError) -> Result<UpdateLocationErrorInterface> {
     let formatted_error = format!("{error:#?}");
 
     let graphql_error = match error {
+        // Structured Errors
+        ServiceError::LocationDoesNotExist => {
+            return Ok(UpdateLocationErrorInterface::LocationNotFound(
+                RecordNotFound,
+            ))
+        }
+        ServiceError::CodeAlreadyExists => {
+            return Ok(UpdateLocationErrorInterface::UniqueValueViolation(
+                UniqueValueViolation(UniqueValueKey::Code),
+            ))
+        }
+        ServiceError::LocationDoesNotBelongToCurrentStore => {
+            return Ok(
+                UpdateLocationErrorInterface::RecordBelongsToAnotherStore(
+                    RecordBelongsToAnotherStore,
+                ),
+            )
+        }
         // Standard Graphql Errors
-        ServiceError::LocationDoesNotExist => BadUserInput(formatted_error),
-        ServiceError::CodeAlreadyExists => BadUserInput(formatted_error),
-        ServiceError::LocationDoesNotBelongToCurrentStore => BadUserInput(formatted_error),
         ServiceError::UpdatedRecordNotFound => InternalError(formatted_error),
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
     };

--- a/server/service/src/location/insert.rs
+++ b/server/service/src/location/insert.rs
@@ -30,7 +30,7 @@ pub fn insert_location(
     let location = ctx
         .connection
         .transaction_sync(|connection| {
-            validate(&input, connection)?;
+            validate(&input, &ctx.store_id, connection)?;
             let new_location = generate(&ctx.store_id, input);
             LocationRowRepository::new(connection).upsert_one(&new_location)?;
 
@@ -42,12 +42,13 @@ pub fn insert_location(
 
 pub fn validate(
     input: &InsertLocation,
+    store_id: &str,
     connection: &StorageConnection,
 ) -> Result<(), InsertLocationError> {
     if !check_location_does_not_exist(&input.id, connection)? {
         return Err(InsertLocationError::LocationAlreadyExists);
     }
-    if !check_location_code_is_unique(&input.id, Some(input.code.clone()), connection)? {
+    if !check_location_code_is_unique(&input.id, Some(input.code.clone()), store_id, connection)? {
         return Err(InsertLocationError::LocationWithCodeAlreadyExists);
     }
 

--- a/server/service/src/location/update.rs
+++ b/server/service/src/location/update.rs
@@ -53,7 +53,7 @@ pub fn validate(
         None => return Err(UpdateLocationError::LocationDoesNotExist),
     };
 
-    if !check_location_code_is_unique(&input.id, input.code.clone(), connection)? {
+    if !check_location_code_is_unique(&input.id, input.code.clone(), store_id, connection)? {
         return Err(UpdateLocationError::CodeAlreadyExists);
     }
 

--- a/server/service/src/location/update.rs
+++ b/server/service/src/location/update.rs
@@ -53,12 +53,12 @@ pub fn validate(
         None => return Err(UpdateLocationError::LocationDoesNotExist),
     };
 
-    if !check_location_code_is_unique(&input.id, input.code.clone(), store_id, connection)? {
-        return Err(UpdateLocationError::CodeAlreadyExists);
-    }
-
     if location_row.store_id != store_id {
         return Err(UpdateLocationError::LocationDoesNotBelongToCurrentStore);
+    }
+
+    if !check_location_code_is_unique(&input.id, input.code.clone(), store_id, connection)? {
+        return Err(UpdateLocationError::CodeAlreadyExists);
     }
 
     Ok(location_row)

--- a/server/service/src/location/validate.rs
+++ b/server/service/src/location/validate.rs
@@ -7,6 +7,7 @@ use repository::{EqualFilter, StringFilter};
 pub fn check_location_code_is_unique(
     id: &str,
     code_option: Option<String>,
+    store_id: &str,
     connection: &StorageConnection,
 ) -> Result<bool, RepositoryError> {
     match code_option {
@@ -16,7 +17,7 @@ pub fn check_location_code_is_unique(
                 LocationFilter::new()
                     .code(StringFilter::equal_to(&code))
                     .id(EqualFilter::not_equal_to(id.to_string()))
-                    .store_id(EqualFilter::equal_to("store_a".to_string())),
+                    .store_id(EqualFilter::equal_to(store_id.to_string())),
             )?;
 
             Ok(locations.is_empty())


### PR DESCRIPTION
## Summary
- The location code uniqueness check in `validate.rs` was hardcoded to `"store_a"` (a test mock ID) instead of the actual store ID — a leftover from a 2021 refactor (`aeab283fef`) that removed the `current_store_id()` helper but never wired the real store ID through as a parameter. This meant duplicate location codes could be created in any store except `store_a` (theoretical store, probs nobody has a store with that id)
- The frontend now checks structured error responses and shows a specific toast message ("A record with this Code already exists").
<img width="1117" height="812" alt="image" src="https://github.com/user-attachments/assets/05f85e24-df9f-479a-9ba3-4384c676320b" />


Closes #11352 (sub-issue of #11348)


This just prevents you from creating locationds with same ids going forwards - it does not clean up any from sync or pre existing

The validation will also fire when updating a location's details:
- so it stops you change a pre existing location's code to match another location - great
- it stops you changing any details about a pre existing location that already has the same code as another, unless you also change its code - this encourages better clean up, and I suspect wont happen a lot. If it's a problem we can make it so we only send the updated fields and so only fail for new locations with duped codes and not pre existing updating otehr features, but doesnt feel worth that hassle

## Test plan
- [ ] Create a location with a code, then try to create another location with the same code in the same store — should show error toast
- [ ] Create locations with the same code in different stores — should succeed
- [ ] Edit a location and change its code to one that already exists in the same store — should show error toast
- [ ] Verify the modal stays open on error so the user can fix the input

🤖 Generated with [Claude Code](https://claude.com/claude-code)