### PR TITLE
#11363 Fix Code and Location sort on stock list view

### DIFF
--- a/client/packages/system/src/Stock/api/hooks/useStockList.ts
+++ b/client/packages/system/src/Stock/api/hooks/useStockList.ts
@@ -64,12 +64,12 @@ const toSortField = (
 ): StockLineSortFieldInput => {
   const sortFieldMap: Record<string, StockLineSortFieldInput> = {
     batch: StockLineSortFieldInput.Batch,
-    itemCode: StockLineSortFieldInput.ItemCode,
+    code: StockLineSortFieldInput.ItemCode,
     name: StockLineSortFieldInput.ItemName,
     packSize: StockLineSortFieldInput.PackSize,
     supplierName: StockLineSortFieldInput.SupplierName,
     numberOfPacks: StockLineSortFieldInput.NumberOfPacks,
-    location: StockLineSortFieldInput.LocationCode,
+    'location.code': StockLineSortFieldInput.LocationCode,
     costPricePerPack: StockLineSortFieldInput.CostPricePerPack,
     expiryDate: StockLineSortFieldInput.ExpiryDate,
     manufactureDate: StockLineSortFieldInput.ManufactureDate,


### PR DESCRIPTION
Fixes #11363

# 👩🏻‍💻 What does this PR do?

Fixes sorting by **Code** and **Location** on the Stock list view (Inventory → Stock). Clicking either column header appeared to reorder rows arbitrarily — they were silently being sorted by item name instead.

**Root cause:** same pattern as #11364. Column ids emitted by material-react-table didn't match the keys in the `toSortField` map in `useStockList.ts`:

| Column id (from `ListView.tsx`) | Old map key | New map key |
|---|---|---|
| `code` | `itemCode` ❌ | `code` ✅ |
| `location.code` | `location` ❌ | `'location.code'` ✅ |

Unmatched keys fall through to the default `StockLineSortFieldInput.ItemName`, which is why both columns appeared to produce a useless reorder.

The fix updates the map keys to match the column ids so the lookup resolves to the correct `StockLineSortFieldInput` value in each case.

## 💌 Any notes for the reviewer?

- Bundled into one PR since both are the same class of bug and both would be shipped together anyway.
- Related in-flight PR #11380 fixes the Pack Qty column via the same mechanism. No conflict with this PR — they touch different lines.
- While auditing the map I also noticed `vvmStatus` has no entry and no matching backend enum — it looks intentional (not server-sortable), so left as-is.

# 🧪 Testing

- [ ] Go to Inventory → Stock
- [ ] Set some item codes to values like `QA001`, `QA002`, `QA303`, `QA1001` (per the issue repro)
- [ ] Click the **Code** column header — rows should sort ascending by code; click again for descending
- [ ] Click the **Location** column header — rows should sort ascending by location code; click again for descending
- [ ] Confirm other sortable columns (Name, Batch, Expiry, Manufacture Date, Pack Size, Pack Cost Price, Supplier) still sort correctly

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend