### PR TITLE
#11403 Login hangs indefinitely on Linux SQLite deployment Fixed

### DIFF
--- a/server/graphql/types/src/types/user.rs
+++ b/server/graphql/types/src/types/user.rs
@@ -1,18 +1,14 @@
 use super::{StorePreferenceNode, UserStorePermissionConnector};
-use async_graphql::{
-    dataloader::DataLoader, Context, Enum, ErrorExtensions, Object, Result, SimpleObject,
-};
+use async_graphql::{Context, Enum, ErrorExtensions, Object, Result, SimpleObject};
 use chrono::NaiveDate;
-use graphql_core::{
-    loader::{HomeCurrencyLoader, NameRowLoader},
-    standard_graphql_error::StandardGraphqlError,
-    ContextExt,
-};
-use repository::{User, UserStore};
+use graphql_core::{standard_graphql_error::StandardGraphqlError, ContextExt};
+use repository::{CurrencyFilter, NameRowRepository, User, UserStore};
 use service::permission::permissions;
 
 pub struct UserStoreNode {
     user_store: UserStore,
+    name: String,
+    home_currency_code: Option<String>,
 }
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq)]
@@ -37,21 +33,8 @@ impl UserStoreNode {
         &self.user_store.store_row.name_id
     }
 
-    pub async fn name(&self, ctx: &Context<'_>) -> Result<String> {
-        let loader = ctx.get_loader::<DataLoader<NameRowLoader>>();
-
-        let name_row = loader
-            .load_one(self.user_store.store_row.name_id.clone())
-            .await?
-            .ok_or(
-                StandardGraphqlError::InternalError(format!(
-                    "Cannot find name ({}) for store ({})",
-                    self.user_store.store_row.name_id, self.user_store.store_row.id
-                ))
-                .extend(),
-            )?;
-
-        Ok(name_row.name)
+    pub async fn name(&self) -> &str {
+        &self.name
     }
 
     pub async fn preferences(&self) -> StorePreferenceNode {
@@ -65,9 +48,9 @@ impl UserStoreNode {
     pub async fn created_date(&self) -> &Option<NaiveDate> {
         &self.user_store.store_row.created_date
     }
-    pub async fn home_currency_code(&self, ctx: &Context<'_>) -> Result<Option<String>> {
-        let loader = ctx.get_loader::<DataLoader<HomeCurrencyLoader>>();
-        Ok(loader.load_one(()).await?)
+
+    pub async fn home_currency_code(&self) -> &Option<String> {
+        &self.home_currency_code
     }
 
     pub async fn is_disabled(&self) -> bool {
@@ -114,25 +97,45 @@ impl UserNode {
         &self.user.user_row.username
     }
 
-    pub async fn default_store(&self) -> Option<UserStoreNode> {
-        self.user.default_store().map(|user_store| UserStoreNode {
-            user_store: user_store.clone(),
-        })
+    pub async fn default_store(&self, ctx: &Context<'_>) -> Result<Option<UserStoreNode>> {
+        let home_currency_code = resolve_home_currency_code(ctx)?;
+        let names = resolve_store_names(ctx, &self.user.stores)?;
+        Ok(self.user.default_store().map(|user_store| {
+            let name = names
+                .get(&user_store.store_row.name_id)
+                .cloned()
+                .unwrap_or_default();
+            UserStoreNode {
+                user_store: user_store.clone(),
+                name,
+                home_currency_code: home_currency_code.clone(),
+            }
+        }))
     }
 
-    pub async fn stores(&self) -> UserStoreConnector {
-        let nodes: Vec<UserStoreNode> = self
+    pub async fn stores(&self, ctx: &Context<'_>) -> Result<UserStoreConnector> {
+        let home_currency_code = resolve_home_currency_code(ctx)?;
+        let names = resolve_store_names(ctx, &self.user.stores)?;
+        let nodes = self
             .user
             .stores
             .iter()
-            .map(|user_store| UserStoreNode {
-                user_store: user_store.clone(),
+            .map(|user_store| {
+                let name = names
+                    .get(&user_store.store_row.name_id)
+                    .cloned()
+                    .unwrap_or_default();
+                UserStoreNode {
+                    user_store: user_store.clone(),
+                    name,
+                    home_currency_code: home_currency_code.clone(),
+                }
             })
-            .collect();
-        UserStoreConnector {
+            .collect::<Vec<_>>();
+        Ok(UserStoreConnector {
             total_count: nodes.len() as u32,
             nodes,
-        }
+        })
     }
 
     pub async fn permissions(
@@ -158,12 +161,15 @@ impl UserNode {
     pub async fn first_name(&self) -> &Option<String> {
         &self.user.user_row.first_name
     }
+
     pub async fn last_name(&self) -> &Option<String> {
         &self.user.user_row.last_name
     }
+
     pub async fn phone_number(&self) -> &Option<String> {
         &self.user.user_row.phone_number
     }
+
     pub async fn job_title(&self) -> &Option<String> {
         &self.user.user_row.job_title
     }
@@ -173,4 +179,41 @@ impl UserNode {
     pub fn from_domain(user: User) -> Self {
         UserNode { user }
     }
+}
+
+fn resolve_store_names(
+    ctx: &Context<'_>,
+    stores: &[UserStore],
+) -> Result<std::collections::HashMap<String, String>> {
+    let name_ids: Vec<String> = stores
+        .iter()
+        .map(|s| s.store_row.name_id.clone())
+        .collect();
+    if name_ids.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    let service_context = ctx.service_provider().basic_context()?;
+    let name_rows = NameRowRepository::new(&service_context.connection)
+        .find_many_by_id(&name_ids)
+        .map_err(|e| StandardGraphqlError::InternalError(format!("{:?}", e)).extend())?;
+    Ok(name_rows
+        .into_iter()
+        .map(|n| (n.id, n.name))
+        .collect())
+}
+
+fn resolve_home_currency_code(ctx: &Context<'_>) -> Result<Option<String>> {
+    let service_provider = ctx.service_provider();
+    let service_context = service_provider.basic_context()?;
+    let home_currency = service_provider
+        .currency_service
+        .get_currencies(
+            &service_context,
+            Some(CurrencyFilter::new().is_home_currency(true)),
+            None,
+        )
+        .map_err(StandardGraphqlError::from_list_error)?
+        .rows
+        .pop();
+    Ok(home_currency.map(|c| c.currency_row.code))
 }


### PR DESCRIPTION
Fixes #11403 

# 👩🏻‍💻 What does this PR do?

The name field on `UserStoreNode` was resolved via `NameRowLoader`, a DataLoader registered with `tokio::spawn`. Inside that spawned task, acquiring a DB connection via `pool.get()` blocks when SQLite's write lock is held by the sync process. This stalls Tokio worker threads, and the me query never completes.

There was also a secondary N+1 issue, `home_currency_code` was issuing one DB query per store in the response.

The fix moves both name and `home_currency_code` resolution out of the async DataLoader path entirely. `UserNode.stores() `and `UserNode.default_store()` now pre-resolve store names in a single batch (NameRowRepository::find_many_by_id) and home currency in one query before constructing UserStoreNode instances. The resolved values are passed in directly, so no DB calls happen during async field resolution.

- Removed DataLoader<NameRowLoader> and DataLoader<HomeCurrencyLoader> imports, no longer needed
- UserStoreNode now carries pre-resolved name: String and `home_currency_code`: Option<String> fields instead of making DataLoader calls per field
- UserNode.default_store() and UserNode.stores() now take ctx and call two helper functions upfront before building nodes
- `resolve_store_names()` -> single batch query via NameRowRepository::find_many_by_id()
- `resolve_home_currency_code()` -> single query via currency_service.get_currencies()


## 💌 Any notes for the reviewer?

The **NameRowLoader** and **HomeCurrencyLoader** DataLoaders are still registered and used elsewhere... this PR only removes their use in `UserStoreNode`. No other callers are affected.

The main risk area is `default_store` and stores on `UserNode`, both now take a ctx argument where they previously didn't. Worth checking if anything calls these outside of the GraphQL resolver context.

The root cause `(DataLoaders using tokio::spawn with blocking pool.get())` is a broader pattern in the codebase. This fix addresses the symptom in the login path... A separate issue should track the wider problem.


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Setup mSupply Central Server with a remote site
- [ ] Deploy the SQLite Docker image on a Linux server
- [ ] Intitialise the created central remote site on linux remote server 
- [ ] Try Login after initialisation
- [ ] See the Issue  
- [ ] Login spins indifenitely

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

