### PR TITLE
#10965 Show unit in New Stock modal

### DIFF
--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -153,44 +153,46 @@ export const StockLineForm = ({
           flexWrap="nowrap"
           maxWidth={900}
         >
-          {!isNewModal && (
-            <Box paddingBottom={1}>
-              <TextWithLabelRow
-                label={`${t('label.item')}`}
-                text={''}
-                labelProps={{ sx: { fontWeight: 'bold', width: '100px' } }}
-                textProps={{ sx: { pl: 1 } }}
-              />
-              <Box
-                sx={{
-                  paddingLeft: '110px',
-                  marginTop: '-24px',
-                  marginBottom: '8px',
-                }}
-              >
-                <Link
-                  to={RouteBuilder.create(AppRoute.Catalogue)
-                    .addPart(AppRoute.Items)
-                    .addPart(draft.itemId)
-                    .build()}
+          <Box paddingBottom={1}>
+            {!isNewModal && (
+              <>
+                <TextWithLabelRow
+                  label={`${t('label.item')}`}
+                  text={''}
+                  labelProps={{ sx: { fontWeight: 'bold', width: '100px' } }}
+                  textProps={{ sx: { pl: 1 } }}
+                />
+                <Box
+                  sx={{
+                    paddingLeft: '110px',
+                    marginTop: '-24px',
+                    marginBottom: '8px',
+                  }}
                 >
-                  {draft.item.name}
-                </Link>
-              </Box>
-              <TextWithLabelRow
-                label={`${t('label.code')}`}
-                text={draft.item.code}
-                labelProps={{ sx: { fontWeight: 'bold', width: '100px' } }}
-                textProps={{ sx: { pl: 1 } }}
-              />
-              <TextWithLabelRow
-                label={`${t('label.unit')}`}
-                text={draft.item.unitName ?? ''}
-                labelProps={{ sx: { fontWeight: 'bold', width: '100px' } }}
-                textProps={{ sx: { pl: 1 } }}
-              />
-            </Box>
-          )}
+                  <Link
+                    to={RouteBuilder.create(AppRoute.Catalogue)
+                      .addPart(AppRoute.Items)
+                      .addPart(draft.itemId)
+                      .build()}
+                  >
+                    {draft.item.name}
+                  </Link>
+                </Box>
+                <TextWithLabelRow
+                  label={`${t('label.code')}`}
+                  text={draft.item.code}
+                  labelProps={{ sx: { fontWeight: 'bold', width: '100px' } }}
+                  textProps={{ sx: { pl: 1 } }}
+                />
+              </>
+            )}
+            <TextWithLabelRow
+              label={`${t('label.unit')}`}
+              text={draft.item.unitName ?? ''}
+              labelProps={{ sx: { fontWeight: 'bold', width: '100px' } }}
+              textProps={{ sx: { pl: 1 } }}
+            />
+          </Box>
           <Box>
             <Grid container gap={isNewModal ? undefined : 10}>
               <Grid container flex={1} flexDirection="column" gap={1}>


### PR DESCRIPTION
Fixes #10965

# 👩🏻‍💻 What does this PR do?

<img align="right" width="300" alt="image" src="https://github.com/user-attachments/assets/e8ad282e-c264-4905-837f-dd3670dc8eae" />

Renders the item's unit in the New Stock modal (positive inventory adjustment). Previously the unit row was only shown in the edit view of an existing stock line.

The fix moves the `Unit` row out of the `!isNewModal` branch in `StockLineForm` so it always renders. Item name + code remain gated on `!isNewModal` because the New Stock modal already shows them via the item search input above the form.

## 💌 Any notes for the reviewer?

Tiny change, single file. The `isNewModal` toggle still exists for the item-name/code block — only the unit row was lifted out.

# 🧪 Testing

- [ ] Inventory > Stock > click 'New Stock'
- [ ] Pick an item; confirm the unit is displayed
- [ ] Open an existing stock line and confirm name / code / unit still render as before

# 📃 Documentation

- [x] **No documentation required**: bug fix, not a behaviour change