### PR TITLE
#11358 Export all locations instead of only current page

### DIFF
--- a/client/packages/system/src/Location/Components/LocationSearchInput.tsx
+++ b/client/packages/system/src/Location/Components/LocationSearchInput.tsx
@@ -67,7 +67,7 @@ const optionRenderer = (
   ) : (
     <MenuItem
       {...props}
-      key={location.label}
+      key={location.value}
       sx={{ justifyContent: 'space-between !important' }}
     >
       <span

--- a/client/packages/system/src/Location/Components/LocationSearchInput.tsx
+++ b/client/packages/system/src/Location/Components/LocationSearchInput.tsx
@@ -45,50 +45,30 @@ const getOptionLabel = (option: LocationOption) =>
 const optionRenderer = (
   props: React.HTMLAttributes<HTMLLIElement>,
   location: LocationOption
-) => {
-  const { style, ...rest } = props;
-
-  return location.value === null ? (
-    <MenuItem
-      {...rest}
-      sx={{
-        ...style,
-        display: 'inline-flex',
-        flex: 1,
-        width: '100%',
-        borderTop: '1px solid',
-        borderTopColor: 'divider',
+) => (
+  <MenuItem
+    {...props}
+    key={location.value}
+    sx={{ justifyContent: 'space-between !important' }}
+  >
+    <span
+      style={{
+        whiteSpace: 'nowrap',
+        maxWidth: '80%',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
       }}
-      key={location.label}
     >
-      <span style={{ whiteSpace: 'nowrap', flex: 1 }}>{location.label}</span>
-      <CloseIcon sx={{ color: 'gray.dark' }} />
-    </MenuItem>
-  ) : (
-    <MenuItem
-      {...props}
-      key={location.value}
-      sx={{ justifyContent: 'space-between !important' }}
+      {getOptionLabel(location)}
+    </span>
+    <Typography
+      component="span"
+      sx={{ color: 'gray.dark', fontSize: 'smaller' }}
     >
-      <span
-        style={{
-          whiteSpace: 'nowrap',
-          maxWidth: '80%',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-        }}
-      >
-        {getOptionLabel(location)}
-      </span>
-      <Typography
-        component="span"
-        sx={{ color: 'gray.dark', fontSize: 'smaller' }}
-      >
-        {location.volumeUsed}
-      </Typography>
-    </MenuItem>
-  );
-};
+      {location.volumeUsed}
+    </Typography>
+  </MenuItem>
+);
 
 enum LocationFilter {
   All = 'all',
@@ -123,22 +103,31 @@ export const LocationSearchInput = ({
   filterRef.current = filter;
   const setFilterRef = useRef(setFilter);
   setFilterRef.current = setFilter;
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  const hasVolumeFilter = typeof volumeRequired === 'number';
 
   const paperSlot = useMemo(() => {
-    if (typeof volumeRequired !== 'number') return undefined;
+    if (!hasVolumeFilter && !includeRemoveOption) return undefined;
     return ({
       children,
       ...paperProps
     }: React.ComponentProps<typeof Paper> & { children?: React.ReactNode }) => (
       <Paper {...paperProps} sx={{ minWidth: '300px' }}>
-        <LocationFilters
-          filter={filterRef.current}
-          setFilter={setFilterRef.current}
-        />
+        {hasVolumeFilter && (
+          <LocationFilters
+            filter={filterRef.current}
+            setFilter={setFilterRef.current}
+          />
+        )}
         {children}
+        {includeRemoveOption && (
+          <StickyRemoveButton onChangeRef={onChangeRef} />
+        )}
       </Paper>
     );
-  }, [volumeRequired]);
+  }, [hasVolumeFilter, includeRemoveOption]);
 
   const {
     query: { data, isLoading },
@@ -192,15 +181,6 @@ export const LocationSearchInput = ({
     code: l.code,
     volumeUsed: getVolumeUsedLabel(l),
   }));
-
-  if (
-    includeRemoveOption &&
-    filteredLocations.length > 0 &&
-    selectedLocation !== null &&
-    selectedLocation !== undefined
-  ) {
-    options.push({ value: null, label: t('label.remove'), volumeUsed: '0' });
-  }
 
   // Define separately - even if the selected location doesn't match current
   // filter, we still want to show it as the selected option
@@ -257,6 +237,38 @@ export const LocationSearchInput = ({
 export const formatLocationLabel = (location: LocationRowFragment) => {
   const { name, locationType } = location;
   return `${name}${locationType ? ` (${locationType.name})` : ''}`;
+};
+
+const StickyRemoveButton = ({
+  onChangeRef,
+}: {
+  onChangeRef: React.RefObject<(location: LocationRowFragment | null) => void>;
+}) => {
+  const t = useTranslation();
+
+  return (
+    <MenuItem
+      onMouseDown={e => {
+        e.stopPropagation();
+        e.preventDefault();
+        onChangeRef.current?.(null);
+      }}
+      sx={{
+        display: 'inline-flex',
+        flex: 1,
+        width: '100%',
+        borderTop: '1px solid',
+        borderTopColor: 'divider',
+        position: 'sticky',
+        bottom: 0,
+        backgroundColor: 'background.paper',
+        zIndex: 1,
+      }}
+    >
+      <span style={{ whiteSpace: 'nowrap', flex: 1 }}>{t('label.remove')}</span>
+      <CloseIcon sx={{ color: 'gray.dark' }} />
+    </MenuItem>
+  );
 };
 
 const LocationFilters = ({

--- a/client/packages/system/src/Location/Components/LocationSearchInput.tsx
+++ b/client/packages/system/src/Location/Components/LocationSearchInput.tsx
@@ -230,6 +230,9 @@ export const LocationSearchInput = ({
       slots={{
         paper: paperSlot,
       }}
+      slotProps={{
+        listbox: { style: { maxHeight: '35vh' } },
+      }}
     />
   );
 };

--- a/client/packages/system/src/Location/ListView/AppBarButtons.tsx
+++ b/client/packages/system/src/Location/ListView/AppBarButtons.tsx
@@ -4,25 +4,26 @@ import {
   AppBarButtonsPortal,
   ButtonWithIcon,
   Grid,
+  SortBy,
   useTranslation,
 } from '@openmsupply-client/common';
 import { ExportSelector } from '@openmsupply-client/system';
-import { LocationRowFragment } from '..';
+import { LocationRowFragment, useExportLocationList } from '../api';
 import { locationsToCsv } from '../../utils';
 
 interface AppBarButtonsProps {
   onCreate: () => void;
-  locations?: LocationRowFragment[];
-  reportIsLoading: boolean;
+  sortBy: SortBy<LocationRowFragment>;
 }
 
-export const AppBarButtons = ({
-  onCreate,
-  locations,
-  reportIsLoading,
-}: AppBarButtonsProps) => {
+export const AppBarButtons = ({ onCreate, sortBy }: AppBarButtonsProps) => {
   const t = useTranslation();
-  const getCsvData = () => (locations ? locationsToCsv(locations, t) : null);
+  const { fetchLocations, isLoading } = useExportLocationList(sortBy);
+
+  const getCsvData = async () => {
+    const { data } = await fetchLocations();
+    return data?.nodes?.length ? locationsToCsv(data.nodes, t) : null;
+  };
 
   return (
     <AppBarButtonsPortal>
@@ -35,7 +36,7 @@ export const AppBarButtons = ({
         <ExportSelector
           getCsvData={getCsvData}
           filename={t('filename.locations')}
-          isLoading={reportIsLoading}
+          isLoading={isLoading}
         />
       </Grid>
     </AppBarButtonsPortal>

--- a/client/packages/system/src/Location/ListView/ListView.tsx
+++ b/client/packages/system/src/Location/ListView/ListView.tsx
@@ -35,7 +35,7 @@ export const LocationListView = () => {
   });
   const queryParams = { sortBy, first, offset, filterBy };
   const {
-    query: { data, isError, isLoading, isFetching },
+    query: { data, isError, isFetching },
   } = useLocationList(queryParams);
   const t = useTranslation();
 
@@ -139,11 +139,7 @@ export const LocationListView = () => {
           location={entity}
         />
       )}
-      <AppBarButtons
-        onCreate={() => onOpen()}
-        locations={data?.nodes}
-        reportIsLoading={isLoading}
-      />
+      <AppBarButtons onCreate={() => onOpen()} sortBy={sortBy} />
       <MaterialTable table={table} />
       <Footer
         selectedRows={selectedRows}

--- a/client/packages/system/src/Location/api/hooks/index.ts
+++ b/client/packages/system/src/Location/api/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './useExportLocationList';
 export * from './useLocationList';
 export * from './useLocation';
 export { LOCATION } from './keys';

--- a/client/packages/system/src/Location/api/hooks/useExportLocationList.ts
+++ b/client/packages/system/src/Location/api/hooks/useExportLocationList.ts
@@ -1,0 +1,38 @@
+import {
+  LocationSortFieldInput,
+  SortBy,
+  useQuery,
+  LIST_KEY,
+} from '@openmsupply-client/common';
+import { LocationRowFragment } from '../operations.generated';
+import { useLocationGraphQL } from '../useLocationGraphQL';
+import { LOCATION } from './keys';
+
+export const useExportLocationList = (sortBy: SortBy<LocationRowFragment>) => {
+  const { locationApi, storeId } = useLocationGraphQL();
+
+  const queryKey = [LOCATION, storeId, LIST_KEY, 'export', sortBy];
+  const queryFn = async (): Promise<{
+    nodes: LocationRowFragment[];
+    totalCount: number;
+  }> => {
+    const result = await locationApi.locations({
+      sort: sortBy?.key
+        ? {
+            key: sortBy.key as LocationSortFieldInput,
+            desc: sortBy.isDesc,
+          }
+        : { key: LocationSortFieldInput.Name, desc: false },
+      storeId,
+    });
+    return result?.locations;
+  };
+
+  const { data, refetch, isLoading } = useQuery({
+    queryKey,
+    queryFn,
+    enabled: false,
+  });
+
+  return { data, fetchLocations: refetch, isLoading };
+};


### PR DESCRIPTION
## Summary
Closes #11358

- Fix duplicate locations in dropdown by using unique ID as React key
- Make location remove button sticky at bottom of dropdown
- Cap location dropdown height for smaller screens
- Export all locations instead of only the current page

## Commits
- `4b2899acbf` #11348 Fix duplicate locations in dropdown by using unique ID as React key
- `3786bcd556` #11348 Make location remove button sticky at bottom of dropdown
- `4ba059bddc` #11348 Cap location dropdown height for smaller screens
- `c872e09f4e` #11348 Export all locations instead of only current page

## Test plan
- [ ] Verify no duplicate locations appear in dropdown
- [ ] Verify remove button stays visible when scrolling the dropdown
- [ ] Verify dropdown height is capped on smaller screens
- [ ] Navigate to Locations list view, export as CSV/Excel and verify all locations are included
- [ ] Change the sort order and export again — verify the export matches the sort

🤖 Generated with [Claude Code](https://claude.com/claude-code)