### PR TITLE
#11261 Fix Add Item button on empty customer return

### DIFF
--- a/client/packages/invoices/src/Returns/CustomerDetailView/DetailView.tsx
+++ b/client/packages/invoices/src/Returns/CustomerDetailView/DetailView.tsx
@@ -57,7 +57,7 @@ export const CustomerReturnDetailView = () => {
       noDataElement: (
         <NothingHere
           body={t('error.no-customer-return-items')}
-          onCreate={isDisabled ? undefined : () => onOpen}
+          onCreate={isDisabled ? undefined : () => onOpen()}
           buttonText={t('button.add-item')}
         />
       ),


### PR DESCRIPTION
Fixes #11261

# 👩🏻‍💻 What does this PR do?

Fixes the "Add item" button on the empty-state of a Customer Return detail view. The `onCreate` prop was passing the `onOpen` function reference instead of calling it, so clicking did nothing.

# 🧪 Testing

- [ ] Distribution → Customer Returns → new return
- [ ] Click "Add item" from the empty main screen — modal should open
- [ ] Top-right "Add item" button still works

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour