### PR TITLE
Fix dataloader patch

### DIFF
--- a/.github/workflows/dockerise.yaml
+++ b/.github/workflows/dockerise.yaml
@@ -51,10 +51,13 @@ jobs:
           name: client-dist
           path: client/packages/host/dist
 
+      # Workaround for async-graphql DataLoader freeze when built via GitHub
+      # Actions docker (upstream issue async-graphql/async-graphql#1716,
+      # filed by andreievg). Fixed upstream in #1780 (≥7.1.0) but a separate
+      # spec regression (#1816) blocks bumping. See docker/async-dataloader.patch.
       - name: Apply async-dataloader patch
-        run: |
-          git apply docker/async-dataloader.patch
-          
+        run: git apply docker/async-dataloader.patch
+
       - name: Build server
         run: docker run --rm --user "$(id -u)":"$(id -g)" -v "$PWD":/usr/src/omsupply -w /usr/src/omsupply/server rust:1.88-slim cargo build --release --bin remote_server --bin remote_server_cli
 

--- a/docker/async-dataloader.patch
+++ b/docker/async-dataloader.patch
@@ -1,8 +1,6 @@
-diff --git a/server/Cargo.toml b/server/Cargo.toml
-index 31a8324562..2332bd0d12 100644
 --- a/server/Cargo.toml
 +++ b/server/Cargo.toml
-@@ -4,8 +4,8 @@ strip = true
+@@ -4,8 +4,8 @@
  [workspace.dependencies]
  # dependencies used in graphql crates:
  # Warning don't add anything above this lines as auto patch is applied during docker build
@@ -10,6 +8,6 @@ index 31a8324562..2332bd0d12 100644
 -async-graphql-actix-web = "7.0.17"
 +async-graphql = {git = "https://github.com/andreievg/async-graphql.git", rev = "6c476d50f0f2132860445b5ed5b3c6dd6e8cec92", version = "7.0.16", features = ["dataloader", "chrono"] }
 +async-graphql-actix-web = {package = "async-graphql-actix-web", git = "https://github.com/andreievg/async-graphql.git",  version = "7.0.16", rev = "6c476d50f0f2132860445b5ed5b3c6dd6e8cec92" }
- actix-web = { version = "4.11.0", default-features = false, features = [
-   "macros",
-   "rustls",
+ actix-web = { version = "4.11.0", default-features = false, features = ["macros", "rustls"] }
+ actix-multipart = "0.7.2"
+ anymap = "0.12.1"


### PR DESCRIPTION
Fixes the `async-dataloader` patch so it applies cleanly against the current `server/Cargo.toml`, and tidies the dockerise workflow step that applies it.

# 🧪 Testing

- [ ] Run the `dockerise` workflow on this branch and confirm the `Apply async-dataloader patch` and `Build server` steps succeed