### PR TITLE
Fix unauthenticated errors on Initialise page (fresh install)

### DIFF
--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -423,7 +423,6 @@ pub async fn start_server(
         .sync_status_service
         .is_initialised(&service_context)
         .unwrap()
-        || !force_trigger_sync_on_startup
     {
         graphql_schema
             .set_operational_status(OperationalStatus::Operational)


### PR DESCRIPTION
Fixes #11455

## Summary

On a fresh install with no sync settings in either yaml or the database, the GraphQL schema was flipping to `Operational` at startup, before any sync had run. This broke the Initialise page: every poll of `latestSyncStatus` and the `syncInfoUpdated` subscription hit the auth-gated operational schema with no token, returning `Unauthenticated` and preventing sync progress from rendering.

The condition lived in [server/server/src/lib.rs:430-440](server/server/src/lib.rs#L430-L440) (introduced in #4745):

```rust
if service_provider
    .sync_status_service
    .is_initialised(&service_context)
    .unwrap()
    || !force_trigger_sync_on_startup   // ← the bug
{
    graphql_schema.set_operational_status(OperationalStatus::Operational).await;
}
```

`force_trigger_sync_on_startup` is `false` exactly when sync settings are absent in both yaml and the database — i.e. the user is *about to go through the Initialise flow*. The OR clause sent the schema to Operational anyway, defeating the purpose of the InitialisationSchema (which is what the Initialise page polls without a token).

This was reproducible on docker / Android setups, and showed up as a flood of `latestSyncStatus → Unauthenticated` errors as soon as the user opened the Initialise page (well before any sync work began).

The fix drops the OR clause: the schema stays in `Initialising` whenever the site isn't actually initialised.

## Test plan
- [ ] Fresh DB, no yaml sync settings → open Initialise page → no `Unauthenticated` errors in server log
- [ ] Submit sync settings via Initialise page → progress UI renders correctly through the first sync
- [ ] After successful first sync, schema flips to Operational (existing trigger at `synchroniser.rs:303`) → operational `latestSyncStatus` correctly requires auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)