### PR TITLE
Fix docker yaml

### DIFF
--- a/.github/workflows/dockerise.yaml
+++ b/.github/workflows/dockerise.yaml
@@ -68,16 +68,28 @@ jobs:
           path: client/packages/host/dist
           retention-days: 1
 
+  generate-matrix:
+    name: Generate Build Matrix
+    runs-on: ubuntu-latest
+    needs: check-tag
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          if [ "${{ needs.check-tag.outputs.is_release }}" = "true" ]; then
+            echo 'matrix={"db":["sqlite","postgres"],"arch":["amd64","arm64"]}' >> $GITHUB_OUTPUT
+          else
+            echo 'matrix={"db":["sqlite","postgres"],"arch":["amd64"]}' >> $GITHUB_OUTPUT
+          fi
+
   build-server:
     name: Build server (${{ matrix.db }}, ${{ matrix.arch }})
-    needs: [build-client, check-tag]
-    if: matrix.arch != 'arm64' || needs.check-tag.outputs.is_release == 'true'
+    needs: [build-client, check-tag, generate-matrix]
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:
-      matrix:
-        db: [sqlite, postgres]
-        arch: [amd64, arm64]
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -149,16 +161,12 @@ jobs:
 
   dockerise:
     name: Dockerise (${{ matrix.db }}, ${{ matrix.arch }})
-    needs: [build-server, check-tag]
-    if: >-
-      always() && !failure() && !cancelled() &&
-      (matrix.arch != 'arm64' || needs.check-tag.outputs.is_release == 'true')
+    needs: [build-server, check-tag, generate-matrix]
+    if: always() && !failure() && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
-      matrix:
-        db: [sqlite, postgres]
-        arch: [amd64, arm64]
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     outputs:
       image_tag: ${{ env.VERSION }}
     steps:


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes broken docker github action

# 👩🏻‍💻 What does this PR do?

The key changes:

Added a generate-matrix job that outputs {"arch":["amd64"]} for non-releases and {"arch":["amd64","arm64"]} for releases — arm64 simply never appears in the matrix when it shouldn't.

Removed the invalid matrix.arch from job-level if conditions — both build-server and dockerise now just reference generate-matrix.outputs.matrix via fromJson(...).

The always() && !failure() && !cancelled() condition on dockerise is kept (it handles the build-server skipping gracefully), just without the invalid matrix reference.


<p style="white-space: pre-wrap; margin-top: 0px; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">A <strong>matrix</strong> in GitHub Actions lets a single job definition run multiple times in parallel with different variable combinations.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">In this workflow, the matrix is:</p><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(18, 19, 20); border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code class="language-yaml" style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
# resolves to either:
# {"db": ["sqlite", "postgres"], "arch": ["amd64", "arm64"]}   ← release
# {"db": ["sqlite", "postgres"], "arch": ["amd64"]}            ← non-release
</code></pre></div><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">GitHub expands this into one job run per combination:</p>
matrix.db | matrix.arch
-- | --
sqlite | amd64
sqlite | arm64
postgres | amd64
postgres | arm64

<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">All 4 run in parallel. Within each job run, <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">${{ matrix.db }}</code> and <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">${{ matrix.arch }}</code> resolve to that combination's values — used for things like the job name, picking the right build flags, artifact names, and Docker tags.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">For a non-release tag, the matrix only has <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">amd64</code>, so you get 2 runs instead of 4.</p>

## 💌 Any notes for the reviewer?

This is AI Generated fix but seems reasonable. Created a tag to test with...

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Check github action triggers correctly.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

