### PR TITLE
#11415 AuthOverlay + drop /error/auth localStorage flag

### DIFF
--- a/client/packages/common/src/authentication/AuthContext.tsx
+++ b/client/packages/common/src/authentication/AuthContext.tsx
@@ -1,13 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useMemo, useState, useEffect, FC } from 'react';
 import { AppRoute } from '@openmsupply-client/config';
-import { useLocalStorage } from '../localStorage';
 import Cookies from 'js-cookie';
 import { addMinutes } from 'date-fns/addMinutes';
 import { useLogin, useGetUserPermissions, useRefreshToken } from './api/hooks';
+import { isAuthRequest } from './api/hooks/useLogin';
 import { AuthenticationResponse } from './api';
 import { useAuthApi } from './api/hooks/useAuthApi';
 import { UnauthenticatedError } from '../api/GqlContext';
+import { useGql } from '../api/GqlContext';
 import { UserStoreNodeFragment } from './api/operations.generated';
 import { PropsWithChildrenOnly, UserPermission } from '@common/types';
 import { RouteBuilder } from '../utils/navigation';
@@ -15,6 +16,7 @@ import { matchPath } from 'react-router-dom';
 import { createRegisteredContext } from 'react-singleton-context';
 import { useUpdateUserInfo } from './hooks/useUpdateUserInfo';
 import { useUserActivity } from './hooks/useUserActivity';
+import { useAuthOverlay } from './AuthOverlay';
 
 const AUTH_TOKEN_LIFETIME_MINUTES = 60;
 const TOKEN_CHECK_INTERVAL = 60 * 1000;
@@ -46,7 +48,6 @@ type User = {
 };
 
 interface AuthControl {
-  error?: AuthError | null;
   isLoggingIn: boolean;
   login: (
     username: string,
@@ -54,7 +55,6 @@ interface AuthControl {
   ) => Promise<AuthenticationResponse>;
   logout: () => void;
   mostRecentUsername?: string;
-  setError?: (error: AuthError) => void;
   setStore: (store: UserStoreNodeFragment) => Promise<void>;
   store?: UserStoreNodeFragment;
   storeId: string;
@@ -110,13 +110,15 @@ const { Provider } = AuthContext;
 export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
   const authCookie = getAuthCookie();
   const [cookie, setCookie] = useState<AuthCookie | undefined>(authCookie);
-  const [error, setError] = useLocalStorage('/error/auth');
+  const { show: showAuthOverlay } = useAuthOverlay();
   const { sdk } = useAuthApi();
+  const { setSkipRequest } = useGql();
   // If we boot with a cookie, the token may belong to a user that no longer
   // exists (e.g. the DB was re-initialised). Validate it before letting any
   // child render — otherwise downstream startup queries fire authed requests
-  // against a stale cookie. Network failures don't invalidate the cookie;
-  // they're handled by the global connection banner and per-query retries.
+  // against a stale cookie and pop the re-auth overlay on cold load.
+  // Network failures don't invalidate the cookie; they're handled by the
+  // global connection banner and per-query retries instead.
   const [isValidatingCookie, setIsValidatingCookie] = useState(
     !!authCookie.token
   );
@@ -133,7 +135,7 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
     () => {
       Cookies.remove('auth');
       setCookie(undefined);
-      setError(AuthError.Timeout);
+      showAuthOverlay('expired');
     },
   );
 
@@ -166,7 +168,6 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
 
   const logout = () => {
     Cookies.remove('auth');
-    setError(undefined);
     setCookie(undefined);
   };
 
@@ -175,7 +176,6 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
 
   const val = useMemo(
     () => ({
-      error,
       isLoggingIn,
       login,
       logout,
@@ -185,7 +185,6 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
       store: cookie?.store,
       mostRecentUsername,
       setStore,
-      setError,
       userHasPermission,
       updateUserIsLoading,
       lastSuccessfulSync,
@@ -195,46 +194,23 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
     [
       login,
       cookie,
-      error,
       mostRecentUsername,
       isLoggingIn,
       setStore,
-      setError,
       userHasPermission,
     ]
   );
 
+  // Suppress non-auth queries when the user is logged in but has no
+  // valid store assigned. Replaces the old `/error/auth = NoStoreAssigned`
+  // localStorage gate.
   useEffect(() => {
-    // check every minute for a valid token
-    // if the cookie has expired, raise an auth error
-    const timer = window.setInterval(() => {
-      const authCookie = getAuthCookie();
-      const { token } = authCookie;
-      const isInitScreen = matchPath(
-        RouteBuilder.create(AppRoute.Initialise).addWildCard().build(),
-        location.pathname
-      );
-
-      const isDiscoveryScreen = matchPath(
-        RouteBuilder.create(AppRoute.Discovery).addWildCard().build(),
-        location.pathname
-      );
-
-      const isNotAuthPath = isDiscoveryScreen || isInitScreen;
-      if (isNotAuthPath) return;
-
-      if (!token) {
-        setError(AuthError.Timeout);
-        window.clearInterval(timer);
-        return;
-      }
-
-      if (isActive()) {
-        refreshToken();
-      }
-    }, TOKEN_CHECK_INTERVAL);
-    return () => window.clearInterval(timer);
-  }, [cookie?.token, isActive, refreshToken, setError]);
+    setSkipRequest(documentNode => {
+      if (!cookie?.token) return false;
+      if (cookie?.store?.id) return false;
+      return !documentNode.definitions.some(isAuthRequest);
+    });
+  }, [cookie?.token, cookie?.store?.id, setSkipRequest]);
 
   useEffect(() => {
     if (!isValidatingCookie) return;
@@ -261,6 +237,40 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
     // Mount-only — we're validating the cookie that was present at boot.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    // check every minute for a valid token
+    // if the cookie has expired, raise an auth error
+    const timer = window.setInterval(() => {
+      const authCookie = getAuthCookie();
+      const { token } = authCookie;
+      // Routes where being unauthenticated is the expected state — don't
+      // try to interpret the absence of a token as a session expiry.
+      const isPublicRoute = [
+        AppRoute.Login,
+        AppRoute.Initialise,
+        AppRoute.Discovery,
+        AppRoute.Android,
+      ].some(route =>
+        matchPath(
+          RouteBuilder.create(route).addWildCard().build(),
+          location.pathname
+        )
+      );
+      if (isPublicRoute) return;
+
+      if (!token) {
+        showAuthOverlay('expired');
+        window.clearInterval(timer);
+        return;
+      }
+
+      if (isActive()) {
+        refreshToken();
+      }
+    }, TOKEN_CHECK_INTERVAL);
+    return () => window.clearInterval(timer);
+  }, [cookie?.token, isActive, refreshToken, showAuthOverlay]);
 
   if (isValidatingCookie) return null;
 

--- a/client/packages/common/src/authentication/AuthOverlay.tsx
+++ b/client/packages/common/src/authentication/AuthOverlay.tsx
@@ -1,0 +1,49 @@
+import React, {
+  FC,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useState,
+} from 'react';
+import { createRegisteredContext } from 'react-singleton-context';
+
+export type AuthOverlayReason = 'unauthenticated' | 'expired';
+
+interface AuthOverlayControl {
+  show: (reason: AuthOverlayReason) => void;
+  hide: () => void;
+  reason: AuthOverlayReason | null;
+}
+
+const noop = () => {};
+const defaultControl: AuthOverlayControl = {
+  show: noop,
+  hide: noop,
+  reason: null,
+};
+
+const AuthOverlayContext = createRegisteredContext<AuthOverlayControl>(
+  'auth-overlay-context',
+  defaultControl
+);
+
+/**
+ * Imperative provider for the "you need to re-authenticate" modal. Replaces
+ * the old `/error/auth` LocalStorage flag for the Unauthenticated/Timeout
+ * cases. The actual modal UI is rendered by the host package
+ * (AuthOverlayModal) so we don't pull host-level deps into common.
+ */
+export const AuthOverlayProvider: FC<PropsWithChildren> = ({ children }) => {
+  const [reason, setReason] = useState<AuthOverlayReason | null>(null);
+  const show = useCallback((r: AuthOverlayReason) => setReason(r), []);
+  const hide = useCallback(() => setReason(null), []);
+
+  return (
+    <AuthOverlayContext.Provider value={{ show, hide, reason }}>
+      {children}
+    </AuthOverlayContext.Provider>
+  );
+};
+
+export const useAuthOverlay = (): AuthOverlayControl =>
+  useContext(AuthOverlayContext);

--- a/client/packages/common/src/authentication/api/api.ts
+++ b/client/packages/common/src/authentication/api/api.ts
@@ -1,8 +1,6 @@
 import {
-  AuthError,
   InternalServerError,
   LocaleKey,
-  LocalStorage,
   NetworkError,
   TypedTFunction,
 } from '../..';
@@ -102,19 +100,13 @@ export const getAuthQueries = (sdk: Sdk, t: TypedTFunction<LocaleKey>) => ({
       return result.isCentralServer;
     },
     me: async (token?: string) => {
-      try {
-        const result = await sdk.me(
-          {},
-          {
-            Authorization: `Bearer ${token}`,
-          }
-        );
-        return result.me;
-      } catch (e) {
-        console.error(e);
-        LocalStorage.setItem('/error/auth', AuthError.ServerError);
-        LocalStorage.setItem('/error/server', (e as Error).message);
-      }
+      const result = await sdk.me(
+        {},
+        {
+          Authorization: `Bearer ${token}`,
+        }
+      );
+      return result.me;
     },
     permissions: async ({
       storeId,

--- a/client/packages/common/src/authentication/api/hooks/useLogin.ts
+++ b/client/packages/common/src/authentication/api/hooks/useLogin.ts
@@ -1,12 +1,10 @@
-import { AuthCookie, AuthError, setAuthCookie } from '../../AuthContext';
+import { AuthCookie, setAuthCookie } from '../../AuthContext';
 import { useGetAuthToken } from './useGetAuthToken';
 import {
   AuthenticationCredentials,
-  LocalStorage,
   useAuthApi,
   useGetUserDetails,
   useGetUserPermissions,
-  useGql,
   useLocalStorage,
   useQueryClient,
   LanguageTypeNode,
@@ -14,31 +12,15 @@ import {
   UserStoreNodeFragment,
   useIntlUtils,
 } from '@openmsupply-client/common';
-import { DefinitionNode, DocumentNode, OperationDefinitionNode } from 'graphql';
+import { DefinitionNode, OperationDefinitionNode } from 'graphql';
 
 const authNameQueries = ['authToken', 'me'];
-const isAuthRequest = (definitionNode: DefinitionNode) => {
+export const isAuthRequest = (definitionNode: DefinitionNode) => {
   const operationNode = definitionNode as OperationDefinitionNode;
   if (!operationNode) return false;
   if (operationNode.operation !== 'query') return false;
 
   return authNameQueries.indexOf(operationNode.name?.value ?? '') !== -1;
-};
-
-const skipNoStoreRequests = (documentNode?: DocumentNode) => {
-  if (!documentNode) return false;
-
-  if (documentNode.definitions.some(isAuthRequest)) return false;
-
-  switch (LocalStorage.getItem('/error/auth')) {
-    case AuthError.NoStoreAssigned:
-    case AuthError.Unauthenticated:
-    case AuthError.Timeout:
-    case AuthError.ServerError:
-      return true;
-    default:
-      return false;
-  }
 };
 
 // mostly this is as a migration fix - previous format is a single object, not an array
@@ -87,15 +69,12 @@ export const useLogin = (
 ) => {
   const { mutateAsync, isLoading: isLoggingIn } = useGetAuthToken();
   const { changeLanguage, getLocaleCode, getUserLocale } = useIntlUtils();
-  const { setSkipRequest } = useGql();
   const { mutateAsync: getUserDetails } = useGetUserDetails();
   const queryClient = useQueryClient();
   const api = useAuthApi();
   const [mostRecentlyUsedCredentials, setMRUCredentials] =
     useLocalStorage('/mru/credentials');
   const getUserPermissions = useGetUserPermissions();
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [_error, setError, removeError] = useLocalStorage('/error/auth');
   const mostRecentCredentials = getMostRecentCredentials(
     mostRecentlyUsedCredentials
   );
@@ -112,32 +91,18 @@ export const useLogin = (
     setMRUCredentials(newMRU);
   };
 
-  const setLoginError = (isLoggedIn: boolean, hasValidStore: boolean) => {
-    if (LocalStorage.getItem('/error/auth') === AuthError.ServerError) return;
-
-    switch (true) {
-      case isLoggedIn && hasValidStore: {
-        removeError();
-        break;
-      }
-      case !isLoggedIn: {
-        setError(AuthError.Unauthenticated);
-        break;
-      }
-      case !hasValidStore: {
-        setError(AuthError.NoStoreAssigned);
-        break;
-      }
-    }
-  };
-
   const login = async (username: string, password: string) => {
     const { token, error } = await mutateAsync({ username, password });
+    // The server rejects auth (NoSiteAccess, InvalidCredentials, etc.) by
+    // returning an AuthTokenError with no token. Bail before any authed
+    // calls — `me` with an empty Bearer header would throw
+    // UnauthenticatedError and trip the global error handler.
+    if (!token) return { token, error };
+
     const userDetails = await getUserDetails(token);
     queryClient.setQueryData(api.keys.me(token), userDetails);
     const store = await getStore(userDetails, mostRecentCredentials);
     const permissions = await getUserPermissions(token, store);
-    setSkipRequest(skipNoStoreRequests);
 
     const authCookie = {
       store,
@@ -154,21 +119,13 @@ export const useLogin = (
       },
     };
 
-    if (token) {
-      const userLocale = getUserLocale(username);
-      if (userLocale === undefined) {
-        changeLanguage(
-          getLocaleCode(userDetails?.language as LanguageTypeNode)
-        );
-      }
-      upsertMostRecentCredential(username, store);
-      setAuthCookie(authCookie);
-      setCookie(authCookie);
+    const userLocale = getUserLocale(username);
+    if (userLocale === undefined) {
+      changeLanguage(getLocaleCode(userDetails?.language as LanguageTypeNode));
     }
-    setLoginError(!!token, !!store);
-    setSkipRequest(
-      () => LocalStorage.getItem('/error/auth') === AuthError.NoStoreAssigned
-    );
+    upsertMostRecentCredential(username, store);
+    setAuthCookie(authCookie);
+    setCookie(authCookie);
 
     return { token, error };
   };

--- a/client/packages/common/src/authentication/api/hooks/usePreferences.ts
+++ b/client/packages/common/src/authentication/api/hooks/usePreferences.ts
@@ -7,8 +7,7 @@ import {
 } from '@openmsupply-client/common';
 import { getSdk } from '../operations.generated';
 
-/** Fields undefined until query has loaded */
-export const usePreferences = (): Partial<PreferencesNode> => {
+export const usePreferences = (enabled = true): Partial<PreferencesNode> => {
   const { client } = useGql();
   const { storeId } = useAuthContext();
   const sdk = getSdk(client);
@@ -24,7 +23,7 @@ export const usePreferences = (): Partial<PreferencesNode> => {
     cacheTime: Infinity,
     staleTime: Infinity,
     suspense: true,
-    enabled: !!storeId,
+    enabled: enabled && !!storeId,
   });
 
   return data ?? {};

--- a/client/packages/common/src/authentication/api/hooks/useUserDetails.ts
+++ b/client/packages/common/src/authentication/api/hooks/useUserDetails.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery } from 'react-query';
 import { useAuthApi } from './useAuthApi';
+import { useAuthContext } from '../../AuthContext';
 
 export const useGetUserDetails = () => {
   const api = useAuthApi();
@@ -20,7 +21,12 @@ export const useUserPermissions = () => {
 
 export const useLastSuccessfulUserSync = () => {
   const api = useAuthApi();
+  const { token, storeId } = useAuthContext();
   return useQuery(api.keys.userSync(), api.get.lastSuccessfulUserSync, {
     cacheTime: 0,
+    // Requires a sync-info-permitted context. Without a store the user has
+    // no permissions, so the server rejects with Unauthenticated — gate by
+    // storeId so we don't fire it on the no-store-assigned screen.
+    enabled: !!token && !!storeId,
   });
 };

--- a/client/packages/common/src/authentication/hooks/usePermissionCheck.ts
+++ b/client/packages/common/src/authentication/hooks/usePermissionCheck.ts
@@ -1,35 +1,29 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { AppRoute } from '@openmsupply-client/config';
 import { UserPermission } from '../../types/schema';
-import { AuthError, useAuthContext } from '../AuthContext';
-import { useLocalStorage } from '../../localStorage';
+import { useAuthContext } from '../AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { RouteBuilder } from '../../utils/navigation';
 
+/**
+ * Redirects the user away from a page they don't have permission to view.
+ * Previously this set a global localStorage flag that drove a modal; now
+ * it just navigates, since the user can't usefully recover from missing
+ * permissions in-place.
+ */
 export const usePermissionCheck = (
   permission: UserPermission,
   onPermissionDenied?: () => void
 ) => {
   const { userHasPermission } = useAuthContext();
   const navigate = useNavigate();
-  const [error, setError] = useLocalStorage('/error/auth');
-  const previous = useRef(error);
 
   useEffect(() => {
-    if (!userHasPermission(permission)) {
-      setError(AuthError.PermissionDenied);
-    }
-  }, []);
-
-  useEffect(() => {
-    previous.current = error;
-  }, [error]);
-
-  if (previous.current === AuthError.PermissionDenied && !error) {
+    if (userHasPermission(permission)) return;
     if (onPermissionDenied) {
       onPermissionDenied();
-    } else {
-      navigate(RouteBuilder.create(AppRoute.Dashboard).build());
+      return;
     }
-  }
+    navigate(RouteBuilder.create(AppRoute.Dashboard).build());
+  }, []);
 };

--- a/client/packages/common/src/authentication/index.ts
+++ b/client/packages/common/src/authentication/index.ts
@@ -1,3 +1,4 @@
 export * from './AuthContext';
+export * from './AuthOverlay';
 export * from './api';
 export * from './hooks';

--- a/client/packages/common/src/localStorage/keys.ts
+++ b/client/packages/common/src/localStorage/keys.ts
@@ -1,7 +1,6 @@
 import { SupportedLocales } from '@common/intl';
 import { ThemeOptions } from '@mui/material';
 import { UserStoreNodeFragment } from '../authentication/api/operations.generated';
-import { AuthError } from '../authentication/AuthContext';
 
 export type GroupByItem = {
   outboundShipment?: boolean;
@@ -25,8 +24,6 @@ export type LocalStorageRecord = {
   '/theme/logo': string;
   '/theme/logohash': string;
   '/mru/credentials': AuthenticationCredentials | AuthenticationCredentials[];
-  '/error/auth': AuthError | undefined;
-  '/error/server': string;
   '/pagination/rowsperpage': number;
   '/columns/hidden': Record<string, string[]> | undefined;
   '/printlabel/isusb': boolean;

--- a/client/packages/host/src/Host.tsx
+++ b/client/packages/host/src/Host.tsx
@@ -18,8 +18,7 @@ import {
   AuthProvider,
   AlertModalProvider,
   EnvUtils,
-  LocalStorage,
-  AuthError,
+  AuthOverlayProvider,
   BadUserInputError,
   InternalServerError,
   NetworkError,
@@ -42,6 +41,7 @@ import { MigrationInfoProvider } from './components/Migration';
 import { Site } from './Site';
 import { ErrorAlert } from './components/ErrorAlert';
 import { ConnectionLostBanner } from './components/ConnectionLostBanner';
+import { AuthOverlayModal } from './components/AuthOverlayModal';
 import { Discovery } from './components/Discovery';
 import { Android } from './components/Android';
 import { BackButtonHandler } from './BackButtonHandler';
@@ -65,9 +65,9 @@ const queryClient = new QueryClient({
       // errors during render unless this is set, which would trip the
       // global ErrorBoundary. Every typed GraphQL error is already
       // surfaced elsewhere — network by the connection banner, auth by
-      // the existing auth-error modal, permission/internal/bad-input by
-      // toasts in QueryErrorHandler — so none of them should escalate.
-      // The error boundary stays as a backstop for unexpected throws.
+      // the AuthOverlay, permission/internal/bad-input by toasts in
+      // QueryErrorHandler — so none of them should escalate. The error
+      // boundary stays as a backstop for genuinely unexpected throws.
       useErrorBoundary: error =>
         !(
           error instanceof NetworkError ||
@@ -91,9 +91,6 @@ Bugsnag.start({
   appVersion: appVersion,
   enabledBreadcrumbTypes: ['error'],
 });
-
-const skipRequest = () =>
-  LocalStorage.getItem('/error/auth') === AuthError.NoStoreAssigned;
 
 const PreInit: React.FC<React.PropsWithChildren> = ({ children }) => {
   const { logout } = useAuthContext();
@@ -167,6 +164,7 @@ const router = createBrowserRouter(
           <Viewport>
             <ConnectionLostBanner />
             <ErrorAlert />
+            <AuthOverlayModal />
             <BackButtonHandler />
             <Box display="flex" style={{ minHeight: '100%' }}>
               <Routes>
@@ -206,21 +204,20 @@ const Host = () => (
           <React.Suspense fallback={<RandomLoader />}>
             <ErrorBoundary Fallback={GenericErrorFallback}>
               <QueryClientProvider client={queryClient}>
-                <GqlProvider
-                  url={Environment.GRAPHQL_URL}
-                  skipRequest={skipRequest}
-                >
+                <GqlProvider url={Environment.GRAPHQL_URL}>
                   <MigrationInfoProvider>
-                    <AuthProvider>
-                      <PreInit>
-                        <Init />
-                      </PreInit>
-                      <ConfirmationModalProvider>
-                        <AlertModalProvider>
-                          <RouterProvider router={router} />
-                        </AlertModalProvider>
-                      </ConfirmationModalProvider>
-                    </AuthProvider>
+                    <AuthOverlayProvider>
+                      <AuthProvider>
+                        <PreInit>
+                          <Init />
+                        </PreInit>
+                        <ConfirmationModalProvider>
+                          <AlertModalProvider>
+                            <RouterProvider router={router} />
+                          </AlertModalProvider>
+                        </ConfirmationModalProvider>
+                      </AuthProvider>
+                    </AuthOverlayProvider>
                   </MigrationInfoProvider>
                   {/* <ReactQueryDevtools initialIsOpen /> */}
                 </GqlProvider>

--- a/client/packages/host/src/QueryErrorHandler.tsx
+++ b/client/packages/host/src/QueryErrorHandler.tsx
@@ -3,20 +3,20 @@ import Bugsnag from '@bugsnag/js';
 import { useNotification } from '@common/hooks';
 import { useTranslation } from '@common/intl';
 import {
-  AuthError,
   BadUserInputError,
   InternalServerError,
   NetworkError,
   PermissionDeniedError,
   UnauthenticatedError,
-  useLocalStorage,
+  useAlertModal,
+  useAuthOverlay,
   useLocation,
   useQueryClient,
 } from '@openmsupply-client/common';
 
-// Background queries (mostly dashboard widgets) that should not raise a
-// toast or modal when permission is denied — the user is already informed
-// by the page-level query that landed them on the page in the first place.
+// Background queries on the dashboard that should not raise a toast when
+// permission is denied; the user is already informed by the page-level
+// query that landed them on the page in the first place.
 //
 // TODO: replace with `meta: { silent: true }` opt-in on each hook.
 const SILENT_PERMISSION_DENIED_PATHS = new Set([
@@ -44,18 +44,24 @@ export const QueryErrorHandler = () => {
   const t = useTranslation();
   const [pending, setPending] = useState<RoutedToast>({ kind: 'none' });
   const location = useLocation();
-  const [authError, setAuthError] = useLocalStorage('/error/auth');
+  const { show: showAuthOverlay, reason: overlayReason } = useAuthOverlay();
+  const showPermissionDenied = useAlertModal({
+    title: t('auth.alert-title'),
+    message: t('auth.permission-denied'),
+  });
 
   useEffect(() => {
     if (pending.kind === 'none') return;
-    if (authError === AuthError.Unauthenticated) return;
+    // Don't pile a toast on top of the re-auth modal — once it's open the
+    // user is mid-relogin and the toast would just be noise.
+    if (overlayReason) return;
     if (pending.kind === 'detail') {
       errorWithDetail(pending.message)();
     } else {
       error(pending.message)();
     }
     setPending({ kind: 'none' });
-  }, [pending, authError]);
+  }, [pending, overlayReason]);
 
   useEffect(() => {
     setPending({ kind: 'none' });
@@ -67,18 +73,18 @@ export const QueryErrorHandler = () => {
       // error states; do not toast.
       if (e instanceof NetworkError) return { kind: 'none' };
 
-      // Auth and permission still drive the existing ErrorAlert modal via
-      // the `/error/auth` localStorage flag for now. A follow-up PR
-      // replaces both with an imperative AuthOverlay (re-auth without
-      // losing form state) and a dedicated permission-denied modal.
       if (e instanceof UnauthenticatedError) {
-        setAuthError(AuthError.Unauthenticated);
+        showAuthOverlay('unauthenticated');
         return { kind: 'none' };
       }
 
       if (e instanceof PermissionDeniedError) {
         if (isSilentPermissionDenied(e)) return { kind: 'none' };
-        setAuthError(AuthError.PermissionDenied);
+        // Use a modal rather than a toast — permission denied usually
+        // means a whole page can't be used, not a single transient
+        // failure, so it deserves a more attention-getting surface.
+        // TODO: replace with per-page inline UI as part of bucket 3.
+        showPermissionDenied();
         return { kind: 'none' };
       }
 

--- a/client/packages/host/src/components/AuthOverlayModal.tsx
+++ b/client/packages/host/src/components/AuthOverlayModal.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect } from 'react';
+import { Grid, Typography } from '@mui/material';
+import {
+  AlertIcon,
+  BasicModal,
+  useAuthContext,
+  useAuthOverlay,
+  useQueryClient,
+} from '@openmsupply-client/common';
+import { useTranslation } from '@common/intl';
+import { Login } from './Login';
+
+/**
+ * Renders the re-authentication modal driven by useAuthOverlay(). Mounted
+ * once near the top so the page underneath is preserved (form state,
+ * scroll, etc.) while the user re-auths.
+ */
+export const AuthOverlayModal = () => {
+  const t = useTranslation();
+  const { reason, hide } = useAuthOverlay();
+  const { token } = useAuthContext();
+  const queryClient = useQueryClient();
+
+  // Auto-hide when a valid token is present again — covers both the
+  // embedded login form succeeding here and a sibling tab landing a fresh
+  // shared auth cookie. Watch only `token` so that opening the modal
+  // doesn't immediately re-hide it: AuthContext's React state can still
+  // hold a token (e.g. the cookie was cleared in DevTools and the next
+  // query 401'd) when QueryErrorHandler shows the overlay; we want
+  // to hide only on a real token-came-back transition.
+  //
+  // Invalidating queries refetches anything that errored on the stale
+  // cookie. Form state lives in component state, not in the query cache,
+  // so it's preserved across the refetch.
+  useEffect(() => {
+    if (token && reason) {
+      queryClient.invalidateQueries();
+      hide();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
+
+  if (!reason) return null;
+
+  const title =
+    reason === 'expired' ? t('auth.timeout-title') : t('auth.alert-title');
+  const message =
+    reason === 'expired'
+      ? t('auth.timeout-message')
+      : t('auth.unauthenticated-message');
+
+  return (
+    <BasicModal open width={400} height={200}>
+      <Grid padding={4} container gap={1} flexDirection="column">
+        <Grid container gap={1} alignItems="center">
+          <AlertIcon color="primary" />
+          <Typography variant="h6" component="span">
+            {title}
+          </Typography>
+        </Grid>
+        <Grid sx={{ whiteSpace: 'pre-line' }}>{message}</Grid>
+        <Login fullSize={false} />
+      </Grid>
+    </BasicModal>
+  );
+};

--- a/client/packages/host/src/components/ErrorAlert.tsx
+++ b/client/packages/host/src/components/ErrorAlert.tsx
@@ -2,35 +2,42 @@ import { useToggle } from '@common/hooks';
 import { AppRoute } from '@openmsupply-client/config';
 import React, { useEffect } from 'react';
 import {
-  AlertIcon,
-  AuthError,
-  Grid,
-  LocalStorage,
   Location,
   RouteBuilder,
   matchPath,
-  useLocalStorage,
+  useAuthContext,
   useLocation,
   useNavigate,
 } from '@openmsupply-client/common';
-import { AlertModal, BasicModal, Typography } from '@common/components';
-import { LocaleKey, TypedTFunction, useTranslation } from '@common/intl';
-import { Login } from './Login';
+import { AlertModal } from '@common/components';
+import { useTranslation } from '@common/intl';
 
-// primarily used to display an error message when the user is not logged in
+/**
+ * Renders a full-screen alert when the user is authenticated but has no
+ * store assigned to them. The condition is derived from the auth cookie
+ * (token present, no store) rather than a localStorage flag, so it
+ * tracks state automatically without anything needing to dispatch.
+ *
+ * Other error flows that used to live here (Unauthenticated, Timeout,
+ * PermissionDenied, ServerError) now go through:
+ *   - AuthOverlay (re-auth without losing form state)
+ *   - AlertModal triggered by QueryErrorHandler (permission denied)
+ *   - ConnectionLostBanner / toasts (network and internal errors)
+ */
 export const ErrorAlert = () => {
   const navigate = useNavigate();
   const { isOn, toggleOff, toggleOn } = useToggle();
   const t = useTranslation();
   const location = useLocation();
-  const [error, , removeError] = useLocalStorage('/error/auth');
+  const { token, store } = useAuthContext();
+  const hasNoStore = !!token && !store;
 
   useEffect(() => {
-    if (!!error) toggleOn();
-    return () => toggleOff();
-  }, [error, toggleOff, toggleOn]);
+    if (hasNoStore) toggleOn();
+    else toggleOff();
+  }, [hasNoStore, toggleOff, toggleOn]);
 
-  // no need to alert if you are on the login screen
+  // Suppress on auth-flow pages — the user is already in the right place.
   if (
     matchPath(
       RouteBuilder.create(AppRoute.Login).addWildCard().build(),
@@ -44,107 +51,21 @@ export const ErrorAlert = () => {
   ) {
     return null;
   }
+
+  if (!hasNoStore) return null;
+
   const onOk = () => {
     const state = {} as { from?: Location };
-    if (error === AuthError.Unauthenticated || error === AuthError.Timeout) {
-      state.from = location;
-    }
-
-    if (error === AuthError.PermissionDenied) {
-      toggleOff();
-      setTimeout(removeError, 200);
-      return;
-    }
-
-    navigate(`/${AppRoute.Login}`, {
-      replace: true,
-      state,
-    });
+    navigate(`/${AppRoute.Login}`, { replace: true, state });
   };
 
-  const translatedError = translateErrorMessage(error, t);
-  if (!translatedError) return null;
-
-  return error === AuthError.Unauthenticated || error === AuthError.Timeout ? (
-    // if the user is unauthenticated or timed out, show a modal with the login form
-    <BasicModal open={isOn} width={400} height={150}>
-      <Grid padding={4} container gap={1} flexDirection="column">
-        <Grid container gap={1}>
-          <Grid>
-            <AlertIcon color="primary" />
-          </Grid>
-          <Grid>
-            <Typography
-              id="transition-modal-title"
-              variant="h6"
-              component="span"
-            >
-              {translatedError.title}
-            </Typography>
-          </Grid>
-        </Grid>
-        <Grid style={{ whiteSpace: 'pre-line' }}>
-          {translatedError.message}
-        </Grid>
-        <Login fullSize={false} />
-      </Grid>
-    </BasicModal>
-  ) : (
-    // for other errors, show a simple alert modal with the error message
+  return (
     <AlertModal
       important
       open={isOn}
-      title={translatedError.title}
-      message={translatedError.message}
+      title={t('auth.alert-title')}
+      message={t('auth.no-store-assigned')}
       onOk={onOk}
     />
   );
-};
-
-const translateErrorMessage = (
-  error: AuthError | null | undefined,
-  t: TypedTFunction<LocaleKey>
-) => {
-  switch (error) {
-    case AuthError.Unauthenticated:
-      return {
-        title: t('auth.alert-title'),
-        message: t('auth.unauthenticated-message'),
-      };
-    case AuthError.Timeout:
-      return {
-        title: t('auth.timeout-title'),
-        message: t('auth.timeout-message'),
-      };
-    case AuthError.NoStoreAssigned:
-      return {
-        title: t('auth.alert-title'),
-        message: t('auth.no-store-assigned'),
-      };
-    case AuthError.PermissionDenied:
-      return {
-        title: t('auth.alert-title'),
-        message: t('auth.permission-denied'),
-      };
-    case AuthError.ServerError:
-      const error = LocalStorage.getItem('/error/server');
-      const message =
-        error === null ? (
-          t('auth.server-error')
-        ) : (
-          <>
-            {t('auth.server-error')}
-            <Typography color="error" paddingBottom={2} paddingTop={2}>
-              {error}
-            </Typography>
-          </>
-        );
-
-      return {
-        title: t('heading.server-error'),
-        message,
-      };
-    default:
-      return undefined;
-  }
 };

--- a/client/packages/host/src/components/Login/Login.tsx
+++ b/client/packages/host/src/components/Login/Login.tsx
@@ -139,7 +139,6 @@ export const Login = ({ fullSize = true }: { fullSize?: boolean }) => {
   useEffect(() => {
     if (fullSize) {
       logout();
-      LocalStorage.removeItem('/error/auth');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
Fixes #11415

# 👩🏻‍💻 What does this PR do?

Replaces the `/error/auth` localStorage flag with an imperative `AuthOverlay` that re-authenticates without unmounting the page, so in-progress form state survives a session expiry. Makes the auth cookie the single source of truth for auth state — the no-store-assigned alert reads from it directly, and a cookie-driven `skipRequest` predicate suppresses non-auth queries when authenticated without a store.

Builds on **#11444** (typed errors / connection banner / cookie validation).

**Highlights**
- New `AuthOverlayProvider` + `AuthOverlayModal`: imperative `show(reason)` / `hide()` API, embeds `<Login fullSize={false} />` inside a `BasicModal`. Auto-hides on token return (only on token transitions, not reason changes — fixes an auto-hide-on-open bug). Invalidates queries on close so data is fresh.
- `QueryErrorHandler` routes `UnauthenticatedError` to `useAuthOverlay().show('expired')`. Permission-denied uses `useAlertModal` (page-level feel rather than a toast).
- `/error/auth` localStorage key is gone. `AuthError` enum is gone (was only used to drive that flag).
- `ErrorAlert` is now exclusively the no-store-assigned alert. Reads `token + !store` from `useAuthContext()` — no flag dispatching needed, the cookie is authoritative.
- `AuthContext`'s `setSkipRequest` predicate now checks the cookie at request time (no token → don't skip; has store → don't skip; otherwise skip non-auth queries). Replaces the static localStorage-gated predicate.
- `useLogin` short-circuits when the server rejects auth (`NoSiteAccess`, `InvalidCredentials`, etc.) — without this, the next call to `me()` with an empty `Bearer` header threw `UnauthenticatedError` and tripped the global handler.
- `useLastSuccessfulUserSync` gated by `storeId` (not just token). The server requires sync permissions, which a no-store user lacks.
- Token-check timer skips public routes (`/login`, `/initialise`, `/discovery`, `/android`) — no more "Session timed out" modal popping on the login page.

## 💌 Any notes for the reviewer?

- The `AuthOverlayProvider` lives **outside** the `AuthProvider` in the tree (`Host.tsx`) so the overlay can call `show()` without circular dependencies. The overlay modal itself is mounted inside the router, so it has access to navigation context.
- `setSkipRequest` is mutated via `useEffect` in `AuthProvider`. Note the timing relationship with React Query subscribes — the predicate is set after the first render commit, so per-hook gating (`enabled: !!storeId`) is still the primary defence; `setSkipRequest` is a safety net.
- Permission-denied no longer swallows. If you find a permission-denied response that *should* be silent (e.g. dashboard widget firing in the background), use `onError: () => {}` on that hook — see PR 3 for the pattern.
- No GraphQL schema changes.
- Stacked on #11444. If #11444 doesn't land, this branch needs a rebase onto develop.
- **React Query v5**: `QueryErrorHandler`'s default-options `onError` registration moves into the `QueryCache`/`MutationCache` constructor. The routing logic (which checks `instanceof` and dispatches to AuthOverlay / AlertModal / toast) is unchanged.

# 🧪 Testing

**Auth flows**
- [ ] Login with valid creds → lands in app, no error flash
- [ ] Login with bad password → "invalid credentials" shown in form
- [ ] Login as no-site-access user → "unable to login" hint shown (no `UnauthenticatedError` modal flash)
- [ ] Logout → returns to login page, form is fresh

**Session expiry / re-auth**
- [ ] Log in, fill in some text in any form, then in DevTools clear the `auth` cookie → AuthOverlay opens within ~60s → re-auth → overlay closes, form text still there
- [ ] AuthOverlay opens twice in a row (clear cookie, re-auth, clear again) → overlay opens both times (no auto-hide bug)

**Cookie boot validation (regression check from #11444)**
- [ ] Refresh while logged in → no overlay flash
- [ ] Set garbage in `auth` cookie, hard reload → cookie cleared, lands on login

**No-store / no-permission edges**
- [ ] No-site-access user → form hint, no modal pop, no `UnauthenticatedError` in console
- [ ] User without permission for some page → AlertModal (not toast)

**Public routes**
- [ ] Sit on `/login` for 2+ minutes → no "session timed out" modal pops up

# 📃 Documentation

- [x] **No documentation required**: internal refactor, only behaviour change is the new re-auth UX

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
