### PR TITLE
11408 Skip uncounted stocktake lines at the time of finalisation

### DIFF
--- a/server/service/src/stocktake/update/mod.rs
+++ b/server/service/src/stocktake/update/mod.rs
@@ -281,13 +281,16 @@ mod test {
         }
 
         fn mock_existing_stock_line_b() -> StockLineRow {
+            // total_number_of_packs (5.0) deliberately differs from the linked
+            // stocktake line's snapshot_number_of_packs (10.0) so finalisation
+            // exercises the snapshot-mismatch path on an uncounted line.
             StockLineRow {
                 id: "existing_stock_b".to_string(),
                 item_link_id: "item_a".to_string(),
                 store_id: "store_a".to_string(),
-                available_number_of_packs: 10.0,
+                available_number_of_packs: 5.0,
                 pack_size: 2.0,
-                total_number_of_packs: 10.0,
+                total_number_of_packs: 5.0,
                 batch: Some("initial batch name".to_string()),
                 ..Default::default()
             }
@@ -656,7 +659,8 @@ mod test {
             mock_stock_line_b().supplier_id
         );
 
-        // success - prunes uncounted lines
+        // success - prunes uncounted lines, and a stale snapshot on an
+        // uncounted line does not block finalisation (regression for #11408)
         let result = service
             .update_stocktake(
                 &context,

--- a/server/service/src/stocktake/update/validate.rs
+++ b/server/service/src/stocktake/update/validate.rs
@@ -67,6 +67,11 @@ fn check_snapshot_matches_current_count(
 ) -> Option<Vec<StocktakeLine>> {
     let mut mismatches = Vec::new();
     for line in stocktake_lines {
+        // Skip uncounted lines as they won't have a snapshot count
+        // to compare against when the stocktake is finalised
+        if line.line.counted_number_of_packs.is_none() {
+            continue;
+        }
         let stock_line = match &line.stock_line {
             Some(stock_line) => stock_line,
             None => continue,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11408 

# 👩🏻‍💻 What does this PR do?
In check_snapshot_matches_current_count, skip stocktake lines where counted_number_of_packs is None so we don't attempt to compare against a missing snapshot count. This prevents false mismatches for uncounted lines when a stocktake is finalised.
<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

