### PR TITLE
#11363 #11364 Fix stock list sort keys (Code, Pack Qty, Location)

### DIFF
--- a/client/packages/system/src/Stock/api/hooks/useStockList.ts
+++ b/client/packages/system/src/Stock/api/hooks/useStockList.ts
@@ -68,12 +68,12 @@ const toSortField = (
 ): StockLineSortFieldInput => {
   const sortFieldMap: Record<string, StockLineSortFieldInput> = {
     batch: StockLineSortFieldInput.Batch,
-    itemCode: StockLineSortFieldInput.ItemCode,
+    code: StockLineSortFieldInput.ItemCode,
     name: StockLineSortFieldInput.ItemName,
     packSize: StockLineSortFieldInput.PackSize,
     supplierName: StockLineSortFieldInput.SupplierName,
-    numberOfPacks: StockLineSortFieldInput.NumberOfPacks,
-    location: StockLineSortFieldInput.LocationCode,
+    totalNumberOfPacks: StockLineSortFieldInput.NumberOfPacks,
+    'location.code': StockLineSortFieldInput.LocationCode,
     costPricePerPack: StockLineSortFieldInput.CostPricePerPack,
     expiryDate: StockLineSortFieldInput.ExpiryDate,
     manufactureDate: StockLineSortFieldInput.ManufactureDate,


### PR DESCRIPTION
Fixes #11363
Fixes #11364

# 👩🏻‍💻 What does this PR do?

Fixes sorting by **Code**, **Pack Qty**, and **Location** on the Stock list view (Inventory → Stock). Clicking any of these column headers previously appeared to reorder rows arbitrarily — they were silently being sorted by item name instead.

**Root cause:** the column ids emitted by material-react-table didn't match the keys in the `toSortField` map in `useStockList.ts`:

| Column id (from `ListView.tsx`) | Old map key | New map key |
|---|---|---|
| `code` | `itemCode` ❌ | `code` ✅ |
| `totalNumberOfPacks` | `numberOfPacks` ❌ | `totalNumberOfPacks` ✅ |
| `location.code` | `location` ❌ | `'location.code'` ✅ |

Unmatched keys fall through to the default `StockLineSortFieldInput.ItemName`, which is why all three columns appeared to produce a useless reorder. The fix updates the map keys to match the column ids so the lookup resolves to the correct `StockLineSortFieldInput` value in each case.

## 💌 Any notes for the reviewer?

- Bundled into one PR since all three are the same class of bug in the same function.
- Supersedes #11380 (Pack Qty, targeted `v2.17.3-RC`) and #11381 (Code + Location, targeted `v2.17.3-RC`) — those are being closed in favour of this consolidated PR against `develop`.

# 🧪 Testing

- [ ] Go to Inventory → Stock
- [ ] Set some item codes to values like `QA001`, `QA002`, `QA303`, `QA1001` (per #11363 repro)
- [ ] Click the **Code** column header — rows should sort ascending by code; click again for descending
- [ ] Click the **Pack Qty** column header — rows should sort ascending by pack quantity; click again for descending
- [ ] Click the **Location** column header — rows should sort ascending by location code; click again for descending
- [ ] Confirm other sortable columns (Name, Batch, Expiry, Manufacture Date, Pack Size, Pack Cost Price, Supplier) still sort correctly

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend