### PR TITLE
#11340 Rename AMC to AMC Zone in District internal orders

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2796,5 +2796,5 @@
   "report-code.customer-returns": "Customer Returns",
   "report-code.supplier-returns": "Supplier Returns",
   "label.customer-return": "Customer return",
-  "label.amc-zone": "AMC Zone"
+  "label.area-amc": "Area AMC"
 }

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2795,5 +2795,6 @@
   "warning.requested-exceeds-suggested": "Your requested quantity is higher than the suggested",
   "report-code.customer-returns": "Customer Returns",
   "report-code.supplier-returns": "Supplier Returns",
-  "label.customer-return": "Customer return"
+  "label.customer-return": "Customer return",
+  "label.amc-zone": "AMC Zone"
 }

--- a/client/packages/common/src/intl/locales/fr/common.json
+++ b/client/packages/common/src/intl/locales/fr/common.json
@@ -2858,5 +2858,5 @@
   "report-code.customer-returns": "Retours clients",
   "report-code.supplier-returns": "Retours fournisseurs",
   "label.customer-return": "Bordereau de retour",
-  "label.amc-zone": "CMM Zone"
+  "label.area-amc": "CMM Zone"
 }

--- a/client/packages/common/src/intl/locales/fr/common.json
+++ b/client/packages/common/src/intl/locales/fr/common.json
@@ -2857,5 +2857,6 @@
   "label.group-by-po-line": "Grouper par ligne du BC",
   "report-code.customer-returns": "Retours clients",
   "report-code.supplier-returns": "Retours fournisseurs",
-  "label.customer-return": "Bordereau de retour"
+  "label.customer-return": "Bordereau de retour",
+  "label.amc-zone": "CMM Zone"
 }

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ModalContentPanels.ts
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ModalContentPanels.ts
@@ -8,7 +8,7 @@ import { DraftRequestLine } from '.';
 export const getLeftPanel = (
   t: TypedTFunction<LocaleKey>,
   draft?: DraftRequestLine | null,
-  showZoneAmc?: boolean
+  showAsAreaAmc?: boolean
 ): ValueInfo[] => {
   const base: ValueInfo[] = [
     {
@@ -16,7 +16,7 @@ export const getLeftPanel = (
       value: draft?.itemStats.availableStockOnHand,
     },
     {
-      label: t(showZoneAmc ? 'label.amc-zone' : 'label.amc/amd'),
+      label: t(showAsAreaAmc ? 'label.area-amc' : 'label.amc/amd'),
       value: draft?.itemStats.averageMonthlyConsumption,
     },
   ];

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ModalContentPanels.ts
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ModalContentPanels.ts
@@ -7,7 +7,8 @@ import { DraftRequestLine } from '.';
 
 export const getLeftPanel = (
   t: TypedTFunction<LocaleKey>,
-  draft?: DraftRequestLine | null
+  draft?: DraftRequestLine | null,
+  showZoneAmc?: boolean
 ): ValueInfo[] => {
   const base: ValueInfo[] = [
     {
@@ -15,7 +16,7 @@ export const getLeftPanel = (
       value: draft?.itemStats.availableStockOnHand,
     },
     {
-      label: t('label.amc/amd'),
+      label: t(showZoneAmc ? 'label.amc-zone' : 'label.amc/amd'),
       value: draft?.itemStats.averageMonthlyConsumption,
     },
   ];

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -271,7 +271,7 @@ export const RequestLineEdit = ({
                   value={currentItem?.doses}
                 />
               ) : null}
-              {renderValueInfoRows(getLeftPanel(t, draft))}
+              {renderValueInfoRows(getLeftPanel(t, draft, showExtraFields))}
               <InfoRow
                 label={t('label.months-of-stock')}
                 value={draft?.itemStats?.availableMonthsOfStockOnHand}

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/columns.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/columns.tsx
@@ -88,7 +88,7 @@ export const useRequestColumns = () => {
       },
       {
         accessorKey: 'itemStats.averageMonthlyConsumption',
-        header: t('label.amc'),
+        header: t(showExtraColumns ? 'label.amc-zone' : 'label.amc'),
         description: t('description.average-monthly-consumption'),
         columnType: ColumnType.Number,
         Cell: UnitsAndDosesCell,

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/columns.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/columns.tsx
@@ -88,7 +88,7 @@ export const useRequestColumns = () => {
       },
       {
         accessorKey: 'itemStats.averageMonthlyConsumption',
-        header: t(showExtraColumns ? 'label.amc-zone' : 'label.amc'),
+        header: t(showExtraColumns ? 'label.area-amc' : 'label.amc'),
         description: t('description.average-monthly-consumption'),
         columnType: ColumnType.Number,
         Cell: UnitsAndDosesCell,


### PR DESCRIPTION
Fixes #11340

# 👩🏻‍💻 What does this PR do?

Adds a new `label.amc-zone` translation key and swaps the AMC label to "AMC Zone" / "CMM Zone" in two places on the Internal Order detail view when the store is operating at "District" level:

1. The `AMC` column header in the request line grid
2. The `AMC/AMD` row in the line-edit modal

"District" here is defined by the existing gate `showExtraColumns` / `showExtraFields`:

```ts
!!programName &&
store?.preferences.useConsumptionAndStockFromCustomersForInternalOrders
```

i.e. a program internal order on a store that consolidates consumption and stock reported up from customer stores.

Other usages of the same `label.amc` string (customer requisitions, R&R forms, item list) are deliberately left untouched per the issue requirement.

**Translations added:**
- `en`: "Area AMC"
- `fr`: "CMM Zone"

## 💌 Any notes for the reviewer?

**Implementation notes / divergence from issue:**
- The issue's text says "Internal Order / Detailed View". The attached screenshot was of the line-edit modal, but the label is equally visible on the column header behind it, so both have been swapped. If only the modal was intended, it's trivial to drop the column change.
- The column's description tooltip (`description.average-monthly-consumption`) is unchanged — still reads "Average Monthly Consumption". Easy to swap if the tooltip should also mention "zone".
- Only English and French translations added. Other locales (es, pt, ar, ru, tet, ps, prs, lo) will fall back to the English "AMC Zone" — add overrides later if needed.
- jmbrunskill's clarifying question in the issue about what "District level" means is still open; this PR assumes it maps to the existing `useConsumptionAndStockFromCustomersForInternalOrders` + program gate. If Cyril confirms a narrower condition, the gate will need tightening.

# 🧪 Testing

- [ ] Log in as a store with `useConsumptionAndStockFromCustomersForInternalOrders` = true
- [ ] Open a **program** internal order (Replenishment → Internal Orders)
- [ ] Verify the grid column header reads **"AMC Zone"** (EN) / **"CMM Zone"** (FR) where it previously said "AMC" / "CMM"
- [ ] Open a line to bring up the edit modal — verify the left panel shows **"AMC Zone:"** / **"CMM Zone:"** where it previously said "AMC/AMD:" / "CMM:"
- [ ] On a **non-program** internal order (or a store without the preference), verify the label is still **"AMC"** / **"CMM"** — no regression
- [ ] Verify the AMC column/label in Customer Requisitions, R&R Forms, and the Item list still read **"AMC"** / **"CMM"** — unchanged
- [ ] Switch language to French and repeat the first three checks

# 📃 Documentation

- [x] **No documentation required**: translation-only change, no behaviour change

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend