### PR TITLE
Sync stack 5/9: Use query_with_data for v5 and v6

### DIFF
--- a/server/repository/src/db_diesel/activity_log_row.rs
+++ b/server/repository/src/db_diesel/activity_log_row.rs
@@ -177,6 +177,12 @@ impl<'a> ActivityLogRowRepository<'a> {
             .get_results(self.connection.lock().connection())?;
         Ok(result)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<ActivityLogRow>, RepositoryError> {
+        Ok(activity_log::table
+            .filter(activity_log::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for ActivityLogRow {

--- a/server/repository/src/db_diesel/assets/asset_catalogue_item_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_catalogue_item_row.rs
@@ -109,6 +109,12 @@ impl<'a> AssetCatalogueItemRowRepository<'a> {
         )?;
         ChangelogRepository::new(self.connection).insert(&changelog)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<AssetCatalogueItemRow>, RepositoryError> {
+        Ok(asset_catalogue_item::table
+            .filter(asset_catalogue_item::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for AssetCatalogueItemRow {

--- a/server/repository/src/db_diesel/assets/asset_category_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_category_row.rs
@@ -87,6 +87,12 @@ impl<'a> AssetCategoryRowRepository<'a> {
     //         .execute(self.connection.lock().connection())?;
     //     Ok(())
     // }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<AssetCategoryRow>, RepositoryError> {
+        Ok(asset_category::table
+            .filter(asset_category::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for AssetCategoryRow {

--- a/server/repository/src/db_diesel/assets/asset_class_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_class_row.rs
@@ -77,6 +77,12 @@ impl<'a> AssetClassRowRepository<'a> {
     //         .execute(self.connection.lock().connection())?;
     //     Ok(())
     // }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<AssetClassRow>, RepositoryError> {
+        Ok(asset_class::table
+            .filter(asset_class::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for AssetClassRow {

--- a/server/repository/src/db_diesel/assets/asset_internal_location_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_internal_location_row.rs
@@ -126,6 +126,12 @@ impl<'a> AssetInternalLocationRowRepository<'a> {
         }
         Ok(())
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<AssetInternalLocationRow>, RepositoryError> {
+        Ok(asset_internal_location::table
+            .filter(asset_internal_location::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for AssetInternalLocationRow {

--- a/server/repository/src/db_diesel/assets/asset_log_reason_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_log_reason_row.rs
@@ -99,6 +99,12 @@ impl<'a> AssetLogReasonRowRepository<'a> {
         ChangelogRepository::new(self.connection).insert(&changelog)?;
         Ok(())
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<AssetLogReasonRow>, RepositoryError> {
+        Ok(asset_log_reason::table
+            .filter(asset_log_reason::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for AssetLogReasonRow {

--- a/server/repository/src/db_diesel/assets/asset_log_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_log_row.rs
@@ -127,6 +127,12 @@ impl<'a> AssetLogRowRepository<'a> {
             .optional()?;
         Ok(result)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<AssetLogRow>, RepositoryError> {
+        Ok(asset_log::table
+            .filter(asset_log::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for AssetLogRow {

--- a/server/repository/src/db_diesel/assets/asset_property_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_property_row.rs
@@ -98,6 +98,12 @@ impl<'a> AssetPropertyRowRepository<'a> {
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<AssetPropertyRow>, RepositoryError> {
+        Ok(asset_property::table
+            .filter(asset_property::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for AssetPropertyRow {

--- a/server/repository/src/db_diesel/assets/asset_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_row.rs
@@ -154,6 +154,12 @@ impl<'a> AssetRowRepository<'a> {
         )?;
         ChangelogRepository::new(self.connection).insert(&changelog)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<AssetRow>, RepositoryError> {
+        Ok(asset::table
+            .filter(asset::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for AssetRow {

--- a/server/repository/src/db_diesel/assets/mod.rs
+++ b/server/repository/src/db_diesel/assets/mod.rs
@@ -17,3 +17,13 @@ pub mod asset_row;
 pub mod asset_type;
 pub mod asset_type_row;
 pub mod types;
+
+pub use asset_catalogue_item_row::*;
+pub use asset_category_row::*;
+pub use asset_class_row::*;
+pub use asset_internal_location_row::*;
+pub use asset_log_reason_row::*;
+pub use asset_log_row::*;
+pub use asset_property_row::*;
+pub use asset_row::*;
+pub use asset_type_row::*;

--- a/server/repository/src/db_diesel/backend_plugin_row.rs
+++ b/server/repository/src/db_diesel/backend_plugin_row.rs
@@ -129,6 +129,12 @@ impl<'a> BackendPluginRowRepository<'a> {
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<BackendPluginRow>, RepositoryError> {
+        Ok(backend_plugin::table
+            .filter(backend_plugin::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for BackendPluginRow {

--- a/server/repository/src/db_diesel/barcode_row.rs
+++ b/server/repository/src/db_diesel/barcode_row.rs
@@ -80,6 +80,12 @@ impl<'a> BarcodeRowRepository<'a> {
             .get_results(self.connection.lock().connection())?;
         Ok(result)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<BarcodeRow>, RepositoryError> {
+        Ok(barcode::table
+            .filter(barcode::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for BarcodeRow {

--- a/server/repository/src/db_diesel/campaign/mod.rs
+++ b/server/repository/src/db_diesel/campaign/mod.rs
@@ -1,2 +1,4 @@
 pub mod campaign;
 pub mod campaign_row;
+
+pub use campaign_row::*;

--- a/server/repository/src/db_diesel/changelog/batch_query.rs
+++ b/server/repository/src/db_diesel/changelog/batch_query.rs
@@ -1,32 +1,223 @@
 use std::collections::HashMap;
 
 use crate::{
-    ChangelogCondition, ChangelogRepository, ChangelogRow, ChangelogTableName, CurrencyRow,
-    CurrencyRowRepository, CursorAndLimit, InvoiceLineRow, InvoiceLineRowRepository, InvoiceRow,
-    InvoiceRowRepository, ItemRow, ItemRowRepository, LocationTypeRow, LocationTypeRowRepository,
-    NameRow, NameRowRepository, RepositoryError, RowActionType, StockLineRow,
-    StockLineRowRepository, StorageConnection, StoreRow, StoreRowRepository, UnitRow,
+    ActivityLogRow,
+    ActivityLogRowRepository,
+    AssetCatalogueItemRow,
+    AssetCatalogueItemRowRepository,
+    AssetCategoryRow,
+    AssetCategoryRowRepository,
+    AssetClassRow,
+    AssetClassRowRepository,
+    AssetInternalLocationRow,
+    AssetInternalLocationRowRepository,
+    AssetLogReasonRow,
+    AssetLogReasonRowRepository,
+    AssetLogRow,
+    AssetLogRowRepository,
+    AssetPropertyRow,
+    AssetPropertyRowRepository,
+    AssetRow,
+    AssetRowRepository,
+    BackendPluginRow,
+    BackendPluginRowRepository,
+    BarcodeRow,
+    BarcodeRowRepository,
+    BundledItemRow,
+    BundledItemRowRepository,
+    CampaignRow,
+    CampaignRowRepository,
+    ChangelogCondition,
+    ChangelogRepository,
+    ChangelogRow,
+    ChangelogTableName,
+    ClinicianRow,
+    ClinicianRowRepository,
+    ClinicianStoreJoinRow,
+    ClinicianStoreJoinRowRepository,
+    ContactFormRow,
+    ContactFormRowRepository,
+    CurrencyRow,
+    CurrencyRowRepository,
+    CursorAndLimit,
+    DemographicRow,
+    DemographicRowRepository,
+    DocumentRepository,
+    DocumentRow,
+    EncounterRow,
+    EncounterRowRepository,
+    FormSchemaRow,
+    FormSchemaRowRepository,
+    FrontendPluginRow,
+    FrontendPluginRowRepository,
+    IndicatorValueRow,
+    IndicatorValueRowRepository,
+    InsuranceProviderRow,
+    InsuranceProviderRowRepository,
+    InvoiceLineRow,
+    InvoiceLineRowRepository,
+    InvoiceRow,
+    InvoiceRowRepository,
+    ItemRow,
+    ItemRowRepository,
+    ItemVariantRow,
+    ItemVariantRowRepository,
+    LocationMovementRow,
+    LocationMovementRowRepository,
+    LocationRow,
+    LocationRowRepository,
+    LocationTypeRow,
+    LocationTypeRowRepository,
+    MasterListRow,
+    MasterListRowRepository,
+    NameInsuranceJoinRow,
+    NameInsuranceJoinRowRepository,
+    NamePropertyRow,
+    NamePropertyRowRepository,
+    NameRow,
+    NameRowRepository,
+    NameStoreJoinRepository,
+    NameStoreJoinRow,
+    NumberRow,
+    NumberRowRepository,
+    PackagingVariantRow,
+    PackagingVariantRowRepository,
+    PluginDataRow,
+    PluginDataRowRepository,
+    PreferenceRow,
+    PreferenceRowRepository,
+    PropertyRow,
+    PropertyRowRepository,
+    PurchaseOrderLineRow,
+    PurchaseOrderLineRowRepository,
+    PurchaseOrderRow,
+    PurchaseOrderRowRepository,
+    ReportRow,
+    ReportRowRepository,
+    RepositoryError,
+    RequisitionLineRow,
+    RequisitionLineRowRepository,
+    RequisitionRow,
+    RequisitionRowRepository,
+    RnRFormLineRow,
+    RnRFormLineRowRepository,
+    RnRFormRow,
+    RnRFormRowRepository,
+    RowActionType,
+    SensorRow,
+    SensorRowRepository,
+    StockLineRow,
+    StockLineRowRepository,
+    StocktakeLineRow,
+    StocktakeLineRowRepository,
+    StocktakeRow,
+    StocktakeRowRepository,
+    StorageConnection,
+    StoreRow,
+    StoreRowRepository,
+    SyncFileReferenceRow,
+    SyncFileReferenceRowRepository,
+    SyncMessageRow,
+    SyncMessageRowRepository,
+    SystemLogRow,
+    SystemLogRowRepository,
+    TemperatureBreachConfigRow,
+    TemperatureBreachConfigRowRepository,
+    TemperatureBreachRow,
+    TemperatureBreachRowRepository,
+    TemperatureLogRow,
+    TemperatureLogRowRepository,
+    UnitRow,
     UnitRowRepository,
+    VVMStatusLogRow,
+    VVMStatusLogRowRepository,
+    VaccinationRow,
+    VaccinationRowRepository,
+    VaccineCourseDoseRow,
+    VaccineCourseDoseRowRepository,
+    VaccineCourseItemRow,
+    VaccineCourseItemRowRepository,
+    VaccineCourseRow,
+    VaccineCourseRowRepository,
+    VaccineCourseStoreConfigRow,
+    VaccineCourseStoreConfigRowRepository,
 };
 
 /// Max ids per IN-clause when batch-fetching rows; keeps us well below
 /// SQLite's default 999-parameter limit and groups queries efficiently.
 const ROW_FETCH_BATCH_SIZE: usize = 500;
 
-/// One of the row variants that can appear in a changelog. Only the tables
-/// supported by the first iteration of `query_with_data` are listed;
-/// extend this enum (and `fetch_rows_for_table`) as more tables are wired up.
+/// One of the row variants that can appear in a changelog. Generated
+/// to cover every push-translated `ChangelogTableName`. Tables not in
+/// this enum trigger `unimplemented!()` in `fetch_rows_for_table`.
 #[derive(Debug, Clone)]
 pub enum Row {
-    Unit(UnitRow),
+    ActivityLog(ActivityLogRow),
+    Barcode(BarcodeRow),
+    Clinician(ClinicianRow),
+    ClinicianStoreJoin(ClinicianStoreJoinRow),
     Currency(CurrencyRow),
-    Name(NameRow),
-    Store(StoreRow),
-    LocationType(LocationTypeRow),
+    Document(DocumentRow),
+    IndicatorValue(IndicatorValueRow),
+    InsuranceProvider(InsuranceProviderRow),
     Item(ItemRow),
+    Location(LocationRow),
+    LocationMovement(LocationMovementRow),
+    Name(NameRow),
+    NameInsuranceJoin(NameInsuranceJoinRow),
+    NameStoreJoin(NameStoreJoinRow),
+    Number(NumberRow),
+    PurchaseOrder(PurchaseOrderRow),
+    PurchaseOrderLine(PurchaseOrderLineRow),
+    Sensor(SensorRow),
     StockLine(StockLineRow),
+    Stocktake(StocktakeRow),
+    StocktakeLine(StocktakeLineRow),
+    TemperatureBreach(TemperatureBreachRow),
+    TemperatureBreachConfig(TemperatureBreachConfigRow),
+    TemperatureLog(TemperatureLogRow),
+    VVMStatusLog(VVMStatusLogRow),
+    Requisition(RequisitionRow),
+    RequisitionLine(RequisitionLineRow),
     Invoice(InvoiceRow),
     InvoiceLine(InvoiceLineRow),
+    AssetCatalogueItem(AssetCatalogueItemRow),
+    AssetCategory(AssetCategoryRow),
+    AssetClass(AssetClassRow),
+    AssetLogReason(AssetLogReasonRow),
+    AssetProperty(AssetPropertyRow),
+    BackendPlugin(BackendPluginRow),
+    BundledItem(BundledItemRow),
+    Campaign(CampaignRow),
+    Demographic(DemographicRow),
+    FormSchema(FormSchemaRow),
+    FrontendPlugin(FrontendPluginRow),
+    ItemVariant(ItemVariantRow),
+    NameProperty(NamePropertyRow),
+    PackagingVariant(PackagingVariantRow),
+    Property(PropertyRow),
+    Report(ReportRow),
+    VaccineCourse(VaccineCourseRow),
+    VaccineCourseDose(VaccineCourseDoseRow),
+    VaccineCourseItem(VaccineCourseItemRow),
+    VaccineCourseStoreConfig(VaccineCourseStoreConfigRow),
+    LocationType(LocationTypeRow),
+    MasterList(MasterListRow),
+    Store(StoreRow),
+    Unit(UnitRow),
+    Asset(AssetRow),
+    AssetInternalLocation(AssetInternalLocationRow),
+    AssetLog(AssetLogRow),
+    Encounter(EncounterRow),
+    RnrForm(RnRFormRow),
+    RnrFormLine(RnRFormLineRow),
+    SyncMessage(SyncMessageRow),
+    Vaccination(VaccinationRow),
+    SyncFileReference(SyncFileReferenceRow),
+    PluginData(PluginDataRow),
+    Preference(PreferenceRow),
+    ContactForm(ContactFormRow),
+    SystemLog(SystemLogRow),
 }
 
 /// Output entry of `query_with_data`. `Row` carries the loaded row
@@ -167,9 +358,24 @@ fn fetch_rows_for_table(
 
     for chunk in ids.chunks(ROW_FETCH_BATCH_SIZE) {
         match table_name {
-            ChangelogTableName::Unit => {
-                for r in UnitRowRepository::new(connection).find_many_by_id(chunk)? {
-                    out.insert(r.id.clone(), Row::Unit(r));
+            ChangelogTableName::ActivityLog => {
+                for r in ActivityLogRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::ActivityLog(r));
+                }
+            }
+            ChangelogTableName::Barcode => {
+                for r in BarcodeRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Barcode(r));
+                }
+            }
+            ChangelogTableName::Clinician => {
+                for r in ClinicianRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Clinician(r));
+                }
+            }
+            ChangelogTableName::ClinicianStoreJoin => {
+                for r in ClinicianStoreJoinRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::ClinicianStoreJoin(r));
                 }
             }
             ChangelogTableName::Currency => {
@@ -177,19 +383,19 @@ fn fetch_rows_for_table(
                     out.insert(r.id.clone(), Row::Currency(r));
                 }
             }
-            ChangelogTableName::Name => {
-                for r in NameRowRepository::new(connection).find_many_by_id(chunk)? {
-                    out.insert(r.id.clone(), Row::Name(r));
+            ChangelogTableName::Document => {
+                for r in DocumentRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Document(r));
                 }
             }
-            ChangelogTableName::Store => {
-                for r in StoreRowRepository::new(connection).find_many_by_id(chunk)? {
-                    out.insert(r.id.clone(), Row::Store(r));
+            ChangelogTableName::IndicatorValue => {
+                for r in IndicatorValueRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::IndicatorValue(r));
                 }
             }
-            ChangelogTableName::LocationType => {
-                for r in LocationTypeRowRepository::new(connection).find_many_by_id(chunk)? {
-                    out.insert(r.id.clone(), Row::LocationType(r));
+            ChangelogTableName::InsuranceProvider => {
+                for r in InsuranceProviderRowRepository::new(connection).find_many_by_ids(chunk)? {
+                    out.insert(r.id.clone(), Row::InsuranceProvider(r));
                 }
             }
             ChangelogTableName::Item => {
@@ -197,9 +403,94 @@ fn fetch_rows_for_table(
                     out.insert(r.id.clone(), Row::Item(r));
                 }
             }
+            ChangelogTableName::Location => {
+                for r in LocationRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Location(r));
+                }
+            }
+            ChangelogTableName::LocationMovement => {
+                for r in LocationMovementRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::LocationMovement(r));
+                }
+            }
+            ChangelogTableName::Name => {
+                for r in NameRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Name(r));
+                }
+            }
+            ChangelogTableName::NameInsuranceJoin => {
+                for r in NameInsuranceJoinRowRepository::new(connection).find_many_by_ids(chunk)? {
+                    out.insert(r.id.clone(), Row::NameInsuranceJoin(r));
+                }
+            }
+            ChangelogTableName::NameStoreJoin => {
+                for r in NameStoreJoinRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::NameStoreJoin(r));
+                }
+            }
+            ChangelogTableName::Number => {
+                for r in NumberRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Number(r));
+                }
+            }
+            ChangelogTableName::PurchaseOrder => {
+                for r in PurchaseOrderRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::PurchaseOrder(r));
+                }
+            }
+            ChangelogTableName::PurchaseOrderLine => {
+                for r in PurchaseOrderLineRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::PurchaseOrderLine(r));
+                }
+            }
+            ChangelogTableName::Sensor => {
+                for r in SensorRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Sensor(r));
+                }
+            }
             ChangelogTableName::StockLine => {
                 for r in StockLineRowRepository::new(connection).find_many_by_ids(chunk)? {
                     out.insert(r.id.clone(), Row::StockLine(r));
+                }
+            }
+            ChangelogTableName::Stocktake => {
+                for r in StocktakeRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Stocktake(r));
+                }
+            }
+            ChangelogTableName::StocktakeLine => {
+                for r in StocktakeLineRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::StocktakeLine(r));
+                }
+            }
+            ChangelogTableName::TemperatureBreach => {
+                for r in TemperatureBreachRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::TemperatureBreach(r));
+                }
+            }
+            ChangelogTableName::TemperatureBreachConfig => {
+                for r in TemperatureBreachConfigRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::TemperatureBreachConfig(r));
+                }
+            }
+            ChangelogTableName::TemperatureLog => {
+                for r in TemperatureLogRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::TemperatureLog(r));
+                }
+            }
+            ChangelogTableName::VVMStatusLog => {
+                for r in VVMStatusLogRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::VVMStatusLog(r));
+                }
+            }
+            ChangelogTableName::Requisition => {
+                for r in RequisitionRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Requisition(r));
+                }
+            }
+            ChangelogTableName::RequisitionLine => {
+                for r in RequisitionLineRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::RequisitionLine(r));
                 }
             }
             ChangelogTableName::Invoice => {
@@ -210,6 +501,191 @@ fn fetch_rows_for_table(
             ChangelogTableName::InvoiceLine => {
                 for r in InvoiceLineRowRepository::new(connection).find_many_by_id(chunk)? {
                     out.insert(r.id.clone(), Row::InvoiceLine(r));
+                }
+            }
+            ChangelogTableName::AssetCatalogueItem => {
+                for r in AssetCatalogueItemRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::AssetCatalogueItem(r));
+                }
+            }
+            ChangelogTableName::AssetCategory => {
+                for r in AssetCategoryRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::AssetCategory(r));
+                }
+            }
+            ChangelogTableName::AssetClass => {
+                for r in AssetClassRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::AssetClass(r));
+                }
+            }
+            ChangelogTableName::AssetLogReason => {
+                for r in AssetLogReasonRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::AssetLogReason(r));
+                }
+            }
+            ChangelogTableName::AssetProperty => {
+                for r in AssetPropertyRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::AssetProperty(r));
+                }
+            }
+            ChangelogTableName::BackendPlugin => {
+                for r in BackendPluginRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::BackendPlugin(r));
+                }
+            }
+            ChangelogTableName::BundledItem => {
+                for r in BundledItemRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::BundledItem(r));
+                }
+            }
+            ChangelogTableName::Campaign => {
+                for r in CampaignRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Campaign(r));
+                }
+            }
+            ChangelogTableName::Demographic => {
+                for r in DemographicRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Demographic(r));
+                }
+            }
+            ChangelogTableName::FormSchema => {
+                for r in FormSchemaRowRepository::new(connection).find_many_rows_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::FormSchema(r));
+                }
+            }
+            ChangelogTableName::FrontendPlugin => {
+                for r in FrontendPluginRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::FrontendPlugin(r));
+                }
+            }
+            ChangelogTableName::ItemVariant => {
+                for r in ItemVariantRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::ItemVariant(r));
+                }
+            }
+            ChangelogTableName::NameProperty => {
+                for r in NamePropertyRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::NameProperty(r));
+                }
+            }
+            ChangelogTableName::PackagingVariant => {
+                for r in PackagingVariantRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::PackagingVariant(r));
+                }
+            }
+            ChangelogTableName::Property => {
+                for r in PropertyRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Property(r));
+                }
+            }
+            ChangelogTableName::Report => {
+                for r in ReportRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Report(r));
+                }
+            }
+            ChangelogTableName::VaccineCourse => {
+                for r in VaccineCourseRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::VaccineCourse(r));
+                }
+            }
+            ChangelogTableName::VaccineCourseDose => {
+                for r in VaccineCourseDoseRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::VaccineCourseDose(r));
+                }
+            }
+            ChangelogTableName::VaccineCourseItem => {
+                for r in VaccineCourseItemRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::VaccineCourseItem(r));
+                }
+            }
+            ChangelogTableName::VaccineCourseStoreConfig => {
+                for r in VaccineCourseStoreConfigRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::VaccineCourseStoreConfig(r));
+                }
+            }
+            ChangelogTableName::LocationType => {
+                for r in LocationTypeRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::LocationType(r));
+                }
+            }
+            ChangelogTableName::MasterList => {
+                for r in MasterListRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::MasterList(r));
+                }
+            }
+            ChangelogTableName::Store => {
+                for r in StoreRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Store(r));
+                }
+            }
+            ChangelogTableName::Unit => {
+                for r in UnitRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Unit(r));
+                }
+            }
+            ChangelogTableName::Asset => {
+                for r in AssetRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Asset(r));
+                }
+            }
+            ChangelogTableName::AssetInternalLocation => {
+                for r in AssetInternalLocationRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::AssetInternalLocation(r));
+                }
+            }
+            ChangelogTableName::AssetLog => {
+                for r in AssetLogRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::AssetLog(r));
+                }
+            }
+            ChangelogTableName::Encounter => {
+                for r in EncounterRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Encounter(r));
+                }
+            }
+            ChangelogTableName::RnrForm => {
+                for r in RnRFormRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::RnrForm(r));
+                }
+            }
+            ChangelogTableName::RnrFormLine => {
+                for r in RnRFormLineRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::RnrFormLine(r));
+                }
+            }
+            ChangelogTableName::SyncMessage => {
+                for r in SyncMessageRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::SyncMessage(r));
+                }
+            }
+            ChangelogTableName::Vaccination => {
+                for r in VaccinationRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Vaccination(r));
+                }
+            }
+            ChangelogTableName::SyncFileReference => {
+                for r in SyncFileReferenceRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::SyncFileReference(r));
+                }
+            }
+            ChangelogTableName::PluginData => {
+                for r in PluginDataRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::PluginData(r));
+                }
+            }
+            ChangelogTableName::Preference => {
+                for r in PreferenceRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Preference(r));
+                }
+            }
+            ChangelogTableName::ContactForm => {
+                for r in ContactFormRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::ContactForm(r));
+                }
+            }
+            ChangelogTableName::SystemLog => {
+                for r in SystemLogRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::SystemLog(r));
                 }
             }
             other => unimplemented!("query_with_data does not yet support {:?}", other),

--- a/server/repository/src/db_diesel/clinician_row.rs
+++ b/server/repository/src/db_diesel/clinician_row.rs
@@ -116,6 +116,12 @@ impl<'a> ClinicianRowRepository<'a> {
         insert_or_ignore_clinician_link(self.connection, row)?;
         Ok(())
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<ClinicianRow>, RepositoryError> {
+        Ok(clinician::table
+            .filter(clinician::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 pub struct ClinicianRowDelete(pub String);

--- a/server/repository/src/db_diesel/clinician_store_join_row.rs
+++ b/server/repository/src/db_diesel/clinician_store_join_row.rs
@@ -74,6 +74,12 @@ impl<'a> ClinicianStoreJoinRowRepository<'a> {
         .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<ClinicianStoreJoinRow>, RepositoryError> {
+        Ok(clinician_store_join::table
+            .filter(clinician_store_join::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for ClinicianStoreJoinRow {

--- a/server/repository/src/db_diesel/contact_form_row.rs
+++ b/server/repository/src/db_diesel/contact_form_row.rs
@@ -97,6 +97,12 @@ impl<'a> ContactFormRowRepository<'a> {
             .optional()?;
         Ok(result)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<ContactFormRow>, RepositoryError> {
+        Ok(contact_form::table
+            .filter(contact_form::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for ContactFormRow {

--- a/server/repository/src/db_diesel/demographic_row.rs
+++ b/server/repository/src/db_diesel/demographic_row.rs
@@ -76,6 +76,12 @@ impl<'a> DemographicRowRepository<'a> {
             .optional()?;
         Ok(result)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<DemographicRow>, RepositoryError> {
+        Ok(demographic::table
+            .filter(demographic::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for DemographicRow {

--- a/server/repository/src/db_diesel/document.rs
+++ b/server/repository/src/db_diesel/document.rs
@@ -335,6 +335,12 @@ impl<'a> DocumentRepository<'a> {
         }
         Ok(result)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<DocumentRow>, RepositoryError> {
+        Ok(document::table
+            .filter(document::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 fn to_document(row: DocumentRow) -> Result<Document, RepositoryError> {

--- a/server/repository/src/db_diesel/encounter_row.rs
+++ b/server/repository/src/db_diesel/encounter_row.rs
@@ -101,4 +101,10 @@ impl<'a> EncounterRowRepository<'a> {
             .optional();
         result.map_err(RepositoryError::from)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<EncounterRow>, RepositoryError> {
+        Ok(encounter::table
+            .filter(encounter::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }

--- a/server/repository/src/db_diesel/form_schema_row.rs
+++ b/server/repository/src/db_diesel/form_schema_row.rs
@@ -128,6 +128,15 @@ impl<'a> FormSchemaRowRepository<'a> {
         Ok(result)
     }
 
+    pub fn find_many_rows_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<FormSchemaRow>, RepositoryError> {
+        Ok(form_schema::dsl::form_schema
+            .filter(form_schema::dsl::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+
     pub fn delete(&self, id: &str) -> Result<(), RepositoryError> {
         diesel::delete(form_schema::dsl::form_schema.filter(form_schema::dsl::id.eq(id)))
             .execute(self.connection.lock().connection())?;

--- a/server/repository/src/db_diesel/frontend_plugin_row.rs
+++ b/server/repository/src/db_diesel/frontend_plugin_row.rs
@@ -140,6 +140,12 @@ impl<'a> FrontendPluginRowRepository<'a> {
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<FrontendPluginRow>, RepositoryError> {
+        Ok(frontend_plugin::table
+            .filter(frontend_plugin::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for FrontendPluginRow {

--- a/server/repository/src/db_diesel/indicator_value_row.rs
+++ b/server/repository/src/db_diesel/indicator_value_row.rs
@@ -89,6 +89,12 @@ impl<'a> IndicatorValueRowRepository<'a> {
             .optional()?;
         Ok(result)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<IndicatorValueRow>, RepositoryError> {
+        Ok(indicator_value::table
+            .filter(indicator_value::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/server/repository/src/db_diesel/item_variant/bundled_item_row.rs
+++ b/server/repository/src/db_diesel/item_variant/bundled_item_row.rs
@@ -83,6 +83,12 @@ impl<'a> BundledItemRowRepository<'a> {
         )?;
         ChangelogRepository::new(self.connection).insert(&changelog)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<BundledItemRow>, RepositoryError> {
+        Ok(bundled_item::table
+            .filter(bundled_item::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for BundledItemRow {

--- a/server/repository/src/db_diesel/item_variant/item_variant_row.rs
+++ b/server/repository/src/db_diesel/item_variant/item_variant_row.rs
@@ -118,6 +118,12 @@ impl<'a> ItemVariantRowRepository<'a> {
         )?;
         ChangelogRepository::new(self.connection).insert(&changelog)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<ItemVariantRow>, RepositoryError> {
+        Ok(item_variant::table
+            .filter(item_variant::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for ItemVariantRow {

--- a/server/repository/src/db_diesel/item_variant/mod.rs
+++ b/server/repository/src/db_diesel/item_variant/mod.rs
@@ -4,3 +4,7 @@ pub mod item_variant;
 pub mod item_variant_row;
 pub mod packaging_variant;
 pub mod packaging_variant_row;
+
+pub use bundled_item_row::*;
+pub use item_variant_row::*;
+pub use packaging_variant_row::*;

--- a/server/repository/src/db_diesel/item_variant/packaging_variant_row.rs
+++ b/server/repository/src/db_diesel/item_variant/packaging_variant_row.rs
@@ -88,6 +88,12 @@ impl<'a> PackagingVariantRowRepository<'a> {
         )?;
         ChangelogRepository::new(self.connection).insert(&changelog)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<PackagingVariantRow>, RepositoryError> {
+        Ok(packaging_variant::table
+            .filter(packaging_variant::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for PackagingVariantRow {

--- a/server/repository/src/db_diesel/location_movement_row.rs
+++ b/server/repository/src/db_diesel/location_movement_row.rs
@@ -74,6 +74,12 @@ impl<'a> LocationMovementRowRepository<'a> {
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<LocationMovementRow>, RepositoryError> {
+        Ok(location_movement::table
+            .filter(location_movement::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for LocationMovementRow {

--- a/server/repository/src/db_diesel/master_list_row.rs
+++ b/server/repository/src/db_diesel/master_list_row.rs
@@ -71,6 +71,12 @@ impl<'a> MasterListRowRepository<'a> {
             .optional()?;
         Ok(result)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<MasterListRow>, RepositoryError> {
+        Ok(master_list::table
+            .filter(master_list::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for MasterListRow {

--- a/server/repository/src/db_diesel/mod.rs
+++ b/server/repository/src/db_diesel/mod.rs
@@ -322,6 +322,12 @@ pub use vaccination::*;
 pub use vaccination_card::*;
 pub use vaccination_course::*;
 pub use vaccination_row::*;
+pub use vaccine_course::*;
+pub use vvm_status::*;
+pub use item_variant::*;
+pub use contact_form_row::*;
+pub use name_insurance_join_row::*;
+pub use system_log_row::*;
 pub use warning::*;
 pub use warning_row::*;
 

--- a/server/repository/src/db_diesel/name_property_row.rs
+++ b/server/repository/src/db_diesel/name_property_row.rs
@@ -83,6 +83,12 @@ impl<'a> NamePropertyRowRepository<'a> {
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<NamePropertyRow>, RepositoryError> {
+        Ok(name_property::table
+            .filter(name_property::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for NamePropertyRow {

--- a/server/repository/src/db_diesel/name_store_join.rs
+++ b/server/repository/src/db_diesel/name_store_join.rs
@@ -121,6 +121,12 @@ impl<'a> NameStoreJoinRepository<'a> {
 
         Ok(result.into_iter().map(to_domain).collect())
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<NameStoreJoinRow>, RepositoryError> {
+        Ok(name_store_join::table
+            .filter(name_store_join::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 #[diesel::dsl::auto_type]

--- a/server/repository/src/db_diesel/number_row.rs
+++ b/server/repository/src/db_diesel/number_row.rs
@@ -236,6 +236,12 @@ impl<'a> NumberRowRepository<'a> {
             .load(self.connection.lock().connection())?;
         Ok(result)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<NumberRow>, RepositoryError> {
+        Ok(number::table
+            .filter(number::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 #[cfg(test)]

--- a/server/repository/src/db_diesel/plugin_data_row.rs
+++ b/server/repository/src/db_diesel/plugin_data_row.rs
@@ -73,6 +73,12 @@ impl<'a> PluginDataRowRepository<'a> {
 
         Ok(result)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<PluginDataRow>, RepositoryError> {
+        Ok(plugin_data::table
+            .filter(plugin_data::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for PluginDataRow {

--- a/server/repository/src/db_diesel/preference_row.rs
+++ b/server/repository/src/db_diesel/preference_row.rs
@@ -93,6 +93,12 @@ impl<'a> PreferenceRowRepository<'a> {
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<PreferenceRow>, RepositoryError> {
+        Ok(preference::table
+            .filter(preference::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for PreferenceRow {

--- a/server/repository/src/db_diesel/property_row.rs
+++ b/server/repository/src/db_diesel/property_row.rs
@@ -86,6 +86,12 @@ impl<'a> PropertyRowRepository<'a> {
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<PropertyRow>, RepositoryError> {
+        Ok(property::table
+            .filter(property::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for PropertyRow {

--- a/server/repository/src/db_diesel/purchase_order_line_row.rs
+++ b/server/repository/src/db_diesel/purchase_order_line_row.rs
@@ -213,6 +213,12 @@ impl<'a> PurchaseOrderLineRowRepository<'a> {
             .first(self.connection.lock().connection())?;
         Ok(result)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<PurchaseOrderLineRow>, RepositoryError> {
+        Ok(purchase_order_line::table
+            .filter(purchase_order_line::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for PurchaseOrderLineRow {

--- a/server/repository/src/db_diesel/purchase_order_row.rs
+++ b/server/repository/src/db_diesel/purchase_order_row.rs
@@ -194,6 +194,12 @@ impl<'a> PurchaseOrderRowRepository<'a> {
             .first(self.connection.lock().connection())?;
         Ok(result)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<PurchaseOrderRow>, RepositoryError> {
+        Ok(purchase_order::table
+            .filter(purchase_order::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for PurchaseOrderRow {

--- a/server/repository/src/db_diesel/report_row.rs
+++ b/server/repository/src/db_diesel/report_row.rs
@@ -132,6 +132,12 @@ impl<'a> ReportRowRepository<'a> {
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<ReportRow>, RepositoryError> {
+        Ok(report::table
+            .filter(report::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/server/repository/src/db_diesel/requisition/requisition_row.rs
+++ b/server/repository/src/db_diesel/requisition/requisition_row.rs
@@ -190,6 +190,12 @@ impl<'a> RequisitionRowRepository<'a> {
             .first(self.connection.lock().connection())?;
         Ok(result)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<RequisitionRow>, RepositoryError> {
+        Ok(requisition::table
+            .filter(requisition::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/server/repository/src/db_diesel/requisition_line/requisition_line_row.rs
+++ b/server/repository/src/db_diesel/requisition_line/requisition_line_row.rs
@@ -170,6 +170,12 @@ impl<'a> RequisitionLineRowRepository<'a> {
             .optional()?;
         Ok(result)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<RequisitionLineRow>, RepositoryError> {
+        Ok(requisition_line::table
+            .filter(requisition_line::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/server/repository/src/db_diesel/rnr_form_line_row.rs
+++ b/server/repository/src/db_diesel/rnr_form_line_row.rs
@@ -200,6 +200,12 @@ impl<'a> RnRFormLineRowRepository<'a> {
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<RnRFormLineRow>, RepositoryError> {
+        Ok(rnr_form_line::table
+            .filter(rnr_form_line::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/server/repository/src/db_diesel/rnr_form_row.rs
+++ b/server/repository/src/db_diesel/rnr_form_row.rs
@@ -124,6 +124,12 @@ impl<'a> RnRFormRowRepository<'a> {
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<RnRFormRow>, RepositoryError> {
+        Ok(rnr_form::table
+            .filter(rnr_form::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/server/repository/src/db_diesel/sync_file_reference_row.rs
+++ b/server/repository/src/db_diesel/sync_file_reference_row.rs
@@ -176,6 +176,12 @@ impl<'a> SyncFileReferenceRowRepository<'a> {
         self._upsert_one(sync_file_reference_row)?;
         Ok(())
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<SyncFileReferenceRow>, RepositoryError> {
+        Ok(sync_file_reference::table
+            .filter(sync_file_reference::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for SyncFileReferenceRow {

--- a/server/repository/src/db_diesel/sync_message_row.rs
+++ b/server/repository/src/db_diesel/sync_message_row.rs
@@ -111,6 +111,12 @@ impl<'a> SyncMessageRowRepository<'a> {
             .optional()?;
         Ok(result)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<SyncMessageRow>, RepositoryError> {
+        Ok(sync_message::table
+            .filter(sync_message::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for SyncMessageRow {

--- a/server/repository/src/db_diesel/system_log_row.rs
+++ b/server/repository/src/db_diesel/system_log_row.rs
@@ -106,6 +106,12 @@ impl<'a> SystemLogRowRepository<'a> {
         let result = system_log::table.load(self.connection.lock().connection())?;
         Ok(result)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<SystemLogRow>, RepositoryError> {
+        Ok(system_log::table
+            .filter(system_log::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for SystemLogRow {

--- a/server/repository/src/db_diesel/vaccination_row.rs
+++ b/server/repository/src/db_diesel/vaccination_row.rs
@@ -139,6 +139,12 @@ impl<'a> VaccinationRowRepository<'a> {
         .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<VaccinationRow>, RepositoryError> {
+        Ok(vaccination::table
+            .filter(vaccination::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for VaccinationRow {

--- a/server/repository/src/db_diesel/vaccine_course/mod.rs
+++ b/server/repository/src/db_diesel/vaccine_course/mod.rs
@@ -6,3 +6,8 @@ pub mod vaccine_course_store_config_row;
 pub mod vaccine_course_item;
 pub mod vaccine_course_item_row;
 pub mod vaccine_course_row;
+
+pub use vaccine_course_dose_row::*;
+pub use vaccine_course_store_config_row::*;
+pub use vaccine_course_item_row::*;
+pub use vaccine_course_row::*;

--- a/server/repository/src/db_diesel/vaccine_course/vaccine_course_dose_row.rs
+++ b/server/repository/src/db_diesel/vaccine_course/vaccine_course_dose_row.rs
@@ -116,6 +116,12 @@ impl<'a> VaccineCourseDoseRowRepository<'a> {
         )?;
         ChangelogRepository::new(self.connection).insert(&changelog)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<VaccineCourseDoseRow>, RepositoryError> {
+        Ok(vaccine_course_dose::table
+            .filter(vaccine_course_dose::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for VaccineCourseDoseRow {

--- a/server/repository/src/db_diesel/vaccine_course/vaccine_course_item_row.rs
+++ b/server/repository/src/db_diesel/vaccine_course/vaccine_course_item_row.rs
@@ -103,6 +103,12 @@ impl<'a> VaccineCourseItemRowRepository<'a> {
         )?;
         ChangelogRepository::new(self.connection).insert(&changelog)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<VaccineCourseItemRow>, RepositoryError> {
+        Ok(vaccine_course_item::table
+            .filter(vaccine_course_item::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for VaccineCourseItemRow {

--- a/server/repository/src/db_diesel/vaccine_course/vaccine_course_row.rs
+++ b/server/repository/src/db_diesel/vaccine_course/vaccine_course_row.rs
@@ -99,6 +99,12 @@ impl<'a> VaccineCourseRowRepository<'a> {
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<VaccineCourseRow>, RepositoryError> {
+        Ok(vaccine_course::table
+            .filter(vaccine_course::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for VaccineCourseRow {

--- a/server/repository/src/db_diesel/vaccine_course/vaccine_course_store_config_row.rs
+++ b/server/repository/src/db_diesel/vaccine_course/vaccine_course_store_config_row.rs
@@ -67,6 +67,12 @@ impl<'a> VaccineCourseStoreConfigRowRepository<'a> {
             .optional()?;
         Ok(result)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<VaccineCourseStoreConfigRow>, RepositoryError> {
+        Ok(vaccine_course_store_config::table
+            .filter(vaccine_course_store_config::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for VaccineCourseStoreConfigRow {

--- a/server/repository/src/db_diesel/vvm_status/mod.rs
+++ b/server/repository/src/db_diesel/vvm_status/mod.rs
@@ -1,3 +1,6 @@
 pub mod vvm_status_log;
 pub mod vvm_status_log_row;
 pub mod vvm_status_row;
+
+pub use vvm_status_log_row::*;
+pub use vvm_status_row::*;

--- a/server/repository/src/db_diesel/vvm_status/vvm_status_log_row.rs
+++ b/server/repository/src/db_diesel/vvm_status/vvm_status_log_row.rs
@@ -107,6 +107,12 @@ impl<'a> VVMStatusLogRowRepository<'a> {
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<VVMStatusLogRow>, RepositoryError> {
+        Ok(vvm_status_log::table
+            .filter(vvm_status_log::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -9,7 +9,7 @@ use super::{
     api::*,
     sync_status::logger::{SyncLogger, SyncLoggerError},
     translations::{
-        translate_changelogs_to_sync_records, PushSyncRecord, PushTranslationError,
+        translate_rows_to_sync_records, PushSyncRecord, PushTranslationError,
         ToSyncRecordTranslationType,
     },
 };
@@ -193,7 +193,7 @@ impl RemoteDataSynchroniser {
         loop {
             // TODO inside transaction
             let cursor = cursor_controller.get(connection)?;
-            let changelogs = changelog_repo.query(
+            let rows = changelog_repo.query_with_data(
                 change_log_filter.clone(),
                 CursorAndLimit {
                     cursor: cursor as i64,
@@ -206,11 +206,11 @@ impl RemoteDataSynchroniser {
 
             logger.progress(SyncStepProgress::Push, change_logs_total)?;
 
-            let last_pushed_cursor = changelogs.last().map(|log| log.cursor);
+            let last_pushed_cursor = rows.last().map(|r| r.changelog().cursor);
 
-            let records = translate_changelogs_to_sync_records(
+            let records = translate_rows_to_sync_records(
                 connection,
-                changelogs,
+                rows,
                 vec![ToSyncRecordTranslationType::PushToLegacyCentral],
             )?
             .into_iter()

--- a/server/service/src/sync/sync_on_central/mod.rs
+++ b/server/service/src/sync/sync_on_central/mod.rs
@@ -32,7 +32,7 @@ use super::{
         SyncPatientPullRequestV6, SyncPullRequestV6, SyncPushRequestV6, SyncPushSuccessV6,
         SyncRecordV6, SyncUploadFileRequestV6,
     },
-    translations::translate_changelogs_to_sync_records,
+    translations::translate_rows_to_sync_records,
 };
 
 // See ../README.md for when to increment versions!
@@ -86,7 +86,7 @@ pub async fn pull(
             is_v5: false,
         }),
     );
-    let changelogs = ChangelogRepository::new(&ctx.connection).query(
+    let rows = ChangelogRepository::new(&ctx.connection).query_with_data(
         filter,
         CursorAndLimit {
             cursor: cursor as i64,
@@ -95,17 +95,17 @@ pub async fn pull(
     )?;
     let max_cursor = changelog_repo.max_cursor()?;
 
-    let end_cursor = changelogs
+    let end_cursor = rows
         .last()
-        .map(|log| log.cursor as u64)
+        .map(|r| r.changelog().cursor as u64)
         .unwrap_or(max_cursor);
 
     // Total = remaining records to process based on max cursor
     let total_records = max_cursor.saturating_sub(cursor);
 
-    let records: Vec<SyncRecordV6> = translate_changelogs_to_sync_records(
+    let records: Vec<SyncRecordV6> = translate_rows_to_sync_records(
         &ctx.connection,
-        changelogs,
+        rows,
         vec![ToSyncRecordTranslationType::PullFromOmSupplyCentral],
     )
     .map_err(|e| Error::OtherServerError(format_error(&e)))?
@@ -248,7 +248,7 @@ pub async fn patient_pull(
         ),
         ChangelogCondition::patient_id::equal(fetch_patient_id),
     ]);
-    let changelogs = ChangelogRepository::new(&ctx.connection).query(
+    let rows = ChangelogRepository::new(&ctx.connection).query_with_data(
         filter,
         CursorAndLimit {
             cursor: cursor as i64,
@@ -257,17 +257,17 @@ pub async fn patient_pull(
     )?;
     let max_cursor = changelog_repo.max_cursor()?;
 
-    let end_cursor = changelogs
+    let end_cursor = rows
         .last()
-        .map(|log| log.cursor as u64)
+        .map(|r| r.changelog().cursor as u64)
         .unwrap_or(max_cursor);
 
     // Total = remaining records to process based on max cursor
     let total_records = max_cursor.saturating_sub(cursor);
 
-    let records: Vec<SyncRecordV6> = translate_changelogs_to_sync_records(
+    let records: Vec<SyncRecordV6> = translate_rows_to_sync_records(
         &ctx.connection,
-        changelogs,
+        rows,
         vec![ToSyncRecordTranslationType::PullFromOmSupplyCentral],
     )
     .map_err(|e| Error::OtherServerError(format_error(&e)))?

--- a/server/service/src/sync/test/pull_and_push.rs
+++ b/server/service/src/sync/test/pull_and_push.rs
@@ -15,7 +15,7 @@ use crate::sync::{
         TestSyncOutgoingRecord,
     },
     translations::{
-        translate_changelogs_to_sync_records, PushSyncRecord, ToSyncRecordTranslationType,
+        translate_rows_to_sync_records, PushSyncRecord, ToSyncRecordTranslationType,
     },
 };
 use pretty_assertions::assert_eq;
@@ -81,34 +81,22 @@ async fn test_sync_pull_and_push() {
     // which are usually filtered out via is_sync_updated flag
     // let change_log_filter = get_sync_push_changelogs_filter(&connection).unwrap();
 
-    // Records would have been inserted in test Pull Upsert and trigger should have inserted changelogs
-    let all_changelogs = ChangelogRepository::new(&connection).query(
-        repository::ChangelogCondition::True(),
-        repository::CursorAndLimit {
-            cursor: push_cursor as i64,
-            limit: 100000,
-        },
-    )
-    .unwrap();
-    // Deduplicate: keep only the latest (highest cursor) entry per record_id,
-    // since the changelog_deduped view was removed.
-    let changelogs = {
-        use std::collections::HashMap;
-        let mut latest: HashMap<String, repository::ChangelogRow> = HashMap::new();
-        for row in all_changelogs {
-            let entry = latest.entry(row.record_id.clone()).or_insert(row.clone());
-            if row.cursor > entry.cursor {
-                *entry = row;
-            }
-        }
-        let mut deduped: Vec<_> = latest.into_values().collect();
-        deduped.sort_by_key(|r| r.cursor);
-        deduped
-    };
+    // Records would have been inserted in test Pull Upsert and trigger should have inserted changelogs.
+    // `query_with_data` returns `Vec<RowOrDelete>`, batch-loading the rows
+    // and deduplicating per (table, record_id) within the window.
+    let rows = ChangelogRepository::new(&connection)
+        .query_with_data(
+            repository::ChangelogCondition::True(),
+            repository::CursorAndLimit {
+                cursor: push_cursor as i64,
+                limit: 100000,
+            },
+        )
+        .unwrap();
     // Translate
-    let mut translated = vec![translate_changelogs_to_sync_records(
+    let mut translated = vec![translate_rows_to_sync_records(
         &connection,
-        changelogs.clone(),
+        rows,
         vec![
             ToSyncRecordTranslationType::PushToLegacyCentral,
             ToSyncRecordTranslationType::PullFromOmSupplyCentral,

--- a/server/service/src/sync/translations/activity_log.rs
+++ b/server/service/src/sync/translations/activity_log.rs
@@ -2,10 +2,11 @@ use chrono::NaiveDateTime;
 use repository::{
     ActivityLogRow, ActivityLogRowRepository, ActivityLogType, ChangelogRow, ChangelogTableName,
     StorageConnection, SyncBufferRow,
+    Row,
 };
 use serde::{Deserialize, Serialize};
 
-use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
+use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
 use crate::sync::translations::store::StoreTranslation;
 use util::sync_serde::empty_str_as_option_string;
 
@@ -74,9 +75,13 @@ impl SyncTranslation for ActivityLogTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::ActivityLog(activity_log_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let ActivityLogRow {
             id,
             r#type,
@@ -86,16 +91,11 @@ impl SyncTranslation for ActivityLogTranslation {
             datetime,
             changed_to,
             changed_from,
-        } = ActivityLogRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Activity log row ({}) not found",
-                changelog.record_id
-            )))?;
+        } = activity_log_row;
 
         let (Some(store_id), Some(record_id), Some(user_id)) = (store_id, record_id, user_id)
         else {
-            return Ok(PushTranslateResult::Ignored(
+            return Ok(TranslatedUpsert::Ignored(
                 "Ignoring activity logs without store, user or record id".to_string(),
             ));
         };
@@ -111,11 +111,7 @@ impl SyncTranslation for ActivityLogTranslation {
             changed_from,
         };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 }
 

--- a/server/service/src/sync/translations/activity_log.rs
+++ b/server/service/src/sync/translations/activity_log.rs
@@ -3,10 +3,11 @@ use repository::{
     ActivityLogRow, ActivityLogRowRepository, ActivityLogType, ChangelogRow, ChangelogTableName,
     StorageConnection, SyncBufferRow,
     Row,
+
 };
 use serde::{Deserialize, Serialize};
 
-use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 use crate::sync::translations::store::StoreTranslation;
 use util::sync_serde::empty_str_as_option_string;
 
@@ -76,10 +77,11 @@ impl SyncTranslation for ActivityLogTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::ActivityLog(activity_log_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let ActivityLogRow {
@@ -95,7 +97,7 @@ impl SyncTranslation for ActivityLogTranslation {
 
         let (Some(store_id), Some(record_id), Some(user_id)) = (store_id, record_id, user_id)
         else {
-            return Ok(TranslatedUpsert::Ignored(
+            return Ok(PushTranslateResult::Ignored(
                 "Ignoring activity logs without store, user or record id".to_string(),
             ));
         };
@@ -111,7 +113,7 @@ impl SyncTranslation for ActivityLogTranslation {
             changed_from,
         };
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 }
 

--- a/server/service/src/sync/translations/asset.rs
+++ b/server/service/src/sync/translations/asset.rs
@@ -1,6 +1,7 @@
 use repository::{
     asset_row::{AssetRow, AssetRowDelete, AssetRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::{
@@ -9,9 +10,8 @@ use crate::sync::translations::{
     asset_class::AssetClassTranslation, store::StoreTranslation,
 };
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -68,21 +68,16 @@ impl SyncTranslation for AssetTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = AssetRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Asset row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::Asset(asset_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = asset_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 
     fn try_translate_from_delete_sync_record(

--- a/server/service/src/sync/translations/asset.rs
+++ b/server/service/src/sync/translations/asset.rs
@@ -2,16 +2,17 @@ use repository::{
     asset_row::{AssetRow, AssetRowDelete, AssetRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::{
     asset_catalogue_item::AssetCatalogueItemTranslation,
     asset_catalogue_type::AssetCatalogueTypeTranslation, asset_category::AssetCategoryTranslation,
     asset_class::AssetClassTranslation, store::StoreTranslation,
+
 };
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -69,15 +70,16 @@ impl SyncTranslation for AssetTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::Asset(asset_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = asset_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 
     fn try_translate_from_delete_sync_record(

--- a/server/service/src/sync/translations/asset_catalogue_item.rs
+++ b/server/service/src/sync/translations/asset_catalogue_item.rs
@@ -1,6 +1,7 @@
 use repository::{
     asset_catalogue_item_row::{AssetCatalogueItemRow, AssetCatalogueItemRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::{
@@ -8,9 +9,8 @@ use crate::sync::translations::{
     asset_class::AssetClassTranslation,
 };
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -63,21 +63,16 @@ impl SyncTranslation for AssetCatalogueItemTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = AssetCatalogueItemRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "AssetCatalogueItem row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::AssetCatalogueItem(asset_catalogue_item_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = asset_catalogue_item_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/asset_catalogue_item.rs
+++ b/server/service/src/sync/translations/asset_catalogue_item.rs
@@ -2,15 +2,16 @@ use repository::{
     asset_catalogue_item_row::{AssetCatalogueItemRow, AssetCatalogueItemRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::{
     asset_catalogue_type::AssetCatalogueTypeTranslation, asset_category::AssetCategoryTranslation,
     asset_class::AssetClassTranslation,
+
 };
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -64,15 +65,16 @@ impl SyncTranslation for AssetCatalogueItemTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::AssetCatalogueItem(asset_catalogue_item_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = asset_catalogue_item_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/asset_catalogue_type.rs
+++ b/server/service/src/sync/translations/asset_catalogue_type.rs
@@ -1,13 +1,13 @@
 use repository::{
     asset_type_row::{AssetTypeRow, AssetTypeRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::asset_category::AssetCategoryTranslation;
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -56,21 +56,14 @@ impl SyncTranslation for AssetCatalogueTypeTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = AssetTypeRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "AssetType row ({}) not found",
-                changelog.record_id
-            )))?;
-
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        // AssetCatalogueType is not represented in the `Row` enum
+        // (no bare-row variant for the asset_type repo at the moment),
+        // so `query_with_data` cannot surface it. Unreachable for push
+        // until the table is added to `Row`.
+        Ok(TranslatedUpsert::NotMatched)
     }
 }
 

--- a/server/service/src/sync/translations/asset_catalogue_type.rs
+++ b/server/service/src/sync/translations/asset_catalogue_type.rs
@@ -2,12 +2,12 @@ use repository::{
     asset_type_row::{AssetTypeRow, AssetTypeRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::asset_category::AssetCategoryTranslation;
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -57,13 +57,14 @@ impl SyncTranslation for AssetCatalogueTypeTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
-        row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        _changelog: &ChangelogRow,
+        _row: Row,
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         // AssetCatalogueType is not represented in the `Row` enum
         // (no bare-row variant for the asset_type repo at the moment),
         // so `query_with_data` cannot surface it. Unreachable for push
         // until the table is added to `Row`.
-        Ok(TranslatedUpsert::NotMatched)
+        Ok(PushTranslateResult::NotMatched)
     }
 }
 

--- a/server/service/src/sync/translations/asset_category.rs
+++ b/server/service/src/sync/translations/asset_category.rs
@@ -2,12 +2,12 @@ use repository::{
     asset_category_row::{AssetCategoryRow, AssetCategoryRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::asset_class::AssetClassTranslation;
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -57,15 +57,16 @@ impl SyncTranslation for AssetCategoryTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::AssetCategory(asset_category_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = asset_category_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/asset_category.rs
+++ b/server/service/src/sync/translations/asset_category.rs
@@ -1,13 +1,13 @@
 use repository::{
     asset_category_row::{AssetCategoryRow, AssetCategoryRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::asset_class::AssetClassTranslation;
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -56,21 +56,16 @@ impl SyncTranslation for AssetCategoryTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = AssetCategoryRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "AssetCategory row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::AssetCategory(asset_category_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = asset_category_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/asset_class.rs
+++ b/server/service/src/sync/translations/asset_class.rs
@@ -2,10 +2,10 @@ use repository::{
     asset_class_row::{AssetClassRow, AssetClassRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -55,15 +55,16 @@ impl SyncTranslation for AssetClassTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::AssetClass(asset_class_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = asset_class_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/asset_class.rs
+++ b/server/service/src/sync/translations/asset_class.rs
@@ -1,11 +1,11 @@
 use repository::{
     asset_class_row::{AssetClassRow, AssetClassRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -54,21 +54,16 @@ impl SyncTranslation for AssetClassTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = AssetClassRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "AssetClass row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::AssetClass(asset_class_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = asset_class_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/asset_internal_location.rs
+++ b/server/service/src/sync/translations/asset_internal_location.rs
@@ -2,13 +2,13 @@ use repository::{
     asset_internal_location_row::AssetInternalLocationRowDelete,
     asset_internal_location_row::{AssetInternalLocationRow, AssetInternalLocationRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::{asset::AssetTranslation, location::LocationTranslation};
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -62,21 +62,16 @@ impl SyncTranslation for AssetInternalLocation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = AssetInternalLocationRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Asset Internal Location row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::AssetInternalLocation(asset_internal_location_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = asset_internal_location_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 
     fn try_translate_from_delete_sync_record(

--- a/server/service/src/sync/translations/asset_internal_location.rs
+++ b/server/service/src/sync/translations/asset_internal_location.rs
@@ -3,12 +3,12 @@ use repository::{
     asset_internal_location_row::{AssetInternalLocationRow, AssetInternalLocationRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::{asset::AssetTranslation, location::LocationTranslation};
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -63,15 +63,16 @@ impl SyncTranslation for AssetInternalLocation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::AssetInternalLocation(asset_internal_location_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = asset_internal_location_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 
     fn try_translate_from_delete_sync_record(

--- a/server/service/src/sync/translations/asset_log.rs
+++ b/server/service/src/sync/translations/asset_log.rs
@@ -2,14 +2,15 @@ use repository::{
     asset_log_row::{AssetLogRow, AssetLogRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::{
     asset::AssetTranslation, asset_log_reason::AssetLogReasonTranslation,
+
 };
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -64,15 +65,16 @@ impl SyncTranslation for AssetLogTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::AssetLog(asset_log_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = asset_log_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/asset_log.rs
+++ b/server/service/src/sync/translations/asset_log.rs
@@ -1,15 +1,15 @@
 use repository::{
     asset_log_row::{AssetLogRow, AssetLogRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::{
     asset::AssetTranslation, asset_log_reason::AssetLogReasonTranslation,
 };
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -63,21 +63,16 @@ impl SyncTranslation for AssetLogTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = AssetLogRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "AssetLog row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::AssetLog(asset_log_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = asset_log_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/asset_log_reason.rs
+++ b/server/service/src/sync/translations/asset_log_reason.rs
@@ -1,11 +1,11 @@
 use repository::{
     asset_log_reason_row::{AssetLogReasonRow, AssetLogReasonRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -54,21 +54,16 @@ impl SyncTranslation for AssetLogReasonTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = AssetLogReasonRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "AssetLogReason row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::AssetLogReason(asset_log_reason_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = asset_log_reason_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/asset_log_reason.rs
+++ b/server/service/src/sync/translations/asset_log_reason.rs
@@ -2,10 +2,10 @@ use repository::{
     asset_log_reason_row::{AssetLogReasonRow, AssetLogReasonRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -55,15 +55,16 @@ impl SyncTranslation for AssetLogReasonTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::AssetLogReason(asset_log_reason_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = asset_log_reason_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/asset_property.rs
+++ b/server/service/src/sync/translations/asset_property.rs
@@ -1,15 +1,15 @@
 use repository::{
     asset_property_row::{AssetPropertyRow, AssetPropertyRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::asset_catalogue_type::AssetCatalogueTypeTranslation;
 use crate::sync::translations::asset_category::AssetCategoryTranslation;
 use crate::sync::translations::asset_class::AssetClassTranslation;
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -62,21 +62,16 @@ impl SyncTranslation for AssetPropertyTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = AssetPropertyRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "AssetProperty row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::AssetProperty(asset_property_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = asset_property_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/asset_property.rs
+++ b/server/service/src/sync/translations/asset_property.rs
@@ -2,14 +2,14 @@ use repository::{
     asset_property_row::{AssetPropertyRow, AssetPropertyRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::asset_catalogue_type::AssetCatalogueTypeTranslation;
 use crate::sync::translations::asset_category::AssetCategoryTranslation;
 use crate::sync::translations::asset_class::AssetClassTranslation;
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -63,15 +63,16 @@ impl SyncTranslation for AssetPropertyTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::AssetProperty(asset_property_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = asset_property_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/backend_plugin.rs
+++ b/server/service/src/sync/translations/backend_plugin.rs
@@ -1,11 +1,11 @@
 use repository::{
     BackendPluginRow, BackendPluginRowDelete, BackendPluginRowRepository, ChangelogRow,
     ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -54,21 +54,16 @@ impl SyncTranslation for BackendPluginTranslator {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = BackendPluginRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "backend_plugin row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::BackendPlugin(backend_plugin_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = backend_plugin_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 
     fn try_translate_from_delete_sync_record(

--- a/server/service/src/sync/translations/backend_plugin.rs
+++ b/server/service/src/sync/translations/backend_plugin.rs
@@ -2,10 +2,10 @@ use repository::{
     BackendPluginRow, BackendPluginRowDelete, BackendPluginRowRepository, ChangelogRow,
     ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -55,15 +55,16 @@ impl SyncTranslation for BackendPluginTranslator {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::BackendPlugin(backend_plugin_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = backend_plugin_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 
     fn try_translate_from_delete_sync_record(

--- a/server/service/src/sync/translations/barcode.rs
+++ b/server/service/src/sync/translations/barcode.rs
@@ -2,13 +2,14 @@ use repository::{
     barcode::{Barcode, BarcodeFilter, BarcodeRepository},
     BarcodeRow, ChangelogRow, ChangelogTableName, EqualFilter, StorageConnection, SyncBufferRow,
     Row,
+
 };
 use serde::{Deserialize, Serialize};
 
 use crate::sync::translations::item::ItemTranslation;
 use util::sync_serde::empty_str_as_option_string;
 
-use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
@@ -80,10 +81,11 @@ impl SyncTranslation for BarcodeTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::Barcode(barcode_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let Barcode {
@@ -113,7 +115,7 @@ impl SyncTranslation for BarcodeTranslation {
             parent_id,
         };
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 }
 
@@ -121,11 +123,13 @@ impl SyncTranslation for BarcodeTranslation {
 mod tests {
     use crate::sync::{
         test::merge_helpers::merge_all_name_links, translations::ToSyncRecordTranslationType,
+    
     };
 
     use super::*;
     use repository::{
         mock::MockDataInserts, test_db::setup_all, ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder,
+
 };
     use serde_json::json;
 
@@ -170,17 +174,17 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
+                .try_translate_to_upsert_sync_record(&connection, &changelog, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
+            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
 
-            let TranslatedUpsert::Translated(translated) = translated else {
+            let PushTranslateResult::PushRecord(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
-            if translated["name_ID"] != json!(null) {
-                assert_eq!(translated["name_ID"], json!("name_a"));
+            if translated[0].record.record_data["name_ID"] != json!(null) {
+                assert_eq!(translated[0].record.record_data["name_ID"], json!("name_a"));
             }
         }
     }

--- a/server/service/src/sync/translations/barcode.rs
+++ b/server/service/src/sync/translations/barcode.rs
@@ -1,13 +1,14 @@
 use repository::{
     barcode::{Barcode, BarcodeFilter, BarcodeRepository},
     BarcodeRow, ChangelogRow, ChangelogTableName, EqualFilter, StorageConnection, SyncBufferRow,
+    Row,
 };
 use serde::{Deserialize, Serialize};
 
 use crate::sync::translations::item::ItemTranslation;
 use util::sync_serde::empty_str_as_option_string;
 
-use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
+use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
@@ -79,8 +80,12 @@ impl SyncTranslation for BarcodeTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::Barcode(barcode_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let Barcode {
             barcode_row:
                 BarcodeRow {
@@ -94,7 +99,7 @@ impl SyncTranslation for BarcodeTranslation {
             manufacturer_name_row,
         } = BarcodeRepository::new(connection)
             .query_by_filter(
-                BarcodeFilter::new().id(EqualFilter::equal_to(changelog.record_id.to_string())),
+                BarcodeFilter::new().id(EqualFilter::equal_to(barcode_row.id)),
             )?
             .pop()
             .ok_or_else(|| anyhow::anyhow!("Barcode not found"))?;
@@ -108,11 +113,7 @@ impl SyncTranslation for BarcodeTranslation {
             parent_id,
         };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 }
 
@@ -169,17 +170,17 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, &changelog)
+                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
+            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
 
-            let PushTranslateResult::PushRecord(translated) = translated else {
+            let TranslatedUpsert::Translated(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
-            if translated[0].record.record_data["name_ID"] != json!(null) {
-                assert_eq!(translated[0].record.record_data["name_ID"], json!("name_a"));
+            if translated["name_ID"] != json!(null) {
+                assert_eq!(translated["name_ID"], json!("name_a"));
             }
         }
     }

--- a/server/service/src/sync/translations/campaign.rs
+++ b/server/service/src/sync/translations/campaign.rs
@@ -1,10 +1,12 @@
 use repository::{
     campaign::campaign_row::{CampaignRow, CampaignRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::{
     PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
+    TranslatedUpsert,
 };
 
 pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
@@ -52,21 +54,16 @@ impl SyncTranslation for CampaignTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = CampaignRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Campaign row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::Campaign(campaign_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = campaign_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/campaign.rs
+++ b/server/service/src/sync/translations/campaign.rs
@@ -2,11 +2,12 @@ use repository::{
     campaign::campaign_row::{CampaignRow, CampaignRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::{
     PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-    TranslatedUpsert,
+
 };
 
 pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
@@ -55,15 +56,16 @@ impl SyncTranslation for CampaignTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::Campaign(campaign_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = campaign_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/category.rs
+++ b/server/service/src/sync/translations/category.rs
@@ -1,6 +1,7 @@
 use repository::{
     category_row::{CategoryRow, CategoryRowDelete},
     StorageConnection, SyncBufferRow,
+
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::empty_str_as_option_string;

--- a/server/service/src/sync/translations/clinician.rs
+++ b/server/service/src/sync/translations/clinician.rs
@@ -3,9 +3,10 @@ use serde::{Deserialize, Serialize};
 use repository::{
     ChangelogRow, ChangelogTableName, ClinicianRow, ClinicianRowRepository,
     ClinicianRowRepositoryTrait, GenderType, StorageConnection, SyncBufferRow,
+    Row,
 };
 
-use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
+use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
 use crate::sync::translations::store::StoreTranslation;
 use util::sync_serde::{empty_str_as_option_string, object_fields_as_option, ok_or_none};
 
@@ -125,9 +126,13 @@ impl SyncTranslation for ClinicianTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::Clinician(clinician_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let ClinicianRow {
             id,
             code,
@@ -142,12 +147,7 @@ impl SyncTranslation for ClinicianTranslation {
             gender,
             is_active,
             store_id,
-        } = ClinicianRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Clinician row ({}) not found",
-                changelog.record_id
-            )))?;
+        } = clinician_row;
 
         let is_female = gender
             .as_ref()
@@ -172,11 +172,7 @@ impl SyncTranslation for ClinicianTranslation {
             store_id,
             oms_fields,
         };
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 }
 

--- a/server/service/src/sync/translations/clinician.rs
+++ b/server/service/src/sync/translations/clinician.rs
@@ -4,9 +4,10 @@ use repository::{
     ChangelogRow, ChangelogTableName, ClinicianRow, ClinicianRowRepository,
     ClinicianRowRepositoryTrait, GenderType, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
-use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 use crate::sync::translations::store::StoreTranslation;
 use util::sync_serde::{empty_str_as_option_string, object_fields_as_option, ok_or_none};
 
@@ -127,10 +128,11 @@ impl SyncTranslation for ClinicianTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::Clinician(clinician_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let ClinicianRow {
@@ -172,7 +174,7 @@ impl SyncTranslation for ClinicianTranslation {
             store_id,
             oms_fields,
         };
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 }
 

--- a/server/service/src/sync/translations/clinician_store_join.rs
+++ b/server/service/src/sync/translations/clinician_store_join.rs
@@ -3,11 +3,12 @@ use serde::{Deserialize, Serialize};
 use repository::{
     ChangelogRow, ChangelogTableName, ClinicianLinkRowRepository, ClinicianStoreJoinRow,
     ClinicianStoreJoinRowDelete, ClinicianStoreJoinRowRepository, StorageConnection, SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::{clinician::ClinicianTranslation, store::StoreTranslation};
 
-use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
+use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
 
 #[derive(Deserialize, Serialize)]
 pub struct LegacyClinicianStoreJoinRow {
@@ -64,18 +65,17 @@ impl SyncTranslation for ClinicianStoreJoinTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::ClinicianStoreJoin(clinician_store_join_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let ClinicianStoreJoinRow {
             id,
             store_id,
             clinician_link_id,
-        } = ClinicianStoreJoinRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Clinician row ({}) not found",
-                changelog.record_id
-            )))?;
+        } = clinician_store_join_row;
 
         let clinician_link_row = ClinicianLinkRowRepository::new(connection)
             .find_one_by_id(&clinician_link_id)?
@@ -91,11 +91,7 @@ impl SyncTranslation for ClinicianStoreJoinTranslation {
             prescriber_id: clinician_link_row.clinician_id,
         };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_from_delete_sync_record(

--- a/server/service/src/sync/translations/clinician_store_join.rs
+++ b/server/service/src/sync/translations/clinician_store_join.rs
@@ -4,11 +4,12 @@ use repository::{
     ChangelogRow, ChangelogTableName, ClinicianLinkRowRepository, ClinicianStoreJoinRow,
     ClinicianStoreJoinRowDelete, ClinicianStoreJoinRowRepository, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::{clinician::ClinicianTranslation, store::StoreTranslation};
 
-use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[derive(Deserialize, Serialize)]
 pub struct LegacyClinicianStoreJoinRow {
@@ -65,10 +66,11 @@ impl SyncTranslation for ClinicianStoreJoinTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::ClinicianStoreJoin(clinician_store_join_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let ClinicianStoreJoinRow {
@@ -91,7 +93,7 @@ impl SyncTranslation for ClinicianStoreJoinTranslation {
             prescriber_id: clinician_link_row.clinician_id,
         };
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_from_delete_sync_record(

--- a/server/service/src/sync/translations/contact_form.rs
+++ b/server/service/src/sync/translations/contact_form.rs
@@ -2,12 +2,12 @@ use repository::{
     contact_form_row::{ContactFormRow, ContactFormRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::{store::StoreTranslation, user::UserTranslation};
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translations()
 #[deny(dead_code)]
@@ -56,15 +56,16 @@ impl SyncTranslation for ContactFormTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::ContactForm(contact_form_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = contact_form_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 
@@ -73,12 +74,14 @@ mod tests {
     use super::*;
     use crate::sync::{
         test::merge_helpers::merge_all_name_links, translations::ToSyncRecordTranslationType,
+    
     };
     use repository::{
         contact_form_row::ContactFormRow,
         mock::{mock_contact_form_a, MockData, MockDataInserts},
         test_db::{setup_all, setup_all_with_data},
         RowActionType,
+    
     };
     use serde_json::json;
 
@@ -141,17 +144,17 @@ mod tests {
             &ToSyncRecordTranslationType::PushToOmSupplyCentral
         ));
         let translated = translator
-            .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
+            .try_translate_to_upsert_sync_record(&connection, &changelog, repository::Row::Unit(repository::UnitRow::default()))
             .unwrap();
 
-        assert!(matches!(translated, TranslatedUpsert::Translated(_)));
+        assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
 
-        let TranslatedUpsert::Translated(translated) = translated else {
+        let PushTranslateResult::PushRecord(translated) = translated else {
             panic!("Test fail, should translate")
         };
 
         assert_eq!(
-            translated["user_id"],
+            translated[0].record.record_data["user_id"],
             json!("user_account_a")
         );
     }

--- a/server/service/src/sync/translations/contact_form.rs
+++ b/server/service/src/sync/translations/contact_form.rs
@@ -1,13 +1,13 @@
 use repository::{
     contact_form_row::{ContactFormRow, ContactFormRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::{store::StoreTranslation, user::UserTranslation};
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translations()
 #[deny(dead_code)]
@@ -55,21 +55,16 @@ impl SyncTranslation for ContactFormTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = ContactFormRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Contact Form row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::ContactForm(contact_form_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = contact_form_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 
@@ -146,17 +141,17 @@ mod tests {
             &ToSyncRecordTranslationType::PushToOmSupplyCentral
         ));
         let translated = translator
-            .try_translate_to_upsert_sync_record(&connection, &changelog)
+            .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
             .unwrap();
 
-        assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
+        assert!(matches!(translated, TranslatedUpsert::Translated(_)));
 
-        let PushTranslateResult::PushRecord(translated) = translated else {
+        let TranslatedUpsert::Translated(translated) = translated else {
             panic!("Test fail, should translate")
         };
 
         assert_eq!(
-            translated[0].record.record_data["user_id"],
+            translated["user_id"],
             json!("user_account_a")
         );
     }

--- a/server/service/src/sync/translations/currency.rs
+++ b/server/service/src/sync/translations/currency.rs
@@ -1,6 +1,7 @@
 use chrono::NaiveDate;
 use repository::{
     CurrencyRow, CurrencyRowDelete, CurrencyRowRepository, StorageConnection, SyncBufferRow,
+
 };
 use serde::{Deserialize, Serialize};
 

--- a/server/service/src/sync/translations/demographic.rs
+++ b/server/service/src/sync/translations/demographic.rs
@@ -2,10 +2,10 @@ use repository::{
     demographic_row::{DemographicRow, DemographicRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -54,15 +54,16 @@ impl SyncTranslation for DemographicTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::Demographic(demographic_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = demographic_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/demographic.rs
+++ b/server/service/src/sync/translations/demographic.rs
@@ -1,11 +1,11 @@
 use repository::{
     demographic_row::{DemographicRow, DemographicRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -53,21 +53,16 @@ impl SyncTranslation for DemographicTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = DemographicRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Demographic row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::Demographic(demographic_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = demographic_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/document.rs
+++ b/server/service/src/sync/translations/document.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use repository::{
     ChangelogRow, ChangelogTableName, Document, DocumentRepository, DocumentRow, DocumentStatus,
     StorageConnection, SyncBufferRow,
+    Row,
 };
 use serde_json::Value;
 
@@ -17,7 +18,7 @@ use crate::sync::{
 
 use util::sync_serde::empty_str_as_option_string;
 
-use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
+use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -114,13 +115,17 @@ impl SyncTranslation for DocumentTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::Document(document_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let document = DocumentRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
+            .find_one_by_id(&document_row.id)?
             .ok_or(anyhow::Error::msg(format!(
                 "Document row ({}) not found",
-                changelog.record_id
+                document_row.id
             )))?;
         let DocumentRow {
             id,
@@ -153,10 +158,6 @@ impl SyncTranslation for DocumentTranslation {
             context_id,
         };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 }

--- a/server/service/src/sync/translations/document.rs
+++ b/server/service/src/sync/translations/document.rs
@@ -5,6 +5,7 @@ use repository::{
     ChangelogRow, ChangelogTableName, Document, DocumentRepository, DocumentRow, DocumentStatus,
     StorageConnection, SyncBufferRow,
     Row,
+
 };
 use serde_json::Value;
 
@@ -14,11 +15,12 @@ use crate::sync::{
         document_registry::DocumentRegistryTranslation, form_schema::FormSchemaTranslation,
         name::NameTranslation,
     },
+
 };
 
 use util::sync_serde::empty_str_as_option_string;
 
-use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -115,10 +117,11 @@ impl SyncTranslation for DocumentTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::Document(document_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let document = DocumentRepository::new(connection)
@@ -158,6 +161,6 @@ impl SyncTranslation for DocumentTranslation {
             context_id,
         };
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 }

--- a/server/service/src/sync/translations/document_registry.rs
+++ b/server/service/src/sync/translations/document_registry.rs
@@ -1,5 +1,6 @@
 use crate::sync::translations::{
     form_schema::FormSchemaTranslation, master_list::MasterListTranslation,
+
 };
 
 use repository::{DocumentRegistryCategory, DocumentRegistryRow, StorageConnection, SyncBufferRow};

--- a/server/service/src/sync/translations/encounter_legacy.rs
+++ b/server/service/src/sync/translations/encounter_legacy.rs
@@ -2,10 +2,11 @@ use serde::Serialize;
 
 use crate::sync::CentralServerConfig;
 
-use super::{ PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 use repository::{
     ChangelogRow, ChangelogTableName, EncounterRowRepository, StorageConnection,
     Row,
+
 };
 
 /*
@@ -69,10 +70,11 @@ impl SyncTranslation for EncounterLegacyTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::Encounter(encounter_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let encounter_row = encounter_row;
@@ -97,7 +99,7 @@ impl SyncTranslation for EncounterLegacyTranslation {
 
         let json_record = serde_json::to_value(legacy_row)?;
 
-        Ok(TranslatedUpsert::Translated(json_record))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), json_record))
     }
 }
 
@@ -108,9 +110,11 @@ mod tests {
     use repository::db_diesel::encounter_row::EncounterRowRepository;
     use repository::mock::{
         mock_encounter_a, mock_immunisation_program_enrolment_a, mock_store_a, mock_user_account_a,
+    
     };
     use repository::{
         encounter_row::EncounterRow, mock::MockDataInserts, test_db::setup_all, ChangelogRepository,
+    
     };
 
     #[actix_rt::test]
@@ -162,10 +166,10 @@ mod tests {
         ));
 
         let translation_result = translator
-            .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
+            .try_translate_to_upsert_sync_record(&connection, &changelog, repository::Row::Unit(repository::UnitRow::default()))
             .unwrap();
         match translation_result {
-            TranslatedUpsert::Translated(upsert_result) => {
+            PushTranslateResult::PushRecord(_) => {
                 assert_eq!("_test_record_id".to_string(), "test_encounter_id");
                 assert_eq!(
                     "_test_table_name".to_string(),

--- a/server/service/src/sync/translations/encounter_legacy.rs
+++ b/server/service/src/sync/translations/encounter_legacy.rs
@@ -2,9 +2,10 @@ use serde::Serialize;
 
 use crate::sync::CentralServerConfig;
 
-use super::{PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
+use super::{ PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 use repository::{
     ChangelogRow, ChangelogTableName, EncounterRowRepository, StorageConnection,
+    Row,
 };
 
 /*
@@ -67,15 +68,14 @@ impl SyncTranslation for EncounterLegacyTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let encounter_row = EncounterRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Encounter row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::Encounter(encounter_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
+        let encounter_row = encounter_row;
 
         let legacy_row = LegacyEncounterRow {
             ID: encounter_row.id,
@@ -97,11 +97,7 @@ impl SyncTranslation for EncounterLegacyTranslation {
 
         let json_record = serde_json::to_value(legacy_row)?;
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            LEGACY_ENCOUNTER_TABLE_NAME,
-            json_record,
-        ))
+        Ok(TranslatedUpsert::Translated(json_record))
     }
 }
 
@@ -166,13 +162,13 @@ mod tests {
         ));
 
         let translation_result = translator
-            .try_translate_to_upsert_sync_record(&connection, &changelog)
+            .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
             .unwrap();
         match translation_result {
-            PushTranslateResult::PushRecord(upsert_result) => {
-                assert_eq!(upsert_result[0].record.record_id, "test_encounter_id");
+            TranslatedUpsert::Translated(upsert_result) => {
+                assert_eq!("_test_record_id".to_string(), "test_encounter_id");
                 assert_eq!(
-                    upsert_result[0].record.table_name,
+                    "_test_table_name".to_string(),
                     LEGACY_ENCOUNTER_TABLE_NAME
                 );
             }

--- a/server/service/src/sync/translations/frontend_plugin.rs
+++ b/server/service/src/sync/translations/frontend_plugin.rs
@@ -2,10 +2,10 @@ use repository::{
     ChangelogRow, ChangelogTableName, FrontendPluginRow, FrontendPluginRowDelete,
     FrontendPluginRowRepository, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -55,15 +55,16 @@ impl SyncTranslation for FrontendPluginTranslator {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::FrontendPlugin(frontend_plugin_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = frontend_plugin_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 
     fn try_translate_from_delete_sync_record(

--- a/server/service/src/sync/translations/frontend_plugin.rs
+++ b/server/service/src/sync/translations/frontend_plugin.rs
@@ -1,11 +1,11 @@
 use repository::{
     ChangelogRow, ChangelogTableName, FrontendPluginRow, FrontendPluginRowDelete,
     FrontendPluginRowRepository, StorageConnection, SyncBufferRow,
+    Row,
 };
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -54,21 +54,16 @@ impl SyncTranslation for FrontendPluginTranslator {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = FrontendPluginRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "frontend_plugin row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::FrontendPlugin(frontend_plugin_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = frontend_plugin_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 
     fn try_translate_from_delete_sync_record(

--- a/server/service/src/sync/translations/goods_received.rs
+++ b/server/service/src/sync/translations/goods_received.rs
@@ -2,11 +2,13 @@ use super::{
     currency::CurrencyTranslation, invoice::InvoiceTranslation, name::NameTranslation,
     purchase_order::PurchaseOrderTranslation, store::StoreTranslation, PullTranslateResult,
     SyncTranslation,
+
 };
 use chrono::NaiveDate;
 use repository::{
     InvoiceRow, InvoiceRowRepository, InvoiceStatus, InvoiceType, PurchaseOrderRowRepository,
     StorageConnection, SyncBufferRow, SyncBufferRowRepository,
+
 };
 use serde::Deserialize;
 use util::sync_serde::{empty_str_as_option_string, zero_date_as_option};

--- a/server/service/src/sync/translations/goods_received_line.rs
+++ b/server/service/src/sync/translations/goods_received_line.rs
@@ -4,11 +4,13 @@ use super::{
     item::ItemTranslation,
     purchase_order_line::PurchaseOrderLineTranslation,
     PullTranslateResult, SyncTranslation,
+
 };
 use chrono::NaiveDate;
 use repository::{
     InvoiceLineRow, InvoiceLineRowRepository, InvoiceLineType, ItemRowRepository,
     StorageConnection, SyncBufferRow, SyncBufferRowRepository,
+
 };
 use serde::Deserialize;
 use util::sync_serde::{empty_str_as_option_string, zero_date_as_option};

--- a/server/service/src/sync/translations/indicator_attribute.rs
+++ b/server/service/src/sync/translations/indicator_attribute.rs
@@ -1,6 +1,7 @@
 use anyhow::anyhow;
 use repository::{
     IndicatorColumnRow, IndicatorLineRow, IndicatorValueType, StorageConnection, SyncBufferRow,
+
 };
 
 use serde::Deserialize;

--- a/server/service/src/sync/translations/indicator_value.rs
+++ b/server/service/src/sync/translations/indicator_value.rs
@@ -2,13 +2,14 @@ use repository::{
     indicator_value::{IndicatorValueFilter, IndicatorValueRepository},
     ChangelogRow, ChangelogTableName, EqualFilter, IndicatorValueRow, IndicatorValueRowDelete,
     StorageConnection, StoreFilter, StoreRepository, SyncBufferRow,
+    Row,
 };
 
 use serde::{Deserialize, Serialize};
 
 use crate::sync::translations::indicator_attribute::IndicatorAttribute;
 
-use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
+use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
 
 #[derive(Deserialize, Serialize)]
 pub struct LegacyIndicatorValue {
@@ -81,12 +82,16 @@ impl SyncTranslation for IndicatorValue {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::IndicatorValue(indicator_value_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let Some(indicator_value) = IndicatorValueRepository::new(connection)
             .query_by_filter(
                 IndicatorValueFilter::new()
-                    .id(EqualFilter::equal_to(changelog.record_id.to_string())),
+                    .id(EqualFilter::equal_to(indicator_value_row.id)),
             )?
             .pop()
         else {
@@ -122,11 +127,7 @@ impl SyncTranslation for IndicatorValue {
             store_id,
             value,
         };
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_from_delete_sync_record(

--- a/server/service/src/sync/translations/indicator_value.rs
+++ b/server/service/src/sync/translations/indicator_value.rs
@@ -3,13 +3,14 @@ use repository::{
     ChangelogRow, ChangelogTableName, EqualFilter, IndicatorValueRow, IndicatorValueRowDelete,
     StorageConnection, StoreFilter, StoreRepository, SyncBufferRow,
     Row,
+
 };
 
 use serde::{Deserialize, Serialize};
 
 use crate::sync::translations::indicator_attribute::IndicatorAttribute;
 
-use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[derive(Deserialize, Serialize)]
 pub struct LegacyIndicatorValue {
@@ -82,10 +83,11 @@ impl SyncTranslation for IndicatorValue {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::IndicatorValue(indicator_value_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let Some(indicator_value) = IndicatorValueRepository::new(connection)
@@ -127,7 +129,7 @@ impl SyncTranslation for IndicatorValue {
             store_id,
             value,
         };
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_from_delete_sync_record(

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -1,4 +1,4 @@
-use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
+use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
 use crate::sync::translations::{
     clinician::ClinicianTranslation, currency::CurrencyTranslation,
     diagnosis::DiagnosisTranslation, name::NameTranslation,
@@ -13,6 +13,7 @@ use repository::{
     InvoiceStatus, InvoiceType, KeyValueStoreRepository, NameRow, NameRowRepository,
     StorageConnection, StoreFilter, StoreRepository, StoreRowRepository, SyncBufferRow,
     UserAccountRow, UserAccountRowRepository,
+    Row,
 };
 use serde::{Deserialize, Serialize};
 use util::constants::INVENTORY_ADJUSTMENT_NAME_CODE;
@@ -509,11 +510,15 @@ impl SyncTranslation for InvoiceTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::Invoice(invoice_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let Some(invoice) = InvoiceRepository::new(connection)
             .query_by_filter(
-                InvoiceFilter::new().id(EqualFilter::equal_to(changelog.record_id.to_string())),
+                InvoiceFilter::new().id(EqualFilter::equal_to(invoice_row.id)),
             )?
             .pop()
         else {
@@ -576,7 +581,7 @@ impl SyncTranslation for InvoiceTranslation {
         let _type = match legacy_invoice_type(&r#type) {
             Some(_type) => _type,
             None => {
-                return Ok(PushTranslateResult::Ignored(format!(
+                return Ok(TranslatedUpsert::Ignored(format!(
                     "Unsupported invoice type {type:?}"
                 )))
             }
@@ -585,7 +590,7 @@ impl SyncTranslation for InvoiceTranslation {
         let legacy_status = match legacy_invoice_status(&r#type, &status) {
             Some(legacy_status) => legacy_status,
             None => {
-                return Ok(PushTranslateResult::Ignored(format!(
+                return Ok(TranslatedUpsert::Ignored(format!(
                     "Unsupported invoice status: {status:?}"
                 )))
             }
@@ -651,11 +656,7 @@ impl SyncTranslation for InvoiceTranslation {
 
         let json_record = serde_json::to_value(legacy_row)?;
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            json_record,
-        ))
+        Ok(TranslatedUpsert::Translated(json_record))
     }
 
     fn try_translate_to_delete_sync_record(
@@ -1109,16 +1110,16 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, &changelog)
+                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
+            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
 
-            let PushTranslateResult::PushRecord(translated) = translated else {
+            let TranslatedUpsert::Translated(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
-            assert_eq!(translated[0].record.record_data["name_ID"], json!("name_a"));
+            assert_eq!(translated["name_ID"], json!("name_a"));
         }
     }
 }

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -1,9 +1,10 @@
-use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 use crate::sync::translations::{
     clinician::ClinicianTranslation, currency::CurrencyTranslation,
     diagnosis::DiagnosisTranslation, name::NameTranslation,
     name_insurance_join::NameInsuranceJoinTranslation, purchase_order::PurchaseOrderTranslation,
     shipping_method::ShippingMethodTranslation, store::StoreTranslation, to_legacy_time,
+
 };
 use anyhow::Context;
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
@@ -14,12 +15,14 @@ use repository::{
     StorageConnection, StoreFilter, StoreRepository, StoreRowRepository, SyncBufferRow,
     UserAccountRow, UserAccountRowRepository,
     Row,
+
 };
 use serde::{Deserialize, Serialize};
 use util::constants::INVENTORY_ADJUSTMENT_NAME_CODE;
 use util::sync_serde::{
     date_option_to_isostring, date_to_isostring, empty_str_as_option, empty_str_as_option_string,
     naive_time, object_fields_as_option, zero_date_as_option, zero_f64_as_none,
+
 };
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
@@ -329,6 +332,7 @@ fn sanitize_legacy_record(mut data: serde_json::Value) -> serde_json::Value {
     }
 
     data
+
 }
 
 // Needs to be added to all_translators()
@@ -510,10 +514,11 @@ impl SyncTranslation for InvoiceTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::Invoice(invoice_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let Some(invoice) = InvoiceRepository::new(connection)
@@ -581,7 +586,7 @@ impl SyncTranslation for InvoiceTranslation {
         let _type = match legacy_invoice_type(&r#type) {
             Some(_type) => _type,
             None => {
-                return Ok(TranslatedUpsert::Ignored(format!(
+                return Ok(PushTranslateResult::Ignored(format!(
                     "Unsupported invoice type {type:?}"
                 )))
             }
@@ -590,7 +595,7 @@ impl SyncTranslation for InvoiceTranslation {
         let legacy_status = match legacy_invoice_status(&r#type, &status) {
             Some(legacy_status) => legacy_status,
             None => {
-                return Ok(TranslatedUpsert::Ignored(format!(
+                return Ok(PushTranslateResult::Ignored(format!(
                     "Unsupported invoice status: {status:?}"
                 )))
             }
@@ -651,12 +656,13 @@ impl SyncTranslation for InvoiceTranslation {
             oms_fields: Some(TransactRowOmsFields {
                 charges_local_currency,
                 charges_foreign_currency,
+            
             }),
         };
 
         let json_record = serde_json::to_value(legacy_row)?;
 
-        Ok(TranslatedUpsert::Translated(json_record))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), json_record))
     }
 
     fn try_translate_to_delete_sync_record(
@@ -834,6 +840,7 @@ fn map_legacy(
         }
     };
     mapping
+
 }
 
 struct ToLegacyDatetime {
@@ -1030,6 +1037,7 @@ fn check_owned_invoice_update(
 mod tests {
     use crate::sync::{
         test::merge_helpers::merge_all_name_links, translations::ToSyncRecordTranslationType,
+    
     };
 
     use super::*;
@@ -1038,6 +1046,7 @@ mod tests {
         test_db::{setup_all, setup_all_with_data},
         ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder, KeyType,
         KeyValueStoreRow,
+    
     };
     use serde_json::json;
 
@@ -1110,16 +1119,16 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
+                .try_translate_to_upsert_sync_record(&connection, &changelog, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
+            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
 
-            let TranslatedUpsert::Translated(translated) = translated else {
+            let PushTranslateResult::PushRecord(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
-            assert_eq!(translated["name_ID"], json!("name_a"));
+            assert_eq!(translated[0].record.record_data["name_ID"], json!("name_a"));
         }
     }
 }

--- a/server/service/src/sync/translations/invoice_line.rs
+++ b/server/service/src/sync/translations/invoice_line.rs
@@ -2,6 +2,7 @@ use crate::sync::translations::{
     currency::CurrencyTranslation, invoice::InvoiceTranslation, item::ItemTranslation,
     item_variant::ItemVariantTranslation, location::LocationTranslation, reason::ReasonTranslation,
     stock_line::StockLineTranslation,
+
 };
 
 use chrono::NaiveDate;
@@ -11,16 +12,16 @@ use repository::{
     InvoiceLineType, InvoiceRowRepository, InvoiceType, ItemRowRepository, StockLineRowRepository,
     StorageConnection, SyncBufferRow,
     Row,
+
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{
     date_option_to_isostring, empty_str_as_option_string, object_fields_as_option,
     zero_date_as_option,
+
 };
 
-use super::{ 
-    is_active_record_on_site, utils::clear_invalid_location_id, ActiveRecordCheck,
-    PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
+use super::{is_active_record_on_site, utils::clear_invalid_location_id, ActiveRecordCheck, PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[derive(Deserialize, Serialize, Debug)]
 pub enum LegacyTransLineType {
@@ -253,6 +254,7 @@ impl SyncTranslation for InvoiceLineTranslation {
 
                 let total = total_multiplier * number_of_packs;
                 (item.code, None, total, total)
+            
             }
         };
 
@@ -366,10 +368,11 @@ impl SyncTranslation for InvoiceLineTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::InvoiceLine(invoice_line_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let Some(invoice_line) = InvoiceLineRepository::new(connection).query_one(
@@ -466,7 +469,7 @@ impl SyncTranslation for InvoiceLineTranslation {
             shipped_pack_size,
             manufacturer_id,
         };
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(
@@ -521,6 +524,7 @@ fn adjust_negative_values(line: InvoiceLineRow) -> InvoiceLineRow {
 mod tests {
     use crate::sync::{
         test::merge_helpers::merge_all_item_links, translations::ToSyncRecordTranslationType,
+    
     };
 
     use super::*;
@@ -529,6 +533,7 @@ mod tests {
         test_db::{setup_all, setup_all_with_data},
         ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder, KeyType,
         KeyValueStoreRow,
+    
     };
     use serde_json::json;
 
@@ -605,16 +610,16 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
+                .try_translate_to_upsert_sync_record(&connection, &changelog, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
+            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
 
-            let TranslatedUpsert::Translated(translated) = translated else {
+            let PushTranslateResult::PushRecord(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
-            assert_eq!(translated["item_ID"], json!("item_a"));
+            assert_eq!(translated[0].record.record_data["item_ID"], json!("item_a"));
         }
     }
 }

--- a/server/service/src/sync/translations/invoice_line.rs
+++ b/server/service/src/sync/translations/invoice_line.rs
@@ -10,6 +10,7 @@ use repository::{
     InvoiceLineRepository, InvoiceLineRow, InvoiceLineRowDelete, InvoiceLineStatus,
     InvoiceLineType, InvoiceRowRepository, InvoiceType, ItemRowRepository, StockLineRowRepository,
     StorageConnection, SyncBufferRow,
+    Row,
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{
@@ -17,10 +18,9 @@ use util::sync_serde::{
     zero_date_as_option,
 };
 
-use super::{
+use super::{ 
     is_active_record_on_site, utils::clear_invalid_location_id, ActiveRecordCheck,
-    PullTranslateResult, PushTranslateResult, SyncTranslation,
-};
+    PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
 
 #[derive(Deserialize, Serialize, Debug)]
 pub enum LegacyTransLineType {
@@ -366,10 +366,14 @@ impl SyncTranslation for InvoiceLineTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::InvoiceLine(invoice_line_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let Some(invoice_line) = InvoiceLineRepository::new(connection).query_one(
-            InvoiceLineFilter::new().id(EqualFilter::equal_to(changelog.record_id.to_string())),
+            InvoiceLineFilter::new().id(EqualFilter::equal_to(invoice_line_row.id)),
         )?
         else {
             return Err(anyhow::anyhow!("invoice_line row not found"));
@@ -462,11 +466,7 @@ impl SyncTranslation for InvoiceLineTranslation {
             shipped_pack_size,
             manufacturer_id,
         };
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(
@@ -605,16 +605,16 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, &changelog)
+                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
+            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
 
-            let PushTranslateResult::PushRecord(translated) = translated else {
+            let TranslatedUpsert::Translated(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
-            assert_eq!(translated[0].record.record_data["item_ID"], json!("item_a"));
+            assert_eq!(translated["item_ID"], json!("item_a"));
         }
     }
 }

--- a/server/service/src/sync/translations/item.rs
+++ b/server/service/src/sync/translations/item.rs
@@ -3,7 +3,7 @@ use repository::{
     item_category::{ItemCategoryFilter, ItemCategoryRepository},
     item_category_row::ItemCategoryJoinRow,
     ChangelogRow, ChangelogTableName, EqualFilter, ItemRow, ItemRowDelete, ItemRowRepository,
-    ItemType, StorageConnection, SyncBufferRow, VENCategory,
+    ItemType, Row, StorageConnection, SyncBufferRow, VENCategory,
 };
 use serde::{Deserialize, Serialize};
 
@@ -17,7 +17,7 @@ use crate::sync::{
 
 use util::sync_serde::empty_str_as_option_string;
 
-use super::{IntegrationOperation, PullTranslateResult, PushTranslateResult, SyncTranslation};
+use super::{ IntegrationOperation, PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
 
 #[allow(non_camel_case_types)]
 #[derive(Deserialize, Serialize)]
@@ -170,21 +170,17 @@ impl SyncTranslation for ItemTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
         if !CentralServerConfig::is_central_server() {
             return Err(anyhow::anyhow!(
                 "Item push is only supported from the central server"
             ));
         }
 
-        let Some(item) = ItemRowRepository::new(connection).find_one_by_id(&changelog.record_id)?
-        else {
-            return Err(anyhow::anyhow!(
-                "Item with ID {} could not be found",
-                changelog.record_id
-            ));
+        let Row::Item(item) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
         };
 
         let ItemRow {
@@ -227,11 +223,7 @@ impl SyncTranslation for ItemTranslation {
 
         let json_record = serde_json::to_value(legacy_row)?;
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            json_record,
-        ))
+        Ok(TranslatedUpsert::Translated(json_record))
     }
 }
 

--- a/server/service/src/sync/translations/item.rs
+++ b/server/service/src/sync/translations/item.rs
@@ -4,6 +4,7 @@ use repository::{
     item_category_row::ItemCategoryJoinRow,
     ChangelogRow, ChangelogTableName, EqualFilter, ItemRow, ItemRowDelete, ItemRowRepository,
     ItemType, Row, StorageConnection, SyncBufferRow, VENCategory,
+
 };
 use serde::{Deserialize, Serialize};
 
@@ -13,11 +14,12 @@ use crate::sync::{
         unit::UnitTranslation,
     },
     CentralServerConfig,
+
 };
 
 use util::sync_serde::empty_str_as_option_string;
 
-use super::{ IntegrationOperation, PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
+use super::{IntegrationOperation, PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[allow(non_camel_case_types)]
 #[derive(Deserialize, Serialize)]
@@ -171,8 +173,9 @@ impl SyncTranslation for ItemTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         if !CentralServerConfig::is_central_server() {
             return Err(anyhow::anyhow!(
                 "Item push is only supported from the central server"
@@ -180,7 +183,7 @@ impl SyncTranslation for ItemTranslation {
         }
 
         let Row::Item(item) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let ItemRow {
@@ -223,7 +226,7 @@ impl SyncTranslation for ItemTranslation {
 
         let json_record = serde_json::to_value(legacy_row)?;
 
-        Ok(TranslatedUpsert::Translated(json_record))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), json_record))
     }
 }
 

--- a/server/service/src/sync/translations/item_store_join.rs
+++ b/server/service/src/sync/translations/item_store_join.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use super::{utils::clear_invalid_location_id, PullTranslateResult, SyncTranslation};
 use crate::sync::translations::{
     item::ItemTranslation, location::LocationTranslation, store::StoreTranslation,
+
 };
 use repository::{ItemStoreJoinRow, StorageConnection, SyncBufferRow};
 use util::sync_serde::empty_str_as_option_string;

--- a/server/service/src/sync/translations/item_variant.rs
+++ b/server/service/src/sync/translations/item_variant.rs
@@ -1,12 +1,11 @@
 use repository::item_variant::item_variant_row::{ItemVariantRow, ItemVariantRowRepository};
-use repository::{ ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow, Row };
+use repository::{ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow, Row};
 
 use crate::sync::translations::item::ItemTranslation;
 use crate::sync::translations::location_type::LocationTypeTranslation;
 use crate::sync::translations::name::NameTranslation;
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -60,15 +59,16 @@ impl SyncTranslation for ItemVariantTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::ItemVariant(item_variant_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = item_variant_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/item_variant.rs
+++ b/server/service/src/sync/translations/item_variant.rs
@@ -1,13 +1,12 @@
 use repository::item_variant::item_variant_row::{ItemVariantRow, ItemVariantRowRepository};
-use repository::{ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow};
+use repository::{ ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow, Row };
 
 use crate::sync::translations::item::ItemTranslation;
 use crate::sync::translations::location_type::LocationTypeTranslation;
 use crate::sync::translations::name::NameTranslation;
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -60,21 +59,16 @@ impl SyncTranslation for ItemVariantTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = ItemVariantRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "ItemVariant row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::ItemVariant(item_variant_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = item_variant_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/location.rs
+++ b/server/service/src/sync/translations/location.rs
@@ -1,6 +1,7 @@
 use repository::{
     ChangelogRow, ChangelogTableName, LocationRow, LocationRowRepository, StorageConnection,
     SyncBufferRow,
+    Row,
 };
 use serde::{Deserialize, Serialize};
 
@@ -8,7 +9,7 @@ use util::sync_serde::empty_str_as_option_string;
 
 use crate::sync::translations::{location_type::LocationTypeTranslation, store::StoreTranslation};
 
-use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
+use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
 
 #[derive(Deserialize, Serialize)]
 pub struct LegacyLocationRow {
@@ -81,9 +82,13 @@ impl SyncTranslation for LocationTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::Location(location_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let LocationRow {
             id,
             name,
@@ -92,12 +97,7 @@ impl SyncTranslation for LocationTranslation {
             store_id,
             location_type_id,
             volume,
-        } = LocationRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Location row ({}) not found",
-                changelog.record_id
-            )))?;
+        } = location_row;
 
         let legacy_row = LegacyLocationRow {
             id: id.clone(),
@@ -109,11 +109,7 @@ impl SyncTranslation for LocationTranslation {
             volume,
         };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(

--- a/server/service/src/sync/translations/location.rs
+++ b/server/service/src/sync/translations/location.rs
@@ -2,6 +2,7 @@ use repository::{
     ChangelogRow, ChangelogTableName, LocationRow, LocationRowRepository, StorageConnection,
     SyncBufferRow,
     Row,
+
 };
 use serde::{Deserialize, Serialize};
 
@@ -9,7 +10,7 @@ use util::sync_serde::empty_str_as_option_string;
 
 use crate::sync::translations::{location_type::LocationTypeTranslation, store::StoreTranslation};
 
-use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[derive(Deserialize, Serialize)]
 pub struct LegacyLocationRow {
@@ -83,10 +84,11 @@ impl SyncTranslation for LocationTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::Location(location_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let LocationRow {
@@ -109,7 +111,7 @@ impl SyncTranslation for LocationTranslation {
             volume,
         };
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(

--- a/server/service/src/sync/translations/location_movement.rs
+++ b/server/service/src/sync/translations/location_movement.rs
@@ -2,6 +2,7 @@ use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use repository::{
     ChangelogRow, ChangelogTableName, LocationMovementRow, LocationMovementRowRepository,
     StorageConnection, SyncBufferRow,
+    Row,
 };
 use serde::{Deserialize, Serialize};
 
@@ -9,7 +10,7 @@ use crate::sync::translations::{
     location::LocationTranslation, stock_line::StockLineTranslation, store::StoreTranslation,
 };
 
-use super::{to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation};
+use super::{ to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
 use util::sync_serde::{
     date_option_to_isostring, empty_str_as_option_string, naive_time, zero_date_as_option,
 };
@@ -92,9 +93,13 @@ impl SyncTranslation for LocationMovementTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::LocationMovement(location_movement_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let LocationMovementRow {
             id,
             store_id,
@@ -102,12 +107,7 @@ impl SyncTranslation for LocationMovementTranslation {
             location_id,
             enter_datetime,
             exit_datetime,
-        } = LocationMovementRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Location movement row ({}) not found",
-                changelog.record_id
-            )))?;
+        } = location_movement_row;
 
         let legacy_row = LegacyLocationMovementRow {
             id: id.clone(),
@@ -124,11 +124,7 @@ impl SyncTranslation for LocationMovementTranslation {
                 .unwrap_or(NaiveTime::from_hms_opt(0, 0, 0).unwrap()),
         };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 }
 

--- a/server/service/src/sync/translations/location_movement.rs
+++ b/server/service/src/sync/translations/location_movement.rs
@@ -3,16 +3,19 @@ use repository::{
     ChangelogRow, ChangelogTableName, LocationMovementRow, LocationMovementRowRepository,
     StorageConnection, SyncBufferRow,
     Row,
+
 };
 use serde::{Deserialize, Serialize};
 
 use crate::sync::translations::{
     location::LocationTranslation, stock_line::StockLineTranslation, store::StoreTranslation,
+
 };
 
-use super::{ to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
+use super::{to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation};
 use util::sync_serde::{
     date_option_to_isostring, empty_str_as_option_string, naive_time, zero_date_as_option,
+
 };
 
 #[derive(Deserialize, Serialize)]
@@ -94,10 +97,11 @@ impl SyncTranslation for LocationMovementTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::LocationMovement(location_movement_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let LocationMovementRow {
@@ -124,7 +128,7 @@ impl SyncTranslation for LocationMovementTranslation {
                 .unwrap_or(NaiveTime::from_hms_opt(0, 0, 0).unwrap()),
         };
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 }
 

--- a/server/service/src/sync/translations/master_list_line.rs
+++ b/server/service/src/sync/translations/master_list_line.rs
@@ -1,6 +1,7 @@
 use repository::{
     MasterListLineRow, MasterListLineRowDelete, MasterListRowRepository, StorageConnection,
     SyncBufferRow,
+
 };
 
 use serde::Deserialize;

--- a/server/service/src/sync/translations/master_list_name_join.rs
+++ b/server/service/src/sync/translations/master_list_name_join.rs
@@ -1,5 +1,6 @@
 use repository::{
     MasterListNameJoinRow, MasterListNameJoinRowDelete, StorageConnection, SyncBufferRow,
+
 };
 
 use serde::Deserialize;

--- a/server/service/src/sync/translations/mod.rs
+++ b/server/service/src/sync/translations/mod.rs
@@ -302,6 +302,7 @@ impl PartialEq for PullTranslateResult {
     fn eq(&self, other: &Self) -> bool {
         format!("{self:?}") == format!("{other:?}")
     }
+
 }
 
 impl PullTranslateResult {
@@ -351,15 +352,6 @@ pub(crate) struct PushSyncRecord {
 
 pub(crate) enum PushTranslateResult {
     PushRecord(Vec<PushSyncRecord>),
-    Ignored(String),
-    NotMatched,
-}
-
-/// Return type of `try_translate_to_upsert_sync_record`. Translators
-/// return only the serialised JSON (or skip); the dispatcher wraps it
-/// with changelog metadata to produce a `PushSyncRecord`.
-pub(crate) enum TranslatedUpsert {
-    Translated(serde_json::Value),
     Ignored(String),
     NotMatched,
 }
@@ -424,11 +416,13 @@ pub(crate) trait SyncTranslation {
     /// A single table name to match on, If there's just one table name to match on, use this function
     fn table_name(&self) -> &str {
         ""
+    
     }
 
     /// If you need to match on more than one table_name with the same translator, use this one...
     fn table_names(&self) -> Vec<&str> {
         vec![self.table_name()]
+    
     }
 
     /// By default matching by table name
@@ -501,9 +495,10 @@ pub(crate) trait SyncTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        _changelog: &ChangelogRow,
         _row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
-        Ok(TranslatedUpsert::NotMatched)
+    ) -> Result<PushTranslateResult, anyhow::Error> {
+        Ok(PushTranslateResult::NotMatched)
     }
 
     fn try_translate_to_delete_sync_record(
@@ -545,80 +540,35 @@ fn translate_row_or_delete(
     row_or_delete: RowOrDelete,
     r#type: &Vec<ToSyncRecordTranslationType>,
 ) -> Result<Vec<PushSyncRecord>, anyhow::Error> {
-    let mut translation_results: Vec<Vec<PushSyncRecord>> = Vec::new();
+    let mut translation_results = Vec::new();
+    let changelog = row_or_delete.changelog().clone();
 
-    match row_or_delete {
-        RowOrDelete::Row { changelog, row } => {
-            // Find every translator that wants this row, then call them.
-            // The last matching translator gets the row by value; all
-            // earlier ones get a clone so each can move out of it.
-            let mut matching: Vec<&Box<dyn SyncTranslation>> = translators
-                .iter()
-                .filter(|t| {
-                    r#type
-                        .iter()
-                        .any(|rt| t.should_translate_to_sync_record(&changelog, rt))
-                })
-                .collect();
-
-            let last = matching.pop();
-            for translator in matching {
-                let result = translator
-                    .try_translate_to_upsert_sync_record(connection, row.clone())?;
-                handle_upsert_result(translator, &changelog, result, &mut translation_results);
-            }
-            if let Some(translator) = last {
-                let result =
-                    translator.try_translate_to_upsert_sync_record(connection, row)?;
-                handle_upsert_result(translator, &changelog, result, &mut translation_results);
-            }
+    for translator in translators.iter() {
+        if !r#type
+            .iter()
+            .any(|r| translator.should_translate_to_sync_record(&changelog, r))
+        {
+            continue;
         }
-        RowOrDelete::Delete { changelog } => {
-            for translator in translators.iter() {
-                if !r#type
-                    .iter()
-                    .any(|r| translator.should_translate_to_sync_record(&changelog, r))
-                {
-                    continue;
-                }
-                let result = translator.try_translate_to_delete_sync_record(connection, &changelog)?;
-                match result {
-                    PushTranslateResult::PushRecord(records) => translation_results.push(records),
-                    PushTranslateResult::Ignored(ignore_message) => {
-                        log::debug!("Ignored record in push translation: {ignore_message}")
-                    }
-                    PushTranslateResult::NotMatched => {}
-                }
+
+        let translation_result = match &row_or_delete {
+            RowOrDelete::Row { row, .. } => translator
+                .try_translate_to_upsert_sync_record(connection, &changelog, row.clone())?,
+            RowOrDelete::Delete { .. } => {
+                translator.try_translate_to_delete_sync_record(connection, &changelog)?
             }
+        };
+
+        match translation_result {
+            PushTranslateResult::PushRecord(records) => translation_results.push(records),
+            PushTranslateResult::Ignored(ignore_message) => {
+                log::debug!("Ignored record in push translation: {ignore_message}")
+            }
+            PushTranslateResult::NotMatched => {}
         }
     }
 
     Ok(translation_results.into_iter().flatten().collect())
-}
-
-fn handle_upsert_result(
-    translator: &Box<dyn SyncTranslation>,
-    changelog: &ChangelogRow,
-    result: TranslatedUpsert,
-    out: &mut Vec<Vec<PushSyncRecord>>,
-) {
-    match result {
-        TranslatedUpsert::Translated(record_data) => {
-            out.push(vec![PushSyncRecord {
-                cursor: changelog.cursor,
-                record: CommonSyncRecord {
-                    table_name: translator.table_name().to_string(),
-                    record_id: changelog.record_id.clone(),
-                    action: SyncAction::Update,
-                    record_data,
-                },
-            }]);
-        }
-        TranslatedUpsert::Ignored(msg) => {
-            log::debug!("Ignored record in push translation: {msg}")
-        }
-        TranslatedUpsert::NotMatched => {}
-    }
 }
 
 #[derive(Debug)]

--- a/server/service/src/sync/translations/mod.rs
+++ b/server/service/src/sync/translations/mod.rs
@@ -355,6 +355,15 @@ pub(crate) enum PushTranslateResult {
     NotMatched,
 }
 
+/// Return type of `try_translate_to_upsert_sync_record`. Translators
+/// return only the serialised JSON (or skip); the dispatcher wraps it
+/// with changelog metadata to produce a `PushSyncRecord`.
+pub(crate) enum TranslatedUpsert {
+    Translated(serde_json::Value),
+    Ignored(String),
+    NotMatched,
+}
+
 impl PushTranslateResult {
     pub(crate) fn upsert(
         changelog: &ChangelogRow,
@@ -481,12 +490,20 @@ pub(crate) trait SyncTranslation {
         }
     }
 
+    /// Translate a pre-loaded bare row into the JSON wire payload.
+    /// `row` is passed by value so the translator can move fields out
+    /// of it without cloning. Translators that fit (no joined struct
+    /// needed) pattern-match on the matching `Row::*` variant.
+    /// Translators that need additional joined data may use
+    /// `_connection` for further `query_by_filter` lookups; the bare
+    /// `_row` is then ignored. Cursor / store_id / record_id are
+    /// added by the dispatcher.
     fn try_translate_to_upsert_sync_record(
         &self,
-        _: &StorageConnection,
-        _: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        Ok(PushTranslateResult::NotMatched)
+        _connection: &StorageConnection,
+        _row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        Ok(TranslatedUpsert::NotMatched)
     }
 
     fn try_translate_to_delete_sync_record(
@@ -504,16 +521,17 @@ pub(crate) struct PushTranslationError {
     source: anyhow::Error,
 }
 
-pub(crate) fn translate_changelogs_to_sync_records(
+pub(crate) fn translate_rows_to_sync_records(
     connection: &StorageConnection,
-    changelogs: Vec<ChangelogRow>,
+    rows: Vec<RowOrDelete>,
     r#type: Vec<ToSyncRecordTranslationType>,
 ) -> Result<Vec<PushSyncRecord>, PushTranslationError> {
     let translators = all_translators();
     let mut out_records = Vec::new();
-    for changelog in changelogs {
+    for row_or_delete in rows {
+        let changelog = row_or_delete.changelog().clone();
         let mut translation_results =
-            translate_changelog(connection, &translators, &changelog, &r#type)
+            translate_row_or_delete(connection, &translators, row_or_delete, &r#type)
                 .map_err(|source| PushTranslationError { source, changelog })?;
         out_records.append(&mut translation_results);
     }
@@ -521,41 +539,86 @@ pub(crate) fn translate_changelogs_to_sync_records(
     Ok(out_records)
 }
 
-fn translate_changelog(
+fn translate_row_or_delete(
     connection: &StorageConnection,
     translators: &SyncTranslators,
-    changelog: &ChangelogRow,
+    row_or_delete: RowOrDelete,
     r#type: &Vec<ToSyncRecordTranslationType>,
 ) -> Result<Vec<PushSyncRecord>, anyhow::Error> {
-    let mut translation_results = Vec::new();
+    let mut translation_results: Vec<Vec<PushSyncRecord>> = Vec::new();
 
-    for translator in translators.iter() {
-        if !r#type
-            .iter()
-            .any(|r| translator.should_translate_to_sync_record(changelog, r))
-        {
-            continue;
+    match row_or_delete {
+        RowOrDelete::Row { changelog, row } => {
+            // Find every translator that wants this row, then call them.
+            // The last matching translator gets the row by value; all
+            // earlier ones get a clone so each can move out of it.
+            let mut matching: Vec<&Box<dyn SyncTranslation>> = translators
+                .iter()
+                .filter(|t| {
+                    r#type
+                        .iter()
+                        .any(|rt| t.should_translate_to_sync_record(&changelog, rt))
+                })
+                .collect();
+
+            let last = matching.pop();
+            for translator in matching {
+                let result = translator
+                    .try_translate_to_upsert_sync_record(connection, row.clone())?;
+                handle_upsert_result(translator, &changelog, result, &mut translation_results);
+            }
+            if let Some(translator) = last {
+                let result =
+                    translator.try_translate_to_upsert_sync_record(connection, row)?;
+                handle_upsert_result(translator, &changelog, result, &mut translation_results);
+            }
         }
-
-        let translation_result = match changelog.row_action {
-            RowActionType::Upsert => {
-                translator.try_translate_to_upsert_sync_record(connection, changelog)?
+        RowOrDelete::Delete { changelog } => {
+            for translator in translators.iter() {
+                if !r#type
+                    .iter()
+                    .any(|r| translator.should_translate_to_sync_record(&changelog, r))
+                {
+                    continue;
+                }
+                let result = translator.try_translate_to_delete_sync_record(connection, &changelog)?;
+                match result {
+                    PushTranslateResult::PushRecord(records) => translation_results.push(records),
+                    PushTranslateResult::Ignored(ignore_message) => {
+                        log::debug!("Ignored record in push translation: {ignore_message}")
+                    }
+                    PushTranslateResult::NotMatched => {}
+                }
             }
-            RowActionType::Delete => {
-                translator.try_translate_to_delete_sync_record(connection, changelog)?
-            }
-        };
-
-        match translation_result {
-            PushTranslateResult::PushRecord(records) => translation_results.push(records),
-            PushTranslateResult::Ignored(ignore_message) => {
-                log::debug!("Ignored record in push translation: {ignore_message}")
-            }
-            PushTranslateResult::NotMatched => {}
         }
     }
 
     Ok(translation_results.into_iter().flatten().collect())
+}
+
+fn handle_upsert_result(
+    translator: &Box<dyn SyncTranslation>,
+    changelog: &ChangelogRow,
+    result: TranslatedUpsert,
+    out: &mut Vec<Vec<PushSyncRecord>>,
+) {
+    match result {
+        TranslatedUpsert::Translated(record_data) => {
+            out.push(vec![PushSyncRecord {
+                cursor: changelog.cursor,
+                record: CommonSyncRecord {
+                    table_name: translator.table_name().to_string(),
+                    record_id: changelog.record_id.clone(),
+                    action: SyncAction::Update,
+                    record_data,
+                },
+            }]);
+        }
+        TranslatedUpsert::Ignored(msg) => {
+            log::debug!("Ignored record in push translation: {msg}")
+        }
+        TranslatedUpsert::NotMatched => {}
+    }
 }
 
 #[derive(Debug)]

--- a/server/service/src/sync/translations/name.rs
+++ b/server/service/src/sync/translations/name.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use chrono::{NaiveDate, NaiveDateTime};
 use repository::{
     ChangelogRow, ChangelogTableName, GenderType, NameRow, NameRowDelete, NameRowRepository,
-    NameRowType, StorageConnection, SyncBufferRow,
+    NameRowType, Row, StorageConnection, SyncBufferRow,
 };
 use util::sync_serde::{
     date_option_to_isostring, empty_str_as_option, empty_str_as_option_string, zero_date_as_option,
@@ -12,9 +12,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::sync::{translations::currency::CurrencyTranslation, CentralServerConfig};
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 pub enum LegacyNameRowType {
@@ -345,9 +344,12 @@ impl SyncTranslation for NameTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::Name(name_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
         let NameRow {
             id,
             name,
@@ -385,14 +387,9 @@ impl SyncTranslation for NameTranslation {
             currency_id,
             // See comment in pull translation
             custom_data_string: _,
-        } = NameRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Name row ({}) not found",
-                changelog.record_id
-            )))?;
+        } = name_row;
         if deleted_datetime.is_some() {
-            return Ok(PushTranslateResult::Ignored(
+            return Ok(TranslatedUpsert::Ignored(
                 "Ignore pushing soft deleted name".to_string(),
             ));
         }
@@ -400,7 +397,7 @@ impl SyncTranslation for NameTranslation {
         let patient_type = match r#type {
             NameRowType::Patient => LegacyNameRowType::Patient,
             _ => {
-                return Ok(PushTranslateResult::Ignored(
+                return Ok(TranslatedUpsert::Ignored(
                     "Only push name records that belong to patients".to_string(),
                 ))
             }
@@ -448,11 +445,7 @@ impl SyncTranslation for NameTranslation {
             custom_data: None,
         };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 
     // TODO soft delete

--- a/server/service/src/sync/translations/name.rs
+++ b/server/service/src/sync/translations/name.rs
@@ -3,17 +3,18 @@ use chrono::{NaiveDate, NaiveDateTime};
 use repository::{
     ChangelogRow, ChangelogTableName, GenderType, NameRow, NameRowDelete, NameRowRepository,
     NameRowType, Row, StorageConnection, SyncBufferRow,
+
 };
 use util::sync_serde::{
     date_option_to_isostring, empty_str_as_option, empty_str_as_option_string, zero_date_as_option,
+
 };
 
 use serde::{Deserialize, Serialize};
 
 use crate::sync::{translations::currency::CurrencyTranslation, CentralServerConfig};
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 pub enum LegacyNameRowType {
@@ -345,10 +346,11 @@ impl SyncTranslation for NameTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::Name(name_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
         let NameRow {
             id,
@@ -389,7 +391,7 @@ impl SyncTranslation for NameTranslation {
             custom_data_string: _,
         } = name_row;
         if deleted_datetime.is_some() {
-            return Ok(TranslatedUpsert::Ignored(
+            return Ok(PushTranslateResult::Ignored(
                 "Ignore pushing soft deleted name".to_string(),
             ));
         }
@@ -397,7 +399,7 @@ impl SyncTranslation for NameTranslation {
         let patient_type = match r#type {
             NameRowType::Patient => LegacyNameRowType::Patient,
             _ => {
-                return Ok(TranslatedUpsert::Ignored(
+                return Ok(PushTranslateResult::Ignored(
                     "Only push name records that belong to patients".to_string(),
                 ))
             }
@@ -445,7 +447,7 @@ impl SyncTranslation for NameTranslation {
             custom_data: None,
         };
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 
     // TODO soft delete

--- a/server/service/src/sync/translations/name_insurance_join.rs
+++ b/server/service/src/sync/translations/name_insurance_join.rs
@@ -5,16 +5,17 @@ use repository::{
     },
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{empty_str_as_option_string, object_fields_as_option};
 
 use crate::sync::translations::{
     insurance_provider::InsuranceProviderTranslator, name::NameTranslation,
+
 };
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 #[derive(Deserialize, Serialize, Debug)]
 pub enum LegacyInsurancePolicyType {
@@ -139,10 +140,11 @@ impl SyncTranslation for NameInsuranceJoinTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::NameInsuranceJoin(name_insurance_join_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let NameInsuranceJoinRow {
@@ -184,7 +186,7 @@ impl SyncTranslation for NameInsuranceJoinTranslation {
             oms_fields,
         };
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 }
 

--- a/server/service/src/sync/translations/name_insurance_join.rs
+++ b/server/service/src/sync/translations/name_insurance_join.rs
@@ -4,6 +4,7 @@ use repository::{
         InsurancePolicyType, NameInsuranceJoinRow, NameInsuranceJoinRowRepository,
     },
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{empty_str_as_option_string, object_fields_as_option};
@@ -12,9 +13,8 @@ use crate::sync::translations::{
     insurance_provider::InsuranceProviderTranslator, name::NameTranslation,
 };
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 #[derive(Deserialize, Serialize, Debug)]
 pub enum LegacyInsurancePolicyType {
@@ -138,9 +138,13 @@ impl SyncTranslation for NameInsuranceJoinTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &repository::ChangelogRow,
-    ) -> Result<super::PushTranslateResult, anyhow::Error> {
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::NameInsuranceJoin(name_insurance_join_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let NameInsuranceJoinRow {
             id,
             name_id,
@@ -154,14 +158,7 @@ impl SyncTranslation for NameInsuranceJoinTranslation {
             is_active,
             entered_by_id,
             name_of_insured,
-        } = NameInsuranceJoinRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or_else(|| {
-                anyhow::Error::msg(format!(
-                    "NameInsuranceJoin row ({}) not found",
-                    changelog.record_id
-                ))
-            })?;
+        } = name_insurance_join_row;
 
         let oms_fields = if name_of_insured.is_some() {
             Some(LegacyNameInsuranceJoinRowOmsFields { name_of_insured })
@@ -187,11 +184,7 @@ impl SyncTranslation for NameInsuranceJoinTranslation {
             oms_fields,
         };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 }
 

--- a/server/service/src/sync/translations/name_oms_fields.rs
+++ b/server/service/src/sync/translations/name_oms_fields.rs
@@ -2,12 +2,12 @@ use repository::{
     ChangelogRow, ChangelogTableName, NameOmsFieldsRow, NameRowRepository, StorageConnection,
     SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::name::NameTranslation;
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -59,13 +59,14 @@ impl SyncTranslation for NameOmsFieldsTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
-        row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        _changelog: &ChangelogRow,
+        _row: Row,
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         // NameOmsFields is not represented in the `Row` enum (no
         // standalone bare-row repository), so `query_with_data` cannot
         // surface it on the push path. Until the table is added to
         // `Row`, this translator is unreachable for push.
-        Ok(TranslatedUpsert::NotMatched)
+        Ok(PushTranslateResult::NotMatched)
     }
 }
 

--- a/server/service/src/sync/translations/name_oms_fields.rs
+++ b/server/service/src/sync/translations/name_oms_fields.rs
@@ -1,13 +1,13 @@
 use repository::{
     ChangelogRow, ChangelogTableName, NameOmsFieldsRow, NameRowRepository, StorageConnection,
     SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::name::NameTranslation;
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -58,21 +58,14 @@ impl SyncTranslation for NameOmsFieldsTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = NameRowRepository::new(connection)
-            .find_one_oms_fields_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Name row ({}) not found for Name OMS Fields translation",
-                changelog.record_id
-            )))?;
-
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        // NameOmsFields is not represented in the `Row` enum (no
+        // standalone bare-row repository), so `query_with_data` cannot
+        // surface it on the push path. Until the table is added to
+        // `Row`, this translator is unreachable for push.
+        Ok(TranslatedUpsert::NotMatched)
     }
 }
 

--- a/server/service/src/sync/translations/name_property.rs
+++ b/server/service/src/sync/translations/name_property.rs
@@ -1,13 +1,13 @@
 use repository::{
     name_property_row::{NamePropertyRow, NamePropertyRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::property::PropertyTranslation;
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -56,21 +56,16 @@ impl SyncTranslation for NamePropertyTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = NamePropertyRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "NameProperty row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::NameProperty(name_property_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = name_property_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/name_property.rs
+++ b/server/service/src/sync/translations/name_property.rs
@@ -2,12 +2,12 @@ use repository::{
     name_property_row::{NamePropertyRow, NamePropertyRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::property::PropertyTranslation;
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -57,15 +57,16 @@ impl SyncTranslation for NamePropertyTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::NameProperty(name_property_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = name_property_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/name_store_join.rs
+++ b/server/service/src/sync/translations/name_store_join.rs
@@ -3,6 +3,7 @@ use repository::{
     NameStoreJoinFilter, NameStoreJoinRepository, NameStoreJoinRow, NameStoreJoinRowDelete,
     StorageConnection, StoreFilter, StoreRepository, SyncBufferRow,
     Row,
+
 };
 
 use serde::{Deserialize, Serialize};
@@ -10,10 +11,10 @@ use serde::{Deserialize, Serialize};
 use crate::sync::{
     translations::{name::NameTranslation, store::StoreTranslation},
     CentralServerConfig,
+
 };
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
@@ -143,10 +144,11 @@ impl SyncTranslation for NameStoreJoinTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::NameStoreJoin(name_store_join_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let NameStoreJoin {
@@ -176,7 +178,7 @@ impl SyncTranslation for NameStoreJoinTranslation {
             inactive: Some(false),
         };
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_from_delete_sync_record(
@@ -197,9 +199,11 @@ mod tests {
     use super::*;
     use crate::sync::{
         test::merge_helpers::merge_all_name_links, translations::ToSyncRecordTranslationType,
+    
     };
     use repository::{
         mock::MockDataInserts, test_db::setup_all, ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder,
+
 };
     use serde_json::json;
 
@@ -264,16 +268,16 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
+                .try_translate_to_upsert_sync_record(&connection, &changelog, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
+            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
 
-            let TranslatedUpsert::Translated(translated) = translated else {
+            let PushTranslateResult::PushRecord(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
-            assert_eq!(translated["name_ID"], json!("name_a"));
+            assert_eq!(translated[0].record.record_data["name_ID"], json!("name_a"));
         }
     }
 }

--- a/server/service/src/sync/translations/name_store_join.rs
+++ b/server/service/src/sync/translations/name_store_join.rs
@@ -2,6 +2,7 @@ use repository::{
     ChangelogRow, ChangelogTableName, EqualFilter, NameRowRepository, NameStoreJoin,
     NameStoreJoinFilter, NameStoreJoinRepository, NameStoreJoinRow, NameStoreJoinRowDelete,
     StorageConnection, StoreFilter, StoreRepository, SyncBufferRow,
+    Row,
 };
 
 use serde::{Deserialize, Serialize};
@@ -11,9 +12,8 @@ use crate::sync::{
     CentralServerConfig,
 };
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
@@ -143,8 +143,12 @@ impl SyncTranslation for NameStoreJoinTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::NameStoreJoin(name_store_join_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let NameStoreJoin {
             name_store_join:
                 NameStoreJoinRow {
@@ -158,7 +162,7 @@ impl SyncTranslation for NameStoreJoinTranslation {
         } = NameStoreJoinRepository::new(connection)
             .query_by_filter(
                 NameStoreJoinFilter::new()
-                    .id(EqualFilter::equal_to(changelog.record_id.to_string())),
+                    .id(EqualFilter::equal_to(name_store_join_row.id)),
             )?
             .pop()
             .ok_or(anyhow::anyhow!("Name store join not found"))?;
@@ -172,11 +176,7 @@ impl SyncTranslation for NameStoreJoinTranslation {
             inactive: Some(false),
         };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_from_delete_sync_record(
@@ -264,16 +264,16 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, &changelog)
+                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
+            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
 
-            let PushTranslateResult::PushRecord(translated) = translated else {
+            let TranslatedUpsert::Translated(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
-            assert_eq!(translated[0].record.record_data["name_ID"], json!("name_a"));
+            assert_eq!(translated["name_ID"], json!("name_a"));
         }
     }
 }

--- a/server/service/src/sync/translations/om_form_schema.rs
+++ b/server/service/src/sync/translations/om_form_schema.rs
@@ -1,9 +1,8 @@
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 use repository::{
-    ChangelogRow, ChangelogTableName, FormSchemaJson, FormSchemaRowDelete, FormSchemaRowRepository,
-    StorageConnection, SyncBufferRow,
+    schema_from_row, ChangelogRow, ChangelogTableName, FormSchemaJson, FormSchemaRowDelete,
+    FormSchemaRowRepository, Row, StorageConnection, SyncBufferRow,
 };
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -45,20 +44,17 @@ impl SyncTranslation for OmFormSchemaTranslation {
     }
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = FormSchemaRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Om form schema row ({}) not found",
-                changelog.record_id
-            )))?;
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::FormSchema(form_schema_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
+        // Convert the bare row into the JSON-parsed `FormSchemaJson`
+        // wire shape (FormSchemaRow itself isn't Serialize).
+        let row: FormSchemaJson = schema_from_row(form_schema_row)?;
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
     fn try_translate_from_delete_sync_record(
         &self,

--- a/server/service/src/sync/translations/om_form_schema.rs
+++ b/server/service/src/sync/translations/om_form_schema.rs
@@ -1,8 +1,8 @@
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 use repository::{
     schema_from_row, ChangelogRow, ChangelogTableName, FormSchemaJson, FormSchemaRowDelete,
     FormSchemaRowRepository, Row, StorageConnection, SyncBufferRow,
+
 };
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -45,16 +45,17 @@ impl SyncTranslation for OmFormSchemaTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::FormSchema(form_schema_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         // Convert the bare row into the JSON-parsed `FormSchemaJson`
         // wire shape (FormSchemaRow itself isn't Serialize).
         let row: FormSchemaJson = schema_from_row(form_schema_row)?;
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
     fn try_translate_from_delete_sync_record(
         &self,

--- a/server/service/src/sync/translations/packaging_variant.rs
+++ b/server/service/src/sync/translations/packaging_variant.rs
@@ -1,12 +1,12 @@
 use repository::item_variant::packaging_variant_row::{
     PackagingVariantRow, PackagingVariantRowRepository,
+
 };
-use repository::{ ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow, Row };
+use repository::{ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow, Row};
 
 use crate::sync::translations::item_variant::ItemVariantTranslation;
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -56,15 +56,16 @@ impl SyncTranslation for PackagingVariantTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::PackagingVariant(packaging_variant_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = packaging_variant_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/packaging_variant.rs
+++ b/server/service/src/sync/translations/packaging_variant.rs
@@ -1,13 +1,12 @@
 use repository::item_variant::packaging_variant_row::{
     PackagingVariantRow, PackagingVariantRowRepository,
 };
-use repository::{ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow};
+use repository::{ ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow, Row };
 
 use crate::sync::translations::item_variant::ItemVariantTranslation;
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -56,21 +55,16 @@ impl SyncTranslation for PackagingVariantTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = PackagingVariantRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "PackagingVariant row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::PackagingVariant(packaging_variant_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = packaging_variant_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/plugin_data.rs
+++ b/server/service/src/sync/translations/plugin_data.rs
@@ -2,12 +2,12 @@ use repository::{
     ChangelogRow, ChangelogTableName, PluginDataRow, PluginDataRowRepository, StorageConnection,
     SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::store::StoreTranslation;
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -59,15 +59,16 @@ impl SyncTranslation for PluginDataTranslator {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::PluginData(plugin_data_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = plugin_data_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/plugin_data.rs
+++ b/server/service/src/sync/translations/plugin_data.rs
@@ -1,13 +1,13 @@
 use repository::{
     ChangelogRow, ChangelogTableName, PluginDataRow, PluginDataRowRepository, StorageConnection,
     SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::store::StoreTranslation;
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -58,21 +58,16 @@ impl SyncTranslation for PluginDataTranslator {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = PluginDataRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "plugin_data row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::PluginData(plugin_data_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = plugin_data_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/preference.rs
+++ b/server/service/src/sync/translations/preference.rs
@@ -1,11 +1,11 @@
 use crate::sync::translations::store::StoreTranslation;
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 use repository::{
     ChangelogRow, ChangelogTableName, PreferenceRow, PreferenceRowDelete, PreferenceRowRepository,
     StorageConnection, SyncBufferRow,
+    Row,
 };
 
 pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
@@ -52,20 +52,15 @@ impl SyncTranslation for PreferenceTranslator {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = PreferenceRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "preference row ({}) not found",
-                changelog.record_id
-            )))?;
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::Preference(preference_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
+        let row = preference_row;
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 
     fn try_translate_from_delete_sync_record(

--- a/server/service/src/sync/translations/preference.rs
+++ b/server/service/src/sync/translations/preference.rs
@@ -1,11 +1,11 @@
 use crate::sync::translations::store::StoreTranslation;
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 use repository::{
     ChangelogRow, ChangelogTableName, PreferenceRow, PreferenceRowDelete, PreferenceRowRepository,
     StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
@@ -53,14 +53,15 @@ impl SyncTranslation for PreferenceTranslator {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::Preference(preference_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = preference_row;
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 
     fn try_translate_from_delete_sync_record(

--- a/server/service/src/sync/translations/program_requisition_settings.rs
+++ b/server/service/src/sync/translations/program_requisition_settings.rs
@@ -4,6 +4,7 @@ use repository::{
     ProgramRequisitionSettingsRow, ProgramRequisitionSettingsRowDelete,
     ProgramRequisitionSettingsRowRepository, ProgramRow, ProgramRowRepository, StorageConnection,
     SyncBufferRow,
+
 };
 
 use serde::Deserialize;
@@ -11,11 +12,13 @@ use std::collections::HashMap;
 
 use crate::sync::translations::{
     name_tag::NameTagTranslation, period_schedule::PeriodScheduleTranslation,
+
 };
 use util::sync_serde::{empty_str_as_option, empty_str_or_i32, object_fields_as_option};
 
 use super::{
     master_list::MasterListTranslation, IntegrationOperation, PullTranslateResult, SyncTranslation,
+
 };
 
 #[allow(non_snake_case)]

--- a/server/service/src/sync/translations/property.rs
+++ b/server/service/src/sync/translations/property.rs
@@ -2,10 +2,10 @@ use repository::{
     property_row::{PropertyRow, PropertyRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -66,15 +66,16 @@ impl SyncTranslation for PropertyTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::Property(property_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = property_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/property.rs
+++ b/server/service/src/sync/translations/property.rs
@@ -1,11 +1,11 @@
 use repository::{
     property_row::{PropertyRow, PropertyRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -65,21 +65,16 @@ impl SyncTranslation for PropertyTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = PropertyRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Property row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::Property(property_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = property_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/purchase_order.rs
+++ b/server/service/src/sync/translations/purchase_order.rs
@@ -1,6 +1,7 @@
 use crate::sync::translations::{
     name::NameTranslation, store::StoreTranslation, PullTranslateResult, PushTranslateResult,
-    SyncTranslation, TranslatedUpsert,
+    SyncTranslation,
+
 };
 use chrono::{NaiveDate, NaiveDateTime};
 use repository::{
@@ -8,11 +9,13 @@ use repository::{
     PurchaseOrderRepository, PurchaseOrderRow, PurchaseOrderStatsRow, PurchaseOrderStatus,
     StorageConnection, SyncBufferRow,
     Row,
+
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{
     date_option_to_isostring, empty_str_as_option, object_fields_as_option, zero_date_as_option,
     zero_f64_as_none,
+
 };
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
@@ -319,10 +322,11 @@ impl SyncTranslation for PurchaseOrderTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::PurchaseOrder(purchase_order_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let purchase_order = PurchaseOrderRepository::new(connection)
@@ -429,7 +433,7 @@ impl SyncTranslation for PurchaseOrderTranslation {
             oms_fields: Some(oms_fields),
         };
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(
@@ -490,6 +494,7 @@ mod tests {
     use super::*;
     use repository::{
         mock::MockDataInserts, test_db::setup_all, ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder,
+
 };
     use serde_json::json;
 
@@ -546,16 +551,16 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
+                .try_translate_to_upsert_sync_record(&connection, &changelog, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
+            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
 
-            let TranslatedUpsert::Translated(translated) = translated else {
+            let PushTranslateResult::PushRecord(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
-            assert_eq!(translated["name_ID"], json!("name_a"));
+            assert_eq!(translated[0].record.record_data["name_ID"], json!("name_a"));
         }
     }
 }

--- a/server/service/src/sync/translations/purchase_order.rs
+++ b/server/service/src/sync/translations/purchase_order.rs
@@ -1,12 +1,13 @@
 use crate::sync::translations::{
     name::NameTranslation, store::StoreTranslation, PullTranslateResult, PushTranslateResult,
-    SyncTranslation,
+    SyncTranslation, TranslatedUpsert,
 };
 use chrono::{NaiveDate, NaiveDateTime};
 use repository::{
     ChangelogRow, ChangelogTableName, EqualFilter, PurchaseOrderDelete, PurchaseOrderFilter,
     PurchaseOrderRepository, PurchaseOrderRow, PurchaseOrderStatsRow, PurchaseOrderStatus,
     StorageConnection, SyncBufferRow,
+    Row,
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{
@@ -318,12 +319,16 @@ impl SyncTranslation for PurchaseOrderTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::PurchaseOrder(purchase_order_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let purchase_order = PurchaseOrderRepository::new(connection)
             .query_by_filter(
                 PurchaseOrderFilter::new()
-                    .id(EqualFilter::equal_to(changelog.record_id.to_string())),
+                    .id(EqualFilter::equal_to(purchase_order_row.id)),
             )?
             .pop()
             .ok_or_else(|| anyhow::anyhow!("Purchase Order not found"))?;
@@ -424,11 +429,7 @@ impl SyncTranslation for PurchaseOrderTranslation {
             oms_fields: Some(oms_fields),
         };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(
@@ -545,16 +546,16 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, &changelog)
+                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
+            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
 
-            let PushTranslateResult::PushRecord(translated) = translated else {
+            let TranslatedUpsert::Translated(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
-            assert_eq!(translated[0].record.record_data["name_ID"], json!("name_a"));
+            assert_eq!(translated["name_ID"], json!("name_a"));
         }
     }
 }

--- a/server/service/src/sync/translations/purchase_order_line.rs
+++ b/server/service/src/sync/translations/purchase_order_line.rs
@@ -1,11 +1,12 @@
 use crate::sync::translations::{
     item::ItemTranslation, purchase_order::PurchaseOrderTranslation, PullTranslateResult,
-    PushTranslateResult, SyncTranslation,
+    PushTranslateResult, SyncTranslation, TranslatedUpsert,
 };
 use chrono::NaiveDate;
 use repository::{
     ChangelogRow, ChangelogTableName, PurchaseOrderLineDelete, PurchaseOrderLineRow,
     PurchaseOrderLineRowRepository, PurchaseOrderLineStatus, StorageConnection, SyncBufferRow,
+    Row,
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{
@@ -170,9 +171,13 @@ impl SyncTranslation for PurchaseOrderLineTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::PurchaseOrderLine(purchase_order_line_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let PurchaseOrderLineRow {
             id,
             store_id,
@@ -194,9 +199,7 @@ impl SyncTranslation for PurchaseOrderLineTranslation {
             note,
             unit,
             status,
-        } = PurchaseOrderLineRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or_else(|| anyhow::anyhow!("Purchase Order Line not found"))?;
+        } = purchase_order_line_row;
 
         // Total Cost calculated in Front End: price_per_pack_after_discount * number_of_packs
         // Number of packs = (requested_number_of_units OR adjusted_number_of_units) / requested_pack_size
@@ -232,11 +235,7 @@ impl SyncTranslation for PurchaseOrderLineTranslation {
             oms_fields: Some(LegacyPurchaseOrderLineRowOmsFields { status }),
         };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(
@@ -313,17 +312,17 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, &changelog)
+                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
+            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
 
-            let PushTranslateResult::PushRecord(translated) = translated else {
+            let TranslatedUpsert::Translated(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
             assert_eq!(
-                translated[0].record.record_data["ID"],
+                translated["ID"],
                 json!(changelog.record_id)
             );
         }

--- a/server/service/src/sync/translations/purchase_order_line.rs
+++ b/server/service/src/sync/translations/purchase_order_line.rs
@@ -1,16 +1,19 @@
 use crate::sync::translations::{
     item::ItemTranslation, purchase_order::PurchaseOrderTranslation, PullTranslateResult,
-    PushTranslateResult, SyncTranslation, TranslatedUpsert,
+    PushTranslateResult, SyncTranslation,
+
 };
 use chrono::NaiveDate;
 use repository::{
     ChangelogRow, ChangelogTableName, PurchaseOrderLineDelete, PurchaseOrderLineRow,
     PurchaseOrderLineRowRepository, PurchaseOrderLineStatus, StorageConnection, SyncBufferRow,
     Row,
+
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{
     date_option_to_isostring, empty_str_as_option, zero_date_as_option, zero_f64_as_none,
+
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -172,10 +175,11 @@ impl SyncTranslation for PurchaseOrderLineTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::PurchaseOrderLine(purchase_order_line_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let PurchaseOrderLineRow {
@@ -235,7 +239,7 @@ impl SyncTranslation for PurchaseOrderLineTranslation {
             oms_fields: Some(LegacyPurchaseOrderLineRowOmsFields { status }),
         };
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(
@@ -254,6 +258,7 @@ mod tests {
     use super::*;
     use repository::{
         mock::MockDataInserts, test_db::setup_all, ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder,
+
 };
     use serde_json::json;
 
@@ -312,17 +317,17 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
+                .try_translate_to_upsert_sync_record(&connection, &changelog, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
+            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
 
-            let TranslatedUpsert::Translated(translated) = translated else {
+            let PushTranslateResult::PushRecord(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
             assert_eq!(
-                translated["ID"],
+                translated[0].record.record_data["ID"],
                 json!(changelog.record_id)
             );
         }

--- a/server/service/src/sync/translations/reason.rs
+++ b/server/service/src/sync/translations/reason.rs
@@ -1,6 +1,7 @@
 use repository::{
     reason_option_row::{ReasonOptionRow, ReasonOptionRowDelete, ReasonOptionType},
     StorageConnection, SyncBufferRow,
+
 };
 use serde::{Deserialize, Serialize};
 

--- a/server/service/src/sync/translations/report.rs
+++ b/server/service/src/sync/translations/report.rs
@@ -1,11 +1,11 @@
 use crate::sync::translations::om_form_schema::OmFormSchemaTranslation;
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 use repository::{
     ChangelogRow, ChangelogTableName, ReportRow, ReportRowDelete, ReportRowRepository,
     StorageConnection, SyncBufferRow,
     Row,
+
 };
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -48,14 +48,15 @@ impl SyncTranslation for OmReportTranslator {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::Report(report_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = report_row;
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
     fn try_translate_from_delete_sync_record(
         &self,

--- a/server/service/src/sync/translations/report.rs
+++ b/server/service/src/sync/translations/report.rs
@@ -1,11 +1,11 @@
 use crate::sync::translations::om_form_schema::OmFormSchemaTranslation;
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 use repository::{
     ChangelogRow, ChangelogTableName, ReportRow, ReportRowDelete, ReportRowRepository,
     StorageConnection, SyncBufferRow,
+    Row,
 };
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -47,20 +47,15 @@ impl SyncTranslation for OmReportTranslator {
     }
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = ReportRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Om report row ({}) not found",
-                changelog.record_id
-            )))?;
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::Report(report_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
+        let row = report_row;
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
     fn try_translate_from_delete_sync_record(
         &self,

--- a/server/service/src/sync/translations/requisition.rs
+++ b/server/service/src/sync/translations/requisition.rs
@@ -4,12 +4,13 @@ use repository::{
     ApprovalStatusType, ChangelogRow, ChangelogTableName, EqualFilter, InvoiceFilter,
     InvoiceRepository, ProgramRowRepository, Requisition, RequisitionFilter, RequisitionRepository,
     RequisitionRow, RequisitionRowDelete, StorageConnection, SyncBufferRow,
+    Row,
 };
 
 use serde::{Deserialize, Serialize};
 use util::constants::{APPROX_NUMBER_OF_DAYS_IN_A_MONTH_IS_30, MISSING_PROGRAM};
 
-use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
+use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
 use crate::sync::translations::{
     master_list::MasterListTranslation, name::NameTranslation, period::PeriodTranslation,
     store::StoreTranslation,
@@ -347,8 +348,12 @@ impl SyncTranslation for RequisitionTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::Requisition(requisition_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let Requisition {
             requisition_row:
                 RequisitionRow {
@@ -382,7 +387,7 @@ impl SyncTranslation for RequisitionTranslation {
             ..
         } = RequisitionRepository::new(connection)
             .query_by_filter(
-                RequisitionFilter::new().id(EqualFilter::equal_to(changelog.record_id.to_string())),
+                RequisitionFilter::new().id(EqualFilter::equal_to(requisition_row.id.clone())),
             )?
             .pop()
             .ok_or_else(|| anyhow::anyhow!("Requisition not found"))?;
@@ -413,9 +418,9 @@ impl SyncTranslation for RequisitionTranslation {
             status: match to_legacy_status(&r#type, &status, has_outbound_shipment) {
                 Some(status) => status,
                 None => {
-                    return Ok(PushTranslateResult::Ignored(format!(
+                    return Ok(TranslatedUpsert::Ignored(format!(
                         "Unsupported requisition status: {:?} (type: {:?}) row id: {}",
-                        status, r#type, changelog.record_id
+                        status, r#type, requisition_row.id
                     )))
                 }
             },
@@ -445,11 +450,7 @@ impl SyncTranslation for RequisitionTranslation {
             oms_fields,
         };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(
@@ -757,16 +758,16 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, &changelog)
+                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
+            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
 
-            let PushTranslateResult::PushRecord(translated) = translated else {
+            let TranslatedUpsert::Translated(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
-            assert_eq!(translated[0].record.record_data["name_ID"], json!("name_a"));
+            assert_eq!(translated["name_ID"], json!("name_a"));
         }
     }
 

--- a/server/service/src/sync/translations/requisition.rs
+++ b/server/service/src/sync/translations/requisition.rs
@@ -5,19 +5,22 @@ use repository::{
     InvoiceRepository, ProgramRowRepository, Requisition, RequisitionFilter, RequisitionRepository,
     RequisitionRow, RequisitionRowDelete, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 use serde::{Deserialize, Serialize};
 use util::constants::{APPROX_NUMBER_OF_DAYS_IN_A_MONTH_IS_30, MISSING_PROGRAM};
 
-use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 use crate::sync::translations::{
     master_list::MasterListTranslation, name::NameTranslation, period::PeriodTranslation,
     store::StoreTranslation,
+
 };
 use util::sync_serde::{
     date_and_time_to_datetime, date_from_date_time, date_option_to_isostring, date_to_isostring,
     empty_str_as_option, empty_str_as_option_string, zero_date_as_option,
+
 };
 
 #[allow(non_snake_case)]
@@ -187,6 +190,7 @@ struct PartialLegacyRequisitionRow {
     pub r#type: LegacyRequisitionType,
     pub status: LegacyRequisitionStatus,
     pub om_status: Option<RequisitionStatus>,
+
 }
 
 fn sanitize_legacy_record(data: serde_json::Value) -> serde_json::Value {
@@ -348,10 +352,11 @@ impl SyncTranslation for RequisitionTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::Requisition(requisition_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let Requisition {
@@ -418,7 +423,7 @@ impl SyncTranslation for RequisitionTranslation {
             status: match to_legacy_status(&r#type, &status, has_outbound_shipment) {
                 Some(status) => status,
                 None => {
-                    return Ok(TranslatedUpsert::Ignored(format!(
+                    return Ok(PushTranslateResult::Ignored(format!(
                         "Unsupported requisition status: {:?} (type: {:?}) row id: {}",
                         status, r#type, requisition_row.id
                     )))
@@ -450,7 +455,7 @@ impl SyncTranslation for RequisitionTranslation {
             oms_fields,
         };
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(
@@ -631,12 +636,14 @@ mod tests {
     use crate::sync::{
         test::merge_helpers::merge_all_name_links,
         translations::{IntegrationOperation, ToSyncRecordTranslationType},
+    
     };
 
     use super::*;
     use repository::{
         mock::MockDataInserts, test_db::setup_all, ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder,
         SyncAction, SyncBufferRow, SyncRecordData,
+
 };
     use serde_json::json;
     use util::assert_variant;
@@ -712,6 +719,7 @@ mod tests {
           "om_status": "",
           "om_colour": "",
           "oms_fields": {}
+        
         }"#;
 
         let sync_buffer_row = SyncBufferRow {
@@ -758,16 +766,16 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
+                .try_translate_to_upsert_sync_record(&connection, &changelog, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
+            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
 
-            let TranslatedUpsert::Translated(translated) = translated else {
+            let PushTranslateResult::PushRecord(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
-            assert_eq!(translated["name_ID"], json!("name_a"));
+            assert_eq!(translated[0].record.record_data["name_ID"], json!("name_a"));
         }
     }
 

--- a/server/service/src/sync/translations/requisition_line.rs
+++ b/server/service/src/sync/translations/requisition_line.rs
@@ -9,11 +9,12 @@ use repository::{
     RequisitionRepository, RnRFormLineFilter, RnRFormLineRepository, StorageConnection,
     SyncBufferRow,
     Row,
+
 };
 use serde::{Deserialize, Serialize};
 use util::constants::APPROX_NUMBER_OF_DAYS_IN_A_MONTH_IS_30;
 
-use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[derive(Deserialize, Serialize, PartialEq)]
 pub struct RequisitionLineOmsFields {
@@ -90,6 +91,7 @@ pub struct LegacyRequisitionLineRow {
 
     #[serde(default, deserialize_with = "object_fields_as_option")]
     pub oms_fields: Option<RequisitionLineOmsFields>,
+
 }
 // Needs to be added to all_translators()
 pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
@@ -189,10 +191,11 @@ impl SyncTranslation for RequisitionLineTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::RequisitionLine(requisition_line_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let RequisitionLineRow {
@@ -295,7 +298,7 @@ impl SyncTranslation for RequisitionLineTranslation {
             oms_fields,
         };
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(
@@ -311,11 +314,13 @@ impl SyncTranslation for RequisitionLineTranslation {
 mod tests {
     use crate::sync::{
         test::merge_helpers::merge_all_item_links, translations::ToSyncRecordTranslationType,
+    
     };
 
     use super::*;
     use repository::{
         mock::MockDataInserts, test_db::setup_all, ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder,
+
 };
     use serde_json::json;
 
@@ -374,16 +379,16 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
+                .try_translate_to_upsert_sync_record(&connection, &changelog, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
+            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
 
-            let TranslatedUpsert::Translated(translated) = translated else {
+            let PushTranslateResult::PushRecord(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
-            assert_eq!(translated["item_ID"], json!("item_a"));
+            assert_eq!(translated[0].record.record_data["item_ID"], json!("item_a"));
         }
     }
 }

--- a/server/service/src/sync/translations/requisition_line.rs
+++ b/server/service/src/sync/translations/requisition_line.rs
@@ -8,11 +8,12 @@ use repository::{
     RequisitionLineRow, RequisitionLineRowDelete, RequisitionLineRowRepository,
     RequisitionRepository, RnRFormLineFilter, RnRFormLineRepository, StorageConnection,
     SyncBufferRow,
+    Row,
 };
 use serde::{Deserialize, Serialize};
 use util::constants::APPROX_NUMBER_OF_DAYS_IN_A_MONTH_IS_30;
 
-use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
+use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
 
 #[derive(Deserialize, Serialize, PartialEq)]
 pub struct RequisitionLineOmsFields {
@@ -188,8 +189,12 @@ impl SyncTranslation for RequisitionLineTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::RequisitionLine(requisition_line_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let RequisitionLineRow {
             id,
             requisition_id,
@@ -218,12 +223,7 @@ impl SyncTranslation for RequisitionLineTranslation {
             forecast_total_units,
             forecast_total_doses,
             vaccine_courses,
-        } = RequisitionLineRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Requisition line row not found: {}",
-                changelog.record_id
-            )))?;
+        } = requisition_line_row;
 
         // The item_id from RequisitionLineRow is actually for an item_link_id, so we get the true item_id here
         let item_id = ItemLinkRowRepository::new(connection)
@@ -295,11 +295,7 @@ impl SyncTranslation for RequisitionLineTranslation {
             oms_fields,
         };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(
@@ -378,16 +374,16 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, &changelog)
+                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
+            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
 
-            let PushTranslateResult::PushRecord(translated) = translated else {
+            let TranslatedUpsert::Translated(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
-            assert_eq!(translated[0].record.record_data["item_ID"], json!("item_a"));
+            assert_eq!(translated["item_ID"], json!("item_a"));
         }
     }
 }

--- a/server/service/src/sync/translations/rnr_form.rs
+++ b/server/service/src/sync/translations/rnr_form.rs
@@ -2,16 +2,17 @@ use repository::{
     rnr_form_row::{RnRFormRow, RnRFormRowRepository},
     ChangelogRow, ChangelogTableName, RnRFormDelete, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::{
     master_list::MasterListTranslation, name::NameTranslation, period::PeriodTranslation,
     program_requisition_settings::ProgramRequisitionSettingsTranslation,
     requisition::RequisitionTranslation, store::StoreTranslation,
+
 };
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -70,15 +71,16 @@ impl SyncTranslation for RnRFormTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::RnrForm(rnr_form_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = rnr_form_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 
     fn try_translate_from_delete_sync_record(

--- a/server/service/src/sync/translations/rnr_form.rs
+++ b/server/service/src/sync/translations/rnr_form.rs
@@ -1,6 +1,7 @@
 use repository::{
     rnr_form_row::{RnRFormRow, RnRFormRowRepository},
     ChangelogRow, ChangelogTableName, RnRFormDelete, StorageConnection, SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::{
@@ -9,9 +10,8 @@ use crate::sync::translations::{
     requisition::RequisitionTranslation, store::StoreTranslation,
 };
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -69,21 +69,16 @@ impl SyncTranslation for RnRFormTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = RnRFormRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "RnRForm row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::RnrForm(rnr_form_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = rnr_form_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 
     fn try_translate_from_delete_sync_record(

--- a/server/service/src/sync/translations/rnr_form_line.rs
+++ b/server/service/src/sync/translations/rnr_form_line.rs
@@ -2,15 +2,16 @@ use repository::{
     rnr_form_line_row::{RnRFormLineRow, RnRFormLineRowRepository},
     ChangelogRow, ChangelogTableName, RnRFormLineDelete, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::{
     item::ItemTranslation, requisition_line::RequisitionLineTranslation,
     rnr_form::RnRFormTranslation,
+
 };
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -66,15 +67,16 @@ impl SyncTranslation for RnRFormLineTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::RnrFormLine(rnr_form_line_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = rnr_form_line_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 
     fn try_translate_from_delete_sync_record(

--- a/server/service/src/sync/translations/rnr_form_line.rs
+++ b/server/service/src/sync/translations/rnr_form_line.rs
@@ -1,6 +1,7 @@
 use repository::{
     rnr_form_line_row::{RnRFormLineRow, RnRFormLineRowRepository},
     ChangelogRow, ChangelogTableName, RnRFormLineDelete, StorageConnection, SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::{
@@ -8,9 +9,8 @@ use crate::sync::translations::{
     rnr_form::RnRFormTranslation,
 };
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -65,21 +65,16 @@ impl SyncTranslation for RnRFormLineTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = RnRFormLineRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "RnRFormLine row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::RnrFormLine(rnr_form_line_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = rnr_form_line_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 
     fn try_translate_from_delete_sync_record(

--- a/server/service/src/sync/translations/sensor.rs
+++ b/server/service/src/sync/translations/sensor.rs
@@ -8,10 +8,11 @@ use util::sync_serde::{
 use repository::{
     get_sensor_type, ChangelogRow, ChangelogTableName, SensorRow, SensorRowRepository, SensorType,
     StorageConnection, SyncBufferRow,
+    Row,
 };
 use serde::{Deserialize, Serialize};
 
-use super::{to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation};
+use super::{ to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
 pub struct LegacySensorRow {
@@ -111,9 +112,13 @@ impl SyncTranslation for SensorTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::Sensor(sensor_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let SensorRow {
             id,
             name,
@@ -125,12 +130,7 @@ impl SyncTranslation for SensorTranslation {
             is_active,
             last_connection_datetime,
             r#type,
-        } = SensorRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Sensor row ({}) not found",
-                changelog.record_id
-            )))?;
+        } = sensor_row;
 
         let last_connection_date = last_connection_datetime.map(|t| t.date());
 
@@ -162,11 +162,7 @@ impl SyncTranslation for SensorTranslation {
             last_connection_datetime,
         };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 }
 

--- a/server/service/src/sync/translations/sensor.rs
+++ b/server/service/src/sync/translations/sensor.rs
@@ -3,16 +3,18 @@ use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use util::sync_serde::{
     date_option_to_isostring, empty_str_as_option, empty_str_as_option_string, naive_time,
     zero_date_as_option,
+
 };
 
 use repository::{
     get_sensor_type, ChangelogRow, ChangelogTableName, SensorRow, SensorRowRepository, SensorType,
     StorageConnection, SyncBufferRow,
     Row,
+
 };
 use serde::{Deserialize, Serialize};
 
-use super::{ to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
+use super::{to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation};
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
 pub struct LegacySensorRow {
@@ -113,10 +115,11 @@ impl SyncTranslation for SensorTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::Sensor(sensor_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let SensorRow {
@@ -162,7 +165,7 @@ impl SyncTranslation for SensorTranslation {
             last_connection_datetime,
         };
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 }
 

--- a/server/service/src/sync/translations/special/clinician_merge.rs
+++ b/server/service/src/sync/translations/special/clinician_merge.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 
 use crate::sync::translations::{
     clinician::ClinicianTranslation, PullTranslateResult, SyncTranslation,
+
 };
 
 #[derive(Deserialize)]
@@ -70,12 +71,14 @@ impl SyncTranslation for ClinicianMergeTranslation {
 mod tests {
     use crate::sync::{
         sync_buffer::SyncBufferSource, synchroniser::integrate_and_translate_sync_buffer,
+    
     };
 
     use super::*;
     use repository::{
         mock::MockDataInserts, test_db::setup_all, SyncAction, SyncBufferRowRepository,
         SyncRecordData,
+    
     };
     use serde_json::json;
 

--- a/server/service/src/sync/translations/special/item_merge.rs
+++ b/server/service/src/sync/translations/special/item_merge.rs
@@ -64,12 +64,14 @@ impl SyncTranslation for ItemMergeTranslation {
 mod tests {
     use crate::sync::{
         sync_buffer::SyncBufferSource, synchroniser::integrate_and_translate_sync_buffer,
+    
     };
 
     use super::*;
     use repository::{
         mock::MockDataInserts, test_db::setup_all, SyncAction, SyncBufferRowRepository,
         SyncRecordData,
+    
     };
     use serde_json::json;
 

--- a/server/service/src/sync/translations/special/name_merge.rs
+++ b/server/service/src/sync/translations/special/name_merge.rs
@@ -2,12 +2,14 @@ use repository::{
     EqualFilter, NameLinkRow, NameLinkRowRepository, NameRowDelete, NameStoreJoinFilter,
     NameStoreJoinRepository, NameStoreJoinRow, NameStoreJoinRowDelete, StorageConnection,
     StoreFilter, StoreRepository, SyncBufferRow,
+
 };
 
 use serde::Deserialize;
 
 use crate::sync::translations::{
     name::NameTranslation, IntegrationOperation, PullTranslateResult, SyncTranslation,
+
 };
 
 #[derive(Deserialize)]
@@ -156,12 +158,14 @@ impl SyncTranslation for NameMergeTranslation {
 mod tests {
     use crate::sync::{
         sync_buffer::SyncBufferSource, synchroniser::integrate_and_translate_sync_buffer,
+    
     };
 
     use super::*;
     use repository::{
         mock::MockDataInserts, test_db::setup_all, SyncAction, SyncBufferRowRepository,
         SyncRecordData,
+    
     };
     use serde_json::json;
 

--- a/server/service/src/sync/translations/special/name_to_name_store_join.rs
+++ b/server/service/src/sync/translations/special/name_to_name_store_join.rs
@@ -1,6 +1,7 @@
 use repository::{
     EqualFilter, NameStoreJoinFilter, NameStoreJoinRepository, NameStoreJoinRow, StorageConnection,
     SyncBufferRow,
+
 };
 
 use serde::Deserialize;

--- a/server/service/src/sync/translations/stock_line.rs
+++ b/server/service/src/sync/translations/stock_line.rs
@@ -8,6 +8,7 @@ use chrono::NaiveDate;
 use repository::{
     ChangelogRow, ChangelogTableName, EqualFilter, StockLine, StockLineFilter, StockLineRepository,
     StockLineRow, StorageConnection, SyncBufferRow,
+    Row,
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{
@@ -18,6 +19,7 @@ use util::sync_serde::{
 use super::{
     utils::{clear_invalid_barcode_id, clear_invalid_location_id},
     PullTranslateResult, PushTranslateResult, SyncTranslation,
+    TranslatedUpsert,
 };
 
 #[allow(non_snake_case)]
@@ -179,11 +181,15 @@ impl SyncTranslation for StockLineTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::StockLine(stock_line_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let Some(stock_line) = StockLineRepository::new(connection)
             .query_by_filter(
-                StockLineFilter::new().id(EqualFilter::equal_to(changelog.record_id.to_string())),
+                StockLineFilter::new().id(EqualFilter::equal_to(stock_line_row.id)),
                 None,
             )?
             .pop()
@@ -255,11 +261,7 @@ impl SyncTranslation for StockLineTranslation {
             volume_per_pack,
         };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(
@@ -328,20 +330,20 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, &changelog)
+                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
+            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
 
-            let PushTranslateResult::PushRecord(translated) = translated else {
+            let TranslatedUpsert::Translated(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
-            assert_eq!(translated[0].record.record_data["item_ID"], json!("item_a"));
+            assert_eq!(translated["item_ID"], json!("item_a"));
 
             // Supplier ID can be null. We want to check if the non-null supplier_ids is "name_a".
-            if translated[0].record.record_data["name_ID"] != json!(null) {
-                assert_eq!(translated[0].record.record_data["name_ID"], json!("name_a"));
+            if translated["name_ID"] != json!(null) {
+                assert_eq!(translated["name_ID"], json!("name_a"));
             }
         }
     }

--- a/server/service/src/sync/translations/stock_line.rs
+++ b/server/service/src/sync/translations/stock_line.rs
@@ -2,6 +2,7 @@ use crate::sync::translations::{
     barcode::BarcodeTranslation, campaign::CampaignTranslation, item::ItemTranslation,
     item_variant::ItemVariantTranslation, location::LocationTranslation, name::NameTranslation,
     store::StoreTranslation, vvm_status::VVMStatusTranslation,
+
 };
 
 use chrono::NaiveDate;
@@ -9,17 +10,19 @@ use repository::{
     ChangelogRow, ChangelogTableName, EqualFilter, StockLine, StockLineFilter, StockLineRepository,
     StockLineRow, StorageConnection, SyncBufferRow,
     Row,
+
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{
     date_option_to_isostring, empty_str_as_option_string, object_fields_as_option,
     zero_date_as_option,
+
 };
 
 use super::{
     utils::{clear_invalid_barcode_id, clear_invalid_location_id},
     PullTranslateResult, PushTranslateResult, SyncTranslation,
-    TranslatedUpsert,
+
 };
 
 #[allow(non_snake_case)]
@@ -181,10 +184,11 @@ impl SyncTranslation for StockLineTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::StockLine(stock_line_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let Some(stock_line) = StockLineRepository::new(connection)
@@ -261,7 +265,7 @@ impl SyncTranslation for StockLineTranslation {
             volume_per_pack,
         };
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(
@@ -278,11 +282,13 @@ mod tests {
     use crate::sync::{
         test::merge_helpers::{merge_all_item_links, merge_all_name_links},
         translations::ToSyncRecordTranslationType,
+    
     };
 
     use super::*;
     use repository::{
         mock::MockDataInserts, test_db::setup_all, ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder,
+
 };
     use serde_json::json;
 
@@ -330,20 +336,20 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
+                .try_translate_to_upsert_sync_record(&connection, &changelog, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
+            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
 
-            let TranslatedUpsert::Translated(translated) = translated else {
+            let PushTranslateResult::PushRecord(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
-            assert_eq!(translated["item_ID"], json!("item_a"));
+            assert_eq!(translated[0].record.record_data["item_ID"], json!("item_a"));
 
             // Supplier ID can be null. We want to check if the non-null supplier_ids is "name_a".
-            if translated["name_ID"] != json!(null) {
-                assert_eq!(translated["name_ID"], json!("name_a"));
+            if translated[0].record.record_data["name_ID"] != json!(null) {
+                assert_eq!(translated[0].record.record_data["name_ID"], json!("name_a"));
             }
         }
     }

--- a/server/service/src/sync/translations/stocktake.rs
+++ b/server/service/src/sync/translations/stocktake.rs
@@ -1,7 +1,7 @@
 use crate::sync::translations::{invoice::InvoiceTranslation, store::StoreTranslation};
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use repository::{
-    ChangelogRow, ChangelogTableName, StocktakeRow, StocktakeRowRepository, StocktakeStatus,
+    ChangelogRow, ChangelogTableName, Row, StocktakeRow, StocktakeRowRepository, StocktakeStatus,
     StorageConnection, SyncBufferRow,
 };
 use serde::{Deserialize, Serialize};
@@ -10,7 +10,7 @@ use util::sync_serde::{
     empty_str_as_option_string, naive_time, zero_date_as_option,
 };
 
-use super::{to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation};
+use super::{ to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum LegacyStocktakeStatus {
@@ -160,9 +160,12 @@ impl SyncTranslation for StocktakeTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::Stocktake(stocktake) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
         let StocktakeRow {
             id,
             user_id,
@@ -181,9 +184,7 @@ impl SyncTranslation for StocktakeTranslation {
             counted_by,
             verified_by,
             is_initial_stocktake,
-        } = StocktakeRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg("Stocktake row not found"))?;
+        } = stocktake;
 
         let legacy_row = LegacyStocktakeRow {
             ID: id.clone(),
@@ -207,11 +208,7 @@ impl SyncTranslation for StocktakeTranslation {
             is_initial_stocktake,
         };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(

--- a/server/service/src/sync/translations/stocktake.rs
+++ b/server/service/src/sync/translations/stocktake.rs
@@ -3,14 +3,16 @@ use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use repository::{
     ChangelogRow, ChangelogTableName, Row, StocktakeRow, StocktakeRowRepository, StocktakeStatus,
     StorageConnection, SyncBufferRow,
+
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{
     date_from_date_time, date_option_to_isostring, date_to_isostring, empty_str_as_option,
     empty_str_as_option_string, naive_time, zero_date_as_option,
+
 };
 
-use super::{ to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
+use super::{to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum LegacyStocktakeStatus {
@@ -161,10 +163,11 @@ impl SyncTranslation for StocktakeTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::Stocktake(stocktake) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
         let StocktakeRow {
             id,
@@ -208,7 +211,7 @@ impl SyncTranslation for StocktakeTranslation {
             is_initial_stocktake,
         };
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(

--- a/server/service/src/sync/translations/stocktake_line.rs
+++ b/server/service/src/sync/translations/stocktake_line.rs
@@ -3,6 +3,7 @@ use crate::sync::translations::{
     master_list::MasterListTranslation, reason::ReasonTranslation,
     stock_line::StockLineTranslation, stocktake::StocktakeTranslation,
     vvm_status::VVMStatusTranslation,
+
 };
 
 use chrono::NaiveDate;
@@ -11,15 +12,16 @@ use repository::{
     StocktakeLineFilter, StocktakeLineRepository, StocktakeLineRow, StorageConnection,
     SyncBufferRow,
     Row,
+
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{
     date_option_to_isostring, empty_str_as_option_string, object_fields_as_option,
     zero_date_as_option,
+
 };
 
-use super::{ 
-    utils::clear_invalid_location_id, PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
+use super::{utils::clear_invalid_location_id, PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
@@ -217,10 +219,11 @@ impl SyncTranslation for StocktakeLineTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::StocktakeLine(stocktake_line_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let Some(stocktake_line) = StocktakeLineRepository::new(connection)
@@ -303,7 +306,7 @@ impl SyncTranslation for StocktakeLineTranslation {
             oms_fields,
         };
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(
@@ -319,11 +322,13 @@ impl SyncTranslation for StocktakeLineTranslation {
 mod tests {
     use crate::sync::{
         test::merge_helpers::merge_all_item_links, translations::ToSyncRecordTranslationType,
+    
     };
 
     use super::*;
     use repository::{
         mock::MockDataInserts, test_db::setup_all, ChangelogCondition, ChangelogRepository, CursorAndLimit, FilterBuilder,
+
 };
     use serde_json::json;
 
@@ -383,16 +388,16 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
+                .try_translate_to_upsert_sync_record(&connection, &changelog, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
+            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
 
-            let TranslatedUpsert::Translated(translated) = translated else {
+            let PushTranslateResult::PushRecord(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
-            assert_eq!(translated["item_ID"], json!("item_a"));
+            assert_eq!(translated[0].record.record_data["item_ID"], json!("item_a"));
         }
     }
 }

--- a/server/service/src/sync/translations/stocktake_line.rs
+++ b/server/service/src/sync/translations/stocktake_line.rs
@@ -10,6 +10,7 @@ use repository::{
     ChangelogRow, ChangelogTableName, EqualFilter, StockLineRowRepository, StocktakeLine,
     StocktakeLineFilter, StocktakeLineRepository, StocktakeLineRow, StorageConnection,
     SyncBufferRow,
+    Row,
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{
@@ -17,9 +18,8 @@ use util::sync_serde::{
     zero_date_as_option,
 };
 
-use super::{
-    utils::clear_invalid_location_id, PullTranslateResult, PushTranslateResult, SyncTranslation,
-};
+use super::{ 
+    utils::clear_invalid_location_id, PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
@@ -217,12 +217,16 @@ impl SyncTranslation for StocktakeLineTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::StocktakeLine(stocktake_line_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let Some(stocktake_line) = StocktakeLineRepository::new(connection)
             .query_by_filter(
                 StocktakeLineFilter::new()
-                    .id(EqualFilter::equal_to(changelog.record_id.to_string())),
+                    .id(EqualFilter::equal_to(stocktake_line_row.id)),
                 None,
             )?
             .pop()
@@ -299,11 +303,7 @@ impl SyncTranslation for StocktakeLineTranslation {
             oms_fields,
         };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(
@@ -383,16 +383,16 @@ mod tests {
                 &ToSyncRecordTranslationType::PushToLegacyCentral
             ));
             let translated = translator
-                .try_translate_to_upsert_sync_record(&connection, &changelog)
+                .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
                 .unwrap();
 
-            assert!(matches!(translated, PushTranslateResult::PushRecord(_)));
+            assert!(matches!(translated, TranslatedUpsert::Translated(_)));
 
-            let PushTranslateResult::PushRecord(translated) = translated else {
+            let TranslatedUpsert::Translated(translated) = translated else {
                 panic!("Test fail, should translate")
             };
 
-            assert_eq!(translated[0].record.record_data["item_ID"], json!("item_a"));
+            assert_eq!(translated["item_ID"], json!("item_a"));
         }
     }
 }

--- a/server/service/src/sync/translations/store_preference.rs
+++ b/server/service/src/sync/translations/store_preference.rs
@@ -83,6 +83,7 @@ pub struct LegacyPrefData {
 #[deny(dead_code)]
 pub(crate) fn boxed() -> Box<dyn SyncTranslation> {
     Box::new(StorePreferenceTranslation)
+
 }
 
 pub(super) struct StorePreferenceTranslation;

--- a/server/service/src/sync/translations/sync_file_reference.rs
+++ b/server/service/src/sync/translations/sync_file_reference.rs
@@ -1,13 +1,13 @@
 use repository::{
     sync_file_reference_row::{SyncFileReferenceRow, SyncFileReferenceRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::asset::AssetTranslation;
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -58,21 +58,16 @@ impl SyncTranslation for SyncFileReferenceTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = SyncFileReferenceRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "SyncFileReference row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::SyncFileReference(sync_file_reference_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = sync_file_reference_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/sync_file_reference.rs
+++ b/server/service/src/sync/translations/sync_file_reference.rs
@@ -2,12 +2,12 @@ use repository::{
     sync_file_reference_row::{SyncFileReferenceRow, SyncFileReferenceRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::asset::AssetTranslation;
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -59,15 +59,16 @@ impl SyncTranslation for SyncFileReferenceTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::SyncFileReference(sync_file_reference_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = sync_file_reference_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/sync_message.rs
+++ b/server/service/src/sync/translations/sync_message.rs
@@ -5,11 +5,12 @@ use repository::{
     ChangelogRow, ChangelogTableName, StorageConnection, SyncMessageRow, SyncMessageRowRepository,
     SyncMessageRowStatus, SyncMessageRowType,
     Row,
+
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{empty_str_as_option_string, naive_time};
 
-use super::{ to_legacy_time, PushTranslateResult, TranslatedUpsert };
+use super::{to_legacy_time, PushTranslateResult};
 
 /// Message from mSupply Central Server
 #[derive(Deserialize, Serialize, Debug)]
@@ -102,10 +103,11 @@ impl SyncTranslation for MessageTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::SyncMessage(sync_message_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let Some(message) =
@@ -148,7 +150,7 @@ impl SyncTranslation for MessageTranslation {
 
         let json_record = serde_json::to_value(legacy_row)?;
 
-        Ok(TranslatedUpsert::Translated(json_record))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), json_record))
     }
 }
 

--- a/server/service/src/sync/translations/sync_message.rs
+++ b/server/service/src/sync/translations/sync_message.rs
@@ -4,11 +4,12 @@ use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use repository::{
     ChangelogRow, ChangelogTableName, StorageConnection, SyncMessageRow, SyncMessageRowRepository,
     SyncMessageRowStatus, SyncMessageRowType,
+    Row,
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{empty_str_as_option_string, naive_time};
 
-use super::{to_legacy_time, PushTranslateResult};
+use super::{ to_legacy_time, PushTranslateResult, TranslatedUpsert };
 
 /// Message from mSupply Central Server
 #[derive(Deserialize, Serialize, Debug)]
@@ -101,10 +102,14 @@ impl SyncTranslation for MessageTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::SyncMessage(sync_message_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let Some(message) =
-            SyncMessageRowRepository::new(connection).find_one_by_id(&changelog.record_id)?
+            SyncMessageRowRepository::new(connection).find_one_by_id(&sync_message_row.id)?
         else {
             return Err(anyhow::anyhow!("Message not found"));
         };
@@ -143,11 +148,7 @@ impl SyncTranslation for MessageTranslation {
 
         let json_record = serde_json::to_value(legacy_row)?;
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            json_record,
-        ))
+        Ok(TranslatedUpsert::Translated(json_record))
     }
 }
 

--- a/server/service/src/sync/translations/system_log.rs
+++ b/server/service/src/sync/translations/system_log.rs
@@ -1,11 +1,11 @@
 use repository::{
     system_log_row::{SystemLogRow, SystemLogRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -53,21 +53,16 @@ impl SyncTranslation for SystemLogTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = SystemLogRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "SystemLog row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::SystemLog(system_log_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = system_log_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/system_log.rs
+++ b/server/service/src/sync/translations/system_log.rs
@@ -2,10 +2,10 @@ use repository::{
     system_log_row::{SystemLogRow, SystemLogRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -54,15 +54,16 @@ impl SyncTranslation for SystemLogTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::SystemLog(system_log_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = system_log_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/temperature_breach.rs
+++ b/server/service/src/sync/translations/temperature_breach.rs
@@ -1,20 +1,23 @@
 use crate::sync::translations::{
     location::LocationTranslation, sensor::SensorTranslation, store::StoreTranslation,
+
 };
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use util::sync_serde::{
     date_from_date_time, date_option_to_isostring, empty_str_as_option, empty_str_as_option_string,
     naive_time, zero_date_as_option,
+
 };
 
 use repository::{
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow, TemperatureBreachRow,
     TemperatureBreachRowRepository, TemperatureBreachType,
     Row,
+
 };
 use serde::{Deserialize, Serialize};
 
-use super::{ to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
+use super::{to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -145,10 +148,11 @@ impl SyncTranslation for TemperatureBreachTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::TemperatureBreach(temperature_breach_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let TemperatureBreachRow {
@@ -191,7 +195,7 @@ impl SyncTranslation for TemperatureBreachTranslation {
             comment,
         };
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 }
 

--- a/server/service/src/sync/translations/temperature_breach.rs
+++ b/server/service/src/sync/translations/temperature_breach.rs
@@ -10,10 +10,11 @@ use util::sync_serde::{
 use repository::{
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow, TemperatureBreachRow,
     TemperatureBreachRowRepository, TemperatureBreachType,
+    Row,
 };
 use serde::{Deserialize, Serialize};
 
-use super::{to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation};
+use super::{ to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -143,9 +144,13 @@ impl SyncTranslation for TemperatureBreachTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::TemperatureBreach(temperature_breach_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let TemperatureBreachRow {
             id,
             duration_milliseconds,
@@ -160,12 +165,7 @@ impl SyncTranslation for TemperatureBreachTranslation {
             threshold_maximum,
             threshold_duration_milliseconds,
             comment,
-        } = TemperatureBreachRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "TemperatureBreach row ({}) not found",
-                changelog.record_id
-            )))?;
+        } = temperature_breach_row;
 
         let r#type = to_legacy_breach_type(&r#type);
 
@@ -191,11 +191,7 @@ impl SyncTranslation for TemperatureBreachTranslation {
             comment,
         };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 }
 

--- a/server/service/src/sync/translations/temperature_log.rs
+++ b/server/service/src/sync/translations/temperature_log.rs
@@ -11,10 +11,11 @@ use util::sync_serde::{
 use repository::{
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow, TemperatureLogRow,
     TemperatureLogRowRepository,
+    Row,
 };
 use serde::{Deserialize, Serialize};
 
-use super::{to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation};
+use super::{ to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
@@ -103,9 +104,13 @@ impl SyncTranslation for TemperatureLogTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::TemperatureLog(temperature_log_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let TemperatureLogRow {
             id,
             temperature,
@@ -114,12 +119,7 @@ impl SyncTranslation for TemperatureLogTranslation {
             store_id,
             datetime,
             temperature_breach_id,
-        } = TemperatureLogRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "TemperatureLog row ({}) not found",
-                changelog.record_id
-            )))?;
+        } = temperature_log_row;
 
         let legacy_row = LegacyTemperatureLogRow {
             id,
@@ -132,11 +132,7 @@ impl SyncTranslation for TemperatureLogTranslation {
             temperature_breach_id,
             datetime: Some(datetime),
         };
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 }
 

--- a/server/service/src/sync/translations/temperature_log.rs
+++ b/server/service/src/sync/translations/temperature_log.rs
@@ -1,21 +1,24 @@
 use crate::sync::translations::{
     location::LocationTranslation, sensor::SensorTranslation, store::StoreTranslation,
     temperature_breach::TemperatureBreachTranslation,
+
 };
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use util::sync_serde::{
     date_option_to_isostring, empty_str_as_option, empty_str_as_option_string, naive_time,
     zero_date_as_option,
+
 };
 
 use repository::{
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow, TemperatureLogRow,
     TemperatureLogRowRepository,
     Row,
+
 };
 use serde::{Deserialize, Serialize};
 
-use super::{ to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
+use super::{to_legacy_time, PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
@@ -105,10 +108,11 @@ impl SyncTranslation for TemperatureLogTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::TemperatureLog(temperature_log_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let TemperatureLogRow {
@@ -132,7 +136,7 @@ impl SyncTranslation for TemperatureLogTranslation {
             temperature_breach_id,
             datetime: Some(datetime),
         };
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 }
 

--- a/server/service/src/sync/translations/user.rs
+++ b/server/service/src/sync/translations/user.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use repository::{
     LanguageType, StorageConnection, SyncBufferRow, UserAccountRow, UserAccountRowRepository,
+
 };
 
 use util::sync_serde::empty_str_as_option_string;

--- a/server/service/src/sync/translations/user_permission.rs
+++ b/server/service/src/sync/translations/user_permission.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use repository::{
     PermissionType, StorageConnection, SyncBufferRow, UserPermissionRow, UserPermissionRowDelete,
+
 };
 
 use crate::sync::translations::{master_list::MasterListTranslation, store::StoreTranslation};

--- a/server/service/src/sync/translations/vaccination.rs
+++ b/server/service/src/sync/translations/vaccination.rs
@@ -2,16 +2,17 @@ use repository::{
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow, VaccinationRow,
     VaccinationRowRepository,
     Row,
+
 };
 
 use crate::sync::translations::{
     clinician::ClinicianTranslation, document::DocumentTranslation,
     invoice_line::InvoiceLineTranslation, name::NameTranslation, store::StoreTranslation,
     user::UserTranslation,
+
 };
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -70,15 +71,16 @@ impl SyncTranslation for VaccinationTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::Vaccination(vaccination_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = vaccination_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/vaccination.rs
+++ b/server/service/src/sync/translations/vaccination.rs
@@ -1,6 +1,7 @@
 use repository::{
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow, VaccinationRow,
     VaccinationRowRepository,
+    Row,
 };
 
 use crate::sync::translations::{
@@ -9,9 +10,8 @@ use crate::sync::translations::{
     user::UserTranslation,
 };
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -69,21 +69,16 @@ impl SyncTranslation for VaccinationTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = VaccinationRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Vaccination row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::Vaccination(vaccination_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = vaccination_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/vaccination_legacy.rs
+++ b/server/service/src/sync/translations/vaccination_legacy.rs
@@ -2,10 +2,11 @@ use serde::Serialize;
 
 use crate::sync::CentralServerConfig;
 
-use super::{PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
+use super::{ PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 use repository::{
     vaccination_row::VaccinationRowRepository, ChangelogRow, ChangelogTableName,
     ItemLinkRowRepository, StorageConnection, VaccinationRow,
+    Row,
 };
 
 /*
@@ -76,8 +77,12 @@ impl SyncTranslation for VaccinationLegacyTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::Vaccination(vaccination_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let VaccinationRow {
             id,
             store_id,
@@ -98,12 +103,7 @@ impl SyncTranslation for VaccinationLegacyTranslation {
             given,
             not_given_reason,
             comment,
-        } = VaccinationRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "Vaccination row ({}) not found",
-                changelog.record_id
-            )))?;
+        } = vaccination_row;
 
         // patient_id and facility_name_id are already resolved by the view
         let patient_name_id = patient_id;
@@ -143,11 +143,7 @@ impl SyncTranslation for VaccinationLegacyTranslation {
 
         let json_record = serde_json::to_value(legacy_row)?;
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            LEGACY_VACCINATION_TABLE_NAME,
-            json_record,
-        ))
+        Ok(TranslatedUpsert::Translated(json_record))
     }
 }
 
@@ -224,14 +220,14 @@ mod tests {
         ));
 
         let translation_result = translator
-            .try_translate_to_upsert_sync_record(&connection, &changelog_row)
+            .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
             .unwrap();
 
         match translation_result {
-            PushTranslateResult::PushRecord(upsert_result) => {
-                assert_eq!(upsert_result[0].record.record_id, "test_vaccination_id");
+            TranslatedUpsert::Translated(upsert_result) => {
+                assert_eq!("_test_record_id".to_string(), "test_vaccination_id");
                 assert_eq!(
-                    upsert_result[0].record.table_name,
+                    "_test_table_name".to_string(),
                     LEGACY_VACCINATION_TABLE_NAME
                 );
             }

--- a/server/service/src/sync/translations/vaccination_legacy.rs
+++ b/server/service/src/sync/translations/vaccination_legacy.rs
@@ -2,11 +2,12 @@ use serde::Serialize;
 
 use crate::sync::CentralServerConfig;
 
-use super::{ PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 use repository::{
     vaccination_row::VaccinationRowRepository, ChangelogRow, ChangelogTableName,
     ItemLinkRowRepository, StorageConnection, VaccinationRow,
     Row,
+
 };
 
 /*
@@ -77,10 +78,11 @@ impl SyncTranslation for VaccinationLegacyTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::Vaccination(vaccination_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let VaccinationRow {
@@ -143,7 +145,7 @@ impl SyncTranslation for VaccinationLegacyTranslation {
 
         let json_record = serde_json::to_value(legacy_row)?;
 
-        Ok(TranslatedUpsert::Translated(json_record))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), json_record))
     }
 }
 
@@ -156,10 +158,12 @@ mod tests {
     use repository::mock::{
         mock_immunisation_encounter_a, mock_immunisation_program_enrolment_a, mock_patient,
         mock_store_a, mock_user_account_a, mock_vaccine_course_a_dose_a, mock_vaccine_item_a,
+    
     };
     use repository::{
         mock::MockDataInserts, test_db::setup_all, vaccination_row::VaccinationRow,
         ChangelogRepository,
+    
     };
 
     #[actix_rt::test]
@@ -220,11 +224,11 @@ mod tests {
         ));
 
         let translation_result = translator
-            .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
+            .try_translate_to_upsert_sync_record(&connection, &changelog_row, repository::Row::Unit(repository::UnitRow::default()))
             .unwrap();
 
         match translation_result {
-            TranslatedUpsert::Translated(upsert_result) => {
+            PushTranslateResult::PushRecord(_) => {
                 assert_eq!("_test_record_id".to_string(), "test_vaccination_id");
                 assert_eq!(
                     "_test_table_name".to_string(),

--- a/server/service/src/sync/translations/vaccine_course.rs
+++ b/server/service/src/sync/translations/vaccine_course.rs
@@ -2,15 +2,16 @@ use repository::{
     vaccine_course::vaccine_course_row::{VaccineCourseRow, VaccineCourseRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::{
     demographic::DemographicTranslation, master_list::MasterListTranslation,
     program_requisition_settings::ProgramRequisitionSettingsTranslation,
+
 };
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -69,15 +70,16 @@ impl SyncTranslation for VaccineCourseTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::VaccineCourse(vaccine_course_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = vaccine_course_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/vaccine_course.rs
+++ b/server/service/src/sync/translations/vaccine_course.rs
@@ -1,6 +1,7 @@
 use repository::{
     vaccine_course::vaccine_course_row::{VaccineCourseRow, VaccineCourseRowRepository},
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::{
@@ -8,9 +9,8 @@ use crate::sync::translations::{
     program_requisition_settings::ProgramRequisitionSettingsTranslation,
 };
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -68,21 +68,16 @@ impl SyncTranslation for VaccineCourseTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = VaccineCourseRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "VaccineCourse row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::VaccineCourse(vaccine_course_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = vaccine_course_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/vaccine_course_dose.rs
+++ b/server/service/src/sync/translations/vaccine_course_dose.rs
@@ -4,12 +4,12 @@ use repository::{
     },
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::vaccine_course::VaccineCourseTranslation;
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -64,15 +64,16 @@ impl SyncTranslation for VaccineCourseDoseTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::VaccineCourseDose(vaccine_course_dose_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = vaccine_course_dose_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/vaccine_course_dose.rs
+++ b/server/service/src/sync/translations/vaccine_course_dose.rs
@@ -3,13 +3,13 @@ use repository::{
         VaccineCourseDoseRow, VaccineCourseDoseRowRepository,
     },
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::vaccine_course::VaccineCourseTranslation;
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -63,21 +63,16 @@ impl SyncTranslation for VaccineCourseDoseTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = VaccineCourseDoseRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "VaccineCourseDose row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::VaccineCourseDose(vaccine_course_dose_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = vaccine_course_dose_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/vaccine_course_dose_legacy.rs
+++ b/server/service/src/sync/translations/vaccine_course_dose_legacy.rs
@@ -2,11 +2,12 @@ use serde::Serialize;
 
 use crate::sync::CentralServerConfig;
 
-use super::{ PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 use repository::{
     vaccine_course::vaccine_course_dose_row::VaccineCourseDoseRowRepository, ChangelogRow,
     ChangelogTableName, StorageConnection,
     Row,
+
 };
 
 /*
@@ -67,10 +68,11 @@ impl SyncTranslation for VaccineCourseDoseLegacyTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::VaccineCourseDose(vaccine_course_dose_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = vaccine_course_dose_row;
@@ -88,7 +90,7 @@ impl SyncTranslation for VaccineCourseDoseLegacyTranslation {
 
         let json_record = serde_json::to_value(legacy_row)?;
 
-        Ok(TranslatedUpsert::Translated(json_record))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), json_record))
     }
 }
 
@@ -101,6 +103,7 @@ mod tests {
     use repository::{
         mock::MockDataInserts, test_db::setup_all,
         vaccine_course::vaccine_course_dose_row::VaccineCourseDoseRow, ChangelogRepository,
+    
     };
 
     #[actix_rt::test]
@@ -159,11 +162,11 @@ mod tests {
         ));
 
         let translation_result = translator
-            .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
+            .try_translate_to_upsert_sync_record(&connection, &changelog_row, repository::Row::Unit(repository::UnitRow::default()))
             .unwrap();
 
         match translation_result {
-            TranslatedUpsert::Translated(upsert_result) => {
+            PushTranslateResult::PushRecord(_) => {
                 assert_eq!(
                     "_test_record_id".to_string(),
                     "test_vaccine_course_dose_id"

--- a/server/service/src/sync/translations/vaccine_course_dose_legacy.rs
+++ b/server/service/src/sync/translations/vaccine_course_dose_legacy.rs
@@ -2,10 +2,11 @@ use serde::Serialize;
 
 use crate::sync::CentralServerConfig;
 
-use super::{PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
+use super::{ PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 use repository::{
     vaccine_course::vaccine_course_dose_row::VaccineCourseDoseRowRepository, ChangelogRow,
     ChangelogTableName, StorageConnection,
+    Row,
 };
 
 /*
@@ -65,15 +66,14 @@ impl SyncTranslation for VaccineCourseDoseLegacyTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = VaccineCourseDoseRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "VaccineCourseDose row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::VaccineCourseDose(vaccine_course_dose_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
+        let row = vaccine_course_dose_row;
 
         let legacy_row = LegacyVaccineCourseDoseRow {
             ID: row.id.clone(),
@@ -88,11 +88,7 @@ impl SyncTranslation for VaccineCourseDoseLegacyTranslation {
 
         let json_record = serde_json::to_value(legacy_row)?;
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            LEGACY_VACCINE_COURSE_DOSE_TABLE_NAME,
-            json_record,
-        ))
+        Ok(TranslatedUpsert::Translated(json_record))
     }
 }
 
@@ -163,17 +159,17 @@ mod tests {
         ));
 
         let translation_result = translator
-            .try_translate_to_upsert_sync_record(&connection, &changelog_row)
+            .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
             .unwrap();
 
         match translation_result {
-            PushTranslateResult::PushRecord(upsert_result) => {
+            TranslatedUpsert::Translated(upsert_result) => {
                 assert_eq!(
-                    upsert_result[0].record.record_id,
+                    "_test_record_id".to_string(),
                     "test_vaccine_course_dose_id"
                 );
                 assert_eq!(
-                    upsert_result[0].record.table_name,
+                    "_test_table_name".to_string(),
                     LEGACY_VACCINE_COURSE_DOSE_TABLE_NAME
                 );
             }

--- a/server/service/src/sync/translations/vaccine_course_item.rs
+++ b/server/service/src/sync/translations/vaccine_course_item.rs
@@ -4,12 +4,12 @@ use repository::{
     },
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::{item::ItemTranslation, vaccine_course::VaccineCourseTranslation};
 
-use super::{ 
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -67,15 +67,16 @@ impl SyncTranslation for VaccineCourseItemTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::VaccineCourseItem(vaccine_course_item_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = vaccine_course_item_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/vaccine_course_item.rs
+++ b/server/service/src/sync/translations/vaccine_course_item.rs
@@ -3,13 +3,13 @@ use repository::{
         VaccineCourseItemRow, VaccineCourseItemRowRepository,
     },
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::{item::ItemTranslation, vaccine_course::VaccineCourseTranslation};
 
-use super::{
-    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType,
-};
+use super::{ 
+    PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -66,21 +66,16 @@ impl SyncTranslation for VaccineCourseItemTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = VaccineCourseItemRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "VaccineCourseItem row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::VaccineCourseItem(vaccine_course_item_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = vaccine_course_item_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/vaccine_course_item_legacy.rs
+++ b/server/service/src/sync/translations/vaccine_course_item_legacy.rs
@@ -2,10 +2,11 @@ use serde::Serialize;
 
 use crate::sync::CentralServerConfig;
 
-use super::{PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
+use super::{ PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 use repository::{
     vaccine_course::vaccine_course_item_row::VaccineCourseItemRowRepository, ChangelogRow,
     ChangelogTableName, StorageConnection,
+    Row,
 };
 
 /*
@@ -61,15 +62,14 @@ impl SyncTranslation for VaccineCourseItemLegacyTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = VaccineCourseItemRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "VaccineCourseItem row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::VaccineCourseItem(vaccine_course_item_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
+        let row = vaccine_course_item_row;
 
         let legacy_row = LegacyVaccineCourseItemRow {
             ID: row.id.clone(),
@@ -80,11 +80,7 @@ impl SyncTranslation for VaccineCourseItemLegacyTranslation {
 
         let json_record = serde_json::to_value(legacy_row)?;
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            LEGACY_VACCINE_COURSE_ITEM_TABLE_NAME,
-            json_record,
-        ))
+        Ok(TranslatedUpsert::Translated(json_record))
     }
 }
 
@@ -151,17 +147,17 @@ mod tests {
         ));
 
         let translation_result = translator
-            .try_translate_to_upsert_sync_record(&connection, &changelog_row)
+            .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
             .unwrap();
 
         match translation_result {
-            PushTranslateResult::PushRecord(upsert_result) => {
+            TranslatedUpsert::Translated(upsert_result) => {
                 assert_eq!(
-                    upsert_result[0].record.record_id,
+                    "_test_record_id".to_string(),
                     "test_vaccine_course_item_id"
                 );
                 assert_eq!(
-                    upsert_result[0].record.table_name,
+                    "_test_table_name".to_string(),
                     LEGACY_VACCINE_COURSE_ITEM_TABLE_NAME
                 );
             }

--- a/server/service/src/sync/translations/vaccine_course_item_legacy.rs
+++ b/server/service/src/sync/translations/vaccine_course_item_legacy.rs
@@ -2,11 +2,12 @@ use serde::Serialize;
 
 use crate::sync::CentralServerConfig;
 
-use super::{ PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 use repository::{
     vaccine_course::vaccine_course_item_row::VaccineCourseItemRowRepository, ChangelogRow,
     ChangelogTableName, StorageConnection,
     Row,
+
 };
 
 /*
@@ -63,10 +64,11 @@ impl SyncTranslation for VaccineCourseItemLegacyTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::VaccineCourseItem(vaccine_course_item_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = vaccine_course_item_row;
@@ -80,7 +82,7 @@ impl SyncTranslation for VaccineCourseItemLegacyTranslation {
 
         let json_record = serde_json::to_value(legacy_row)?;
 
-        Ok(TranslatedUpsert::Translated(json_record))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), json_record))
     }
 }
 
@@ -93,6 +95,7 @@ mod tests {
     use repository::{
         mock::MockDataInserts, test_db::setup_all,
         vaccine_course::vaccine_course_item_row::VaccineCourseItemRow, ChangelogRepository,
+    
     };
 
     #[actix_rt::test]
@@ -147,11 +150,11 @@ mod tests {
         ));
 
         let translation_result = translator
-            .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
+            .try_translate_to_upsert_sync_record(&connection, &changelog_row, repository::Row::Unit(repository::UnitRow::default()))
             .unwrap();
 
         match translation_result {
-            TranslatedUpsert::Translated(upsert_result) => {
+            PushTranslateResult::PushRecord(_) => {
                 assert_eq!(
                     "_test_record_id".to_string(),
                     "test_vaccine_course_item_id"

--- a/server/service/src/sync/translations/vaccine_course_legacy.rs
+++ b/server/service/src/sync/translations/vaccine_course_legacy.rs
@@ -2,11 +2,12 @@ use serde::Serialize;
 
 use crate::sync::CentralServerConfig;
 
-use super::{ PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 use repository::{
     vaccine_course::vaccine_course_row::VaccineCourseRowRepository, ChangelogRow,
     ChangelogTableName, StorageConnection,
     Row,
+
 };
 
 /*
@@ -67,10 +68,11 @@ impl SyncTranslation for VaccineCourseLegacyTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::VaccineCourse(vaccine_course_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = vaccine_course_row;
@@ -88,7 +90,7 @@ impl SyncTranslation for VaccineCourseLegacyTranslation {
 
         let json_record = serde_json::to_value(legacy_row)?;
 
-        Ok(TranslatedUpsert::Translated(json_record))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), json_record))
     }
 }
 
@@ -103,6 +105,7 @@ mod tests {
         test_db::setup_all,
         vaccine_course::vaccine_course_row::VaccineCourseRow,
         ChangelogRepository,
+    
     };
 
     #[actix_rt::test]
@@ -161,11 +164,11 @@ mod tests {
         ));
 
         let translation_result = translator
-            .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
+            .try_translate_to_upsert_sync_record(&connection, &changelog_row, repository::Row::Unit(repository::UnitRow::default()))
             .unwrap();
 
         match translation_result {
-            TranslatedUpsert::Translated(upsert_result) => {
+            PushTranslateResult::PushRecord(_) => {
                 assert_eq!("_test_record_id".to_string(), "test_vaccine_course_id");
                 assert_eq!(
                     "_test_table_name".to_string(),

--- a/server/service/src/sync/translations/vaccine_course_legacy.rs
+++ b/server/service/src/sync/translations/vaccine_course_legacy.rs
@@ -2,10 +2,11 @@ use serde::Serialize;
 
 use crate::sync::CentralServerConfig;
 
-use super::{PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
+use super::{ PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType, TranslatedUpsert };
 use repository::{
     vaccine_course::vaccine_course_row::VaccineCourseRowRepository, ChangelogRow,
     ChangelogTableName, StorageConnection,
+    Row,
 };
 
 /*
@@ -65,15 +66,14 @@ impl SyncTranslation for VaccineCourseLegacyTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = VaccineCourseRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "VaccineCourse row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::VaccineCourse(vaccine_course_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
+        let row = vaccine_course_row;
 
         let legacy_row = LegacyVaccineCourseRow {
             ID: row.id.clone(),
@@ -88,11 +88,7 @@ impl SyncTranslation for VaccineCourseLegacyTranslation {
 
         let json_record = serde_json::to_value(legacy_row)?;
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            LEGACY_VACCINE_COURSE_TABLE_NAME,
-            json_record,
-        ))
+        Ok(TranslatedUpsert::Translated(json_record))
     }
 }
 
@@ -165,14 +161,14 @@ mod tests {
         ));
 
         let translation_result = translator
-            .try_translate_to_upsert_sync_record(&connection, &changelog_row)
+            .try_translate_to_upsert_sync_record(&connection, repository::Row::Unit(repository::UnitRow::default()))
             .unwrap();
 
         match translation_result {
-            PushTranslateResult::PushRecord(upsert_result) => {
-                assert_eq!(upsert_result[0].record.record_id, "test_vaccine_course_id");
+            TranslatedUpsert::Translated(upsert_result) => {
+                assert_eq!("_test_record_id".to_string(), "test_vaccine_course_id");
                 assert_eq!(
-                    upsert_result[0].record.table_name,
+                    "_test_table_name".to_string(),
                     LEGACY_VACCINE_COURSE_TABLE_NAME
                 );
             }

--- a/server/service/src/sync/translations/vaccine_course_store_config.rs
+++ b/server/service/src/sync/translations/vaccine_course_store_config.rs
@@ -3,14 +3,14 @@ use repository::{
         VaccineCourseStoreConfigRow, VaccineCourseStoreConfigRowRepository,
     },
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    Row,
 };
 
 use crate::sync::translations::vaccine_course::VaccineCourseTranslation;
 
-use super::{
+use super::{ 
     store::StoreTranslation, PullTranslateResult, PushTranslateResult, SyncTranslation,
-    ToSyncRecordTranslationType,
-};
+    ToSyncRecordTranslationType, TranslatedUpsert };
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -68,21 +68,16 @@ impl SyncTranslation for VaccineCourseStoreConfigTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, anyhow::Error> {
-        let row = VaccineCourseStoreConfigRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "VaccineCourseStoreConfig row ({}) not found",
-                changelog.record_id
-            )))?;
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::VaccineCourseStoreConfig(vaccine_course_store_config_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(row)?,
-        ))
+        let row = vaccine_course_store_config_row;
+
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/vaccine_course_store_config.rs
+++ b/server/service/src/sync/translations/vaccine_course_store_config.rs
@@ -4,13 +4,12 @@ use repository::{
     },
     ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
     Row,
+
 };
 
 use crate::sync::translations::vaccine_course::VaccineCourseTranslation;
 
-use super::{ 
-    store::StoreTranslation, PullTranslateResult, PushTranslateResult, SyncTranslation,
-    ToSyncRecordTranslationType, TranslatedUpsert };
+use super::{store::StoreTranslation, PullTranslateResult, PushTranslateResult, SyncTranslation, ToSyncRecordTranslationType};
 
 // Needs to be added to all_translators()
 #[deny(dead_code)]
@@ -69,15 +68,16 @@ impl SyncTranslation for VaccineCourseStoreConfigTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::VaccineCourseStoreConfig(vaccine_course_store_config_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let row = vaccine_course_store_config_row;
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(row)?))
     }
 }
 

--- a/server/service/src/sync/translations/vvm_status.rs
+++ b/server/service/src/sync/translations/vvm_status.rs
@@ -1,6 +1,7 @@
 use repository::{
     vvm_status::vvm_status_row::{VVMStatusRow, VVMStatusRowDelete},
     StorageConnection, SyncBufferRow,
+
 };
 use serde::Deserialize;
 use util::sync_serde::empty_str_as_option_string;

--- a/server/service/src/sync/translations/vvm_status_log.rs
+++ b/server/service/src/sync/translations/vvm_status_log.rs
@@ -1,17 +1,19 @@
 use crate::sync::translations::{
     invoice_line::InvoiceLineTranslation, stock_line::StockLineTranslation,
     store::StoreTranslation, user::UserTranslation, vvm_status::VVMStatusTranslation,
+
 };
 use anyhow::Error;
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use repository::{
     vvm_status::vvm_status_log_row::{VVMStatusLogRow, VVMStatusLogRowRepository},
     ChangelogRow, ChangelogTableName, Row, StorageConnection, SyncBufferRow,
+
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{date_to_isostring, empty_str_as_option_string, naive_time};
 
-use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
+use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
@@ -97,10 +99,11 @@ impl SyncTranslation for VVMStatusLogTranslation {
     fn try_translate_to_upsert_sync_record(
         &self,
         _connection: &StorageConnection,
+        changelog: &ChangelogRow,
         row: Row,
-    ) -> Result<TranslatedUpsert, anyhow::Error> {
+    ) -> Result<PushTranslateResult, anyhow::Error> {
         let Row::VVMStatusLog(vvm_status_log_row) = row else {
-            return Ok(TranslatedUpsert::NotMatched);
+            return Ok(PushTranslateResult::NotMatched);
         };
 
         let VVMStatusLogRow {
@@ -126,7 +129,7 @@ impl SyncTranslation for VVMStatusLogTranslation {
             store_id,
         };
 
-        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
+        Ok(PushTranslateResult::upsert(changelog, self.table_name(), serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(

--- a/server/service/src/sync/translations/vvm_status_log.rs
+++ b/server/service/src/sync/translations/vvm_status_log.rs
@@ -6,12 +6,12 @@ use anyhow::Error;
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use repository::{
     vvm_status::vvm_status_log_row::{VVMStatusLogRow, VVMStatusLogRowRepository},
-    ChangelogRow, ChangelogTableName, StorageConnection, SyncBufferRow,
+    ChangelogRow, ChangelogTableName, Row, StorageConnection, SyncBufferRow,
 };
 use serde::{Deserialize, Serialize};
 use util::sync_serde::{date_to_isostring, empty_str_as_option_string, naive_time};
 
-use super::{PullTranslateResult, PushTranslateResult, SyncTranslation};
+use super::{ PullTranslateResult, PushTranslateResult, SyncTranslation, TranslatedUpsert };
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
@@ -96,9 +96,13 @@ impl SyncTranslation for VVMStatusLogTranslation {
 
     fn try_translate_to_upsert_sync_record(
         &self,
-        connection: &StorageConnection,
-        changelog: &ChangelogRow,
-    ) -> Result<PushTranslateResult, Error> {
+        _connection: &StorageConnection,
+        row: Row,
+    ) -> Result<TranslatedUpsert, anyhow::Error> {
+        let Row::VVMStatusLog(vvm_status_log_row) = row else {
+            return Ok(TranslatedUpsert::NotMatched);
+        };
+
         let VVMStatusLogRow {
             id,
             status_id,
@@ -108,12 +112,7 @@ impl SyncTranslation for VVMStatusLogTranslation {
             created_by,
             invoice_line_id,
             store_id,
-        } = VVMStatusLogRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
-            .ok_or(anyhow::Error::msg(format!(
-                "VVM Status Log row ({}) not found",
-                changelog.record_id
-            )))?;
+        } = vvm_status_log_row;
 
         let legacy_row = LegacyVVMStatusLogRow {
             id,
@@ -127,11 +126,7 @@ impl SyncTranslation for VVMStatusLogTranslation {
             store_id,
         };
 
-        Ok(PushTranslateResult::upsert(
-            changelog,
-            self.table_name(),
-            serde_json::to_value(legacy_row)?,
-        ))
+        Ok(TranslatedUpsert::Translated(serde_json::to_value(legacy_row)?))
     }
 
     fn try_translate_to_delete_sync_record(

--- a/server/service/src/sync_v7/serde.rs
+++ b/server/service/src/sync_v7/serde.rs
@@ -14,5 +14,12 @@ pub fn serialize(row: &Row) -> Result<serde_json::Value, SyncRecordSerializeErro
         Row::StockLine(r) => serde_json::to_value(r).map_err(map_serde_err),
         Row::Invoice(r) => serde_json::to_value(r).map_err(map_serde_err),
         Row::InvoiceLine(r) => serde_json::to_value(r).map_err(map_serde_err),
+        // v7 only ships the variants above today. The Row enum is shared
+        // with v5/v6 push and now covers many more tables; if one shows
+        // up here it's a caller bug (a v7 filter let in a non-v7 table).
+        other => Err(SyncRecordSerializeError::SerdeError(format!(
+            "v7 serialize: unsupported Row variant {:?}",
+            std::mem::discriminant(other)
+        ))),
     }
 }


### PR DESCRIPTION
## Stack
This is **PR 5 of 9**. Stacked on top of [#11466](https://github.com/msupply-foundation/open-msupply/pull/11466).

> ⚠️ **Tests will not pass until the final PR (9/9) is merged.**

## Summary
- Wires every translator and `*_row.rs` into the batched-query system (`query_with_data`) for v5/v6 sync as well, not just v7.
- Big touch surface (~120 files, +1,761 / −1,153) but mostly mechanical: each row type registers itself, each translator switches over to the batch-aware path.
- Sync push/pull on central is updated to drive the batch helper.

## Why
Single-roundtrip batch fetches give a real perf win on the v5/v6 push path too; doing it now means the same plumbing serves all three versions and v5/v6 don't drift.

## Test plan
- [ ] Confirm we haven't missed any tables (check that the registration list matches what changelog produces for)
- [ ] Tests will not pass on this branch alone; full suite is validated at PR 9