### PR TITLE
11370 - build give create_condition macro a unique module name per call site

### DIFF
--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -475,6 +475,7 @@ impl<'a> ChangelogRepository<'a> {
 // Dynamic query filter for changelog
 // Source type is the changelog table (for queries directly against the table)
 create_condition!(
+    ChangelogCondition,
     changelog::table,
     (cursor, i64, changelog::cursor),
     (table_name, ChangelogTableName, changelog::table_name),

--- a/server/repository/src/db_diesel/sync_log_v7.rs
+++ b/server/repository/src/db_diesel/sync_log_v7.rs
@@ -73,6 +73,7 @@ pub struct SyncLogV7Repository<'a> {
 type Source = sync_log_v7::table;
 
 create_condition!(
+    SyncLogV7Condition,
     Source,
     (
         StartedDatetime,
@@ -104,7 +105,7 @@ impl<'a> SyncLogV7Repository<'a> {
     // Sorts by started_datetime descending
     pub fn query_one(
         &self,
-        filter: Condition::Inner,
+        filter: SyncLogV7Condition::Inner,
     ) -> Result<Option<SyncLogV7Row>, RepositoryError> {
         let results = sync_log_v7::table
             .filter(filter.to_boxed())
@@ -153,7 +154,7 @@ mod test {
 
         let repo = SyncLogV7Repository::new(&connection);
 
-        use super::Condition;
+        use super::SyncLogV7Condition as Condition;
         use crate::dynamic_query_filter::FilterBuilder;
 
         let is_initialised = || {

--- a/server/repository/src/dynamic_query_filter.rs
+++ b/server/repository/src/dynamic_query_filter.rs
@@ -76,9 +76,9 @@ pub trait FilterBuilder<T: Clone + serde::Serialize + serde::de::DeserializeOwne
 }
 
 macro_rules! create_condition {
-    ($source:ty, $(($variant:ident, $filter_kind:ident, $dsl_expr:expr)),+ $(,)?) => {
+    ($mod_name:ident, $source:ty, $(($variant:ident, $filter_kind:ident, $dsl_expr:expr)),+ $(,)?) => {
         #[allow(non_snake_case, non_camel_case_types)]
-        pub mod Condition {
+        pub mod $mod_name {
             use super::*;
 
             #[derive(Clone, serde::Serialize, serde::Deserialize)]

--- a/server/service/src/sync_v7/sync_status/status.rs
+++ b/server/service/src/sync_v7/sync_status/status.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use repository::{
-    syncv7::SyncError, Condition, FilterBuilder, RepositoryError,
+    syncv7::SyncError, FilterBuilder, RepositoryError, SyncLogV7Condition,
     SyncLogV7Repository, SyncLogV7Row,
 };
 
@@ -119,7 +119,7 @@ impl SyncStatusV7Trait for SyncStatusV7Service {}
 fn get_latest_sync_status_v7(
     ctx: &ServiceContext,
 ) -> Result<Option<FullSyncStatusV7>, RepositoryError> {
-    let row = SyncLogV7Repository::new(&ctx.connection).query_one(Condition::TRUE)?;
+    let row = SyncLogV7Repository::new(&ctx.connection).query_one(SyncLogV7Condition::TRUE)?;
     Ok(row.map(FullSyncStatusV7::from_sync_log_v7_row))
 }
 
@@ -127,9 +127,9 @@ fn get_latest_sync_status_v7(
 fn get_latest_successful_sync_status_v7(
     ctx: &ServiceContext,
 ) -> Result<Option<FullSyncStatusV7>, RepositoryError> {
-    let row = SyncLogV7Repository::new(&ctx.connection).query_one(Condition::And(vec![
-        Condition::FinishedDatetime::is_not_null(),
-        Condition::Error::is_null(),
+    let row = SyncLogV7Repository::new(&ctx.connection).query_one(SyncLogV7Condition::And(vec![
+        SyncLogV7Condition::FinishedDatetime::is_not_null(),
+        SyncLogV7Condition::Error::is_null(),
     ]))?;
     Ok(row.map(FullSyncStatusV7::from_sync_log_v7_row))
 }
@@ -137,9 +137,9 @@ fn get_latest_successful_sync_status_v7(
 fn get_initialisation_status_v7(
     ctx: &ServiceContext,
 ) -> Result<InitialisationStatus, RepositoryError> {
-    let filter = Condition::And(vec![
-        Condition::FinishedDatetime::is_not_null(),
-        Condition::Error::is_null(),
+    let filter = SyncLogV7Condition::And(vec![
+        SyncLogV7Condition::FinishedDatetime::is_not_null(),
+        SyncLogV7Condition::Error::is_null(),
     ]);
 
     match SyncLogV7Repository::new(&ctx.connection).query_one(filter)? {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11370

# 👩🏻‍💻 What does this PR do?

Changes `create_condition!` to take the generated module name as its first argument, so each call site produces a uniquely named module (`SyncLogV7Condition`, `ChangelogCondition`) instead of all generating `Condition`

Updates the two existing call sites and the sync_v7 status consumer to use the new names

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Compiles, tests pass

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

