### PR TITLE
#10770 React 19 followup render-loop and console error fixes

### DIFF
--- a/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
+++ b/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
@@ -223,7 +223,7 @@ export const useNativeClient = ({
         connectToPrevious(previousServer);
       }
     });
-  }, [state.previousServer, autoconnect, state, nativeAPI, connectToPrevious]);
+  }, [state.previousServer, autoconnect, nativeAPI, connectToPrevious]);
 
   return {
     ...state,

--- a/client/packages/common/src/intl/number/IntlNumber.ts
+++ b/client/packages/common/src/intl/number/IntlNumber.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { RegexUtils } from '../../utils/regex';
 import { useCurrency } from '../currency';
 import { MAX_FRACTION_DIGITS, SupportedLocales, useIntlUtils } from '../utils';
@@ -21,8 +22,8 @@ export const useFormatNumber = () => {
     options: { separator, decimal },
   } = useCurrency();
 
-  return {
-    format: (
+  const format = useCallback(
+    (
       value: number | undefined,
       options?: Intl.NumberFormatOptions & { locale?: SupportedLocales }
     ) => {
@@ -48,7 +49,11 @@ export const useFormatNumber = () => {
             : (maximumFractionDigits ?? MAX_FRACTION_DIGITS),
       }).format(value);
     },
-    round: (value?: number, dp?: number): string => {
+    [currentLanguage]
+  );
+
+  const round = useCallback(
+    (value?: number, dp?: number): string => {
       if (value === undefined || value === null || typeof value !== 'number')
         return '';
 
@@ -63,7 +68,11 @@ export const useFormatNumber = () => {
       });
       return intl.format(newVal ?? 0);
     },
-    roundUpToWholeNumber: (value?: number): string => {
+    [currentLanguage]
+  );
+
+  const roundUpToWholeNumber = useCallback(
+    (value?: number): string => {
       if (value === undefined || value === null || typeof value !== 'number')
         return '';
 
@@ -73,7 +82,11 @@ export const useFormatNumber = () => {
       });
       return intl.format(newVal ?? 0);
     },
-    parse: (numberString: string, decimalChar: string = decimal) => {
+    [currentLanguage]
+  );
+
+  const parse = useCallback(
+    (numberString: string, decimalChar: string = decimal) => {
       const negative = numberString.startsWith('-') ? -1 : 1;
 
       const num = RegexUtils.convertIndoArToArNumerals(numberString)
@@ -88,5 +101,8 @@ export const useFormatNumber = () => {
 
       return Number(num) * negative;
     },
-  };
+    [separator, decimal]
+  );
+
+  return { format, round, roundUpToWholeNumber, parse };
 };

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { getLocale, useIntlUtils, useTranslation } from '@common/intl';
 import {
   addMinutes,
@@ -226,49 +227,74 @@ export const useFormatDateTime = () => {
   const locale = getLocale(currentLanguage);
   const t = useTranslation();
 
-  const localisedDate = (date: Date | string | number): string =>
-    formatIfValid(dateInputHandler(date), 'P', { locale });
+  const localisedDate = useCallback(
+    (date: Date | string | number): string =>
+      formatIfValid(dateInputHandler(date), 'P', { locale }),
+    [locale]
+  );
 
-  const localisedTime = (date: Date | string | number): string =>
-    formatIfValid(dateInputHandler(date), 'p', { locale });
+  const localisedTime = useCallback(
+    (date: Date | string | number): string =>
+      formatIfValid(dateInputHandler(date), 'p', { locale }),
+    [locale]
+  );
 
-  const localisedDateTime = (date: Date | string | number): string =>
-    format(dateInputHandler(date), 'P p', { locale });
+  const localisedDateTime = useCallback(
+    (date: Date | string | number): string =>
+      format(dateInputHandler(date), 'P p', { locale }),
+    [locale]
+  );
 
-  const dayMonthShort = (date: Date | string | number): string =>
-    formatIfValid(dateInputHandler(date), 'dd MMM', { locale });
+  const dayMonthShort = useCallback(
+    (date: Date | string | number): string =>
+      formatIfValid(dateInputHandler(date), 'dd MMM', { locale }),
+    [locale]
+  );
 
-  const dayMonthTime = (date: Date | string | number): string =>
-    formatIfValid(dateInputHandler(date), 'dd/MM HH:mm', { locale });
+  const dayMonthTime = useCallback(
+    (date: Date | string | number): string =>
+      formatIfValid(dateInputHandler(date), 'dd/MM HH:mm', { locale }),
+    [locale]
+  );
 
-  const customDate = (
-    date: Date | string | number,
-    formatString: string
-  ): string => formatIfValid(dateInputHandler(date), formatString, { locale });
+  const customDate = useCallback(
+    (date: Date | string | number, formatString: string): string =>
+      formatIfValid(dateInputHandler(date), formatString, { locale }),
+    [locale]
+  );
 
-  const relativeDateTime = (
-    date: Date | string | number,
-    baseDate: Date = new Date()
-  ): string => {
-    const d = dateInputHandler(date);
-    return isValid(d) ? formatRelative(d, baseDate, { locale }) : '';
-  };
+  const relativeDateTime = useCallback(
+    (
+      date: Date | string | number,
+      baseDate: Date = new Date()
+    ): string => {
+      const d = dateInputHandler(date);
+      return isValid(d) ? formatRelative(d, baseDate, { locale }) : '';
+    },
+    [locale]
+  );
 
-  const localisedDistanceToNow = (date: Date | string | number) => {
-    const d = dateInputHandler(date);
-    return isValid(d) ? formatDistanceToNow(d, { locale }) : '';
-  };
+  const localisedDistanceToNow = useCallback(
+    (date: Date | string | number) => {
+      const d = dateInputHandler(date);
+      return isValid(d) ? formatDistanceToNow(d, { locale }) : '';
+    },
+    [locale]
+  );
 
-  const localisedDistance = (
-    startDate: Date | string | number,
-    endDate: Date | string | number
-  ) => {
-    const from = dateInputHandler(startDate);
-    const to = dateInputHandler(endDate);
-    return isValid(from) && isValid(to)
-      ? formatDistance(from, to, { locale })
-      : '';
-  };
+  const localisedDistance = useCallback(
+    (
+      startDate: Date | string | number,
+      endDate: Date | string | number
+    ) => {
+      const from = dateInputHandler(startDate);
+      const to = dateInputHandler(endDate);
+      return isValid(from) && isValid(to)
+        ? formatDistance(from, to, { locale })
+        : '';
+    },
+    [locale]
+  );
 
   // Returns a formatted age for the input date (of birth) relative to the
   // current date. Will format as whole number of years unless the age is less
@@ -277,21 +303,27 @@ export const useFormatDateTime = () => {
   // - DOB is 2 years in the past => "2"
   // - DOB is 9 months and 2 days ago => "9 months, 2 days"
   // - DOB is 5 days ago => "5 days"
-  const getDisplayAge = (dob: Date | null | undefined): string => {
-    if (!dob) return '';
-    const patientAge = DateUtils.age(dob);
-    const { months, days } = DateUtils.ageInMonthsAndDays(dob ?? '');
+  const getDisplayAge = useCallback(
+    (dob: Date | null | undefined): string => {
+      if (!dob) return '';
+      const patientAge = DateUtils.age(dob);
+      const { months, days } = DateUtils.ageInMonthsAndDays(dob ?? '');
 
-    if (patientAge >= 1) {
-      return `${t('label.age-years', { count: patientAge })}`;
-    } else
-      return `${months > 0 ? t('label.age-months-and', { count: months }) : ''}${t('label.age-days', { count: days })}`;
-  };
+      if (patientAge >= 1) {
+        return `${t('label.age-years', { count: patientAge })}`;
+      } else
+        return `${months > 0 ? t('label.age-months-and', { count: months }) : ''}${t('label.age-days', { count: days })}`;
+    },
+    [t]
+  );
 
-  const formatDaysFromToday = (days?: number): string => {
-    const date = days ? DateUtils.addDays(new Date(), days) : new Date();
-    return customDate(date, URL_QUERY_DATE);
-  };
+  const formatDaysFromToday = useCallback(
+    (days?: number): string => {
+      const date = days ? DateUtils.addDays(new Date(), days) : new Date();
+      return customDate(date, URL_QUERY_DATE);
+    },
+    [customDate]
+  );
 
   return {
     urlQueryDate: URL_QUERY_DATE,

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteMulti.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteMulti.tsx
@@ -50,6 +50,7 @@ export function AutocompleteMulti<
   slotProps,
   loadingText,
   noOptionsText,
+  inputProps,
   ...restOfAutocompleteProps
 }: PropsWithChildren<
   AutocompleteMultiProps<T, true, DisableClearable, FreeSolo, ChipComponent>
@@ -58,6 +59,7 @@ export function AutocompleteMulti<
   const defaultRenderInput = (props: AutocompleteRenderInputParams) => (
     <BasicTextInput
       {...props}
+      {...inputProps}
       autoFocus={autoFocus}
       slotProps={{
         input: {

--- a/client/packages/common/src/ui/layout/tables/components/SettingsMenu.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/SettingsMenu.tsx
@@ -180,9 +180,10 @@ export const SettingsMenu = ({
           <ListItemIcon>{densityIcon()}</ListItemIcon>
           <ListItemText> {t('label.toggle-density')}</ListItemText>
         </MenuItem>
-        {onSaveAsGlobalDefault && <Divider />}
-        {onSaveAsGlobalDefault && (
+        {onSaveAsGlobalDefault && [
+          <Divider key="save-default-divider" />,
           <MenuItem
+            key="save-default"
             onClick={() => {
               onSaveAsGlobalDefault();
               setAnchorEl(null);
@@ -194,8 +195,8 @@ export const SettingsMenu = ({
             <ListItemText>
               {t('label.save-table-config-as-global-default')}
             </ListItemText>
-          </MenuItem>
-        )}
+          </MenuItem>,
+        ]}
         <Divider />
         <MenuItem
           disabled={!hasAnySavedState}

--- a/client/packages/common/src/ui/layout/tables/components/SettingsMenu.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/SettingsMenu.tsx
@@ -115,112 +115,108 @@ export const SettingsMenu = ({
         >
           <Typography fontWeight="bold">Settings</Typography>
         </MenuItem>
-        <>
+        <MenuItem
+          disabled={!state?.columnOrder}
+          onClick={() => {
+            if (globalDefaults?.columnOrder)
+              table.setColumnOrder(globalDefaults.columnOrder);
+            else table.resetColumnOrder();
+            columnOrder.update(columnOrder.initial);
+            setAnchorEl(null);
+          }}
+        >
+          <ListItemIcon>
+            <SwapHorizIcon />
+          </ListItemIcon>
+          <ListItemText>{t('label.reset-column-order')}</ListItemText>
+        </MenuItem>
+        <MenuItem
+          disabled={!state?.columnVisibility}
+          onClick={() => {
+            if (globalDefaults?.columnVisibility)
+              table.setColumnVisibility(globalDefaults.columnVisibility);
+            else table.resetColumnVisibility();
+            columnVisibility.update(columnVisibility.initial);
+            setAnchorEl(null);
+          }}
+        >
+          <ListItemIcon>
+            <EyeIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>{t('label.show-all-columns')}</ListItemText>
+        </MenuItem>
+        <MenuItem
+          disabled={!state?.columnSizing}
+          onClick={() => {
+            if (globalDefaults?.columnSizing)
+              table.setColumnSizing(globalDefaults.columnSizing);
+            else table.resetColumnSizing();
+            columnSizing.update(columnSizing.initial);
+            setAnchorEl(null);
+          }}
+        >
+          <ListItemIcon>
+            <RestartAltIcon />
+          </ListItemIcon>
+          <ListItemText>{t('label.reset-column-sizes')}</ListItemText>
+        </MenuItem>
+        <MenuItem
+          disabled={!state?.columnPinning}
+          onClick={() => {
+            if (globalDefaults?.columnPinning)
+              table.setColumnPinning(globalDefaults.columnPinning);
+            else table.resetColumnPinning();
+            columnPinning.update(columnPinning.initial);
+            setAnchorEl(null);
+          }}
+        >
+          <ListItemIcon>
+            <PushPinIcon />
+          </ListItemIcon>
+          <ListItemText>{t('label.reset-pinned-columns')}</ListItemText>
+        </MenuItem>
+        <Divider />
+        <MenuItem onClick={() => density.update(nextDensity)}>
+          <ListItemIcon>{densityIcon()}</ListItemIcon>
+          <ListItemText> {t('label.toggle-density')}</ListItemText>
+        </MenuItem>
+        {onSaveAsGlobalDefault && <Divider />}
+        {onSaveAsGlobalDefault && (
           <MenuItem
-            disabled={!state?.columnOrder}
             onClick={() => {
-              if (globalDefaults?.columnOrder)
-                table.setColumnOrder(globalDefaults.columnOrder);
-              else table.resetColumnOrder();
-              columnOrder.update(columnOrder.initial);
+              onSaveAsGlobalDefault();
               setAnchorEl(null);
             }}
           >
             <ListItemIcon>
-              <SwapHorizIcon />
+              <SaveIcon fontSize="small" />
             </ListItemIcon>
-            <ListItemText>{t('label.reset-column-order')}</ListItemText>
-          </MenuItem>
-          <MenuItem
-            disabled={!state?.columnVisibility}
-            onClick={() => {
-              if (globalDefaults?.columnVisibility)
-                table.setColumnVisibility(globalDefaults.columnVisibility);
-              else table.resetColumnVisibility();
-              columnVisibility.update(columnVisibility.initial);
-              setAnchorEl(null);
-            }}
-          >
-            <ListItemIcon>
-              <EyeIcon fontSize="small" />
-            </ListItemIcon>
-            <ListItemText>{t('label.show-all-columns')}</ListItemText>
-          </MenuItem>
-          <MenuItem
-            disabled={!state?.columnSizing}
-            onClick={() => {
-              if (globalDefaults?.columnSizing)
-                table.setColumnSizing(globalDefaults.columnSizing);
-              else table.resetColumnSizing();
-              columnSizing.update(columnSizing.initial);
-              setAnchorEl(null);
-            }}
-          >
-            <ListItemIcon>
-              <RestartAltIcon />
-            </ListItemIcon>
-            <ListItemText>{t('label.reset-column-sizes')}</ListItemText>
-          </MenuItem>
-          <MenuItem
-            disabled={!state?.columnPinning}
-            onClick={() => {
-              if (globalDefaults?.columnPinning)
-                table.setColumnPinning(globalDefaults.columnPinning);
-              else table.resetColumnPinning();
-              columnPinning.update(columnPinning.initial);
-              setAnchorEl(null);
-            }}
-          >
-            <ListItemIcon>
-              <PushPinIcon />
-            </ListItemIcon>
-            <ListItemText>{t('label.reset-pinned-columns')}</ListItemText>
-          </MenuItem>
-          <Divider />
-          <MenuItem onClick={() => density.update(nextDensity)}>
-            <ListItemIcon>{densityIcon()}</ListItemIcon>
-            <ListItemText> {t('label.toggle-density')}</ListItemText>
-          </MenuItem>
-          {onSaveAsGlobalDefault && (
-            <>
-              <Divider />
-              <MenuItem
-                onClick={() => {
-                  onSaveAsGlobalDefault();
-                  setAnchorEl(null);
-                }}
-              >
-                <ListItemIcon>
-                  <SaveIcon fontSize="small" />
-                </ListItemIcon>
-                <ListItemText>
-                  {t('label.save-table-config-as-global-default')}
-                </ListItemText>
-              </MenuItem>
-            </>
-          )}
-          <Divider />
-          <MenuItem
-            disabled={!hasAnySavedState}
-            onClick={() => {
-              getResetConfirmation();
-              setAnchorEl(null);
-            }}
-          >
-            <ListItemIcon>
-              <RefreshIcon fontSize="small" color={'error'} />
-            </ListItemIcon>
-            <ListItemText
-              sx={{
-                '& .MuiTypography-root': {
-                  color: 'error.main',
-                },
-              }}
-            >
-              {t('label.reset-table-defaults')}
+            <ListItemText>
+              {t('label.save-table-config-as-global-default')}
             </ListItemText>
           </MenuItem>
-        </>
+        )}
+        <Divider />
+        <MenuItem
+          disabled={!hasAnySavedState}
+          onClick={() => {
+            getResetConfirmation();
+            setAnchorEl(null);
+          }}
+        >
+          <ListItemIcon>
+            <RefreshIcon fontSize="small" color={'error'} />
+          </ListItemIcon>
+          <ListItemText
+            sx={{
+              '& .MuiTypography-root': {
+                color: 'error.main',
+              },
+            }}
+          >
+            {t('label.reset-table-defaults')}
+          </ListItemText>
+        </MenuItem>
       </Menu>
     </>
   );

--- a/client/packages/common/src/ui/layout/tables/tableState/useColumnOrder.ts
+++ b/client/packages/common/src/ui/layout/tables/tableState/useColumnOrder.ts
@@ -48,11 +48,12 @@ export const useColumnOrder = <T extends MRT_RowData>(
 
   // If initial state changes (due to plugin column loading, for example) and no
   // custom column order has been saved, update the column order to the new
-  // default
+  // default. globalDefaults?.columnOrder is included so the saved global order
+  // applies when preferences load after this hook has already mounted.
   useEffect(() => {
     if (!getSavedState(tableId)?.columnOrder)
       setState(globalDefaults?.columnOrder ?? initial);
-  }, [initial, hasExpanding]);
+  }, [initial, globalDefaults?.columnOrder]);
 
   const update = useCallback<
     NonNullable<MRT_TableOptions<MRT_RowData>['onColumnOrderChange']>

--- a/client/packages/common/src/ui/layout/tables/tableState/useColumnOrder.ts
+++ b/client/packages/common/src/ui/layout/tables/tableState/useColumnOrder.ts
@@ -17,6 +17,8 @@ export const useColumnOrder = <T extends MRT_RowData>(
   enableExpanding: MRT_TableOptions<T>['enableExpanding']
 ) => {
   const globalDefaults = useGlobalTableDefaults(tableId);
+  const hasRowSelection = !!enableRowSelection;
+  const hasExpanding = !!enableExpanding;
   const initial = useMemo(() => {
     for (const col of columns) {
       // if column has a custom columnIndex, remove it from its current position
@@ -33,10 +35,10 @@ export const useColumnOrder = <T extends MRT_RowData>(
     return getDefaultColumnOrderIds({
       columns,
       state: {},
-      enableRowSelection, // adds `mrt-row-select`
-      enableExpanding, // adds `mrt-row-expand`
+      enableRowSelection: hasRowSelection, // adds `mrt-row-select`
+      enableExpanding: hasExpanding, // adds `mrt-row-expand`
     } as MRT_StatefulTableOptions<MRT_RowData>);
-  }, [columns, enableRowSelection, enableExpanding]);
+  }, [columns, hasRowSelection, hasExpanding]);
 
   const [state, setState] = useState<MRT_ColumnOrderState>(
     getSavedState(tableId)?.columnOrder ??
@@ -50,7 +52,7 @@ export const useColumnOrder = <T extends MRT_RowData>(
   useEffect(() => {
     if (!getSavedState(tableId)?.columnOrder)
       setState(globalDefaults?.columnOrder ?? initial);
-  }, [initial, enableExpanding]);
+  }, [initial, hasExpanding]);
 
   const update = useCallback<
     NonNullable<MRT_TableOptions<MRT_RowData>['onColumnOrderChange']>

--- a/client/packages/invoices/src/Returns/CustomerDetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Returns/CustomerDetailView/Toolbar.tsx
@@ -64,7 +64,7 @@ export const Toolbar: FC = () => {
                   size="small"
                   sx={{ width: 250 }}
                   disabled={isDisabled}
-                  value={theirReference}
+                  value={theirReference ?? ''}
                   onChange={event => {
                     update({ theirReference: event.target.value });
                   }}

--- a/client/packages/purchasing/src/purchase_order/DetailView/Tabs/InboundShipments.tsx
+++ b/client/packages/purchasing/src/purchase_order/DetailView/Tabs/InboundShipments.tsx
@@ -103,6 +103,7 @@ export const InboundShipments = () => {
     columns,
     data: data?.nodes,
     initialSort: { key: 'createdDatetime', dir: 'desc' },
+    localStateOnly: true,
     enableRowSelection: false,
     noDataElement: (
       <NothingHere body={t('error.no-inbound-shipments-linked')} />

--- a/client/packages/requisitions/src/RnRForms/ListView/ListView.tsx
+++ b/client/packages/requisitions/src/RnRForms/ListView/ListView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import {
   useUrlQueryParams,
   useNavigate,
@@ -63,6 +63,11 @@ export const RnRFormListView = () => {
     []
   );
 
+  const enableRowSelection = useCallback(
+    (row: { original: RnRFormFragment }) => !isRnRFormDisabled(row.original),
+    []
+  );
+
   const { table, selectedRows } = usePaginatedMaterialTable<RnRFormFragment>({
     tableId: 'rnr-form-list',
     columns,
@@ -72,7 +77,7 @@ export const RnRFormListView = () => {
     isError,
     onRowClick: row => navigate(row.id),
     getIsRestrictedRow: row => isRnRFormDisabled(row.original),
-    enableRowSelection: row => !isRnRFormDisabled(row.original),
+    enableRowSelection,
     noDataElement: <NothingHere body={t('error.no-rnr-forms')} onCreate={onOpen} />,
   });
 

--- a/client/packages/system/src/Asset/ListView/ListView.tsx
+++ b/client/packages/system/src/Asset/ListView/ListView.tsx
@@ -30,8 +30,12 @@ export const AssetListView: FC = () => {
   const categoryId = urlQuery['categoryId'];
 
   // only show type options in the filter which are relevant for the selected category
-  const filteredTypes = (typeData?.nodes || []).filter(
-    type => !categoryId || type.categoryId === categoryId
+  const filteredTypes = useMemo(
+    () =>
+      (typeData?.nodes || []).filter(
+        type => !categoryId || type.categoryId === categoryId
+      ),
+    [typeData?.nodes, categoryId]
   );
 
   const t = useTranslation();

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
@@ -147,10 +147,7 @@ const ItemLedgerTable = ({
         accessorFn: row => row.user?.username,
       },
     ],
-    // localisedTime is excluded from deps as useFormatDateTime creates new
-    // function refs every render; the locale is already covered by `t`.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [t]
+    [t, localisedTime]
   );
 
   const { table } = usePaginatedMaterialTable<ItemLedgerFragment>({

--- a/client/packages/system/src/Patient/VaccinationCard/ListView.tsx
+++ b/client/packages/system/src/Patient/VaccinationCard/ListView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   MaterialTable,
   NothingHere,
@@ -34,36 +34,39 @@ const VaccinationCardListComponent = () => {
   const navigate = useNavigate();
   const { setModal: selectModal } = usePatientModalStore();
 
-  const columns: ColumnDef<ProgramEnrolmentRowFragment>[] = [
-    {
-      id: 'type',
-      header: t('label.enrolment-program'),
-      accessorFn: row => row?.document?.documentRegistry?.name,
-      enableSorting: true,
-      enableColumnFilter: true,
-    },
-    {
-      accessorKey: 'programEnrolmentId',
-      header: t('label.enrolment-patient-id'),
-      enableSorting: true,
-    },
-    // TODO - add column for next appointment
-    {
-      accessorKey: 'status',
-      header: t('label.program-status'),
-      enableSorting: true,
-      enableColumnFilter: true,
-      filterVariant: 'select',
-    },
-    {
-      accessorKey: 'enrolmentDatetime',
-      header: t('label.enrolment-datetime'),
-      columnType: ColumnType.Date,
-      size: 175,
-      enableSorting: true,
-      enableColumnFilter: true,
-    },
-  ];
+  const columns = useMemo<ColumnDef<ProgramEnrolmentRowFragment>[]>(
+    () => [
+      {
+        id: 'type',
+        header: t('label.enrolment-program'),
+        accessorFn: row => row?.document?.documentRegistry?.name,
+        enableSorting: true,
+        enableColumnFilter: true,
+      },
+      {
+        accessorKey: 'programEnrolmentId',
+        header: t('label.enrolment-patient-id'),
+        enableSorting: true,
+      },
+      // TODO - add column for next appointment
+      {
+        accessorKey: 'status',
+        header: t('label.program-status'),
+        enableSorting: true,
+        enableColumnFilter: true,
+        filterVariant: 'select',
+      },
+      {
+        accessorKey: 'enrolmentDatetime',
+        header: t('label.enrolment-datetime'),
+        columnType: ColumnType.Date,
+        size: 175,
+        enableSorting: true,
+        enableColumnFilter: true,
+      },
+    ],
+    [t]
+  );
 
   const { table } = useNonPaginatedMaterialTable({
     tableId: 'vaccination-card-list',


### PR DESCRIPTION
Fixes #10770

# 👩🏻‍💻 What does this PR do?

Followup to the React 19 / TanStack Query v5 upgrade in #10770. Fixes a batch of console errors and render loops surfaced by re-running the smoke suite after the migration:

- **RnR forms list view infinite render loop** — `enableRowSelection: row => !isRnRFormDisabled(row.original)` was a fresh function each render. It feeds into `useColumnOrder`'s `initial` memo, whose setState effect then ran every render. Wrapped in `useCallback` so the reference is stable.
- **`useColumnOrder` hardening** — the hook now depends on `!!enableRowSelection` / `!!enableExpanding` rather than the raw values. Only the truthiness affects column order, so this stops any future caller passing a function literal from re-tripping the same loop.
- **Patient VaccinationCard list view loop** — same pattern: `columns` was a plain array literal. Wrapped in `useMemo`.
- **`MUI: Menu doesn't accept Fragment as a child` warnings** — `SettingsMenu` had two nested `<>` fragments inside `<Menu>`. Removed them so MenuItems / Dividers are direct children.
- **Customer return toolbar `value={null}` warning** — `theirReference` is `string | null | undefined`. Coerced with `?? ''` so the input stays controlled.
- **Equipment detail `inputProps` DOM leak** — `AutocompleteMulti` declared `inputProps` in its prop interface but never destructured it, so it spread onto MUI's Autocomplete (MUI 6 uses `slotProps`) and leaked to the DOM. Destructured and forwarded to the underlying `BasicTextInput`.
- **`[Table] Column with id 'createdDatetime' does not exist`** in the purchase-order detail view — the always-mounted General-tab table reads URL sort that the Inbound Shipments tab writes. Set `localStateOnly: true` on the inbound shipments table as a near-term fix; the proper fix is to lazy-mount tab content in `DetailTabs`, but that's out of scope here.

## 💌 Any notes for the reviewer?

- The diagnosis flow on the RnR loop took a while because the React 19 error pointed at `<MRT_TableContainer>` (its `useIsomorphicLayoutEffect` calls `setState`), which is a *symptom* — once any state in the tree thrashes every render, that effect triggers max-update-depth. The actual driver was upstream in `useColumnOrder`. Worth keeping in mind for any future "MRT is looping" report.
- The `useColumnOrder` change is intentionally defensive: the only call site with an unstable `enableRowSelection` is now fixed, but the hook will also tolerate it correctly if anyone re-introduces the pattern.
- I considered fixing the tab-mounting issue properly in `DetailTabs` rather than `localStateOnly`, but kept this PR scoped to the failing smoke tests.

# 🧪 Testing

- [ ] Open `/replenishment/r-and-r-forms` — list renders without crashing the error boundary, no `Maximum update depth exceeded` in the console
- [ ] Open a patient → Vaccinations tab — same: no loop, no `MUI: Menu doesn't accept Fragment` warnings
- [ ] Open a customer return detail view — no `value prop on input should not be null` warning
- [ ] Open an equipment detail view with locations selected — no `React does not recognize the inputProps prop on a DOM element` warning
- [ ] Open a purchase order detail view, switch to the Inbound Shipments / Documents tabs, then back to General — no `[Table] Column with id 'createdDatetime' does not exist.` warning
- [ ] Run the smoke spec (`smoke-all-sections.spec.ts`) end-to-end and confirm the previously failing sections now pass

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **These areas should be updated or checked**:
  1.
  2.

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend