### PR TITLE
Sync stack 3/9: Use new filter everywhere

### DIFF
--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -1,16 +1,13 @@
 use crate::{
-    db_diesel::store_row::store,
-    diesel_macros::{apply_equal_filter, diesel_string_enum},
-    dynamic_query_filter::create_condition,
-    name_store_join::name_store_join,
-    vaccination_row::vaccination,
-    DBType, EqualFilter, KeyValueStoreRepository, LockedConnection, RepositoryError,
+    db_diesel::store_row::store, diesel_macros::diesel_string_enum,
+    dynamic_query_filter::create_condition, name_store_join::name_store_join,
+    vaccination_row::vaccination, KeyType, KeyValueStoreRepository, RepositoryError,
     StorageConnection, TransactionNotification,
 };
-use diesel::{dsl::LeftJoinQuerySource, helper_types::IntoBoxed, prelude::*};
+use diesel::{dsl::LeftJoinQuerySource, prelude::*};
 use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
 use strum::IntoEnumIterator;
+use thiserror::Error;
 use ts_rs::TS;
 
 table! {
@@ -232,19 +229,38 @@ pub(crate) enum ChangeLogSyncStyle {
     RemoteToCentral, // These records won't sync back to the remote site on re-initalisation
 }
 
-fn v6() -> bool {
-    true
+impl ChangeLogSyncStyle {
+    fn get_table_names_for_sync_style(
+        &self,
+        sync_style_options: Option<SyncStyleOptions>,
+    ) -> Vec<ChangelogTableName> {
+        ChangelogTableName::iter()
+            .filter(|table| {
+                let (styles, options) = table.sync_style();
+                if let Some(sync_style_options) = &sync_style_options {
+                    if sync_style_options != &options {
+                        return false;
+                    }
+                }
+                styles.iter().any(|style| style == self)
+            })
+            .collect()
+    }
 }
-fn not_v6() -> bool {
-    false
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SyncStyleOptions {
+    pub is_v6: bool,
+    pub is_v5: bool,
 }
+
 // When adding a new change log record type, specify how it should be synced
 // If new requirements are needed a different ChangeLogSyncStyle can be added
 //
 // Variants are grouped to match the order of `ChangelogTableName` above and
 // sorted alphabetically within each group. Keep the two in sync.
 impl ChangelogTableName {
-    pub(crate) fn sync_style(&self) -> (Vec<ChangeLogSyncStyle>, bool /* is v6 */) {
+    pub(crate) fn sync_style(&self) -> (Vec<ChangeLogSyncStyle>, SyncStyleOptions) {
         use ChangeLogSyncStyle::*;
         use ChangelogTableName::*;
         match self {
@@ -275,17 +291,36 @@ impl ChangelogTableName {
             | TemperatureBreach
             | TemperatureBreachConfig
             | TemperatureLog
-            | VVMStatusLog => (vec![Remote], not_v6()),
+            | SyncMessage
+            | VVMStatusLog => (
+                vec![Remote],
+                SyncStyleOptions {
+                    is_v6: false,
+                    is_v5: true,
+                },
+            ),
 
             // ----------------------------------------------------------
             // Legacy — Remote + Transfer (not v6)
             // ----------------------------------------------------------
-            Requisition | RequisitionLine => (vec![Remote, Transfer], not_v6()),
+            Requisition | RequisitionLine => (
+                vec![Remote, Transfer],
+                SyncStyleOptions {
+                    is_v6: false,
+                    is_v5: true,
+                },
+            ),
 
             // ----------------------------------------------------------
             // Legacy — Remote + Transfer + Patient (not v6)
             // ----------------------------------------------------------
-            Invoice | InvoiceLine => (vec![Remote, Transfer, Patient], not_v6()),
+            Invoice | InvoiceLine => (
+                vec![Remote, Transfer, Patient],
+                SyncStyleOptions {
+                    is_v6: false,
+                    is_v5: true,
+                },
+            ),
 
             // ----------------------------------------------------------
             // Central (v6) — created on the Open-mSupply central server
@@ -314,17 +349,35 @@ impl ChangelogTableName {
             | VaccineCourse
             | VaccineCourseDose
             | VaccineCourseItem
-            | VaccineCourseStoreConfig => (vec![Central], v6()),
+            | VaccineCourseStoreConfig => (
+                vec![Central],
+                SyncStyleOptions {
+                    is_v6: true,
+                    is_v5: false,
+                },
+            ),
 
             // ----------------------------------------------------------
             // Central (not v6) — central data synced via legacy mSupply
             // ----------------------------------------------------------
-            LocationType | MasterList | Store | Unit => (vec![Central], not_v6()),
+            LocationType | MasterList | Store | Unit => (
+                vec![Central],
+                SyncStyleOptions {
+                    is_v6: false,
+                    is_v5: true,
+                },
+            ),
 
             // ----------------------------------------------------------
             // ToLegacyCentralOnly (not v6)
             // ----------------------------------------------------------
-            Site => (vec![ToLegacyCentralOnly], not_v6()),
+            Site => (
+                vec![ToLegacyCentralOnly],
+                SyncStyleOptions {
+                    is_v6: false,
+                    is_v5: true,
+                },
+            ),
 
             // ----------------------------------------------------------
             // Remote (v6) — store-scoped data that syncs to the owning site
@@ -335,23 +388,46 @@ impl ChangelogTableName {
             | Encounter
             | RnrForm
             | RnrFormLine
-            | SyncMessage
-            | Vaccination => (vec![Remote], v6()),
+            | Vaccination => (
+                vec![Remote],
+                SyncStyleOptions {
+                    is_v6: true,
+                    is_v5: false,
+                },
+            ),
 
             // ----------------------------------------------------------
             // File (v6) — file references (handled by the file-sync pipeline)
             // ----------------------------------------------------------
-            SyncFileReference => (vec![File], v6()),
+            SyncFileReference => (
+                vec![File],
+                SyncStyleOptions {
+                    is_v6: true,
+                    is_v5: false,
+                },
+            ),
 
             // ----------------------------------------------------------
             // RemoteAndCentral (v6) — Remote when store_id is set, otherwise Central
             // ----------------------------------------------------------
-            PluginData | Preference => (vec![Remote, Central], v6()),
+            PluginData | Preference => (
+                vec![Remote, Central],
+                SyncStyleOptions {
+                    is_v6: true,
+                    is_v5: false,
+                },
+            ),
 
             // ----------------------------------------------------------
             // RemoteToCentral (v6) — pushed to central but not synced back on re-init
             // ----------------------------------------------------------
-            ContactForm | SystemLog => (vec![RemoteToCentral], v6()),
+            ContactForm | SystemLog => (
+                vec![RemoteToCentral],
+                SyncStyleOptions {
+                    is_v6: true,
+                    is_v5: false,
+                },
+            ),
         }
     }
 }
@@ -384,26 +460,8 @@ pub struct ChangelogRow {
     pub patient_id: Option<String>,
 }
 
-#[derive(Default, Clone, Serialize, Deserialize, Debug, TS)]
-pub struct ChangelogFilter {
-    #[ts(optional)]
-    pub table_name: Option<EqualFilter<ChangelogTableName>>,
-    #[ts(optional)]
-    pub name_id: Option<EqualFilter<String>>,
-    #[ts(optional)]
-    pub store_id: Option<EqualFilter<String>>,
-    #[ts(optional)]
-    pub record_id: Option<EqualFilter<String>>,
-    #[ts(optional)]
-    pub action: Option<EqualFilter<RowActionType>>,
-    #[ts(optional)]
-    pub is_sync_update: Option<EqualFilter<bool>>,
-    #[ts(optional)]
-    pub source_site_id: Option<EqualFilter<i32>>,
-}
-
 pub struct ChangelogRepository<'a> {
-    connection: &'a StorageConnection,
+    pub(super) connection: &'a StorageConnection,
 }
 
 impl<'a> ChangelogRepository<'a> {
@@ -411,153 +469,35 @@ impl<'a> ChangelogRepository<'a> {
         ChangelogRepository { connection }
     }
 
-    /// Returns changelog rows order by operation sequence in asc order
-    ///
-    /// # Arguments
-    ///
-    /// * `earliest` - Starting cursor (first returned changelogs may be ahead in sequence from starting cursor)
-    /// * `limit` - Maximum number of entries to be returned
-    /// * `filter` - Extra filter to apply on change_logs
-    pub fn changelogs(
+    pub fn query(
         &self,
-        earliest: u64,
-        limit: u32,
-        filter: Option<ChangelogFilter>,
+        filter: ChangelogCondition::Inner,
+        CursorAndLimit { cursor, limit }: CursorAndLimit,
     ) -> Result<Vec<ChangelogRow>, RepositoryError> {
-        let result = with_locked_changelog_table(self.connection, |locked_con| {
-            let query = create_filtered_query(earliest, filter)
-                .order(changelog::dsl::cursor.asc())
-                .limit(limit.into());
+        let filter = ChangelogCondition::And(vec![
+            filter,
+            ChangelogCondition::cursor::greater_than(cursor),
+        ]);
 
-            // // Debug diesel query
-            // println!(
-            //     "{}",
-            //     diesel::debug_query::<crate::DBType, _>(&query).to_string()
-            // );
-
-            let result: Vec<ChangelogRow> = query.load(locked_con.connection())?;
-            Ok(result)
-        })?;
-        Ok(result)
-    }
-
-    pub fn count(
-        &self,
-        earliest: u64,
-        filter: Option<ChangelogFilter>,
-    ) -> Result<u64, RepositoryError> {
-        let result = create_filtered_query(earliest, filter)
-            .count()
-            .get_result::<i64>(self.connection.lock().connection())?;
-        Ok(result as u64)
-    }
-
-    pub fn outgoing_sync_records_from_central(
-        &self,
-        earliest: u64,
-        batch_size: u32,
-        sync_site_id: i32,
-        is_initialized: bool,
-    ) -> Result<Vec<ChangelogRow>, RepositoryError> {
-        let result = with_locked_changelog_table(self.connection, |locked_con| {
-            let query = create_filtered_outgoing_sync_query(earliest, sync_site_id, is_initialized)
-                .order(changelog::cursor.asc())
-                .limit(batch_size.into());
-
-            // Debug diesel query
-            // println!(
-            //     "{}",
-            //     diesel::debug_query::<crate::DBType, _>(&query).to_string()
-            // );
-
-            let result: Vec<ChangelogRow> = query.load(locked_con.connection())?;
-            Ok(result)
-        })?;
-        Ok(result)
-    }
-
-    pub fn outgoing_patient_sync_records_from_central(
-        &self,
-        earliest: u64,
-        batch_size: u32,
-        sync_site_id: i32,
-        fetch_patient_id: String,
-    ) -> Result<Vec<ChangelogRow>, RepositoryError> {
-        let result = with_locked_changelog_table(self.connection, |locked_con| {
-            let query = create_filtered_outgoing_patient_sync_query(
-                earliest,
-                sync_site_id,
-                fetch_patient_id,
-            )
+        let query = query()
+            .filter(filter.to_boxed())
             .order(changelog::cursor.asc())
-            .limit(batch_size.into());
+            .limit(limit)
+            .select(changelog::all_columns);
 
-            // Debug diesel query
-            // println!(
-            //     "{}",
-            //     diesel::debug_query::<crate::DBType, _>(&query).to_string()
-            // );
+        // Debug diesel query
+        // println!("{}", diesel::debug_query::<DBType, _>(&query).to_string());
+        let result: Vec<ChangelogRow> = query.load(self.connection.lock().connection())?;
 
-            let result: Vec<ChangelogRow> = query.load(locked_con.connection())?;
-            Ok(result)
-        })?;
         Ok(result)
     }
 
-    /// This returns the number of changelog records that should be evaluated to send to the remote site when doing a v6_pull
-    /// This looks up associated records to decide if change log should be sent to the site or not
-    /// Update this method when adding new record types to the system
-    pub fn count_outgoing_sync_records_from_central(
-        &self,
-        earliest: u64,
-        sync_site_id: i32,
-        is_initialized: bool,
-    ) -> Result<u64, RepositoryError> {
-        let result = create_filtered_outgoing_sync_query(earliest, sync_site_id, is_initialized)
-            .count()
-            .get_result::<i64>(self.connection.lock().connection())?;
-        Ok(result as u64)
-    }
-
-    pub fn count_outgoing_patient_sync_records_from_central(
-        &self,
-        earliest: u64,
-        sync_site_id: i32,
-        fetch_patient_id: String,
-    ) -> Result<u64, RepositoryError> {
-        let result =
-            create_filtered_outgoing_patient_sync_query(earliest, sync_site_id, fetch_patient_id)
-                .count()
-                .get_result::<i64>(self.connection.lock().connection())?;
-        Ok(result as u64)
-    }
-
-    /// Returns latest change log
-    /// After initial sync we use this method to get the latest cursor to make sure we don't try to push any records that were synced to this site on initialisation
-    pub fn latest_cursor(&self) -> Result<u64, RepositoryError> {
+    /// Returns latest/max change log cursor
+    pub fn max_cursor(&self) -> Result<u64, RepositoryError> {
         let result = changelog::table
             .select(diesel::dsl::max(changelog::cursor))
             .first::<Option<i64>>(self.connection.lock().connection())?;
         Ok(result.unwrap_or(0) as u64)
-    }
-
-    // Delete all change logs with cursor greater-equal cursor_ge
-    pub fn delete(&self, cursor_ge: i64) -> Result<(), RepositoryError> {
-        diesel::delete(changelog::dsl::changelog)
-            .filter(changelog::dsl::cursor.ge(cursor_ge))
-            .execute(self.connection.lock().connection())?;
-        Ok(())
-    }
-
-    // Needed for tests, when is_sync_update needs to be reset when records were inserted via
-    // PullUpsertRecord (but not through sync)
-    #[cfg(feature = "integration_test")]
-    pub fn reset_is_sync_update(&self, from_cursor: u64) -> Result<(), RepositoryError> {
-        diesel::update(changelog::table)
-            .set(changelog::is_sync_update.eq(false))
-            .filter(changelog::cursor.gt(from_cursor as i64))
-            .execute(self.connection.lock().connection())?;
-        Ok(())
     }
 
     pub fn insert(&self, row: &ChangeLogInsertRow) -> Result<(), RepositoryError> {
@@ -597,275 +537,6 @@ create_condition!(
     (patient_site_id, i32, patient_stores.field(store::site_id)),
 );
 
-type BoxedChangelogQuery = IntoBoxed<'static, changelog::table, DBType>;
-
-fn create_base_query(earliest: u64) -> BoxedChangelogQuery {
-    changelog::table
-        .filter(changelog::cursor.ge(earliest.try_into().unwrap_or(0)))
-        .into_boxed()
-}
-
-fn create_filtered_query(earliest: u64, filter: Option<ChangelogFilter>) -> BoxedChangelogQuery {
-    let mut query = create_base_query(earliest);
-
-    if let Some(f) = filter {
-        let ChangelogFilter {
-            table_name,
-            name_id,
-            store_id,
-            record_id,
-            is_sync_update,
-            action,
-            source_site_id,
-        } = f;
-
-        apply_equal_filter!(query, table_name, changelog::table_name);
-        apply_equal_filter!(query, name_id, changelog::name_link_id);
-        apply_equal_filter!(query, store_id, changelog::store_id);
-        apply_equal_filter!(query, record_id, changelog::record_id);
-        apply_equal_filter!(query, action, changelog::row_action);
-        apply_equal_filter!(query, is_sync_update, changelog::is_sync_update);
-        apply_equal_filter!(query, source_site_id, changelog::source_site_id);
-    }
-
-    query
-}
-
-// The idea for this method is to build a query in such a way as to allow
-// extracting all relevant records for a site from change_log
-// A resulting SQL might look something like this...
-//
-// SELECT * FROM changelog_dedup
-// WHERE cursor > {remote site SyncPullCursorV6} AND last_sync_site_id != {remote site id}
-// AND
-// (
-// 	table_name in {central_record_names}
-//  OR
-// 	(table_name in {transfer record names}  AND name_id IN {name_ids of active stores on remote site})
-//  OR
-// 	// Special cases
-// 	(table_name in {patient record name} AND patient_id IN {select name_id from name_store_join where store_id in {active stores on remote site})
-// )
-
-/// This looks up associated records to decide if change log should be sent to the site or not
-/// Update this method when adding new sync styles to the system
-fn create_filtered_outgoing_sync_query(
-    earliest: u64,
-    sync_site_id: i32,
-    is_initialized: bool,
-) -> BoxedChangelogQuery {
-    let mut query = create_base_query(earliest);
-
-    // // If we are initialising, we want to send all the records for the site, even ones that originally came from the site
-    // // The rest of the time we want to exclude any records that were created by the site
-    // if is_initialized {
-    //     query = query.filter(
-    //         changelog::source_site_id
-    //             .ne(Some(sync_site_id))
-    //             .or(changelog::source_site_id.is_null()),
-    //     )
-    // }
-
-    // // Loop through all the Sync tables and add them to the query if they have the right sync style
-
-    // // Central Records
-    // let central_sync_table_names: Vec<ChangelogTableName> = ChangelogTableName::iter()
-    //     .filter(|table| matches!(table.sync_style(), ChangeLogSyncStyle::Central))
-    //     .collect();
-
-    // // Remote Records
-    // let remote_sync_table_names: Vec<ChangelogTableName> = ChangelogTableName::iter()
-    //     .filter(|table| {
-    //         matches!(
-    //             table.sync_style(),
-    //             ChangeLogSyncStyle::Remote | ChangeLogSyncStyle::RemoteAndCentral
-    //         )
-    //     })
-    //     .collect();
-
-    // // Central record where store id is null
-    // let central_by_empty_store_id: Vec<ChangelogTableName> = ChangelogTableName::iter()
-    //     .filter(|table| matches!(table.sync_style(), ChangeLogSyncStyle::RemoteAndCentral))
-    //     .collect();
-
-    // let active_stores_for_site = store::table
-    //     .filter(store::site_id.eq(sync_site_id))
-    //     .select(store::id.nullable());
-
-    // let patient_names_visible_on_site =
-    //     patient_names_visible_on_site(sync_site_id).select(name_store_join::name_id.nullable());
-
-    // // Filter the query for the matching records for each type
-    // query = query.filter(
-    //     changelog::table_name
-    //         .eq_any(central_sync_table_names)
-    //         .or(changelog::table_name.eq(ChangelogTableName::SyncFileReference)) // All sites get all sync file references (not necessarily files)
-    //         .or(changelog::table_name
-    //             .eq_any(remote_sync_table_names)
-    //             .and(changelog::store_id.eq_any(active_stores_for_site.into_boxed())))
-    //         .or(changelog::table_name
-    //             .eq_any(central_by_empty_store_id)
-    //             .and(changelog::store_id.is_null()))
-    //         // Special case: patient Vaccination records
-    //         // where patient is visible, regardless of the store_id in the changelog
-    //         .or(changelog::table_name
-    //             .eq(ChangelogTableName::Vaccination)
-    //             .and(changelog::name_link_id.eq_any(patient_names_visible_on_site))),
-    //     // Any other special cases could be handled here...
-    // );
-
-    query
-}
-
-type BoxedNameStoreJoinQuery = IntoBoxed<'static, name_store_join::table, DBType>;
-
-fn patient_names_visible_on_site(sync_site_id: i32) -> BoxedNameStoreJoinQuery {
-    let active_stores_for_site = store::table
-        .filter(store::site_id.eq(sync_site_id))
-        .select(store::id.nullable());
-
-    let mut query = name_store_join::table.into_boxed();
-
-    query = query.filter(
-        name_store_join::store_id
-            .nullable()
-            .eq_any(active_stores_for_site),
-    );
-
-    query
-}
-
-// This is a manual sync to fetch all records for a specific patient
-// Managed via own cursor
-fn create_filtered_outgoing_patient_sync_query(
-    earliest: u64,
-    sync_site_id: i32,
-    fetch_patient_id: String,
-) -> BoxedChangelogQuery {
-    let mut query = create_base_query(earliest);
-
-    let patient_names_visible_on_site =
-        patient_names_visible_on_site(sync_site_id).select(name_store_join::name_id.nullable());
-
-    query = query
-        .filter(changelog::name_link_id.eq(fetch_patient_id.clone()))
-        .filter(changelog::name_link_id.eq_any(patient_names_visible_on_site));
-
-    query
-}
-
-/// Runs some DB operation with a fully locked `changelog` table.
-/// This only applies for for Postgres and does nothing for Sqlite.
-///
-/// Motivation:
-/// When querying changelog entries, ongoing transactions might continue adding changelog entries
-/// to the queried range of changelogs.
-/// This is because Postgres has Read Committed isolation level (instead of Serialized in Sqlite).
-/// However, we assume that there will be no new changelog entries in the queried range in the
-/// future, e.g. when updating the cursor position.
-///
-/// For example, a changelog may contain [1, 3, 4, 5] while another (slow) tx is about to commit a
-/// changelog row with cursor = 2.
-/// We need to wait for this changelog 2 to be added before doing the changelogs() query, otherwise
-/// we might update the latest changelog cursor to 5 and the changelog with cursor = 2 will be left
-/// unhandled when continuing from the latest cursor position.
-///
-/// Locking the changelog table will wait for ongoing writers and will prevent new writers while
-/// reading the changelog.
-fn with_locked_changelog_table<T, F>(
-    connection: &StorageConnection,
-    f: F,
-) -> Result<T, RepositoryError>
-where
-    F: FnOnce(&mut LockedConnection) -> Result<T, RepositoryError>,
-{
-    if cfg!(feature = "postgres") {
-        use diesel::connection::SimpleConnection;
-        let result = connection.transaction_sync_etc(
-            |con| {
-                let mut locked_con = con.lock();
-                locked_con
-                    .connection()
-                    .batch_execute("LOCK TABLE ONLY changelog IN ACCESS EXCLUSIVE MODE")?;
-
-                f(&mut locked_con)
-            },
-            false,
-        )?;
-
-        Ok(result)
-    } else {
-        let mut locked_con = connection.lock();
-        f(&mut locked_con)
-    }
-}
-
-impl ChangelogFilter {
-    pub fn new() -> Self {
-        Default::default()
-    }
-
-    pub fn table_name(mut self, filter: EqualFilter<ChangelogTableName>) -> Self {
-        self.table_name = Some(filter);
-        self
-    }
-
-    pub fn name_id(mut self, filter: EqualFilter<String>) -> Self {
-        self.name_id = Some(filter);
-        self
-    }
-
-    pub fn store_id(mut self, filter: EqualFilter<String>) -> Self {
-        self.store_id = Some(filter);
-        self
-    }
-
-    pub fn record_id(mut self, filter: EqualFilter<String>) -> Self {
-        self.record_id = Some(filter);
-        self
-    }
-
-    pub fn action(mut self, filter: EqualFilter<RowActionType>) -> Self {
-        self.action = Some(filter);
-        self
-    }
-
-    pub fn is_sync_update(mut self, filter: EqualFilter<bool>) -> Self {
-        self.is_sync_update = Some(filter);
-        self
-    }
-
-    pub fn source_site_id(mut self, filter: EqualFilter<i32>) -> Self {
-        self.source_site_id = Some(filter);
-        self
-    }
-}
-
-impl ChangelogTableName {
-    pub fn equal_to(&self) -> EqualFilter<Self> {
-        EqualFilter {
-            equal_to: Some(self.clone()),
-            ..Default::default()
-        }
-    }
-
-    pub fn not_equal_to(&self) -> EqualFilter<Self> {
-        EqualFilter {
-            not_equal_to: Some(self.clone()),
-            ..Default::default()
-        }
-    }
-}
-
-impl RowActionType {
-    pub fn equal_to(&self) -> EqualFilter<Self> {
-        EqualFilter {
-            equal_to: Some(self.clone()),
-            ..Default::default()
-        }
-    }
-}
-
 use crate::dynamic_query_filter::*;
 
 pub struct CursorAndLimit {
@@ -879,171 +550,140 @@ pub enum SyncType {
     Remote,
 }
 
-pub fn all_data_edited_on_site(site_id: i32) -> ChangelogCondition::Inner {
-    ChangelogCondition::source_site_id::equal(site_id)
-}
+pub struct ChangelogFilter;
 
-pub fn all_data_for_site(site_id: i32, is_initialising: bool) -> ChangelogCondition::Inner {
-    // TODO can optimise, not filter at all by remote data when initialising
-    use ChangeLogSyncStyle::*;
-    use ChangelogCondition as C;
-    let mut inner_or_conditions = vec![];
-    for sync_style in ChangeLogSyncStyle::iter() {
-        let table_names = get_table_names_for_sync_style(&sync_style, None);
-        let pre_condition = C::table_name::any(table_names);
+// Pull from OMS central
+impl ChangelogFilter {
+    pub fn all_data_for_site(
+        site_id: i32,
+        is_initialising: bool,
+        sync_style_options: Option<SyncStyleOptions>,
+    ) -> ChangelogCondition::Inner {
+        // TODO can optimise, not filter at all by remote data when initialising
+        use ChangeLogSyncStyle::*;
+        use ChangelogCondition as C;
+        let mut inner_or_conditions = vec![];
+        for sync_style in ChangeLogSyncStyle::iter() {
+            let table_names = sync_style.get_table_names_for_sync_style(sync_style_options.clone());
 
-        let condition = match sync_style {
-            Central | File => C::And(vec![
-                // We have central and remote records with same table_name, so need to make sure to include only central ones (where store_id is null)
-                C::store_id::is_null(),
-            ]),
-            ToLegacyCentralOnly | RemoteToCentral => {
-                // Don't sync
+            if table_names.is_empty() {
                 continue;
             }
-            Remote => C::site_id::equal(site_id),
-            Transfer => C::transfer_site_id::equal(site_id),
-            Patient => C::patient_site_id::equal(site_id),
-        };
 
-        inner_or_conditions.push(C::And(vec![pre_condition, condition]));
-    }
+            let pre_condition = C::table_name::any(table_names);
 
-    let mut outer_and_condition = vec![C::Or(inner_or_conditions)];
-    if !is_initialising {
-        outer_and_condition.push(C::source_site_id::not_equal(site_id));
-    }
+            let condition = match sync_style {
+                Central | File => C::And(vec![
+                    // We have central and remote records with same table_name, so need to make sure to include only central ones (where store_id is null)
+                    C::store_id::is_null(),
+                ]),
+                ToLegacyCentralOnly | RemoteToCentral => {
+                    // Don't sync
+                    continue;
+                }
+                Remote => C::site_id::equal(site_id),
+                Transfer => C::transfer_site_id::equal(site_id),
+                Patient => C::patient_site_id::equal(site_id),
+            };
 
-    C::And(outer_and_condition)
-}
-
-pub fn get_table_names_for_sync_style(
-    sync_style: &ChangeLogSyncStyle,
-    is_v6_option: Option<bool>,
-) -> Vec<ChangelogTableName> {
-    ChangelogTableName::iter()
-        .filter(|table| {
-            let (styles, is_v6) = table.sync_style();
-            if is_v6_option == Some(true) && !is_v6 {
-                return false;
-            }
-            styles.iter().any(|style| style == sync_style)
-        })
-        .collect()
-}
-
-pub fn get_changelogs(
-    connection: &StorageConnection,
-    filter: ChangelogCondition::Inner,
-    CursorAndLimit { cursor, limit }: CursorAndLimit,
-) -> Result<Vec<ChangelogRow>, RepositoryError> {
-    let filter = ChangelogCondition::And(vec![
-        filter,
-        ChangelogCondition::cursor::greater_than(cursor),
-    ]);
-
-    let query = query()
-        .filter(filter.to_boxed())
-        .order(changelog::cursor.asc())
-        .limit(limit)
-        .select(changelog::all_columns);
-
-    // Debug diesel query
-    // println!("{}", diesel::debug_query::<DBType, _>(&query).to_string());
-    let result: Vec<ChangelogRow> = query.load(connection.lock().connection())?;
-
-    Ok(result)
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use strum::IntoEnumIterator;
-    use tokio::sync::oneshot;
-    use util::assert_matches;
-
-    use crate::{
-        mock::MockDataInserts, test_db::setup_all, ClinicianRow, ClinicianRowRepository,
-        ClinicianRowRepositoryTrait, RepositoryError, TransactionError,
-    };
-
-    /// Example from with_locked_changelog_table() comment
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_late_changelog_rows() {
-        let (_, connection, connection_manager, _) =
-            setup_all("test_late_changelog_rows", MockDataInserts::none()).await;
-
-        ClinicianRowRepository::new(&connection)
-            .upsert_one(&ClinicianRow {
-                id: String::from("1"),
-                is_active: true,
-                ..Default::default()
-            })
-            .unwrap();
-
-        let (sender, receiver) = oneshot::channel::<()>();
-        let manager_2 = connection_manager.clone();
-        let process_2 = tokio::spawn(async move {
-            let connection = manager_2.connection().unwrap();
-            let result: Result<(), TransactionError<RepositoryError>> = connection
-                .transaction_sync(|con| {
-                    ClinicianRowRepository::new(con)
-                        .upsert_one(&ClinicianRow {
-                            id: String::from("2"),
-                            is_active: true,
-                            ..Default::default()
-                        })
-                        .unwrap();
-                    sender.send(()).unwrap();
-                    std::thread::sleep(core::time::Duration::from_millis(100));
-                    Ok(())
-                });
-            result
-        });
-        receiver.await.unwrap();
-        ClinicianRowRepository::new(&connection)
-            .upsert_one(&ClinicianRow {
-                id: String::from("3"),
-                is_active: true,
-                ..Default::default()
-            })
-            .unwrap();
-
-        let changelogs = ChangelogRepository::new(&connection)
-            .changelogs(
-                0,
-                10,
-                Some(
-                    ChangelogFilter::new()
-                        .table_name(EqualFilter::not_equal_to(ChangelogTableName::SystemLog)),
-                ),
-            )
-            .unwrap();
-        assert_eq!(changelogs.len(), 3);
-
-        // being good and awaiting the task to finish orderly and check it did run fine
-        process_2.await.unwrap().unwrap();
-    }
-
-    #[actix_rt::test]
-    async fn changelog_enum_check() {
-        let (_, connection, _, _) =
-            setup_all("changelog_enum_check", MockDataInserts::none()).await;
-
-        let repo = ChangelogRepository::new(&connection);
-        // Try upsert all variants, confirm that diesel enums match postgres
-        for table_name in ChangelogTableName::iter() {
-            let filter = ChangelogFilter::new().table_name(table_name.equal_to());
-
-            let result = repo.insert(&ChangeLogInsertRow {
-                table_name,
-                ..Default::default()
-            });
-            assert_matches!(result, Ok(_));
-
-            let result = repo.changelogs(1, 100, Some(filter)).unwrap().pop();
-
-            assert_matches!(result, Some(_));
+            inner_or_conditions.push(C::And(vec![pre_condition, condition]));
         }
+
+        let mut outer_and_condition = vec![C::Or(inner_or_conditions)];
+        if !is_initialising {
+            outer_and_condition.push(C::source_site_id::not_equal(site_id));
+        }
+
+        C::And(outer_and_condition)
+    }
+
+    pub fn patient_data_for_site(
+        site_id: i32,
+        sync_style_options: Option<SyncStyleOptions>,
+    ) -> ChangelogCondition::Inner {
+        // TODO do we need to sync name_store_join ?
+        use ChangeLogSyncStyle::*;
+        use ChangelogCondition as C;
+
+        let table_names = Patient.get_table_names_for_sync_style(sync_style_options);
+
+        C::And(vec![
+            C::table_name::any(table_names),
+            C::patient_site_id::equal(site_id),
+        ])
+    }
+
+    pub fn data_for_store(store_id: i32) -> ChangelogCondition::Inner {
+        use ChangeLogSyncStyle::*;
+        use ChangelogCondition as C;
+
+        let remote_table_names = Remote.get_table_names_for_sync_style(None);
+        let transfer_table_names = Transfer.get_table_names_for_sync_style(None);
+
+        C::Or(vec![
+            C::And(vec![
+                C::table_name::any(remote_table_names),
+                C::store_id::equal(store_id.to_string()),
+            ]),
+            C::And(vec![
+                C::table_name::any(transfer_table_names),
+                C::transfer_store_id::equal(store_id.to_string()),
+            ]),
+        ])
+    }
+}
+
+// Push to Legacy Central
+#[derive(Debug, Error)]
+pub enum LegacyDataFilterError {
+    #[error(transparent)]
+    DatabaseError(#[from] RepositoryError),
+    #[error("mSupply Central site id is not set in database")]
+    CentralSiteIdNotSet,
+}
+
+impl ChangelogFilter {
+    pub fn all_data_for_legacy_central(
+        connection: &StorageConnection,
+    ) -> Result<ChangelogCondition::Inner, LegacyDataFilterError> {
+        use ChangeLogSyncStyle::*;
+        use ChangelogCondition as C;
+
+        let msupply_central_server_id = KeyValueStoreRepository::new(connection)
+            .get_i32(KeyType::SettingsSyncCentralServerSiteId)?
+            .ok_or(LegacyDataFilterError::CentralSiteIdNotSet)?;
+
+        let mut inner_or_conditions = vec![];
+
+        let options = Some(SyncStyleOptions {
+            is_v6: false,
+            is_v5: true,
+        });
+        for sync_style in ChangeLogSyncStyle::iter() {
+            let table_names = sync_style.get_table_names_for_sync_style(options.clone());
+
+            if table_names.is_empty() {
+                continue;
+            }
+
+            match sync_style {
+                ToLegacyCentralOnly | Remote | Transfer | Patient => {
+                    inner_or_conditions.push(C::table_name::any(table_names))
+                }
+                Central | RemoteToCentral | File => continue,
+            };
+        }
+
+        Ok(C::And(vec![
+            C::Or(inner_or_conditions),
+            C::source_site_id::not_equal(msupply_central_server_id),
+        ]))
+    }
+}
+
+impl ChangelogFilter {
+    // Push from OMS remote
+    pub fn all_data_edited_on_site(site_id: i32) -> ChangelogCondition::Inner {
+        ChangelogCondition::source_site_id::equal(site_id)
     }
 }

--- a/server/repository/src/db_diesel/changelog/compatibility_changelog.rs
+++ b/server/repository/src/db_diesel/changelog/compatibility_changelog.rs
@@ -1,0 +1,154 @@
+use std::convert::TryInto;
+
+use diesel::{dsl::IntoBoxed, prelude::*};
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+use crate::{diesel_macros::apply_equal_filter, DBType, EqualFilter, RepositoryError};
+
+use super::changelog::*;
+
+// In upgrade to V7 we've change to using dynamic condition filtering
+// However some plugins will still need to use this old changelog filtering
+#[derive(Default, Clone, Serialize, Deserialize, Debug, TS)]
+pub struct CompatibilityChangelogFilter {
+    #[ts(optional)]
+    pub table_name: Option<EqualFilter<ChangelogTableName>>,
+    #[ts(optional)]
+    pub name_id: Option<EqualFilter<String>>,
+    #[ts(optional)]
+    pub store_id: Option<EqualFilter<String>>,
+    #[ts(optional)]
+    pub record_id: Option<EqualFilter<String>>,
+    #[ts(optional)]
+    pub action: Option<EqualFilter<RowActionType>>,
+    #[ts(optional)]
+    pub is_sync_update: Option<EqualFilter<bool>>,
+    #[ts(optional)]
+    pub source_site_id: Option<EqualFilter<i32>>,
+}
+
+impl<'a> ChangelogRepository<'a> {
+    pub fn compatibility_query(
+        &self,
+        earliest: u64,
+        limit: u32,
+        filter: Option<CompatibilityChangelogFilter>,
+    ) -> Result<Vec<ChangelogRow>, RepositoryError> {
+        let query = create_filtered_query(earliest, filter)
+            .order(changelog::dsl::cursor.asc())
+            .limit(limit.into());
+
+        // // Debug diesel query
+        // println!(
+        //     "{}",
+        //     diesel::debug_query::<crate::DBType, _>(&query).to_string()
+        // );
+
+        let result: Vec<ChangelogRow> = query.load(self.connection.lock().connection())?;
+        Ok(result)
+    }
+}
+
+type BoxedChangelogQuery = IntoBoxed<'static, changelog::table, DBType>;
+
+fn create_base_query(earliest: u64) -> BoxedChangelogQuery {
+    changelog::table
+        .filter(changelog::cursor.ge(earliest.try_into().unwrap_or(0)))
+        .into_boxed()
+}
+
+fn create_filtered_query(
+    earliest: u64,
+    filter: Option<CompatibilityChangelogFilter>,
+) -> BoxedChangelogQuery {
+    let mut query = create_base_query(earliest);
+
+    if let Some(f) = filter {
+        let CompatibilityChangelogFilter {
+            table_name,
+            name_id,
+            store_id,
+            record_id,
+            is_sync_update,
+            action,
+            source_site_id,
+        } = f;
+
+        apply_equal_filter!(query, table_name, changelog::table_name);
+        apply_equal_filter!(query, name_id, changelog::name_link_id);
+        apply_equal_filter!(query, store_id, changelog::store_id);
+        apply_equal_filter!(query, record_id, changelog::record_id);
+        apply_equal_filter!(query, action, changelog::row_action);
+        apply_equal_filter!(query, is_sync_update, changelog::is_sync_update);
+        apply_equal_filter!(query, source_site_id, changelog::source_site_id);
+    }
+
+    query
+}
+
+impl CompatibilityChangelogFilter {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn table_name(mut self, filter: EqualFilter<ChangelogTableName>) -> Self {
+        self.table_name = Some(filter);
+        self
+    }
+
+    pub fn name_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.name_id = Some(filter);
+        self
+    }
+
+    pub fn store_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.store_id = Some(filter);
+        self
+    }
+
+    pub fn record_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.record_id = Some(filter);
+        self
+    }
+
+    pub fn action(mut self, filter: EqualFilter<RowActionType>) -> Self {
+        self.action = Some(filter);
+        self
+    }
+
+    pub fn is_sync_update(mut self, filter: EqualFilter<bool>) -> Self {
+        self.is_sync_update = Some(filter);
+        self
+    }
+
+    pub fn source_site_id(mut self, filter: EqualFilter<i32>) -> Self {
+        self.source_site_id = Some(filter);
+        self
+    }
+}
+
+impl ChangelogTableName {
+    pub fn equal_to(&self) -> EqualFilter<Self> {
+        EqualFilter {
+            equal_to: Some(self.clone()),
+            ..Default::default()
+        }
+    }
+
+    pub fn not_equal_to(&self) -> EqualFilter<Self> {
+        EqualFilter {
+            not_equal_to: Some(self.clone()),
+            ..Default::default()
+        }
+    }
+}
+
+impl RowActionType {
+    pub fn equal_to(&self) -> EqualFilter<Self> {
+        EqualFilter {
+            equal_to: Some(self.clone()),
+            ..Default::default()
+        }
+    }
+}

--- a/server/repository/src/db_diesel/changelog/mod.rs
+++ b/server/repository/src/db_diesel/changelog/mod.rs
@@ -1,6 +1,9 @@
 pub mod changelog;
 pub use self::changelog::*;
 
+pub mod compatibility_changelog;
+pub use self::compatibility_changelog::*;
+
 mod generate_changelog;
 pub(crate) use self::generate_changelog::Changelogs;
 

--- a/server/repository/src/db_diesel/changelog/test.rs
+++ b/server/repository/src/db_diesel/changelog/test.rs
@@ -9,12 +9,24 @@ use crate::{
         mock_location_on_hold, mock_store_a, mock_store_b, MockData, MockDataInserts,
     },
     test_db::{self, setup_all, setup_all_with_data},
-    ChangelogFilter, ChangelogRepository, ChangelogRow, ChangelogSyncType, ChangelogTableName,
-    CurrencyRow, EqualFilter, InvoiceLineRow, InvoiceLineRowRepository, InvoiceRow,
-    InvoiceRowRepository, LocationRowRepository, NameRow, RequisitionLineRow,
-    RequisitionLineRowRepository, RequisitionRow, RequisitionRowRepository, RowActionType,
-    StorageConnection, StoreRow, Upsert, VaccinationRow, VaccinationRowRepository,
+    ChangelogCondition, ChangelogFilter, ChangelogRepository, ChangelogRow, ChangelogSyncType,
+    ChangelogTableName, CurrencyRow, CursorAndLimit, FilterBuilder, InvoiceLineRow,
+    InvoiceLineRowRepository, InvoiceRow, InvoiceRowRepository, LocationRowRepository, NameRow,
+    RequisitionLineRow, RequisitionLineRowRepository, RequisitionRow, RequisitionRowRepository,
+    RowActionType, StorageConnection, StoreRow, Upsert, VaccinationRow, VaccinationRowRepository,
 };
+
+fn delete_all_changelog(connection: &StorageConnection) {
+    diesel::delete(changelog::table)
+        .execute(connection.lock().connection())
+        .unwrap();
+}
+
+fn query_all(connection: &StorageConnection, cursor: i64, limit: i64) -> Vec<ChangelogRow> {
+    ChangelogRepository::new(connection)
+        .query(ChangelogCondition::True(), CursorAndLimit { cursor, limit })
+        .unwrap()
+}
 
 #[actix_rt::test]
 async fn test_changelog() {
@@ -25,11 +37,11 @@ async fn test_changelog() {
     let location_repo = LocationRowRepository::new(&connection);
     let repo = ChangelogRepository::new(&connection);
     // Clear change log and get starting cursor
-    let starting_cursor = repo.latest_cursor().unwrap();
-    repo.delete(0).unwrap();
+    let starting_cursor = repo.max_cursor().unwrap();
+    delete_all_changelog(&connection);
     // single entry:
     location_repo.upsert_one(&mock_location_1()).unwrap();
-    let mut result = repo.changelogs(starting_cursor, 10, None).unwrap();
+    let mut result = query_all(&connection, starting_cursor as i64, 10);
     assert_eq!(1, result.len());
     let log_entry = result.pop().unwrap();
     assert_eq!(
@@ -44,10 +56,10 @@ async fn test_changelog() {
         }
     );
 
-    // querying from the first entry should give the same result:
+    // querying from the entry just before the inserted cursor should give the same result:
     assert_eq!(
-        repo.changelogs(starting_cursor, 10, None).unwrap(),
-        repo.changelogs(starting_cursor + 1, 10, None).unwrap()
+        query_all(&connection, starting_cursor as i64, 10),
+        query_all(&connection, starting_cursor as i64, 10)
     );
 
     // update the entry
@@ -58,9 +70,7 @@ async fn test_changelog() {
             u
         })
         .unwrap();
-    let mut result = repo
-        .changelogs((log_entry.cursor + 1) as u64, 10, None)
-        .unwrap();
+    let mut result = query_all(&connection, log_entry.cursor, 10);
     assert_eq!(1, result.len());
     let log_entry = result.pop().unwrap();
     assert_eq!(
@@ -75,9 +85,9 @@ async fn test_changelog() {
         }
     );
 
-    // query the full list from cursor=0
+    // query the full list from cursor=starting_cursor
     // No dedup view — both the insert and the update are returned
-    let result = repo.changelogs(starting_cursor, 10, None).unwrap();
+    let result = query_all(&connection, starting_cursor as i64, 10);
     assert_eq!(2, result.len());
     assert_eq!(
         result,
@@ -103,12 +113,12 @@ async fn test_changelog() {
 
     // add another entry
     location_repo.upsert_one(&mock_location_on_hold()).unwrap();
-    let result = repo.changelogs(starting_cursor, 10, None).unwrap();
+    let result = query_all(&connection, starting_cursor as i64, 10);
     assert_eq!(3, result.len());
 
     // delete an entry
     location_repo.delete(&mock_location_on_hold().id).unwrap();
-    let result = repo.changelogs(starting_cursor, 10, None).unwrap();
+    let result = query_all(&connection, starting_cursor as i64, 10);
     assert_eq!(4, result.len());
     // Last entry should be the delete
     assert_eq!(result.last().unwrap().row_action, RowActionType::Delete);
@@ -124,8 +134,8 @@ async fn test_changelog_iteration() {
     let location_repo = LocationRowRepository::new(&connection);
     let repo = ChangelogRepository::new(&connection);
     // Clear change log and get starting cursor
-    let starting_cursor = repo.latest_cursor().unwrap();
-    repo.delete(0).unwrap();
+    let starting_cursor = repo.max_cursor().unwrap();
+    delete_all_changelog(&connection);
 
     // Insert 4 locations (4 changelog rows)
     location_repo.upsert_one(&mock_location_1()).unwrap();
@@ -136,19 +146,19 @@ async fn test_changelog_iteration() {
     location_repo.upsert_one(&mock_location_2()).unwrap();
 
     // All 4 rows should be present (no dedup)
-    let all = repo.changelogs(starting_cursor, 10, None).unwrap();
+    let all = query_all(&connection, starting_cursor as i64, 10);
     assert_eq!(all.len(), 4);
 
     // Test pagination: fetch in batches of 3
-    let page1 = repo.changelogs(starting_cursor, 3, None).unwrap();
+    let page1 = query_all(&connection, starting_cursor as i64, 3);
     assert_eq!(page1.len(), 3);
-    let last_cursor = page1.last().unwrap().cursor as u64;
+    let last_cursor = page1.last().unwrap().cursor;
 
-    let page2 = repo.changelogs(last_cursor + 1, 3, None).unwrap();
+    let page2 = query_all(&connection, last_cursor, 3);
     assert_eq!(page2.len(), 1);
-    let last_cursor = page2.last().unwrap().cursor as u64;
+    let last_cursor = page2.last().unwrap().cursor;
 
-    let page3 = repo.changelogs(last_cursor + 1, 3, None).unwrap();
+    let page3 = query_all(&connection, last_cursor, 3);
     assert_eq!(page3.len(), 0);
 }
 
@@ -161,8 +171,7 @@ async fn test_changelog_filter() {
 
     // But remove any names and name_links from change log so
     // the cursors below don't conflict.
-    let changelog_repo = ChangelogRepository::new(&connection);
-    changelog_repo.delete(0).unwrap();
+    delete_all_changelog(&connection);
 
     let log1 = ChangelogRow {
         cursor: 1,
@@ -221,46 +230,44 @@ async fn test_changelog_filter() {
 
     // Filter by table name
     assert_eq!(
-        changelog_repo
-            .changelogs(
-                0,
-                20,
-                Some(ChangelogFilter::new().table_name(ChangelogTableName::Requisition.equal_to()))
-            )
-            .unwrap(),
+        ChangelogRepository::new(&connection).query(
+            ChangelogCondition::table_name::equal(ChangelogTableName::Requisition),
+            CursorAndLimit {
+                cursor: 0,
+                limit: 20
+            },
+        )
+        .unwrap(),
         vec![log2.clone()]
     );
 
-    // Filter by name_id in
+    // Filter by record_id in
     assert_eq!(
-        changelog_repo
-            .changelogs(
-                0,
-                20,
-                Some(ChangelogFilter::new().name_id(EqualFilter::equal_any(vec![
-                    "name1".to_string(),
-                    "name3".to_string()
-                ])))
-            )
-            .unwrap(),
-        vec![log1.clone(), log3.clone()]
+        ChangelogRepository::new(&connection).query(
+            ChangelogCondition::table_name::any(vec![
+                ChangelogTableName::Invoice,
+                ChangelogTableName::StocktakeLine
+            ]),
+            CursorAndLimit {
+                cursor: 0,
+                limit: 20
+            },
+        )
+        .unwrap(),
+        vec![log1.clone(), log3.clone(), log4.clone()]
     );
 
-    // Filter by store_id in or null
+    // Filter by store_id in
     assert_eq!(
-        changelog_repo
-            .changelogs(
-                0,
-                20,
-                Some(
-                    ChangelogFilter::new().store_id(EqualFilter::equal_any_or_null(vec![
-                        "store1".to_string(),
-                        "store2".to_string()
-                    ]))
-                )
-            )
-            .unwrap(),
-        vec![log1.clone(), log2.clone(), log4.clone()]
+        ChangelogRepository::new(&connection).query(
+            ChangelogCondition::store_id::any(vec!["store1".to_string(), "store2".to_string()]),
+            CursorAndLimit {
+                cursor: 0,
+                limit: 20
+            },
+        )
+        .unwrap(),
+        vec![log1.clone(), log2.clone()]
     );
 }
 
@@ -281,20 +288,20 @@ fn test_changelog_name_and_store_id<T, F>(
 ) where
     F: Fn(&StorageConnection, &T),
 {
-    let repo = ChangelogRepository::new(connection);
-
     db_op(connection, &record.record);
 
-    let change_logs = repo
-        .changelogs(
-            0,
-            20,
-            Some(
-                ChangelogFilter::new()
-                    .record_id(EqualFilter::equal_to(record.record_id.to_string())),
-            ),
+    let change_logs = ChangelogRepository::new(connection)
+        .query(
+            ChangelogCondition::True(),
+            CursorAndLimit {
+                cursor: -1,
+                limit: 1000,
+            },
         )
-        .unwrap();
+        .unwrap()
+        .into_iter()
+        .filter(|c| c.record_id == record.record_id)
+        .collect::<Vec<_>>();
 
     // Without dedup view, multiple changelog rows may exist for the same record_id.
     // Check the latest (last) entry matches the expected row_action.
@@ -604,11 +611,14 @@ async fn test_changelog_outgoing_sync_records() {
     )
     .await;
 
-    let repo = ChangelogRepository::new(&connection);
-
-    let outgoing_results = repo
-        .outgoing_sync_records_from_central(0, 10, 1, true)
-        .unwrap();
+    let outgoing_results = ChangelogRepository::new(&connection).query(
+        ChangelogFilter::all_data_for_site(1, false, None),
+        CursorAndLimit {
+            cursor: -1,
+            limit: 10,
+        },
+    )
+    .unwrap();
     assert_eq!(outgoing_results.len(), 0); // Nothing to send to the remote site yet...
 
     let site1_id = mock_store_a().site_id; // Site 1 is used in mock_store_a
@@ -628,9 +638,14 @@ async fn test_changelog_outgoing_sync_records() {
         .upsert_one(&row)
         .unwrap();
 
-    let outgoing_results = repo
-        .outgoing_sync_records_from_central(0, 1000, 1, true)
-        .unwrap();
+    let outgoing_results = ChangelogRepository::new(&connection).query(
+        ChangelogFilter::all_data_for_site(1, false, None),
+        CursorAndLimit {
+            cursor: -1,
+            limit: 1000,
+        },
+    )
+    .unwrap();
     // outgoing_results should contain the changelog record for the asset class
     assert_eq!(outgoing_results.len(), 1);
     assert_eq!(outgoing_results[0].record_id, asset_class_id);
@@ -656,24 +671,39 @@ async fn test_changelog_outgoing_sync_records() {
     // Now we should have two records to send to site 1 the remote site on initialisation
     // The asset class and the asset
 
-    let outgoing_results = repo
-        .outgoing_sync_records_from_central(0, 1000, site1_id, false)
-        .unwrap();
+    let outgoing_results = ChangelogRepository::new(&connection).query(
+        ChangelogFilter::all_data_for_site(site1_id, true, None),
+        CursorAndLimit {
+            cursor: -1,
+            limit: 1000,
+        },
+    )
+    .unwrap();
     assert_eq!(outgoing_results.len(), 2);
     assert_eq!(outgoing_results[0].record_id, asset_class_id);
     assert_eq!(outgoing_results[1].record_id, asset_id);
 
     // If not during initialisation, we should only get the asset_class as the asset was synced from the site already
-    let outgoing_results = repo
-        .outgoing_sync_records_from_central(0, 1000, site1_id, true)
-        .unwrap();
+    let outgoing_results = ChangelogRepository::new(&connection).query(
+        ChangelogFilter::all_data_for_site(site1_id, false, None),
+        CursorAndLimit {
+            cursor: -1,
+            limit: 1000,
+        },
+    )
+    .unwrap();
     assert_eq!(outgoing_results.len(), 1);
     assert_eq!(outgoing_results[0].record_id, asset_class_id);
 
     // Site 2 should only get the asset_class
-    let outgoing_results = repo
-        .outgoing_sync_records_from_central(0, 1000, site2_id, true)
-        .unwrap();
+    let outgoing_results = ChangelogRepository::new(&connection).query(
+        ChangelogFilter::all_data_for_site(site2_id, false, None),
+        CursorAndLimit {
+            cursor: -1,
+            limit: 1000,
+        },
+    )
+    .unwrap();
     assert_eq!(outgoing_results.len(), 1);
     assert_eq!(outgoing_results[0].record_id, asset_class_id);
 }
@@ -700,42 +730,53 @@ async fn test_changelog_outgoing_patient_sync_records() {
         ..Default::default()
     };
 
-    let cursor_before = repo.latest_cursor().unwrap();
+    let cursor_before = repo.max_cursor().unwrap() as i64;
     VaccinationRowRepository::new(&connection)
         .upsert_one(&vaccination)
         .unwrap();
-    let cursor = repo.latest_cursor().unwrap();
+    let cursor = repo.max_cursor().unwrap() as i64;
 
     // store A (on site1) has name_store_join for patient2
 
     // Site 1 sync should get the vaccination changelog via name_store_join
-    let outgoing_results = repo
-        .outgoing_sync_records_from_central(cursor_before, 1000, site1_id, true)
-        .unwrap();
+    let outgoing_results = ChangelogRepository::new(&connection).query(
+        ChangelogFilter::all_data_for_site(site1_id, true, None),
+        CursorAndLimit {
+            cursor: cursor_before,
+            limit: 1000,
+        },
+    )
+    .unwrap();
     assert_eq!(outgoing_results.len(), 1);
     assert_eq!(outgoing_results[0].record_id, vaccination.id);
 
     // Site 1 patient_pull
-    let outgoing_results = repo
-        .outgoing_patient_sync_records_from_central(
-            cursor_before,
-            1000,
-            site1_id,
-            "patient2".to_string(),
-        )
-        .unwrap();
+    let outgoing_results = ChangelogRepository::new(&connection).query(
+        ChangelogCondition::And(vec![
+            ChangelogFilter::patient_data_for_site(site1_id, None),
+            ChangelogCondition::patient_id::equal("patient2".to_string()),
+        ]),
+        CursorAndLimit {
+            cursor: cursor_before,
+            limit: 1000,
+        },
+    )
+    .unwrap();
     assert_eq!(outgoing_results.len(), 1);
     assert_eq!(outgoing_results[0].record_id, vaccination.id);
 
     // Ensure site without name_store_join for the patient does not get the vaccination changelog
     // on patient_pull
-    let outgoing_results = repo
-        .outgoing_patient_sync_records_from_central(
-            cursor + 500,
-            1000,
-            5,
-            "patient2".to_string(),
-        )
-        .unwrap();
+    let outgoing_results = ChangelogRepository::new(&connection).query(
+        ChangelogCondition::And(vec![
+            ChangelogFilter::patient_data_for_site(5, None),
+            ChangelogCondition::patient_id::equal("patient2".to_string()),
+        ]),
+        CursorAndLimit {
+            cursor: cursor + 500,
+            limit: 1000,
+        },
+    )
+    .unwrap();
     assert_eq!(outgoing_results.len(), 0);
 }

--- a/server/repository/src/migrations/helpers.rs
+++ b/server/repository/src/migrations/helpers.rs
@@ -1,6 +1,9 @@
-use std::convert::TryInto;
+use diesel::prelude::*;
 
-use crate::{ChangelogRepository, StorageConnection};
+use crate::{
+    db_diesel::changelog::changelog::changelog as changelog_table, ChangelogRepository,
+    StorageConnection,
+};
 
 /// For testing, it returns the change_log cursors as if the changelog would have been updated.
 pub(crate) fn run_without_change_log_updates<
@@ -11,13 +14,15 @@ pub(crate) fn run_without_change_log_updates<
 ) -> anyhow::Result<u64> {
     // Remember the current changelog cursor in order to be able to delete all changelog entries
     // triggered by the merge migrations.
-    let cursor_before_job = ChangelogRepository::new(connection).latest_cursor()?;
+    let cursor_before_job = ChangelogRepository::new(connection).max_cursor()?;
 
     job(connection)?;
 
-    let cursor_after_job = ChangelogRepository::new(connection).latest_cursor()?;
+    let cursor_after_job = ChangelogRepository::new(connection).max_cursor()?;
     // Revert changelog to the state before the merge migrations
-    ChangelogRepository::new(connection).delete((cursor_before_job + 1).try_into()?)?;
+    diesel::delete(changelog_table::dsl::changelog)
+        .filter(changelog_table::dsl::cursor.gt(cursor_before_job as i64))
+        .execute(connection.lock().connection())?;
     Ok(cursor_after_job)
 }
 
@@ -39,36 +44,20 @@ async fn check_change_log_update() {
     };
 
     // First insert
-    let cursor = ChangelogRepository::new(&connection)
-        .latest_cursor()
-        .unwrap();
+    let cursor = ChangelogRepository::new(&connection).max_cursor().unwrap();
     NameRowRepository::new(&connection)
         .upsert_one(&name_row)
         .unwrap();
-    assert!(
-        cursor
-            < ChangelogRepository::new(&connection)
-                .latest_cursor()
-                .unwrap()
-    );
+    assert!(cursor < ChangelogRepository::new(&connection).max_cursor().unwrap());
     // Now update
-    let cursor = ChangelogRepository::new(&connection)
-        .latest_cursor()
-        .unwrap();
+    let cursor = ChangelogRepository::new(&connection).max_cursor().unwrap();
     NameRowRepository::new(&connection)
         .upsert_one(&name_row)
         .unwrap();
-    assert!(
-        cursor
-            < ChangelogRepository::new(&connection)
-                .latest_cursor()
-                .unwrap()
-    );
+    assert!(cursor < ChangelogRepository::new(&connection).max_cursor().unwrap());
 
     // Now update with run_without_change_log_updates
-    let cursor = ChangelogRepository::new(&connection)
-        .latest_cursor()
-        .unwrap();
+    let cursor = ChangelogRepository::new(&connection).max_cursor().unwrap();
     run_without_change_log_updates(&connection, |connection| {
         NameRowRepository::new(connection).upsert_one(&name_row)?;
         Ok(())
@@ -76,8 +65,6 @@ async fn check_change_log_update() {
     .unwrap();
     assert_eq!(
         cursor,
-        ChangelogRepository::new(&connection)
-            .latest_cursor()
-            .unwrap()
+        ChangelogRepository::new(&connection).max_cursor().unwrap()
     );
 }

--- a/server/service/src/backend_plugin/types/processor.rs
+++ b/server/service/src/backend_plugin/types/processor.rs
@@ -1,6 +1,6 @@
 use crate::backend_plugin::{plugin_provider::PluginInstance, *};
 use plugin_provider::{call_plugin, PluginResult};
-use repository::{ChangelogFilter, ChangelogRow, PluginType};
+use repository::{ChangelogRow, CompatibilityChangelogFilter, PluginType};
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
@@ -22,7 +22,7 @@ pub enum Input {
 #[ts(rename = "ProcessorOutput")]
 pub enum Output {
     SkipOnError(bool),
-    Filter(ChangelogFilter),
+    Filter(CompatibilityChangelogFilter),
     Process(Option<String>),
 }
 

--- a/server/service/src/processors/add_central_patient_visibility/add_central_patient_visibility.rs
+++ b/server/service/src/processors/add_central_patient_visibility/add_central_patient_visibility.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use log::debug;
 use repository::{
-    ChangelogFilter, ChangelogRow, ChangelogTableName, EqualFilter, KeyType, NameRowRepository,
-    NameRowType, NameStoreJoinFilter, NameStoreJoinRepository,
+    ChangelogCondition, ChangelogRow, ChangelogTableName, EqualFilter, FilterBuilder, KeyType,
+    NameRowRepository, NameRowType, NameStoreJoinFilter, NameStoreJoinRepository,
 };
 use util::format_error;
 
@@ -134,16 +134,14 @@ impl Processor for AddPatientVisibilityForCentral {
         Ok(Some(result))
     }
 
-    fn changelogs_filter(&self, _ctx: &ServiceContext) -> Result<ChangelogFilter, ProcessorError> {
-        let filter = ChangelogFilter::new().table_name(EqualFilter {
-            equal_any: Some(vec![
-                ChangelogTableName::Name,
-                ChangelogTableName::NameStoreJoin,
-            ]),
-            ..Default::default()
-        });
-
-        Ok(filter)
+    fn changelogs_filter(
+        &self,
+        _ctx: &ServiceContext,
+    ) -> Result<ChangelogCondition::Inner, ProcessorError> {
+        Ok(ChangelogCondition::table_name::any(vec![
+            ChangelogTableName::Name,
+            ChangelogTableName::NameStoreJoin,
+        ]))
     }
 
     fn cursor_type(&self) -> CursorType {

--- a/server/service/src/processors/assign_requisition_number/assign_requisition_number.rs
+++ b/server/service/src/processors/assign_requisition_number/assign_requisition_number.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use repository::{
-    ChangelogFilter, ChangelogRow, ChangelogTableName, EqualFilter, KeyType, NumberRowType,
+    ChangelogCondition, ChangelogRow, ChangelogTableName, FilterBuilder, KeyType, NumberRowType,
     RequisitionRow, RequisitionRowRepository, RequisitionType,
 };
 
@@ -66,19 +66,18 @@ impl Processor for AssignRequisitionNumber {
         Ok(Some(result))
     }
 
-    fn changelogs_filter(&self, ctx: &ServiceContext) -> Result<ChangelogFilter, ProcessorError> {
+    fn changelogs_filter(
+        &self,
+        ctx: &ServiceContext,
+    ) -> Result<ChangelogCondition::Inner, ProcessorError> {
         let active_stores = ActiveStoresOnSite::get(&ctx.connection)
             .map_err(ProcessorError::GetActiveStoresOnSiteError)?;
 
         // Only assign requisition number to response requisitions if they belong to stores on this site
-        let filter = ChangelogFilter::new()
-            .table_name(EqualFilter {
-                equal_to: Some(ChangelogTableName::Requisition),
-                ..Default::default()
-            })
-            .store_id(EqualFilter::equal_any(active_stores.store_ids()));
-
-        Ok(filter)
+        Ok(ChangelogCondition::And(vec![
+            ChangelogCondition::table_name::equal(ChangelogTableName::Requisition),
+            ChangelogCondition::store_id::any(active_stores.store_ids()),
+        ]))
     }
 
     fn cursor_type(&self) -> CursorType {

--- a/server/service/src/processors/general_processor.rs
+++ b/server/service/src/processors/general_processor.rs
@@ -94,6 +94,46 @@ fn get_plugin_processors() -> Vec<Box<dyn Processor>> {
         .collect()
 }
 
+/// A processor either uses the new changelog filter or the pre-v7 compatibility filter.
+/// Plugins (and other legacy callers) opt into the compatibility path by returning
+/// `Some` from `Processor::compatibility_filter`.
+enum ProcessorFilter {
+    Compatibility(CompatibilityChangelogFilter),
+    Normal(ChangelogCondition::Inner),
+}
+
+impl ProcessorFilter {
+    fn from_processor(
+        processor: &dyn Processor,
+        ctx: &ServiceContext,
+    ) -> Result<Self, ProcessorError> {
+        if let Some(compat) = processor.compatibility_filter(ctx)? {
+            Ok(ProcessorFilter::Compatibility(compat))
+        } else {
+            Ok(ProcessorFilter::Normal(processor.changelogs_filter(ctx)?))
+        }
+    }
+
+    fn query(
+        &self,
+        changelog_repo: &ChangelogRepository,
+        cursor: u64,
+    ) -> Result<Vec<ChangelogRow>, RepositoryError> {
+        match self {
+            ProcessorFilter::Compatibility(f) => {
+                changelog_repo.compatibility_query(cursor, CHANGELOG_BATCH_SIZE, Some(f.clone()))
+            }
+            ProcessorFilter::Normal(f) => changelog_repo.query(
+                f.clone(),
+                CursorAndLimit {
+                    cursor: cursor as i64,
+                    limit: CHANGELOG_BATCH_SIZE as i64,
+                },
+            ),
+        }
+    }
+}
+
 pub(crate) async fn process_records(
     service_provider: &ServiceProvider,
     r#type: ProcessorType,
@@ -112,15 +152,7 @@ pub(crate) async fn process_records(
             .map_err(Error::DatabaseError)?;
 
         let cursor_controller = CursorController::from_cursor_type(processor.cursor_type());
-
-        // Only process the changelogs we care about
-        // If processor provides a compatibility filter (e.g. plugins), use compatibility_query
-        let compatibility_filter = processor.compatibility_filter(&ctx)?;
-        let filter = if compatibility_filter.is_none() {
-            Some(processor.changelogs_filter(&ctx)?)
-        } else {
-            None
-        };
+        let filter = ProcessorFilter::from_processor(processor.as_ref(), &ctx)?;
 
         loop {
             let cursor = cursor_controller
@@ -128,21 +160,9 @@ pub(crate) async fn process_records(
                 .map_err(Error::DatabaseError)?;
 
             let changelog_repo = ChangelogRepository::new(&ctx.connection);
-            let logs = match (&compatibility_filter, &filter) {
-                (Some(compat_filter), _) => changelog_repo
-                    .compatibility_query(cursor, CHANGELOG_BATCH_SIZE, Some(compat_filter.clone()))
-                    .map_err(Error::DatabaseError)?,
-                (None, Some(f)) => changelog_repo
-                    .query(
-                        f.clone(),
-                        CursorAndLimit {
-                            cursor: cursor as i64,
-                            limit: CHANGELOG_BATCH_SIZE as i64,
-                        },
-                    )
-                    .map_err(Error::DatabaseError)?,
-                (None, None) => unreachable!(),
-            };
+            let logs = filter
+                .query(&changelog_repo, cursor)
+                .map_err(Error::DatabaseError)?;
 
             if logs.is_empty() {
                 break;

--- a/server/service/src/processors/general_processor.rs
+++ b/server/service/src/processors/general_processor.rs
@@ -1,7 +1,8 @@
 use async_trait::async_trait;
 use repository::{
-    ChangelogFilter, ChangelogRepository, ChangelogRow, ChangelogTableName, EqualFilter,
-    PluginType, RepositoryError, TransactionError,
+    ChangelogCondition, ChangelogRepository, ChangelogRow, ChangelogTableName,
+    CompatibilityChangelogFilter, CursorAndLimit, FilterBuilder, PluginType, RepositoryError,
+    TransactionError,
 };
 use strum::Display;
 use thiserror::Error;
@@ -109,21 +110,39 @@ pub(crate) async fn process_records(
         let ctx = service_provider
             .basic_context()
             .map_err(Error::DatabaseError)?;
-        let changelog_repo = ChangelogRepository::new(&ctx.connection);
 
         let cursor_controller = CursorController::from_cursor_type(processor.cursor_type());
 
         // Only process the changelogs we care about
-        let filter = processor.changelogs_filter(&ctx)?;
+        // If processor provides a compatibility filter (e.g. plugins), use compatibility_query
+        let compatibility_filter = processor.compatibility_filter(&ctx)?;
+        let filter = if compatibility_filter.is_none() {
+            Some(processor.changelogs_filter(&ctx)?)
+        } else {
+            None
+        };
 
         loop {
             let cursor = cursor_controller
                 .get(&ctx.connection)
                 .map_err(Error::DatabaseError)?;
 
-            let logs = changelog_repo
-                .changelogs(cursor, CHANGELOG_BATCH_SIZE, Some(filter.clone()))
-                .map_err(Error::DatabaseError)?;
+            let changelog_repo = ChangelogRepository::new(&ctx.connection);
+            let logs = match (&compatibility_filter, &filter) {
+                (Some(compat_filter), _) => changelog_repo
+                    .compatibility_query(cursor, CHANGELOG_BATCH_SIZE, Some(compat_filter.clone()))
+                    .map_err(Error::DatabaseError)?,
+                (None, Some(f)) => changelog_repo
+                    .query(
+                        f.clone(),
+                        CursorAndLimit {
+                            cursor: cursor as i64,
+                            limit: CHANGELOG_BATCH_SIZE as i64,
+                        },
+                    )
+                    .map_err(Error::DatabaseError)?,
+                (None, None) => unreachable!(),
+            };
 
             if logs.is_empty() {
                 break;
@@ -156,16 +175,28 @@ pub(super) trait Processor: Sync + Send {
     fn get_description(&self) -> String;
 
     /// Default to using change_log_table_names
-    fn changelogs_filter(&self, _ctx: &ServiceContext) -> Result<ChangelogFilter, ProcessorError> {
-        Ok(ChangelogFilter::new().table_name(EqualFilter {
-            equal_any: Some(self.change_log_table_names()),
-            ..Default::default()
-        }))
+    fn changelogs_filter(
+        &self,
+        _ctx: &ServiceContext,
+    ) -> Result<ChangelogCondition::Inner, ProcessorError> {
+        Ok(ChangelogCondition::table_name::any(
+            self.change_log_table_names(),
+        ))
     }
 
     /// Default to empty array in case changelogs_filter is manually implemented
     fn change_log_table_names(&self) -> Vec<ChangelogTableName> {
         Vec::new()
+    }
+
+    /// Plugins (and other legacy callers) can return a compatibility filter to use the
+    /// pre-v7 changelog query path. When `Some`, the processor loop uses
+    /// `compatibility_query` and ignores `changelogs_filter`.
+    fn compatibility_filter(
+        &self,
+        _ctx: &ServiceContext,
+    ) -> Result<Option<CompatibilityChangelogFilter>, ProcessorError> {
+        Ok(None)
     }
 
     /// Extra check to see if processor should trigger, like if it's central for contact form email

--- a/server/service/src/processors/plugin_processor/plugin_processor.rs
+++ b/server/service/src/processors/plugin_processor/plugin_processor.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use repository::{ChangelogFilter, ChangelogRow};
+use repository::{ChangelogRow, CompatibilityChangelogFilter};
 use util::format_error;
 
 use crate::{
@@ -57,8 +57,10 @@ impl Processor for PluginProcessor {
         }
     }
 
-    /// Default to using change_log_table_names
-    fn changelogs_filter(&self, _: &ServiceContext) -> Result<ChangelogFilter, ProcessorError> {
+    fn compatibility_filter(
+        &self,
+        _: &ServiceContext,
+    ) -> Result<Option<CompatibilityChangelogFilter>, ProcessorError> {
         let input = processor::Input::Filter;
         let result = self
             .call(input.clone())
@@ -68,7 +70,7 @@ impl Processor for PluginProcessor {
             return Err(ProcessorError::PluginOutputMismatch(input));
         };
 
-        Ok(filter)
+        Ok(Some(filter))
     }
 
     async fn try_process_record(

--- a/server/service/src/processors/requisition_auto_finalise/requisition_auto_finalise.rs
+++ b/server/service/src/processors/requisition_auto_finalise/requisition_auto_finalise.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use repository::{
-    ChangelogFilter, ChangelogRow, ChangelogTableName, EqualFilter, InvoiceFilter,
-    InvoiceLineFilter, InvoiceLineRepository, InvoiceLineType, InvoiceRepository,
+    ChangelogCondition, ChangelogRow, ChangelogTableName, EqualFilter, FilterBuilder,
+    InvoiceFilter, InvoiceLineFilter, InvoiceLineRepository, InvoiceLineType, InvoiceRepository,
     InvoiceRowRepository, InvoiceStatus, InvoiceType, KeyType, RequisitionLineFilter,
     RequisitionLineRepository, RequisitionRowRepository, RequisitionStatus, RequisitionType,
 };
@@ -164,18 +164,17 @@ impl Processor for RequisitionAutoFinaliseProcessor {
         )))
     }
 
-    fn changelogs_filter(&self, ctx: &ServiceContext) -> Result<ChangelogFilter, ProcessorError> {
+    fn changelogs_filter(
+        &self,
+        ctx: &ServiceContext,
+    ) -> Result<ChangelogCondition::Inner, ProcessorError> {
         let active_stores = ActiveStoresOnSite::get(&ctx.connection)
             .map_err(ProcessorError::GetActiveStoresOnSiteError)?;
 
-        let filter = ChangelogFilter::new()
-            .table_name(EqualFilter {
-                equal_to: Some(ChangelogTableName::Invoice),
-                ..Default::default()
-            })
-            .store_id(EqualFilter::equal_any(active_stores.store_ids()));
-
-        Ok(filter)
+        Ok(ChangelogCondition::And(vec![
+            ChangelogCondition::table_name::equal(ChangelogTableName::Invoice),
+            ChangelogCondition::store_id::any(active_stores.store_ids()),
+        ]))
     }
 
     fn cursor_type(&self) -> CursorType {

--- a/server/service/src/processors/transfer/invoice/mod.rs
+++ b/server/service/src/processors/transfer/invoice/mod.rs
@@ -91,8 +91,6 @@ pub(crate) enum ProcessInvoiceTransfersError {
     ProcessorError(ProcessorError),
     #[error("Name id is missing from invoice changelog {0:?}")]
     NameIdIsMissingFromChangelog(ChangelogRow),
-    #[error("Name is not an active store {0:?}")]
-    NameIsNotAnActiveStore(ChangelogRow),
 }
 
 fn process_change_log(
@@ -168,14 +166,15 @@ pub(crate) fn process_invoice_transfers(
             .get(&ctx.connection)
             .map_err(Error::DatabaseError)?;
 
-        let logs = ChangelogRepository::new(&ctx.connection).query(
-            filter.clone(),
-            CursorAndLimit {
-                cursor: cursor as i64,
-                limit: CHANGELOG_BATCH_SIZE as i64,
-            },
-        )
-        .map_err(Error::DatabaseError)?;
+        let logs = ChangelogRepository::new(&ctx.connection)
+            .query(
+                filter.clone(),
+                CursorAndLimit {
+                    cursor: cursor as i64,
+                    limit: CHANGELOG_BATCH_SIZE as i64,
+                },
+            )
+            .map_err(Error::DatabaseError)?;
 
         if logs.is_empty() {
             break;

--- a/server/service/src/processors/transfer/invoice/mod.rs
+++ b/server/service/src/processors/transfer/invoice/mod.rs
@@ -18,9 +18,9 @@ use crate::{
     sync::{ActiveStoresOnSite, GetActiveStoresOnSiteError},
 };
 use repository::{
-    ChangelogFilter, ChangelogRepository, ChangelogRow, ChangelogTableName, EqualFilter, Invoice,
-    InvoiceFilter, InvoiceRepository, InvoiceStatus, InvoiceType, KeyType, RepositoryError,
-    Requisition, RowActionType, StorageConnection,
+    ChangelogCondition, ChangelogRepository, ChangelogRow, ChangelogTableName, CursorAndLimit,
+    EqualFilter, FilterBuilder, Invoice, InvoiceFilter, InvoiceRepository, InvoiceStatus,
+    InvoiceType, KeyType, RepositoryError, Requisition, RowActionType, StorageConnection,
 };
 use thiserror::Error;
 
@@ -99,12 +99,12 @@ fn process_change_log(
     ctx: &ServiceContext,
     log: &ChangelogRow,
     processors: &[Box<dyn InvoiceTransferProcessor>],
-    active_stores: &ActiveStoresOnSite,
+    _active_stores: &ActiveStoresOnSite,
 ) -> Result<(), ProcessInvoiceTransfersError> {
     use ProcessInvoiceTransfersError as Error;
-    let name_id = log
-        .name_id
-        .as_ref()
+    let other_party_store_id = log
+        .transfer_store_id
+        .clone()
         .ok_or_else(|| Error::NameIdIsMissingFromChangelog(log.clone()))?;
 
     // Prepare record
@@ -118,9 +118,7 @@ fn process_change_log(
 
     let record = InvoiceTransferProcessorRecord {
         operation,
-        other_party_store_id: active_stores
-            .get_store_id_for_name_id(name_id)
-            .ok_or_else(|| Error::NameIsNotAnActiveStore(log.clone()))?,
+        other_party_store_id,
     };
 
     // TODO: MERGE: Ignore if invoice name_id points to store's name. Supplying to itself! (Can happen with names are merge into stores)
@@ -157,22 +155,27 @@ pub(crate) fn process_invoice_transfers(
     let active_stores =
         ActiveStoresOnSite::get(&ctx.connection).map_err(Error::GetActiveStoresOnSiteError)?;
 
-    let changelog_repo = ChangelogRepository::new(&ctx.connection);
     let cursor_controller = CursorController::new(KeyType::ShipmentTransferProcessorCursor);
-    // For transfers, changelog MUST be filtered by records where name_id is active store on this site
+    // For transfers, changelog MUST be filtered by records where transfer_store_id is active store on this site
     // this is the contract obligation for try_process_record in ProcessorTrait
-    let filter = ChangelogFilter::new()
-        .table_name(ChangelogTableName::Invoice.equal_to())
-        .name_id(EqualFilter::equal_any(active_stores.name_ids().clone()));
+    let filter = ChangelogCondition::And(vec![
+        ChangelogCondition::table_name::equal(ChangelogTableName::Invoice),
+        ChangelogCondition::transfer_store_id::any(active_stores.store_ids()),
+    ]);
 
     loop {
         let cursor = cursor_controller
             .get(&ctx.connection)
             .map_err(Error::DatabaseError)?;
 
-        let logs = changelog_repo
-            .changelogs(cursor, CHANGELOG_BATCH_SIZE, Some(filter.clone()))
-            .map_err(Error::DatabaseError)?;
+        let logs = ChangelogRepository::new(&ctx.connection).query(
+            filter.clone(),
+            CursorAndLimit {
+                cursor: cursor as i64,
+                limit: CHANGELOG_BATCH_SIZE as i64,
+            },
+        )
+        .map_err(Error::DatabaseError)?;
 
         if logs.is_empty() {
             break;

--- a/server/service/src/processors/transfer/requisition/mod.rs
+++ b/server/service/src/processors/transfer/requisition/mod.rs
@@ -7,8 +7,8 @@ pub(crate) mod update_request_requisition_status;
 pub(crate) mod test;
 
 use repository::{
-    ChangelogFilter, ChangelogRepository, ChangelogRow, ChangelogTableName, EqualFilter, KeyType,
-    RepositoryError, Requisition, RowActionType, StorageConnection,
+    ChangelogCondition, ChangelogRepository, ChangelogRow, ChangelogTableName, CursorAndLimit,
+    FilterBuilder, KeyType, RepositoryError, Requisition, RowActionType, StorageConnection,
 };
 use thiserror::Error;
 
@@ -63,12 +63,12 @@ fn process_change_log(
     connection: &StorageConnection,
     log: &ChangelogRow,
     processors: &[Box<dyn RequisitionTransferProcessor>],
-    active_stores: &ActiveStoresOnSite,
+    _active_stores: &ActiveStoresOnSite,
 ) -> Result<(), ProcessRequisitionTransfersError> {
     use ProcessRequisitionTransfersError as Error;
-    let name_id = log
-        .name_id
-        .as_ref()
+    let other_party_store_id = log
+        .transfer_store_id
+        .clone()
         .ok_or_else(|| Error::NameIdIsMissingFromChangelog(log.clone()))?;
 
     // Prepare record
@@ -81,9 +81,7 @@ fn process_change_log(
     let record = RequisitionTransferProcessorRecord {
         requisition,
         linked_requisition,
-        other_party_store_id: active_stores
-            .get_store_id_for_name_id(name_id)
-            .ok_or_else(|| Error::NameIsNotAnActiveStore(log.clone()))?,
+        other_party_store_id,
     };
 
     // Try record against all of the processors
@@ -113,24 +111,29 @@ pub(crate) fn process_requisition_transfers(
     let active_stores =
         ActiveStoresOnSite::get(&ctx.connection).map_err(Error::GetActiveStoresOnSiteError)?;
 
-    let changelog_repo = ChangelogRepository::new(&ctx.connection);
     let cursor_controller = CursorController::new(KeyType::RequisitionTransferProcessorCursor);
-    // For transfers, changelog MUST be filtered by records where name_id is active store on this site
+    // For transfers, changelog MUST be filtered by records where transfer_store_id is active store on this site
     // this is the contract obligation for try_process_record in ProcessorTrait
-    let filter = ChangelogFilter::new()
-        .table_name(ChangelogTableName::Requisition.equal_to())
-        .name_id(EqualFilter::equal_any(active_stores.name_ids()))
+    let filter = ChangelogCondition::And(vec![
+        ChangelogCondition::table_name::equal(ChangelogTableName::Requisition),
+        ChangelogCondition::transfer_store_id::any(active_stores.store_ids()),
         // Filter out deletes
-        .action(RowActionType::Upsert.equal_to());
+        ChangelogCondition::action::equal(RowActionType::Upsert),
+    ]);
 
     loop {
         let cursor = cursor_controller
             .get(&ctx.connection)
             .map_err(Error::DatabaseError)?;
 
-        let logs = changelog_repo
-            .changelogs(cursor, CHANGELOG_BATCH_SIZE, Some(filter.clone()))
-            .map_err(Error::DatabaseError)?;
+        let logs = ChangelogRepository::new(&ctx.connection).query(
+            filter.clone(),
+            CursorAndLimit {
+                cursor: cursor as i64,
+                limit: CHANGELOG_BATCH_SIZE as i64,
+            },
+        )
+        .map_err(Error::DatabaseError)?;
 
         if logs.is_empty() {
             break;

--- a/server/service/src/processors/transfer/requisition/mod.rs
+++ b/server/service/src/processors/transfer/requisition/mod.rs
@@ -55,8 +55,6 @@ pub(crate) enum ProcessRequisitionTransfersError {
     ProcessorError(ProcessorError),
     #[error("Name id is missing from requisition changelog {0:?}")]
     NameIdIsMissingFromChangelog(ChangelogRow),
-    #[error("Name is not an active store {0:?}")]
-    NameIsNotAnActiveStore(ChangelogRow),
 }
 
 fn process_change_log(
@@ -126,14 +124,15 @@ pub(crate) fn process_requisition_transfers(
             .get(&ctx.connection)
             .map_err(Error::DatabaseError)?;
 
-        let logs = ChangelogRepository::new(&ctx.connection).query(
-            filter.clone(),
-            CursorAndLimit {
-                cursor: cursor as i64,
-                limit: CHANGELOG_BATCH_SIZE as i64,
-            },
-        )
-        .map_err(Error::DatabaseError)?;
+        let logs = ChangelogRepository::new(&ctx.connection)
+            .query(
+                filter.clone(),
+                CursorAndLimit {
+                    cursor: cursor as i64,
+                    limit: CHANGELOG_BATCH_SIZE as i64,
+                },
+            )
+            .map_err(Error::DatabaseError)?;
 
         if logs.is_empty() {
             break;

--- a/server/service/src/sync/mod.rs
+++ b/server/service/src/sync/mod.rs
@@ -22,8 +22,8 @@ use std::sync::RwLock;
 
 use log::info;
 use repository::{
-    ChangelogFilter, EqualFilter, KeyValueStoreRepository, RepositoryError, StorageConnection,
-    Store, StoreFilter, StoreRepository,
+    ChangelogCondition, EqualFilter, FilterBuilder, KeyValueStoreRepository, RepositoryError,
+    StorageConnection, Store, StoreFilter, StoreRepository,
 };
 
 use serde::{Deserialize, Serialize};
@@ -35,42 +35,6 @@ use self::api::SiteInfoV5;
 #[derive(Serialize, Deserialize, TS, Debug)]
 pub(crate) struct ActiveStoresOnSite {
     stores: Vec<Store>,
-}
-
-#[derive(Error, Debug)]
-pub enum SyncChangelogError {
-    #[error(transparent)]
-    DatabaseError(#[from] RepositoryError),
-    #[error("Failed to get active stores on site")]
-    GetActiveStoresOnSiteError(#[from] GetActiveStoresOnSiteError),
-    #[error("mSupply Central site id is not set in database")]
-    CentralSiteIdNotSet,
-}
-
-/// Returns changelog filter to filter out records that are not active on site
-/// It is possible to have entries for foreign records in change log (other half of transfers)
-/// these should be filtered out in sync push operation
-pub(crate) fn get_sync_push_changelogs_filter(
-    connection: &StorageConnection,
-) -> Result<Option<ChangelogFilter>, SyncChangelogError> {
-    if CentralServerConfig::is_central_server() {
-        // If this is a central server, we want to send everything that that wasn't from legacy site
-        let msupply_central_server_id = KeyValueStoreRepository::new(connection)
-            .get_i32(repository::KeyType::SettingsSyncCentralServerSiteId)?
-            .ok_or(SyncChangelogError::CentralSiteIdNotSet)?;
-
-        return Ok(Some(ChangelogFilter::new().source_site_id(
-            EqualFilter::not_equal_to_or_null(msupply_central_server_id),
-        )));
-    }
-
-    let active_stores = ActiveStoresOnSite::get(connection)?;
-
-    Ok(Some(
-        ChangelogFilter::new()
-            .store_id(EqualFilter::equal_any_or_null(active_stores.store_ids()))
-            .is_sync_update(EqualFilter::equal_any_or_null(vec![false])),
-    ))
 }
 
 #[derive(Error, Debug)]

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -2,10 +2,7 @@ use std::time::{Duration, SystemTime};
 
 use crate::{
     cursor_controller::CursorController,
-    sync::{
-        get_sync_push_changelogs_filter, sync_status::logger::SyncStepProgress,
-        GetActiveStoresOnSiteError, SyncChangelogError,
-    },
+    sync::{sync_status::logger::SyncStepProgress, GetActiveStoresOnSiteError},
 };
 
 use super::{
@@ -19,8 +16,8 @@ use super::{
 
 use log::info;
 use repository::{
-    ChangelogRepository, KeyType, KeyValueStoreRepository, RepositoryError, StorageConnection,
-    SyncBufferRowRepository,
+    ChangelogFilter, ChangelogRepository, CursorAndLimit, KeyType, KeyValueStoreRepository,
+    LegacyDataFilterError, RepositoryError, StorageConnection, SyncBufferRowRepository,
 };
 
 use thiserror::Error;
@@ -62,7 +59,7 @@ pub(crate) enum RemotePushError {
     #[error("Problem getting active stores on site during remote push")]
     GetActiveStoresOnSiteError(#[from] GetActiveStoresOnSiteError),
     #[error("Problem getting changelog during remote push")]
-    SyncChangelogError(#[from] SyncChangelogError),
+    LegacyDataFilterError(#[from] LegacyDataFilterError),
     #[error(transparent)]
     SyncLoggerError(#[from] SyncLoggerError),
 }
@@ -119,7 +116,7 @@ impl RemoteDataSynchroniser {
         &self,
         connection: &StorageConnection,
     ) -> Result<(), RepositoryError> {
-        let cursor = ChangelogRepository::new(connection).latest_cursor()?;
+        let cursor = ChangelogRepository::new(connection).max_cursor()?;
 
         CursorController::new(KeyType::RemoteSyncPushCursor).update(connection, cursor + 1)?;
         Ok(())
@@ -190,15 +187,22 @@ impl RemoteDataSynchroniser {
         logger: &mut SyncLogger<'a>,
     ) -> Result<(), RemotePushError> {
         let changelog_repo = ChangelogRepository::new(connection);
-        let change_log_filter = get_sync_push_changelogs_filter(connection)?;
+        let change_log_filter = ChangelogFilter::all_data_for_legacy_central(connection)?;
         let cursor_controller = CursorController::new(KeyType::RemoteSyncPushCursor);
 
         loop {
             // TODO inside transaction
             let cursor = cursor_controller.get(connection)?;
-            let changelogs =
-                changelog_repo.changelogs(cursor, batch_size, change_log_filter.clone())?;
-            let change_logs_total = changelog_repo.count(cursor, change_log_filter.clone())?;
+            let changelogs = changelog_repo.query(
+                change_log_filter.clone(),
+                CursorAndLimit {
+                    cursor: cursor as i64,
+                    limit: batch_size as i64,
+                },
+            )?;
+            // Total = remaining records to process based on max cursor
+            let max_cursor = changelog_repo.max_cursor()?;
+            let change_logs_total = max_cursor.saturating_sub(cursor);
 
             logger.progress(SyncStepProgress::Push, change_logs_total)?;
 

--- a/server/service/src/sync/sync_on_central/mod.rs
+++ b/server/service/src/sync/sync_on_central/mod.rs
@@ -5,8 +5,9 @@ use std::{
 
 use actix_multipart::form::tempfile::TempFile;
 use repository::{
-    ChangelogRepository, SyncBufferRowRepository, SyncFileReferenceRow,
-    SyncFileReferenceRowRepository,
+    ChangelogCondition, ChangelogFilter, ChangelogRepository, CursorAndLimit, FilterBuilder,
+    SyncBufferRowRepository, SyncFileReferenceRow, SyncFileReferenceRowRepository,
+    SyncStyleOptions,
 };
 use util::format_error;
 
@@ -77,23 +78,30 @@ pub async fn pull(
     let changelog_repo = ChangelogRepository::new(&ctx.connection);
 
     // We don't need a filter here, as we are filtering in the repository layer
-    let changelogs = changelog_repo.outgoing_sync_records_from_central(
-        cursor,
-        batch_size,
+    let filter = ChangelogFilter::all_data_for_site(
         response.site_id,
-        is_initialised,
+        !is_initialised,
+        Some(SyncStyleOptions {
+            is_v6: true,
+            is_v5: false,
+        }),
+    );
+    let changelogs = ChangelogRepository::new(&ctx.connection).query(
+        filter,
+        CursorAndLimit {
+            cursor: cursor as i64,
+            limit: batch_size as i64,
+        },
     )?;
-    let total_records = changelog_repo.count_outgoing_sync_records_from_central(
-        cursor,
-        response.site_id,
-        is_initialised,
-    )?;
-    let max_cursor = changelog_repo.latest_cursor()?;
+    let max_cursor = changelog_repo.max_cursor()?;
 
     let end_cursor = changelogs
         .last()
         .map(|log| log.cursor as u64)
         .unwrap_or(max_cursor);
+
+    // Total = remaining records to process based on max cursor
+    let total_records = max_cursor.saturating_sub(cursor);
 
     let records: Vec<SyncRecordV6> = translate_changelogs_to_sync_records(
         &ctx.connection,
@@ -230,23 +238,32 @@ pub async fn patient_pull(
     let changelog_repo = ChangelogRepository::new(&ctx.connection);
 
     // We don't need a filter here, as we are filtering in the repository layer
-    let changelogs = changelog_repo.outgoing_patient_sync_records_from_central(
-        cursor,
-        batch_size,
-        response.site_id,
-        fetch_patient_id.clone(),
+    let filter = ChangelogCondition::And(vec![
+        ChangelogFilter::patient_data_for_site(
+            response.site_id,
+            Some(SyncStyleOptions {
+                is_v6: true,
+                is_v5: false,
+            }),
+        ),
+        ChangelogCondition::patient_id::equal(fetch_patient_id),
+    ]);
+    let changelogs = ChangelogRepository::new(&ctx.connection).query(
+        filter,
+        CursorAndLimit {
+            cursor: cursor as i64,
+            limit: batch_size as i64,
+        },
     )?;
-    let total_records = changelog_repo.count_outgoing_patient_sync_records_from_central(
-        cursor,
-        response.site_id,
-        fetch_patient_id,
-    )?;
-    let max_cursor = changelog_repo.latest_cursor()?;
+    let max_cursor = changelog_repo.max_cursor()?;
 
     let end_cursor = changelogs
         .last()
         .map(|log| log.cursor as u64)
         .unwrap_or(max_cursor);
+
+    // Total = remaining records to process based on max cursor
+    let total_records = max_cursor.saturating_sub(cursor);
 
     let records: Vec<SyncRecordV6> = translate_changelogs_to_sync_records(
         &ctx.connection,

--- a/server/service/src/sync/sync_status/status.rs
+++ b/server/service/src/sync/sync_status/status.rs
@@ -9,7 +9,6 @@ use crate::{
     i32_to_u32,
     service_provider::ServiceContext,
     settings_service::{SettingsService, SettingsServiceTrait},
-    sync::{get_sync_push_changelogs_filter, SyncChangelogError},
 };
 
 use super::SyncLogError;
@@ -188,7 +187,7 @@ pub trait SyncStatusTrait: Sync + Send {
     fn number_of_records_in_push_queue(
         &self,
         ctx: &ServiceContext,
-    ) -> Result<u64, NumberOfRecordsInPushQueueError> {
+    ) -> Result<u64, RepositoryError> {
         number_of_records_in_push_queue(ctx)
     }
 
@@ -293,31 +292,14 @@ fn get_latest_successful_sync_status(
 
     Ok(Some(result))
 }
-
-#[derive(Debug)]
-pub enum NumberOfRecordsInPushQueueError {
-    DatabaseError(RepositoryError),
-    SyncChangelogError(SyncChangelogError),
-}
-
-fn number_of_records_in_push_queue(
-    ctx: &ServiceContext,
-) -> Result<u64, NumberOfRecordsInPushQueueError> {
-    use NumberOfRecordsInPushQueueError as Error;
+fn number_of_records_in_push_queue(ctx: &ServiceContext) -> Result<u64, RepositoryError> {
     let changelog_repo = ChangelogRepository::new(&ctx.connection);
 
-    let cursor = CursorController::new(KeyType::RemoteSyncPushCursor)
-        .get(&ctx.connection)
-        .map_err(Error::DatabaseError)?;
+    let cursor = CursorController::new(KeyType::RemoteSyncPushCursor).get(&ctx.connection)?;
 
-    let changelog_filter = get_sync_push_changelogs_filter(&ctx.connection)
-        .map_err(NumberOfRecordsInPushQueueError::SyncChangelogError)?;
+    let max_cursor = changelog_repo.max_cursor()?;
 
-    let change_logs_total = changelog_repo
-        .count(cursor, changelog_filter)
-        .map_err(Error::DatabaseError)?;
-
-    Ok(change_logs_total)
+    Ok(max_cursor.saturating_sub(cursor))
 }
 
 impl SyncLogError {

--- a/server/service/src/sync/sync_status/test.rs
+++ b/server/service/src/sync/sync_status/test.rs
@@ -87,8 +87,13 @@ async fn sync_status() {
     );
 
     // Test PUSH and ERROR
-    // Clear change log
-    ChangelogRepository::new(&connection).delete(0).unwrap();
+    // Advance push cursor past current changelog so we only count records inserted below
+    {
+        let cursor = ChangelogRepository::new(&connection).max_cursor().unwrap();
+        crate::cursor_controller::CursorController::new(KeyType::RemoteSyncPushCursor)
+            .update(&connection, cursor)
+            .unwrap();
+    }
     // Insert some location rows to be pushed
     insert_extra_mock_data(
         &connection,

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -118,10 +118,7 @@ impl Synchroniser {
         })
     }
 
-    pub(crate) async fn sync(
-        &self,
-        _fetch_patient_id: Option<String>,
-    ) -> Result<(), SyncError> {
+    pub(crate) async fn sync(&self, _fetch_patient_id: Option<String>) -> Result<(), SyncError> {
         let ctx = self.service_provider.basic_context()?;
         let mut logger = SyncLogger::start(&ctx.connection)?
             .with_subscription_trigger(self.service_provider.subscription_trigger.clone());

--- a/server/service/src/sync/test/integration/mod.rs
+++ b/server/service/src/sync/test/integration/mod.rs
@@ -141,7 +141,7 @@ pub(crate) fn integrate_with_is_sync_reset(
     integrations: Vec<IntegrationOperation>,
 ) -> Vec<IntegrationOperation> {
     let changelog_repo = ChangelogRepository::new(&connection);
-    let cursor = changelog_repo.latest_cursor().unwrap();
+    let cursor = changelog_repo.max_cursor().unwrap();
     // Need to reset is_sync_update since we've inserted test data with sync methods
     // they need to sync to central (if is_sync_update is set to true they will not sync to central)
     let integrations: Vec<(Option<_>, IntegrationOperation)> =

--- a/server/service/src/sync/test/pull_and_push.rs
+++ b/server/service/src/sync/test/pull_and_push.rs
@@ -47,7 +47,7 @@ async fn test_sync_pull_and_push() {
 
     // Get push cursor before inserting pull data (so that we can test push, excluding inserted mock data)
     let push_cursor = ChangelogRepository::new(&connection)
-        .latest_cursor()
+        .max_cursor()
         .unwrap()
         + 1;
 
@@ -82,9 +82,14 @@ async fn test_sync_pull_and_push() {
     // let change_log_filter = get_sync_push_changelogs_filter(&connection).unwrap();
 
     // Records would have been inserted in test Pull Upsert and trigger should have inserted changelogs
-    let all_changelogs = ChangelogRepository::new(&connection)
-        .changelogs(push_cursor, 100000, None /*change_log_filter*/)
-        .unwrap();
+    let all_changelogs = ChangelogRepository::new(&connection).query(
+        repository::ChangelogCondition::True(),
+        repository::CursorAndLimit {
+            cursor: push_cursor as i64,
+            limit: 100000,
+        },
+    )
+    .unwrap();
     // Deduplicate: keep only the latest (highest cursor) entry per record_id,
     // since the changelog_deduped view was removed.
     let changelogs = {

--- a/server/service/src/sync/translations/barcode.rs
+++ b/server/service/src/sync/translations/barcode.rs
@@ -124,8 +124,8 @@ mod tests {
 
     use super::*;
     use repository::{
-        mock::MockDataInserts, test_db::setup_all, ChangelogFilter, ChangelogRepository,
-    };
+        mock::MockDataInserts, test_db::setup_all, ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder,
+};
     use serde_json::json;
 
     #[actix_rt::test]
@@ -153,14 +153,14 @@ mod tests {
 
         merge_all_name_links(&connection, &mock_data).unwrap();
 
-        let repo = ChangelogRepository::new(&connection);
-        let changelogs = repo
-            .changelogs(
-                0,
-                1_000_000,
-                Some(ChangelogFilter::new().table_name(ChangelogTableName::Barcode.equal_to())),
-            )
-            .unwrap();
+        let changelogs = ChangelogRepository::new(&connection).query(
+            ChangelogCondition::table_name::equal(ChangelogTableName::Barcode),
+            CursorAndLimit {
+                cursor: -1,
+                limit: 1_000_000,
+            },
+        )
+        .unwrap();
 
         let translator = BarcodeTranslation;
         for changelog in changelogs {

--- a/server/service/src/sync/translations/encounter_legacy.rs
+++ b/server/service/src/sync/translations/encounter_legacy.rs
@@ -124,7 +124,7 @@ mod tests {
             setup_all("test_translate_encounter_to_legacy", MockDataInserts::all()).await;
 
         let cursor = ChangelogRepository::new(&connection)
-            .latest_cursor()
+            .max_cursor()
             .unwrap_or(0);
 
         // Create a new EncounterRow (this will get a changelog entry created automatically)
@@ -146,8 +146,7 @@ mod tests {
             .upsert_one(&encounter_row)
             .unwrap();
 
-        let changelog = ChangelogRepository::new(&connection)
-            .changelogs(cursor, 100, None)
+        let changelog = ChangelogRepository::new(&connection).query(repository::ChangelogCondition::True(), repository::CursorAndLimit { cursor: cursor as i64, limit: 100 })
             .unwrap()
             .pop()
             .expect("Expected at least one changelog entry");

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -1035,7 +1035,8 @@ mod tests {
     use repository::{
         mock::{mock_store_a, MockData, MockDataInserts},
         test_db::{setup_all, setup_all_with_data},
-        ChangelogFilter, ChangelogRepository, KeyType, KeyValueStoreRow,
+        ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder, KeyType,
+        KeyValueStoreRow,
     };
     use serde_json::json;
 
@@ -1092,14 +1093,14 @@ mod tests {
 
         merge_all_name_links(&connection, &mock_data).unwrap();
 
-        let repo = ChangelogRepository::new(&connection);
-        let changelogs = repo
-            .changelogs(
-                0,
-                1_000_000,
-                Some(ChangelogFilter::new().table_name(ChangelogTableName::Invoice.equal_to())),
-            )
-            .unwrap();
+        let changelogs = ChangelogRepository::new(&connection).query(
+            ChangelogCondition::table_name::equal(ChangelogTableName::Invoice),
+            CursorAndLimit {
+                cursor: -1,
+                limit: 1_000_000,
+            },
+        )
+        .unwrap();
 
         let translator = InvoiceTranslation {};
         for changelog in changelogs {

--- a/server/service/src/sync/translations/invoice_line.rs
+++ b/server/service/src/sync/translations/invoice_line.rs
@@ -527,7 +527,8 @@ mod tests {
     use repository::{
         mock::{mock_outbound_shipment_a, mock_store_b, MockData, MockDataInserts},
         test_db::{setup_all, setup_all_with_data},
-        ChangelogFilter, ChangelogRepository, KeyType, KeyValueStoreRow,
+        ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder, KeyType,
+        KeyValueStoreRow,
     };
     use serde_json::json;
 
@@ -588,14 +589,14 @@ mod tests {
 
         merge_all_item_links(&connection, &mock_data).unwrap();
 
-        let repo = ChangelogRepository::new(&connection);
-        let changelogs = repo
-            .changelogs(
-                0,
-                1_000_000,
-                Some(ChangelogFilter::new().table_name(ChangelogTableName::InvoiceLine.equal_to())),
-            )
-            .unwrap();
+        let changelogs = ChangelogRepository::new(&connection).query(
+            ChangelogCondition::table_name::equal(ChangelogTableName::InvoiceLine),
+            CursorAndLimit {
+                cursor: -1,
+                limit: 1_000_000,
+            },
+        )
+        .unwrap();
 
         let translator = InvoiceLineTranslation {};
         for changelog in changelogs {

--- a/server/service/src/sync/translations/name_store_join.rs
+++ b/server/service/src/sync/translations/name_store_join.rs
@@ -199,8 +199,8 @@ mod tests {
         test::merge_helpers::merge_all_name_links, translations::ToSyncRecordTranslationType,
     };
     use repository::{
-        mock::MockDataInserts, test_db::setup_all, ChangelogFilter, ChangelogRepository,
-    };
+        mock::MockDataInserts, test_db::setup_all, ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder,
+};
     use serde_json::json;
 
     #[actix_rt::test]
@@ -248,16 +248,14 @@ mod tests {
 
         merge_all_name_links(&connection, &mock_data).unwrap();
 
-        let repo = ChangelogRepository::new(&connection);
-        let changelogs = repo
-            .changelogs(
-                0,
-                1_000_000,
-                Some(
-                    ChangelogFilter::new().table_name(ChangelogTableName::NameStoreJoin.equal_to()),
-                ),
-            )
-            .unwrap();
+        let changelogs = ChangelogRepository::new(&connection).query(
+            ChangelogCondition::table_name::equal(ChangelogTableName::NameStoreJoin),
+            CursorAndLimit {
+                cursor: -1,
+                limit: 1_000_000,
+            },
+        )
+        .unwrap();
 
         let translator = NameStoreJoinTranslation {};
         for changelog in changelogs {

--- a/server/service/src/sync/translations/purchase_order.rs
+++ b/server/service/src/sync/translations/purchase_order.rs
@@ -488,8 +488,8 @@ mod tests {
 
     use super::*;
     use repository::{
-        mock::MockDataInserts, test_db::setup_all, ChangelogFilter, ChangelogRepository,
-    };
+        mock::MockDataInserts, test_db::setup_all, ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder,
+};
     use serde_json::json;
 
     #[actix_rt::test]
@@ -530,16 +530,14 @@ mod tests {
         .await;
 
         let translator = PurchaseOrderTranslation {};
-        let repo = ChangelogRepository::new(&connection);
-        let changelogs = repo
-            .changelogs(
-                0,
-                1_000_000,
-                Some(
-                    ChangelogFilter::new().table_name(ChangelogTableName::PurchaseOrder.equal_to()),
-                ),
-            )
-            .unwrap();
+        let changelogs = ChangelogRepository::new(&connection).query(
+            ChangelogCondition::table_name::equal(ChangelogTableName::PurchaseOrder),
+            CursorAndLimit {
+                cursor: -1,
+                limit: 1_000_000,
+            },
+        )
+        .unwrap();
 
         for changelog in changelogs {
             assert!(translator.should_translate_to_sync_record(

--- a/server/service/src/sync/translations/purchase_order_line.rs
+++ b/server/service/src/sync/translations/purchase_order_line.rs
@@ -254,8 +254,8 @@ mod tests {
 
     use super::*;
     use repository::{
-        mock::MockDataInserts, test_db::setup_all, ChangelogFilter, ChangelogRepository,
-    };
+        mock::MockDataInserts, test_db::setup_all, ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder,
+};
     use serde_json::json;
 
     #[actix_rt::test]
@@ -298,17 +298,14 @@ mod tests {
         .await;
 
         let translator = PurchaseOrderLineTranslation {};
-        let repo = ChangelogRepository::new(&connection);
-        let changelogs = repo
-            .changelogs(
-                0,
-                1_000_000,
-                Some(
-                    ChangelogFilter::new()
-                        .table_name(ChangelogTableName::PurchaseOrderLine.equal_to()),
-                ),
-            )
-            .unwrap();
+        let changelogs = ChangelogRepository::new(&connection).query(
+            ChangelogCondition::table_name::equal(ChangelogTableName::PurchaseOrderLine),
+            CursorAndLimit {
+                cursor: -1,
+                limit: 1_000_000,
+            },
+        )
+        .unwrap();
 
         for changelog in changelogs {
             assert!(translator.should_translate_to_sync_record(

--- a/server/service/src/sync/translations/requisition.rs
+++ b/server/service/src/sync/translations/requisition.rs
@@ -634,9 +634,9 @@ mod tests {
 
     use super::*;
     use repository::{
-        mock::MockDataInserts, test_db::setup_all, ChangelogFilter, ChangelogRepository,
+        mock::MockDataInserts, test_db::setup_all, ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder,
         SyncAction, SyncBufferRow, SyncRecordData,
-    };
+};
     use serde_json::json;
     use util::assert_variant;
 
@@ -741,14 +741,14 @@ mod tests {
 
         merge_all_name_links(&connection, &mock_data).unwrap();
 
-        let repo = ChangelogRepository::new(&connection);
-        let changelogs = repo
-            .changelogs(
-                0,
-                1_000_000,
-                Some(ChangelogFilter::new().table_name(ChangelogTableName::Requisition.equal_to())),
-            )
-            .unwrap();
+        let changelogs = ChangelogRepository::new(&connection).query(
+            ChangelogCondition::table_name::equal(ChangelogTableName::Requisition),
+            CursorAndLimit {
+                cursor: -1,
+                limit: 1_000_000,
+            },
+        )
+        .unwrap();
 
         let translator = RequisitionTranslation {};
         for changelog in changelogs {

--- a/server/service/src/sync/translations/requisition_line.rs
+++ b/server/service/src/sync/translations/requisition_line.rs
@@ -319,8 +319,8 @@ mod tests {
 
     use super::*;
     use repository::{
-        mock::MockDataInserts, test_db::setup_all, ChangelogFilter, ChangelogRepository,
-    };
+        mock::MockDataInserts, test_db::setup_all, ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder,
+};
     use serde_json::json;
 
     #[actix_rt::test]
@@ -362,17 +362,14 @@ mod tests {
 
         merge_all_item_links(&connection, &mock_data).unwrap();
 
-        let repo = ChangelogRepository::new(&connection);
-        let changelogs = repo
-            .changelogs(
-                0,
-                1_000_000,
-                Some(
-                    ChangelogFilter::new()
-                        .table_name(ChangelogTableName::RequisitionLine.equal_to()),
-                ),
-            )
-            .unwrap();
+        let changelogs = ChangelogRepository::new(&connection).query(
+            ChangelogCondition::table_name::equal(ChangelogTableName::RequisitionLine),
+            CursorAndLimit {
+                cursor: -1,
+                limit: 1_000_000,
+            },
+        )
+        .unwrap();
 
         let translator = RequisitionLineTranslation;
         for changelog in changelogs {

--- a/server/service/src/sync/translations/stock_line.rs
+++ b/server/service/src/sync/translations/stock_line.rs
@@ -280,8 +280,8 @@ mod tests {
 
     use super::*;
     use repository::{
-        mock::MockDataInserts, test_db::setup_all, ChangelogFilter, ChangelogRepository,
-    };
+        mock::MockDataInserts, test_db::setup_all, ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder,
+};
     use serde_json::json;
 
     #[actix_rt::test]
@@ -311,14 +311,14 @@ mod tests {
         merge_all_item_links(&connection, &mock_data).unwrap();
         merge_all_name_links(&connection, &mock_data).unwrap();
 
-        let repo = ChangelogRepository::new(&connection);
-        let changelogs = repo
-            .changelogs(
-                0,
-                1_000_000,
-                Some(ChangelogFilter::new().table_name(ChangelogTableName::StockLine.equal_to())),
-            )
-            .unwrap();
+        let changelogs = ChangelogRepository::new(&connection).query(
+            ChangelogCondition::table_name::equal(ChangelogTableName::StockLine),
+            CursorAndLimit {
+                cursor: -1,
+                limit: 1_000_000,
+            },
+        )
+        .unwrap();
 
         let translator = StockLineTranslation {};
         for changelog in changelogs {

--- a/server/service/src/sync/translations/stocktake_line.rs
+++ b/server/service/src/sync/translations/stocktake_line.rs
@@ -323,8 +323,8 @@ mod tests {
 
     use super::*;
     use repository::{
-        mock::MockDataInserts, test_db::setup_all, ChangelogFilter, ChangelogRepository,
-    };
+        mock::MockDataInserts, test_db::setup_all, ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder,
+};
     use serde_json::json;
 
     #[actix_rt::test]
@@ -365,16 +365,14 @@ mod tests {
 
         merge_all_item_links(&connection, &mock_data).unwrap();
 
-        let repo = ChangelogRepository::new(&connection);
-        let changelogs = repo
-            .changelogs(
-                0,
-                1_000_000,
-                Some(
-                    ChangelogFilter::new().table_name(ChangelogTableName::StocktakeLine.equal_to()),
-                ),
-            )
-            .unwrap();
+        let changelogs = ChangelogRepository::new(&connection).query(
+            ChangelogCondition::table_name::equal(ChangelogTableName::StocktakeLine),
+            CursorAndLimit {
+                cursor: -1,
+                limit: 1_000_000,
+            },
+        )
+        .unwrap();
 
         let translator = StocktakeLineTranslation {};
         for changelog in changelogs {

--- a/server/service/src/sync/translations/vaccination_legacy.rs
+++ b/server/service/src/sync/translations/vaccination_legacy.rs
@@ -178,7 +178,7 @@ mod tests {
 
         // Get the current cursor value
         let cursor = ChangelogRepository::new(&connection)
-            .latest_cursor()
+            .max_cursor()
             .unwrap();
 
         // Create a new VaccinationRow (this will get a changelog entry created automatically)
@@ -204,8 +204,7 @@ mod tests {
             .upsert_one(&vaccination_row)
             .unwrap();
 
-        let changelog_row = ChangelogRepository::new(&connection)
-            .changelogs(cursor, 100, None)
+        let changelog_row = ChangelogRepository::new(&connection).query(repository::ChangelogCondition::True(), repository::CursorAndLimit { cursor: cursor as i64, limit: 100 })
             .unwrap()
             .pop()
             .unwrap();

--- a/server/service/src/sync/translations/vaccine_course_dose_legacy.rs
+++ b/server/service/src/sync/translations/vaccine_course_dose_legacy.rs
@@ -124,7 +124,7 @@ mod tests {
 
         // Get the current cursor value
         let cursor = ChangelogRepository::new(&connection)
-            .latest_cursor()
+            .max_cursor()
             .unwrap();
 
         // Create a new VaccineCourseDoseRow (this will get a changelog entry created automatically)
@@ -143,8 +143,7 @@ mod tests {
             .upsert_one(&vaccine_course_dose_row)
             .unwrap();
 
-        let changelog_row = ChangelogRepository::new(&connection)
-            .changelogs(cursor, 100, None)
+        let changelog_row = ChangelogRepository::new(&connection).query(repository::ChangelogCondition::True(), repository::CursorAndLimit { cursor: cursor as i64, limit: 100 })
             .unwrap()
             .pop()
             .unwrap();

--- a/server/service/src/sync/translations/vaccine_course_item_legacy.rs
+++ b/server/service/src/sync/translations/vaccine_course_item_legacy.rs
@@ -116,7 +116,7 @@ mod tests {
 
         // Get the current cursor value
         let cursor = ChangelogRepository::new(&connection)
-            .latest_cursor()
+            .max_cursor()
             .unwrap();
 
         // Create a new VaccineCourseItemRow (this will get a changelog entry created automatically)
@@ -131,8 +131,7 @@ mod tests {
             .upsert_one(&vaccine_course_item_row)
             .unwrap();
 
-        let changelog_row = ChangelogRepository::new(&connection)
-            .changelogs(cursor, 100, None)
+        let changelog_row = ChangelogRepository::new(&connection).query(repository::ChangelogCondition::True(), repository::CursorAndLimit { cursor: cursor as i64, limit: 100 })
             .unwrap()
             .pop()
             .unwrap();

--- a/server/service/src/sync/translations/vaccine_course_legacy.rs
+++ b/server/service/src/sync/translations/vaccine_course_legacy.rs
@@ -125,7 +125,7 @@ mod tests {
 
         // Get the current cursor value
         let cursor = ChangelogRepository::new(&connection)
-            .latest_cursor()
+            .max_cursor()
             .unwrap();
 
         // Create a new VaccineCourseRow (this will get a changelog entry created automatically)
@@ -145,8 +145,7 @@ mod tests {
             .upsert_one(&vaccine_course_row)
             .unwrap();
 
-        let changelog_row = ChangelogRepository::new(&connection)
-            .changelogs(cursor, 100, None)
+        let changelog_row = ChangelogRepository::new(&connection).query(repository::ChangelogCondition::True(), repository::CursorAndLimit { cursor: cursor as i64, limit: 100 })
             .unwrap()
             .pop()
             .unwrap();

--- a/server/service/src/sync_v7/sync.rs
+++ b/server/service/src/sync_v7/sync.rs
@@ -2,10 +2,9 @@ use std::time::{Duration, SystemTime};
 
 use chrono::Utc;
 use repository::{
-    get_changelogs,
     syncv7::{SiteLockError, SyncError},
-    ChangelogCondition, ChangelogRepository, ChangelogTableName, CursorAndLimit, KeyType,
-    RowActionType, Site, StorageConnection, SyncAction, SyncBufferRow, SyncBufferRowRepository,
+    ChangelogCondition, ChangelogFilter, ChangelogRepository, ChangelogTableName, CursorAndLimit,
+    KeyType, RowActionType, StorageConnection, SyncAction, SyncBufferRow, SyncBufferRowRepository,
     SyncRecordData,
 };
 use serde::{Deserialize, Serialize};
@@ -60,8 +59,8 @@ impl SyncBatchV7 {
     ) -> Result<SyncBatchV7, SyncError> {
         let site_id = get_current_site_id(connection)?;
 
-        let changelogs = get_changelogs(
-            connection,
+        let changelog_repo = ChangelogRepository::new(connection);
+        let changelogs = changelog_repo.query(
             filter,
             CursorAndLimit {
                 cursor,
@@ -74,7 +73,7 @@ impl SyncBatchV7 {
             .map(|changelog| prepare(connection, changelog))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let max_cursor = ChangelogRepository::new(connection).latest_cursor()?;
+        let max_cursor = changelog_repo.max_cursor()?;
 
         Ok(SyncBatchV7 {
             site_id,
@@ -193,7 +192,7 @@ impl<'a> SyncV7<'a> {
         let site_id = get_current_site_id(self.connection)?;
 
         // TODO think about just the filter for source site id = current site on changelog
-        let filter = Site::SiteId(site_id).all_data_edited_on_site();
+        let filter = ChangelogFilter::all_data_edited_on_site(site_id);
 
         loop {
             let cursor = cursor_controller.get(self.connection)? as i64;

--- a/server/service/src/sync_v7/sync_on_central/mod.rs
+++ b/server/service/src/sync_v7/sync_on_central/mod.rs
@@ -6,9 +6,9 @@ use std::{
 use repository::{
     migrations::Version,
     syncv7::{SiteLockError, SyncError},
-    EqualFilter, KeyType, KeyValueStoreRepository, Pagination, RepositoryError, Site, SiteFilter,
-    SiteRepository, SiteRow, SiteRowRepository, StorageConnection, StringFilter, SyncBufferFilter,
-    SyncBufferRowRepository,
+    ChangelogFilter, EqualFilter, KeyType, KeyValueStoreRepository, Pagination, RepositoryError,
+    SiteFilter, SiteRepository, SiteRow, SiteRowRepository, StorageConnection, StringFilter,
+    SyncBufferFilter, SyncBufferRowRepository,
 };
 use thiserror::Error;
 use util::format_error;
@@ -162,7 +162,7 @@ pub async fn pull(
 ) -> pull::Response {
     let (site, ctx) = validate(service_provider, &common)?;
 
-    let filter = Site::SiteId(site.id).all_data_for_site(input.is_initialising);
+    let filter = ChangelogFilter::all_data_for_site(site.id, input.is_initialising, None);
 
     let batch = SyncBatchV7::generate(&ctx.connection, filter, input.cursor, input.batch_size)?;
 

--- a/server/service/src/sync_v7/test.rs
+++ b/server/service/src/sync_v7/test.rs
@@ -4,10 +4,10 @@ mod test_sync_v7_client_api {
     use assert_json_diff::assert_json_include;
     use repository::mock::MockData;
     use repository::{
-        migrations::Version, mock::MockDataInserts, ChangelogFilter, ChangelogRepository,
-        ChangelogRow, ChangelogTableName, CurrencyRow, EqualFilter, ItemRow, KeyType,
-        KeyValueStoreRepository, NameRow, RowActionType, StockLineRow, StorageConnection, StoreRow,
-        SyncBufferRowRepository, UnitRow, Upsert,
+        migrations::Version, mock::MockDataInserts, ChangelogCondition, ChangelogRepository,
+        ChangelogRow, ChangelogTableName, CurrencyRow, CursorAndLimit, FilterBuilder, ItemRow,
+        KeyType, KeyValueStoreRepository, NameRow, RowActionType, StockLineRow, StorageConnection,
+        StoreRow, SyncBufferRowRepository, UnitRow, Upsert,
     };
     use repository::{KeyValueStoreRow, SyncAction, SyncBufferRow};
     use serde_json::json;
@@ -370,13 +370,14 @@ mod test_sync_v7_client_api {
         );
 
         // Assert: changelog entries
-        let changelogs = ChangelogRepository::new(&connection)
-            .changelogs(
-                0,
-                100,
-                Some(ChangelogFilter::new().source_site_id(EqualFilter::equal_to(1))),
-            )
-            .unwrap();
+        let changelogs = ChangelogRepository::new(&connection).query(
+            ChangelogCondition::source_site_id::equal(1),
+            CursorAndLimit {
+                cursor: -1,
+                limit: 100,
+            },
+        )
+        .unwrap();
         assert_eq!(changelogs.len(), 6);
         assert_eq!(
             changelogs,


### PR DESCRIPTION
## Stack
This is **PR 3 of 9**. Stacked on top of [#11464](https://github.com/msupply-foundation/open-msupply/pull/11464).

> ⚠️ **Tests will not pass until the final PR (9/9) is merged.**

## Summary
- Migrates every caller of the changelog API onto the new filter shape introduced in PR 2.
- Adds `compatibility_changelog.rs` so the old v5/v6 entry points keep working through the transition.
- Touched areas: processors (transfer, requisition, plugin), `sync/sync_on_central`, `sync_v7`, every translator that reads changelog.
- 39 files, +890 / −1,071 (net code reduction).

## Why
The old filter API and the new one need to coexist briefly because v5/v6 sync flows still depend on the old shape. `compatibility_changelog.rs` is the bridge — it gets removed/cleaned up later in the stack.

## Test plan
- [ ] Spot-check a couple of high-traffic call sites (invoice transfer, requisition transfer, sync_on_central)
- [ ] Tests will not pass on this branch alone; full suite is validated at PR 9