### PR TITLE
#10920 Add PurchaseOrderFinalise permission and refactor PO update auth

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -525,7 +525,7 @@ export type AssetLogNode = {
   createdDatetime: Scalars['NaiveDateTime']['output'];
   documents: SyncFileReferenceConnector;
   id: Scalars['String']['output'];
-  logDatetime: Scalars['NaiveDateTime']['output'];
+  logDatetime: Scalars['DateTime']['output'];
   reason?: Maybe<AssetLogReasonNode>;
   status?: Maybe<AssetLogStatusNodeType>;
   type: AssetLogTypeNodeType;
@@ -623,7 +623,7 @@ export type AssetNode = {
   catalogProperties?: Maybe<Scalars['String']['output']>;
   catalogueItem?: Maybe<AssetCatalogueItemNode>;
   catalogueItemId?: Maybe<Scalars['String']['output']>;
-  createdDatetime: Scalars['NaiveDateTime']['output'];
+  createdDatetime: Scalars['DateTime']['output'];
   documents: SyncFileReferenceConnector;
   donor?: Maybe<NameNode>;
   donorNameId?: Maybe<Scalars['String']['output']>;
@@ -631,7 +631,7 @@ export type AssetNode = {
   installationDate?: Maybe<Scalars['NaiveDate']['output']>;
   locations: LocationConnector;
   lockedFields: LockedAssetFieldsNode;
-  modifiedDatetime: Scalars['NaiveDateTime']['output'];
+  modifiedDatetime: Scalars['DateTime']['output'];
   needsReplacement?: Maybe<Scalars['Boolean']['output']>;
   notes?: Maybe<Scalars['String']['output']>;
   /** Returns a JSON string of the asset properties (defined on the asset itself) e.g {"property_key": "value"} */
@@ -9777,7 +9777,7 @@ export type SyncFileReferenceConnector = {
 
 export type SyncFileReferenceNode = {
   __typename: 'SyncFileReferenceNode';
-  createdDatetime: Scalars['NaiveDateTime']['output'];
+  createdDatetime: Scalars['DateTime']['output'];
   fileName: Scalars['String']['output'];
   id: Scalars['String']['output'];
   mimeType?: Maybe<Scalars['String']['output']>;
@@ -11352,6 +11352,7 @@ export enum UserPermission {
   PrescriptionMutate = 'PRESCRIPTION_MUTATE',
   PrescriptionQuery = 'PRESCRIPTION_QUERY',
   PurchaseOrderAuthorise = 'PURCHASE_ORDER_AUTHORISE',
+  PurchaseOrderFinalise = 'PURCHASE_ORDER_FINALISE',
   PurchaseOrderMutate = 'PURCHASE_ORDER_MUTATE',
   PurchaseOrderQuery = 'PURCHASE_ORDER_QUERY',
   Report = 'REPORT',

--- a/server/graphql/purchase_order/src/mutations/mod.rs
+++ b/server/graphql/purchase_order/src/mutations/mod.rs
@@ -3,7 +3,83 @@ pub mod delete;
 pub mod insert;
 pub mod update;
 
+use async_graphql::*;
+use graphql_core::standard_graphql_error::{validate_auth, StandardGraphqlError};
+use graphql_types::types::PurchaseOrderNodeStatus;
+use repository::{PurchaseOrderRowRepository, PurchaseOrderStatus, StorageConnection};
+use service::auth::{Resource, ResourceAccessRequest};
+use service::preference::{AuthorisePurchaseOrder, Preference};
 use service::purchase_order::add_to_purchase_order_from_master_list::AddToPurchaseOrderFromMasterListInput as ServiceInput;
+
+/// Run the auth checks needed to update a purchase order.
+///
+/// Always requires `MutatePurchaseOrder`. Additionally requires:
+/// - `AuthorisePurchaseOrder` when transitioning to Confirmed and the store
+///   has the `purchase_order_must_be_authorised` preference enabled.
+/// - `FinalisePurchaseOrder` when transitioning to Finalised.
+///
+/// Perms are only checked on actual transitions, so re-submitting the current
+/// status doesn't fire a misleading auth error.
+// TODO: same pattern as validate_line_edit_authorisation — the graphql/service
+// split makes data-driven perms awkward. Splitting `updatePurchaseOrder` into
+// per-transition mutations would remove this helper entirely.
+pub fn validate_purchase_order_update_authorisation(
+    ctx: &Context<'_>,
+    store_id: &str,
+    connection: &StorageConnection,
+    purchase_order_id: &str,
+    new_status: &Option<PurchaseOrderNodeStatus>,
+) -> Result<()> {
+    validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::MutatePurchaseOrder,
+            store_id: Some(store_id.to_string()),
+        },
+    )?;
+
+    let Some(new_status) = new_status.map(PurchaseOrderStatus::from) else {
+        return Ok(());
+    };
+
+    let current_status = PurchaseOrderRowRepository::new(connection)
+        .find_one_by_id(purchase_order_id)
+        .map_err(StandardGraphqlError::from_repository_error)?
+        .map(|p| p.status);
+
+    if current_status.as_ref() == Some(&new_status) {
+        return Ok(());
+    }
+
+    match new_status {
+        PurchaseOrderStatus::Confirmed => {
+            let auth_required = AuthorisePurchaseOrder
+                .load(connection, Some(store_id.to_string()))
+                .map_err(|e| StandardGraphqlError::InternalError(format!("{e:?}")).extend())?;
+            if auth_required {
+                validate_auth(
+                    ctx,
+                    &ResourceAccessRequest {
+                        resource: Resource::AuthorisePurchaseOrder,
+                        store_id: Some(store_id.to_string()),
+                    },
+                )?;
+            }
+        }
+        PurchaseOrderStatus::Finalised => {
+            validate_auth(
+                ctx,
+                &ResourceAccessRequest {
+                    resource: Resource::FinalisePurchaseOrder,
+                    store_id: Some(store_id.to_string()),
+                },
+            )?;
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
 
 #[derive(async_graphql::InputObject)]
 pub struct AddToPurchaseOrderFromMasterListInput {

--- a/server/graphql/purchase_order/src/mutations/update.rs
+++ b/server/graphql/purchase_order/src/mutations/update.rs
@@ -181,25 +181,19 @@ pub fn update_purchase_order(
 
     let service_provider = ctx.service_provider();
     let service_context = service_provider.context(store_id.to_string(), user.user_id)?;
-    let user_has_auth_permission = input.status == Some(PurchaseOrderNodeStatus::Confirmed)
-        && validate_auth(
-            ctx,
-            &ResourceAccessRequest {
-                resource: Resource::AuthorisePurchaseOrder,
-                store_id: Some(store_id.to_string()),
-            },
-        )
-        .is_ok();
+
+    super::validate_purchase_order_update_authorisation(
+        ctx,
+        store_id,
+        &service_context.connection,
+        &input.id,
+        &input.status,
+    )?;
 
     map_response(
         service_provider
             .purchase_order_service
-            .update_purchase_order(
-                &service_context,
-                store_id,
-                input.to_domain(),
-                Some(user_has_auth_permission),
-            ),
+            .update_purchase_order(&service_context, store_id, input.to_domain()),
     )
 }
 
@@ -233,7 +227,6 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
         | ServiceError::PurchaseOrderDoesNotExist
         | ServiceError::NotASupplier
         | ServiceError::DonorDoesNotExist
-        | ServiceError::UserUnableToAuthorisePurchaseOrder
         | ServiceError::CannotEditSentPurchaseOrder => BadUserInput(formatted_error),
         ServiceError::DatabaseError(_) | ServiceError::UpdatedRecordNotFound => {
             InternalError(formatted_error)

--- a/server/graphql/types/src/types/permissions.rs
+++ b/server/graphql/types/src/types/permissions.rs
@@ -47,6 +47,7 @@ pub enum UserPermission {
     PurchaseOrderQuery,
     PurchaseOrderMutate,
     PurchaseOrderAuthorise,
+    PurchaseOrderFinalise,
     InboundShipmentExternalQuery,
     InboundShipmentExternalMutate,
     InboundShipmentExternalAuthorise,

--- a/server/repository/src/db_diesel/user_permission_row.rs
+++ b/server/repository/src/db_diesel/user_permission_row.rs
@@ -71,6 +71,7 @@ pub enum PermissionType {
     PurchaseOrderQuery,
     PurchaseOrderMutate,
     PurchaseOrderAuthorise,
+    PurchaseOrderFinalise,
     // inbound shipment external
     InboundShipmentExternalQuery,
     InboundShipmentExternalMutate,

--- a/server/repository/src/migrations/mod.rs
+++ b/server/repository/src/migrations/mod.rs
@@ -41,6 +41,7 @@ mod v2_16_00;
 mod v2_17_00;
 mod v2_17_03;
 mod v2_18_00;
+mod v2_19_00;
 mod version;
 mod views;
 
@@ -150,6 +151,7 @@ pub fn migrate(
         Box::new(v2_17_00::V2_17_00),
         Box::new(v2_17_03::V2_17_03),
         Box::new(v2_18_00::V2_18_00),
+        Box::new(v2_19_00::V2_19_00),
     ];
 
     // Check if the database has been initialised, if not run the base sql to kick start the process

--- a/server/repository/src/migrations/v2_19_00/add_purchase_order_finalise_permission.rs
+++ b/server/repository/src/migrations/v2_19_00/add_purchase_order_finalise_permission.rs
@@ -1,0 +1,22 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_purchase_order_finalise_permission"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        if cfg!(feature = "postgres") {
+            sql!(
+                connection,
+                r#"
+                    ALTER TYPE permission_type ADD VALUE 'PURCHASE_ORDER_FINALISE';
+                "#
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_19_00/mod.rs
+++ b/server/repository/src/migrations/v2_19_00/mod.rs
@@ -1,0 +1,44 @@
+use super::{version::Version, Migration, MigrationFragment};
+use crate::StorageConnection;
+
+mod add_purchase_order_finalise_permission;
+
+pub(crate) struct V2_19_00;
+impl Migration for V2_19_00 {
+    fn version(&self) -> Version {
+        Version::from_str("2.19.0")
+    }
+
+    fn migrate(&self, _connection: &StorageConnection) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn migrate_fragments(&self) -> Vec<Box<dyn MigrationFragment>> {
+        vec![Box::new(add_purchase_order_finalise_permission::Migrate)]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[actix_rt::test]
+    async fn migration_2_19_00() {
+        use crate::migrations::*;
+        use crate::test_db::*;
+        use v2_18_00::V2_18_00;
+        use v2_19_00::V2_19_00;
+
+        let previous_version = V2_18_00.version();
+        let version = V2_19_00.version();
+
+        let SetupResult { connection, .. } = setup_test(SetupOption {
+            db_name: &format!("migration_{version}"),
+            version: Some(previous_version.clone()),
+            ..Default::default()
+        })
+        .await;
+
+        // Run this migration
+        migrate(&connection, Some(version.clone())).unwrap();
+        assert_eq!(get_database_version(&connection), version);
+    }
+}

--- a/server/service/src/auth.rs
+++ b/server/service/src/auth.rs
@@ -168,6 +168,7 @@ pub enum Resource {
     QueryPurchaseOrder,
     MutatePurchaseOrder,
     AuthorisePurchaseOrder,
+    FinalisePurchaseOrder,
     // Inbound Shipment External
     MutateInboundShipmentExternal,
     QueryInboundShipmentExternal,
@@ -842,6 +843,13 @@ fn all_permissions() -> HashMap<Resource, PermissionDSL> {
         PermissionDSL::And(vec![
             PermissionDSL::HasStoreAccess,
             PermissionDSL::HasPermission(PermissionType::PurchaseOrderAuthorise),
+        ]),
+    );
+    map.insert(
+        Resource::FinalisePurchaseOrder,
+        PermissionDSL::And(vec![
+            PermissionDSL::HasStoreAccess,
+            PermissionDSL::HasPermission(PermissionType::PurchaseOrderFinalise),
         ]),
     );
 

--- a/server/service/src/login.rs
+++ b/server/service/src/login.rs
@@ -471,6 +471,9 @@ fn permissions_to_domain(permissions: Vec<Permissions>) -> HashSet<PermissionTyp
             Permissions::AuthorisePurchaseOrders => {
                 output.insert(PermissionType::PurchaseOrderAuthorise);
             }
+            Permissions::FinalisePurchaseOrders => {
+                output.insert(PermissionType::PurchaseOrderFinalise);
+            }
             // goods received
             Permissions::ViewGoodsReceived => {
                 output.insert(PermissionType::InboundShipmentExternalQuery);

--- a/server/service/src/purchase_order/mod.rs
+++ b/server/service/src/purchase_order/mod.rs
@@ -58,9 +58,8 @@ pub trait PurchaseOrderServiceTrait: Sync + Send {
         ctx: &ServiceContext,
         store_id: &str,
         input: UpdatePurchaseOrderInput,
-        user_has_permission: Option<bool>,
     ) -> Result<PurchaseOrderRow, UpdatePurchaseOrderError> {
-        update_purchase_order(ctx, store_id, input, user_has_permission)
+        update_purchase_order(ctx, store_id, input)
     }
 
     fn delete_purchase_order(

--- a/server/service/src/purchase_order/update/mod.rs
+++ b/server/service/src/purchase_order/update/mod.rs
@@ -25,7 +25,6 @@ pub enum UpdatePurchaseOrderError {
     UpdatedRecordNotFound,
     NotASupplier,
     DonorDoesNotExist,
-    UserUnableToAuthorisePurchaseOrder,
     CannotEditSentPurchaseOrder,
     DatabaseError(RepositoryError),
     ItemsCannotBeOrdered(Vec<PurchaseOrderLine>),
@@ -130,13 +129,11 @@ pub fn update_purchase_order(
     ctx: &ServiceContext,
     store_id: &str,
     input: UpdatePurchaseOrderInput,
-    user_has_auth_permission: Option<bool>,
 ) -> Result<PurchaseOrderRow, UpdatePurchaseOrderError> {
     let purchase_order = ctx
         .connection
         .transaction_sync(|connection: &repository::StorageConnection| {
-            let (purchase_order, next_status) =
-                validate(&input, store_id, connection, user_has_auth_permission)?;
+            let (purchase_order, next_status) = validate(&input, store_id, connection)?;
             let existing_purchase_order = purchase_order.clone();
             let mut purchase_order_input = input.clone();
             if let Some(new_status) = next_status {

--- a/server/service/src/purchase_order/update/test.rs
+++ b/server/service/src/purchase_order/update/test.rs
@@ -40,7 +40,6 @@ mod update {
 
         let store_id = &mock_store_a().id;
         let purchase_order_id = "purchase_order_id".to_string();
-        let user_permission = false;
 
         service
             .insert_purchase_order(
@@ -63,7 +62,6 @@ mod update {
                     supplier_id: Some("non_existent_supplier".to_string()),
                     ..Default::default()
                 },
-                None
             ),
             Err(UpdatePurchaseOrderError::SupplierDoesNotExist)
         );
@@ -78,7 +76,6 @@ mod update {
                     supplier_id: Some(mock_name_store_b().id.to_string()),
                     ..Default::default()
                 },
-                None
             ),
             Err(UpdatePurchaseOrderError::NotASupplier)
         );
@@ -95,34 +92,8 @@ mod update {
                     }),
                     ..Default::default()
                 },
-                None
             ),
             Err(UpdatePurchaseOrderError::DonorDoesNotExist)
-        );
-
-        // UserUnableToAuthorisePurchaseOrder
-        // Add preference to require authorisation on purchase orders
-        PreferenceRowRepository::new(&context.connection)
-            .upsert_one(&PreferenceRow {
-                id: "authorise_purchase_order_pref".to_string(),
-                key: AuthorisePurchaseOrder.key().to_string(),
-                value: "true".to_string(),
-                store_id: None, // Global pref so needs store: None
-            })
-            .unwrap();
-
-        assert_eq!(
-            service.update_purchase_order(
-                &context,
-                store_id,
-                UpdatePurchaseOrderInput {
-                    id: "purchase_order_id".to_string(),
-                    status: Some(PurchaseOrderStatus::Confirmed),
-                    ..Default::default()
-                },
-                Some(user_permission)
-            ),
-            Err(UpdatePurchaseOrderError::UserUnableToAuthorisePurchaseOrder)
         );
     }
 
@@ -139,7 +110,6 @@ mod update {
 
         let store_id = &mock_store_a().id;
         let purchase_order_id = "purchase_order_id".to_string();
-        let user_permission = true;
 
         // Create a purchase order row with a valid supplier
         service
@@ -214,7 +184,6 @@ mod update {
                     }),
                     ..Default::default()
                 },
-                None,
             )
             .unwrap();
 
@@ -240,7 +209,6 @@ mod update {
                     status: Some(PurchaseOrderStatus::RequestApproval),
                     ..Default::default()
                 },
-                Some(user_permission),
             )
             .unwrap();
 
@@ -272,7 +240,6 @@ mod update {
                     status: Some(PurchaseOrderStatus::Sent),
                     ..Default::default()
                 },
-                None,
             )
             .unwrap();
 
@@ -382,7 +349,6 @@ mod update {
                     status: Some(PurchaseOrderStatus::Sent),
                     ..Default::default()
                 },
-                None,
             )
             .unwrap();
 
@@ -411,7 +377,6 @@ mod update {
 
         let store_id = &mock_store_a().id;
         let purchase_order_id = "purchase_order_id_with_auth".to_string();
-        let user_permission = true;
 
         // Add preference to require authorisation on purchase orders
         PreferenceRowRepository::new(&context.connection)
@@ -471,7 +436,6 @@ mod update {
                     status: Some(PurchaseOrderStatus::RequestApproval),
                     ..Default::default()
                 },
-                None,
             )
             .unwrap();
 
@@ -500,7 +464,6 @@ mod update {
                     status: Some(PurchaseOrderStatus::Confirmed),
                     ..Default::default()
                 },
-                Some(user_permission),
             )
             .unwrap();
 
@@ -528,7 +491,6 @@ mod update {
                     status: Some(PurchaseOrderStatus::Sent),
                     ..Default::default()
                 },
-                None,
             )
             .unwrap();
 
@@ -553,7 +515,6 @@ mod update {
                     status: Some(PurchaseOrderStatus::Finalised),
                     ..Default::default()
                 },
-                None,
             )
             .unwrap();
 

--- a/server/service/src/purchase_order/update/validate.rs
+++ b/server/service/src/purchase_order/update/validate.rs
@@ -16,7 +16,6 @@ pub fn validate(
     input: &UpdatePurchaseOrderInput,
     store_id: &str,
     connection: &StorageConnection,
-    user_has_auth_permission: Option<bool>,
 ) -> Result<(PurchaseOrder, Option<PurchaseOrderStatus>), UpdatePurchaseOrderError> {
     let purchase_order = PurchaseOrderRepository::new(connection)
         .query_by_filter(
@@ -35,20 +34,12 @@ pub fn validate(
         return Err(UpdatePurchaseOrderError::CannotEditSentPurchaseOrder);
     }
 
-    // Check auth is required before changing to Request Approval
+    // If RequestApproval is asked for but the store doesn't require authorisation,
+    // skip straight to Confirmed.
     if input.status == Some(PurchaseOrderStatus::RequestApproval) {
         let requires_auth = check_requires_auth(connection, store_id)?;
         if !requires_auth {
-            // If no authorisation required, return status Confirmed
             return Ok((purchase_order, Some(PurchaseOrderStatus::Confirmed)));
-        }
-    }
-
-    // Check user has permission to authorise purchase order, if authorisation is required
-    if input.status == Some(PurchaseOrderStatus::Confirmed) {
-        let requires_auth = check_requires_auth(connection, store_id)?;
-        if requires_auth && user_has_auth_permission != Some(true) {
-            return Err(UpdatePurchaseOrderError::UserUnableToAuthorisePurchaseOrder);
         }
     }
 

--- a/server/service/src/purchase_order_line/update/mod.rs
+++ b/server/service/src/purchase_order_line/update/mod.rs
@@ -90,12 +90,7 @@ pub fn update_purchase_order_line(
 
                 // Update purchase order status
                 if purchase_order.status == PurchaseOrderStatus::Sent {
-                    update_order_status_on_adjusted_quantity_change(
-                        ctx,
-                        store_id,
-                        purchase_order,
-                        user_has_auth_permission,
-                    )?;
+                    update_order_status_on_adjusted_quantity_change(ctx, store_id, purchase_order)?;
                 }
 
                 // Handle line status change to New separately. The Purchase Order status may have already been changed by another line
@@ -142,17 +137,11 @@ fn update_order_status_on_adjusted_quantity_change(
     ctx: &ServiceContext,
     store_id: &str,
     purchase_order: PurchaseOrderRow,
-    user_has_auth_permission: Option<bool>,
 ) -> Result<(), UpdatePurchaseOrderLineInputError> {
     let purchase_order_input = create_purchase_order_input(&purchase_order.id);
 
-    update_purchase_order(
-        ctx,
-        store_id,
-        purchase_order_input,
-        user_has_auth_permission,
-    )
-    .map_err(|_| UpdatePurchaseOrderLineInputError::DatabaseError(RepositoryError::NotFound))?;
+    update_purchase_order(ctx, store_id, purchase_order_input)
+        .map_err(|_| UpdatePurchaseOrderLineInputError::DatabaseError(RepositoryError::NotFound))?;
 
     Ok(())
 }

--- a/server/service/src/purchase_order_line/update/test.rs
+++ b/server/service/src/purchase_order_line/update/test.rs
@@ -31,7 +31,7 @@ mod update {
             .unwrap();
         let service = service_provider.purchase_order_line_service;
         let purchase_order_service = service_provider.purchase_order_service;
-        let mut user_permission = true;
+        let mut user_permission;
 
         // Create a purchase order line
         service
@@ -129,7 +129,6 @@ mod update {
                     status: Some(repository::PurchaseOrderStatus::Sent),
                     ..Default::default()
                 },
-                Some(user_permission),
             )
             .unwrap();
 
@@ -253,7 +252,6 @@ mod update {
                     status: Some(repository::PurchaseOrderStatus::Finalised),
                     ..Default::default()
                 },
-                None,
             ),
             Err(UpdatePurchaseOrderError::InboundShipmentsNotVerified)
         );
@@ -276,7 +274,6 @@ mod update {
                     status: Some(repository::PurchaseOrderStatus::Finalised),
                     ..Default::default()
                 },
-                None,
             )
             .unwrap();
 


### PR DESCRIPTION
Fixes #10920 (item #<!-- -->9 only — see scope notes below)

# 👩🏻‍💻 What does this PR do?

Adds a new `PurchaseOrderFinalise` permission that gates the transition to `Finalised` status. Previously anyone with `PurchaseOrderMutate` could finalise a PO, with no separate gate — issue #10920 #<!-- -->9.

While doing this, refactors the PO update auth flow into a single GraphQL-layer helper that reads current state and only enforces `Authorise`/`Finalise` perms on actual transitions. This drops the `Option<bool> user_has_auth_permission` flag that was previously threaded through the service layer for the Authorise check.

The new helper mirrors the existing `validate_line_edit_authorisation` precedent for inbound shipment lines.

### Concrete changes

**Server**
- New `PermissionType::PurchaseOrderFinalise` enum variant
- New `Resource::FinalisePurchaseOrder` + auth.rs DSL mapping (`HasStoreAccess + PurchaseOrderFinalise`)
- New `v2_19_00` migration: `ALTER TYPE permission_type ADD VALUE 'PURCHASE_ORDER_FINALISE'` (Postgres only; SQLite stores as TEXT)
- Legacy mSupply `Permissions::FinalisePurchaseOrders` (perm 37) now maps to `PurchaseOrderFinalise` on login
- New `validate_purchase_order_update_authorisation` helper at `server/graphql/purchase_order/src/mutations/mod.rs` — fetches current PO row, checks `Mutate` always, `Authorise` only on transition to Confirmed when store pref requires it, `Finalise` only on transition to Finalised
- `update_purchase_order` service no longer takes `user_has_auth_permission: Option<bool>`
- `UserUnableToAuthorisePurchaseOrder` service error variant removed (now a GraphQL-layer auth error)
- Cascade from `update_purchase_order_line` → `update_purchase_order` no longer threads the flag
- Service tests updated; obsolete `UserUnableToAuthorisePurchaseOrder` test deleted

**Frontend**
- `client/packages/common/src/types/schema.ts` regenerated. Includes the new `UserPermission.PurchaseOrderFinalise` (intentional) and also picks up unrelated stale-schema drift on Asset/SyncFileReference datetime fields from #11208 — flagged for the reviewer below.

# 💌 Any notes for the reviewer?

**Scope is intentionally narrow.** Issue #10920 lists 14 items. This PR only addresses #<!-- -->9 (Finalise permission) plus the auth refactor needed to do it cleanly. Other items still open:
- #<!-- -->1 (granular stocktake perms), #<!-- -->3 (view cost prices), #<!-- -->4 (modify sell/cost prices), #<!-- -->7 (PO pricing field gate), #<!-- -->11 (PO print perm) — each needs its own design discussion or new perm + migration.
- #<!-- -->6, #<!-- -->10, #<!-- -->12 — backend already checks; suspected to be JWT/session staleness or test-environment artefact. Worth re-testing before treating as bugs.
- #<!-- -->14 (goods received label) — code routing is correct; mismatch is in legacy mSupply text only.
- #<!-- -->8 (Authorise alone can't authorise) — design call about whether Authorise should imply Mutate; intentionally not changed.

**Architectural pattern note.** The `validate_purchase_order_update_authorisation` helper carries a TODO comment matching the one already in `validate_line_edit_authorisation`: data-driven perms are awkward at the GraphQL/service split. The proper long-term fix is to split `updatePurchaseOrder` into per-transition mutations (`confirmPurchaseOrder`, `finalisePurchaseOrder`, etc.) — out of scope here, worth a follow-up issue.

**Schema drift in this PR.** `client/packages/common/src/types/schema.ts` includes 4 unrelated lines flipping `NaiveDateTime` → `DateTime` on AssetLogNode, AssetNode, SyncFileReferenceNode. These are stale codegen catching up to commit `bc093dbe92` from #11208 (already merged). Not part of the auth work but came along with `yarn generate`. Easy to drop into a separate PR if preferred — happy to.

**Not part of this PR's refactor.** `update_purchase_order_line` still has its own `user_has_auth_permission` flag — `can_edit_adjusted_quantity` legitimately uses it for service-layer gating (allows editing adjusted quantities on Sent POs only with Authorise perm). Same shape of cleanup is possible but explicitly out of scope.

# 🧪 Testing

- [ ] Sync up legacy mSupply user with `Finalise Purchase Orders` (perm 37) granted
- [ ] As a user **without** `PurchaseOrderFinalise` (but with `PurchaseOrderMutate`): take a PO to Confirmed/Sent, attempt to set status to Finalised via the GraphiQL `updatePurchaseOrder` mutation — expect auth error
- [ ] Grant `PurchaseOrderFinalise` to the same user; repeat — expect success
- [ ] ~~As a user with `PurchaseOrderMutate` only, on an already-Finalised PO, submit `updatePurchaseOrder({status: Finalised, comment: "x"})` — expect `CannotEditSentPurchaseOrder` error (NOT a misleading auth error)~~
- [ ] On a store with `purchase_order_must_be_authorised` preference enabled: a user with `PurchaseOrderMutate` but not `PurchaseOrderAuthorise` cannot transition to Confirmed; a user with both can
- [ ] Existing PO line update flows (adjusting quantities on a Sent PO with Authorise perm) still work — service-side flag is unchanged
- [ ] Activity log still records Finalised event correctly when PO is finalised
- [ ] Postgres + SQLite migration both apply cleanly from a 2.18 DB

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**:
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)
