### PR TITLE
#11377 Route ledger & return related-docs clicks to correct inbound path

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -4474,6 +4474,7 @@ export type InvoiceNode = {
   program?: Maybe<ProgramNode>;
   programId?: Maybe<Scalars['String']['output']>;
   purchaseOrder?: Maybe<PurchaseOrderNode>;
+  purchaseOrderId?: Maybe<Scalars['String']['output']>;
   receivedDatetime?: Maybe<Scalars['DateTime']['output']>;
   /**
    * Response Requisition that is the origin of this Outbound Shipment

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -4715,6 +4715,13 @@ export type ItemLedgerNode = {
   invoiceNumber: Scalars['Int']['output'];
   invoiceStatus: InvoiceNodeStatus;
   invoiceType: InvoiceNodeType;
+  /**
+   * True when the invoice is an external inbound shipment (i.e. linked to a
+   * purchase order). The client uses this to route to the correct detail
+   * page, since internal and external inbound shipments live on separate
+   * routes.
+   */
+  isExternal: Scalars['Boolean']['output'];
   itemId: Scalars['String']['output'];
   movementInUnits: Scalars['Float']['output'];
   name: Scalars['String']['output'];

--- a/client/packages/invoices/src/Returns/SupplierDetailView/SidePanel/RelatedDocumentsSection.tsx
+++ b/client/packages/invoices/src/Returns/SupplierDetailView/SidePanel/RelatedDocumentsSection.tsx
@@ -45,7 +45,11 @@ export const RelatedDocumentsSectionComponent = () => {
               <PanelField>
                 <Link
                   to={RouteBuilder.create(AppRoute.Replenishment)
-                    .addPart(AppRoute.InboundShipment)
+                    .addPart(
+                      originalShipment?.purchaseOrderId
+                        ? AppRoute.InboundShipmentExternal
+                        : AppRoute.InboundShipment
+                    )
                     .addPart(String(originalShipment?.id))
                     .build()}
                 >{`#${originalShipment?.invoiceNumber}`}</Link>

--- a/client/packages/invoices/src/Returns/api/operations.generated.ts
+++ b/client/packages/invoices/src/Returns/api/operations.generated.ts
@@ -72,6 +72,7 @@ export type SupplierReturnFragment = {
     __typename: 'InvoiceNode';
     id: string;
     invoiceNumber: number;
+    purchaseOrderId?: string | null;
     createdDatetime: string;
     user?: { __typename: 'UserNode'; username: string } | null;
   } | null;
@@ -447,6 +448,7 @@ export type SupplierReturnByNumberQuery = {
           __typename: 'InvoiceNode';
           id: string;
           invoiceNumber: number;
+          purchaseOrderId?: string | null;
           createdDatetime: string;
           user?: { __typename: 'UserNode'; username: string } | null;
         } | null;
@@ -521,6 +523,7 @@ export type SupplierReturnByIdQuery = {
           __typename: 'InvoiceNode';
           id: string;
           invoiceNumber: number;
+          purchaseOrderId?: string | null;
           createdDatetime: string;
           user?: { __typename: 'UserNode'; username: string } | null;
         } | null;
@@ -898,6 +901,7 @@ export const SupplierReturnFragmentDoc = gql`
     originalShipment {
       id
       invoiceNumber
+      purchaseOrderId
       createdDatetime
       user {
         username

--- a/client/packages/invoices/src/Returns/api/operations.graphql
+++ b/client/packages/invoices/src/Returns/api/operations.graphql
@@ -78,6 +78,7 @@ fragment SupplierReturn on InvoiceNode {
   originalShipment {
     id
     invoiceNumber
+    purchaseOrderId
     createdDatetime
     user {
       username

--- a/client/packages/system/src/Item/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Item/DetailView/DetailView.tsx
@@ -40,7 +40,11 @@ export const ItemDetailView = () => {
       case InvoiceNodeType.InboundShipment:
         navigate(
           RouteBuilder.create(AppRoute.Replenishment)
-            .addPart(AppRoute.InboundShipment)
+            .addPart(
+              ledger.isExternal
+                ? AppRoute.InboundShipmentExternal
+                : AppRoute.InboundShipment
+            )
             .addPart(String(ledger.invoiceId))
             .build()
         );

--- a/client/packages/system/src/Item/api/operations.generated.ts
+++ b/client/packages/system/src/Item/api/operations.generated.ts
@@ -1463,6 +1463,7 @@ export type ItemLedgerFragment = {
   invoiceId: string;
   invoiceStatus: Types.InvoiceNodeStatus;
   invoiceType: Types.InvoiceNodeType;
+  isExternal: boolean;
   name: string;
   packSize: number;
   movementInUnits: number;
@@ -1497,6 +1498,7 @@ export type ItemLedgerQuery = {
       invoiceId: string;
       invoiceStatus: Types.InvoiceNodeStatus;
       invoiceType: Types.InvoiceNodeType;
+      isExternal: boolean;
       name: string;
       packSize: number;
       movementInUnits: number;
@@ -1820,6 +1822,7 @@ export const ItemLedgerFragmentDoc = gql`
     invoiceId
     invoiceStatus
     invoiceType
+    isExternal
     name
     packSize
     movementInUnits

--- a/client/packages/system/src/Item/api/operations.graphql
+++ b/client/packages/system/src/Item/api/operations.graphql
@@ -516,6 +516,7 @@ fragment ItemLedger on ItemLedgerNode {
   invoiceId
   invoiceStatus
   invoiceType
+  isExternal
   name
   packSize
   movementInUnits

--- a/server/graphql/general/src/queries/item_ledger.rs
+++ b/server/graphql/general/src/queries/item_ledger.rs
@@ -2,7 +2,7 @@ use async_graphql::{dataloader::DataLoader, *};
 use chrono::{DateTime, NaiveDate, Utc};
 use graphql_core::{
     generic_filters::{DatetimeFilterInput, EqualFilterStringInput},
-    loader::UserLoader,
+    loader::{InvoiceByIdLoader, UserLoader},
     map_filter,
     pagination::PaginationInput,
     standard_graphql_error::{validate_auth, StandardGraphqlError},
@@ -104,6 +104,23 @@ impl ItemLedgerNode {
 
     pub async fn number_of_packs(&self) -> &f64 {
         &self.item_ledger.number_of_packs
+    }
+
+    /// True when the invoice is an external inbound shipment (i.e. linked to a
+    /// purchase order). The client uses this to route to the correct detail
+    /// page, since internal and external inbound shipments live on separate
+    /// routes.
+    pub async fn is_external(&self, ctx: &Context<'_>) -> Result<bool> {
+        if !matches!(self.item_ledger.invoice_type, InvoiceType::InboundShipment) {
+            return Ok(false);
+        }
+        let loader = ctx.get_loader::<DataLoader<InvoiceByIdLoader>>();
+        let invoice = loader
+            .load_one(self.item_ledger.invoice_id.clone())
+            .await?;
+        Ok(invoice
+            .and_then(|i| i.invoice_row.purchase_order_id)
+            .is_some())
     }
 
     pub async fn user(&self, ctx: &Context<'_>) -> Result<Option<UserNode>> {

--- a/server/graphql/types/src/types/invoice_query.rs
+++ b/server/graphql/types/src/types/invoice_query.rs
@@ -520,6 +520,10 @@ impl InvoiceNode {
         Ok(result)
     }
 
+    pub async fn purchase_order_id(&self) -> &Option<String> {
+        &self.row().purchase_order_id
+    }
+
     pub async fn purchase_order(&self, ctx: &Context<'_>) -> Result<Option<PurchaseOrderNode>> {
         // &self.row().purchase_order_id
         let Some(purchase_order_id) = &self.row().purchase_order_id else {


### PR DESCRIPTION
Fixes #11377

# 👩🏻‍💻 What does this PR do?

Clicking an inbound shipment row in the item ledger (and a supplier return's related-documents back link) always routed to `/replenishment/inbound-shipment/:id`. That URL drives `useInboundShipment` to query the invoice with `InvoiceTypeInput.InboundShipment`, which adds a `purchase_order_id IS NULL` filter ([invoice_queries.rs:117-121](https://github.com/msupply-foundation/open-msupply/blob/develop/server/graphql/invoice/src/invoice_queries.rs#L117-L121)) — so any *external* inbound shipment (i.e. one linked to a purchase order) is filtered out and the detail page errors with "Could not find invoice".

This is why #11377 surfaced after the OG → OMS goods-received migration — migrated GR invoices always have `purchase_order_id` set — but the bug pre-dates the migration and affects any manually-created external inbound as well.

The fix:

- Adds an `is_external` resolver to `ItemLedgerNode`, derived from the invoice's `purchase_order_id` via `InvoiceByIdLoader`. The ledger click handler uses it to route to `AppRoute.InboundShipmentExternal` when the invoice is external.
- Exposes `purchase_order_id` as a scalar on `InvoiceNode` and uses it on the `originalShipment` fragment to fix the equivalent bug in the supplier return's Related Documents side panel.

## 💌 Any notes for the reviewer?

- `is_external` only makes sense for `InboundShipment` rows, so it short-circuits to `false` for other invoice types to avoid unnecessary loader calls.
- I scanned all other `AppRoute.InboundShipment` usages in the client. The rest are either list/base routes, routing config, post-delete navs, or "not found" redirects — none link to a specific invoice id, so they're unaffected.
- The requisition sidebar (`SideBarComponents.tsx`) also has an `AppRoute.InboundShipment` link to a specific shipment id, but requisition-linked inbounds are transfers (internal), so it's not reachable for external inbounds in practice.

# 🧪 Testing

- [ ] On a store with a finalised external inbound shipment (either manually created with a PO link, or migrated from an OG goods receive)
- [ ] Catalogue → Items → pick an item that has stock from that shipment → Ledger tab → click the inbound row → should open the external inbound shipment detail page (previously: "Could not find invoice")
- [ ] Click a row for a non-external inbound — should still open the normal inbound shipment page
- [ ] Click rows for other invoice types (outbound, prescription, supplier return, customer return) — should still route correctly
- [ ] Create a supplier return from the external inbound shipment → open the supplier return → Related Documents panel → click the shipment link → should land on the external inbound detail page

# 📃 Documentation

- [x] **No documentation required**: bug fix, no change to user-facing behaviour when things work

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend