### PR TITLE
#11366 Resolve PR base ref at runtime to fix migration CI flakiness

### DIFF
--- a/.github/workflows/validate-db-migration-with-views.yml
+++ b/.github/workflows/validate-db-migration-with-views.yml
@@ -38,6 +38,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - name: Drop existing database
+        run: rm -f validate_views
       - name: Initialize database with base branch code
         working-directory: server
         run: APP__DATABASE__DATABASE_NAME=validate_views cargo run --bin remote_server_cli -- initialise-database
@@ -67,6 +69,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - name: Drop existing database
+        run: dropdb --if-exists validate_views
       - name: Initialize database with base branch code
         working-directory: server
         run: APP__DATABASE__DATABASE_NAME=validate_views cargo run --bin remote_server_cli --features postgres -- initialise-database

--- a/.github/workflows/validate-db-migration-with-views.yml
+++ b/.github/workflows/validate-db-migration-with-views.yml
@@ -31,15 +31,31 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      # Resolve the PR's base ref live from the API rather than using
+      # github.base_ref, which is frozen at trigger time and goes stale when a
+      # PR is retargeted or a queued run lags behind a develop version bump.
+      - name: Resolve base branch
+        id: base
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            if (context.payload.pull_request) {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+              });
+              return pr.base.ref;
+            }
+            return process.env.GITHUB_BASE_REF;
       - name: Check out base branch
         run: |
-          git checkout ${{ github.base_ref }}
-          echo "Checked out base branch: ${{ github.base_ref }}"
+          git checkout ${{ steps.base.outputs.result }}
+          echo "Checked out base branch: ${{ steps.base.outputs.result }}"
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - name: Drop existing database
-        run: rm -f validate_views
       - name: Initialize database with base branch code
         working-directory: server
         run: APP__DATABASE__DATABASE_NAME=validate_views cargo run --bin remote_server_cli -- initialise-database
@@ -62,15 +78,28 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Resolve base branch
+        id: base
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            if (context.payload.pull_request) {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+              });
+              return pr.base.ref;
+            }
+            return process.env.GITHUB_BASE_REF;
       - name: Check out base branch
         run: |
-          git checkout ${{ github.base_ref }}
-          echo "Checked out base branch: ${{ github.base_ref }}"
+          git checkout ${{ steps.base.outputs.result }}
+          echo "Checked out base branch: ${{ steps.base.outputs.result }}"
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - name: Drop existing database
-        run: dropdb --if-exists validate_views
       - name: Initialize database with base branch code
         working-directory: server
         run: APP__DATABASE__DATABASE_NAME=validate_views cargo run --bin remote_server_cli --features postgres -- initialise-database

--- a/.github/workflows/validate-db-migration-with-views.yml
+++ b/.github/workflows/validate-db-migration-with-views.yml
@@ -31,20 +31,31 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      # Check out the merge base (where this PR diverged from its target),
-      # not the tip of the base branch. The tip can move under us — either
-      # because the PR is retargeted after trigger, or because a queued run
-      # spans a version bump on the base branch — and an advanced base leaves
-      # the DB stamped at a higher version than the PR's migrate step expects.
-      # The merge base is a property of the commit tree, so it can only change
-      # via a new push to the PR, which cancels the run via concurrency.
-      - name: Resolve merge base
+      # Resolve the commit to stamp the database from. The base ref tip can move
+      # under us — either because the PR is retargeted after trigger, or because
+      # a queued run spans a version bump on the base — and an advanced base
+      # leaves the DB stamped at a higher version than the PR's migrate step
+      # expects. We pick a deterministic commit from the local checkout instead:
+      #
+      #   pull_request: actions/checkout pulls refs/pull/N/merge, a synthetic
+      #     merge of (base tip, PR head). HEAD^1 is the base tip at sync time
+      #     and HEAD^2 is the PR head; merge-base of those is the actual fork
+      #     point — the right "what did this PR branch from" check.
+      #   merge_group: HEAD is a queue merge commit whose HEAD^1 is the develop
+      #     tip at queue time — the right "does this integrate?" check.
+      - name: Resolve base commit
         id: base
-        run: echo "sha=$(git merge-base HEAD origin/${{ github.base_ref }})" >> $GITHUB_OUTPUT
-      - name: Check out merge base
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            sha=$(git merge-base HEAD^1 HEAD^2)
+          else
+            sha=$(git rev-parse HEAD^1)
+          fi
+          echo "sha=$sha" >> $GITHUB_OUTPUT
+      - name: Check out base commit
         run: |
           git checkout ${{ steps.base.outputs.sha }}
-          echo "Checked out merge base: ${{ steps.base.outputs.sha }}"
+          echo "Checked out base commit: ${{ steps.base.outputs.sha }}"
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -70,13 +81,19 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Resolve merge base
+      - name: Resolve base commit
         id: base
-        run: echo "sha=$(git merge-base HEAD origin/${{ github.base_ref }})" >> $GITHUB_OUTPUT
-      - name: Check out merge base
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            sha=$(git merge-base HEAD^1 HEAD^2)
+          else
+            sha=$(git rev-parse HEAD^1)
+          fi
+          echo "sha=$sha" >> $GITHUB_OUTPUT
+      - name: Check out base commit
         run: |
           git checkout ${{ steps.base.outputs.sha }}
-          echo "Checked out merge base: ${{ steps.base.outputs.sha }}"
+          echo "Checked out base commit: ${{ steps.base.outputs.sha }}"
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/validate-db-migration-with-views.yml
+++ b/.github/workflows/validate-db-migration-with-views.yml
@@ -31,28 +31,20 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      # Resolve the PR's base ref live from the API rather than using
-      # github.base_ref, which is frozen at trigger time and goes stale when a
-      # PR is retargeted or a queued run lags behind a develop version bump.
-      - name: Resolve base branch
+      # Check out the merge base (where this PR diverged from its target),
+      # not the tip of the base branch. The tip can move under us — either
+      # because the PR is retargeted after trigger, or because a queued run
+      # spans a version bump on the base branch — and an advanced base leaves
+      # the DB stamped at a higher version than the PR's migrate step expects.
+      # The merge base is a property of the commit tree, so it can only change
+      # via a new push to the PR, which cancels the run via concurrency.
+      - name: Resolve merge base
         id: base
-        uses: actions/github-script@v7
-        with:
-          result-encoding: string
-          script: |
-            if (context.payload.pull_request) {
-              const { data: pr } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.payload.pull_request.number,
-              });
-              return pr.base.ref;
-            }
-            return process.env.GITHUB_BASE_REF;
-      - name: Check out base branch
+        run: echo "sha=$(git merge-base HEAD origin/${{ github.base_ref }})" >> $GITHUB_OUTPUT
+      - name: Check out merge base
         run: |
-          git checkout ${{ steps.base.outputs.result }}
-          echo "Checked out base branch: ${{ steps.base.outputs.result }}"
+          git checkout ${{ steps.base.outputs.sha }}
+          echo "Checked out merge base: ${{ steps.base.outputs.sha }}"
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -78,25 +70,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Resolve base branch
+      - name: Resolve merge base
         id: base
-        uses: actions/github-script@v7
-        with:
-          result-encoding: string
-          script: |
-            if (context.payload.pull_request) {
-              const { data: pr } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.payload.pull_request.number,
-              });
-              return pr.base.ref;
-            }
-            return process.env.GITHUB_BASE_REF;
-      - name: Check out base branch
+        run: echo "sha=$(git merge-base HEAD origin/${{ github.base_ref }})" >> $GITHUB_OUTPUT
+      - name: Check out merge base
         run: |
-          git checkout ${{ steps.base.outputs.result }}
-          echo "Checked out base branch: ${{ steps.base.outputs.result }}"
+          git checkout ${{ steps.base.outputs.sha }}
+          echo "Checked out merge base: ${{ steps.base.outputs.sha }}"
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable


### PR DESCRIPTION
Closes #11366

## Summary

Check out the merge base (`git merge-base HEAD origin/<base>`) instead of the tip of the base branch when stamping the database in the migration CI workflow. The base branch tip is unstable while the workflow runs:
- PR retargets between trigger and execution leave `github.base_ref` frozen at the old value
- Queued runs crossing a version bump on develop see the tip move from e.g. 2.18.0 to 2.19.0

The merge base is a property of the commit tree, so it can only change via a new push to the PR — which cancels the in-flight run via the concurrency group.

Also removes the "Drop existing database" steps — investigation showed they did not address the real bug:
- `initialise-database` already drops and recreates the DB in both SQLite and Postgres paths
- The SQLite `rm -f validate_views` ran from the wrong working directory (a no-op)
- The Postgres `dropdb --if-exists` was failing on the self-hosted runner because `dropdb` is not on PATH

## Root cause

Both failing example runs show `initialise-database` completing successfully. The panic is in the subsequent `migrate` step: `DatabaseVersionAboveAppVersion(2.19.0, 2.18.0)`.

This happens because:
1. `github.base_ref` is captured at workflow trigger time, not at runtime.
2. When the PR is retargeted after triggering, or when the queued run waits long enough for develop to bump its `package.json` version, the captured `base_ref` is stale.
3. The workflow then checks out develop at execution time, whose `package.json` says `2.19.00-develop`.
4. `Version::from_package_json()` parses that as `2.19.0` (the `-develop` pre-release is ignored for comparison).
5. `initialise-database` stamps the fresh DB as `2.19.0` via `set_database_version(connection, &to_version)` in `server/repository/src/migrations/mod.rs`.
6. The `migrate` step on the PR branch (2.18.0-era) sees DB > app and panics.

### Example failures

- **#11359** — Created targeting develop; retargeted to v2.18.0-RC 25 seconds after workflow trigger. The run was locked to `base_ref=develop`.
- **#11204** — Queued for ~20 hours on self-hosted runners; during the queue, develop was bumped from `2.18.00-develop` to `2.19.00-develop`.

## Test plan

Code review, plus observation of future runs on PRs targeting RC branches. Reproducing the retarget race pre-merge is timing-sensitive, so the previous draft PR #11368 is being closed — the workflow under test is now structurally different.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
