### PR TITLE
#11413 Preserve CSV-imported mapping dates after UI mapping

### DIFF
--- a/client/packages/system/src/utils.ts
+++ b/client/packages/system/src/utils.ts
@@ -1,4 +1,4 @@
-import { LocaleKey, TypedTFunction } from '@common/intl';
+import { DateUtils, LocaleKey, TypedTFunction } from '@common/intl';
 import { Formatter } from '@common/utils';
 import { AssetPropertyFragment, MasterListRowFragment } from '.';
 import { LocationRowFragment } from './Location/api';
@@ -132,6 +132,27 @@ export const processProperties = <
             value.toLowerCase() === 'true' || value.toLowerCase() === 'yes';
           importRow.properties[property.key] = isTrue ? 'true' : 'false';
           break;
+        case 'DATE': {
+          // CSV template documents date columns as DD/MM/YYYY; reject anything
+          // else so we don't silently push unparseable strings into properties
+          // (the server stores YYYY-MM-DD and would lose the value otherwise).
+          const hasFourDigitYear = value.split('/')[2]?.length === 4;
+          const parsed = hasFourDigitYear
+            ? DateUtils.getDateOrNull(value, 'dd/MM/yyyy')
+            : null;
+          const normalised = parsed ? Formatter.naiveDate(parsed) : null;
+          if (!normalised) {
+            rowErrors.push(
+              t('error.invalid-field-value', {
+                field: property.name,
+                value: value,
+              })
+            );
+            break;
+          }
+          importRow.properties[property.key] = normalised;
+          break;
+        }
         default:
           importRow.properties[property.key] = value;
       }

--- a/server/graphql/asset/src/mutations/insert.rs
+++ b/server/graphql/asset/src/mutations/insert.rs
@@ -148,6 +148,7 @@ fn map_error(error: ServiceError) -> Result<InsertAssetErrorInterface> {
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
         ServiceError::SerialNumberAlreadyExists => BadUserInput(formatted_error),
         ServiceError::AssetNumberAlreadyExists => BadUserInput(formatted_error),
+        ServiceError::InvalidMappingDate { .. } => BadUserInput(formatted_error),
     };
 
     Err(graphql_error.extend())

--- a/server/service/src/asset/insert.rs
+++ b/server/service/src/asset/insert.rs
@@ -27,6 +27,7 @@ pub enum InsertAssetError {
     DatabaseError(RepositoryError),
     SerialNumberAlreadyExists,
     AssetNumberAlreadyExists,
+    InvalidMappingDate { key: String, value: String },
 }
 
 #[derive(PartialEq, Debug, Clone, Default)]
@@ -80,6 +81,7 @@ pub fn insert_asset(
             let new_asset = generate(input);
             AssetRowRepository::new(connection).upsert_one(&new_asset, None)?;
 
+            println!("Inserted asset with ID: {}", new_asset.id);
             if let Some(props) = &new_asset.properties {
                 create_logs_for_imported_mapping_dates(
                     connection,

--- a/server/service/src/asset/insert.rs
+++ b/server/service/src/asset/insert.rs
@@ -1,4 +1,5 @@
 use super::{
+    insert_log::create_logs_for_imported_mapping_dates,
     location::set_asset_location,
     query::get_asset,
     validate::{check_asset_exists, check_asset_number_exists},
@@ -78,6 +79,15 @@ pub fn insert_asset(
 
             let new_asset = generate(input);
             AssetRowRepository::new(connection).upsert_one(&new_asset, None)?;
+
+            if let Some(props) = &new_asset.properties {
+                create_logs_for_imported_mapping_dates(
+                    connection,
+                    &new_asset.id,
+                    &ctx.user_id,
+                    props,
+                )?;
+            }
 
             // Automatically create a location for this asset (if it's a cold chain asset, and store is active on this site)
             if new_asset.asset_class_id == Some(COLD_CHAIN_EQUIPMENT_UUID.to_string()) {

--- a/server/service/src/asset/insert.rs
+++ b/server/service/src/asset/insert.rs
@@ -81,7 +81,6 @@ pub fn insert_asset(
             let new_asset = generate(input);
             AssetRowRepository::new(connection).upsert_one(&new_asset, None)?;
 
-            println!("Inserted asset with ID: {}", new_asset.id);
             if let Some(props) = &new_asset.properties {
                 create_logs_for_imported_mapping_dates(
                     connection,

--- a/server/service/src/asset/insert_log.rs
+++ b/server/service/src/asset/insert_log.rs
@@ -232,10 +232,6 @@ pub fn create_logs_for_imported_mapping_dates(
     user_id: &str,
     properties_json: &str,
 ) -> Result<(), InsertAssetError> {
-    println!(
-        "Creating logs for imported mapping dates: asset_id={}, user_id={}, properties={}",
-        asset_id, user_id, properties_json
-    );
     let props: serde_json::Map<String, serde_json::Value> =
         match serde_json::from_str(properties_json) {
             Ok(p) => p,

--- a/server/service/src/asset/insert_log.rs
+++ b/server/service/src/asset/insert_log.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::{
     activity_log::activity_log_entry, service_provider::ServiceContext, SingleRecordError,
 };
-use chrono::Utc;
+use chrono::{NaiveDate, Utc};
 
 use repository::{
     asset_log_row::{AssetLogStatus, AssetLogType},
@@ -21,6 +21,9 @@ use repository::{
     },
     ActivityLogType, EqualFilter, RepositoryError, StorageConnection,
 };
+use util::uuid::uuid;
+
+pub const IMPORTED_FROM_CSV_COMMENT: &str = "Imported from CSV";
 
 #[derive(PartialEq, Debug)]
 pub enum InsertAssetLogError {
@@ -214,6 +217,57 @@ pub fn recalculate_mapping_dates(
     updated_row.modified_datetime = Utc::now().naive_utc();
 
     AssetRowRepository::new(connection).upsert_one(&updated_row, None)?;
+
+    Ok(())
+}
+
+/// CSV imports persist `initial_mapping_date` / `most_recent_mapping_date` directly into
+/// `asset.properties`. Without a corresponding `TemperatureMapping` log, the next call to
+/// `recalculate_mapping_dates` (triggered by any UI-recorded mapping) would overwrite those
+/// values from the log table and the imported dates would be lost. This creates synthetic
+/// log entries so the recalc treats the imported dates as part of the history.
+pub fn create_logs_for_imported_mapping_dates(
+    connection: &StorageConnection,
+    asset_id: &str,
+    user_id: &str,
+    properties_json: &str,
+) -> Result<(), RepositoryError> {
+    let props: serde_json::Map<String, serde_json::Value> =
+        match serde_json::from_str(properties_json) {
+            Ok(p) => p,
+            Err(_) => return Ok(()),
+        };
+
+    let mut dates: Vec<NaiveDate> = ["initial_mapping_date", "most_recent_mapping_date"]
+        .iter()
+        .filter_map(|key| props.get(*key).and_then(|v| v.as_str()))
+        .filter_map(|s| NaiveDate::parse_from_str(s, "%Y-%m-%d").ok())
+        .collect();
+    dates.sort();
+    dates.dedup();
+
+    if dates.is_empty() {
+        return Ok(());
+    }
+
+    let now = Utc::now().naive_utc();
+    let repo = AssetLogRowRepository::new(connection);
+
+    for date in dates {
+        let log_datetime = date.and_hms_opt(0, 0, 0).unwrap_or(now);
+        let log = AssetLogRow {
+            id: uuid(),
+            asset_id: asset_id.to_string(),
+            user_id: user_id.to_string(),
+            status: None,
+            comment: Some(IMPORTED_FROM_CSV_COMMENT.to_string()),
+            r#type: Some(AssetLogType::TemperatureMapping),
+            reason_id: None,
+            log_datetime,
+            created_datetime: now,
+        };
+        repo.upsert_one(&log)?;
+    }
 
     Ok(())
 }

--- a/server/service/src/asset/insert_log.rs
+++ b/server/service/src/asset/insert_log.rs
@@ -1,6 +1,7 @@
 use std::ops::Not;
 
 use super::{
+    insert::InsertAssetError,
     query_log::get_asset_log,
     validate::{
         check_asset_exists, check_asset_log_exists, check_comment_required_for_reason,
@@ -181,11 +182,10 @@ pub fn recalculate_mapping_dates(
         .find_one_by_id(asset_id)?
         .ok_or(InsertAssetLogError::AssetDoesNotExist)?;
 
-    let mut properties: serde_json::Map<String, serde_json::Value> =
-        match &asset_row.properties {
-            Some(props) => serde_json::from_str(props).unwrap_or_default(),
-            None => serde_json::Map::new(),
-        };
+    let mut properties: serde_json::Map<String, serde_json::Value> = match &asset_row.properties {
+        Some(props) => serde_json::from_str(props).unwrap_or_default(),
+        None => serde_json::Map::new(),
+    };
 
     let format_date = |dt: chrono::NaiveDateTime| dt.format("%Y-%m-%d").to_string();
 
@@ -231,18 +231,37 @@ pub fn create_logs_for_imported_mapping_dates(
     asset_id: &str,
     user_id: &str,
     properties_json: &str,
-) -> Result<(), RepositoryError> {
+) -> Result<(), InsertAssetError> {
+    println!(
+        "Creating logs for imported mapping dates: asset_id={}, user_id={}, properties={}",
+        asset_id, user_id, properties_json
+    );
     let props: serde_json::Map<String, serde_json::Value> =
         match serde_json::from_str(properties_json) {
             Ok(p) => p,
             Err(_) => return Ok(()),
         };
 
-    let mut dates: Vec<NaiveDate> = ["initial_mapping_date", "most_recent_mapping_date"]
-        .iter()
-        .filter_map(|key| props.get(*key).and_then(|v| v.as_str()))
-        .filter_map(|s| NaiveDate::parse_from_str(s, "%Y-%m-%d").ok())
-        .collect();
+    let mut dates: Vec<NaiveDate> = Vec::new();
+    for key in ["initial_mapping_date", "most_recent_mapping_date"] {
+        let Some(raw) = props.get(key).and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        // Canonical form is YYYY-MM-DD (what `recalculate_mapping_dates` writes
+        // and what the fixed client now sends). Accept DD/MM/YYYY too as a
+        // safety net for any caller that still sends the CSV display format.
+        let parsed = NaiveDate::parse_from_str(trimmed, "%Y-%m-%d")
+            .or_else(|_| NaiveDate::parse_from_str(trimmed, "%d/%m/%Y"))
+            .map_err(|_| InsertAssetError::InvalidMappingDate {
+                key: key.to_string(),
+                value: trimmed.to_string(),
+            })?;
+        dates.push(parsed);
+    }
     dates.sort();
     dates.dedup();
 

--- a/server/service/src/asset/tests/insert.rs
+++ b/server/service/src/asset/tests/insert.rs
@@ -1,13 +1,23 @@
 #[cfg(test)]
 mod query {
+    use chrono::{Duration, Utc};
     use repository::{
         asset_internal_location_row::AssetInternalLocationRowRepository,
-        mock::{mock_store_a, MockDataInserts},
+        asset_log_row::AssetLogType,
+        assets::{
+            asset_log::{AssetLogFilter, AssetLogRepository},
+            asset_row::AssetRowRepository,
+        },
+        mock::{mock_store_a, mock_user_account_a, MockDataInserts},
         test_db::setup_all,
+        EqualFilter,
     };
 
     use crate::{
-        asset::insert::{InsertAsset, InsertAssetError},
+        asset::{
+            insert::{InsertAsset, InsertAssetError},
+            insert_log::InsertAssetLog,
+        },
         service_provider::ServiceProvider,
     };
 
@@ -105,4 +115,152 @@ mod query {
             Err(InsertAssetError::SerialNumberAlreadyExists)
         );
     }
+
+    /// Regression test for #11413: CSV-imported mapping dates were stored only as static
+    /// properties on the asset. When a UI mapping was later recorded, `recalculate_mapping_dates`
+    /// would overwrite both dates from the (single) new log, losing the imported initial date.
+    /// The fix creates synthetic `TemperatureMapping` logs at insert time so the imported dates
+    /// survive future recalcs.
+    #[actix_rt::test]
+    async fn asset_service_insert_with_csv_mapping_dates_preserves_initial_date() {
+        let (_, connection, connection_manager, _) = setup_all(
+            "asset_service_insert_with_csv_mapping_dates",
+            MockDataInserts::none().stores().user_accounts(),
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let ctx = service_provider
+            .context(mock_store_a().id, mock_user_account_a().id)
+            .unwrap();
+        let service = service_provider.asset_service;
+
+        let asset_id = "csv_imported_asset".to_string();
+        let csv_initial = "2024-01-15";
+        let csv_recent = "2024-03-10";
+
+        let properties = serde_json::json!({
+            "initial_mapping_date": csv_initial,
+            "most_recent_mapping_date": csv_recent,
+        })
+        .to_string();
+
+        service
+            .insert_asset(
+                &ctx,
+                InsertAsset {
+                    id: asset_id.clone(),
+                    store_id: Some(mock_store_a().id),
+                    asset_number: Some("csv_asset_1".to_string()),
+                    serial_number: Some("csv_serial_1".to_string()),
+                    catalogue_item_id: Some("189ef51c-d232-4da7-b090-ca3a53d31f58".to_string()),
+                    properties: Some(properties),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        // Synthetic TemperatureMapping logs should exist for both CSV dates
+        let logs = AssetLogRepository::new(&connection)
+            .query_by_filter(
+                AssetLogFilter::new()
+                    .asset_id(EqualFilter::equal_to(asset_id.clone()))
+                    .r#type(AssetLogType::TemperatureMapping.equal_to()),
+            )
+            .unwrap();
+        assert_eq!(logs.len(), 2);
+
+        let log_dates: Vec<String> = logs
+            .iter()
+            .map(|l| l.log_datetime.format("%Y-%m-%d").to_string())
+            .collect();
+        assert!(log_dates.contains(&csv_initial.to_string()));
+        assert!(log_dates.contains(&csv_recent.to_string()));
+
+        // Now record a UI mapping with a new (later) date - the bug scenario
+        let new_mapping_date = Utc::now() - Duration::days(1);
+        service
+            .insert_asset_log(
+                &ctx,
+                InsertAssetLog {
+                    id: "ui_mapping_log".to_string(),
+                    asset_id: asset_id.clone(),
+                    status: None,
+                    comment: None,
+                    r#type: Some(AssetLogType::TemperatureMapping),
+                    reason_id: None,
+                    log_datetime: Some(new_mapping_date),
+                },
+            )
+            .unwrap();
+
+        // Initial date should still be the CSV one - the bug would have replaced it.
+        let asset_row = AssetRowRepository::new(&connection)
+            .find_one_by_id(&asset_id)
+            .unwrap()
+            .unwrap();
+        let props: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(asset_row.properties.as_deref().unwrap()).unwrap();
+
+        assert_eq!(
+            props.get("initial_mapping_date").unwrap(),
+            &serde_json::Value::String(csv_initial.to_string()),
+            "initial_mapping_date should be preserved from CSV import"
+        );
+        assert_eq!(
+            props.get("most_recent_mapping_date").unwrap(),
+            &serde_json::Value::String(new_mapping_date.naive_utc().format("%Y-%m-%d").to_string()),
+            "most_recent_mapping_date should be the latest mapping (the new UI one)"
+        );
+    }
+
+    #[actix_rt::test]
+    async fn asset_service_insert_with_only_initial_mapping_date() {
+        let (_, connection, connection_manager, _) = setup_all(
+            "asset_service_insert_with_only_initial_mapping_date",
+            MockDataInserts::none().stores().user_accounts(),
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let ctx = service_provider
+            .context(mock_store_a().id, mock_user_account_a().id)
+            .unwrap();
+        let service = service_provider.asset_service;
+
+        let asset_id = "asset_initial_only".to_string();
+        let properties = serde_json::json!({
+            "initial_mapping_date": "2024-02-01",
+        })
+        .to_string();
+
+        service
+            .insert_asset(
+                &ctx,
+                InsertAsset {
+                    id: asset_id.clone(),
+                    store_id: Some(mock_store_a().id),
+                    asset_number: Some("init_only_1".to_string()),
+                    serial_number: Some("init_only_serial".to_string()),
+                    catalogue_item_id: Some("189ef51c-d232-4da7-b090-ca3a53d31f58".to_string()),
+                    properties: Some(properties),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let logs = AssetLogRepository::new(&connection)
+            .query_by_filter(
+                AssetLogFilter::new()
+                    .asset_id(EqualFilter::equal_to(asset_id))
+                    .r#type(AssetLogType::TemperatureMapping.equal_to()),
+            )
+            .unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(
+            logs[0].log_datetime.format("%Y-%m-%d").to_string(),
+            "2024-02-01"
+        );
+    }
+
 }


### PR DESCRIPTION
Fixes #11413

# 👩🏻‍💻 What does this PR do?

CSV imports persist `initial_mapping_date` / `most_recent_mapping_date` directly into `asset.properties`. The first UI-recorded mapping then triggers `recalculate_mapping_dates`, which rewrites both dates from `min`/`max` of `TemperatureMapping` logs — and since the imported dates had no corresponding logs, both got overwritten with the new mapping date.

On insert, when `properties` contain mapping dates, create synthetic `TemperatureMapping` log entries (one per distinct date, comment `"Imported from CSV"`, attributed to the importer). The recalc now finds these in the log table and the imported initial date survives.

## 💌 Any notes for the reviewer?

**Must merge into 2.18 — this is why there is no migration.** The cold-room mapping feature shipped in [#11204](https://github.com/msupply-foundation/open-msupply/pull/11204) into `v2.18.0-RC` and is not yet in production. Anyone receiving 2.18 will hit this bug the moment they CSV-import equipment with mapping dates and then record any mapping in the UI. Because there is no production data with the broken state, no backfill migration is needed — fixing the insert path is sufficient.

If this slips to a later release, we'd need to add a one-shot migration to scan existing assets for mapping dates in `properties` without corresponding logs and synthesise them. Avoiding that is the reason for targeting 2.18.

The dual storage (dates live in both `asset.properties` JSON and as derived `min`/`max` of logs) is mildly ugly but deliberate: registering them as `asset_property` rows reuses the existing display, CSV import/export, translation, and typed-input scaffolding. This PR patches the one missed edge case (CSV import bypassing log creation) rather than unwinding that design.

# 🧪 Testing

- [ ] Build a CSV import with a cold room asset that has both `initial_mapping_date` and `most_recent_mapping_date` set to historical dates
- [ ] Import via the Cold Chain Equipment import flow → open the asset's Details tab → both dates display as imported
- [ ] Open the asset's Status History tab → two `Temperature Mapping` entries with comment "Imported from CSV", dated to the CSV values
- [ ] Click the split dropdown → Record Mapping → pick today → confirm
- [ ] Return to Details tab → `initial_mapping_date` is **still the original CSV value** (this is the regression that was failing before)
- [ ] `most_recent_mapping_date` is now today
- [ ] Repeat with a CSV that has only `initial_mapping_date` (no most_recent) — single synthetic log created, behaves as expected after a UI mapping
- [ ] Repeat with a CSV that has neither date — no synthetic logs created, normal flow
- [ ] Existing UI-only flow (record mapping on a fresh asset with no CSV history) still works as before

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend