### PR TITLE
#10995 Backport: Move remaining qty to PO line selector header (2.18)

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1485,6 +1485,7 @@
   "label.rejected": "Rejected",
   "label.relationship": "Relationship",
   "label.remaining": "Remaining",
+  "label.remaining-quantity-to-receive": "Remaining quantity to receive: {{count}}",
   "label.remaining-to-supply": "Remaining",
   "label.remove": "Remove",
   "label.remove-all-filters": "Remove all filters",

--- a/client/packages/common/src/ui/forms/Modal/ModalLabel.tsx
+++ b/client/packages/common/src/ui/forms/Modal/ModalLabel.tsx
@@ -5,6 +5,7 @@ import { Property } from 'csstype';
 export interface ModalLabelProps {
   label: string;
   justifyContent?: Property.JustifyContent;
+  minWidth?: string;
 }
 
 const labelStyle = {
@@ -15,6 +16,7 @@ const labelStyle = {
 export const ModalLabel: React.FC<ModalLabelProps> = ({
   label,
   justifyContent = 'flex-start',
+  minWidth = '80px',
 }) => (
   <Grid
     item
@@ -24,7 +26,7 @@ export const ModalLabel: React.FC<ModalLabelProps> = ({
     sx={{
       alignItems: 'center',
       display: 'flex',
-      minWidth: '80px',
+      minWidth,
       '&.MuiGrid-root': { flexBasis: 0 },
     }}
   >

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
@@ -46,7 +46,6 @@ import { PatchDraftLineInput } from '../../../api';
 import { useInboundShipment } from '../../../api/hooks/document/useInboundShipment';
 import { isInboundPlaceholderRow } from '../../../../utils';
 import { useInvoiceLineStatusMap } from '../../..';
-import { usePurchaseOrder } from '@openmsupply-client/purchasing/src/purchase_order/api';
 
 interface CardProps {
   lines: DraftInboundLine[];
@@ -108,29 +107,8 @@ export const InboundLineEditCards = ({
     hasAuthorisePermission,
     isExternal,
   } = useInboundShipment();
-  const purchaseOrderId = inboundData?.purchaseOrder?.id;
   const isManualShipment =
     !inboundData?.purchaseOrder && !inboundData?.linkedShipment;
-  const { query: poQuery } = usePurchaseOrder(purchaseOrderId);
-
-  // Calculate outstanding packs for the current item from PO lines
-  // Outstanding = ordered packs - shipped packs, calculated per-line using requestedPackSize
-  const poOutstandingPacks = useMemo(() => {
-    if (!purchaseOrderId || !item?.id || !poQuery.data) return null;
-    let totalOutstandingPacks = 0;
-    for (const line of poQuery.data.lines.nodes) {
-      if (line.item.id === item.id) {
-        const orderedUnits =
-          line.adjustedNumberOfUnits ?? line.requestedNumberOfUnits;
-        const shippedUnits = line.shippedNumberOfUnits ?? 0;
-        const packSize = line.requestedPackSize || 1;
-        const orderedPacks = Math.ceil(orderedUnits / packSize);
-        const shippedPacks = Math.ceil(shippedUnits / packSize);
-        totalOutstandingPacks += orderedPacks - shippedPacks;
-      }
-    }
-    return totalOutstandingPacks;
-  }, [purchaseOrderId, item?.id, poQuery.data]);
 
   const showLineStatus =
     lines.some(line => line.status != null) ||
@@ -227,15 +205,6 @@ export const InboundLineEditCards = ({
                   sx={{ mt: 0.5, display: 'block' }}
                 >
                   {`${t('label.shipped-number-of-packs')}: ${shippedPacks}`}
-                </Typography>
-              )}
-              {!!purchaseOrderId && poOutstandingPacks != null && (
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  sx={{ mt: 0.5, display: 'block' }}
-                >
-                  {`${t('label.outstanding-packs')}: ${poOutstandingPacks}`}
                 </Typography>
               )}
             </Box>
@@ -788,7 +757,6 @@ export const InboundLineEditCards = ({
     isManualShipment,
     item?.isVaccine,
     pluralisedUnitName,
-    poOutstandingPacks,
     removeDraftLine,
     restrictedToLocationTypeId,
     setPackRoundingMessage,

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
@@ -4,6 +4,7 @@ import {
   ModalLabel,
   Grid,
   Box,
+  Typography,
   useTranslation,
   BasicTextInput,
   PurchaseOrderLineStatusNode,
@@ -78,50 +79,60 @@ export const InboundLineEditForm = ({
     );
   }, [query.data, data, selectedPOLine?.id, hasPurchaseOrder]);
 
+  const remainingUnits =
+    hasPurchaseOrder && selectedPOLine
+      ? (selectedPOLine.adjustedNumberOfUnits ??
+          selectedPOLine.requestedNumberOfUnits) -
+        (selectedPOLine.shippedNumberOfUnits ?? 0)
+      : null;
+
   if (hasPurchaseOrder) {
     return (
-      <Box display="flex" flexWrap="wrap" alignItems="center" gap={1}>
-        <Box
-          display="flex"
-          alignItems="center"
-          flex={1}
-          minWidth={300}
-          gap={1}
-        >
-          <ModalLabel
-            label={t('label.purchase-order-line')}
-            justifyContent="flex-end"
-          />
-          <Grid flex={1}>
-            <Autocomplete
-              autoFocus={!selectedPOLine}
-              disabled={disabled}
-              options={availablePOLines}
-              value={selectedPOLine}
-              getOptionLabel={(option: PurchaseOrderLineFragment) => {
-                const qty =
-                  option.adjustedNumberOfUnits ?? option.requestedNumberOfUnits;
-                return `#${option.lineNumber} ${option.item.name} (${option.item.code}) - ${qty} units`;
-              }}
-              isOptionEqualToValue={(a, b) => a.id === b.id}
-              onChange={(_, line) => onChangePOLine(line ?? null)}
-              width="100%"
+      <>
+        <Box display="flex" flexWrap="wrap" alignItems="center" gap={1}>
+          <Box
+            display="flex"
+            alignItems="center"
+            flex={1}
+            minWidth={300}
+            gap={1}
+          >
+            <ModalLabel
+              label={t('label.purchase-order-line')}
+              justifyContent="flex-end"
+              minWidth="fit-content"
             />
-          </Grid>
+            <Grid flex={1}>
+              <Autocomplete
+                autoFocus={!selectedPOLine}
+                disabled={disabled}
+                options={availablePOLines}
+                value={selectedPOLine}
+                getOptionLabel={(option: PurchaseOrderLineFragment) =>
+                  `#${option.lineNumber} ${option.item.name} (${option.item.code}) - ${t('label.pack-size')} ${option.requestedPackSize}`
+                }
+                isOptionEqualToValue={(a, b) => a.id === b.id}
+                onChange={(_, line) => onChangePOLine(line ?? null)}
+                width="100%"
+              />
+            </Grid>
+          </Box>
         </Box>
         {selectedPOLine && (
-          <Box display="flex" alignItems="center" gap={1}>
-            <ModalLabel label={t('label.unit')} justifyContent="flex-end" />
-            <BasicTextInput
-              disabled
-              sx={{ width: 150 }}
-              value={
-                selectedPOLine.unit ?? selectedPOLine.item.unitName ?? ''
-              }
-            />
+          <Box display="flex" justifyContent="space-between" sx={{ mt: 1, ml: 1 }}>
+            {remainingUnits != null && (
+              <Typography variant="body2" color="text.secondary">
+                {t('label.remaining-quantity-to-receive', {
+                  count: remainingUnits,
+                })}
+              </Typography>
+            )}
+            <Typography variant="body2" color="text.secondary">
+              {`${t('label.unit')}: ${selectedPOLine.unit ?? selectedPOLine.item.unitName ?? ''}`}
+            </Typography>
           </Box>
         )}
-      </Box>
+      </>
     );
   }
 


### PR DESCRIPTION
Fixes #10995

# 👩🏻‍💻 What does this PR do?

Backports #11306 to the `v2.18.0-RC` branch.

The original PR was merged to `develop` on 2026-04-22 (merge commit `8f5d1186`) but never made it onto `v2.18.0-RC`, so the QA build `2.18.00-RC-04241406` still showed the old behaviour ("outstanding packs" on each batch card and a truncated "Purchase..." label) — see [this comment](https://github.com/msupply-foundation/open-msupply/issues/10995#issuecomment-4340949316).

This branch is a clean cherry-pick (`-m 1`) of the merge commit onto `v2.18.0-RC`. Only one trivial auto-merge in `client/packages/common/src/intl/locales/en/common.json`.

## 💌 Any notes for the reviewer?

- Pure backport — no logic changes vs #11306.
- Touches only client code: `ModalLabel.tsx`, `InboundLineEditCards.tsx`, `InboundLineEditForm.tsx`, and one translation key.
- Same behavioural change described on #11306: per-batch "outstanding packs" removed, "Remaining quantity to receive" shown below the PO line selector, full "Purchase order lines" label visible, unit type moved out of the disabled input into a label row.

# 🧪 Testing

- [ ] Build from `v2.18.0-RC` with this branch merged
- [ ] Open an external inbound shipment linked to a purchase order with multiple lines for the same item
- [ ] Confirm "Purchase order lines" label is no longer truncated to "Purchase…"
- [ ] Confirm "Remaining quantity to receive: {n}" appears below the PO line selector and updates per selected PO line
- [ ] Confirm the disabled unit-type input is gone from the selector row and the unit appears as a label below
- [ ] Confirm individual batch cards no longer show "outstanding packs"

# 📃 Documentation

- [x] **No documentation required**: backport of an already-documented change