### PR TITLE
Sync stack 6/9: Add all tables to changelog

### DIFF
--- a/server/repository/src/db_diesel/abbreviation_row.rs
+++ b/server/repository/src/db_diesel/abbreviation_row.rs
@@ -1,8 +1,8 @@
 use super::abbreviation_row::abbreviation::dsl::*;
-use crate::Delete;
-use crate::RepositoryError;
-use crate::StorageConnection;
-use crate::{ChangelogSyncType, Upsert};
+use crate::{
+    ChangelogRepository, ChangelogSyncType, Delete, RepositoryError, RowActionType, SourceSiteId,
+    StorageConnection, Upsert,
+};
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -34,7 +34,7 @@ impl<'a> AbbreviationRowRepository<'a> {
         AbbreviationRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &AbbreviationRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &AbbreviationRow) -> Result<(), RepositoryError> {
         diesel::insert_into(abbreviation)
             .values(row)
             .on_conflict(id)
@@ -42,6 +42,17 @@ impl<'a> AbbreviationRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &AbbreviationRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = AbbreviationRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_all(&self) -> Result<Vec<AbbreviationRow>, RepositoryError> {
@@ -60,17 +71,50 @@ impl<'a> AbbreviationRowRepository<'a> {
         Ok(result)
     }
 
-    pub fn delete(&self, abbreviation_id: &str) -> Result<(), RepositoryError> {
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<AbbreviationRow>, RepositoryError> {
+        Ok(abbreviation
+            .filter(id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+
+    fn _delete(&self, abbreviation_id: &str) -> Result<(), RepositoryError> {
         diesel::delete(abbreviation.filter(id.eq(abbreviation_id)))
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn delete(&self, abbreviation_id: &str) -> Result<(), RepositoryError> {
+        self._delete(abbreviation_id)?;
+        let changelog = AbbreviationRow::generate_changelog(
+            abbreviation_id.to_string(),
+            self.connection,
+            RowActionType::Delete,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
 }
 
 impl Upsert for AbbreviationRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        AbbreviationRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        AbbreviationRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only
@@ -85,9 +129,28 @@ impl Upsert for AbbreviationRow {
 #[derive(Debug, Clone)]
 pub struct AbbreviationRowDelete(pub String);
 impl Delete for AbbreviationRowDelete {
-    fn delete_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        AbbreviationRowRepository::new(con).delete(&self.0)?;
-        Ok(()) // Table not in Changelog
+    fn delete_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        let repo = AbbreviationRowRepository::new(con);
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => {
+                AbbreviationRow::generate_changelog(
+                    self.0.clone(),
+                    con,
+                    RowActionType::Delete,
+                    SourceSiteId::SourceSiteId(source_site_id),
+                )?
+            }
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        repo._delete(&self.0)?;
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only

--- a/server/repository/src/db_diesel/assets/asset_log_reason_row.rs
+++ b/server/repository/src/db_diesel/assets/asset_log_reason_row.rs
@@ -93,7 +93,7 @@ impl<'a> AssetLogReasonRowRepository<'a> {
         let changelog = AssetLogReasonRow::generate_changelog(
             asset_log_reason_id.to_string(),
             self.connection,
-            RowActionType::Delete,
+            RowActionType::Upsert,
             SourceSiteId::CurrentSiteId,
         )?;
         ChangelogRepository::new(self.connection).insert(&changelog)?;

--- a/server/repository/src/db_diesel/category_row.rs
+++ b/server/repository/src/db_diesel/category_row.rs
@@ -1,5 +1,8 @@
 use super::item_link_row::item_link;
-use crate::{item_row::item, repository_error::RepositoryError, Delete, StorageConnection, ChangelogSyncType, Upsert};
+use crate::{
+    item_row::item, repository_error::RepositoryError, ChangelogRepository, ChangelogSyncType,
+    Delete, RowActionType, SourceSiteId, StorageConnection, Upsert,
+};
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 
@@ -35,7 +38,7 @@ impl<'a> CategoryRowRepository<'a> {
         CategoryRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, category_row: &CategoryRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, category_row: &CategoryRow) -> Result<(), RepositoryError> {
         diesel::insert_into(category::table)
             .values(category_row)
             .on_conflict(category::id)
@@ -44,6 +47,17 @@ impl<'a> CategoryRowRepository<'a> {
             .execute(self.connection.lock().connection())?;
 
         Ok(())
+    }
+
+    pub fn upsert_one(&self, category_row: &CategoryRow) -> Result<(), RepositoryError> {
+        self._upsert_one(category_row)?;
+        let changelog = CategoryRow::generate_changelog(
+            category_row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_one_by_id(
@@ -57,19 +71,51 @@ impl<'a> CategoryRowRepository<'a> {
         Ok(result)
     }
 
-    pub fn mark_deleted(&self, category_id: &str) -> Result<(), RepositoryError> {
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<CategoryRow>, RepositoryError> {
+        Ok(category::table
+            .filter(category::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+
+    fn _mark_deleted(&self, category_id: &str) -> Result<(), RepositoryError> {
         diesel::update(category::table.filter(category::id.eq(category_id)))
             .set(category::deleted_datetime.eq(Some(chrono::Utc::now().naive_utc())))
             .execute(self.connection.lock().connection())?;
 
         Ok(())
     }
+
+    pub fn mark_deleted(&self, category_id: &str) -> Result<(), RepositoryError> {
+        self._mark_deleted(category_id)?;
+        let changelog = CategoryRow::generate_changelog(
+            category_id.to_string(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
 }
 
 impl Upsert for CategoryRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        CategoryRowRepository::new(con).upsert_one(self)?;
-        // Not in changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        CategoryRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
         Ok(())
     }
 
@@ -81,12 +127,30 @@ impl Upsert for CategoryRow {
         )
     }
 }
+
 #[derive(Debug, Clone)]
 pub struct CategoryRowDelete(pub String);
 impl Delete for CategoryRowDelete {
-    fn delete_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        CategoryRowRepository::new(con).mark_deleted(&self.0)?;
-        Ok(()) // Table not in Changelog
+    fn delete_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        let repo = CategoryRowRepository::new(con);
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => CategoryRow::generate_changelog(
+                self.0.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        repo._mark_deleted(&self.0)?;
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
     // Test only
     fn assert_deleted(&self, con: &StorageConnection) {

--- a/server/repository/src/db_diesel/changelog/batch_query.rs
+++ b/server/repository/src/db_diesel/changelog/batch_query.rs
@@ -1,146 +1,65 @@
 use std::collections::HashMap;
 
 use crate::{
-    ActivityLogRow,
-    ActivityLogRowRepository,
-    AssetCatalogueItemRow,
-    AssetCatalogueItemRowRepository,
-    AssetCategoryRow,
-    AssetCategoryRowRepository,
-    AssetClassRow,
-    AssetClassRowRepository,
-    AssetInternalLocationRow,
-    AssetInternalLocationRowRepository,
-    AssetLogReasonRow,
-    AssetLogReasonRowRepository,
-    AssetLogRow,
-    AssetLogRowRepository,
-    AssetPropertyRow,
-    AssetPropertyRowRepository,
-    AssetRow,
-    AssetRowRepository,
-    BackendPluginRow,
-    BackendPluginRowRepository,
-    BarcodeRow,
-    BarcodeRowRepository,
-    BundledItemRow,
-    BundledItemRowRepository,
-    CampaignRow,
-    CampaignRowRepository,
-    ChangelogCondition,
-    ChangelogRepository,
-    ChangelogRow,
-    ChangelogTableName,
-    ClinicianRow,
-    ClinicianRowRepository,
-    ClinicianStoreJoinRow,
-    ClinicianStoreJoinRowRepository,
-    ContactFormRow,
-    ContactFormRowRepository,
-    CurrencyRow,
-    CurrencyRowRepository,
+    AbbreviationRow, AbbreviationRowRepository, ActivityLogRow, ActivityLogRowRepository,
+    AssetCatalogueItemRow, AssetCatalogueItemRowRepository, AssetCategoryRow,
+    AssetCategoryRowRepository, AssetClassRow, AssetClassRowRepository, AssetInternalLocationRow,
+    AssetInternalLocationRowRepository, AssetLogReasonRow, AssetLogReasonRowRepository, AssetLogRow,
+    AssetLogRowRepository, AssetPropertyRow, AssetPropertyRowRepository, AssetRow,
+    AssetRowRepository, BackendPluginRow, BackendPluginRowRepository, BarcodeRow,
+    BarcodeRowRepository, BundledItemRow, BundledItemRowRepository, CampaignRow,
+    CampaignRowRepository, ChangelogCondition, ChangelogRepository, ChangelogRow,
+    ChangelogTableName, ClinicianRow, ClinicianRowRepository, ClinicianStoreJoinRow,
+    ClinicianStoreJoinRowRepository, ContactFormRow, ContactFormRowRepository, ContactRow,
+    ContactRowRepository, ContextRow, ContextRowRepository, CurrencyRow, CurrencyRowRepository,
     CursorAndLimit,
-    DemographicRow,
-    DemographicRowRepository,
-    DocumentRepository,
-    DocumentRow,
-    EncounterRow,
-    EncounterRowRepository,
-    FormSchemaRow,
-    FormSchemaRowRepository,
-    FrontendPluginRow,
-    FrontendPluginRowRepository,
-    IndicatorValueRow,
-    IndicatorValueRowRepository,
-    InsuranceProviderRow,
-    InsuranceProviderRowRepository,
-    InvoiceLineRow,
-    InvoiceLineRowRepository,
-    InvoiceRow,
-    InvoiceRowRepository,
-    ItemRow,
-    ItemRowRepository,
-    ItemVariantRow,
-    ItemVariantRowRepository,
-    LocationMovementRow,
-    LocationMovementRowRepository,
-    LocationRow,
-    LocationRowRepository,
-    LocationTypeRow,
-    LocationTypeRowRepository,
-    MasterListRow,
-    MasterListRowRepository,
-    NameInsuranceJoinRow,
-    NameInsuranceJoinRowRepository,
-    NamePropertyRow,
-    NamePropertyRowRepository,
-    NameRow,
-    NameRowRepository,
-    NameStoreJoinRepository,
-    NameStoreJoinRow,
-    NumberRow,
-    NumberRowRepository,
-    PackagingVariantRow,
-    PackagingVariantRowRepository,
-    PluginDataRow,
-    PluginDataRowRepository,
-    PreferenceRow,
-    PreferenceRowRepository,
-    PropertyRow,
-    PropertyRowRepository,
-    PurchaseOrderLineRow,
-    PurchaseOrderLineRowRepository,
-    PurchaseOrderRow,
-    PurchaseOrderRowRepository,
-    ReportRow,
-    ReportRowRepository,
-    RepositoryError,
-    RequisitionLineRow,
-    RequisitionLineRowRepository,
-    RequisitionRow,
-    RequisitionRowRepository,
-    RnRFormLineRow,
-    RnRFormLineRowRepository,
-    RnRFormRow,
-    RnRFormRowRepository,
-    RowActionType,
-    SensorRow,
-    SensorRowRepository,
-    StockLineRow,
-    StockLineRowRepository,
-    StocktakeLineRow,
-    StocktakeLineRowRepository,
-    StocktakeRow,
-    StocktakeRowRepository,
-    StorageConnection,
-    StoreRow,
-    StoreRowRepository,
-    SyncFileReferenceRow,
-    SyncFileReferenceRowRepository,
-    SyncMessageRow,
-    SyncMessageRowRepository,
-    SystemLogRow,
-    SystemLogRowRepository,
-    TemperatureBreachConfigRow,
-    TemperatureBreachConfigRowRepository,
-    TemperatureBreachRow,
-    TemperatureBreachRowRepository,
-    TemperatureLogRow,
-    TemperatureLogRowRepository,
-    UnitRow,
-    UnitRowRepository,
-    VVMStatusLogRow,
-    VVMStatusLogRowRepository,
-    VaccinationRow,
-    VaccinationRowRepository,
-    VaccineCourseDoseRow,
-    VaccineCourseDoseRowRepository,
-    VaccineCourseItemRow,
-    VaccineCourseItemRowRepository,
-    VaccineCourseRow,
-    VaccineCourseRowRepository,
-    VaccineCourseStoreConfigRow,
-    VaccineCourseStoreConfigRowRepository,
+    DemographicIndicatorRow, DemographicIndicatorRowRepository, DemographicProjectionRow,
+    DemographicProjectionRowRepository, DemographicRow, DemographicRowRepository, DiagnosisRow,
+    DiagnosisRowRepository, DocumentRegistryRow, DocumentRegistryRowRepository, DocumentRepository,
+    DocumentRow, EncounterRow, EncounterRowRepository, FormSchemaRow, FormSchemaRowRepository,
+    FrontendPluginRow, FrontendPluginRowRepository, IndicatorColumnRow,
+    IndicatorColumnRowRepository, IndicatorLineRow, IndicatorLineRowRepository, IndicatorValueRow,
+    IndicatorValueRowRepository, InsuranceProviderRow, InsuranceProviderRowRepository,
+    InvoiceLineRow, InvoiceLineRowRepository, InvoiceRow, InvoiceRowRepository, ItemDirectionRow,
+    ItemDirectionRowRepository, ItemRow, ItemRowRepository, ItemStoreJoinRow,
+    ItemStoreJoinRowRepository, ItemVariantRow, ItemVariantRowRepository, ItemWarningJoinRow,
+    ItemWarningJoinRowRepository, LocationMovementRow, LocationMovementRowRepository, LocationRow,
+    LocationRowRepository, LocationTypeRow, LocationTypeRowRepository, MasterListLineRow,
+    MasterListLineRowRepository, MasterListNameJoinRepository, MasterListNameJoinRow,
+    MasterListRow, MasterListRowRepository, NameInsuranceJoinRow, NameInsuranceJoinRowRepository,
+    NamePropertyRow, NamePropertyRowRepository, NameRow, NameRowRepository, NameStoreJoinRepository,
+    NameStoreJoinRow, NameTagJoinRepository, NameTagJoinRow, NameTagRow, NameTagRowRepository,
+    NumberRow, NumberRowRepository, PackagingVariantRow, PackagingVariantRowRepository, PeriodRow,
+    PeriodRowRepository, PeriodScheduleRow, PeriodScheduleRowRepository, PluginDataRow,
+    PluginDataRowRepository, PreferenceRow, PreferenceRowRepository, PrinterRow,
+    PrinterRowRepository, ProgramEnrolmentRow, ProgramEnrolmentRowRepository, ProgramEventRow,
+    ProgramEventRowRepository, ProgramIndicatorRow, ProgramIndicatorRowRepository,
+    ProgramRequisitionOrderTypeRow, ProgramRequisitionOrderTypeRowRepository,
+    ProgramRequisitionSettingsRow, ProgramRequisitionSettingsRowRepository, ProgramRow,
+    ProgramRowRepository, PropertyRow, PropertyRowRepository, PurchaseOrderLineRow,
+    PurchaseOrderLineRowRepository, PurchaseOrderRow, PurchaseOrderRowRepository, ReasonOptionRow,
+    ReasonOptionRowRepository, ReportRow, ReportRowRepository, RepositoryError, RequisitionLineRow,
+    RequisitionLineRowRepository, RequisitionRow, RequisitionRowRepository, RnRFormLineRow,
+    RnRFormLineRowRepository, RnRFormRow, RnRFormRowRepository, RowActionType, SensorRow,
+    SensorRowRepository, ShippingMethodRow, ShippingMethodRowRepository, StockLineRow,
+    StockLineRowRepository, StocktakeLineRow, StocktakeLineRowRepository, StocktakeRow,
+    StocktakeRowRepository, StorageConnection, StorePreferenceRow, StorePreferenceRowRepository,
+    StoreRow, StoreRowRepository, SyncFileReferenceRow, SyncFileReferenceRowRepository,
+    SyncMessageRow, SyncMessageRowRepository, SystemLogRow, SystemLogRowRepository,
+    TemperatureBreachConfigRow, TemperatureBreachConfigRowRepository, TemperatureBreachRow,
+    TemperatureBreachRowRepository, TemperatureLogRow, TemperatureLogRowRepository, UnitRow,
+    UnitRowRepository, UserAccountRow, UserAccountRowRepository, UserPermissionRow,
+    UserPermissionRowRepository, UserStoreJoinRow, UserStoreJoinRowRepository, VVMStatusLogRow,
+    VVMStatusLogRowRepository, VVMStatusRow, VVMStatusRowRepository, VaccinationRow,
+    VaccinationRowRepository, VaccineCourseDoseRow, VaccineCourseDoseRowRepository,
+    VaccineCourseItemRow, VaccineCourseItemRowRepository, VaccineCourseRow, VaccineCourseRowRepository,
+    VaccineCourseStoreConfigRow, VaccineCourseStoreConfigRowRepository,
+};
+// Types only reachable via their full submodule path (no flat re-export).
+use crate::{
+    category_row::{CategoryRow, CategoryRowRepository},
+    contact_trace_row::{ContactTraceRow, ContactTraceRowRepository},
+    item_category_row::{ItemCategoryJoinRow, ItemCategoryJoinRowRepository},
 };
 
 /// Max ids per IN-clause when batch-fetching rows; keeps us well below
@@ -218,6 +137,41 @@ pub enum Row {
     Preference(PreferenceRow),
     ContactForm(ContactFormRow),
     SystemLog(SystemLogRow),
+    Abbreviation(AbbreviationRow),
+    Category(CategoryRow),
+    Contact(ContactRow),
+    ContactTrace(ContactTraceRow),
+    Context(ContextRow),
+    DemographicIndicator(DemographicIndicatorRow),
+    DemographicProjection(DemographicProjectionRow),
+    Diagnosis(DiagnosisRow),
+    DocumentRegistry(DocumentRegistryRow),
+    IndicatorColumn(IndicatorColumnRow),
+    IndicatorLine(IndicatorLineRow),
+    ItemCategoryJoin(ItemCategoryJoinRow),
+    ItemDirection(ItemDirectionRow),
+    ItemStoreJoin(ItemStoreJoinRow),
+    ItemWarningJoin(ItemWarningJoinRow),
+    MasterListLine(MasterListLineRow),
+    MasterListNameJoin(MasterListNameJoinRow),
+    NameTag(NameTagRow),
+    NameTagJoin(NameTagJoinRow),
+    Period(PeriodRow),
+    PeriodSchedule(PeriodScheduleRow),
+    Printer(PrinterRow),
+    Program(ProgramRow),
+    ProgramEnrolment(ProgramEnrolmentRow),
+    ProgramEvent(ProgramEventRow),
+    ProgramIndicator(ProgramIndicatorRow),
+    ProgramRequisitionOrderType(ProgramRequisitionOrderTypeRow),
+    ProgramRequisitionSettings(ProgramRequisitionSettingsRow),
+    ReasonOption(ReasonOptionRow),
+    ShippingMethod(ShippingMethodRow),
+    StorePreference(StorePreferenceRow),
+    UserAccount(UserAccountRow),
+    UserPermission(UserPermissionRow),
+    UserStoreJoin(UserStoreJoinRow),
+    VVMStatus(VVMStatusRow),
 }
 
 /// Output entry of `query_with_data`. `Row` carries the loaded row
@@ -686,6 +640,189 @@ fn fetch_rows_for_table(
             ChangelogTableName::SystemLog => {
                 for r in SystemLogRowRepository::new(connection).find_many_by_id(chunk)? {
                     out.insert(r.id.clone(), Row::SystemLog(r));
+                }
+            }
+            ChangelogTableName::Abbreviation => {
+                for r in AbbreviationRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Abbreviation(r));
+                }
+            }
+            ChangelogTableName::Category => {
+                for r in CategoryRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Category(r));
+                }
+            }
+            ChangelogTableName::Contact => {
+                for r in ContactRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Contact(r));
+                }
+            }
+            ChangelogTableName::ContactTrace => {
+                for r in ContactTraceRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::ContactTrace(r));
+                }
+            }
+            ChangelogTableName::Context => {
+                for r in ContextRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Context(r));
+                }
+            }
+            ChangelogTableName::DemographicIndicator => {
+                for r in
+                    DemographicIndicatorRowRepository::new(connection).find_many_by_id(chunk)?
+                {
+                    out.insert(r.id.clone(), Row::DemographicIndicator(r));
+                }
+            }
+            ChangelogTableName::DemographicProjection => {
+                for r in
+                    DemographicProjectionRowRepository::new(connection).find_many_by_id(chunk)?
+                {
+                    out.insert(r.id.clone(), Row::DemographicProjection(r));
+                }
+            }
+            ChangelogTableName::Diagnosis => {
+                for r in DiagnosisRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Diagnosis(r));
+                }
+            }
+            ChangelogTableName::DocumentRegistry => {
+                for r in DocumentRegistryRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::DocumentRegistry(r));
+                }
+            }
+            ChangelogTableName::IndicatorColumn => {
+                for r in IndicatorColumnRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::IndicatorColumn(r));
+                }
+            }
+            ChangelogTableName::IndicatorLine => {
+                for r in IndicatorLineRowRepository::new(connection).find_many_by_ids(chunk)? {
+                    out.insert(r.id.clone(), Row::IndicatorLine(r));
+                }
+            }
+            ChangelogTableName::ItemCategoryJoin => {
+                for r in ItemCategoryJoinRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::ItemCategoryJoin(r));
+                }
+            }
+            ChangelogTableName::ItemDirection => {
+                for r in ItemDirectionRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::ItemDirection(r));
+                }
+            }
+            ChangelogTableName::ItemStoreJoin => {
+                for r in ItemStoreJoinRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::ItemStoreJoin(r));
+                }
+            }
+            ChangelogTableName::ItemWarningJoin => {
+                for r in ItemWarningJoinRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::ItemWarningJoin(r));
+                }
+            }
+            ChangelogTableName::MasterListLine => {
+                for r in MasterListLineRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::MasterListLine(r));
+                }
+            }
+            ChangelogTableName::MasterListNameJoin => {
+                for r in MasterListNameJoinRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::MasterListNameJoin(r));
+                }
+            }
+            ChangelogTableName::NameTag => {
+                for r in NameTagRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::NameTag(r));
+                }
+            }
+            ChangelogTableName::NameTagJoin => {
+                for r in NameTagJoinRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::NameTagJoin(r));
+                }
+            }
+            ChangelogTableName::Period => {
+                for r in PeriodRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Period(r));
+                }
+            }
+            ChangelogTableName::PeriodSchedule => {
+                for r in PeriodScheduleRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::PeriodSchedule(r));
+                }
+            }
+            ChangelogTableName::Printer => {
+                for r in PrinterRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Printer(r));
+                }
+            }
+            ChangelogTableName::Program => {
+                for r in ProgramRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::Program(r));
+                }
+            }
+            ChangelogTableName::ProgramEnrolment => {
+                for r in ProgramEnrolmentRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::ProgramEnrolment(r));
+                }
+            }
+            ChangelogTableName::ProgramEvent => {
+                for r in ProgramEventRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::ProgramEvent(r));
+                }
+            }
+            ChangelogTableName::ProgramIndicator => {
+                for r in ProgramIndicatorRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::ProgramIndicator(r));
+                }
+            }
+            ChangelogTableName::ProgramRequisitionOrderType => {
+                for r in ProgramRequisitionOrderTypeRowRepository::new(connection)
+                    .find_many_by_id(chunk)?
+                {
+                    out.insert(r.id.clone(), Row::ProgramRequisitionOrderType(r));
+                }
+            }
+            ChangelogTableName::ProgramRequisitionSettings => {
+                for r in ProgramRequisitionSettingsRowRepository::new(connection)
+                    .find_many_by_id(chunk)?
+                {
+                    out.insert(r.id.clone(), Row::ProgramRequisitionSettings(r));
+                }
+            }
+            ChangelogTableName::ReasonOption => {
+                for r in ReasonOptionRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::ReasonOption(r));
+                }
+            }
+            ChangelogTableName::ShippingMethod => {
+                for r in ShippingMethodRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::ShippingMethod(r));
+                }
+            }
+            ChangelogTableName::StorePreference => {
+                for r in StorePreferenceRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::StorePreference(r));
+                }
+            }
+            ChangelogTableName::UserAccount => {
+                for r in UserAccountRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::UserAccount(r));
+                }
+            }
+            ChangelogTableName::UserPermission => {
+                for r in UserPermissionRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::UserPermission(r));
+                }
+            }
+            ChangelogTableName::UserStoreJoin => {
+                for r in UserStoreJoinRowRepository::new(connection).find_many_by_id(chunk)? {
+                    out.insert(r.id.clone(), Row::UserStoreJoin(r));
+                }
+            }
+            ChangelogTableName::VVMStatus => {
+                for r in VVMStatusRowRepository::new(connection).find_many_by_ids(chunk)? {
+                    out.insert(r.id.clone(), Row::VVMStatus(r));
                 }
             }
             other => unimplemented!("query_with_data does not yet support {:?}", other),

--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -162,10 +162,45 @@ diesel_string_enum! {
         VaccineCourseStoreConfig,
 
         // ---- Central (not v6) ----
+        Abbreviation,
+        Category,
+        Contact,
+        ContactTrace,
+        Context,
+        DemographicIndicator,
+        DemographicProjection,
+        Diagnosis,
+        DocumentRegistry,
+        IndicatorColumn,
+        IndicatorLine,
+        ItemCategoryJoin,
+        ItemDirection,
+        ItemStoreJoin,
+        ItemWarningJoin,
         LocationType,
         MasterList,
+        MasterListLine,
+        MasterListNameJoin,
+        NameTag,
+        NameTagJoin,
+        Period,
+        PeriodSchedule,
+        Printer,
+        Program,
+        ProgramEnrolment,
+        ProgramEvent,
+        ProgramIndicator,
+        ProgramRequisitionOrderType,
+        ProgramRequisitionSettings,
+        ReasonOption,
+        ShippingMethod,
         Store,
+        StorePreference,
         Unit,
+        UserAccount,
+        UserPermission,
+        UserStoreJoin,
+        VVMStatus,
 
         // ---- ToLegacyCentralOnly (not v6) ----
         Site,
@@ -358,9 +393,49 @@ impl ChangelogTableName {
             ),
 
             // ----------------------------------------------------------
-            // Central (not v6) — central data synced via legacy mSupply
+            // Central (not v6) — central data synced via legacy mSupply.
+            // Also a catch-all bucket for tables not yet classified into a
+            // more specific sync style.
             // ----------------------------------------------------------
-            LocationType | MasterList | Store | Unit => (
+            Abbreviation
+            | Category
+            | Contact
+            | ContactTrace
+            | Context
+            | DemographicIndicator
+            | DemographicProjection
+            | Diagnosis
+            | DocumentRegistry
+            | IndicatorColumn
+            | IndicatorLine
+            | ItemCategoryJoin
+            | ItemDirection
+            | ItemStoreJoin
+            | ItemWarningJoin
+            | LocationType
+            | MasterList
+            | MasterListLine
+            | MasterListNameJoin
+            | NameTag
+            | NameTagJoin
+            | Period
+            | PeriodSchedule
+            | Printer
+            | Program
+            | ProgramEnrolment
+            | ProgramEvent
+            | ProgramIndicator
+            | ProgramRequisitionOrderType
+            | ProgramRequisitionSettings
+            | ReasonOption
+            | ShippingMethod
+            | Store
+            | StorePreference
+            | Unit
+            | UserAccount
+            | UserPermission
+            | UserStoreJoin
+            | VVMStatus => (
                 vec![Central],
                 SyncStyleOptions {
                     is_v6: false,

--- a/server/repository/src/db_diesel/changelog/generate_changelog.rs
+++ b/server/repository/src/db_diesel/changelog/generate_changelog.rs
@@ -5,19 +5,26 @@
 use super::{ChangeLogInsertRow, ChangelogTableName, RowActionType, RowOrId, SourceSiteId};
 // Types re-exported flat at the crate root via `pub use db_diesel::*`.
 use crate::{
-    ActivityLogRow, BackendPluginRow, BarcodeRow, ClinicianRow, ClinicianStoreJoinRow, CurrencyRow,
-    DemographicRow, Document, EncounterRow, FormSchemaJson, FrontendPluginRow, IndicatorValueRow,
-    InsuranceProviderRow, InvoiceLineRow, InvoiceLineRowRepository, InvoiceRow,
-    InvoiceRowRepository, LocationMovementRow, LocationRow, LocationRowRepository, MasterListRow,
-    NameOmsFieldsRow, NamePropertyRow, NameRow, NameStoreJoinRepository, NameStoreJoinRow,
-    PluginDataRow, PreferenceRow, PreferenceRowRepository, PropertyRow, PurchaseOrderLineRow,
-    PurchaseOrderLineRowRepository, PurchaseOrderRow, PurchaseOrderRowRepository, RepositoryError,
-    ReportRow, RequisitionLineRow, RequisitionLineRowRepository, RequisitionRow,
+    AbbreviationRow, ActivityLogRow, BackendPluginRow, BarcodeRow, ClinicianRow,
+    ClinicianStoreJoinRow, ContactRow, ContextRow, CurrencyRow, DemographicIndicatorRow,
+    DemographicProjectionRow, DemographicRow, DiagnosisRow, Document, DocumentRegistryRow,
+    EncounterRow, FormSchemaJson, FrontendPluginRow, IndicatorColumnRow, IndicatorLineRow,
+    IndicatorValueRow, InsuranceProviderRow, InvoiceLineRow, InvoiceLineRowRepository, InvoiceRow,
+    InvoiceRowRepository, ItemDirectionRow, ItemStoreJoinRow, ItemWarningJoinRow,
+    LocationMovementRow, LocationRow, LocationRowRepository, MasterListLineRow,
+    MasterListNameJoinRow, MasterListRow, NameOmsFieldsRow, NamePropertyRow, NameRow,
+    NameStoreJoinRepository, NameStoreJoinRow, NameTagJoinRow, NameTagRow, PeriodRow,
+    PeriodScheduleRow, PluginDataRow, PreferenceRow, PreferenceRowRepository, PrinterRow,
+    ProgramEnrolmentRow, ProgramEventRow, ProgramIndicatorRow, ProgramRequisitionOrderTypeRow,
+    ProgramRequisitionSettingsRow, ProgramRow, PropertyRow, PurchaseOrderLineRow,
+    PurchaseOrderLineRowRepository, PurchaseOrderRow, PurchaseOrderRowRepository, ReasonOptionRow,
+    ReportRow, RepositoryError, RequisitionLineRow, RequisitionLineRowRepository, RequisitionRow,
     RequisitionRowRepository, RnRFormLineRow, RnRFormLineRowRepository, RnRFormRow,
-    RnRFormRowRepository, SensorRow, StockLineRow, StockLineRowRepository, StocktakeLineRow,
-    StocktakeLineRowRepository, StocktakeRow, StocktakeRowRepository, StorageConnection,
-    StoreRowRepository, SyncFileReferenceRow, SyncMessageRow, TemperatureBreachConfigRow,
-    TemperatureBreachRow, TemperatureLogRow, VaccinationRow,
+    RnRFormRowRepository, SensorRow, ShippingMethodRow, StockLineRow, StockLineRowRepository,
+    StocktakeLineRow, StocktakeLineRowRepository, StocktakeRow, StocktakeRowRepository,
+    StorageConnection, StorePreferenceRow, StoreRowRepository, SyncFileReferenceRow,
+    SyncMessageRow, TemperatureBreachConfigRow, TemperatureBreachRow, TemperatureLogRow,
+    UserAccountRow, UserPermissionRow, UserStoreJoinRow, VaccinationRow,
 };
 // Types only reachable via their full submodule path (no flat re-export).
 use crate::{
@@ -25,7 +32,9 @@ use crate::{
         asset_catalogue_item_row::AssetCatalogueItemRow,
         asset_category_row::AssetCategoryRow,
         asset_class_row::AssetClassRow,
-        asset_internal_location_row::{AssetInternalLocationRow, AssetInternalLocationRowRepository},
+        asset_internal_location_row::{
+            AssetInternalLocationRow, AssetInternalLocationRowRepository,
+        },
         asset_log_reason_row::AssetLogReasonRow,
         asset_log_row::AssetLogRow,
         asset_property_row::AssetPropertyRow,
@@ -33,7 +42,10 @@ use crate::{
         asset_type_row::AssetTypeRow,
     },
     campaign::campaign_row::CampaignRow,
+    category_row::CategoryRow,
     contact_form_row::ContactFormRow,
+    contact_trace_row::ContactTraceRow,
+    item_category_row::ItemCategoryJoinRow,
     item_variant::{
         bundled_item_row::BundledItemRow, item_variant_row::ItemVariantRow,
         packaging_variant_row::PackagingVariantRow,
@@ -42,11 +54,13 @@ use crate::{
     system_log_row::SystemLogRow,
     vaccine_course::{
         vaccine_course_dose_row::VaccineCourseDoseRow,
-        vaccine_course_item_row::VaccineCourseItemRow,
-        vaccine_course_row::VaccineCourseRow,
+        vaccine_course_item_row::VaccineCourseItemRow, vaccine_course_row::VaccineCourseRow,
         vaccine_course_store_config_row::VaccineCourseStoreConfigRow,
     },
-    vvm_status::vvm_status_log_row::{VVMStatusLogRow, VVMStatusLogRowRepository},
+    vvm_status::{
+        vvm_status_log_row::{VVMStatusLogRow, VVMStatusLogRowRepository},
+        vvm_status_row::VVMStatusRow,
+    },
 };
 
 /// Returned from `PurchaseOrderLineRow::generate_changelogs`.
@@ -1357,6 +1371,601 @@ impl AssetPropertyRow {
     ) -> Result<ChangeLogInsertRow, RepositoryError> {
         Ok(ChangeLogInsertRow {
             table_name: ChangelogTableName::AssetProperty,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl AbbreviationRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Abbreviation,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl CategoryRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Category,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ContactRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Contact,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ContactTraceRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::ContactTrace,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ContextRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Context,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl DemographicIndicatorRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::DemographicIndicator,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl DemographicProjectionRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::DemographicProjection,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl DiagnosisRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Diagnosis,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl DocumentRegistryRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::DocumentRegistry,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl IndicatorColumnRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::IndicatorColumn,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl IndicatorLineRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::IndicatorLine,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ItemCategoryJoinRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::ItemCategoryJoin,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ItemDirectionRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::ItemDirection,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ItemStoreJoinRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::ItemStoreJoin,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ItemWarningJoinRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::ItemWarningJoin,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl MasterListLineRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::MasterListLine,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl MasterListNameJoinRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::MasterListNameJoin,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl NameTagRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::NameTag,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl NameTagJoinRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::NameTagJoin,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl PeriodRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Period,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl PeriodScheduleRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::PeriodSchedule,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl PrinterRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Printer,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ProgramRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::Program,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ProgramEnrolmentRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::ProgramEnrolment,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ProgramEventRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::ProgramEvent,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ProgramIndicatorRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::ProgramIndicator,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ProgramRequisitionOrderTypeRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::ProgramRequisitionOrderType,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ProgramRequisitionSettingsRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::ProgramRequisitionSettings,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ReasonOptionRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::ReasonOption,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl ShippingMethodRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::ShippingMethod,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl StorePreferenceRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::StorePreference,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl UserAccountRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::UserAccount,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl UserPermissionRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::UserPermission,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl UserStoreJoinRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::UserStoreJoin,
+            record_id,
+            row_action: action,
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
+impl VVMStatusRow {
+    pub(crate) fn generate_changelog(
+        record_id: String,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::VVMStatus,
             record_id,
             row_action: action,
             source_site_id: source_site_id.get_id(con)?,

--- a/server/repository/src/db_diesel/changelog/sync_styles.md
+++ b/server/repository/src/db_diesel/changelog/sync_styles.md
@@ -1,0 +1,107 @@
+# Changelog filtering and sync styles
+
+This document describes how the outgoing-sync query in [changelog.rs](changelog.rs) selects records for a remote site, and how each `ChangeLogSyncStyle` lines up with the per-table translators in [server/service/src/sync/translations/](../../../../../service/src/sync/translations/).
+
+## Filtering in `create_filtered_outgoing_sync_query`
+
+Defined at [changelog.rs:514-580](changelog.rs#L514-L580). It builds the query that picks which `changelog_deduped` rows should be sent to a given remote site during a v6 pull.
+
+### Sync style buckets
+
+Sync styles are declared per-table in [`ChangelogTableName::sync_style`](changelog.rs#L142-L213) and defined in [`ChangeLogSyncStyle`](changelog.rs#L130-L138):
+
+- **`Legacy`** — goes to legacy mSupply server, never picked up here.
+- **`Central`** — created on OMS central, fans out to every site.
+- **`Remote`** — site-owned data; only sent to sites that own the `store_id`.
+- **`File`** — sync file references; sent to all sites (handled by the `SyncFileReference` literal at [changelog.rs:564](changelog.rs#L564)).
+- **`RemoteAndCentral`** — behaves Remote when `store_id` is set, Central when `store_id` is null.
+- **`RemoteToCentral`** — flows site→central only; not selected here.
+- **`ProcessorOnly`** — never synced, used internally.
+
+### Filter layers applied
+
+1. **Cursor floor** — `cursor >= earliest` from [`create_base_query`](changelog.rs#L464-L468).
+2. **Skip echoes back to origin** ([changelog.rs:523-529](changelog.rs#L523-L529)) — when `is_initialized`, exclude rows whose `source_site_id` equals the requesting site (allow nulls). On initialisation this filter is skipped so the site receives the full set.
+3. **Table-name OR group** ([changelog.rs:561-577](changelog.rs#L561-L577)) — a row is included if it matches any of:
+   - `table_name IN central_sync_table_names` (all `Central` tables, [changelog.rs:534-536](changelog.rs#L534-L536)).
+   - `table_name = SyncFileReference` (every site receives these).
+   - `table_name IN remote_sync_table_names` (`Remote` + `RemoteAndCentral`, [changelog.rs:539-546](changelog.rs#L539-L546)) **AND** `store_id IN active_stores_for_site` — i.e. limited to stores whose `site_id = sync_site_id` ([changelog.rs:553-555](changelog.rs#L553-L555)).
+   - `table_name IN central_by_empty_store_id` (`RemoteAndCentral` only, [changelog.rs:549-551](changelog.rs#L549-L551)) **AND** `store_id IS NULL` — the "central-like" half of `RemoteAndCentral`.
+   - Special case: `table_name = Vaccination` **AND** `name_id` is a patient visible to the site via `name_store_join` ([changelog.rs:573-575](changelog.rs#L573-L575), helper at [changelog.rs:584-598](changelog.rs#L584-L598)). This bypasses the `store_id` check so vaccinations follow the patient.
+
+The pseudo-SQL in the comment block at [changelog.rs:496-510](changelog.rs#L496-L510) is the canonical summary of this shape. Other one-off rules (like the patient-vaccination clause) are intended to slot into the same OR group.
+
+## How records actually sync, by `ChangeLogSyncStyle`
+
+Two layers conspire here:
+
+1. **`ChangeLogSyncStyle`** in [changelog.rs:130-138](changelog.rs#L130-L138) decides **which remote sites** a row in the central changelog is fanned out to — it filters [`create_filtered_outgoing_sync_query`](changelog.rs#L514-L580).
+2. **`SyncTranslation::should_translate_to_sync_record`** ([mod.rs:465-480](../../../../../service/src/sync/translations/mod.rs#L465-L480)) per-table at [translations/](../../../../../service/src/sync/translations/) decides **which transport** carries the row: `PushToLegacyCentral` (remote → 4D mSupply central), `PushToOmSupplyCentral` (remote → OMS central, v6 push), `PullFromOmSupplyCentral` (OMS central → remote, v6 pull, filtered by the query above).
+
+The trait default is "push to legacy if `change_log_type()` matches; never push/pull v6 unless overridden."
+
+### `Legacy` — the legacy mSupply backbone
+
+`Number, Location, LocationMovement, StockLine, Invoice, InvoiceLine, Stocktake, StocktakeLine, Requisition, RequisitionLine, ActivityLog, Barcode, Clinician, ClinicianStoreJoin, Document, Sensor, TemperatureBreach, TemperatureBreachConfig, TemperatureLog, Currency, Item, IndicatorValue, InsuranceProvider, NameInsuranceJoin, VVMStatusLog, PurchaseOrder, PurchaseOrderLine`
+
+- Translators use trait defaults: **push to 4D legacy central** when changed; not pushed to OMS central; not selected by the v6 outgoing query (it filters out `Legacy`).
+- `Name` and `NameStoreJoin` are special: legacy by classification, but their translators also override `PushToOmSupplyCentral=true` so they round-trip via OMS too (with a guard against echoing rows received from legacy).
+- Effect: site ↔ 4D mSupply central; OMS central is not the source of truth.
+
+### `Central` — created on OMS central, fanned to all sites
+
+`BackendPlugin, PackVariant, AssetClass, AssetCategory, AssetCatalogueType, AssetCatalogueItem, AssetCatalogueItemProperty, AssetCatalogueProperty, AssetLogReason, AssetProperty, Property, NameProperty, NameOmsFields, Demographic, VaccineCourse, VaccineCourseItem, VaccineCourseDose, VaccineCourseStoreConfig, ItemVariant, PackagingVariant, BundledItem, FrontendPlugin, Report, FormSchema, Campaign`
+
+- Selected by the v6 query for **every** site (no `store_id` predicate).
+- Translators override only `PullFromOmSupplyCentral=true`; explicit `PushToLegacyCentral=false, PushToOmSupplyCentral=false` so a site can't push these back.
+- Quirks worth noting:
+  - `NameOmsFields` is `Central`-style but also has `PushToOmSupplyCentral=true`, allowing a site to write back to central.
+  - `VaccineCourse*` have parallel `*_legacy.rs` translators that **do** push to legacy central from OMS central — so OMS central re-publishes these records to 4D for stores still on legacy sync.
+
+### `Remote` — site-owned data
+
+`Asset, AssetInternalLocation, AssetLog, RnrForm, RnrFormLine, Vaccination, Encounter, SyncMessage`
+
+- v6 query only selects rows whose `store_id` belongs to a store on the requesting site ([changelog.rs:565-567](changelog.rs#L565-L567)).
+- Most translators set `PushToOmSupplyCentral=true` and `PullFromOmSupplyCentral=true` — so the site pushes to OMS central, and OMS central distributes back to the owning site (and not others). `SyncMessage` is pull-only on this list (handled elsewhere).
+- `Vaccination` has the patient-visibility special case in the query so it follows the patient even if the changelog row's `store_id` is on a different site.
+
+### `RemoteAndCentral` — hybrid by `store_id`
+
+`PluginData, Preference`
+
+- v6 query covers both halves: `store_id IS NOT NULL` → treated like `Remote` (only owning site); `store_id IS NULL` → fanned out like `Central` (every site, see [changelog.rs:568-570](changelog.rs#L568-L570)).
+- `PluginData` translator pushes both ways (`PushToOmSupplyCentral=true`, `PullFromOmSupplyCentral=true`); `Preference` is pull-only on the wire because it's only authored on central.
+
+### `RemoteToCentral` — one-way upload to OMS central
+
+`ContactForm, SystemLog`
+
+- Translators override `PushToOmSupplyCentral=true` only. They are deliberately **excluded** from the v6 outgoing query (no clause matches them), so OMS central does **not** redistribute them to other sites — and crucially, on re-initialisation a site does not get its old contact-forms / system-logs back.
+
+### `File` — sync file references
+
+`SyncFileReference`
+
+- v6 query has a hard-coded clause for it ([changelog.rs:564](changelog.rs#L564)): **every** site receives every reference row (the file blobs themselves are negotiated separately).
+- Translator overrides both `PushToOmSupplyCentral` and `PullFromOmSupplyCentral` to `true`.
+
+### `ProcessorOnly` — never on the wire
+
+`MasterList`
+
+- Not selected by any sync query and the translator does not set `change_log_type()`. The changelog entry exists purely so in-process processors can react to changes; nothing is shipped to other sites.
+
+## Summary table
+
+| Sync style | Site selection | Push to legacy | Push to OMS central | Pull from OMS central |
+|---|---|---|---|---|
+| `Legacy` | n/a (legacy transport) | yes | usually no (Name/NameStoreJoin: yes) | no |
+| `Central` | all sites | no | no (NameOmsFields: yes) | yes |
+| `Remote` | sites owning `store_id` (+ patient name for Vaccination) | no | yes | yes |
+| `RemoteAndCentral` | owning site if `store_id` set, else all sites | no | yes (PluginData), no (Preference) | yes |
+| `RemoteToCentral` | none (excluded from v6 query) | no | yes | no |
+| `File` | all sites | no | yes | yes |
+| `ProcessorOnly` | none | no | no | no |
+
+The single most useful invariant: `sync_style()` chooses **which sites are eligible recipients** in the v6 pull, and the translator's `should_translate_to_sync_record` chooses **which directions on the wire** the row actually moves. A row only reaches a site if both agree.

--- a/server/repository/src/db_diesel/contact_row.rs
+++ b/server/repository/src/db_diesel/contact_row.rs
@@ -1,7 +1,7 @@
 use crate::db_diesel::name_row::name;
 use crate::{
-    diesel_macros::define_linked_tables,
-    Delete, RepositoryError, StorageConnection, ChangelogSyncType, Upsert,
+    diesel_macros::define_linked_tables, ChangelogRepository, ChangelogSyncType, Delete,
+    RepositoryError, RowActionType, SourceSiteId, StorageConnection, Upsert,
 };
 use diesel::prelude::*;
 
@@ -81,7 +81,13 @@ impl<'a> ContactRowRepository<'a> {
 
     pub fn upsert_one(&self, row: &ContactRow) -> Result<(), RepositoryError> {
         self._upsert(row)?;
-        Ok(())
+        let changelog = ContactRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_all(&self) -> Result<Vec<ContactRow>, RepositoryError> {
@@ -97,6 +103,12 @@ impl<'a> ContactRowRepository<'a> {
         Ok(result)
     }
 
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<ContactRow>, RepositoryError> {
+        Ok(contact::table
+            .filter(contact::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+
     pub fn find_all_by_name_id(
         &self,
         input_name_id: &str,
@@ -108,17 +120,44 @@ impl<'a> ContactRowRepository<'a> {
         Ok(result)
     }
 
-    pub fn delete(&self, contact_id: &str) -> Result<(), RepositoryError> {
+    fn _delete(&self, contact_id: &str) -> Result<(), RepositoryError> {
         diesel::delete(contact_with_links::table.filter(contact_with_links::id.eq(contact_id)))
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn delete(&self, contact_id: &str) -> Result<(), RepositoryError> {
+        self._delete(contact_id)?;
+        let changelog = ContactRow::generate_changelog(
+            contact_id.to_string(),
+            self.connection,
+            RowActionType::Delete,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
 }
 
 impl Upsert for ContactRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        ContactRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        ContactRowRepository::new(con)._upsert(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only
@@ -132,9 +171,26 @@ impl Upsert for ContactRow {
 #[derive(Debug, Clone)]
 pub struct ContactRowDelete(pub String);
 impl Delete for ContactRowDelete {
-    fn delete_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        ContactRowRepository::new(con).delete(&self.0)?;
-        Ok(()) // Table not in Changelog
+    fn delete_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        let repo = ContactRowRepository::new(con);
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => ContactRow::generate_changelog(
+                self.0.clone(),
+                con,
+                RowActionType::Delete,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        repo._delete(&self.0)?;
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only

--- a/server/repository/src/db_diesel/contact_trace_row.rs
+++ b/server/repository/src/db_diesel/contact_trace_row.rs
@@ -1,6 +1,9 @@
 use super::{document::document, program_row::program, StorageConnection};
 
-use crate::{repository_error::RepositoryError, GenderType};
+use crate::{
+    repository_error::RepositoryError, ChangelogRepository, ChangelogSyncType, GenderType,
+    RowActionType, SourceSiteId, Upsert,
+};
 
 use chrono::{NaiveDate, NaiveDateTime};
 use diesel::prelude::*;
@@ -135,7 +138,7 @@ impl<'a> ContactTraceRowRepository<'a> {
         ContactTraceRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &ContactTraceRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &ContactTraceRow) -> Result<(), RepositoryError> {
         diesel::insert_into(contact_trace::dsl::contact_trace)
             .values(row.to_raw())
             .on_conflict(contact_trace::dsl::id)
@@ -145,11 +148,73 @@ impl<'a> ContactTraceRowRepository<'a> {
         Ok(())
     }
 
+    pub fn upsert_one(&self, row: &ContactTraceRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = ContactTraceRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
+
     pub async fn insert_one(&self, row: &ContactTraceRow) -> Result<(), RepositoryError> {
         diesel::insert_into(contact_trace::dsl::contact_trace)
             .values(row.to_raw())
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn find_one_by_id(
+        &self,
+        contact_trace_id: &str,
+    ) -> Result<Option<ContactTraceRow>, RepositoryError> {
+        let result = contact_trace_name_link_view::table
+            .filter(contact_trace_name_link_view::id.eq(contact_trace_id))
+            .first(self.connection.lock().connection())
+            .optional()?;
+        Ok(result)
+    }
+
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<ContactTraceRow>, RepositoryError> {
+        Ok(contact_trace_name_link_view::table
+            .filter(contact_trace_name_link_view::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+}
+
+impl Upsert for ContactTraceRow {
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        ContactTraceRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert!(ContactTraceRowRepository::new(con)
+            .find_one_by_id(&self.id)
+            .unwrap()
+            .is_some())
     }
 }
 

--- a/server/repository/src/db_diesel/context_row.rs
+++ b/server/repository/src/db_diesel/context_row.rs
@@ -1,6 +1,9 @@
 use super::StorageConnection;
 
-use crate::{repository_error::RepositoryError, ChangelogSyncType, Upsert};
+use crate::{
+    repository_error::RepositoryError, ChangelogRepository, ChangelogSyncType, RowActionType,
+    SourceSiteId, Upsert,
+};
 
 use diesel::prelude::*;
 
@@ -27,7 +30,7 @@ impl<'a> ContextRowRepository<'a> {
         ContextRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &ContextRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &ContextRow) -> Result<(), RepositoryError> {
         diesel::insert_into(context::dsl::context)
             .values(row)
             .on_conflict(context::dsl::id)
@@ -35,6 +38,17 @@ impl<'a> ContextRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &ContextRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = ContextRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub async fn insert_one(&self, row: &ContextRow) -> Result<(), RepositoryError> {
@@ -56,12 +70,34 @@ impl<'a> ContextRowRepository<'a> {
             .optional()?;
         Ok(result)
     }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<ContextRow>, RepositoryError> {
+        Ok(context::dsl::context
+            .filter(context::dsl::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for ContextRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        ContextRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        ContextRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only

--- a/server/repository/src/db_diesel/currency_row.rs
+++ b/server/repository/src/db_diesel/currency_row.rs
@@ -99,7 +99,7 @@ impl<'a> CurrencyRowRepository<'a> {
         let changelog = CurrencyRow::generate_changelog(
             currency_id.to_string(),
             self.connection,
-            RowActionType::Delete,
+            RowActionType::Upsert,
             SourceSiteId::CurrentSiteId,
         )?;
         ChangelogRepository::new(self.connection).insert(&changelog)
@@ -120,7 +120,7 @@ impl Delete for CurrencyRowDelete {
             ChangelogSyncType::SyncTypeV5V6 { source_site_id } => CurrencyRow::generate_changelog(
                 self.0.clone(),
                 con,
-                RowActionType::Delete,
+                RowActionType::Upsert,
                 SourceSiteId::SourceSiteId(source_site_id),
             )?,
             ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,

--- a/server/repository/src/db_diesel/demographic_indicator_row.rs
+++ b/server/repository/src/db_diesel/demographic_indicator_row.rs
@@ -1,6 +1,8 @@
 use super::StorageConnection;
 
-use crate::RepositoryError;
+use crate::{
+    ChangelogRepository, ChangelogSyncType, RepositoryError, RowActionType, SourceSiteId, Upsert,
+};
 
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -48,7 +50,7 @@ impl<'a> DemographicIndicatorRowRepository<'a> {
         DemographicIndicatorRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &DemographicIndicatorRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &DemographicIndicatorRow) -> Result<(), RepositoryError> {
         diesel::insert_into(demographic_indicator::table)
             .values(row)
             .on_conflict(demographic_indicator::id)
@@ -57,6 +59,17 @@ impl<'a> DemographicIndicatorRowRepository<'a> {
             .execute(self.connection.lock().connection())?;
 
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &DemographicIndicatorRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = DemographicIndicatorRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_one_by_id(
@@ -68,5 +81,45 @@ impl<'a> DemographicIndicatorRowRepository<'a> {
             .first(self.connection.lock().connection())
             .optional()?;
         Ok(result)
+    }
+
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<DemographicIndicatorRow>, RepositoryError> {
+        Ok(demographic_indicator::table
+            .filter(demographic_indicator::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+}
+
+impl Upsert for DemographicIndicatorRow {
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        DemographicIndicatorRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            DemographicIndicatorRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/demographic_projection_row.rs
+++ b/server/repository/src/db_diesel/demographic_projection_row.rs
@@ -1,6 +1,9 @@
 use super::StorageConnection;
 
-use crate::repository_error::RepositoryError;
+use crate::{
+    repository_error::RepositoryError, ChangelogRepository, ChangelogSyncType, RowActionType,
+    SourceSiteId, Upsert,
+};
 
 use diesel::prelude::*;
 use serde::Serialize;
@@ -38,7 +41,7 @@ impl<'a> DemographicProjectionRowRepository<'a> {
         DemographicProjectionRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &DemographicProjectionRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &DemographicProjectionRow) -> Result<(), RepositoryError> {
         diesel::insert_into(demographic_projection::table)
             .values(row)
             .on_conflict(demographic_projection::id)
@@ -46,6 +49,17 @@ impl<'a> DemographicProjectionRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &DemographicProjectionRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = DemographicProjectionRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_one_by_id(
@@ -57,5 +71,45 @@ impl<'a> DemographicProjectionRowRepository<'a> {
             .first(self.connection.lock().connection())
             .optional()?;
         Ok(result)
+    }
+
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<DemographicProjectionRow>, RepositoryError> {
+        Ok(demographic_projection::table
+            .filter(demographic_projection::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+}
+
+impl Upsert for DemographicProjectionRow {
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        DemographicProjectionRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            DemographicProjectionRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/diagnosis_row.rs
+++ b/server/repository/src/db_diesel/diagnosis_row.rs
@@ -1,7 +1,8 @@
 use super::diagnosis_row::diagnosis::dsl::*;
-use crate::RepositoryError;
-use crate::StorageConnection;
-use crate::{ChangelogSyncType, Upsert};
+use crate::{
+    ChangelogRepository, ChangelogSyncType, Delete, RepositoryError, RowActionType, SourceSiteId,
+    StorageConnection, Upsert,
+};
 use chrono::NaiveDate;
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -38,7 +39,7 @@ impl<'a> DiagnosisRowRepository<'a> {
         DiagnosisRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &DiagnosisRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &DiagnosisRow) -> Result<(), RepositoryError> {
         diesel::insert_into(diagnosis)
             .values(row)
             .on_conflict(id)
@@ -46,6 +47,17 @@ impl<'a> DiagnosisRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &DiagnosisRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = DiagnosisRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_all(&self) -> Result<Vec<DiagnosisRow>, RepositoryError> {
@@ -64,17 +76,50 @@ impl<'a> DiagnosisRowRepository<'a> {
         Ok(result)
     }
 
-    pub fn delete(&self, diagnosis_id: &str) -> Result<(), RepositoryError> {
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<DiagnosisRow>, RepositoryError> {
+        Ok(diagnosis
+            .filter(id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+
+    fn _delete(&self, diagnosis_id: &str) -> Result<(), RepositoryError> {
         diesel::delete(diagnosis.filter(id.eq(diagnosis_id)))
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn delete(&self, diagnosis_id: &str) -> Result<(), RepositoryError> {
+        self._delete(diagnosis_id)?;
+        let changelog = DiagnosisRow::generate_changelog(
+            diagnosis_id.to_string(),
+            self.connection,
+            RowActionType::Delete,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
 }
 
 impl Upsert for DiagnosisRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        DiagnosisRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        DiagnosisRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only
@@ -82,6 +127,40 @@ impl Upsert for DiagnosisRow {
         assert_eq!(
             DiagnosisRowRepository::new(con).find_one_by_id(&self.id),
             Ok(Some(self.clone()))
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DiagnosisRowDelete(pub String);
+impl Delete for DiagnosisRowDelete {
+    fn delete_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        let repo = DiagnosisRowRepository::new(con);
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => DiagnosisRow::generate_changelog(
+                self.0.clone(),
+                con,
+                RowActionType::Delete,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        repo._delete(&self.0)?;
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
+    }
+
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            DiagnosisRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
         )
     }
 }

--- a/server/repository/src/db_diesel/document_registry_row.rs
+++ b/server/repository/src/db_diesel/document_registry_row.rs
@@ -1,6 +1,9 @@
 use super::StorageConnection;
 
-use crate::{db_diesel::form_schema_row::form_schema, RepositoryError, ChangelogSyncType, Upsert};
+use crate::{
+    db_diesel::form_schema_row::form_schema, ChangelogRepository, ChangelogSyncType,
+    RepositoryError, RowActionType, SourceSiteId, Upsert,
+};
 
 use diesel::prelude::*;
 use diesel_derive_enum::DbEnum;
@@ -54,7 +57,7 @@ impl<'a> DocumentRegistryRowRepository<'a> {
         DocumentRegistryRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &DocumentRegistryRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &DocumentRegistryRow) -> Result<(), RepositoryError> {
         diesel::insert_into(document_registry::table)
             .values(row)
             .on_conflict(document_registry::id)
@@ -62,6 +65,17 @@ impl<'a> DocumentRegistryRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &DocumentRegistryRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = DocumentRegistryRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_one_by_id(&self, id: &str) -> Result<Option<DocumentRegistryRow>, RepositoryError> {
@@ -90,9 +104,25 @@ impl<'a> DocumentRegistryRowRepository<'a> {
 }
 
 impl Upsert for DocumentRegistryRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        DocumentRegistryRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        DocumentRegistryRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only

--- a/server/repository/src/db_diesel/indicator_column_row.rs
+++ b/server/repository/src/db_diesel/indicator_column_row.rs
@@ -1,5 +1,8 @@
 use super::{IndicatorValueType, StorageConnection};
-use crate::{repository_error::RepositoryError, ChangelogSyncType, Upsert};
+use crate::{
+    repository_error::RepositoryError, ChangelogRepository, ChangelogSyncType, RowActionType,
+    SourceSiteId, Upsert,
+};
 use diesel::prelude::*;
 
 table! {
@@ -35,7 +38,7 @@ impl<'a> IndicatorColumnRowRepository<'a> {
         IndicatorColumnRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &IndicatorColumnRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &IndicatorColumnRow) -> Result<(), RepositoryError> {
         let query = diesel::insert_into(indicator_column::table)
             .values(row)
             .on_conflict(indicator_column::id)
@@ -50,6 +53,17 @@ impl<'a> IndicatorColumnRowRepository<'a> {
         Ok(())
     }
 
+    pub fn upsert_one(&self, row: &IndicatorColumnRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = IndicatorColumnRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
+
     pub fn find_one_by_id(
         &self,
         record_id: &str,
@@ -59,6 +73,15 @@ impl<'a> IndicatorColumnRowRepository<'a> {
             .first(self.connection.lock().connection())
             .optional()?;
         Ok(result)
+    }
+
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<IndicatorColumnRow>, RepositoryError> {
+        Ok(indicator_column::table
+            .filter(indicator_column::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
     }
 
     pub fn find_many_by_indicator_ids(
@@ -72,9 +95,25 @@ impl<'a> IndicatorColumnRowRepository<'a> {
     }
 }
 impl Upsert for IndicatorColumnRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        IndicatorColumnRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        IndicatorColumnRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only

--- a/server/repository/src/db_diesel/indicator_line_row.rs
+++ b/server/repository/src/db_diesel/indicator_line_row.rs
@@ -1,6 +1,9 @@
 use super::StorageConnection;
 
-use crate::{repository_error::RepositoryError, ChangelogSyncType, Upsert};
+use crate::{
+    repository_error::RepositoryError, ChangelogRepository, ChangelogSyncType, RowActionType,
+    SourceSiteId, Upsert,
+};
 use diesel::prelude::*;
 use diesel_derive_enum::DbEnum;
 use serde::{Deserialize, Serialize};
@@ -53,7 +56,7 @@ impl<'a> IndicatorLineRowRepository<'a> {
         IndicatorLineRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &IndicatorLineRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &IndicatorLineRow) -> Result<(), RepositoryError> {
         diesel::insert_into(indicator_line::table)
             .values(row)
             .on_conflict(indicator_line::id)
@@ -61,6 +64,17 @@ impl<'a> IndicatorLineRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &IndicatorLineRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = IndicatorLineRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_one_by_id(
@@ -96,9 +110,25 @@ impl<'a> IndicatorLineRowRepository<'a> {
 }
 
 impl Upsert for IndicatorLineRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        IndicatorLineRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        IndicatorLineRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only

--- a/server/repository/src/db_diesel/item_category_row.rs
+++ b/server/repository/src/db_diesel/item_category_row.rs
@@ -1,5 +1,8 @@
 use super::{category_row::category, item_link_row::item_link, item_row::item, StorageConnection};
-use crate::{repository_error::RepositoryError, ChangelogSyncType, Upsert};
+use crate::{
+    repository_error::RepositoryError, ChangelogRepository, ChangelogSyncType, RowActionType,
+    SourceSiteId, Upsert,
+};
 
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
@@ -37,7 +40,7 @@ impl<'a> ItemCategoryJoinRowRepository<'a> {
         ItemCategoryJoinRowRepository { connection }
     }
 
-    pub fn upsert_one(
+    fn _upsert_one(
         &self,
         item_category_join_row: &ItemCategoryJoinRow,
     ) -> Result<(), RepositoryError> {
@@ -51,6 +54,20 @@ impl<'a> ItemCategoryJoinRowRepository<'a> {
         Ok(())
     }
 
+    pub fn upsert_one(
+        &self,
+        item_category_join_row: &ItemCategoryJoinRow,
+    ) -> Result<(), RepositoryError> {
+        self._upsert_one(item_category_join_row)?;
+        let changelog = ItemCategoryJoinRow::generate_changelog(
+            item_category_join_row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
+
     pub fn find_one_by_id(
         &self,
         item_category_join_id: &str,
@@ -62,19 +79,36 @@ impl<'a> ItemCategoryJoinRowRepository<'a> {
         Ok(result)
     }
 
-    pub fn delete(&self, item_category_join_id: &str) -> Result<(), RepositoryError> {
-        diesel::delete(
-            item_category_join::table.filter(item_category_join::id.eq(item_category_join_id)),
-        )
-        .execute(self.connection.lock().connection())?;
-        Ok(())
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<ItemCategoryJoinRow>, RepositoryError> {
+        Ok(item_category_join::table
+            .filter(item_category_join::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
     }
+
 }
 
 impl Upsert for ItemCategoryJoinRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        ItemCategoryJoinRowRepository::new(con).upsert_one(self)?;
-        // Not in changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        ItemCategoryJoinRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
         Ok(())
     }
 
@@ -86,3 +120,4 @@ impl Upsert for ItemCategoryJoinRow {
         )
     }
 }
+

--- a/server/repository/src/db_diesel/item_direction_row.rs
+++ b/server/repository/src/db_diesel/item_direction_row.rs
@@ -1,10 +1,10 @@
 use super::item_direction_row::item_direction::dsl::*;
 use super::item_link;
 use super::item_row::item;
-use crate::Delete;
-use crate::RepositoryError;
-use crate::StorageConnection;
-use crate::{ChangelogSyncType, Upsert};
+use crate::{
+    ChangelogRepository, ChangelogSyncType, Delete, RepositoryError, RowActionType, SourceSiteId,
+    StorageConnection, Upsert,
+};
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -42,7 +42,7 @@ impl<'a> ItemDirectionRowRepository<'a> {
         ItemDirectionRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &ItemDirectionRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &ItemDirectionRow) -> Result<(), RepositoryError> {
         diesel::insert_into(item_direction)
             .values(row)
             .on_conflict(id)
@@ -50,6 +50,17 @@ impl<'a> ItemDirectionRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &ItemDirectionRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = ItemDirectionRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_all(&self) -> Result<Vec<ItemDirectionRow>, RepositoryError> {
@@ -68,17 +79,53 @@ impl<'a> ItemDirectionRowRepository<'a> {
         Ok(result)
     }
 
-    pub fn delete(&self, item_direction_id: &str) -> Result<(), RepositoryError> {
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<ItemDirectionRow>, RepositoryError> {
+        Ok(item_direction
+            .filter(id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+
+    fn _delete(&self, item_direction_id: &str) -> Result<(), RepositoryError> {
         diesel::delete(item_direction.filter(id.eq(item_direction_id)))
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn delete(&self, item_direction_id: &str) -> Result<(), RepositoryError> {
+        self._delete(item_direction_id)?;
+        let changelog = ItemDirectionRow::generate_changelog(
+            item_direction_id.to_string(),
+            self.connection,
+            RowActionType::Delete,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
 }
 
 impl Upsert for ItemDirectionRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        ItemDirectionRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        ItemDirectionRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only
@@ -93,9 +140,28 @@ impl Upsert for ItemDirectionRow {
 #[derive(Debug, Clone)]
 pub struct ItemDirectionRowDelete(pub String);
 impl Delete for ItemDirectionRowDelete {
-    fn delete_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        ItemDirectionRowRepository::new(con).delete(&self.0)?;
-        Ok(()) // Table not in Changelog
+    fn delete_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        let repo = ItemDirectionRowRepository::new(con);
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => {
+                ItemDirectionRow::generate_changelog(
+                    self.0.clone(),
+                    con,
+                    RowActionType::Delete,
+                    SourceSiteId::SourceSiteId(source_site_id),
+                )?
+            }
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        repo._delete(&self.0)?;
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only

--- a/server/repository/src/db_diesel/item_store_join.rs
+++ b/server/repository/src/db_diesel/item_store_join.rs
@@ -1,6 +1,9 @@
 use diesel::prelude::*;
 
-use crate::{item_link, RepositoryError, StorageConnection, ChangelogSyncType, Upsert};
+use crate::{
+    item_link, ChangelogRepository, ChangelogSyncType, RepositoryError, RowActionType,
+    SourceSiteId, StorageConnection, Upsert,
+};
 
 table! {
   item_store_join (id) {
@@ -67,6 +70,23 @@ impl<'a> ItemStoreJoinRowRepositoryTrait<'a> for ItemStoreJoinRowRepository<'a> 
     }
 
     fn upsert_one(&self, row: &ItemStoreJoinRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = ItemStoreJoinRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
+}
+
+impl<'a> ItemStoreJoinRowRepository<'a> {
+    pub fn new(connection: &'a StorageConnection) -> Self {
+        ItemStoreJoinRowRepository { connection }
+    }
+
+    fn _upsert_one(&self, row: &ItemStoreJoinRow) -> Result<(), RepositoryError> {
         diesel::insert_into(item_store_join::dsl::item_store_join)
             .values(row)
             .on_conflict(item_store_join::dsl::id)
@@ -75,17 +95,36 @@ impl<'a> ItemStoreJoinRowRepositoryTrait<'a> for ItemStoreJoinRowRepository<'a> 
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
-}
 
-impl<'a> ItemStoreJoinRowRepository<'a> {
-    pub fn new(connection: &'a StorageConnection) -> Self {
-        ItemStoreJoinRowRepository { connection }
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<ItemStoreJoinRow>, RepositoryError> {
+        Ok(item_store_join::dsl::item_store_join
+            .filter(item_store_join::dsl::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
     }
 }
 
 impl Upsert for ItemStoreJoinRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        ItemStoreJoinRowRepository::new(con).upsert_one(self)?;
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        ItemStoreJoinRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
         Ok(())
     }
 

--- a/server/repository/src/db_diesel/item_warning_join_row.rs
+++ b/server/repository/src/db_diesel/item_warning_join_row.rs
@@ -1,5 +1,8 @@
 use super::{item_link, item_row::item, warning_row::warning};
-use crate::{RepositoryError, StorageConnection, ChangelogSyncType, Upsert};
+use crate::{
+    ChangelogRepository, ChangelogSyncType, RepositoryError, RowActionType, SourceSiteId,
+    StorageConnection, Upsert,
+};
 
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -40,7 +43,7 @@ impl<'a> ItemWarningJoinRowRepository<'a> {
         ItemWarningJoinRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &ItemWarningJoinRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &ItemWarningJoinRow) -> Result<(), RepositoryError> {
         diesel::insert_into(item_warning_join::table)
             .values(row)
             .on_conflict(item_warning_join::id)
@@ -48,6 +51,17 @@ impl<'a> ItemWarningJoinRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &ItemWarningJoinRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = ItemWarningJoinRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_one_by_id(
@@ -60,12 +74,37 @@ impl<'a> ItemWarningJoinRowRepository<'a> {
             .optional()?;
         Ok(result)
     }
+
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<ItemWarningJoinRow>, RepositoryError> {
+        Ok(item_warning_join::table
+            .filter(item_warning_join::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for ItemWarningJoinRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        ItemWarningJoinRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        ItemWarningJoinRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only

--- a/server/repository/src/db_diesel/master_list_line_row.rs
+++ b/server/repository/src/db_diesel/master_list_line_row.rs
@@ -3,7 +3,9 @@ use super::{
     master_list_row::master_list, StorageConnection,
 };
 use crate::repository_error::RepositoryError;
-use crate::{Delete, ChangelogSyncType, Upsert};
+use crate::{
+    ChangelogRepository, ChangelogSyncType, Delete, RowActionType, SourceSiteId, Upsert,
+};
 
 use diesel::prelude::*;
 
@@ -38,7 +40,7 @@ impl<'a> MasterListLineRowRepository<'a> {
         MasterListLineRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &MasterListLineRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &MasterListLineRow) -> Result<(), RepositoryError> {
         diesel::insert_into(master_list_line)
             .values(row)
             .on_conflict(id)
@@ -46,6 +48,17 @@ impl<'a> MasterListLineRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &MasterListLineRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = MasterListLineRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_one_by_id(
@@ -59,17 +72,53 @@ impl<'a> MasterListLineRowRepository<'a> {
         Ok(result)
     }
 
-    pub fn delete(&self, line_id: &str) -> Result<(), RepositoryError> {
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<MasterListLineRow>, RepositoryError> {
+        Ok(master_list_line
+            .filter(id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+
+    fn _delete(&self, line_id: &str) -> Result<(), RepositoryError> {
         diesel::delete(master_list_line.filter(id.eq(line_id)))
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn delete(&self, line_id: &str) -> Result<(), RepositoryError> {
+        self._delete(line_id)?;
+        let changelog = MasterListLineRow::generate_changelog(
+            line_id.to_string(),
+            self.connection,
+            RowActionType::Delete,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
 }
 
 impl Upsert for MasterListLineRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        MasterListLineRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        MasterListLineRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only
@@ -84,9 +133,28 @@ impl Upsert for MasterListLineRow {
 #[derive(Debug, Clone)]
 pub struct MasterListLineRowDelete(pub String);
 impl Delete for MasterListLineRowDelete {
-    fn delete_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        MasterListLineRowRepository::new(con).delete(&self.0)?;
-        Ok(()) // Table not in Changelog
+    fn delete_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        let repo = MasterListLineRowRepository::new(con);
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => {
+                MasterListLineRow::generate_changelog(
+                    self.0.clone(),
+                    con,
+                    RowActionType::Delete,
+                    SourceSiteId::SourceSiteId(source_site_id),
+                )?
+            }
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        repo._delete(&self.0)?;
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
     // Test only
     fn assert_deleted(&self, con: &StorageConnection) {

--- a/server/repository/src/db_diesel/master_list_name_join.rs
+++ b/server/repository/src/db_diesel/master_list_name_join.rs
@@ -6,7 +6,9 @@ use super::{
 use crate::diesel_macros::define_linked_tables;
 use crate::name_row::name;
 use crate::repository_error::RepositoryError;
-use crate::{Delete, ChangelogSyncType, Upsert};
+use crate::{
+    ChangelogRepository, ChangelogSyncType, Delete, RowActionType, SourceSiteId, Upsert,
+};
 use diesel::prelude::*;
 
 define_linked_tables! {
@@ -47,7 +49,13 @@ impl<'a> MasterListNameJoinRepository<'a> {
 
     pub fn upsert_one(&self, row: &MasterListNameJoinRow) -> Result<(), RepositoryError> {
         self._upsert(row)?;
-        Ok(())
+        let changelog = MasterListNameJoinRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_one_by_id(
@@ -61,7 +69,16 @@ impl<'a> MasterListNameJoinRepository<'a> {
         Ok(result)
     }
 
-    pub fn delete(&self, record_id: &str) -> Result<(), RepositoryError> {
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<MasterListNameJoinRow>, RepositoryError> {
+        Ok(master_list_name_join
+            .filter(id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+
+    fn _delete(&self, record_id: &str) -> Result<(), RepositoryError> {
         diesel::delete(
             master_list_name_join_with_links::table
                 .filter(master_list_name_join_with_links::id.eq(record_id)),
@@ -69,14 +86,44 @@ impl<'a> MasterListNameJoinRepository<'a> {
         .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn delete(&self, record_id: &str) -> Result<(), RepositoryError> {
+        self._delete(record_id)?;
+        let changelog = MasterListNameJoinRow::generate_changelog(
+            record_id.to_string(),
+            self.connection,
+            RowActionType::Delete,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct MasterListNameJoinRowDelete(pub String);
 impl Delete for MasterListNameJoinRowDelete {
-    fn delete_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        MasterListNameJoinRepository::new(con).delete(&self.0)?;
-        Ok(()) // Table not in Changelog
+    fn delete_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        let repo = MasterListNameJoinRepository::new(con);
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => {
+                MasterListNameJoinRow::generate_changelog(
+                    self.0.clone(),
+                    con,
+                    RowActionType::Delete,
+                    SourceSiteId::SourceSiteId(source_site_id),
+                )?
+            }
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        repo._delete(&self.0)?;
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
     // Test only
     fn assert_deleted(&self, con: &StorageConnection) {
@@ -88,9 +135,25 @@ impl Delete for MasterListNameJoinRowDelete {
 }
 
 impl Upsert for MasterListNameJoinRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        MasterListNameJoinRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        MasterListNameJoinRepository::new(con)._upsert(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only

--- a/server/repository/src/db_diesel/name_row.rs
+++ b/server/repository/src/db_diesel/name_row.rs
@@ -268,7 +268,7 @@ impl<'a> NameRowRepository<'a> {
         let changelog = NameRow::generate_changelog(
             name_id.to_string(),
             self.connection,
-            RowActionType::Delete,
+            RowActionType::Upsert,
             SourceSiteId::CurrentSiteId,
         )?;
         ChangelogRepository::new(self.connection).insert(&changelog)
@@ -371,7 +371,7 @@ impl Delete for NameRowDelete {
             ChangelogSyncType::SyncTypeV5V6 { source_site_id } => NameRow::generate_changelog(
                 self.0.clone(),
                 con,
-                RowActionType::Delete,
+                RowActionType::Upsert,
                 SourceSiteId::SourceSiteId(source_site_id),
             )?,
             ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,

--- a/server/repository/src/db_diesel/name_tag_join.rs
+++ b/server/repository/src/db_diesel/name_tag_join.rs
@@ -2,7 +2,9 @@ use super::{name_oms_fields, name_tag_row::name_tag, StorageConnection};
 use crate::diesel_macros::define_linked_tables;
 use crate::name_row::name;
 use crate::repository_error::RepositoryError;
-use crate::{Delete, ChangelogSyncType, Upsert};
+use crate::{
+    ChangelogRepository, ChangelogSyncType, Delete, RowActionType, SourceSiteId, Upsert,
+};
 use diesel::prelude::*;
 
 #[derive(Clone, Queryable, Insertable, Debug, PartialEq, Eq, AsChangeset, Default)]
@@ -43,7 +45,13 @@ impl<'a> NameTagJoinRepository<'a> {
 
     pub fn upsert_one(&self, row: &NameTagJoinRow) -> Result<(), RepositoryError> {
         self._upsert(row)?;
-        Ok(())
+        let changelog = NameTagJoinRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_one_by_id(&self, id: &str) -> Result<Option<NameTagJoinRow>, RepositoryError> {
@@ -54,19 +62,55 @@ impl<'a> NameTagJoinRepository<'a> {
         Ok(result)
     }
 
-    pub fn delete(&self, id: &str) -> Result<(), RepositoryError> {
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<NameTagJoinRow>, RepositoryError> {
+        Ok(name_tag_join::table
+            .filter(name_tag_join::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+
+    fn _delete(&self, id: &str) -> Result<(), RepositoryError> {
         diesel::delete(name_tag_join_with_links::table.filter(name_tag_join_with_links::id.eq(id)))
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn delete(&self, id: &str) -> Result<(), RepositoryError> {
+        self._delete(id)?;
+        let changelog = NameTagJoinRow::generate_changelog(
+            id.to_string(),
+            self.connection,
+            RowActionType::Delete,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct NameTagJoinRowDelete(pub String);
 impl Delete for NameTagJoinRowDelete {
-    fn delete_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        NameTagJoinRepository::new(con).delete(&self.0)?;
-        Ok(()) // Table not in Changelog
+    fn delete_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        let repo = NameTagJoinRepository::new(con);
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => {
+                NameTagJoinRow::generate_changelog(
+                    self.0.clone(),
+                    con,
+                    RowActionType::Delete,
+                    SourceSiteId::SourceSiteId(source_site_id),
+                )?
+            }
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        repo._delete(&self.0)?;
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
     // Test only
     fn assert_deleted(&self, con: &StorageConnection) {
@@ -78,9 +122,25 @@ impl Delete for NameTagJoinRowDelete {
 }
 
 impl Upsert for NameTagJoinRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        NameTagJoinRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        NameTagJoinRepository::new(con)._upsert(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only

--- a/server/repository/src/db_diesel/name_tag_row.rs
+++ b/server/repository/src/db_diesel/name_tag_row.rs
@@ -1,6 +1,9 @@
 use super::{name_oms_fields, StorageConnection};
 
-use crate::{repository_error::RepositoryError, ChangelogSyncType, Upsert};
+use crate::{
+    repository_error::RepositoryError, ChangelogRepository, ChangelogSyncType, Delete,
+    RowActionType, SourceSiteId, Upsert,
+};
 
 use diesel::prelude::*;
 
@@ -29,7 +32,7 @@ impl<'a> NameTagRowRepository<'a> {
         NameTagRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &NameTagRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &NameTagRow) -> Result<(), RepositoryError> {
         diesel::insert_into(name_tag::table)
             .values(row)
             .on_conflict(name_tag::id)
@@ -37,6 +40,17 @@ impl<'a> NameTagRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &NameTagRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = NameTagRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_one_by_id(&self, id: &str) -> Result<Option<NameTagRow>, RepositoryError> {
@@ -47,6 +61,12 @@ impl<'a> NameTagRowRepository<'a> {
         Ok(result)
     }
 
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<NameTagRow>, RepositoryError> {
+        Ok(name_tag::table
+            .filter(name_tag::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+
     pub fn find_one_by_name(&self, name: &str) -> Result<Option<NameTagRow>, RepositoryError> {
         let result = name_tag::table
             .filter(name_tag::name.like(name))
@@ -55,17 +75,44 @@ impl<'a> NameTagRowRepository<'a> {
         Ok(result)
     }
 
-    pub fn delete(&self, id: &str) -> Result<(), RepositoryError> {
+    fn _delete(&self, id: &str) -> Result<(), RepositoryError> {
         diesel::delete(name_tag::table.filter(name_tag::id.eq(id)))
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn delete(&self, id: &str) -> Result<(), RepositoryError> {
+        self._delete(id)?;
+        let changelog = NameTagRow::generate_changelog(
+            id.to_string(),
+            self.connection,
+            RowActionType::Delete,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
 }
 
 impl Upsert for NameTagRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        NameTagRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        NameTagRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only
@@ -73,6 +120,40 @@ impl Upsert for NameTagRow {
         assert_eq!(
             NameTagRowRepository::new(con).find_one_by_id(&self.id),
             Ok(Some(self.clone()))
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NameTagRowDelete(pub String);
+impl Delete for NameTagRowDelete {
+    fn delete_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        let repo = NameTagRowRepository::new(con);
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => NameTagRow::generate_changelog(
+                self.0.clone(),
+                con,
+                RowActionType::Delete,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        repo._delete(&self.0)?;
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
+    }
+
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            NameTagRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
         )
     }
 }

--- a/server/repository/src/db_diesel/period/period_row.rs
+++ b/server/repository/src/db_diesel/period/period_row.rs
@@ -1,8 +1,8 @@
 use super::period_row::period::dsl::*;
 
 use crate::{
-    period_schedule_row::period_schedule,
-    repository_error::RepositoryError, StorageConnection, ChangelogSyncType, Upsert,
+    period_schedule_row::period_schedule, repository_error::RepositoryError, ChangelogRepository,
+    ChangelogSyncType, RowActionType, SourceSiteId, StorageConnection, Upsert,
 };
 
 use chrono::NaiveDate;
@@ -41,7 +41,7 @@ impl<'a> PeriodRowRepository<'a> {
         PeriodRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &PeriodRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &PeriodRow) -> Result<(), RepositoryError> {
         diesel::insert_into(period)
             .values(row)
             .on_conflict(id)
@@ -51,12 +51,29 @@ impl<'a> PeriodRowRepository<'a> {
         Ok(())
     }
 
+    pub fn upsert_one(&self, row: &PeriodRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = PeriodRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
+
     pub fn find_one_by_id(&self, period_id: &str) -> Result<Option<PeriodRow>, RepositoryError> {
         let result = period
             .filter(id.eq(period_id))
             .first(self.connection.lock().connection())
             .optional()?;
         Ok(result)
+    }
+
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<PeriodRow>, RepositoryError> {
+        Ok(period
+            .filter(id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
     }
 
     pub fn find_many_by_program_schedule_ids(
@@ -71,9 +88,25 @@ impl<'a> PeriodRowRepository<'a> {
 }
 
 impl Upsert for PeriodRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        PeriodRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        PeriodRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only

--- a/server/repository/src/db_diesel/period/period_schedule_row.rs
+++ b/server/repository/src/db_diesel/period/period_schedule_row.rs
@@ -1,6 +1,8 @@
-use crate::{repository_error::RepositoryError, StorageConnection};
+use crate::{
+    repository_error::RepositoryError, ChangelogRepository, ChangelogSyncType, RowActionType,
+    SourceSiteId, StorageConnection, Upsert,
+};
 
-use crate::{ChangelogSyncType, Upsert};
 use diesel::prelude::*;
 
 table! {
@@ -26,7 +28,7 @@ impl<'a> PeriodScheduleRowRepository<'a> {
         PeriodScheduleRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &PeriodScheduleRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &PeriodScheduleRow) -> Result<(), RepositoryError> {
         diesel::insert_into(period_schedule::table)
             .values(row)
             .on_conflict(period_schedule::id)
@@ -36,12 +38,32 @@ impl<'a> PeriodScheduleRowRepository<'a> {
         Ok(())
     }
 
+    pub fn upsert_one(&self, row: &PeriodScheduleRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = PeriodScheduleRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
+
     pub fn find_one_by_id(&self, id: &str) -> Result<Option<PeriodScheduleRow>, RepositoryError> {
         let result = period_schedule::table
             .filter(period_schedule::id.eq(id))
             .first(self.connection.lock().connection())
             .optional()?;
         Ok(result)
+    }
+
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<PeriodScheduleRow>, RepositoryError> {
+        Ok(period_schedule::table
+            .filter(period_schedule::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
     }
 
     pub fn find_one_by_name(
@@ -57,9 +79,25 @@ impl<'a> PeriodScheduleRowRepository<'a> {
 }
 
 impl Upsert for PeriodScheduleRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        PeriodScheduleRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        PeriodScheduleRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only

--- a/server/repository/src/db_diesel/printer_row.rs
+++ b/server/repository/src/db_diesel/printer_row.rs
@@ -1,6 +1,8 @@
 use super::printer_row::printer::dsl::*;
-use crate::RepositoryError;
-use crate::StorageConnection;
+use crate::{
+    ChangelogRepository, ChangelogSyncType, RepositoryError, RowActionType, SourceSiteId,
+    StorageConnection, Upsert,
+};
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -37,7 +39,7 @@ impl<'a> PrinterRowRepository<'a> {
         PrinterRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &PrinterRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &PrinterRow) -> Result<(), RepositoryError> {
         diesel::insert_into(printer::table)
             .values(row)
             .on_conflict(printer::id)
@@ -46,6 +48,17 @@ impl<'a> PrinterRowRepository<'a> {
             .execute(self.connection.lock().connection())?;
 
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &PrinterRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = PrinterRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_one_by_id(&self, printer_id: &str) -> Result<Option<PrinterRow>, RepositoryError> {
@@ -57,8 +70,45 @@ impl<'a> PrinterRowRepository<'a> {
         Ok(result)
     }
 
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<PrinterRow>, RepositoryError> {
+        Ok(printer::table
+            .filter(printer::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+
     pub fn find_all(&self) -> Result<Vec<PrinterRow>, RepositoryError> {
         let result = printer.load(self.connection.lock().connection())?;
         Ok(result)
+    }
+}
+
+impl Upsert for PrinterRow {
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        PrinterRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            PrinterRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/program_enrolment_row.rs
+++ b/server/repository/src/db_diesel/program_enrolment_row.rs
@@ -1,9 +1,12 @@
 use super::{
-    name_row::name, name_store_join::name_store_join,
-    program_row::program, store_row::store, RepositoryError, StorageConnection,
+    name_row::name, name_store_join::name_store_join, program_row::program, store_row::store,
+    RepositoryError, StorageConnection,
 };
 
-use crate::diesel_macros::define_linked_tables;
+use crate::{
+    diesel_macros::define_linked_tables, ChangelogRepository, ChangelogSyncType, RowActionType,
+    SourceSiteId, Upsert,
+};
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 
@@ -72,8 +75,54 @@ impl<'a> ProgramEnrolmentRowRepository<'a> {
         Ok(result)
     }
 
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<ProgramEnrolmentRow>, RepositoryError> {
+        Ok(program_enrolment::table
+            .filter(program_enrolment::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+
     pub fn upsert_one(&self, row: &ProgramEnrolmentRow) -> Result<(), RepositoryError> {
         self._upsert(row)?;
+        let changelog = ProgramEnrolmentRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
+}
+
+impl Upsert for ProgramEnrolmentRow {
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        ProgramEnrolmentRowRepository::new(con)._upsert(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
         Ok(())
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert!(ProgramEnrolmentRowRepository::new(con)
+            .find_one_by_id(&self.id)
+            .unwrap()
+            .is_some())
     }
 }

--- a/server/repository/src/db_diesel/program_event_row.rs
+++ b/server/repository/src/db_diesel/program_event_row.rs
@@ -3,6 +3,9 @@ use super::StorageConnection;
 use crate::db_diesel::{name_link_row::name_link, name_row::name};
 use crate::diesel_macros::define_linked_tables;
 use crate::repository_error::RepositoryError;
+use crate::{
+    ChangelogRepository, ChangelogSyncType, RowActionType, SourceSiteId, Upsert,
+};
 
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
@@ -90,8 +93,54 @@ impl<'a> ProgramEventRowRepository<'a> {
         Ok(result)
     }
 
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<ProgramEventRow>, RepositoryError> {
+        Ok(program_event::dsl::program_event
+            .filter(program_event::dsl::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+
     pub fn upsert_one(&self, row: &ProgramEventRow) -> Result<(), RepositoryError> {
         self._upsert(row)?;
+        let changelog = ProgramEventRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
+}
+
+impl Upsert for ProgramEventRow {
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        ProgramEventRowRepository::new(con)._upsert(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
         Ok(())
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert!(ProgramEventRowRepository::new(con)
+            .find_one_by_id(&self.id)
+            .unwrap()
+            .is_some())
     }
 }

--- a/server/repository/src/db_diesel/program_indicator_row.rs
+++ b/server/repository/src/db_diesel/program_indicator_row.rs
@@ -1,6 +1,9 @@
 use super::StorageConnection;
 
-use crate::{repository_error::RepositoryError, ChangelogSyncType, Upsert};
+use crate::{
+    repository_error::RepositoryError, ChangelogRepository, ChangelogSyncType, RowActionType,
+    SourceSiteId, Upsert,
+};
 
 use diesel::prelude::*;
 
@@ -31,7 +34,7 @@ impl<'a> ProgramIndicatorRowRepository<'a> {
         ProgramIndicatorRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &ProgramIndicatorRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &ProgramIndicatorRow) -> Result<(), RepositoryError> {
         diesel::insert_into(program_indicator::table)
             .values(row)
             .on_conflict(program_indicator::id)
@@ -39,6 +42,17 @@ impl<'a> ProgramIndicatorRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &ProgramIndicatorRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = ProgramIndicatorRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_one_by_id(
@@ -51,12 +65,37 @@ impl<'a> ProgramIndicatorRowRepository<'a> {
             .optional()?;
         Ok(result)
     }
+
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<ProgramIndicatorRow>, RepositoryError> {
+        Ok(program_indicator::table
+            .filter(program_indicator::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for ProgramIndicatorRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        ProgramIndicatorRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        ProgramIndicatorRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only

--- a/server/repository/src/db_diesel/program_requisition/program_requisition_order_type_row.rs
+++ b/server/repository/src/db_diesel/program_requisition/program_requisition_order_type_row.rs
@@ -1,6 +1,9 @@
 use super::program_requisition_settings_row::program_requisition_settings;
 
-use crate::{repository_error::RepositoryError, StorageConnection};
+use crate::{
+    repository_error::RepositoryError, ChangelogRepository, RowActionType, SourceSiteId,
+    StorageConnection,
+};
 
 use diesel::prelude::*;
 
@@ -42,7 +45,7 @@ impl<'a> ProgramRequisitionOrderTypeRowRepository<'a> {
         ProgramRequisitionOrderTypeRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &ProgramRequisitionOrderTypeRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &ProgramRequisitionOrderTypeRow) -> Result<(), RepositoryError> {
         diesel::insert_into(program_requisition_order_type::table)
             .values(row)
             .on_conflict(program_requisition_order_type::id)
@@ -50,6 +53,17 @@ impl<'a> ProgramRequisitionOrderTypeRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &ProgramRequisitionOrderTypeRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = ProgramRequisitionOrderTypeRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_one_by_id(
@@ -61,6 +75,15 @@ impl<'a> ProgramRequisitionOrderTypeRowRepository<'a> {
             .first(self.connection.lock().connection())
             .optional()?;
         Ok(result)
+    }
+
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<ProgramRequisitionOrderTypeRow>, RepositoryError> {
+        Ok(program_requisition_order_type::table
+            .filter(program_requisition_order_type::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
     }
 
     pub fn find_many_by_program_requisition_settings_ids(
@@ -90,7 +113,7 @@ impl<'a> ProgramRequisitionOrderTypeRowRepository<'a> {
         Ok(result)
     }
 
-    pub fn delete(&self, order_type_id: &str) -> Result<(), RepositoryError> {
+    fn _delete(&self, order_type_id: &str) -> Result<(), RepositoryError> {
         diesel::delete(
             program_requisition_order_type::table
                 .filter(program_requisition_order_type::id.eq(order_type_id)),
@@ -98,14 +121,44 @@ impl<'a> ProgramRequisitionOrderTypeRowRepository<'a> {
         .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn delete(&self, order_type_id: &str) -> Result<(), RepositoryError> {
+        self._delete(order_type_id)?;
+        let changelog = ProgramRequisitionOrderTypeRow::generate_changelog(
+            order_type_id.to_string(),
+            self.connection,
+            RowActionType::Delete,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct ProgramRequisitionOrderTypeRowDelete(pub String);
 impl Delete for ProgramRequisitionOrderTypeRowDelete {
-    fn delete_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        ProgramRequisitionOrderTypeRowRepository::new(con).delete(&self.0)?;
-        Ok(()) // Table not in Changelog
+    fn delete_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        let repo = ProgramRequisitionOrderTypeRowRepository::new(con);
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => {
+                ProgramRequisitionOrderTypeRow::generate_changelog(
+                    self.0.clone(),
+                    con,
+                    RowActionType::Delete,
+                    SourceSiteId::SourceSiteId(source_site_id),
+                )?
+            }
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        repo._delete(&self.0)?;
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
     // Test only
     fn assert_deleted(&self, con: &StorageConnection) {
@@ -117,9 +170,25 @@ impl Delete for ProgramRequisitionOrderTypeRowDelete {
 }
 
 impl Upsert for ProgramRequisitionOrderTypeRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        ProgramRequisitionOrderTypeRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        ProgramRequisitionOrderTypeRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only

--- a/server/repository/src/db_diesel/program_requisition/program_requisition_settings_row.rs
+++ b/server/repository/src/db_diesel/program_requisition/program_requisition_settings_row.rs
@@ -4,7 +4,10 @@ use crate::{
     db_diesel::name_tag_row::name_tag, period_schedule_row::period_schedule,
     repository_error::RepositoryError, StorageConnection,
 };
-use crate::{name_oms_fields, Delete, ChangelogSyncType, Upsert};
+use crate::{
+    name_oms_fields, ChangelogRepository, ChangelogSyncType, Delete, RowActionType, SourceSiteId,
+    Upsert,
+};
 use diesel::prelude::*;
 
 table! {
@@ -39,7 +42,7 @@ impl<'a> ProgramRequisitionSettingsRowRepository<'a> {
         ProgramRequisitionSettingsRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &ProgramRequisitionSettingsRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &ProgramRequisitionSettingsRow) -> Result<(), RepositoryError> {
         diesel::insert_into(program_requisition_settings::table)
             .values(row)
             .on_conflict(program_requisition_settings::id)
@@ -47,6 +50,17 @@ impl<'a> ProgramRequisitionSettingsRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &ProgramRequisitionSettingsRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = ProgramRequisitionSettingsRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_one_by_id(
@@ -60,6 +74,15 @@ impl<'a> ProgramRequisitionSettingsRowRepository<'a> {
         Ok(result)
     }
 
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<ProgramRequisitionSettingsRow>, RepositoryError> {
+        Ok(program_requisition_settings::table
+            .filter(program_requisition_settings::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+
     pub fn find_many_by_program_id(
         &self,
         program_id: &str,
@@ -70,7 +93,7 @@ impl<'a> ProgramRequisitionSettingsRowRepository<'a> {
         Ok(result)
     }
 
-    pub fn delete(&self, settings_id: &str) -> Result<(), RepositoryError> {
+    fn _delete(&self, settings_id: &str) -> Result<(), RepositoryError> {
         diesel::delete(
             program_requisition_settings::table
                 .filter(program_requisition_settings::id.eq(settings_id)),
@@ -78,14 +101,44 @@ impl<'a> ProgramRequisitionSettingsRowRepository<'a> {
         .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn delete(&self, settings_id: &str) -> Result<(), RepositoryError> {
+        self._delete(settings_id)?;
+        let changelog = ProgramRequisitionSettingsRow::generate_changelog(
+            settings_id.to_string(),
+            self.connection,
+            RowActionType::Delete,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct ProgramRequisitionSettingsRowDelete(pub String);
 impl Delete for ProgramRequisitionSettingsRowDelete {
-    fn delete_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        ProgramRequisitionSettingsRowRepository::new(con).delete(&self.0)?;
-        Ok(()) // Table not in Changelog
+    fn delete_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        let repo = ProgramRequisitionSettingsRowRepository::new(con);
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => {
+                ProgramRequisitionSettingsRow::generate_changelog(
+                    self.0.clone(),
+                    con,
+                    RowActionType::Delete,
+                    SourceSiteId::SourceSiteId(source_site_id),
+                )?
+            }
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        repo._delete(&self.0)?;
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
     // Test only
     fn assert_deleted(&self, con: &StorageConnection) {
@@ -97,9 +150,25 @@ impl Delete for ProgramRequisitionSettingsRowDelete {
 }
 
 impl Upsert for ProgramRequisitionSettingsRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        ProgramRequisitionSettingsRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        ProgramRequisitionSettingsRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only

--- a/server/repository/src/db_diesel/program_requisition/program_row.rs
+++ b/server/repository/src/db_diesel/program_requisition/program_row.rs
@@ -7,7 +7,8 @@ use crate::{
         master_list_row::master_list,
     },
     repository_error::RepositoryError,
-    StorageConnection, ChangelogSyncType, Upsert,
+    ChangelogRepository, ChangelogSyncType, Delete, RowActionType, SourceSiteId, StorageConnection,
+    Upsert,
 };
 
 use diesel::prelude::*;
@@ -51,7 +52,7 @@ impl<'a> ProgramRowRepository<'a> {
         ProgramRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &ProgramRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &ProgramRow) -> Result<(), RepositoryError> {
         diesel::insert_into(program::table)
             .values(row)
             .on_conflict(program::id)
@@ -59,6 +60,17 @@ impl<'a> ProgramRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &ProgramRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = ProgramRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_one_by_id(&self, id: &str) -> Result<Option<ProgramRow>, RepositoryError> {
@@ -70,18 +82,51 @@ impl<'a> ProgramRowRepository<'a> {
         Ok(result)
     }
 
-    pub fn delete(&self, id: &str) -> Result<(), RepositoryError> {
+    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<ProgramRow>, RepositoryError> {
+        Ok(program::table
+            .filter(program::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+
+    fn _delete(&self, id: &str) -> Result<(), RepositoryError> {
         diesel::update(program::table.filter(program::id.eq(id)))
             .set(deleted_datetime.eq(Some(chrono::Utc::now().naive_utc())))
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn delete(&self, id: &str) -> Result<(), RepositoryError> {
+        self._delete(id)?;
+        let changelog = ProgramRow::generate_changelog(
+            id.to_string(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
 }
 
 impl Upsert for ProgramRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        ProgramRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        ProgramRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only
@@ -89,6 +134,40 @@ impl Upsert for ProgramRow {
         assert_eq!(
             ProgramRowRepository::new(con).find_one_by_id(&self.id),
             Ok(Some(self.clone()))
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ProgramRowDelete(pub String);
+impl Delete for ProgramRowDelete {
+    fn delete_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        let repo = ProgramRowRepository::new(con);
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => ProgramRow::generate_changelog(
+                self.0.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        repo._delete(&self.0)?;
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
+    }
+
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            ProgramRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
         )
     }
 }

--- a/server/repository/src/db_diesel/reason_option_row.rs
+++ b/server/repository/src/db_diesel/reason_option_row.rs
@@ -1,6 +1,9 @@
 use super::StorageConnection;
 
-use crate::{repository_error::RepositoryError, Delete, ChangelogSyncType, Upsert};
+use crate::{
+    repository_error::RepositoryError, ChangelogRepository, ChangelogSyncType, Delete,
+    RowActionType, SourceSiteId, Upsert,
+};
 
 use diesel::prelude::*;
 use diesel_derive_enum::DbEnum;
@@ -60,7 +63,7 @@ impl<'a> ReasonOptionRowRepository<'a> {
         ReasonOptionRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &ReasonOptionRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &ReasonOptionRow) -> Result<(), RepositoryError> {
         diesel::insert_into(reason_option::table)
             .values(row)
             .on_conflict(reason_option::id)
@@ -68,6 +71,17 @@ impl<'a> ReasonOptionRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &ReasonOptionRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = ReasonOptionRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_one_by_id(&self, id: &str) -> Result<Option<ReasonOptionRow>, RepositoryError> {
@@ -78,12 +92,32 @@ impl<'a> ReasonOptionRowRepository<'a> {
         Ok(result)
     }
 
-    pub fn soft_delete(&self, reason_option_id: &str) -> Result<(), RepositoryError> {
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<ReasonOptionRow>, RepositoryError> {
+        Ok(reason_option::table
+            .filter(reason_option::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+
+    fn _soft_delete(&self, reason_option_id: &str) -> Result<(), RepositoryError> {
         diesel::update(reason_option::table)
             .filter(reason_option::id.eq(reason_option_id))
             .set(reason_option::is_active.eq(false))
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn soft_delete(&self, reason_option_id: &str) -> Result<(), RepositoryError> {
+        self._soft_delete(reason_option_id)?;
+        let changelog = ReasonOptionRow::generate_changelog(
+            reason_option_id.to_string(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 }
 
@@ -91,9 +125,28 @@ impl<'a> ReasonOptionRowRepository<'a> {
 pub struct ReasonOptionRowDelete(pub String);
 
 impl Delete for ReasonOptionRowDelete {
-    fn delete_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        ReasonOptionRowRepository::new(con).soft_delete(&self.0)?;
-        Ok(()) // Table not in Changelog
+    fn delete_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        let repo = ReasonOptionRowRepository::new(con);
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => {
+                ReasonOptionRow::generate_changelog(
+                    self.0.clone(),
+                    con,
+                    RowActionType::Upsert,
+                    SourceSiteId::SourceSiteId(source_site_id),
+                )?
+            }
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        repo._soft_delete(&self.0)?;
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only
@@ -106,9 +159,25 @@ impl Delete for ReasonOptionRowDelete {
 }
 
 impl Upsert for ReasonOptionRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        ReasonOptionRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        ReasonOptionRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only

--- a/server/repository/src/db_diesel/shipping_method_row.rs
+++ b/server/repository/src/db_diesel/shipping_method_row.rs
@@ -1,4 +1,7 @@
-use crate::{RepositoryError, StorageConnection, ChangelogSyncType, Upsert};
+use crate::{
+    ChangelogRepository, ChangelogSyncType, RepositoryError, RowActionType, SourceSiteId,
+    StorageConnection, Upsert,
+};
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -32,7 +35,7 @@ impl<'a> ShippingMethodRowRepository<'a> {
         ShippingMethodRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &ShippingMethodRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &ShippingMethodRow) -> Result<(), RepositoryError> {
         diesel::insert_into(shipping_method::table)
             .values(row)
             .on_conflict(shipping_method::id)
@@ -42,6 +45,17 @@ impl<'a> ShippingMethodRowRepository<'a> {
         Ok(())
     }
 
+    pub fn upsert_one(&self, row: &ShippingMethodRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = ShippingMethodRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
+    }
+
     pub fn find_one_by_id(&self, id: &str) -> Result<Option<ShippingMethodRow>, RepositoryError> {
         let result = shipping_method::table
             .filter(shipping_method::id.eq(id))
@@ -49,12 +63,36 @@ impl<'a> ShippingMethodRowRepository<'a> {
             .optional()?;
         Ok(result)
     }
+
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<ShippingMethodRow>, RepositoryError> {
+        Ok(shipping_method::table
+            .filter(shipping_method::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for ShippingMethodRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        ShippingMethodRowRepository::new(con).upsert_one(self)?;
-        // Not in changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        ShippingMethodRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
         Ok(())
     }
 

--- a/server/repository/src/db_diesel/store_preference_row.rs
+++ b/server/repository/src/db_diesel/store_preference_row.rs
@@ -1,6 +1,9 @@
 use super::{user_store_join_row::user_store_join, StorageConnection};
 
-use crate::{repository_error::RepositoryError, ChangelogSyncType, Upsert};
+use crate::{
+    repository_error::RepositoryError, ChangelogRepository, ChangelogSyncType, RowActionType,
+    SourceSiteId, Upsert,
+};
 
 use super::{store_row::store, user_row::user_account};
 use diesel::prelude::*;
@@ -109,7 +112,7 @@ impl<'a> StorePreferenceRowRepository<'a> {
         StorePreferenceRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &StorePreferenceRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &StorePreferenceRow) -> Result<(), RepositoryError> {
         diesel::insert_into(store_preference::table)
             .values(row)
             .on_conflict(store_preference::id)
@@ -117,6 +120,17 @@ impl<'a> StorePreferenceRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &StorePreferenceRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = StorePreferenceRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_one_by_id_or_default(
@@ -140,12 +154,37 @@ impl<'a> StorePreferenceRowRepository<'a> {
             .optional();
         result.map_err(RepositoryError::from)
     }
+
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<StorePreferenceRow>, RepositoryError> {
+        Ok(store_preference::table
+            .filter(store_preference::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for StorePreferenceRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        StorePreferenceRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        StorePreferenceRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only

--- a/server/repository/src/db_diesel/user_permission_row.rs
+++ b/server/repository/src/db_diesel/user_permission_row.rs
@@ -1,7 +1,9 @@
 use super::StorageConnection;
 
 use crate::repository_error::RepositoryError;
-use crate::{Delete, ChangelogSyncType, Upsert};
+use crate::{
+    ChangelogRepository, ChangelogSyncType, Delete, RowActionType, SourceSiteId, Upsert,
+};
 use diesel::prelude::*;
 
 use diesel_derive_enum::DbEnum;
@@ -126,7 +128,7 @@ impl<'a> UserPermissionRowRepository<'a> {
         UserPermissionRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &UserPermissionRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &UserPermissionRow) -> Result<(), RepositoryError> {
         diesel::insert_into(user_permission::table)
             .values(row)
             .on_conflict(user_permission::id)
@@ -134,6 +136,17 @@ impl<'a> UserPermissionRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &UserPermissionRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = UserPermissionRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_one_by_id(&self, id: &str) -> Result<Option<UserPermissionRow>, RepositoryError> {
@@ -144,25 +157,64 @@ impl<'a> UserPermissionRowRepository<'a> {
         Ok(result)
     }
 
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<UserPermissionRow>, RepositoryError> {
+        Ok(user_permission::table
+            .filter(user_permission::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+
     pub fn delete_by_user_id(&self, user_id: &str) -> Result<(), RepositoryError> {
         diesel::delete(user_permission::table.filter(user_permission::user_id.eq(user_id)))
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
 
-    pub fn delete(&self, id: &str) -> Result<(), RepositoryError> {
+    fn _delete(&self, id: &str) -> Result<(), RepositoryError> {
         diesel::delete(user_permission::table.filter(user_permission::id.eq(id)))
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn delete(&self, id: &str) -> Result<(), RepositoryError> {
+        self._delete(id)?;
+        let changelog = UserPermissionRow::generate_changelog(
+            id.to_string(),
+            self.connection,
+            RowActionType::Delete,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct UserPermissionRowDelete(pub String);
 impl Delete for UserPermissionRowDelete {
-    fn delete_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        UserPermissionRowRepository::new(con).delete(&self.0)?;
-        Ok(()) // Table not in Changelog
+    fn delete_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        let repo = UserPermissionRowRepository::new(con);
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => {
+                UserPermissionRow::generate_changelog(
+                    self.0.clone(),
+                    con,
+                    RowActionType::Delete,
+                    SourceSiteId::SourceSiteId(source_site_id),
+                )?
+            }
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        repo._delete(&self.0)?;
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
     // Test only
     fn assert_deleted(&self, con: &StorageConnection) {
@@ -174,9 +226,25 @@ impl Delete for UserPermissionRowDelete {
 }
 
 impl Upsert for UserPermissionRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        UserPermissionRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        UserPermissionRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only

--- a/server/repository/src/db_diesel/user_row.rs
+++ b/server/repository/src/db_diesel/user_row.rs
@@ -1,6 +1,9 @@
 use super::StorageConnection;
 
-use crate::{lower, repository_error::RepositoryError, ChangelogSyncType, Upsert};
+use crate::{
+    lower, repository_error::RepositoryError, ChangelogRepository, ChangelogSyncType, Delete,
+    RowActionType, SourceSiteId, Upsert,
+};
 
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
@@ -61,7 +64,7 @@ impl<'a> UserAccountRowRepository<'a> {
         UserAccountRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &UserAccountRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &UserAccountRow) -> Result<(), RepositoryError> {
         diesel::insert_into(user_account::table)
             .values(row)
             .on_conflict(user_account::id)
@@ -69,6 +72,17 @@ impl<'a> UserAccountRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &UserAccountRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = UserAccountRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn insert_one(&self, user_account_row: &UserAccountRow) -> Result<(), RepositoryError> {
@@ -118,18 +132,46 @@ impl<'a> UserAccountRowRepository<'a> {
         Ok(result)
     }
 
-    pub fn delete_by_id(&self, id: &str) -> Result<usize, RepositoryError> {
+    fn _delete_by_id(&self, id: &str) -> Result<usize, RepositoryError> {
         let result = diesel::delete(user_account::table)
             .filter(user_account::id.eq(id))
             .execute(self.connection.lock().connection())?;
         Ok(result)
     }
+
+    pub fn delete_by_id(&self, id: &str) -> Result<usize, RepositoryError> {
+        let result = self._delete_by_id(id)?;
+        let changelog = UserAccountRow::generate_changelog(
+            id.to_string(),
+            self.connection,
+            RowActionType::Delete,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)?;
+        Ok(result)
+    }
 }
 
 impl Upsert for UserAccountRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        UserAccountRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        UserAccountRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only
@@ -137,6 +179,42 @@ impl Upsert for UserAccountRow {
         assert_eq!(
             UserAccountRowRepository::new(con).find_one_by_id(&self.id),
             Ok(Some(self.clone()))
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UserAccountRowDelete(pub String);
+impl Delete for UserAccountRowDelete {
+    fn delete_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        let repo = UserAccountRowRepository::new(con);
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => {
+                UserAccountRow::generate_changelog(
+                    self.0.clone(),
+                    con,
+                    RowActionType::Delete,
+                    SourceSiteId::SourceSiteId(source_site_id),
+                )?
+            }
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        repo._delete_by_id(&self.0)?;
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
+    }
+
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            UserAccountRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
         )
     }
 }

--- a/server/repository/src/db_diesel/user_store_join_row.rs
+++ b/server/repository/src/db_diesel/user_store_join_row.rs
@@ -1,6 +1,9 @@
 use super::{store_row::store, user_row::user_account, StorageConnection};
 
 use crate::repository_error::RepositoryError;
+use crate::{
+    ChangelogRepository, ChangelogSyncType, RowActionType, SourceSiteId, Upsert,
+};
 
 use diesel::prelude::*;
 
@@ -37,7 +40,7 @@ impl<'a> UserStoreJoinRowRepository<'a> {
         UserStoreJoinRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &UserStoreJoinRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &UserStoreJoinRow) -> Result<(), RepositoryError> {
         diesel::insert_into(user_store_join::table)
             .values(row)
             .on_conflict(user_store_join::id)
@@ -45,6 +48,17 @@ impl<'a> UserStoreJoinRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &UserStoreJoinRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = UserStoreJoinRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_one_by_id(&self, id: &str) -> Result<Option<UserStoreJoinRow>, RepositoryError> {
@@ -55,9 +69,49 @@ impl<'a> UserStoreJoinRowRepository<'a> {
         Ok(result)
     }
 
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<UserStoreJoinRow>, RepositoryError> {
+        Ok(user_store_join::table
+            .filter(user_store_join::id.eq_any(ids))
+            .load(self.connection.lock().connection())?)
+    }
+
     pub fn delete_by_user_id(&self, id: &str) -> Result<(), RepositoryError> {
         diesel::delete(user_store_join::table.filter(user_store_join::user_id.eq(id)))
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+}
+
+impl Upsert for UserStoreJoinRow {
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        UserStoreJoinRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
+    }
+
+    // Test only
+    fn assert_upserted(&self, con: &StorageConnection) {
+        assert_eq!(
+            UserStoreJoinRowRepository::new(con).find_one_by_id(&self.id),
+            Ok(Some(self.clone()))
+        )
     }
 }

--- a/server/repository/src/db_diesel/vvm_status/vvm_status_row.rs
+++ b/server/repository/src/db_diesel/vvm_status/vvm_status_row.rs
@@ -4,11 +4,10 @@ use crate::db_diesel::{
     item_variant::item_variant_row::item_variant, location_row::location,
     name_row::name, stock_line_row::stock_line,
 };
-use crate::ChangelogRepository;
-use crate::Delete;
-use crate::RepositoryError;
-use crate::StorageConnection;
-use crate::{ChangelogSyncType, Upsert};
+use crate::{
+    ChangelogRepository, ChangelogSyncType, Delete, RepositoryError, RowActionType, SourceSiteId,
+    StorageConnection, Upsert,
+};
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -56,7 +55,7 @@ impl<'a> VVMStatusRowRepository<'a> {
         VVMStatusRowRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &VVMStatusRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &VVMStatusRow) -> Result<(), RepositoryError> {
         diesel::insert_into(vvm_status)
             .values(row)
             .on_conflict(id)
@@ -64,6 +63,17 @@ impl<'a> VVMStatusRowRepository<'a> {
             .set(row)
             .execute(self.connection.lock().connection())?;
         Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &VVMStatusRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        let changelog = VVMStatusRow::generate_changelog(
+            row.id.clone(),
+            self.connection,
+            RowActionType::Upsert,
+            SourceSiteId::CurrentSiteId,
+        )?;
+        ChangelogRepository::new(self.connection).insert(&changelog)
     }
 
     pub fn find_many_by_ids(&self, ids: &[String]) -> Result<Vec<VVMStatusRow>, RepositoryError> {
@@ -92,7 +102,7 @@ impl<'a> VVMStatusRowRepository<'a> {
         Ok(result)
     }
 
-    pub fn delete(&self, vvm_status_id: &str) -> Result<(), RepositoryError> {
+    fn _delete(&self, vvm_status_id: &str) -> Result<(), RepositoryError> {
         diesel::delete(vvm_status.filter(id.eq(vvm_status_id)))
             .execute(self.connection.lock().connection())?;
         Ok(())
@@ -100,9 +110,25 @@ impl<'a> VVMStatusRowRepository<'a> {
 }
 
 impl Upsert for VVMStatusRow {
-    fn upsert_sync(&self, con: &StorageConnection, _sync_type: ChangelogSyncType) -> Result<(), RepositoryError> {
-        VVMStatusRowRepository::new(con).upsert_one(self)?;
-        Ok(()) // Table not in Changelog
+    fn upsert_sync(
+        &self,
+        con: &StorageConnection,
+        sync_type: ChangelogSyncType,
+    ) -> Result<(), RepositoryError> {
+        VVMStatusRowRepository::new(con)._upsert_one(self)?;
+
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
+                self.id.clone(),
+                con,
+                RowActionType::Upsert,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
+
+        ChangelogRepository::new(con).insert(&changelog)?;
+        Ok(())
     }
 
     // Test only
@@ -122,12 +148,20 @@ impl Delete for VVMStatusRowDelete {
         con: &StorageConnection,
         sync_type: ChangelogSyncType,
     ) -> Result<(), RepositoryError> {
-        VVMStatusRowRepository::new(con).delete(&self.0)?;
+        let repo = VVMStatusRowRepository::new(con);
 
-        if let ChangelogSyncType::SyncTypeV7 { changelog_row } = sync_type {
-            ChangelogRepository::new(con).insert(&changelog_row)?;
-        }
+        let changelog = match sync_type {
+            ChangelogSyncType::SyncTypeV5V6 { source_site_id } => VVMStatusRow::generate_changelog(
+                self.0.clone(),
+                con,
+                RowActionType::Delete,
+                SourceSiteId::SourceSiteId(source_site_id),
+            )?,
+            ChangelogSyncType::SyncTypeV7 { changelog_row } => changelog_row,
+        };
 
+        repo._delete(&self.0)?;
+        ChangelogRepository::new(con).insert(&changelog)?;
         Ok(())
     }
 


### PR DESCRIPTION
## Stack
This is **PR 6 of 9**. Stacked on top of [#11467](https://github.com/msupply-foundation/open-msupply/pull/11467).

> ⚠️ **Tests will not pass until the final PR (9/9) is merged.**

## Summary
Adds changelog triggers to every remaining table that didn't have them yet. Tables newly covered:

- `abbreviation`, `category`, `contact`, `contact_trace`, `context`
- `demographic_indicator`, `demographic_projection`, `diagnosis`
- `document_registry`
- `indicator_column`, `indicator_line`
- `item_category`, `item_direction`, `item_store_join`, `item_warning_join`
- `master_list_line`, `master_list_name_join`
- `name_tag`, `name_tag_join`
- `period`, `period_schedule`, `printer`
- `program_enrolment`, `program_event`, `program_indicator`, `program`
- `program_requisition_order_type`, `program_requisition_settings`
- `reason_option`, `shipping_method`, `store_preference`
- `user`, `user_permission`, `user_store_join`
- `vvm_status`

Also: first draft of `server/repository/src/db_diesel/changelog/sync_styles.md` documenting the patterns.

42 files, +3,196 / −393.

## Why
Goal is full parity: every syncable table emits changelog rows. Required for v7 to be able to replicate everything without per-table special cases.

## Test plan
- [ ] Confirm the table list is complete vs the schema
- [ ] Sanity-check trigger SQL shape matches existing tables
- [ ] Tests will not pass on this branch alone; full suite is validated at PR 9