### PR TITLE
#11376 Add save icon to demographic footer button

### DIFF
--- a/client/packages/system/src/Manage/IndicatorsDemographics/DetailView/Footer.tsx
+++ b/client/packages/system/src/Manage/IndicatorsDemographics/DetailView/Footer.tsx
@@ -8,7 +8,7 @@ import {
   UserPermission,
   useCallbackWithPermission,
 } from '@openmsupply-client/common';
-import { XCircleIcon } from '@common/icons';
+import { SaveIcon, XCircleIcon } from '@common/icons';
 
 interface DemographicsFooterProps {
   isDirty: boolean;
@@ -50,6 +50,7 @@ export const FooterComponent = ({
             isLoading={false}
             color="secondary"
             label={t('button.save')}
+            startIcon={<SaveIcon />}
           />
         </Box>
       }


### PR DESCRIPTION
Fixes #11376

# 👩🏻‍💻 What does this PR do?

Adds a `SaveIcon` to the Save button on the Indicators & Demographics detail view footer.

The button is shrinkable, so on narrow viewports the text label collapses. Without an icon, nothing is visible. This mirrors the pattern already used on the patient view footer, which includes a `startIcon={<SaveIcon />}`.

On a small screen
<img width="448" height="706" alt="image" src="https://github.com/user-attachments/assets/b94eb708-2ea6-4730-9e48-58f2b2800c76" />
And a larger screen
<img width="1895" height="795" alt="image" src="https://github.com/user-attachments/assets/233757d5-40c3-4977-99ae-65b0069dad21" />



## 💌 Any notes for the reviewer?

Single-file change — see `client/packages/system/src/Manage/IndicatorsDemographics/DetailView/Footer.tsx`. Matches the existing approach in `client/packages/system/src/Patient/PatientView/Footer.tsx`.

I got claude to audit any other places which would have the same problem but decided not worth the time in reproducing them for dev and testing, so left for now
```
Two other LoadingButtons have the same shrink-without-icon issue:

Barcode Scanner Settings — Detect Scanners button
[client/packages/host/src/Admin/BarcodeScannerSettings.tsx:267-271](vscode-webview://1478dmuefalm317eduev7r747nk6lj5bdaqfstvrnfoeh4i3uio1/client/packages/host/src/Admin/BarcodeScannerSettings.tsx#L267-L271) — label={t('label.detect-scanners')}, no icon. Lives in Admin → Barcode Scanner Settings (USB Serial section).

Create Patient Modal — Retry button
[client/packages/system/src/Patient/CreatePatientModal/PatientResultsTab.tsx:253-260](vscode-webview://1478dmuefalm317eduev7r747nk6lj5bdaqfstvrnfoeh4i3uio1/client/packages/system/src/Patient/CreatePatientModal/PatientResultsTab.tsx#L253-L260) — label={t('button.retry')}, no icon. Shown in the patient search results tab when the central fetch fails.
```


# 🧪 Testing

- [ ] Open a remote site running this PR
- [ ] Navigate to Manage → Indicators & Demographics
- [ ] Open a demographic to enter the detail view
- [ ] Make a change so the Save button becomes enabled
- [ ] Confirm the Save button shows a save icon
- [ ] Narrow the window so the footer shrinks; confirm the icon stays visible when the label collapses

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**:
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend