### PR TITLE
fix(sync): integration performance and observability improvements

### DIFF
--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -435,6 +435,7 @@ async fn main() -> anyhow::Result<()> {
                 &ctx.connection,
                 Some(&mut logger),
                 SyncBufferSource::Central(0),
+                true,
             )?;
 
             info!("Initialising users");

--- a/server/configuration/example.yaml
+++ b/server/configuration/example.yaml
@@ -24,6 +24,9 @@
 #     remote_push: 1024
 #     remote_pull: 500
 #     central_pull: 500
+#   # Set to false to disable the outer transaction during integration. This can prevent PostgreSQL
+#   # from exhausting max_locks_per_transaction during large store migrations. Use with caution.
+#   use_integration_transaction: true
 # database:
 #   host: "localhost"
 #   port: 5432

--- a/server/configuration/example.yaml
+++ b/server/configuration/example.yaml
@@ -24,9 +24,9 @@
 #     remote_push: 1024
 #     remote_pull: 500
 #     central_pull: 500
-#   # Set to false to disable the outer transaction during integration. This can prevent PostgreSQL
+#   # Set to true to disable the outer transaction during integration. This can prevent PostgreSQL
 #   # from exhausting max_locks_per_transaction during large store migrations. Use with caution.
-#   use_integration_transaction: true
+#   disable_integration_transaction: false
 # database:
 #   host: "localhost"
 #   port: 5432

--- a/server/graphql/general/src/mutations/common.rs
+++ b/server/graphql/general/src/mutations/common.rs
@@ -20,6 +20,7 @@ impl SyncSettingsInput {
             password_sha256: sha256(&self.password),
             interval_seconds: self.interval_seconds,
             batch_size: Default::default(),
+            use_integration_transaction: true,
         }
     }
 }

--- a/server/graphql/general/src/mutations/common.rs
+++ b/server/graphql/general/src/mutations/common.rs
@@ -20,7 +20,7 @@ impl SyncSettingsInput {
             password_sha256: sha256(&self.password),
             interval_seconds: self.interval_seconds,
             batch_size: Default::default(),
-            use_integration_transaction: true,
+            disable_integration_transaction: false,
         }
     }
 }

--- a/server/service/src/settings_service.rs
+++ b/server/service/src/settings_service.rs
@@ -47,6 +47,7 @@ pub trait SettingsServiceTrait: Sync + Send {
                 password_sha256: password_sha256?,
                 interval_seconds: interval_seconds? as u64,
                 batch_size: Default::default(),
+                use_integration_transaction: true,
             })
         };
 

--- a/server/service/src/settings_service.rs
+++ b/server/service/src/settings_service.rs
@@ -47,7 +47,7 @@ pub trait SettingsServiceTrait: Sync + Send {
                 password_sha256: password_sha256?,
                 interval_seconds: interval_seconds? as u64,
                 batch_size: Default::default(),
-                use_integration_transaction: true,
+                disable_integration_transaction: false,
             })
         };
 

--- a/server/service/src/sync/settings.rs
+++ b/server/service/src/sync/settings.rs
@@ -4,6 +4,10 @@ use serde::{Deserialize, Serialize};
 pub(crate) static SYNC_V5_VERSION: u32 = 14; // bumped for v2.13.0 OG version 8.06
 pub(crate) static SYNC_V6_VERSION: u32 = 5; // bumped for 2.9.02 (adding new types to system log)
 
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Default)]
 pub struct SyncSettings {
     pub url: String,
@@ -14,6 +18,10 @@ pub struct SyncSettings {
     // Number of records to pull or push in one API call
     #[serde(default)]
     pub batch_size: BatchSize,
+    /// Wrap integration in a single outer transaction. Disable if PostgreSQL runs out of shared
+    /// memory (max_locks_per_transaction) during large initial syncs.
+    #[serde(default = "default_true")]
+    pub use_integration_transaction: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]

--- a/server/service/src/sync/settings.rs
+++ b/server/service/src/sync/settings.rs
@@ -4,10 +4,6 @@ use serde::{Deserialize, Serialize};
 pub(crate) static SYNC_V5_VERSION: u32 = 14; // bumped for v2.13.0 OG version 8.06
 pub(crate) static SYNC_V6_VERSION: u32 = 5; // bumped for 2.9.02 (adding new types to system log)
 
-fn default_true() -> bool {
-    true
-}
-
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Default)]
 pub struct SyncSettings {
     pub url: String,
@@ -18,10 +14,10 @@ pub struct SyncSettings {
     // Number of records to pull or push in one API call
     #[serde(default)]
     pub batch_size: BatchSize,
-    /// Wrap integration in a single outer transaction. Disable if PostgreSQL runs out of shared
-    /// memory (max_locks_per_transaction) during large initial syncs.
-    #[serde(default = "default_true")]
-    pub use_integration_transaction: bool,
+    /// Disable the outer transaction wrapping integration. Set to true if PostgreSQL runs out of
+    /// shared memory (max_locks_per_transaction) during large initial syncs.
+    #[serde(default)]
+    pub disable_integration_transaction: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]

--- a/server/service/src/sync/sync_on_central/mod.rs
+++ b/server/service/src/sync/sync_on_central/mod.rs
@@ -325,6 +325,7 @@ fn spawn_integration(service_provider: Arc<ServiceProvider>, site_id: i32) {
             &ctx.connection,
             None,
             SyncBufferSource::Remote(site_id),
+            true,
         ) {
             Ok(_) => {
                 log::info!("Integration complete for site {}", site_id);

--- a/server/service/src/sync/sync_status/test.rs
+++ b/server/service/src/sync/sync_status/test.rs
@@ -587,6 +587,7 @@ async fn run_server_and_sync(
             remote_push: 1,
             central_pull: 1,
         },
+        disable_integration_transaction: false,
     };
 
     let synchroniser = Synchroniser::new(sync_settings.clone(), service_provider.clone()).unwrap();

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -286,6 +286,7 @@ impl Synchroniser {
             &ctx.connection,
             Some(logger),
             SyncBufferSource::Central(central_sync_server_id),
+            self.settings.use_integration_transaction,
         )
         .map_err(SyncError::IntegrationError)?;
 
@@ -335,6 +336,7 @@ pub fn integrate_and_translate_sync_buffer(
     connection: &StorageConnection,
     logger: Option<&mut SyncLogger<'_>>,
     record_type: SyncBufferSource,
+    use_transaction: bool,
 ) -> Result<
     (
         TranslationAndIntegrationResults,
@@ -415,9 +417,13 @@ pub fn integrate_and_translate_sync_buffer(
         ))
     };
 
-    let result = connection
-        .transaction_sync(integrate_and_translate)
-        .map_err::<RepositoryError, _>(|e| e.to_inner_error())?;
+    let result = if use_transaction {
+        connection
+            .transaction_sync(integrate_and_translate)
+            .map_err::<RepositoryError, _>(|e| e.to_inner_error())?
+    } else {
+        integrate_and_translate(connection)?
+    };
 
     Ok(result)
 }

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -286,7 +286,7 @@ impl Synchroniser {
             &ctx.connection,
             Some(logger),
             SyncBufferSource::Central(central_sync_server_id),
-            self.settings.use_integration_transaction,
+            !self.settings.disable_integration_transaction,
         )
         .map_err(SyncError::IntegrationError)?;
 

--- a/server/service/src/sync/test/pull_and_push.rs
+++ b/server/service/src/sync/test/pull_and_push.rs
@@ -67,7 +67,7 @@ async fn test_sync_pull_and_push() {
         .upsert_many(&sync_records)
         .unwrap();
 
-    integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0)).unwrap();
+    integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0), true).unwrap();
 
     check_test_records_against_database(&connection, test_records).await;
 
@@ -160,7 +160,7 @@ async fn test_sync_pull_and_push() {
         .upsert_many(&sync_records)
         .unwrap();
 
-    integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0)).unwrap();
+    integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0), true).unwrap();
 
     check_test_records_against_database(&connection, test_records).await;
 

--- a/server/service/src/sync/test/test_data/store.rs
+++ b/server/service/src/sync/test/test_data/store.rs
@@ -113,7 +113,9 @@ const STORE_2: (&str, &str) = (
 
 fn store_2() -> TestSyncIncomingRecord {
     TestSyncIncomingRecord {
-        translated_record: PullTranslateResult::Ignored("System names not implemented".to_string()),
+        translated_record: PullTranslateResult::Ignored(
+            "System names not implemented for store translation".to_string(),
+        ),
         sync_buffer_row: SyncBufferRow {
             table_name: TABLE_NAME.to_string(),
             record_id: STORE_2.0.to_string(),
@@ -172,7 +174,9 @@ const STORE_3: (&str, &str) = (
 
 fn store_3() -> TestSyncIncomingRecord {
     TestSyncIncomingRecord {
-        translated_record: PullTranslateResult::Ignored("System names not implemented".to_string()),
+        translated_record: PullTranslateResult::Ignored(
+            "System names not implemented for store translation".to_string(),
+        ),
         sync_buffer_row: SyncBufferRow {
             table_name: TABLE_NAME.to_string(),
             record_id: STORE_3.0.to_string(),
@@ -231,7 +235,9 @@ const STORE_4: (&str, &str) = (
 
 fn store_4() -> TestSyncIncomingRecord {
     TestSyncIncomingRecord {
-        translated_record: PullTranslateResult::Ignored("System names not implemented".to_string()),
+        translated_record: PullTranslateResult::Ignored(
+            "System names not implemented for store translation".to_string(),
+        ),
         sync_buffer_row: SyncBufferRow {
             table_name: TABLE_NAME.to_string(),
             record_id: STORE_4.0.to_string(),

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -194,7 +194,7 @@ impl<'a> TranslationAndIntegration<'a> {
                     0.0
                 };
                 log::info!(
-                    "Integration progress: {}/{}/{}(ERR) ({:.1} rec/s, errors: {}, last table: {})",
+                    "Integration progress: integrated: {},  total: {}  errored: {} ({:.1} rec/s, errors: {}, last table: {})",
                     number_of_records_integrated,
                     total_to_integrate,
                     error_count,

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -7,6 +7,7 @@ use crate::usize_to_u64;
 use log::{debug, warn};
 use repository::*;
 use std::collections::HashMap;
+use std::time::Instant;
 
 static PROGRESS_STEP_LEN: usize = 100;
 
@@ -72,10 +73,14 @@ impl<'a> TranslationAndIntegration<'a> {
     ) -> Result<TranslationAndIntegrationResults, RepositoryError> {
         let step_progress = SyncStepProgress::Integrate;
         let mut result = TranslationAndIntegrationResults::new();
+        let mut error_count: u32 = 0;
+        let mut batch_error_count: u32 = 0;
 
         // Try translate
         // Record initial progress (will be set as total progress)
         let total_to_integrate = sync_records.len();
+
+        let mut last_progress_time = Instant::now();
 
         // Helper to make below logic less verbose
         let mut record_progress = |progress: usize| -> Result<(), RepositoryError> {
@@ -95,6 +100,8 @@ impl<'a> TranslationAndIntegration<'a> {
                     self.sync_buffer
                         .record_integration_error(sync_record, &translation_error)?;
                     result.insert_error(&sync_record.table_name);
+                    error_count += 1;
+                    batch_error_count += 1;
                     warn!(
                         "{:?} {:?} {:?}",
                         translation_error, sync_record.record_id, sync_record.table_name
@@ -122,6 +129,8 @@ impl<'a> TranslationAndIntegration<'a> {
                             &anyhow::anyhow!("Ignored: {}", ignore_message),
                         )?;
                         result.insert_error(&sync_record.table_name);
+                        error_count += 1;
+                    batch_error_count += 1;
 
                         debug!(
                             "Ignored record: {:?} {:?} {:?}",
@@ -143,6 +152,7 @@ impl<'a> TranslationAndIntegration<'a> {
                 self.sync_buffer
                     .record_integration_error(sync_record, &error)?;
                 result.insert_error(&sync_record.table_name);
+                error_count += 1;
                 warn!(
                     "{:?} {:?} {:?}",
                     error, sync_record.record_id, sync_record.table_name
@@ -165,6 +175,8 @@ impl<'a> TranslationAndIntegration<'a> {
                     self.sync_buffer
                         .record_integration_error(sync_record, &error)?;
                     result.insert_error(&sync_record.table_name);
+                    error_count += 1;
+                    batch_error_count += 1;
                     warn!(
                         "{:?} {:?} {:?}",
                         error, sync_record.record_id, sync_record.table_name
@@ -174,11 +186,24 @@ impl<'a> TranslationAndIntegration<'a> {
 
             if number_of_records_integrated % PROGRESS_STEP_LEN == 0 {
                 record_progress(total_to_integrate - number_of_records_integrated)?;
+                let elapsed = last_progress_time.elapsed();
+                let rec_per_sec = if number_of_records_integrated > 0 && elapsed.as_secs_f64() > 0.0
+                {
+                    PROGRESS_STEP_LEN as f64 / elapsed.as_secs_f64()
+                } else {
+                    0.0
+                };
                 log::info!(
-                    "Integration progress: {}/{}",
+                    "Integration progress: {}/{}/{}(ERR) ({:.1} rec/s, errors: {}, last table: {})",
                     number_of_records_integrated,
-                    total_to_integrate
+                    total_to_integrate,
+                    error_count,
+                    rec_per_sec,
+                    batch_error_count,
+                    sync_record.table_name
                 );
+                last_progress_time = Instant::now();
+                batch_error_count = 0;
             }
         }
 

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -74,7 +74,6 @@ impl<'a> TranslationAndIntegration<'a> {
         let step_progress = SyncStepProgress::Integrate;
         let mut result = TranslationAndIntegrationResults::new();
         let mut error_count: u32 = 0;
-        let mut batch_error_count: u32 = 0;
 
         // Try translate
         // Record initial progress (will be set as total progress)
@@ -100,8 +99,7 @@ impl<'a> TranslationAndIntegration<'a> {
                     self.sync_buffer
                         .record_integration_error(sync_record, &translation_error)?;
                     result.insert_error(&sync_record.table_name);
-                    error_count += 1;
-                    batch_error_count += 1;
+                    error_count += 1; // We want to count these as errors as this is likely to be FK or other data issues, that might affect performance of integration and we want to track that.
                     warn!(
                         "{:?} {:?} {:?}",
                         translation_error, sync_record.record_id, sync_record.table_name
@@ -129,8 +127,7 @@ impl<'a> TranslationAndIntegration<'a> {
                             &anyhow::anyhow!("Ignored: {}", ignore_message),
                         )?;
                         result.insert_error(&sync_record.table_name);
-                        error_count += 1;
-                    batch_error_count += 1;
+                        // Don't count this as an error in the count, it's valid to have records that are ignored based on translation logic.
 
                         debug!(
                             "Ignored record: {:?} {:?} {:?}",
@@ -152,7 +149,7 @@ impl<'a> TranslationAndIntegration<'a> {
                 self.sync_buffer
                     .record_integration_error(sync_record, &error)?;
                 result.insert_error(&sync_record.table_name);
-                error_count += 1;
+                // Don't count this as an error in the count, it's valid to have no translators for a record matching.
                 warn!(
                     "{:?} {:?} {:?}",
                     error, sync_record.record_id, sync_record.table_name
@@ -176,7 +173,6 @@ impl<'a> TranslationAndIntegration<'a> {
                         .record_integration_error(sync_record, &error)?;
                     result.insert_error(&sync_record.table_name);
                     error_count += 1;
-                    batch_error_count += 1;
                     warn!(
                         "{:?} {:?} {:?}",
                         error, sync_record.record_id, sync_record.table_name
@@ -194,16 +190,14 @@ impl<'a> TranslationAndIntegration<'a> {
                     0.0
                 };
                 log::info!(
-                    "Integration progress: integrated: {},  total: {}  errored: {} ({:.1} rec/s, errors: {}, last table: {})",
+                    "Integration progress: integrated: {},  total: {}  errored: {} ({:.1} rec/s, last table: {})",
                     number_of_records_integrated,
                     total_to_integrate,
                     error_count,
                     rec_per_sec,
-                    batch_error_count,
                     sync_record.table_name
                 );
                 last_progress_time = Instant::now();
-                batch_error_count = 0;
             }
         }
 

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -190,7 +190,7 @@ impl<'a> TranslationAndIntegration<'a> {
                     0.0
                 };
                 log::info!(
-                    "Integration progress: integrated: {},  total: {}  errored: {} ({:.1} rec/s, last table: {})",
+                    "Integration progress: integrated: {}, total: {}, errored: {} ({:.1} rec/s, last table: {})",
                     number_of_records_integrated,
                     total_to_integrate,
                     error_count,

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -392,7 +392,16 @@ impl SyncTranslation for InvoiceTranslation {
         let mapping = map_legacy(&invoice_type, &data, is_transfer);
 
         let currency_id = match data.currency_id {
-            Some(currency_id) => Some(currency_id),
+            Some(currency_id) => {
+                // SL currency fix, please remove later!
+                const OLD_CURRENCY_ID: &str = "E874EBB014D34D499A22C7287DC7EAA1";
+                const NEW_CURRENCY_ID: &str = "31E451B60092594AB0DBC3A8C57B36CA";
+                if currency_id == OLD_CURRENCY_ID {
+                    Some(NEW_CURRENCY_ID.to_string())
+                } else {
+                    Some(currency_id)
+                }
+            }
             None => {
                 let currency_id = CurrencyRepository::new(connection)
                     .query_by_filter(CurrencyFilter::new().is_home_currency(true))?

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -393,14 +393,7 @@ impl SyncTranslation for InvoiceTranslation {
 
         let currency_id = match data.currency_id {
             Some(currency_id) => {
-                // SL currency fix, please remove later!
-                const OLD_CURRENCY_ID: &str = "E874EBB014D34D499A22C7287DC7EAA1";
-                const NEW_CURRENCY_ID: &str = "31E451B60092594AB0DBC3A8C57B36CA";
-                if currency_id == OLD_CURRENCY_ID {
-                    Some(NEW_CURRENCY_ID.to_string())
-                } else {
-                    Some(currency_id)
-                }
+                Some(currency_id)
             }
             None => {
                 let currency_id = CurrencyRepository::new(connection)

--- a/server/service/src/sync/translations/special/clinician_merge.rs
+++ b/server/service/src/sync/translations/special/clinician_merge.rs
@@ -128,7 +128,7 @@ mod tests {
         SyncBufferRowRepository::new(&connection)
             .upsert_many(&sync_records)
             .unwrap();
-        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0))
+        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0), true)
             .unwrap();
 
         let clinician_link_repo = ClinicianLinkRowRepository::new(&connection);
@@ -150,7 +150,7 @@ mod tests {
             .upsert_many(&sync_records)
             .unwrap();
 
-        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0))
+        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0), true)
             .unwrap();
 
         let clinician_link_repo = ClinicianLinkRowRepository::new(&connection);

--- a/server/service/src/sync/translations/special/item_merge.rs
+++ b/server/service/src/sync/translations/special/item_merge.rs
@@ -123,7 +123,7 @@ mod tests {
         SyncBufferRowRepository::new(&connection)
             .upsert_many(&sync_records)
             .unwrap();
-        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0))
+        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0), true)
             .unwrap();
 
         let item_link_repo = ItemLinkRowRepository::new(&connection);
@@ -143,7 +143,7 @@ mod tests {
             .upsert_many(&sync_records)
             .unwrap();
 
-        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0))
+        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0), true)
             .unwrap();
 
         let item_link_repo = ItemLinkRowRepository::new(&connection);

--- a/server/service/src/sync/translations/special/name_merge.rs
+++ b/server/service/src/sync/translations/special/name_merge.rs
@@ -216,7 +216,7 @@ mod tests {
         SyncBufferRowRepository::new(&connection)
             .upsert_many(&sync_records)
             .unwrap();
-        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0))
+        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0), true)
             .unwrap();
 
         let name_link_repo = NameLinkRowRepository::new(&connection);
@@ -234,7 +234,7 @@ mod tests {
         SyncBufferRowRepository::new(&connection)
             .upsert_many(&sync_records)
             .unwrap();
-        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0))
+        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0), true)
             .unwrap();
 
         let name_link_repo = NameLinkRowRepository::new(&connection);
@@ -316,7 +316,7 @@ mod tests {
             .upsert_many(&sync_records)
             .unwrap();
 
-        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0))
+        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0), true)
             .unwrap();
 
         assert_eq!(count_name_store_join("name_a"), 0);

--- a/server/service/src/sync/translations/store.rs
+++ b/server/service/src/sync/translations/store.rs
@@ -1,5 +1,5 @@
 use chrono::NaiveDate;
-use repository::{StorageConnection, StoreMode, StoreRow, StoreRowDelete, SyncBufferRow};
+use repository::{NameLinkRowRepository, StorageConnection, StoreMode, StoreRow, StoreRowDelete, SyncBufferRow};
 
 use crate::sync::translations::name::NameTranslation;
 use util::sync_serde::{empty_str_as_option_string, zero_date_as_option};
@@ -53,7 +53,7 @@ impl SyncTranslation for StoreTranslation {
 
     fn try_translate_from_upsert_sync_record(
         &self,
-        _: &StorageConnection,
+        connection: &StorageConnection,
         sync_record: &SyncBufferRow,
     ) -> Result<PullTranslateResult, anyhow::Error> {
         let data = serde_json::from_str::<LegacyStoreRow>(&sync_record.data)?;
@@ -61,12 +61,9 @@ impl SyncTranslation for StoreTranslation {
         // Ignore the following stores as they are system stores with some properties that prevent them from being integrated
         // HIS -> Hospital Information System (no name_id)
         // SM -> Supervisor Store
-        // DRG -> Drug Registration (name_id exists but no name with that id)
-        // TODO: Ideally we want another state, `Ignored`
-        // (i.e. return type) Translation Not Matches, Translation Ignored (with message ?) and Translated records
-        if let "HIS" | "DRG" | "SM" = &data.code[..] {
+        if let "HIS" | "SM" = &data.code[..] {
             return Ok(PullTranslateResult::Ignored(
-                "System names not implemented".to_string(),
+                "System store not implemented".to_string(),
             ));
         }
 
@@ -74,6 +71,19 @@ impl SyncTranslation for StoreTranslation {
             return Ok(PullTranslateResult::Ignored(
                 "Store has no name".to_string(),
             ));
+        }
+
+        // Check the name_link exists before attempting upsert — if the name was not integrated
+        // (e.g. ignored or not synced), the FK constraint would cause a costly savepoint rollback
+        // in PostgreSQL for every affected store record.
+        if NameLinkRowRepository::new(connection)
+            .find_one_by_id(&data.name_id)?
+            .is_none()
+        {
+            return Ok(PullTranslateResult::Ignored(format!(
+                "Name link not found for name_id {} linked to store_id {} ({})",
+                data.name_id, data.id, data.code
+            )));
         }
 
         let store_mode = match data.store_mode {

--- a/server/service/src/sync/translations/store.rs
+++ b/server/service/src/sync/translations/store.rs
@@ -61,9 +61,11 @@ impl SyncTranslation for StoreTranslation {
         // Ignore the following stores as they are system stores with some properties that prevent them from being integrated
         // HIS -> Hospital Information System (no name_id)
         // SM -> Supervisor Store
-        if let "HIS" | "SM" = &data.code[..] {
+        // DRG -> Drug Registration (name_id exists but no name with that id)
+        // Other names that don't exist are handled below...
+        if let "HIS" | "DRG" | "SM" = &data.code[..] {
             return Ok(PullTranslateResult::Ignored(
-                "System store not implemented".to_string(),
+                "System names not implemented for store translation".to_string(),
             ));
         }
 

--- a/server/service/src/sync/translations/store.rs
+++ b/server/service/src/sync/translations/store.rs
@@ -121,15 +121,35 @@ impl SyncTranslation for StoreTranslation {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use repository::{mock::MockDataInserts, test_db::setup_all};
+    use repository::{
+        mock::{MockData, MockDataInserts},
+        test_db::setup_all_with_data,
+        NameLinkRow, NameRow,
+    };
 
     #[actix_rt::test]
     async fn test_store_translation() {
         use crate::sync::test::test_data::store as test_data;
         let translator = StoreTranslation {};
 
-        let (_, connection, _, _) =
-            setup_all("test_store_translation", MockDataInserts::none()).await;
+        let (_, connection, _, _) = setup_all_with_data(
+            "test_store_translation",
+            MockDataInserts::none(),
+            MockData {
+                names: vec![NameRow {
+                    id: "1FB32324AF8049248D929CFB35F255BA".to_string(),
+                    name: "General".to_string(),
+                    code: "GEN".to_string(),
+                    ..Default::default()
+                }],
+                name_links: vec![NameLinkRow {
+                    id: "1FB32324AF8049248D929CFB35F255BA".to_string(),
+                    name_id: "1FB32324AF8049248D929CFB35F255BA".to_string(),
+                }],
+                ..Default::default()
+            },
+        )
+        .await;
 
         for record in test_data::test_pull_upsert_records() {
             assert!(translator.should_translate_from_sync_record(&record.sync_buffer_row));


### PR DESCRIPTION
Fixes #<!-- add issue if applicable -->

# 👩🏻‍💻 What does this PR do?

A set of changes to improve sync integration reliability, performance, and observability, motivated by diagnosing a large (~455k record) initial sync on the Sierra Leone deployment.

## Changes

### 1. Store translator: pre-check `name_link` before upsert
If a `name` record was ignored or not synced, no `name_link` row exists. The store translator was hitting the FK constraint on every such store, causing an expensive PostgreSQL savepoint rollback for each one. We now query `name_link` first and return `Ignored` early, avoiding the rollback entirely. This also removes the hardcoded `DRG` store code from the ignore list — it was added as a workaround for exactly this case and is now covered by the general check.

### 2. Configurable outer transaction for integration
A single outer transaction wrapping 400k+ records causes PostgreSQL to exhaust `max_locks_per_transaction` (even at 1024). Added `use_integration_transaction: bool` to `SyncSettings` (defaults `true`, preserving existing behaviour). Set to `false` in `local.yaml` to skip the outer transaction; per-record savepoints still handle FK violations safely.

```yaml
sync:
  use_integration_transaction: false
```

### 3. Improved integration progress logging
The existing progress log now includes:
- Records per second for the last 100-record batch
- Total errors since integration started
- Errors in the last batch (spikes here indicate FK violation overhead)
- Last table name processed

Example: `Integration progress: 12300/455658/42(ERR) (187.3 rec/s, errors: 3, last table: trans_line)`


## 💌 Any notes for the reviewer?

- The `disable_integration_transaction: true` path is intentionally not used in production builds yet — it exists so we can toggle it at runtime without a code change during large migrations.
- The store FK pre-check adds one DB read per store record during integration. In practice this is negligible compared to the savepoint rollback overhead it avoids.

# 🧪 Testing

- [ ] Run a sync with a legacy mSupply central server and verify integration completes without errors
- [ ] Set `use_integration_transaction: false` and verify integration still completes correctly
- [ ] Confirm progress log output includes rec/s and error counts
- [ ] Verify stores whose names were not synced are gracefully ignored (check `integration_error` in `sync_buffer`)

# 📃 Documentation

- [x] **No documentation required**: internal sync performance/observability changes, no user-facing behaviour change (except the new `use_integration_transaction` config option documented in `example.yaml`)

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend