### PR TITLE
Limit query retries to 3 and disable refetchOnWindowFocus

### DIFF
--- a/client/packages/host/src/Host.tsx
+++ b/client/packages/host/src/Host.tsx
@@ -6,7 +6,6 @@ import {
   Box,
   AppThemeProvider,
   QueryClient,
-  // ReactQueryDevtools,
   QueryClientProvider,
   RouteBuilder,
   ErrorBoundary,
@@ -31,6 +30,7 @@ import {
   InitialisationStatusType,
   useAuthContext,
 } from '@openmsupply-client/common';
+// import { ReactQueryDevtools } from 'react-query/devtools';
 import { AppRoute, Environment } from '@openmsupply-client/config';
 import { Initialise, Login, Viewport } from './components';
 import { Site } from './Site';
@@ -46,10 +46,8 @@ const appVersion = require('../../../../package.json').version; // eslint-disabl
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      // These are disabled during development because they're
-      // annoying to have constantly refetching.
-      refetchOnWindowFocus: EnvUtils.isProduction(),
-      retry: EnvUtils.isProduction(),
+      // Creates unnecessary requests
+      refetchOnWindowFocus: false,
       // This is the default in v4 which is currently in alpha as it is
       // what most users think the default is.
       // This will subscribe components of a query only to the data they
@@ -186,7 +184,7 @@ const Host = () => (
                       </AlertModalProvider>
                     </ConfirmationModalProvider>
                   </AuthProvider>
-                  {/* <ReactQueryDevtools initialIsOpen /> */}
+                  {/* <ReactQueryDevtools initialIsOpen={false} /> */}
                 </GqlProvider>
               </QueryClientProvider>
             </ErrorBoundary>


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Trims the `QueryClient` defaults in `Host.tsx`:

- `retry`: previously `EnvUtils.isProduction()` (so prod was effectively infinite retries, dev was none). Now omitted, falling back to react-query's default of **3 retries** with exponential backoff in all environments.
- `refetchOnWindowFocus`: previously `EnvUtils.isProduction()`. Now hard-coded to `false` everywhere — these refetches were creating unnecessary requests.

**Motivation**: infinite retries are bad for both sides of the wire. Server-side, every client whose request fails keeps hammering the endpoint forever, which makes a struggling server worse. Client-side, the user sees a spinner that never resolves with no feedback that the server is unreachable. Capping at 3 retries bounds the load and lets the query reach an error state in a reasonable time. One pertinent situation that I hadn't realised due to the prod switch is when the server is unreachable the client will show a loading animation forever with no feedback that the server is unreachable.

## 💌 Any notes for the reviewer?

- **Caveat**: without this PR, when the server is down the client just tries to load forever with no feedback — not great. With this PR, after 3 retries the query enters an error state — but most pages don't handle that so at the end of the retries the client shows either some cached data or nothing here but doesn't show an error.
- Adding proper error-surfacing first (e.g. a global `QueryCache.onError` plumbed into `ErrorAlert`, or `useErrorBoundary: true` on the defaults, or just consume error and isError on all the pages) and *then* dropping infinite retries would be better. Its a question of whether we prefer showing cached data/no data or infinite spinner. In the case where server is completly unreachable having max retries of three correctly results in an error being thrown.
- No mutations defaults are touched. Mutations continue to use react-query's default of `retry: 0`.
- `ReactQueryDevtools` import was uncommented (still commented out at the JSX usage site) for future debugging convenience.

# 🧪 Testing

- [ ] Run the client against a working server, navigate around — queries should resolve normally with no behavioural change
- [ ] Block `/graphql` in DevTools (Network tab → Block request URL) on a page that triggers queries; observe exactly 3 retries (4 total attempts) at ~1s, 2s, 4s intervals before the query gives up
- [ ] Unblock `/graphql` mid-retry — the in-flight retry should succeed and data should populate
- [ ] Switch tabs / refocus the window with the app open — confirm no flurry of refetches in the Network tab
- [ ] Trigger a mutation while the server is unreachable — confirm it fails immediately (no retries on mutations)
- [ ] Can also close and start the server instead of blocking in dev tools

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend