### PR TITLE
#11364 Fix Pack Qty sort on stock list view

### DIFF
--- a/client/packages/system/src/Stock/api/hooks/useStockList.ts
+++ b/client/packages/system/src/Stock/api/hooks/useStockList.ts
@@ -68,7 +68,7 @@ const toSortField = (
     name: StockLineSortFieldInput.ItemName,
     packSize: StockLineSortFieldInput.PackSize,
     supplierName: StockLineSortFieldInput.SupplierName,
-    numberOfPacks: StockLineSortFieldInput.NumberOfPacks,
+    totalNumberOfPacks: StockLineSortFieldInput.NumberOfPacks,
     location: StockLineSortFieldInput.LocationCode,
     costPricePerPack: StockLineSortFieldInput.CostPricePerPack,
     expiryDate: StockLineSortFieldInput.ExpiryDate,


### PR DESCRIPTION
Fixes #11364

# 👩🏻‍💻 What does this PR do?

Fixes sorting by the **Pack Qty** column on the Stock list view (Inventory → Stock). Previously, clicking the column header appeared to do nothing meaningful — rows would reorder, but not by pack quantity.

**Root cause:** the Pack Qty column in `ListView.tsx` uses `accessorKey: 'totalNumberOfPacks'`, so material-react-table emits `totalNumberOfPacks` as the sort key. The `toSortField` map in `useStockList.ts` keyed on `numberOfPacks` instead, so the lookup missed and the code fell through to the default `StockLineSortFieldInput.ItemName` — meaning the column was silently sorting by item name.

The fix renames the map entry from `numberOfPacks` → `totalNumberOfPacks` so it matches the column's accessor.

## 💌 Any notes for the reviewer?

- One-line change in `client/packages/system/src/Stock/api/hooks/useStockList.ts`.
- Worth checking whether any other entries in the same `sortFieldMap` have the same class of mismatch (e.g. `location` vs the column id `location.code`, `itemCode` vs the column id `code`). Those look similarly suspicious but are out of scope for this issue — happy to file a follow-up if confirmed.

# 🧪 Testing

- [ ] Go to Inventory → Stock
- [ ] Click the **Pack Qty** column header — rows should sort ascending by pack quantity
- [ ] Click again — rows should sort descending by pack quantity
- [ ] Confirm that other sortable columns (Code, Name, Batch, Expiry, Manufacture Date, Location, Pack Size, Pack Cost Price, Supplier) still sort correctly

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend