### PR TITLE
Test: verify migration workflow with database drop step

### DIFF
--- a/server/repository/src/migrations/v2_17_03/mod.rs
+++ b/server/repository/src/migrations/v2_17_03/mod.rs
@@ -1,3 +1,4 @@
+// Test commit to trigger CI workflow — safe to revert
 use super::{version::Version, Migration, MigrationFragment};
 use crate::StorageConnection;
 


### PR DESCRIPTION
## Purpose

Throwaway PR to trigger the `Test DB Migrations against base branch views` workflow against the fix in #11367. The base branch includes the `dropdb`/`rm -f` step, so this will verify the full workflow still passes.

**Close this PR after the workflow completes — do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)