### PR TITLE
#11429 Show items with fully reserved stock in grouped stock search

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -525,7 +525,7 @@ export type AssetLogNode = {
   createdDatetime: Scalars['NaiveDateTime']['output'];
   documents: SyncFileReferenceConnector;
   id: Scalars['String']['output'];
-  logDatetime: Scalars['NaiveDateTime']['output'];
+  logDatetime: Scalars['DateTime']['output'];
   reason?: Maybe<AssetLogReasonNode>;
   status?: Maybe<AssetLogStatusNodeType>;
   type: AssetLogTypeNodeType;
@@ -623,7 +623,7 @@ export type AssetNode = {
   catalogProperties?: Maybe<Scalars['String']['output']>;
   catalogueItem?: Maybe<AssetCatalogueItemNode>;
   catalogueItemId?: Maybe<Scalars['String']['output']>;
-  createdDatetime: Scalars['NaiveDateTime']['output'];
+  createdDatetime: Scalars['DateTime']['output'];
   documents: SyncFileReferenceConnector;
   donor?: Maybe<NameNode>;
   donorNameId?: Maybe<Scalars['String']['output']>;
@@ -631,7 +631,7 @@ export type AssetNode = {
   installationDate?: Maybe<Scalars['NaiveDate']['output']>;
   locations: LocationConnector;
   lockedFields: LockedAssetFieldsNode;
-  modifiedDatetime: Scalars['NaiveDateTime']['output'];
+  modifiedDatetime: Scalars['DateTime']['output'];
   needsReplacement?: Maybe<Scalars['Boolean']['output']>;
   notes?: Maybe<Scalars['String']['output']>;
   /** Returns a JSON string of the asset properties (defined on the asset itself) e.g {"property_key": "value"} */
@@ -4704,8 +4704,19 @@ export type ItemFilterInput = {
   categoryName?: InputMaybe<Scalars['String']['input']>;
   code?: InputMaybe<StringFilterInput>;
   codeOrName?: InputMaybe<StringFilterInput>;
-  /** Items with available stock on hand, regardless of item visibility. This filter is ignored if `is_visible_or_on_hand` is true */
+  /**
+   * Items with available stock on hand (i.e. stock not reserved by an unfinalised
+   * outbound), regardless of item visibility. This filter is ignored if
+   * `is_visible_or_on_hand` is true. Use `has_total_stock_on_hand` if you want to
+   * include items whose physical stock is fully reserved.
+   */
   hasStockOnHand?: InputMaybe<Scalars['Boolean']['input']>;
+  /**
+   * Items with any physical stock on hand in the store, including stock currently
+   * reserved by an unfinalised outbound. Mirrors the `total_stock_on_hand` column on
+   * the `stock_on_hand` view.
+   */
+  hasTotalStockOnHand?: InputMaybe<Scalars['Boolean']['input']>;
   id?: InputMaybe<EqualFilterStringInput>;
   ignoreForOrders?: InputMaybe<Scalars['Boolean']['input']>;
   isActive?: InputMaybe<Scalars['Boolean']['input']>;
@@ -9777,7 +9788,7 @@ export type SyncFileReferenceConnector = {
 
 export type SyncFileReferenceNode = {
   __typename: 'SyncFileReferenceNode';
-  createdDatetime: Scalars['NaiveDateTime']['output'];
+  createdDatetime: Scalars['DateTime']['output'];
   fileName: Scalars['String']['output'];
   id: Scalars['String']['output'];
   mimeType?: Maybe<Scalars['String']['output']>;

--- a/client/packages/system/src/Stock/api/hooks/useGroupedStockList.ts
+++ b/client/packages/system/src/Stock/api/hooks/useGroupedStockList.ts
@@ -53,7 +53,7 @@ export const useGroupedStockList = (
     totalCount: number;
   }> => {
     const filter = {
-      hasStockOnHand: true,
+      hasTotalStockOnHand: true,
       ...(filterBy?.search ? { codeOrName: filterBy.search } : {}),
       ...(filterBy?.name ? { codeOrName: filterBy.name } : {}),
       ...(filterBy?.code ? { code: filterBy.code } : {}),

--- a/server/graphql/general/src/queries/item.rs
+++ b/server/graphql/general/src/queries/item.rs
@@ -52,8 +52,15 @@ pub struct ItemFilterInput {
     pub is_visible_or_on_hand: Option<bool>,
     /// Items that are part of a masterlist which is visible in this store. This filter is ignored if `is_visible_or_on_hand` is true
     pub is_visible: Option<bool>,
-    /// Items with available stock on hand, regardless of item visibility. This filter is ignored if `is_visible_or_on_hand` is true
+    /// Items with available stock on hand (i.e. stock not reserved by an unfinalised
+    /// outbound), regardless of item visibility. This filter is ignored if
+    /// `is_visible_or_on_hand` is true. Use `has_total_stock_on_hand` if you want to
+    /// include items whose physical stock is fully reserved.
     pub has_stock_on_hand: Option<bool>,
+    /// Items with any physical stock on hand in the store, including stock currently
+    /// reserved by an unfinalised outbound. Mirrors the `total_stock_on_hand` column on
+    /// the `stock_on_hand` view.
+    pub has_total_stock_on_hand: Option<bool>,
     pub code_or_name: Option<StringFilterInput>,
     pub is_active: Option<bool>,
     pub is_vaccine: Option<bool>,
@@ -116,6 +123,7 @@ impl ItemFilterInput {
             is_active,
             is_vaccine,
             has_stock_on_hand,
+            has_total_stock_on_hand,
             is_visible_or_on_hand,
             master_list_id,
             is_program_item,
@@ -139,6 +147,7 @@ impl ItemFilterInput {
             is_active,
             is_vaccine,
             has_stock_on_hand,
+            has_total_stock_on_hand,
             is_visible_or_on_hand,
             master_list_id: master_list_id.map(EqualFilter::from),
             is_program_item,

--- a/server/repository/src/db_diesel/item.rs
+++ b/server/repository/src/db_diesel/item.rs
@@ -57,9 +57,17 @@ pub struct ItemFilter {
     /// If true it returns ItemAndMasterList that have a name join row (including items with no stock), or items with stock on hand
     #[ts(optional)]
     pub is_visible_or_on_hand: Option<bool>,
-    /// Return items with stock on hand, including non-visible items (ignored if is_visible_or_on_hand is true!)
+    /// Return items with available stock on hand (i.e. stock not reserved by an
+    /// unfinalised outbound), including non-visible items (ignored if is_visible_or_on_hand is true!).
+    /// Use `has_total_stock_on_hand` if you want to include items whose physical stock
+    /// is fully reserved.
     #[ts(optional)]
     pub has_stock_on_hand: Option<bool>,
+    /// Return items with any physical stock on hand in the store, including stock that
+    /// is currently reserved by an unfinalised outbound. Mirrors the
+    /// `total_stock_on_hand` column on the `stock_on_hand` view.
+    #[ts(optional)]
+    pub has_total_stock_on_hand: Option<bool>,
     #[ts(optional)]
     pub code_or_name: Option<StringFilter>,
     #[ts(optional)]
@@ -140,6 +148,11 @@ impl ItemFilter {
 
     pub fn has_stock_on_hand(mut self, value: bool) -> Self {
         self.has_stock_on_hand = Some(value);
+        self
+    }
+
+    pub fn has_total_stock_on_hand(mut self, value: bool) -> Self {
+        self.has_total_stock_on_hand = Some(value);
         self
     }
 
@@ -259,6 +272,7 @@ impl<'a> ItemRepository<'a> {
                 is_active,
                 is_vaccine,
                 has_stock_on_hand,
+                has_total_stock_on_hand,
                 is_visible_or_on_hand,
                 master_list_id,
                 is_program_item,
@@ -350,6 +364,18 @@ impl<'a> ItemRepository<'a> {
                 )
                 .group_by(item_link::item_id);
 
+            // Parallel subquery for items with any physical stock on hand, including
+            // stock that is reserved by an unfinalised outbound.
+            let item_ids_with_total_stock_on_hand = item_link::table
+                .select(item_link::item_id)
+                .inner_join(stock_on_hand::table)
+                .filter(
+                    stock_on_hand::total_stock_on_hand
+                        .gt(0.0)
+                        .and(stock_on_hand::store_id.eq(store_id.clone())),
+                )
+                .group_by(item_link::item_id);
+
             query =
                 match (is_visible_or_on_hand, has_stock_on_hand) {
                     // visible items AND non-visible items with stock on hand
@@ -370,6 +396,16 @@ impl<'a> ItemRepository<'a> {
                     // no stock_on_hand filters
                     (_, _) => query,
                 };
+
+            query = match has_total_stock_on_hand {
+                Some(true) => query.filter(
+                    item::id.eq_any(item_ids_with_total_stock_on_hand.clone().into_boxed()),
+                ),
+                Some(false) => query.filter(
+                    item::id.ne_all(item_ids_with_total_stock_on_hand.clone().into_boxed()),
+                ),
+                None => query,
+            };
 
             query = match (is_visible_or_on_hand, is_visible) {
                 // visible items AND non-visible items with stock on hand
@@ -918,6 +954,58 @@ mod tests {
                 .map(|r| r.item_row.id)
                 .collect::<Vec<String>>(),
             vec!["item1", "item2", "item3"]
+        );
+
+        // Test has_total_stock_on_hand filter (regression for issue #11429)
+
+        // Add a stock line for item 4 with total > 0 but available == 0, e.g. fully
+        // reserved by an unfinalised outbound. This item should be excluded by
+        // `has_stock_on_hand` (which checks available stock) but matched by
+        // `has_total_stock_on_hand` (which checks physical stock).
+        StockLineRowRepository::new(&storage_connection)
+            .upsert_one(&StockLineRow {
+                id: "stock_line_for_item_4".to_string(),
+                item_link_id: "item4".to_string(),
+                store_id: "name1_store".to_string(),
+                available_number_of_packs: 0.0,
+                total_number_of_packs: 1.0,
+                pack_size: 1.0,
+                ..Default::default()
+            })
+            .unwrap();
+
+        // has_stock_on_hand(true) excludes item 4 — its physical stock is fully reserved.
+        let results = ItemRepository::new(&storage_connection)
+            .query(
+                Pagination::new(),
+                Some(ItemFilter::new().has_stock_on_hand(true)),
+                None,
+                Some("name1_store".to_string()),
+            )
+            .unwrap();
+        assert_eq!(
+            results
+                .into_iter()
+                .map(|r| r.item_row.id)
+                .collect::<Vec<String>>(),
+            vec!["item3"]
+        );
+
+        // has_total_stock_on_hand(true) includes item 4.
+        let results = ItemRepository::new(&storage_connection)
+            .query(
+                Pagination::new(),
+                Some(ItemFilter::new().has_total_stock_on_hand(true)),
+                None,
+                Some("name1_store".to_string()),
+            )
+            .unwrap();
+        assert_eq!(
+            results
+                .into_iter()
+                .map(|r| r.item_row.id)
+                .collect::<Vec<String>>(),
+            vec!["item4"]
         );
 
         // Make sure stock on hand filter applies to only one store


### PR DESCRIPTION
Fixes #11429

# 👩🏻‍💻 What does this PR do?

In the Stock list, the **aggregate (grouped) view** searches items via the `stockItemsGrouped` query with `hasStockOnHand: true`. That filter checks `available_stock_on_hand > 0`, so an item whose physical stock is entirely reserved by an unfinalised outbound (i.e. `total > 0` but `available = 0`) is **excluded from the grouped search results**, even though it still has packs in store. The non-aggregated view uses the `hasPacksInStore` filter on stock lines (`total_number_of_packs > 0`), so it shows the item as expected — hence the inconsistency reported in the ticket.

Rather than change the semantics of the existing `hasStockOnHand` filter (which is also used by the dashboard out-of-stock count, the stocktake "no stock items" count, the items list, the supplier returns picker, and several variants of `useItems`), this PR adds a **sibling filter `has_total_stock_on_hand`** that mirrors the `total_stock_on_hand` column on the `stock_on_hand` view. Only the grouped stock list switches to the new filter; every other callsite is untouched.

Filter naming follows the underlying view columns one-for-one:

- `has_stock_on_hand` → `available_stock_on_hand > 0` (excludes reserved)
- `has_total_stock_on_hand` → `total_stock_on_hand > 0` (includes reserved)

Both fields have doc comments cross-referencing each other so future devs aren't left guessing which to reach for.

## 💌 Any notes for the reviewer?

- The bug only manifests when `total > 0` and `available = 0` — i.e. an item with one or more stock lines whose entire physical quantity is currently allocated to an unfinalised outbound. Items with `available > 0` were never affected.
- No GraphQL breaking change: `hasStockOnHand` is unchanged on the input type; `hasTotalStockOnHand` is a new optional field.
- The `availableBatches` resolver on `ItemNode` already uses `has_packs_in_store(true)` (i.e. `total > 0`) when loading stock lines for an item, so once an item is matched by the new filter the nested batches will include the reserved-but-physical ones — end-to-end consistency.
- I deliberately did **not** change `hasStockOnHand` semantics, even though I think the dashboard out-of-stock count is arguably wrong today (it counts items with reserved-but-physical stock as out-of-stock). That is a separate behaviour question and out of scope here.
- **Schema regen drift**: running `yarn generate` also picked up four `NaiveDateTime` → `DateTime` changes on `AssetLogNode.logDatetime`, `AssetNode.createdDatetime`, `AssetNode.modifiedDatetime`, and `SyncFileReferenceNode.createdDatetime`. The Rust side was changed in commit `bc093dbe92` but `schema.ts` was never regenerated, leaving the checked-in TS types out of sync. I've left the regenerated values in this PR so the types match what the server actually returns — but flagging it explicitly so the reviewer knows it isn't related to the bug fix.
- Files touched:
  - `server/repository/src/db_diesel/item.rs` — new field, builder, parallel subquery, match arm, regression test.
  - `server/graphql/general/src/queries/item.rs` — new field on `ItemFilterInput` and `to_domain` mapping.
  - `client/packages/common/src/types/schema.ts` — regenerated via `yarn generate` (filter addition + the unrelated datetime regen above).
  - `client/packages/system/src/Stock/api/hooks/useGroupedStockList.ts` — switched to new filter.

# 🧪 Testing

- [ ] OMS remote site running this PR, any datafile with at least one stock-controlled item.
- [ ] Pick an item that has a single stock line with e.g. 1 pack in store. Confirm in the non-aggregated Stock list that it shows SOH = 1, Available = 1.
- [ ] Create a new outbound shipment in the same store, add a line for that item, allocate the full quantity, and **leave the outbound unfinalised** (status: New / Allocated / Picked).
- [ ] Confirm in the non-aggregated Stock list: item still appears, SOH = 1, Available = 0.
- [ ] Toggle the **aggregate** option on the Stock list. Search for the item by code or name.
  - Pre-fix: the item does not appear.
  - Post-fix: the item appears in the search results.
- [ ] Sanity-check that the dashboard "out of stock products" count, the items list, the supplier returns item picker, and the stocktake creation modal "no stock items" counter all still behave as they did before this PR (they should — none of them use the new filter).
- [ ] Repository tests: `cargo test -p repository --lib test_item_query_repository_visibility` (covers the regression case).
- [ ] Service tests: `cargo test -p service --lib stocktake::insert dashboard::item_count`.

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API

**Issue Review**
- [ ] All requirements in original issue have been covered

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)