### PR TITLE
Location list: add code as secondary sort when sorting by name

### DIFF
--- a/server/repository/src/db_diesel/location.rs
+++ b/server/repository/src/db_diesel/location.rs
@@ -2,6 +2,7 @@ use super::{location_row::location, LocationRow, StorageConnection};
 
 use crate::{
     asset_internal_location_row::asset_internal_location,
+    diesel_extensions::OrderByExtensions,
     diesel_macros::{apply_equal_filter, apply_sort_no_case, apply_string_filter},
     StringFilter,
 };
@@ -70,7 +71,8 @@ impl<'a> LocationRepository<'a> {
         if let Some(sort) = sort {
             match sort.key {
                 LocationSortField::Name => {
-                    apply_sort_no_case!(query, sort, location::name)
+                    apply_sort_no_case!(query, sort, location::name);
+                    query = query.then_order_by(location::code.asc_no_case());
                 }
                 LocationSortField::Code => {
                     apply_sort_no_case!(query, sort, location::code)

--- a/server/service/src/location/tests/query.rs
+++ b/server/service/src/location/tests/query.rs
@@ -162,6 +162,72 @@ mod query {
     }
 
     #[actix_rt::test]
+    async fn location_service_sort_by_name_secondary_sort_by_code() {
+        let (_, connection, connection_manager, _) = setup_all(
+            "test_location_sort_name_then_code",
+            MockDataInserts::none().names().stores(),
+        )
+        .await;
+
+        // Insert three locations with the same name but different codes,
+        // in an order that wouldn't sort correctly by chance (id or insertion order)
+        LocationRow {
+            id: "loc_a".to_string(),
+            name: "Same Name".to_string(),
+            code: "code_c".to_string(),
+            store_id: "store_a".to_string(),
+            ..Default::default()
+        }
+        .upsert(&connection)
+        .unwrap();
+
+        LocationRow {
+            id: "loc_b".to_string(),
+            name: "Same Name".to_string(),
+            code: "code_a".to_string(),
+            store_id: "store_a".to_string(),
+            ..Default::default()
+        }
+        .upsert(&connection)
+        .unwrap();
+
+        LocationRow {
+            id: "loc_c".to_string(),
+            name: "Same Name".to_string(),
+            code: "code_b".to_string(),
+            store_id: "store_a".to_string(),
+            ..Default::default()
+        }
+        .upsert(&connection)
+        .unwrap();
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider.basic_context().unwrap();
+        let service = service_provider.location_service;
+
+        // Sort by name ascending — secondary sort by code should put code_a first
+        let result = service
+            .get_locations(
+                &context,
+                None,
+                None,
+                Some(Sort {
+                    key: LocationSortField::Name,
+                    desc: None,
+                }),
+            )
+            .unwrap();
+
+        let result_codes: Vec<String> = result
+            .rows
+            .into_iter()
+            .map(|l| l.location_row.code)
+            .collect();
+
+        assert_eq!(result_codes, vec!["code_a", "code_b", "code_c"]);
+    }
+
+    #[actix_rt::test]
     async fn location_service_assigned_to_asset() {
         let (_mock_data, _, connection_manager, _) =
             setup_all("test_location_asset_assigned", MockDataInserts::all()).await;


### PR DESCRIPTION
## Summary
- Adds `code` as a secondary tiebreaker sort (ascending, case-insensitive) when locations are sorted by name
- Previously, locations with the same name had non-deterministic ordering
- Adds test with 3 same-named locations inserted in non-alphabetical code order to verify the tiebreaker

Closes #11355
Part of #11348 (point 2)

<img width="1257" height="739" alt="image" src="https://github.com/user-attachments/assets/f85fe95b-e017-4d59-acfa-9ab962feab47" />


## Test plan
- [ ] Verify locations with the same name are ordered by code in the location list view
- [ ] Verify sorting by name descending still shows same-named locations in ascending code order
- [ ] Verify `cargo test -- location_service_sort_by_name_secondary_sort_by_code` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)