### PR TITLE
Sync stack 1/9: Move changelog generation to single file

### DIFF
--- a/server/repository/src/db_diesel/activity_log_row.rs
+++ b/server/repository/src/db_diesel/activity_log_row.rs
@@ -4,7 +4,7 @@ use crate::{
     db_diesel::store_row::store, repository_error::RepositoryError, user_account,
     ChangelogSyncType, Delete, SourceSiteId, Upsert,
 };
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
@@ -137,26 +137,6 @@ pub struct ActivityLogRow {
     pub changed_to: Option<String>,
     pub changed_from: Option<String>,
 }
-
-impl ActivityLogRow {
-    pub(crate) fn generate_changelog(
-        &self,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::ActivityLog,
-            record_id: self.id.clone(),
-            row_action: action,
-            store_id: self.store_id.clone(),
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct ActivityLogRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/assets/asset_catalogue_item_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_catalogue_item_row.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::RepositoryError;
 use crate::SourceSiteId;
 use crate::StorageConnection;
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 use crate::{ChangelogSyncType, Upsert};
 
 use diesel::prelude::*;
@@ -45,26 +45,6 @@ pub struct AssetCatalogueItemRow {
     pub properties: Option<String>,
     pub deleted_datetime: Option<chrono::NaiveDateTime>,
 }
-
-impl AssetCatalogueItemRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::AssetCatalogueItem,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct AssetCatalogueItemRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/assets/asset_category_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_category_row.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use crate::RepositoryError;
 use crate::SourceSiteId;
 use crate::StorageConnection;
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 use crate::{ChangelogSyncType, Upsert};
 
 use diesel::prelude::*;
@@ -29,26 +29,6 @@ pub struct AssetCategoryRow {
     #[diesel(column_name = "asset_class_id")]
     pub class_id: String,
 }
-
-impl AssetCategoryRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::AssetCategory,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct AssetCategoryRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/assets/asset_class_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_class_row.rs
@@ -3,7 +3,7 @@ use super::asset_class_row::asset_class::dsl::*;
 use crate::RepositoryError;
 use crate::SourceSiteId;
 use crate::StorageConnection;
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 use crate::{ChangelogSyncType, Upsert};
 
 use diesel::prelude::*;
@@ -25,26 +25,6 @@ pub struct AssetClassRow {
     pub id: String,
     pub name: String,
 }
-
-impl AssetClassRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::AssetClass,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct AssetClassRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/assets/asset_internal_location_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_internal_location_row.rs
@@ -1,13 +1,11 @@
 use super::asset_internal_location_row::asset_internal_location::dsl::*;
 
-use crate::asset_row::AssetRowRepository;
 use crate::db_diesel::changelog::changelog::RowOrId;
 use crate::Delete;
-use crate::LocationRowRepository;
 use crate::RepositoryError;
 use crate::SourceSiteId;
 use crate::StorageConnection;
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 use crate::{ChangelogSyncType, Upsert};
 use serde::Deserialize;
 use serde::Serialize;
@@ -31,41 +29,6 @@ pub struct AssetInternalLocationRow {
     pub asset_id: String,
     pub location_id: String,
 }
-
-impl AssetInternalLocationRow {
-    pub(crate) fn generate_changelog(
-        row_or_id: RowOrId<AssetInternalLocationRow>,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        let row = match row_or_id {
-            RowOrId::Row(row) => row,
-            RowOrId::Id(row_id) => &AssetInternalLocationRowRepository::new(con)
-                .find_one_by_id(row_id)?
-                .ok_or(RepositoryError::NotFound)?,
-        };
-
-        let store_id_location = LocationRowRepository::new(con)
-            .find_one_by_id(&row.location_id)?
-            .map(|r| r.store_id);
-
-        let store_id_asset = AssetRowRepository::new(con)
-            .find_one_by_id(&row.asset_id)?
-            .and_then(|r| r.store_id);
-
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::AssetInternalLocation,
-            record_id: row.id.clone(),
-            row_action: action,
-            store_id: store_id_location.or(store_id_asset),
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct AssetInternalLocationRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/assets/asset_log_reason_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_log_reason_row.rs
@@ -1,9 +1,7 @@
 use super::asset_log_reason_row::asset_log_reason::dsl::*;
 
 use crate::asset_log_row::AssetLogStatus;
-use crate::ChangeLogInsertRow;
 use crate::ChangelogRepository;
-use crate::ChangelogTableName;
 use crate::RepositoryError;
 use crate::RowActionType;
 use crate::SourceSiteId;
@@ -35,26 +33,6 @@ pub struct AssetLogReasonRow {
     pub deleted_datetime: Option<NaiveDateTime>,
     pub comments_required: bool,
 }
-
-impl AssetLogReasonRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::AssetLogReason,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct AssetLogReasonRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/assets/asset_log_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_log_row.rs
@@ -1,8 +1,8 @@
 use super::asset_log_row::asset_log::dsl::*;
 
-use crate::asset_row::{asset, AssetRowRepository};
+use crate::asset_row::asset;
 use crate::{
-    ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType, ChangelogTableName,
+    ChangelogRepository, ChangelogSyncType,
     RepositoryError, RowActionType, SourceSiteId, StorageConnection, Upsert,
 };
 
@@ -83,29 +83,6 @@ pub struct AssetLogRow {
     #[serde(default)]
     pub created_datetime: NaiveDateTime,
 }
-
-impl AssetLogRow {
-    pub(crate) fn generate_changelog(
-        &self,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        let store_id = AssetRowRepository::new(con)
-            .find_one_by_id(&self.asset_id)?
-            .and_then(|a| a.store_id);
-
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::AssetLog,
-            record_id: self.id.clone(),
-            row_action: action,
-            store_id,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct AssetLogRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/assets/asset_property_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_property_row.rs
@@ -3,9 +3,7 @@ use super::asset_property_row::asset_property::dsl::*;
 use serde::{Deserialize, Serialize};
 
 use crate::types::PropertyValueType;
-use crate::ChangeLogInsertRow;
 use crate::ChangelogRepository;
-use crate::ChangelogTableName;
 use crate::RepositoryError;
 use crate::RowActionType;
 use crate::SourceSiteId;
@@ -42,26 +40,6 @@ pub struct AssetPropertyRow {
     pub value_type: PropertyValueType,
     pub allowed_values: Option<String>,
 }
-
-impl AssetPropertyRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::AssetProperty,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct AssetPropertyRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/assets/asset_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_row.rs
@@ -2,7 +2,7 @@ use super::asset_row::asset::dsl::*;
 use crate::asset_log_row::latest_asset_log;
 use crate::db_diesel::store_row::store;
 use crate::{
-    ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType, ChangelogTableName, Delete,
+    ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType, Delete,
     RepositoryError, RowActionType, SourceSiteId, StorageConnection, Upsert,
 };
 use chrono::{NaiveDate, NaiveDateTime};
@@ -68,21 +68,6 @@ pub struct AssetRow {
 }
 
 impl AssetRow {
-    pub(crate) fn generate_changelog(
-        &self,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::Asset,
-            record_id: self.id.clone(),
-            row_action: action,
-            store_id: self.store_id.clone(),
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
 
     pub(crate) fn soft_delete_and_get_changelog(
         row_id: &str,

--- a/server/repository/src/db_diesel/assets/asset_type_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_type_row.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use crate::RepositoryError;
 use crate::SourceSiteId;
 use crate::StorageConnection;
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 use crate::{ChangelogSyncType, Upsert};
 
 use diesel::prelude::*;
@@ -29,26 +29,6 @@ pub struct AssetTypeRow {
     #[diesel(column_name = "asset_category_id")]
     pub category_id: String,
 }
-
-impl AssetTypeRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::AssetCatalogueType,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct AssetTypeRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/backend_plugin_row.rs
+++ b/server/repository/src/db_diesel/backend_plugin_row.rs
@@ -1,5 +1,5 @@
 use super::{
-    ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType, StorageConnection,
+    ChangelogRepository, RowActionType, StorageConnection,
 };
 
 use crate::{
@@ -70,26 +70,6 @@ pub struct BackendPluginRow {
     pub types: PluginTypes,
     pub variant_type: PluginVariantType,
 }
-
-impl BackendPluginRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::BackendPlugin,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct BackendPluginRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/barcode_row.rs
+++ b/server/repository/src/db_diesel/barcode_row.rs
@@ -6,7 +6,7 @@ use super::{
     name_link_row::name_link, RepositoryError, StorageConnection,
 };
 use crate::diesel_macros::define_linked_tables;
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 
 use diesel::prelude::*;
 
@@ -46,26 +46,6 @@ pub struct BarcodeRow {
     // Resolved from name_link - must be last to match view column order
     pub manufacturer_id: Option<String>,
 }
-
-impl BarcodeRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::Barcode,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct BarcodeRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/campaign/campaign_row.rs
+++ b/server/repository/src/db_diesel/campaign/campaign_row.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType, ChangelogTableName,
+    ChangelogRepository, ChangelogSyncType,
     RepositoryError, RowActionType, SourceSiteId, StorageConnection, Upsert,
 };
 use chrono::NaiveDate;
@@ -28,25 +28,6 @@ pub struct CampaignRow {
     pub end_date: Option<NaiveDate>,
     pub deleted_datetime: Option<chrono::NaiveDateTime>,
 }
-
-impl CampaignRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::Campaign,
-            record_id,
-            row_action: action,
-            store_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct CampaignRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -268,8 +268,6 @@ pub struct ChangeLogInsertRow {
     pub table_name: ChangelogTableName,
     pub record_id: String,
     pub row_action: RowActionType,
-    #[diesel(column_name = "name_link_id")]
-    pub name_id: Option<String>,
     pub store_id: Option<String>,
     pub source_site_id: Option<i32>,
     pub transfer_store_id: Option<String>,

--- a/server/repository/src/db_diesel/changelog/generate_changelog.rs
+++ b/server/repository/src/db_diesel/changelog/generate_changelog.rs
@@ -1,0 +1,1366 @@
+// All `generate_changelog` implementations live here so the sync mechanism
+// can be read as a whole. Sections below group impls by the characteristic
+// of how the changelog row is built (store_id, transfer_store_id, parent linking, etc).
+
+use super::{ChangeLogInsertRow, ChangelogTableName, RowActionType, RowOrId, SourceSiteId};
+// Types re-exported flat at the crate root via `pub use db_diesel::*`.
+use crate::{
+    ActivityLogRow, BackendPluginRow, BarcodeRow, ClinicianRow, ClinicianStoreJoinRow, CurrencyRow,
+    DemographicRow, Document, EncounterRow, FormSchemaJson, FrontendPluginRow, IndicatorValueRow,
+    InsuranceProviderRow, InvoiceLineRow, InvoiceLineRowRepository, InvoiceRow,
+    InvoiceRowRepository, LocationMovementRow, LocationRow, LocationRowRepository, MasterListRow,
+    NameOmsFieldsRow, NamePropertyRow, NameRow, NameStoreJoinRepository, NameStoreJoinRow,
+    PluginDataRow, PreferenceRow, PreferenceRowRepository, PropertyRow, PurchaseOrderLineRow,
+    PurchaseOrderLineRowRepository, PurchaseOrderRow, PurchaseOrderRowRepository, RepositoryError,
+    ReportRow, RequisitionLineRow, RequisitionLineRowRepository, RequisitionRow,
+    RequisitionRowRepository, RnRFormLineRow, RnRFormLineRowRepository, RnRFormRow,
+    RnRFormRowRepository, SensorRow, StockLineRow, StockLineRowRepository, StocktakeLineRow,
+    StocktakeLineRowRepository, StocktakeRow, StocktakeRowRepository, StorageConnection,
+    StoreRowRepository, SyncFileReferenceRow, SyncMessageRow, TemperatureBreachConfigRow,
+    TemperatureBreachRow, TemperatureLogRow, VaccinationRow,
+};
+// Types only reachable via their full submodule path (no flat re-export).
+use crate::{
+    assets::{
+        asset_catalogue_item_row::AssetCatalogueItemRow,
+        asset_category_row::AssetCategoryRow,
+        asset_class_row::AssetClassRow,
+        asset_internal_location_row::{AssetInternalLocationRow, AssetInternalLocationRowRepository},
+        asset_log_reason_row::AssetLogReasonRow,
+        asset_log_row::AssetLogRow,
+        asset_property_row::AssetPropertyRow,
+        asset_row::{AssetRow, AssetRowRepository},
+        asset_type_row::AssetTypeRow,
+    },
+    campaign::campaign_row::CampaignRow,
+    contact_form_row::ContactFormRow,
+    item_variant::{
+        bundled_item_row::BundledItemRow, item_variant_row::ItemVariantRow,
+        packaging_variant_row::PackagingVariantRow,
+    },
+    name_insurance_join_row::NameInsuranceJoinRow,
+    system_log_row::SystemLogRow,
+    vaccine_course::{
+        vaccine_course_dose_row::VaccineCourseDoseRow,
+        vaccine_course_item_row::VaccineCourseItemRow,
+        vaccine_course_row::VaccineCourseRow,
+        vaccine_course_store_config_row::VaccineCourseStoreConfigRow,
+    },
+    vvm_status::vvm_status_log_row::{VVMStatusLogRow, VVMStatusLogRowRepository},
+};
+
+/// Returned from `PurchaseOrderLineRow::generate_changelogs`.
+/// Mutating a purchase order line also generates a changelog for the parent
+/// purchase order so it syncs.
+pub(crate) struct Changelogs {
+    pub(crate) purchase_order_changelog: ChangeLogInsertRow,
+    pub(crate) purchase_order_line_changelog: ChangeLogInsertRow,
+}
+
+/// Resolve `name_id` to the id of the store that backs that name (if any).
+/// Used when a record references a name and we want the changelog's
+/// `transfer_store_id` to point at the corresponding store.
+fn transfer_store_id_for_name(
+    con: &StorageConnection,
+    name_id: &str,
+) -> Result<Option<String>, RepositoryError> {
+    Ok(StoreRowRepository::new(con)
+        .find_one_by_name_id(name_id)?
+        .map(|s| s.id))
+}
+
+// ==========================================================================
+// Records resolved by RowOrId — sets store_id AND transfer_store_id
+// --------------------------------------------------------------------------
+// Mutating methods may have either the full row or just an id (e.g. delete by id),
+// so the row is fetched when only an id is given. These records reference another
+// party (a customer/supplier name); the changelog stores that party's store as
+// `transfer_store_id` so the changelog can be sharded/filtered per store. Invoice
+// reads it directly from `name_store_id`; the others look it up via the name.
+// ==========================================================================
+
+impl InvoiceRow {
+    pub(crate) fn generate_changelog(
+        row_or_id: RowOrId<InvoiceRow>,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        let row = match row_or_id {
+            RowOrId::Row(row) => row,
+            RowOrId::Id(id) => &InvoiceRowRepository::new(con)
+                .find_one_by_id(id)?
+                .ok_or(RepositoryError::NotFound)?,
+        };
+
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Invoice,
+            record_id: row.id.clone(),
+            row_action: action,
+            store_id: Some(row.store_id.clone()),
+            transfer_store_id: row.name_store_id.clone(),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl RequisitionRow {
+    pub(crate) fn generate_changelog(
+        row_or_id: RowOrId<RequisitionRow>,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        let row = match row_or_id {
+            RowOrId::Row(row) => row,
+            RowOrId::Id(row_id) => &RequisitionRowRepository::new(con)
+                .find_one_by_id(row_id)?
+                .ok_or(RepositoryError::NotFound)?,
+        };
+
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Requisition,
+            record_id: row.id.clone(),
+            row_action: action,
+            store_id: Some(row.store_id.clone()),
+            transfer_store_id: transfer_store_id_for_name(con, &row.name_id)?,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl RnRFormRow {
+    pub(crate) fn generate_changelog(
+        row_or_id: RowOrId<RnRFormRow>,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        let row = match row_or_id {
+            RowOrId::Row(row) => row,
+            RowOrId::Id(row_id) => &RnRFormRowRepository::new(con)
+                .find_one_by_id(row_id)?
+                .ok_or(RepositoryError::NotFound)?,
+        };
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::RnrForm,
+            record_id: row.id.clone(),
+            row_action: action,
+            store_id: Some(row.store_id.clone()),
+            transfer_store_id: transfer_store_id_for_name(con, &row.name_id)?,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl NameStoreJoinRow {
+    pub(crate) fn generate_changelog(
+        row_or_id: RowOrId<NameStoreJoinRow>,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        let row = match row_or_id {
+            RowOrId::Row(row) => row,
+            RowOrId::Id(row_id) => &NameStoreJoinRepository::new(con)
+                .find_one_by_id(row_id)?
+                .ok_or(RepositoryError::NotFound)?,
+        };
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::NameStoreJoin,
+            record_id: row.id.clone(),
+            row_action: action,
+            store_id: Some(row.store_id.clone()),
+            transfer_store_id: transfer_store_id_for_name(con, &row.name_id)?,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+// ==========================================================================
+// Records resolved by RowOrId — sets store_id only
+// --------------------------------------------------------------------------
+// Same RowOrId pattern, but only store-scoped (no name link).
+// ==========================================================================
+
+impl StockLineRow {
+    pub(crate) fn generate_changelog(
+        row_or_id: RowOrId<StockLineRow>,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        let row = match row_or_id {
+            RowOrId::Row(row) => row,
+            RowOrId::Id(row_id) => &StockLineRowRepository::new(con)
+                .find_one_by_id(row_id)?
+                .ok_or(RepositoryError::NotFound)?,
+        };
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::StockLine,
+            record_id: row.id.clone(),
+            row_action: action,
+            store_id: Some(row.store_id.clone()),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl StocktakeRow {
+    pub(crate) fn generate_changelog(
+        row_or_id: RowOrId<StocktakeRow>,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        let row = match row_or_id {
+            RowOrId::Row(row) => row,
+            RowOrId::Id(row_id) => &StocktakeRowRepository::new(con)
+                .find_one_by_id(row_id)?
+                .ok_or(RepositoryError::NotFound)?,
+        };
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Stocktake,
+            record_id: row.id.clone(),
+            row_action: action,
+            store_id: Some(row.store_id.clone()),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl LocationRow {
+    pub(crate) fn generate_changelog(
+        row_or_id: RowOrId<LocationRow>,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        let row = match row_or_id {
+            RowOrId::Row(row) => row,
+            RowOrId::Id(row_id) => &LocationRowRepository::new(con)
+                .find_one_by_id(row_id)?
+                .ok_or(RepositoryError::NotFound)?,
+        };
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Location,
+            record_id: row.id.clone(),
+            row_action: action,
+            store_id: Some(row.store_id.clone()),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl PurchaseOrderRow {
+    pub(crate) fn generate_changelog(
+        row_or_id: RowOrId<PurchaseOrderRow>,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        let row = match row_or_id {
+            RowOrId::Row(row) => row,
+            RowOrId::Id(row_id) => &PurchaseOrderRowRepository::new(con)
+                .find_one_by_id(row_id)?
+                .ok_or(RepositoryError::NotFound)?,
+        };
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::PurchaseOrder,
+            record_id: row.id.clone(),
+            row_action: action,
+            store_id: Some(row.store_id.clone()),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl PreferenceRow {
+    pub(crate) fn generate_changelog(
+        row_or_id: RowOrId<PreferenceRow>,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        let row = match row_or_id {
+            RowOrId::Row(row) => row,
+            RowOrId::Id(row_id) => &PreferenceRowRepository::new(con)
+                .find_one_by_id(row_id)?
+                .ok_or(RepositoryError::NotFound)?,
+        };
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Preference,
+            record_id: row.id.clone(),
+            row_action: action,
+            store_id: row.store_id.clone(),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl VVMStatusLogRow {
+    pub(crate) fn generate_changelog(
+        row_or_id: RowOrId<VVMStatusLogRow>,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        let row = match row_or_id {
+            RowOrId::Row(row) => row,
+            RowOrId::Id(row_id) => &VVMStatusLogRowRepository::new(con)
+                .find_one_by_id(row_id)?
+                .ok_or(RepositoryError::NotFound)?,
+        };
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::VVMStatusLog,
+            record_id: row.id.clone(),
+            row_action: action,
+            store_id: Some(row.store_id.clone()),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+// ==========================================================================
+// Lines that inherit their parent's changelog
+// --------------------------------------------------------------------------
+// Line records ride along with the parent. The parent's changelog is generated first,
+// then we override `table_name` and `record_id` so it points at the line. This keeps
+// store_id / transfer_store_id / source_site_id consistent between parent and line.
+// ==========================================================================
+
+impl InvoiceLineRow {
+    pub(crate) fn generate_changelog(
+        row_or_id: RowOrId<InvoiceLineRow>,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        let row = match row_or_id {
+            RowOrId::Row(row) => row,
+            RowOrId::Id(row_id) => &InvoiceLineRowRepository::new(con)
+                .find_one_by_id(row_id)?
+                .ok_or(RepositoryError::NotFound)?,
+        };
+        let invoice_changelog = InvoiceRow::generate_changelog(
+            RowOrId::Id(&row.invoice_id),
+            con,
+            action,
+            source_site_id,
+        )?;
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::InvoiceLine,
+            record_id: row.id.clone(),
+            ..invoice_changelog
+        })
+    }
+}
+
+impl StocktakeLineRow {
+    pub(crate) fn generate_changelog(
+        row_or_id: RowOrId<StocktakeLineRow>,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        let row = match row_or_id {
+            RowOrId::Row(row) => row,
+            RowOrId::Id(row_id) => &StocktakeLineRowRepository::new(con)
+                .find_one_by_id(row_id)?
+                .ok_or(RepositoryError::NotFound)?,
+        };
+        let stocktake_changelog = StocktakeRow::generate_changelog(
+            RowOrId::Id(&row.stocktake_id),
+            con,
+            action,
+            source_site_id,
+        )?;
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::StocktakeLine,
+            record_id: row.id.clone(),
+            ..stocktake_changelog
+        })
+    }
+}
+
+impl RequisitionLineRow {
+    pub(crate) fn generate_changelog(
+        row_or_id: RowOrId<RequisitionLineRow>,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        let row = match row_or_id {
+            RowOrId::Row(row) => row,
+            RowOrId::Id(row_id) => &RequisitionLineRowRepository::new(con)
+                .find_one_by_id(row_id)?
+                .ok_or(RepositoryError::NotFound)?,
+        };
+        let requisition_changelog = RequisitionRow::generate_changelog(
+            RowOrId::Id(&row.requisition_id),
+            con,
+            action,
+            source_site_id,
+        )?;
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::RequisitionLine,
+            record_id: row.id.clone(),
+            ..requisition_changelog
+        })
+    }
+}
+
+impl RnRFormLineRow {
+    pub(crate) fn generate_changelog(
+        row_or_id: RowOrId<RnRFormLineRow>,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        let row = match row_or_id {
+            RowOrId::Row(row) => row,
+            RowOrId::Id(row_id) => &RnRFormLineRowRepository::new(con)
+                .find_one_by_id(row_id)?
+                .ok_or(RepositoryError::NotFound)?,
+        };
+        let rnr_form_changelog = RnRFormRow::generate_changelog(
+            RowOrId::Id(&row.rnr_form_id),
+            con,
+            action,
+            source_site_id,
+        )?;
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::RnrFormLine,
+            record_id: row.id.clone(),
+            ..rnr_form_changelog
+        })
+    }
+}
+
+// ==========================================================================
+// Lines that emit BOTH parent and child changelogs
+// --------------------------------------------------------------------------
+// Mutating a purchase order line also nudges the parent purchase order to re-sync,
+// so we emit two changelogs and let the caller batch-insert them.
+// ==========================================================================
+
+impl PurchaseOrderLineRow {
+    pub(crate) fn generate_changelogs(
+        row_or_id: RowOrId<PurchaseOrderLineRow>,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<Changelogs, RepositoryError> {
+        let row = match row_or_id {
+            RowOrId::Row(row) => row,
+            RowOrId::Id(row_id) => &PurchaseOrderLineRowRepository::new(con)
+                .find_one_by_id(row_id)?
+                .ok_or(RepositoryError::NotFound)?,
+        };
+        let purchase_order_changelog = PurchaseOrderRow::generate_changelog(
+            RowOrId::Id(&row.purchase_order_id),
+            con,
+            RowActionType::Upsert, // Even when deleting purchase order line the parent changelog should be only upsert
+            source_site_id,
+        )?;
+        let purchase_order_line_changelog = ChangeLogInsertRow {
+            table_name: ChangelogTableName::PurchaseOrderLine,
+            record_id: row.id.clone(),
+            row_action: action,
+            ..purchase_order_changelog.clone()
+        };
+
+        Ok(Changelogs {
+            purchase_order_changelog,
+            purchase_order_line_changelog,
+        })
+    }
+}
+
+// ==========================================================================
+// Built from &self — store-scoped (action already has the row)
+// --------------------------------------------------------------------------
+// These are called from upsert/delete flows that already hold the row, so we read
+// store_id directly from `self` without an extra repository lookup.
+// ==========================================================================
+
+impl ActivityLogRow {
+    pub(crate) fn generate_changelog(
+        &self,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::ActivityLog,
+            record_id: self.id.clone(),
+            row_action: action,
+            store_id: self.store_id.clone(),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl LocationMovementRow {
+    pub(crate) fn generate_changelog(
+        &self,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::LocationMovement,
+            record_id: self.id.clone(),
+            row_action: action,
+            store_id: Some(self.store_id.clone()),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ContactFormRow {
+    pub(crate) fn generate_changelog(
+        &self,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::ContactForm,
+            record_id: self.id.clone(),
+            row_action: action,
+            store_id: Some(self.store_id.clone()),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl TemperatureBreachRow {
+    pub(crate) fn generate_changelog(
+        &self,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::TemperatureBreach,
+            record_id: self.id.clone(),
+            row_action: action,
+            store_id: Some(self.store_id.clone()),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl TemperatureBreachConfigRow {
+    pub(crate) fn generate_changelog(
+        &self,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::TemperatureBreachConfig,
+            record_id: self.id.clone(),
+            row_action: action,
+            store_id: Some(self.store_id.clone()),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl TemperatureLogRow {
+    pub(crate) fn generate_changelog(
+        &self,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::TemperatureLog,
+            record_id: self.id.clone(),
+            row_action: action,
+            store_id: Some(self.store_id.clone()),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl SensorRow {
+    pub(crate) fn generate_changelog(
+        &self,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Sensor,
+            record_id: self.id.clone(),
+            row_action: action,
+            store_id: Some(self.store_id.clone()),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl PluginDataRow {
+    pub(crate) fn generate_changelog(
+        &self,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::PluginData,
+            record_id: self.id.clone(),
+            row_action: action,
+            store_id: self.store_id.clone(),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl VaccineCourseStoreConfigRow {
+    pub(crate) fn generate_changelog(
+        &self,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::VaccineCourseStoreConfig,
+            record_id: self.id.clone(),
+            row_action: action,
+            store_id: Some(self.store_id.clone()),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl AssetRow {
+    pub(crate) fn generate_changelog(
+        &self,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Asset,
+            record_id: self.id.clone(),
+            row_action: action,
+            store_id: self.store_id.clone(),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+// ==========================================================================
+// Built from &self — patient-scoped
+// --------------------------------------------------------------------------
+// Patient-scoped records use patient_id so the changelog can
+// be filtered/sharded per patient.
+// ==========================================================================
+
+impl VaccinationRow {
+    pub(crate) fn generate_changelog(
+        &self,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Vaccination,
+            record_id: self.id.clone(),
+            row_action: action,
+            patient_id: Some(self.patient_id.clone()),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl EncounterRow {
+    pub(crate) fn generate_changelog(
+        &self,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Encounter,
+            record_id: self.id.clone(),
+            row_action: action,
+            store_id: self.store_id.clone(),
+            patient_id: Some(self.patient_id.clone()),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+// ==========================================================================
+// Cross-table lookups for store_id
+// --------------------------------------------------------------------------
+// These records don't carry a store_id directly, so we query a related row to derive it.
+// ==========================================================================
+
+impl AssetLogRow {
+    pub(crate) fn generate_changelog(
+        &self,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        let store_id = AssetRowRepository::new(con)
+            .find_one_by_id(&self.asset_id)?
+            .and_then(|a| a.store_id);
+
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::AssetLog,
+            record_id: self.id.clone(),
+            row_action: action,
+            store_id,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl AssetInternalLocationRow {
+    pub(crate) fn generate_changelog(
+        row_or_id: RowOrId<AssetInternalLocationRow>,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        let row = match row_or_id {
+            RowOrId::Row(row) => row,
+            RowOrId::Id(row_id) => &AssetInternalLocationRowRepository::new(con)
+                .find_one_by_id(row_id)?
+                .ok_or(RepositoryError::NotFound)?,
+        };
+
+        let store_id_location = LocationRowRepository::new(con)
+            .find_one_by_id(&row.location_id)?
+            .map(|r| r.store_id);
+
+        let store_id_asset = AssetRowRepository::new(con)
+            .find_one_by_id(&row.asset_id)?
+            .and_then(|r| r.store_id);
+
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::AssetInternalLocation,
+            record_id: row.id.clone(),
+            row_action: action,
+            store_id: store_id_location.or(store_id_asset),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+// ==========================================================================
+// Central data — record_id only
+// --------------------------------------------------------------------------
+// Non-store-scoped reference data: only `record_id`, `table_name`, `row_action`,
+// and `source_site_id` are set. No row lookup is needed because the changelog row
+// doesn't carry any per-row metadata.
+// ==========================================================================
+
+impl NameRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Name,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl NameOmsFieldsRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::NameOmsFields,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl NamePropertyRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::NameProperty,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl NameInsuranceJoinRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::NameInsuranceJoin,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl InsuranceProviderRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::InsuranceProvider,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ClinicianRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Clinician,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ClinicianStoreJoinRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::ClinicianStoreJoin,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl CurrencyRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Currency,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl BarcodeRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Barcode,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl MasterListRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::MasterList,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl IndicatorValueRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::IndicatorValue,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl DemographicRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Demographic,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl PropertyRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Property,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl VaccineCourseRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::VaccineCourse,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl VaccineCourseItemRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::VaccineCourseItem,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl VaccineCourseDoseRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::VaccineCourseDose,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ItemVariantRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::ItemVariant,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl PackagingVariantRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::PackagingVariant,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl BundledItemRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::BundledItem,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl BackendPluginRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::BackendPlugin,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl FrontendPluginRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::FrontendPlugin,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl FormSchemaJson {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::FormSchema,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ReportRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Report,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl Document {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Document,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl SystemLogRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::SystemLog,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl SyncMessageRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::SyncMessage,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl SyncFileReferenceRow {
+    pub(crate) fn generate_changelog(
+        changelog_record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::SyncFileReference,
+            record_id: changelog_record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl CampaignRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Campaign,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl AssetClassRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::AssetClass,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl AssetCategoryRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::AssetCategory,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl AssetTypeRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::AssetCatalogueType,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl AssetCatalogueItemRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::AssetCatalogueItem,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl AssetLogReasonRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::AssetLogReason,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl AssetPropertyRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::AssetProperty,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}

--- a/server/repository/src/db_diesel/changelog/mod.rs
+++ b/server/repository/src/db_diesel/changelog/mod.rs
@@ -1,5 +1,8 @@
 pub mod changelog;
 pub use self::changelog::*;
 
+mod generate_changelog;
+pub(crate) use self::generate_changelog::Changelogs;
+
 #[cfg(test)]
 mod test;

--- a/server/repository/src/db_diesel/clinician_row.rs
+++ b/server/repository/src/db_diesel/clinician_row.rs
@@ -4,7 +4,7 @@ use crate::{
     clinician_link, ChangelogSyncType, ClinicianLinkRow, ClinicianLinkRowRepository, GenderType,
     RepositoryError, SourceSiteId, Upsert,
 };
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 
 use diesel::prelude::*;
 
@@ -46,26 +46,6 @@ pub struct ClinicianRow {
 }
 
 allow_tables_to_appear_in_same_query!(clinician, clinician_link);
-
-impl ClinicianRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::Clinician,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 fn insert_or_ignore_clinician_link(
     connection: &StorageConnection,
     row: &ClinicianRow,

--- a/server/repository/src/db_diesel/clinician_store_join_row.rs
+++ b/server/repository/src/db_diesel/clinician_store_join_row.rs
@@ -1,6 +1,6 @@
 use super::{clinician_link_row::clinician_link, clinician_row::clinician, StorageConnection};
 
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, Delete, RowActionType};
+use crate::{ChangelogRepository, Delete, RowActionType};
 use crate::{ChangelogSyncType, RepositoryError, SourceSiteId, Upsert};
 
 use diesel::prelude::*;
@@ -24,26 +24,6 @@ pub struct ClinicianStoreJoinRow {
     pub store_id: String,
     pub clinician_link_id: String,
 }
-
-impl ClinicianStoreJoinRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::ClinicianStoreJoin,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct ClinicianStoreJoinRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/contact_form_row.rs
+++ b/server/repository/src/db_diesel/contact_form_row.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType, ChangelogTableName,
+    ChangelogRepository, ChangelogSyncType,
     RepositoryError, RowActionType, SourceSiteId, StorageConnection, Upsert,
 };
 
@@ -58,26 +58,6 @@ pub enum ContactType {
     Feedback,
     Support,
 }
-
-impl ContactFormRow {
-    pub(crate) fn generate_changelog(
-        &self,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::ContactForm,
-            record_id: self.id.clone(),
-            row_action: action,
-            store_id: Some(self.store_id.clone()),
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct ContactFormRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/currency_row.rs
+++ b/server/repository/src/db_diesel/currency_row.rs
@@ -2,7 +2,7 @@ use super::StorageConnection;
 use crate::{ChangelogSyncType, Delete, SourceSiteId, Upsert};
 
 use crate::repository_error::RepositoryError;
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 
 use chrono::NaiveDate;
 use diesel::prelude::*;
@@ -39,24 +39,6 @@ pub struct CurrencyRow {
     pub date_updated: Option<NaiveDate>,
     pub is_active: bool,
 }
-
-impl CurrencyRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::Currency,
-            record_id,
-            row_action: action,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct CurrencyRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/demographic_row.rs
+++ b/server/repository/src/db_diesel/demographic_row.rs
@@ -1,7 +1,7 @@
 use super::StorageConnection;
 
 use crate::{
-    ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType, ChangelogTableName,
+    ChangelogRepository, ChangelogSyncType,
     RepositoryError, RowActionType, SourceSiteId, Upsert,
 };
 
@@ -25,25 +25,6 @@ pub struct DemographicRow {
     pub name: String,
     pub population_percentage: f64,
 }
-
-impl DemographicRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::Demographic,
-            record_id,
-            row_action: action,
-            store_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct DemographicRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/document.rs
+++ b/server/repository/src/db_diesel/document.rs
@@ -5,7 +5,7 @@ use crate::diesel_macros::{
     define_linked_tables,
 };
 use crate::SourceSiteId;
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 use crate::{DBType, DatetimeFilter, EqualFilter, Pagination, RepositoryError, Sort, StringFilter};
 
 use chrono::{DateTime, NaiveDateTime, Utc};
@@ -381,22 +381,6 @@ fn to_document(row: DocumentRow) -> Result<Document, RepositoryError> {
 }
 
 impl Document {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::Document,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
 
     pub fn to_row(&self) -> Result<DocumentRow, RepositoryError> {
         let parents =

--- a/server/repository/src/db_diesel/encounter_row.rs
+++ b/server/repository/src/db_diesel/encounter_row.rs
@@ -6,7 +6,7 @@ use super::{
 use crate::diesel_macros::define_linked_tables;
 use crate::SourceSiteId;
 use crate::{
-    repository_error::RepositoryError, ChangeLogInsertRow, ChangelogRepository, ChangelogTableName,
+    repository_error::RepositoryError, ChangelogRepository,
     RowActionType,
 };
 
@@ -75,26 +75,6 @@ pub struct EncounterRow {
     // Resolved from name_link - must be last to match view column order
     pub patient_id: String,
 }
-
-impl EncounterRow {
-    pub(crate) fn generate_changelog(
-        &self,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::Encounter,
-            record_id: self.id.clone(),
-            row_action: action,
-            store_id: self.store_id.clone(),
-            name_id: Some(self.patient_id.clone()),
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct EncounterRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/form_schema_row.rs
+++ b/server/repository/src/db_diesel/form_schema_row.rs
@@ -1,5 +1,5 @@
 use super::{
-    ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType, StorageConnection,
+    ChangelogRepository, RowActionType, StorageConnection,
 };
 
 use crate::{ChangelogSyncType, Delete, RepositoryError, SourceSiteId, Upsert};
@@ -34,26 +34,6 @@ pub struct FormSchemaJson {
     pub json_schema: serde_json::Value,
     pub ui_schema: serde_json::Value,
 }
-
-impl FormSchemaJson {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::FormSchema,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct FormSchemaRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/frontend_plugin_row.rs
+++ b/server/repository/src/db_diesel/frontend_plugin_row.rs
@@ -1,5 +1,5 @@
 use super::{
-    ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType, StorageConnection,
+    ChangelogRepository, RowActionType, StorageConnection,
 };
 
 use crate::{
@@ -81,26 +81,6 @@ pub struct FrontendPluginRow {
     #[diesel(deserialize_as = String)]
     pub files: FrontendPluginFiles,
 }
-
-impl FrontendPluginRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::FrontendPlugin,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct FrontendPluginRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/indicator_value_row.rs
+++ b/server/repository/src/db_diesel/indicator_value_row.rs
@@ -1,5 +1,5 @@
 use super::{
-    name_row::name, ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType,
+    name_row::name, ChangelogRepository, RowActionType,
     StorageConnection,
 };
 use crate::ChangelogSyncType;
@@ -43,26 +43,6 @@ pub struct IndicatorValueRow {
     // Resolved from name_link - must be last to match view column order
     pub customer_name_id: String,
 }
-
-impl IndicatorValueRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::IndicatorValue,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct IndicatorValueRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/insurance_provider_row.rs
+++ b/server/repository/src/db_diesel/insurance_provider_row.rs
@@ -1,5 +1,5 @@
 use super::{
-    ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType, StorageConnection,
+    ChangelogRepository, RowActionType, StorageConnection,
 };
 
 use crate::{
@@ -29,26 +29,6 @@ pub struct InsuranceProviderRow {
     pub prescription_validity_days: Option<i32>,
     pub comment: Option<String>,
 }
-
-impl InsuranceProviderRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::InsuranceProvider,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct InsuranceProviderRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/invoice_line_row.rs
+++ b/server/repository/src/db_diesel/invoice_line_row.rs
@@ -8,8 +8,8 @@ use crate::diesel_macros::define_linked_tables;
 use crate::item_row::item;
 use crate::repository_error::RepositoryError;
 use crate::{
-    db_diesel::changelog::changelog::RowOrId, ChangeLogInsertRow, ChangelogRepository,
-    ChangelogSyncType, ChangelogTableName, Delete, InvoiceRow, RowActionType, SourceSiteId, Upsert,
+    db_diesel::changelog::changelog::RowOrId, ChangelogRepository,
+    ChangelogSyncType, Delete, RowActionType, SourceSiteId, Upsert,
 };
 
 use diesel::prelude::*;
@@ -150,34 +150,6 @@ pub struct InvoiceLineRow {
     pub donor_id: Option<String>,
     pub manufacturer_id: Option<String>,
 }
-
-impl InvoiceLineRow {
-    pub(crate) fn generate_changelog(
-        row_or_id: RowOrId<InvoiceLineRow>,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        let row = match row_or_id {
-            RowOrId::Row(row) => row,
-            RowOrId::Id(row_id) => &InvoiceLineRowRepository::new(con)
-                .find_one_by_id(row_id)?
-                .ok_or(RepositoryError::NotFound)?,
-        };
-        let invoice_changelog = InvoiceRow::generate_changelog(
-            RowOrId::Id(&row.invoice_id),
-            con,
-            action,
-            source_site_id,
-        )?;
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::InvoiceLine,
-            record_id: row.id.clone(),
-            ..invoice_changelog
-        })
-    }
-}
-
 #[derive(Clone, Insertable, Queryable, Debug, PartialEq, Default)]
 #[diesel(table_name = invoice_line_stats)]
 pub struct InvoiceLineStatsRow {

--- a/server/repository/src/db_diesel/invoice_row.rs
+++ b/server/repository/src/db_diesel/invoice_row.rs
@@ -5,8 +5,7 @@ use super::{
 };
 use crate::{
     db_diesel::changelog::changelog::RowOrId, diesel_macros::define_linked_tables,
-    repository_error::RepositoryError, ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType,
-    ChangelogTableName, Delete, RowActionType, SourceSiteId, Upsert,
+    repository_error::RepositoryError, ChangelogRepository, ChangelogSyncType, Delete, RowActionType, SourceSiteId, Upsert,
 };
 use chrono::{NaiveDate, NaiveDateTime};
 use diesel::prelude::*;
@@ -167,33 +166,6 @@ pub struct InvoiceRow {
     pub name_id: String,
     pub default_donor_id: Option<String>,
 }
-
-impl InvoiceRow {
-    pub(crate) fn generate_changelog(
-        row_or_id: RowOrId<InvoiceRow>,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        let row = match row_or_id {
-            RowOrId::Row(row) => row,
-            RowOrId::Id(id) => &InvoiceRowRepository::new(con)
-                .find_one_by_id(id)?
-                .ok_or(RepositoryError::NotFound)?,
-        };
-
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::Invoice,
-            record_id: row.id.clone(),
-            row_action: action,
-            store_id: Some(row.store_id.clone()),
-            name_id: Some(row.name_id.clone()),
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct InvoiceRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/item_variant/bundled_item_row.rs
+++ b/server/repository/src/db_diesel/item_variant/bundled_item_row.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType, ChangelogTableName,
+    ChangelogRepository, ChangelogSyncType,
     RepositoryError, RowActionType, SourceSiteId, StorageConnection, Upsert,
 };
 
@@ -28,25 +28,6 @@ pub struct BundledItemRow {
     pub ratio: f64,
     pub deleted_datetime: Option<NaiveDateTime>,
 }
-
-impl BundledItemRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::BundledItem,
-            record_id,
-            row_action: action,
-            store_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct BundledItemRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/item_variant/item_variant_row.rs
+++ b/server/repository/src/db_diesel/item_variant/item_variant_row.rs
@@ -4,8 +4,7 @@ use crate::{
         location_type_row::location_type, name_link_row::name_link, name_row::name,
     },
     diesel_macros::define_linked_tables,
-    item_link, user_account, ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType,
-    ChangelogTableName, RepositoryError, RowActionType, SourceSiteId,
+    item_link, user_account, ChangelogRepository, ChangelogSyncType, RepositoryError, RowActionType, SourceSiteId,
     StorageConnection, Upsert,
 };
 
@@ -61,25 +60,6 @@ pub struct ItemVariantRow {
     // Resolved from name_link - must be last to match view column order
     pub manufacturer_id: Option<String>,
 }
-
-impl ItemVariantRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::ItemVariant,
-            record_id,
-            row_action: action,
-            store_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct ItemVariantRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/item_variant/packaging_variant_row.rs
+++ b/server/repository/src/db_diesel/item_variant/packaging_variant_row.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType, ChangelogTableName,
+    ChangelogRepository, ChangelogSyncType,
     RepositoryError, RowActionType, SourceSiteId, StorageConnection, Upsert,
 };
 
@@ -31,25 +31,6 @@ pub struct PackagingVariantRow {
     pub volume_per_unit: Option<f64>,
     pub deleted_datetime: Option<chrono::NaiveDateTime>,
 }
-
-impl PackagingVariantRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::PackagingVariant,
-            record_id,
-            row_action: action,
-            store_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct PackagingVariantRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/location_movement_row.rs
+++ b/server/repository/src/db_diesel/location_movement_row.rs
@@ -2,7 +2,7 @@ use super::{
     location_row::location, stock_line_row::stock_line, store_row::store, StorageConnection,
 };
 use crate::{repository_error::RepositoryError, ChangelogSyncType, SourceSiteId, Upsert};
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
@@ -32,26 +32,6 @@ pub struct LocationMovementRow {
     pub enter_datetime: Option<NaiveDateTime>,
     pub exit_datetime: Option<NaiveDateTime>,
 }
-
-impl LocationMovementRow {
-    pub(crate) fn generate_changelog(
-        &self,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::LocationMovement,
-            record_id: self.id.clone(),
-            row_action: action,
-            store_id: Some(self.store_id.clone()),
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct LocationMovementRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/location_row.rs
+++ b/server/repository/src/db_diesel/location_row.rs
@@ -3,7 +3,7 @@ use super::{
     store_row::store, RepositoryError, StorageConnection,
 };
 use crate::db_diesel::changelog::changelog::RowOrId;
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 use crate::{ChangelogSyncType, Delete, SourceSiteId, Upsert};
 use diesel::prelude::*;
 
@@ -35,32 +35,6 @@ pub struct LocationRow {
     pub location_type_id: Option<String>,
     pub volume: f64,
 }
-
-impl LocationRow {
-    pub(crate) fn generate_changelog(
-        row_or_id: RowOrId<LocationRow>,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        let row = match row_or_id {
-            RowOrId::Row(row) => row,
-            RowOrId::Id(row_id) => &LocationRowRepository::new(con)
-                .find_one_by_id(row_id)?
-                .ok_or(RepositoryError::NotFound)?,
-        };
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::Location,
-            record_id: row.id.clone(),
-            row_action: action,
-            store_id: Some(row.store_id.clone()),
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct LocationRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/master_list_row.rs
+++ b/server/repository/src/db_diesel/master_list_row.rs
@@ -1,8 +1,7 @@
 use super::{item_link_row::item_link, master_list_row::master_list::dsl::*, StorageConnection};
 
 use crate::{
-    repository_error::RepositoryError, ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType,
-    ChangelogTableName, RowActionType, SourceSiteId, Upsert,
+    repository_error::RepositoryError, ChangelogRepository, ChangelogSyncType, RowActionType, SourceSiteId, Upsert,
 };
 
 use diesel::prelude::*;
@@ -32,24 +31,6 @@ pub struct MasterListRow {
 }
 
 allow_tables_to_appear_in_same_query!(master_list, item_link);
-
-impl MasterListRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::MasterList,
-            record_id,
-            row_action: action,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct MasterListRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/name_insurance_join_row.rs
+++ b/server/repository/src/db_diesel/name_insurance_join_row.rs
@@ -1,5 +1,5 @@
 use super::{
-    name_row::name, ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType,
+    name_row::name, ChangelogRepository, RowActionType,
     StorageConnection,
 };
 
@@ -76,26 +76,6 @@ pub struct NameInsuranceJoinRow {
     // Resolved from name_link - must be last to match view column order
     pub name_id: String,
 }
-
-impl NameInsuranceJoinRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::NameInsuranceJoin,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct NameInsuranceJoinRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/name_property_row.rs
+++ b/server/repository/src/db_diesel/name_property_row.rs
@@ -2,9 +2,7 @@ use super::{name_property_row::name_property::dsl::*, property_row::property};
 
 use serde::{Deserialize, Serialize};
 
-use crate::ChangeLogInsertRow;
 use crate::ChangelogRepository;
-use crate::ChangelogTableName;
 use crate::RepositoryError;
 use crate::RowActionType;
 use crate::SourceSiteId;
@@ -33,26 +31,6 @@ pub struct NamePropertyRow {
     pub property_id: String,
     pub remote_editable: bool,
 }
-
-impl NamePropertyRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::NameProperty,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct NamePropertyRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/name_row.rs
+++ b/server/repository/src/db_diesel/name_row.rs
@@ -5,8 +5,8 @@ use super::{
     StorageConnection,
 };
 use crate::{
-    item_link, name_link, repository_error::RepositoryError, ChangeLogInsertRow,
-    ChangelogRepository, ChangelogTableName, EqualFilter, NameLinkRow, NameLinkRowRepository,
+    item_link, name_link, repository_error::RepositoryError,
+    ChangelogRepository, EqualFilter, NameLinkRow, NameLinkRowRepository,
     RowActionType,
 };
 use crate::{ChangelogSyncType, Delete, SourceSiteId, Upsert};
@@ -203,41 +203,6 @@ pub struct NameRow {
     pub freight_factor: Option<f64>,
     pub currency_id: Option<String>,
 }
-
-impl NameRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::Name,
-            record_id,
-            row_action: action,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
-impl NameOmsFieldsRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::NameOmsFields,
-            record_id,
-            row_action: action,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 #[derive(
     Clone, Queryable, Insertable, Debug, PartialEq, Eq, AsChangeset, Default, Serialize, Deserialize,
 )]

--- a/server/repository/src/db_diesel/name_store_join.rs
+++ b/server/repository/src/db_diesel/name_store_join.rs
@@ -5,7 +5,7 @@ use crate::{
     diesel_macros::apply_equal_filter, repository_error::RepositoryError, DBType, EqualFilter,
     NameRow,
 };
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 use crate::{ChangelogSyncType, Delete, SourceSiteId, Upsert};
 
 use diesel::{dsl::IntoBoxed, prelude::*};
@@ -54,32 +54,6 @@ pub struct NameStoreJoinFilter {
     pub name_id: Option<EqualFilter<String>>,
     pub store_id: Option<EqualFilter<String>>,
 }
-
-impl NameStoreJoinRow {
-    pub(crate) fn generate_changelog(
-        row_or_id: RowOrId<NameStoreJoinRow>,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        let row = match row_or_id {
-            RowOrId::Row(row) => row,
-            RowOrId::Id(row_id) => &NameStoreJoinRepository::new(con)
-                .find_one_by_id(row_id)?
-                .ok_or(RepositoryError::NotFound)?,
-        };
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::NameStoreJoin,
-            record_id: row.id.clone(),
-            row_action: action,
-            store_id: Some(row.store_id.clone()),
-            name_id: Some(row.name_id.clone()),
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct NameStoreJoinRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/plugin_data_row.rs
+++ b/server/repository/src/db_diesel/plugin_data_row.rs
@@ -1,5 +1,5 @@
 use super::{
-    store_row::store, ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType,
+    store_row::store, ChangelogRepository, RowActionType,
     StorageConnection,
 };
 
@@ -36,26 +36,6 @@ pub struct PluginDataRow {
     pub data_identifier: String, // Used by the plugin to identify the data, often would be a table name
     pub data: String,
 }
-
-impl PluginDataRow {
-    pub(crate) fn generate_changelog(
-        &self,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::PluginData,
-            record_id: self.id.clone(),
-            row_action: action,
-            store_id: self.store_id.clone(),
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct PluginDataRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/preference_row.rs
+++ b/server/repository/src/db_diesel/preference_row.rs
@@ -1,6 +1,6 @@
 use crate::{
-    db_diesel::changelog::changelog::RowOrId, ChangeLogInsertRow, ChangelogRepository,
-    ChangelogSyncType, ChangelogTableName, Delete, RepositoryError, RowActionType, SourceSiteId,
+    db_diesel::changelog::changelog::RowOrId, ChangelogRepository,
+    ChangelogSyncType, Delete, RepositoryError, RowActionType, SourceSiteId,
     StorageConnection, Upsert,
 };
 
@@ -28,32 +28,6 @@ pub struct PreferenceRow {
     pub value: String,
     pub store_id: Option<String>,
 }
-
-impl PreferenceRow {
-    pub(crate) fn generate_changelog(
-        row_or_id: RowOrId<PreferenceRow>,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        let row = match row_or_id {
-            RowOrId::Row(row) => row,
-            RowOrId::Id(row_id) => &PreferenceRowRepository::new(con)
-                .find_one_by_id(row_id)?
-                .ok_or(RepositoryError::NotFound)?,
-        };
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::Preference,
-            record_id: row.id.clone(),
-            row_action: action,
-            store_id: row.store_id.clone(),
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct PreferenceRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/property_row.rs
+++ b/server/repository/src/db_diesel/property_row.rs
@@ -3,9 +3,7 @@ use super::property_row::property::dsl::*;
 use serde::{Deserialize, Serialize};
 
 use crate::types::PropertyValueType;
-use crate::ChangeLogInsertRow;
 use crate::ChangelogRepository;
-use crate::ChangelogTableName;
 use crate::RepositoryError;
 use crate::RowActionType;
 use crate::SourceSiteId;
@@ -36,26 +34,6 @@ pub struct PropertyRow {
     pub value_type: PropertyValueType,
     pub allowed_values: Option<String>,
 }
-
-impl PropertyRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::Property,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct PropertyRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/purchase_order_line_row.rs
+++ b/server/repository/src/db_diesel/purchase_order_line_row.rs
@@ -1,14 +1,15 @@
 use crate::{
     db_diesel::{
-        changelog::changelog::RowOrId, item_link_row::item_link, item_row::item,
+        changelog::{changelog::RowOrId, Changelogs},
+        item_link_row::item_link,
+        item_row::item,
         purchase_order_row::purchase_order,
     },
     diesel_macros::define_linked_tables,
-    ChangelogSyncType, Delete, PurchaseOrderRow, SourceSiteId, Upsert,
+    ChangelogSyncType, Delete, SourceSiteId, Upsert,
 };
 use crate::{
-    ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RepositoryError, RowActionType,
-    StorageConnection,
+    ChangelogRepository, RepositoryError, RowActionType, StorageConnection,
 };
 use chrono::NaiveDate;
 use diesel::prelude::*;
@@ -111,44 +112,6 @@ pub enum PurchaseOrderLineStatus {
     New,
     Sent,
     Closed,
-}
-
-struct Changelogs {
-    purchase_order_changelog: ChangeLogInsertRow,
-    purchase_order_line_changelog: ChangeLogInsertRow,
-}
-
-impl PurchaseOrderLineRow {
-    fn generate_changelogs(
-        row_or_id: RowOrId<PurchaseOrderLineRow>,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<Changelogs, RepositoryError> {
-        let row = match row_or_id {
-            RowOrId::Row(row) => row,
-            RowOrId::Id(row_id) => &PurchaseOrderLineRowRepository::new(con)
-                .find_one_by_id(row_id)?
-                .ok_or(RepositoryError::NotFound)?,
-        };
-        let purchase_order_changelog = PurchaseOrderRow::generate_changelog(
-            RowOrId::Id(&row.purchase_order_id),
-            con,
-            RowActionType::Upsert, // Even when deleting purchase order line the parent changelog should be only upsert
-            source_site_id,
-        )?;
-        let purchase_order_line_changelog = ChangeLogInsertRow {
-            table_name: ChangelogTableName::PurchaseOrderLine,
-            record_id: row.id.clone(),
-            row_action: action,
-            ..purchase_order_changelog.clone()
-        };
-
-        Ok(Changelogs {
-            purchase_order_changelog,
-            purchase_order_line_changelog,
-        })
-    }
 }
 
 pub struct PurchaseOrderLineRowRepository<'a> {

--- a/server/repository/src/db_diesel/purchase_order_row.rs
+++ b/server/repository/src/db_diesel/purchase_order_row.rs
@@ -2,8 +2,7 @@ use crate::{
     db_diesel::{
         changelog::changelog::RowOrId, item_link_row::item_link, item_row::item,
     },
-    diesel_macros::define_linked_tables,
-    ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType, ChangelogTableName, Delete,
+    diesel_macros::define_linked_tables, ChangelogRepository, ChangelogSyncType, Delete,
     RepositoryError, RowActionType, SourceSiteId, StorageConnection, Upsert,
 };
 use chrono::{NaiveDate, NaiveDateTime};
@@ -131,32 +130,6 @@ pub enum PurchaseOrderStatus {
     Sent,
     Finalised,
 }
-
-impl PurchaseOrderRow {
-    pub(crate) fn generate_changelog(
-        row_or_id: RowOrId<PurchaseOrderRow>,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        let row = match row_or_id {
-            RowOrId::Row(row) => row,
-            RowOrId::Id(row_id) => &PurchaseOrderRowRepository::new(con)
-                .find_one_by_id(row_id)?
-                .ok_or(RepositoryError::NotFound)?,
-        };
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::PurchaseOrder,
-            record_id: row.id.clone(),
-            row_action: action,
-            store_id: Some(row.store_id.clone()),
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct PurchaseOrderRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/report_row.rs
+++ b/server/repository/src/db_diesel/report_row.rs
@@ -1,5 +1,5 @@
 use super::{
-    form_schema_row::form_schema, ChangeLogInsertRow, ChangelogRepository, ChangelogTableName,
+    form_schema_row::form_schema, ChangelogRepository,
     RowActionType, StorageConnection,
 };
 
@@ -89,26 +89,6 @@ pub struct ReportMetaDataRow {
     pub code: String,
     pub is_active: bool,
 }
-
-impl ReportRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::Report,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct ReportRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/requisition/requisition_row.rs
+++ b/server/repository/src/db_diesel/requisition/requisition_row.rs
@@ -9,7 +9,7 @@ use crate::diesel_macros::define_linked_tables;
 use crate::repository_error::RepositoryError;
 
 use crate::db_diesel::changelog::changelog::RowOrId;
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 use crate::{ChangelogSyncType, Delete, SourceSiteId, Upsert};
 use chrono::{NaiveDate, NaiveDateTime};
 use diesel::prelude::*;
@@ -130,33 +130,6 @@ pub struct RequisitionRow {
     pub name_id: String,
     pub destination_customer_id: Option<String>,
 }
-
-impl RequisitionRow {
-    pub(crate) fn generate_changelog(
-        row_or_id: RowOrId<RequisitionRow>,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        let row = match row_or_id {
-            RowOrId::Row(row) => row,
-            RowOrId::Id(row_id) => &RequisitionRowRepository::new(con)
-                .find_one_by_id(row_id)?
-                .ok_or(RepositoryError::NotFound)?,
-        };
-
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::Requisition,
-            record_id: row.id.clone(),
-            row_action: action,
-            store_id: Some(row.store_id.clone()),
-            name_id: Some(row.name_id.clone()),
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct RequisitionRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/requisition_line/requisition_line_row.rs
+++ b/server/repository/src/db_diesel/requisition_line/requisition_line_row.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
 use crate::db_diesel::changelog::changelog::RowOrId;
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RequisitionRow, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 use crate::{ChangelogSyncType, Delete, SourceSiteId, Upsert};
 
 use chrono::NaiveDateTime;
@@ -85,34 +85,6 @@ pub struct RequisitionLineRow {
     pub forecast_total_doses: Option<f64>,
     pub vaccine_courses: Option<String>,
 }
-
-impl RequisitionLineRow {
-    pub(crate) fn generate_changelog(
-        row_or_id: RowOrId<RequisitionLineRow>,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        let row = match row_or_id {
-            RowOrId::Row(row) => row,
-            RowOrId::Id(row_id) => &RequisitionLineRowRepository::new(con)
-                .find_one_by_id(row_id)?
-                .ok_or(RepositoryError::NotFound)?,
-        };
-        let requisition_changelog = RequisitionRow::generate_changelog(
-            RowOrId::Id(&row.requisition_id),
-            con,
-            action,
-            source_site_id,
-        )?;
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::RequisitionLine,
-            record_id: row.id.clone(),
-            ..requisition_changelog
-        })
-    }
-}
-
 pub struct RequisitionLineRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/rnr_form_line_row.rs
+++ b/server/repository/src/db_diesel/rnr_form_line_row.rs
@@ -3,8 +3,8 @@ use super::{
     rnr_form_line_row::rnr_form_line::dsl::*, rnr_form_row::rnr_form,
 };
 use crate::{
-    db_diesel::changelog::changelog::RowOrId, ChangeLogInsertRow, ChangelogRepository,
-    ChangelogSyncType, ChangelogTableName, Delete, RepositoryError, RnRFormRow, RowActionType,
+    db_diesel::changelog::changelog::RowOrId, ChangelogRepository,
+    ChangelogSyncType, Delete, RepositoryError, RowActionType,
     SourceSiteId, StorageConnection, Upsert,
 };
 
@@ -94,34 +94,6 @@ pub enum RnRFormLowStock {
     BelowHalf,
     BelowQuarter,
 }
-
-impl RnRFormLineRow {
-    pub(crate) fn generate_changelog(
-        row_or_id: RowOrId<RnRFormLineRow>,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        let row = match row_or_id {
-            RowOrId::Row(row) => row,
-            RowOrId::Id(row_id) => &RnRFormLineRowRepository::new(con)
-                .find_one_by_id(row_id)?
-                .ok_or(RepositoryError::NotFound)?,
-        };
-        let rnr_form_changelog = RnRFormRow::generate_changelog(
-            RowOrId::Id(&row.rnr_form_id),
-            con,
-            action,
-            source_site_id,
-        )?;
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::RnrFormLine,
-            record_id: row.id.clone(),
-            ..rnr_form_changelog
-        })
-    }
-}
-
 pub struct RnRFormLineRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/rnr_form_row.rs
+++ b/server/repository/src/db_diesel/rnr_form_row.rs
@@ -3,8 +3,7 @@ use super::{
     store_row::store, StorageConnection,
 };
 use crate::{
-    db_diesel::changelog::changelog::RowOrId, diesel_macros::define_linked_tables,
-    ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType, ChangelogTableName, Delete,
+    db_diesel::changelog::changelog::RowOrId, diesel_macros::define_linked_tables, ChangelogRepository, ChangelogSyncType, Delete,
     RepositoryError, RowActionType, SourceSiteId, Upsert,
 };
 
@@ -75,32 +74,6 @@ pub enum RnRFormStatus {
     Draft,
     Finalised,
 }
-
-impl RnRFormRow {
-    pub(crate) fn generate_changelog(
-        row_or_id: RowOrId<RnRFormRow>,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        let row = match row_or_id {
-            RowOrId::Row(row) => row,
-            RowOrId::Id(row_id) => &RnRFormRowRepository::new(con)
-                .find_one_by_id(row_id)?
-                .ok_or(RepositoryError::NotFound)?,
-        };
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::RnrForm,
-            record_id: row.id.clone(),
-            row_action: action,
-            store_id: Some(row.store_id.clone()),
-            name_id: Some(row.name_id.clone()),
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct RnRFormRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/sensor_row.rs
+++ b/server/repository/src/db_diesel/sensor_row.rs
@@ -3,7 +3,7 @@ use super::{location_row::location, store_row::store, StorageConnection};
 use crate::{
     repository_error::RepositoryError, ChangelogSyncType, SourceSiteId, Upsert,
 };
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
@@ -66,26 +66,6 @@ pub struct SensorRow {
     #[diesel(column_name = "type_")]
     pub r#type: SensorType,
 }
-
-impl SensorRow {
-    pub(crate) fn generate_changelog(
-        &self,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::Sensor,
-            record_id: self.id.clone(),
-            row_action: action,
-            store_id: Some(self.store_id.clone()),
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct SensorRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/stock_line_row.rs
+++ b/server/repository/src/db_diesel/stock_line_row.rs
@@ -8,7 +8,7 @@ use crate::{
     db_diesel::vvm_status::vvm_status_row::vvm_status, diesel_macros::define_linked_tables,
     repository_error::RepositoryError, ChangelogSyncType, Delete, SourceSiteId, Upsert,
 };
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 
 use diesel::prelude::*;
 
@@ -91,32 +91,6 @@ pub struct StockLineRow {
     pub donor_id: Option<String>,
     pub manufacturer_id: Option<String>,
 }
-
-impl StockLineRow {
-    pub(crate) fn generate_changelog(
-        row_or_id: RowOrId<StockLineRow>,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        let row = match row_or_id {
-            RowOrId::Row(row) => row,
-            RowOrId::Id(row_id) => &StockLineRowRepository::new(con)
-                .find_one_by_id(row_id)?
-                .ok_or(RepositoryError::NotFound)?,
-        };
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::StockLine,
-            record_id: row.id.clone(),
-            row_action: action,
-            store_id: Some(row.store_id.clone()),
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct StockLineRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/stocktake_line_row.rs
+++ b/server/repository/src/db_diesel/stocktake_line_row.rs
@@ -7,10 +7,10 @@ use super::{
 use crate::db_diesel::changelog::changelog::RowOrId;
 use crate::diesel_macros::define_linked_tables;
 use crate::{
-    repository_error::RepositoryError, ChangelogSyncType, Delete, SourceSiteId, StocktakeRow,
+    repository_error::RepositoryError, ChangelogSyncType, Delete, SourceSiteId,
     Upsert,
 };
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 
 use diesel::prelude::*;
 
@@ -94,34 +94,6 @@ pub struct StocktakeLineRow {
     pub donor_id: Option<String>,
     pub manufacturer_id: Option<String>,
 }
-
-impl StocktakeLineRow {
-    pub(crate) fn generate_changelog(
-        row_or_id: RowOrId<StocktakeLineRow>,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        let row = match row_or_id {
-            RowOrId::Row(row) => row,
-            RowOrId::Id(row_id) => &StocktakeLineRowRepository::new(con)
-                .find_one_by_id(row_id)?
-                .ok_or(RepositoryError::NotFound)?,
-        };
-        let stocktake_changelog = StocktakeRow::generate_changelog(
-            RowOrId::Id(&row.stocktake_id),
-            con,
-            action,
-            source_site_id,
-        )?;
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::StocktakeLine,
-            record_id: row.id.clone(),
-            ..stocktake_changelog
-        })
-    }
-}
-
 pub struct StocktakeLineRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/stocktake_row.rs
+++ b/server/repository/src/db_diesel/stocktake_row.rs
@@ -2,7 +2,7 @@ use super::{user_row::user_account, StorageConnection};
 
 use crate::db_diesel::changelog::changelog::RowOrId;
 use crate::{repository_error::RepositoryError, Delete};
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 use crate::{ChangelogSyncType, SourceSiteId, Upsert};
 
 use chrono::{NaiveDate, NaiveDateTime};
@@ -63,32 +63,6 @@ pub struct StocktakeRow {
     pub verified_by: Option<String>,
     pub is_initial_stocktake: bool,
 }
-
-impl StocktakeRow {
-    pub(crate) fn generate_changelog(
-        row_or_id: RowOrId<StocktakeRow>,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        let row = match row_or_id {
-            RowOrId::Row(row) => row,
-            RowOrId::Id(row_id) => &StocktakeRowRepository::new(con)
-                .find_one_by_id(row_id)?
-                .ok_or(RepositoryError::NotFound)?,
-        };
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::Stocktake,
-            record_id: row.id.clone(),
-            row_action: action,
-            store_id: Some(row.store_id.clone()),
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct StocktakeRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/store_row.rs
+++ b/server/repository/src/db_diesel/store_row.rs
@@ -118,6 +118,14 @@ impl<'a> StoreRowRepository<'a> {
         Ok(result)
     }
 
+    pub fn find_one_by_name_id(&self, name_id: &str) -> Result<Option<StoreRow>, RepositoryError> {
+        let result = store::table
+            .filter(store::name_id.eq(name_id))
+            .first(self.connection.lock().connection())
+            .optional()?;
+        Ok(result)
+    }
+
     pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<StoreRow>, RepositoryError> {
         let result = store::table
             .filter(store::id.eq_any(ids))

--- a/server/repository/src/db_diesel/sync_file_reference_row.rs
+++ b/server/repository/src/db_diesel/sync_file_reference_row.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::SourceSiteId;
 use crate::{
-    ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType, ChangelogTableName, RowActionType,
+    ChangelogRepository, ChangelogSyncType, RowActionType,
     Upsert,
 };
 
@@ -89,24 +89,6 @@ pub struct SyncFileReferenceRow {
     pub created_datetime: NaiveDateTime,
     pub deleted_datetime: Option<NaiveDateTime>,
 }
-
-impl SyncFileReferenceRow {
-    pub(crate) fn generate_changelog(
-        changelog_record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::SyncFileReference,
-            record_id: changelog_record_id,
-            row_action: action,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct SyncFileReferenceRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/sync_message_row.rs
+++ b/server/repository/src/db_diesel/sync_message_row.rs
@@ -1,5 +1,5 @@
 use super::{
-    store_row::store, ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType,
+    store_row::store, ChangelogRepository, RowActionType,
     StorageConnection,
 };
 use crate::{ChangelogSyncType, RepositoryError, SourceSiteId, Upsert};
@@ -74,26 +74,6 @@ pub struct SyncMessageRow {
     #[ts(optional)]
     pub error_message: Option<String>,
 }
-
-impl SyncMessageRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::SyncMessage,
-            record_id,
-            row_action: action,
-            name_id: None,
-            store_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct SyncMessageRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/system_log_row.rs
+++ b/server/repository/src/db_diesel/system_log_row.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType, ChangelogTableName, RowActionType,
+    ChangelogRepository, ChangelogSyncType, RowActionType,
     Upsert,
 };
 use crate::{RepositoryError, SourceSiteId, StorageConnection};
@@ -59,26 +59,6 @@ pub struct SystemLogRow {
     pub message: Option<String>,
     pub is_error: bool,
 }
-
-impl SystemLogRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::SystemLog,
-            record_id,
-            row_action: action,
-            store_id: None,
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct SystemLogRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/temperature_breach_config_row.rs
+++ b/server/repository/src/db_diesel/temperature_breach_config_row.rs
@@ -5,7 +5,7 @@ use super::{
 
 use crate::repository_error::RepositoryError;
 use crate::SourceSiteId;
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 
 use diesel::prelude::*;
 
@@ -40,26 +40,6 @@ pub struct TemperatureBreachConfigRow {
     pub minimum_temperature: f64,
     pub maximum_temperature: f64,
 }
-
-impl TemperatureBreachConfigRow {
-    pub(crate) fn generate_changelog(
-        &self,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::TemperatureBreachConfig,
-            record_id: self.id.clone(),
-            row_action: action,
-            store_id: Some(self.store_id.clone()),
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct TemperatureBreachConfigRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/temperature_breach_row.rs
+++ b/server/repository/src/db_diesel/temperature_breach_row.rs
@@ -3,7 +3,7 @@ use super::{location_row::location, sensor_row::sensor, store_row::store, Storag
 use crate::{
     repository_error::RepositoryError, ChangelogSyncType, SourceSiteId, Upsert,
 };
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
@@ -65,26 +65,6 @@ pub struct TemperatureBreachRow {
     pub threshold_duration_milliseconds: i32,
     pub comment: Option<String>,
 }
-
-impl TemperatureBreachRow {
-    pub(crate) fn generate_changelog(
-        &self,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::TemperatureBreach,
-            record_id: self.id.clone(),
-            row_action: action,
-            store_id: Some(self.store_id.clone()),
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct TemperatureBreachRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/temperature_log_row.rs
+++ b/server/repository/src/db_diesel/temperature_log_row.rs
@@ -3,7 +3,7 @@ use super::{sensor_row::sensor, store_row::store, StorageConnection};
 use crate::{
     repository_error::RepositoryError, ChangelogSyncType, SourceSiteId, Upsert,
 };
-use crate::{ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RowActionType};
+use crate::{ChangelogRepository, RowActionType};
 
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
@@ -37,26 +37,6 @@ pub struct TemperatureLogRow {
     pub datetime: NaiveDateTime,
     pub temperature_breach_id: Option<String>,
 }
-
-impl TemperatureLogRow {
-    pub(crate) fn generate_changelog(
-        &self,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::TemperatureLog,
-            record_id: self.id.clone(),
-            row_action: action,
-            store_id: Some(self.store_id.clone()),
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct TemperatureLogRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/vaccination_row.rs
+++ b/server/repository/src/db_diesel/vaccination_row.rs
@@ -1,6 +1,6 @@
 use crate::diesel_macros::define_linked_tables;
 use crate::{
-    ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType, ChangelogTableName,
+    ChangelogRepository, ChangelogSyncType,
     RepositoryError, RowActionType, SourceSiteId, StorageConnection, Upsert,
 };
 
@@ -97,26 +97,6 @@ pub enum VaccinationStatus {
     Draft,
     Finalised,
 }
-
-impl VaccinationRow {
-    pub(crate) fn generate_changelog(
-        &self,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::Vaccination,
-            record_id: self.id.clone(),
-            row_action: action,
-            store_id: None,
-            name_id: Some(self.patient_id.clone()),
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct VaccinationRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/vaccine_course/vaccine_course_dose_row.rs
+++ b/server/repository/src/db_diesel/vaccine_course/vaccine_course_dose_row.rs
@@ -6,8 +6,7 @@ use crate::{
     db_diesel::{
         clinician_link_row::clinician_link, clinician_row::clinician, item_link_row::item_link,
         item_row::item, name_row::name,
-    },
-    ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType, ChangelogTableName,
+    }, ChangelogRepository, ChangelogSyncType,
     RepositoryError, RowActionType, SourceSiteId, StorageConnection, Upsert,
 };
 
@@ -51,25 +50,6 @@ pub struct VaccineCourseDoseRow {
     pub min_interval_days: i32,
     pub deleted_datetime: Option<NaiveDateTime>,
 }
-
-impl VaccineCourseDoseRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::VaccineCourseDose,
-            record_id,
-            row_action: action,
-            store_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct VaccineCourseDoseRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/vaccine_course/vaccine_course_item_row.rs
+++ b/server/repository/src/db_diesel/vaccine_course/vaccine_course_item_row.rs
@@ -4,7 +4,7 @@ use crate::db_diesel::item_row::item;
 use crate::RepositoryError;
 use crate::StorageConnection;
 use crate::{
-    ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType, ChangelogTableName, RowActionType,
+    ChangelogRepository, ChangelogSyncType, RowActionType,
     SourceSiteId, Upsert,
 };
 
@@ -37,25 +37,6 @@ pub struct VaccineCourseItemRow {
     pub item_link_id: String,
     pub deleted_datetime: Option<NaiveDateTime>,
 }
-
-impl VaccineCourseItemRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::VaccineCourseItem,
-            record_id,
-            row_action: action,
-            store_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct VaccineCourseItemRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/vaccine_course/vaccine_course_row.rs
+++ b/server/repository/src/db_diesel/vaccine_course/vaccine_course_row.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::{
-    ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType, ChangelogTableName,
+    ChangelogRepository, ChangelogSyncType,
     RepositoryError, RowActionType, SourceSiteId, StorageConnection, Upsert,
 };
 
@@ -41,25 +41,6 @@ pub struct VaccineCourseRow {
     pub deleted_datetime: Option<chrono::NaiveDateTime>,
     pub can_skip_dose: bool,
 }
-
-impl VaccineCourseRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::VaccineCourse,
-            record_id,
-            row_action: action,
-            store_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct VaccineCourseRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/vaccine_course/vaccine_course_store_config_row.rs
+++ b/server/repository/src/db_diesel/vaccine_course/vaccine_course_store_config_row.rs
@@ -1,6 +1,6 @@
 use super::vaccine_course_store_config_row::vaccine_course_store_config::dsl::*;
 use crate::{
-    ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType, ChangelogTableName,
+    ChangelogRepository, ChangelogSyncType,
     RepositoryError, RowActionType, SourceSiteId, StorageConnection, Upsert,
 };
 use diesel::prelude::*;
@@ -28,25 +28,6 @@ pub struct VaccineCourseStoreConfigRow {
     pub wastage_rate: Option<f64>,
     pub coverage_rate: Option<f64>,
 }
-
-impl VaccineCourseStoreConfigRow {
-    pub(crate) fn generate_changelog(
-        &self,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::VaccineCourseStoreConfig,
-            record_id: self.id.clone(),
-            row_action: action,
-            store_id: Some(self.store_id.clone()),
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct VaccineCourseStoreConfigRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/vvm_status/vvm_status_log_row.rs
+++ b/server/repository/src/db_diesel/vvm_status/vvm_status_log_row.rs
@@ -3,8 +3,7 @@ use crate::{
     db_diesel::{
         changelog::changelog::RowOrId, invoice_line_row::invoice_line,
         stock_line_row::stock_line, store_row::store,
-    },
-    ChangeLogInsertRow, ChangelogRepository, ChangelogSyncType, ChangelogTableName, Delete,
+    }, ChangelogRepository, ChangelogSyncType, Delete,
     RepositoryError, RowActionType, SourceSiteId, StorageConnection, Upsert,
 };
 
@@ -43,32 +42,6 @@ pub struct VVMStatusLogRow {
     pub invoice_line_id: Option<String>,
     pub store_id: String,
 }
-
-impl VVMStatusLogRow {
-    pub(crate) fn generate_changelog(
-        row_or_id: RowOrId<VVMStatusLogRow>,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        let row = match row_or_id {
-            RowOrId::Row(row) => row,
-            RowOrId::Id(row_id) => &VVMStatusLogRowRepository::new(con)
-                .find_one_by_id(row_id)?
-                .ok_or(RepositoryError::NotFound)?,
-        };
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::VVMStatusLog,
-            record_id: row.id.clone(),
-            row_action: action,
-            store_id: Some(row.store_id.clone()),
-            name_id: None,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
 pub struct VVMStatusLogRowRepository<'a> {
     connection: &'a StorageConnection,
 }


### PR DESCRIPTION
## Stack
This is **PR 1 of 9** in a stacked refactor of the sync system, based on `feature-sync`.

> ⚠️ **Tests will not pass until the final PR (9/9) in the stack is merged.** Each PR in the stack is a logically scoped chunk; the suite only goes green at the top of the stack.

| # | Branch | Status |
|---|--------|--------|
| **1** | `feature-sync-1-changelog-single-file` | 👈 this PR |
| 2 | `feature-sync-2-v7-filtering` | next |
| 3 | `feature-sync-3-use-new-filter` | |
| 4 | `feature-sync-4-query-with-data` | |
| 5 | `feature-sync-5-query-with-data-v5-v6` | |
| 6 | `feature-sync-6-all-tables-changelog` | |
| 7 | `feature-sync-7-v7-translations` | |
| 8 | `feature-sync-8-sync-style-docs` | |
| 9 | `feature-sync-9-rebuild-sync-buffer` | |

## Summary
- Pure refactor: pulls all the per-row changelog trigger SQL out of each `*_row.rs` file and consolidates it into a single new `server/repository/src/db_diesel/changelog/generate_changelog.rs`.
- The triggers produced are the same as before — only the source location changes.
- ~66 row files touched; one new ~1,366-line `generate_changelog.rs`.

## Why
Having changelog/trigger SQL scattered across every row module made it hard to audit which tables had triggers, hard to keep style consistent, and hard to add new tables. Putting it in one file is groundwork for the v7 work that follows in the rest of the stack.

## Test plan
- [ ] No behaviour change expected — generated triggers should be byte-identical to before
- [ ] Tests will not pass on this branch alone; full suite is validated at PR 9