### PR TITLE
#11269 Fix Supplier Return delete hanging on detail page

### DIFF
--- a/client/packages/invoices/src/Returns/CustomerDetailView/SidePanel/SidePanel.tsx
+++ b/client/packages/invoices/src/Returns/CustomerDetailView/SidePanel/SidePanel.tsx
@@ -8,7 +8,10 @@ import {
   useDeleteConfirmation,
   useTranslation,
   InvoiceNodeStatus,
+  useNavigate,
+  RouteBuilder,
 } from '@openmsupply-client/common';
+import { AppRoute } from '@openmsupply-client/config';
 import { useReturns } from '../../api';
 import { AdditionalInfoSection } from './AdditionalInfoSection';
 import { RelatedDocumentsSection } from './RelatedDocumentsSection';
@@ -19,6 +22,7 @@ export const SidePanelComponent = () => {
   const t = useTranslation();
   const { data } = useReturns.document.customerReturn();
   const { mutateAsync } = useReturns.document.deleteCustomer();
+  const navigate = useNavigate();
 
   const isTransfer = !!data?.linkedShipment?.id;
 
@@ -26,6 +30,11 @@ export const SidePanelComponent = () => {
   const deleteAction = async () => {
     if (!data) return;
     await mutateAsync(data.id);
+    navigate(
+      RouteBuilder.create(AppRoute.Distribution)
+        .addPart(AppRoute.CustomerReturn)
+        .build()
+    );
   };
 
   const onDelete = useDeleteConfirmation({

--- a/client/packages/invoices/src/Returns/api/hooks/document/useCustomerDelete.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/document/useCustomerDelete.ts
@@ -1,25 +1,13 @@
-import {
-  RouteBuilder,
-  useMutation,
-  useNavigate,
-  useQueryClient,
-} from '@openmsupply-client/common';
-import { AppRoute } from '@openmsupply-client/config';
+import { useMutation, useQueryClient } from '@openmsupply-client/common';
 import { useReturnsApi } from '../utils/useReturnsApi';
 
 export const useCustomerReturnDelete = () => {
   const queryClient = useQueryClient();
   const api = useReturnsApi();
-  const navigate = useNavigate();
 
   return useMutation(api.deleteCustomer, {
-    onSuccess: () => {
-      queryClient.invalidateQueries(api.keys.base());
-      navigate(
-        RouteBuilder.create(AppRoute.Distribution)
-          .addPart(AppRoute.CustomerReturn)
-          .build()
-      );
-    },
+    // `void` is load-bearing: returning the invalidateQueries promise would make
+    // mutateAsync await the refetch of the just-deleted detail query and hang.
+    onSuccess: () => void queryClient.invalidateQueries(api.keys.base()),
   });
 };

--- a/client/packages/invoices/src/Returns/api/hooks/document/useSupplierDelete.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/document/useSupplierDelete.ts
@@ -6,6 +6,8 @@ export const useSupplierReturnDelete = () => {
   const api = useReturnsApi();
 
   return useMutation(api.deleteSupplier, {
-    onSuccess: () => queryClient.invalidateQueries(api.keys.base()),
+    // `void` is load-bearing: returning the invalidateQueries promise would make
+    // mutateAsync await the refetch of the just-deleted detail query and hang.
+    onSuccess: () => void queryClient.invalidateQueries(api.keys.base()),
   });
 };


### PR DESCRIPTION
Fixes #11269

# 👩🏻‍💻 What does this PR do?

When deleting a Supplier Return from its detail page, the confirmation modal's OK button hangs and the page never navigates back to the list. Refreshing reveals the deletion did succeed.

Root cause: [`useSupplierReturnDelete`](client/packages/invoices/src/Returns/api/hooks/document/useSupplierDelete.ts) used an arrow expression body for `onSuccess`, which implicitly returned the `invalidateQueries` promise. React Query then made `mutateAsync` await every invalidated query's refetch — including the still-mounted detail page's own `useReturns.document.supplierReturn()` query, which was refetching the just-deleted record. With retries enabled in production, that refetch never settles, so `await mutateAsync(...)` never resolves and `navigate(...)` never fires.

The fix: use `void` so the `invalidateQueries` promise isn't returned. The mutation now resolves as soon as the delete itself succeeds; navigation runs immediately; the background refetch happens fire-and-forget after the detail page has unmounted.

Same shape applied to `useCustomerReturnDelete` for consistency, and the customer-return navigation moved out of the hook into [`CustomerDetailView/SidePanel.tsx`](client/packages/invoices/src/Returns/CustomerDetailView/SidePanel/SidePanel.tsx) so the hook is route-agnostic and matches the supplier pattern.

## 💌 Any notes for the reviewer?

I had trouble reproducing this locally — the modal would show loading for a moment under throttling but never actually got stuck. Claude eventually pinned it on React Query's `retry` setting: dev disables it (so the doomed refetch errors out after one attempt and `mutateAsync` resolves), while prod has `retry: true` (retry forever, so the refetch loops indefinitely and `mutateAsync` hangs). Setting `retry: true` locally reproduces it cleanly. That's probably why no devs caught this.

Could have been avoided with #11412 to remove the infinite retry. Also is better to have dev and prod behave the same imo.

# 🧪 Testing

- [ ] On a production build with React Query retry enabled (or temporarily flip `retry: true` in [Host.tsx](client/packages/host/src/Host.tsx) to simulate prod), go to Replenishment → Supplier Returns → open or create a return
- [ ] More → Delete → confirm. Modal should close immediately and the page should navigate back to the Supplier Returns list
- [ ] Repeat for Customer Returns (Distribution → Customer Returns) — same expected behaviour
- [ ] Verify list-view multi-row delete (Footer "Delete lines" action) still works for both supplier and customer returns

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend