### PR TITLE
#11415 Per-feature error UI: table error state, isError on list views

### DIFF
--- a/client/packages/coldchain/src/Monitoring/api/TemperatureNotification/hooks/useTemperatureNotificationList.ts
+++ b/client/packages/coldchain/src/Monitoring/api/TemperatureNotification/hooks/useTemperatureNotificationList.ts
@@ -54,6 +54,7 @@ export const useTemperatureNotificationList = (queryParams?: ListParams) => {
     refetchInterval: POLLING_INTERVAL_MS,
     staleTime: STALE_TIME_MS,
     enabled: !!storeId && canViewSensorDetails,
+    onError: () => {},
   });
 
   return query;

--- a/client/packages/common/src/ui/layout/tables/useBaseMaterialTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/useBaseMaterialTable.tsx
@@ -194,7 +194,12 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
 
     localization,
 
-    data: data ?? [],
+    // When the underlying query is in error state, hide any cached
+    // rows it has — otherwise the table renders stale data alongside
+    // an "error" badge with no obvious indication that what's on
+    // screen is potentially out of date. Empty rows + isError trigger
+    // the DataError fallback below.
+    data: isError ? [] : (data ?? []),
     enablePagination: false,
 
     layoutMode: 'grid',

--- a/client/packages/dashboard/src/api/hooks/useInboundExternalCounts.ts
+++ b/client/packages/dashboard/src/api/hooks/useInboundExternalCounts.ts
@@ -14,6 +14,7 @@ export const useInboundExternalCounts = (enabled = true) => {
     {
       retry: false,
       enabled,
+      onError: () => {},
     }
   );
 

--- a/client/packages/dashboard/src/api/hooks/useInboundInternalCounts.ts
+++ b/client/packages/dashboard/src/api/hooks/useInboundInternalCounts.ts
@@ -13,6 +13,7 @@ export const useInboundInternalCounts = () => {
       }),
     {
       retry: false,
+      onError: () => {},
     }
   );
 

--- a/client/packages/dashboard/src/api/hooks/useInternalOrderCounts.ts
+++ b/client/packages/dashboard/src/api/hooks/useInternalOrderCounts.ts
@@ -13,6 +13,7 @@ export const useInternalOrderCounts = () => {
       }),
     {
       retry: false,
+      onError: () => {},
     }
   );
 

--- a/client/packages/dashboard/src/api/hooks/useItemCounts.ts
+++ b/client/packages/dashboard/src/api/hooks/useItemCounts.ts
@@ -15,6 +15,7 @@ export const useItemCounts = (lowStockThreshold: number, highStockThreshold: num
       }),
     {
       retry: false,
+      onError: () => {},
     }
   );
 

--- a/client/packages/dashboard/src/api/hooks/useOutboundCounts.ts
+++ b/client/packages/dashboard/src/api/hooks/useOutboundCounts.ts
@@ -13,6 +13,7 @@ export const useOutboundCounts = () => {
       }),
     {
       retry: false,
+      onError: () => {},
     }
   );
 

--- a/client/packages/dashboard/src/api/hooks/useRequisitionCounts.ts
+++ b/client/packages/dashboard/src/api/hooks/useRequisitionCounts.ts
@@ -13,6 +13,7 @@ export const useRequisitionCounts = () => {
       }),
     {
       retry: false,
+      onError: () => {},
     }
   );
 

--- a/client/packages/dashboard/src/api/hooks/useStockCounts.ts
+++ b/client/packages/dashboard/src/api/hooks/useStockCounts.ts
@@ -14,6 +14,10 @@ export const useStockCounts = (daysTillExpired: number) => {
       }),
     {
       retry: false,
+      // Silent on error — the dashboard widget shows its own empty state
+      // when the user lacks permission; the page-level query has already
+      // informed them.
+      onError: () => {},
     }
   );
 

--- a/client/packages/host/src/QueryErrorHandler.tsx
+++ b/client/packages/host/src/QueryErrorHandler.tsx
@@ -14,25 +14,6 @@ import {
   useQueryClient,
 } from '@openmsupply-client/common';
 
-// Background queries (mostly dashboard widgets) that should not raise a
-// toast or modal when permission is denied — the user is already informed
-// by the page-level query that landed them on the page in the first place.
-//
-// TODO: replace with `meta: { silent: true }` opt-in on each hook.
-const SILENT_PERMISSION_DENIED_PATHS = new Set([
-  'reports',
-  'stockCounts',
-  'inboundShipmentCounts',
-  'inboundShipmentExternalCounts',
-  'outboundShipmentCounts',
-  'itemCounts',
-  'requisitionCounts',
-  'temperatureNotifications',
-]);
-
-const isSilentPermissionDenied = (e: PermissionDeniedError): boolean =>
-  (e.path ?? []).every(p => SILENT_PERMISSION_DENIED_PATHS.has(p));
-
 type RoutedToast =
   | { kind: 'none' }
   | { kind: 'short'; message: string }
@@ -77,7 +58,6 @@ export const QueryErrorHandler = () => {
       }
 
       if (e instanceof PermissionDeniedError) {
-        if (isSilentPermissionDenied(e)) return { kind: 'none' };
         setAuthError(AuthError.PermissionDenied);
         return { kind: 'none' };
       }

--- a/client/packages/purchasing/src/purchase_order/ListView/ListView.tsx
+++ b/client/packages/purchasing/src/purchase_order/ListView/ListView.tsx
@@ -50,7 +50,7 @@ export const PurchaseOrderListView = () => {
     filterBy,
   };
   const {
-    query: { data, isFetching },
+    query: { data, isFetching, isError },
   } = usePurchaseOrderList(listParams);
 
   const columns = useMemo(
@@ -156,6 +156,7 @@ export const PurchaseOrderListView = () => {
     usePaginatedMaterialTable<PurchaseOrderRowFragment>({
       tableId: 'purchase-order-list-view',
       isLoading: isFetching,
+      isError,
       onRowClick: row => navigate(row.id),
       columns,
       data: data?.nodes ?? [],

--- a/client/packages/reports/src/ListView/ListView.tsx
+++ b/client/packages/reports/src/ListView/ListView.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import {
   BasicSpinner,
+  DataError,
   Grid,
   NothingHere,
   ReportContext,
@@ -26,7 +27,7 @@ export const ListView = () => {
   const t = useTranslation();
   const { store } = useAuthContext();
   const navigate = useNavigate();
-  const { data, isLoading } = useReportList({
+  const { data, isLoading, isError } = useReportList({
     queryParams: {
       filterBy: {
         context: { equalAny: [ReportContext.Report, ReportContext.Dispensary] },
@@ -64,6 +65,10 @@ export const ListView = () => {
 
   if (isLoading) {
     return <BasicSpinner messageKey="loading" />;
+  }
+
+  if (isError) {
+    return <DataError error={t('error.unable-to-load-data')} />;
   }
 
   if (!categorisedReports.stockAndItems?.length) {

--- a/client/packages/system/src/Report/api/hooks/useReportList.ts
+++ b/client/packages/system/src/Report/api/hooks/useReportList.ts
@@ -23,10 +23,15 @@ export const useReportList = ({
   context,
   subContext,
   queryParams,
+  silentOnPermissionDenied = false,
 }: {
   context?: ReportContext;
   subContext?: string;
   queryParams?: ReportListParams;
+  /** Set when used as a background widget (e.g. ReportSelector on detail
+   * pages) so a permission-denied response doesn't pop a modal — the
+   * surrounding page is the user's primary signal. */
+  silentOnPermissionDenied?: boolean;
 }) => {
   const { reportApi, storeId } = useReportGraphQL();
   const { currentLanguage: language } = useIntlUtils();
@@ -44,54 +49,51 @@ export const useReportList = ({
 
   const queryKey = [REPORT, storeId, LIST, sortBy, filterBy, offset];
   const queryFn = async () => {
-    try {
-      const query = await reportApi.reports({
-        filter: {
-          ...filterBy,
-          ...(context ? { context: { equalTo: context } } : null),
-          ...(subContext ? { subContext: { equalTo: subContext } } : null),
-          isActive: true,
-        },
-        key: isEnumValue(ReportSortFieldInput, sortBy.key)
-          ? sortBy.key
-          : ReportSortFieldInput.Name,
-        desc: sortBy.isDesc,
-        storeId,
-        userLanguage: language,
-      });
+    const query = await reportApi.reports({
+      filter: {
+        ...filterBy,
+        ...(context ? { context: { equalTo: context } } : null),
+        ...(subContext ? { subContext: { equalTo: subContext } } : null),
+        isActive: true,
+      },
+      key: isEnumValue(ReportSortFieldInput, sortBy.key)
+        ? sortBy.key
+        : ReportSortFieldInput.Name,
+      desc: sortBy.isDesc,
+      storeId,
+      userLanguage: language,
+    });
 
-      if (query?.reports?.__typename == 'ReportConnector') {
-        return {
-          nodes: query.reports.nodes,
-          totalCount: query.reports.totalCount,
-        };
+    if (query?.reports?.__typename == 'ReportConnector') {
+      return {
+        nodes: query.reports.nodes,
+        totalCount: query.reports.totalCount,
+      };
+    }
+    if (query?.reports.__typename == 'QueryReportsError') {
+      // Domain error returned as a union variant — surface as a toast
+      // and treat as empty data; not the same as a transport/auth
+      // error, which should bubble to isError on the query.
+      // TODO add never exhaustive error handling if adding more error types to QueryReportError
+      let errorMessage;
+      switch (query.reports.error.__typename) {
+        case 'FailedTranslation':
+          errorMessage = t('report.error-translating', {
+            key: query.reports.error.description,
+          });
+          break;
       }
-      if (query?.reports.__typename == 'QueryReportsError') {
-        let errorMessage;
-        switch (query.reports.error.__typename) {
-          case 'FailedTranslation':
-            errorMessage = t('report.error-translating', {
-              key: query.reports.error.description,
-            });
-            break;
-          // TODO add never exhaustive error handling if adding more error types to QueryReportError
-          // default:
-          //   noOtherVariants(query.reports.error.__typename);
-        }
-        error(errorMessage)();
-        console.error(errorMessage);
-      }
-    } catch (e) {
-      console.error(e);
+      error(errorMessage)();
+      console.error(errorMessage);
+      return { nodes: [], totalCount: 0 };
     }
   };
 
   return useQuery({
     queryKey,
     queryFn,
-    onError: (e: Error) => {
-      if (/HasPermission\(Report\)/.test(e.message)) return null;
-      return [];
-    },
+    // Spread so we don't pass `onError: undefined` and override the
+    // QueryClient default (which routes everything to a toast/modal).
+    ...(silentOnPermissionDenied ? { onError: () => {} } : {}),
   });
 };

--- a/client/packages/system/src/Report/components/ReportSelector.tsx
+++ b/client/packages/system/src/Report/components/ReportSelector.tsx
@@ -53,6 +53,7 @@ export const ReportSelector = ({
     context,
     subContext,
     queryParams,
+    silentOnPermissionDenied: true,
   });
 
   const { printAsync, isPrinting } = usePrintReport();


### PR DESCRIPTION
Fixes #11415

# 👩🏻‍💻 What does this PR do?

Closes the loop on per-feature error UI. #11444 made errors typed and propagating; This PR makes pages actually do something useful with `isError`.

Builds on **#11444** (typed errors). **Independent of #11445** — this branch can land before, after, or instead of #11445.

**Highlights**
- `useBaseMaterialTable` now hides cached rows when `isError` is set so the existing `DataError` fallback can render. Previously a permission-denied response left the previous list on screen with a small "error" badge — easy to miss.
- Wires `isError` through the **purchase order list** view.
- **Reports list** view renders a full-page `DataError` on transport / permission failures.
- `useReportList` drops a try/catch + `onError` shim that swallowed transport errors. Domain errors (the `QueryReportsError` union variant) still toast and treat as empty data, but transport / auth errors now propagate as `isError`.
- Replaces the path-based `SILENT_PERMISSION_DENIED_PATHS` allowlist in `QueryErrorHandler` with a per-query `onError` opt-out. Dashboard widgets (`useStockCounts`, `useItemCounts`, `useInbound*Counts`, `useOutboundCounts`, `useRequisitionCounts`, `useInternalOrderCounts`) and `useTemperatureNotificationList` pass `onError: () => {}` so a permission-denied response doesn't pop a modal on every detail page that mounts a print-report selector. `useReportList` takes a `silentOnPermissionDenied` param so the selector can opt in while the list page stays loud.

## 💌 Any notes for the reviewer?

- The "stale data on permission denied" was the most visible symptom — easy to demo: navigate to a list as a permitted user, log in as a non-permitted user, navigate back. Before: previous data stays on screen. After: `DataError` fallback.
- The path-based silent allowlist was deleted entirely. Each silent hook is now self-evident at the call site (`onError: () => {}`). If a *new* widget fires a query that should be silent, the change is local — no edits to a centralised list.
- React Query v3 quirk: per-query `onError` **replaces** the QueryClient default (it doesn't compose). The pattern is a conditional spread (`...(silent ? { onError: () => {} } : {})`) — passing `onError: undefined` would override the default to no-op.
- Only **purchase orders** and **reports** are wired up so far. Other list views still show stale data on error. Future PRs can sweep through them; the table change makes that a one-liner per consumer.
- No GraphQL schema changes.
- **React Query v5**: per-query `onError` is removed in v5, so the silent-widget pattern (`onError: () => {}`) used by ~10 hooks here becomes `meta: { silentOnPermissionDenied: true }`, with the check moved to a cache-level `onError` in #11445's `QueryErrorHandler`. Same intent, more idiomatic in v5. Worth coordinating with whoever owns the v5 upgrade PR — this is the highest-conflict surface.

# 🧪 Testing

**Tables / `isError`**
- [ ] Open the purchase order list, then make the user lose permission (e.g. via /admin or SQL) and refresh → `DataError` fallback, no stale rows
- [ ] Same for the reports list → full-page `DataError` (not the row-level fallback, this page renders directly)
- [ ] Restore permissions, navigate back → list refetches and shows data

**Silent / loud permission-denied**
- [ ] Visit reports list page as a user without `Report` permission → permission-denied modal pops (loud) **and** inline `DataError` shows
- [ ] Open an invoice / purchase order as a user without `Report` permission → no modal flash from the `ReportSelector` print button (silent)
- [ ] Same user lands on the dashboard → no modal flash from any of the count widgets (silent)
- [ ] Cold-chain notification widget for a user without `SensorQuery` → no modal (silent + already gated)

# 📃 Documentation

- [x] **No documentation required**: UX consistency improvement, no new user-facing feature

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
