### PR TITLE
Sync stack 9/9: Re-build sync buffer to a new shape

### DIFF
--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -12,7 +12,8 @@ use report_builder::{
 use repository::{
     get_storage_connection_manager, migrations::migrate, schema_from_row, test_db, ContextType,
     EqualFilter, FormSchemaRow, FormSchemaRowRepository, KeyType, KeyValueStoreRepository,
-    ReportFilter, ReportRepository, ReportRow, ReportRowRepository, SyncBufferRowRepository,
+    ReportFilter, ReportRepository, ReportRow, ReportRowRepository, SyncBufferRepository,
+    SyncBufferRowInsert,
 };
 use serde::{Deserialize, Serialize};
 use server::{configuration, logging_init};
@@ -25,7 +26,7 @@ use service::{
     settings::Settings,
     standard_reports::{ReportData, ReportsData, StandardReports},
     sync::{
-        settings::SyncSettings, sync_buffer::SyncBufferSource,
+        settings::SyncSettings,
         sync_status::logger::SyncLogger, synchroniser::integrate_and_translate_sync_buffer,
         synchroniser_driver::SynchroniserDriver,
     },
@@ -389,7 +390,7 @@ async fn main() -> anyhow::Result<()> {
 
             let data = InitialisationData {
                 // Sync Buffer Rows
-                sync_buffer_rows: SyncBufferRowRepository::new(&ctx.connection).get_all()?,
+                sync_buffer_rows: SyncBufferRepository::new(&ctx.connection).get_all()?,
                 users: synced_user_info_rows,
                 site_id: service_provider
                     .site_info_service
@@ -429,23 +430,26 @@ async fn main() -> anyhow::Result<()> {
             // Need to set site_id before integration
             KeyValueStoreRepository::new(&ctx.connection)
                 .set_i32(KeyType::SettingsSyncSiteId, Some(data.site_id))?;
-            let buffer_repo = SyncBufferRowRepository::new(&ctx.connection);
-            let buffer_rows = data
+            let buffer_repo = SyncBufferRepository::new(&ctx.connection);
+            let buffer_rows: Vec<SyncBufferRowInsert> = data
                 .sync_buffer_rows
                 .into_iter()
                 .map(|mut r| {
+                    // Reset integration state — we want re-init to retry integration
+                    r.integration_started_datetime = None;
                     r.integration_datetime = None;
                     r.integration_error = None;
-                    r
+                    r.integration_result = None;
+                    SyncBufferRowInsert::from(r)
                 })
                 .collect();
-            buffer_repo.upsert_many(&buffer_rows)?;
+            buffer_repo.insert_many(&buffer_rows)?;
 
             let mut logger = SyncLogger::start(&ctx.connection).unwrap();
             integrate_and_translate_sync_buffer(
                 &ctx.connection,
                 Some(&mut logger),
-                SyncBufferSource::Central(0),
+                0,
             )?;
 
             info!("Initialising users");

--- a/server/repository/src/db_diesel/sync_buffer.rs
+++ b/server/repository/src/db_diesel/sync_buffer.rs
@@ -2,14 +2,12 @@ use std::ops::Deref;
 
 use super::StorageConnection;
 use crate::{
-    diesel_macros::{
-        apply_date_time_filter, apply_equal_filter, diesel_json_type, diesel_string_enum,
-    },
+    diesel_macros::{diesel_json_type, diesel_string_enum},
+    migrations::Version,
     repository_error::RepositoryError,
-    DBType, DatetimeFilter, EqualFilter,
 };
-use chrono::NaiveDateTime;
-use diesel::{dsl::IntoBoxed, prelude::*};
+use chrono::{NaiveDateTime, Utc};
+use diesel::prelude::*;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 diesel_string_enum! {
@@ -20,6 +18,27 @@ diesel_string_enum! {
         Upsert,
         Delete,
         Merge,
+    }
+}
+
+diesel_string_enum! {
+    #[derive(Clone, Copy, Serialize, Deserialize, Eq)]
+    pub enum SyncVersion {
+        #[default]
+        #[strum(serialize = "V5_V6")]
+        V5V6,
+        V7,
+    }
+}
+
+diesel_string_enum! {
+    #[derive(Clone, Copy, Serialize, Deserialize, Eq)]
+    #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+    pub enum IntegrationResult {
+        #[default]
+        Success,
+        Error,
+        Ignored,
     }
 }
 
@@ -36,39 +55,70 @@ impl Deref for SyncRecordData {
     }
 }
 
+diesel_json_type! {
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct AppVersion(pub Version);
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CursorDirection {
+    Asc,
+    Desc,
+}
+
 table! {
-    sync_buffer (record_id) {
+    sync_buffer (cursor) {
+        cursor -> Integer,
         record_id -> Text,
         received_datetime -> Timestamp,
+        integration_started_datetime -> Nullable<Timestamp>,
         integration_datetime -> Nullable<Timestamp>,
         integration_error -> Nullable<Text>,
+        integration_result -> Nullable<Text>,
         table_name -> Text,
         action -> Text,
         data -> Text,
-        source_site_id -> Nullable<Integer>,
+        sync_version -> Text,
+        app_version -> Nullable<Text>,
+        source_site_id -> Integer,
         store_id -> Nullable<Text>,
         transfer_store_id -> Nullable<Text>,
         patient_id -> Nullable<Text>,
+        reference -> Nullable<Text>,
+        is_integrated -> Bool,
     }
 }
 
-#[derive(
-    Clone, Queryable, Insertable, Serialize, Deserialize, Debug, AsChangeset, PartialEq, Default,
-)]
-#[diesel(treat_none_as_null = true)]
-#[diesel(table_name = sync_buffer)]
+#[derive(Clone, Queryable, Serialize, Deserialize, Debug, PartialEq, Default)]
 pub struct SyncBufferRow {
+    #[serde(default)]
+    pub cursor: i32,
     pub record_id: String,
     pub received_datetime: NaiveDateTime,
+    #[serde(default)]
+    pub integration_started_datetime: Option<NaiveDateTime>,
     pub integration_datetime: Option<NaiveDateTime>,
     pub integration_error: Option<String>,
+    #[serde(default)]
+    pub integration_result: Option<IntegrationResult>,
     pub table_name: String,
     pub action: SyncAction,
     pub data: SyncRecordData,
-    pub source_site_id: Option<i32>,
+    #[serde(default)]
+    pub sync_version: SyncVersion,
+    #[serde(default)]
+    pub app_version: Option<AppVersion>,
+    pub source_site_id: i32,
+    #[serde(default)]
     pub store_id: Option<String>,
+    #[serde(default)]
     pub transfer_store_id: Option<String>,
+    #[serde(default)]
     pub patient_id: Option<String>,
+    #[serde(default)]
+    pub reference: Option<String>,
+    #[serde(default)]
+    pub is_integrated: bool,
 }
 
 impl SyncBufferRow {
@@ -77,66 +127,175 @@ impl SyncBufferRow {
     }
 }
 
-pub struct SyncBufferRowRepository<'a> {
+/// Insert shape for `sync_buffer` — `cursor` is auto-assigned by the DB
+/// (SERIAL on Postgres / INTEGER PRIMARY KEY AUTOINCREMENT on SQLite).
+#[derive(Clone, Insertable, Debug, PartialEq, Default)]
+#[diesel(table_name = sync_buffer)]
+pub struct SyncBufferRowInsert {
+    pub record_id: String,
+    pub received_datetime: NaiveDateTime,
+    pub table_name: String,
+    pub action: SyncAction,
+    pub data: SyncRecordData,
+    pub sync_version: SyncVersion,
+    pub app_version: Option<AppVersion>,
+    pub source_site_id: i32,
+    pub store_id: Option<String>,
+    pub transfer_store_id: Option<String>,
+    pub patient_id: Option<String>,
+    pub reference: Option<String>,
+}
+
+impl From<SyncBufferRow> for SyncBufferRowInsert {
+    fn from(row: SyncBufferRow) -> Self {
+        SyncBufferRowInsert {
+            record_id: row.record_id,
+            received_datetime: row.received_datetime,
+            table_name: row.table_name,
+            action: row.action,
+            data: row.data,
+            sync_version: row.sync_version,
+            app_version: row.app_version,
+            source_site_id: row.source_site_id,
+            store_id: row.store_id,
+            transfer_store_id: row.transfer_store_id,
+            patient_id: row.patient_id,
+            reference: row.reference,
+        }
+    }
+}
+
+pub struct PendingQuery<'a> {
+    pub source_site_id: i32,
+    pub sync_version: SyncVersion,
+    pub reference: Option<&'a str>,
+    pub table_name: &'a str,
+    pub action: SyncAction,
+    pub direction: CursorDirection,
+}
+
+pub struct SyncBufferRepository<'a> {
     connection: &'a StorageConnection,
 }
 
-impl<'a> SyncBufferRowRepository<'a> {
+impl<'a> SyncBufferRepository<'a> {
     pub fn new(connection: &'a StorageConnection) -> Self {
-        SyncBufferRowRepository { connection }
+        SyncBufferRepository { connection }
     }
 
-    pub fn upsert_one(&self, row: &SyncBufferRow) -> Result<(), RepositoryError> {
-        let statement = diesel::insert_into(sync_buffer::table)
-            .values(row)
-            .on_conflict(sync_buffer::record_id)
-            .do_update()
-            .set(row);
-
-        // //   Debug diesel query
-        // println!("{}", diesel::debug_query::<DBType, _>(&statement).to_string());
-
-        statement.execute(self.connection.lock().connection())?;
-        Ok(())
-    }
-
-    pub fn upsert_many(&self, rows: &Vec<SyncBufferRow>) -> Result<(), RepositoryError> {
-        for row in rows {
-            self.upsert_one(row)?
+    /// The only insertion path. Cursor is auto-assigned per row.
+    pub fn insert_many(&self, rows: &[SyncBufferRowInsert]) -> Result<(), RepositoryError> {
+        if rows.is_empty() {
+            return Ok(());
         }
+        diesel::insert_into(sync_buffer::table)
+            .values(rows)
+            .execute(self.connection.lock().connection())?;
         Ok(())
     }
 
-    pub fn get_all(&self) -> Result<Vec<SyncBufferRow>, RepositoryError> {
-        Ok(sync_buffer::table.load(self.connection.lock().connection())?)
+    /// The only filtered list query. Always filters `is_integrated = false`,
+    /// orders by `cursor` in the requested direction, and returns all matching rows.
+    pub fn pending_ordered_by_cursor(
+        &self,
+        query: PendingQuery,
+    ) -> Result<Vec<SyncBufferRow>, RepositoryError> {
+        let PendingQuery {
+            source_site_id,
+            sync_version,
+            reference,
+            table_name,
+            action,
+            direction,
+        } = query;
+
+        let mut q = sync_buffer::table
+            .filter(sync_buffer::is_integrated.eq(false))
+            .filter(sync_buffer::sync_version.eq(sync_version))
+            .filter(sync_buffer::table_name.eq(table_name.to_string()))
+            .filter(sync_buffer::action.eq(action))
+            .filter(sync_buffer::source_site_id.eq(source_site_id))
+            .into_boxed();
+
+        if let Some(reference) = reference {
+            q = q.filter(sync_buffer::reference.eq(reference.to_string()));
+        }
+
+        let rows = match direction {
+            CursorDirection::Asc => q
+                .order(sync_buffer::cursor.asc())
+                .load(self.connection.lock().connection())?,
+            CursorDirection::Desc => q
+                .order(sync_buffer::cursor.desc())
+                .load(self.connection.lock().connection())?,
+        };
+
+        Ok(rows)
     }
 
+    /// Total pending rows across all tables and actions, for the given source/version/reference.
+    /// Used for progress reporting.
+    pub fn count_pending(
+        &self,
+        source_site_id: i32,
+        sync_version: SyncVersion,
+        reference: Option<&str>,
+    ) -> Result<i64, RepositoryError> {
+        let mut q = sync_buffer::table
+            .filter(sync_buffer::is_integrated.eq(false))
+            .filter(sync_buffer::sync_version.eq(sync_version))
+            .filter(sync_buffer::source_site_id.eq(source_site_id))
+            .into_boxed();
+
+        if let Some(reference) = reference {
+            q = q.filter(sync_buffer::reference.eq(reference.to_string()));
+        }
+
+        let count: i64 = q.count().get_result(self.connection.lock().connection())?;
+        Ok(count)
+    }
+
+    /// Records the outcome of integrating a single buffer row.
+    ///
+    /// `started_datetime` is captured by the caller immediately before integration begins
+    /// and passed in here once integration completes (success, error, or ignored). Sets
+    /// `is_integrated = true`, which moves the row out of the pending partition (PG) and
+    /// drops it from the partial pending index (SQLite).
+    pub fn set_integration_result(
+        &self,
+        cursor: i32,
+        started_datetime: NaiveDateTime,
+        result: IntegrationResult,
+        error: Option<&str>,
+    ) -> Result<(), RepositoryError> {
+        diesel::update(sync_buffer::table.filter(sync_buffer::cursor.eq(cursor)))
+            .set((
+                sync_buffer::integration_started_datetime.eq(Some(started_datetime)),
+                sync_buffer::integration_datetime.eq(Some(Utc::now().naive_utc())),
+                sync_buffer::integration_result.eq(Some(result)),
+                sync_buffer::integration_error.eq(error.map(|s| s.to_string())),
+                sync_buffer::is_integrated.eq(true),
+            ))
+            .execute(self.connection.lock().connection())?;
+        Ok(())
+    }
+
+    /// Escape hatch: returns the most recent (highest cursor) row matching the record_id,
+    /// across both pending and integrated rows. Used by translators that look up parent records.
     pub fn find_one_by_record_id(
         &self,
         record_id: &str,
     ) -> Result<Option<SyncBufferRow>, RepositoryError> {
         let result = sync_buffer::table
             .filter(sync_buffer::record_id.eq(record_id))
+            .order(sync_buffer::cursor.desc())
             .first(self.connection.lock().connection())
             .optional()?;
         Ok(result)
     }
-    /// Updates only integration_datetime and integration_error for a sync buffer record.
-    pub fn set_integration_result(
-        &self,
-        record_id: &str,
-        integration_error: Option<&str>,
-    ) -> Result<(), RepositoryError> {
-        diesel::update(sync_buffer::table.filter(sync_buffer::record_id.eq(record_id)))
-            .set((
-                sync_buffer::integration_datetime.eq(Some(chrono::Utc::now().naive_utc())),
-                sync_buffer::integration_error.eq(integration_error),
-            ))
-            .execute(self.connection.lock().connection())?;
-        Ok(())
-    }
 
-    /// Find sync_buffer records by table_name where the JSON data column contains the given pattern.
+    /// Escape hatch: returns rows for the given table whose JSON `data` matches the LIKE pattern,
+    /// ordered by cursor DESC so callers see the most recent first.
     pub fn find_by_table_and_data_like(
         &self,
         table_name: &str,
@@ -148,168 +307,27 @@ impl<'a> SyncBufferRowRepository<'a> {
                     .eq(table_name)
                     .and(sync_buffer::data.like(data_pattern)),
             )
+            .order(sync_buffer::cursor.desc())
             .load(self.connection.lock().connection())?;
         Ok(result)
     }
-}
 
-#[derive(Clone, Default)]
-pub struct SyncBufferFilter {
-    pub record_id: Option<EqualFilter<String>>,
-    pub integration_datetime: Option<DatetimeFilter>,
-    pub integration_error: Option<EqualFilter<String>>,
-    pub action: Option<EqualFilter<SyncAction>>,
-    pub table_name: Option<EqualFilter<String>>,
-    pub source_site_id: Option<EqualFilter<i32>>,
-}
-
-impl SyncBufferFilter {
-    pub fn new() -> SyncBufferFilter {
-        SyncBufferFilter::default()
+    pub fn get_all(&self) -> Result<Vec<SyncBufferRow>, RepositoryError> {
+        Ok(sync_buffer::table
+            .order(sync_buffer::cursor.asc())
+            .load(self.connection.lock().connection())?)
     }
-
-    pub fn integration_datetime(mut self, filter: DatetimeFilter) -> Self {
-        self.integration_datetime = Some(filter);
-        self
-    }
-
-    pub fn record_id(mut self, filter: EqualFilter<String>) -> Self {
-        self.record_id = Some(filter);
-        self
-    }
-
-    pub fn integration_error(mut self, filter: EqualFilter<String>) -> Self {
-        self.integration_error = Some(filter);
-        self
-    }
-
-    pub fn table_name(mut self, filter: EqualFilter<String>) -> Self {
-        self.table_name = Some(filter);
-        self
-    }
-
-    pub fn action(mut self, filter: EqualFilter<SyncAction>) -> Self {
-        self.action = Some(filter);
-        self
-    }
-
-    pub fn source_site_id(mut self, filter: EqualFilter<i32>) -> Self {
-        self.source_site_id = Some(filter);
-        self
-    }
-}
-
-impl SyncAction {
-    pub fn equal_to(&self) -> EqualFilter<Self> {
-        EqualFilter {
-            equal_to: Some(self.clone()),
-            ..Default::default()
-        }
-    }
-}
-
-type SyncBuffer = SyncBufferRow;
-
-pub struct SyncBufferRepository<'a> {
-    connection: &'a StorageConnection,
-}
-
-impl<'a> SyncBufferRepository<'a> {
-    pub fn new(connection: &'a StorageConnection) -> Self {
-        SyncBufferRepository { connection }
-    }
-
-    pub fn count(&self, filter: SyncBufferFilter) -> Result<i64, RepositoryError> {
-        let count = create_filtered_query(Some(filter))
-            .count()
-            .get_result(self.connection.lock().connection())?;
-        Ok(count)
-    }
-
-    pub fn query_by_filter(
-        &self,
-        filter: SyncBufferFilter,
-    ) -> Result<Vec<SyncBuffer>, RepositoryError> {
-        self.query(Some(filter))
-    }
-
-    pub fn query(
-        &self,
-        filter: Option<SyncBufferFilter>,
-    ) -> Result<Vec<SyncBuffer>, RepositoryError> {
-        let query = create_filtered_query(filter);
-
-        let result = query.load::<SyncBuffer>(self.connection.lock().connection())?;
-
-        Ok(result)
-    }
-}
-
-type BoxedSyncBufferQuery = IntoBoxed<'static, sync_buffer::table, DBType>;
-
-fn create_filtered_query(filter: Option<SyncBufferFilter>) -> BoxedSyncBufferQuery {
-    let mut query = sync_buffer::table.into_boxed();
-
-    if let Some(f) = filter {
-        let SyncBufferFilter {
-            integration_datetime,
-            integration_error,
-            action,
-            table_name,
-            record_id,
-            source_site_id,
-        } = f;
-
-        apply_equal_filter!(query, record_id, sync_buffer::record_id);
-        apply_date_time_filter!(
-            query,
-            integration_datetime,
-            sync_buffer::integration_datetime
-        );
-        apply_equal_filter!(query, integration_error, sync_buffer::integration_error);
-        apply_equal_filter!(query, action, sync_buffer::action);
-        apply_equal_filter!(query, table_name, sync_buffer::table_name);
-        apply_equal_filter!(query, source_site_id, sync_buffer::source_site_id);
-    }
-
-    query
 }
 
 #[cfg(test)]
 mod test {
+    use super::*;
+    use crate::{mock::MockDataInserts, test_db};
 
-    use crate::{
-        mock::{MockData, MockDataInserts},
-        test_db, DatetimeFilter, EqualFilter, SyncAction, SyncBufferFilter, SyncBufferRepository,
-        SyncBufferRow, SyncBufferRowRepository, SyncRecordData,
-    };
-
-    pub fn row_a() -> SyncBufferRow {
-        SyncBufferRow {
-            record_id: "store_a".to_string(),
-            integration_datetime: Some(Default::default()),
-            table_name: "store".to_string(),
-            action: SyncAction::Upsert,
-            data: SyncRecordData(serde_json::json!({})),
-            ..Default::default()
-        }
-    }
-
-    pub fn row_b() -> SyncBufferRow {
-        SyncBufferRow {
-            record_id: "store_b".to_string(),
-            integration_error: Some("error".to_string()),
-            table_name: "store".to_string(),
-            action: SyncAction::Delete,
-            data: SyncRecordData(serde_json::json!({})),
-            ..Default::default()
-        }
-    }
-
-    pub fn row_c() -> SyncBufferRow {
-        SyncBufferRow {
-            record_id: "store_c".to_string(),
-            table_name: "store".to_string(),
+    fn insert(record_id: &str, table_name: &str) -> SyncBufferRowInsert {
+        SyncBufferRowInsert {
+            record_id: record_id.to_string(),
+            table_name: table_name.to_string(),
             action: SyncAction::Upsert,
             data: SyncRecordData(serde_json::json!({})),
             ..Default::default()
@@ -317,62 +335,208 @@ mod test {
     }
 
     #[actix_rt::test]
-    async fn test_sync_buffer() {
-        let (_, connection, _, _) = test_db::setup_all_with_data(
-            "test_sync_buffer",
+    async fn test_sync_buffer_insert_and_query() {
+        let (_, connection, _, _) = test_db::setup_all(
+            "test_sync_buffer_insert_and_query",
             MockDataInserts::none(),
-            MockData {
-                sync_buffer_rows: vec![row_a(), row_b(), row_c()],
-                ..Default::default()
-            },
         )
         .await;
 
-        assert_eq!(
-            SyncBufferRepository::new(&connection)
-                .query_by_filter(
-                    SyncBufferFilter::new()
-                        .integration_datetime(DatetimeFilter::is_null(true))
-                        .integration_error(EqualFilter::is_null(true))
-                )
-                .unwrap(),
-            vec![row_c()]
-        );
+        let repo = SyncBufferRepository::new(&connection);
 
-        assert_eq!(
-            SyncBufferRepository::new(&connection)
-                .query_by_filter(
-                    SyncBufferFilter::new()
-                        .integration_datetime(DatetimeFilter::is_null(true))
-                        .integration_error(EqualFilter::is_null(true))
-                )
-                .unwrap(),
-            vec![row_c()]
-        );
+        // Insert four rows in order — cursor must reflect insertion order
+        repo.insert_many(&[
+            SyncBufferRowInsert {
+                source_site_id: 1,
+                sync_version: SyncVersion::V5V6,
+                ..insert("a1", "store")
+            },
+            SyncBufferRowInsert {
+                source_site_id: 1,
+                sync_version: SyncVersion::V5V6,
+                ..insert("a2", "store")
+            },
+            SyncBufferRowInsert {
+                source_site_id: 2,
+                sync_version: SyncVersion::V7,
+                ..insert("b1", "store")
+            },
+            SyncBufferRowInsert {
+                source_site_id: 1,
+                sync_version: SyncVersion::V5V6,
+                reference: Some("batch-x".to_string()),
+                ..insert("c1", "store")
+            },
+        ])
+        .unwrap();
 
-        assert_eq!(
-            SyncBufferRepository::new(&connection)
-                .query_by_filter(SyncBufferFilter::new().action(SyncAction::Delete.equal_to()))
-                .unwrap(),
-            vec![row_b()]
-        );
-        // Test upsert overwrites integration_datetime
-        let mut new_a = row_a().clone();
-        new_a.integration_datetime = None;
+        // Filter by source_site_id + sync_version, no reference filter
+        let rows = repo
+            .pending_ordered_by_cursor(PendingQuery {
+                source_site_id: 1,
+                sync_version: SyncVersion::V5V6,
+                reference: None,
+                table_name: "store",
+                action: SyncAction::Upsert,
+                direction: CursorDirection::Asc,
+            })
+            .unwrap();
+        let ids: Vec<_> = rows.iter().map(|r| r.record_id.as_str()).collect();
+        assert_eq!(ids, vec!["a1", "a2", "c1"]);
 
-        SyncBufferRowRepository::new(&connection)
-            .upsert_one(&new_a)
+        // Filter narrowed to the batch reference
+        let rows = repo
+            .pending_ordered_by_cursor(PendingQuery {
+                source_site_id: 1,
+                sync_version: SyncVersion::V5V6,
+                reference: Some("batch-x"),
+                table_name: "store",
+                action: SyncAction::Upsert,
+                direction: CursorDirection::Asc,
+            })
+            .unwrap();
+        let ids: Vec<_> = rows.iter().map(|r| r.record_id.as_str()).collect();
+        assert_eq!(ids, vec!["c1"]);
+
+        // Reverse direction (deletes use Desc within table)
+        let rows = repo
+            .pending_ordered_by_cursor(PendingQuery {
+                source_site_id: 1,
+                sync_version: SyncVersion::V5V6,
+                reference: None,
+                table_name: "store",
+                action: SyncAction::Upsert,
+                direction: CursorDirection::Desc,
+            })
+            .unwrap();
+        let ids: Vec<_> = rows.iter().map(|r| r.record_id.as_str()).collect();
+        assert_eq!(ids, vec!["c1", "a2", "a1"]);
+
+        // V7 partition is isolated
+        let rows = repo
+            .pending_ordered_by_cursor(PendingQuery {
+                source_site_id: 2,
+                sync_version: SyncVersion::V7,
+                reference: None,
+                table_name: "store",
+                action: SyncAction::Upsert,
+                direction: CursorDirection::Asc,
+            })
+            .unwrap();
+        let ids: Vec<_> = rows.iter().map(|r| r.record_id.as_str()).collect();
+        assert_eq!(ids, vec!["b1"]);
+    }
+
+    #[actix_rt::test]
+    async fn test_sync_buffer_set_integration_result() {
+        let (_, connection, _, _) = test_db::setup_all(
+            "test_sync_buffer_set_integration_result",
+            MockDataInserts::none(),
+        )
+        .await;
+
+        let repo = SyncBufferRepository::new(&connection);
+
+        repo.insert_many(&[
+            SyncBufferRowInsert {
+                source_site_id: 1,
+                ..insert("r1", "store")
+            },
+            SyncBufferRowInsert {
+                source_site_id: 1,
+                ..insert("r2", "store")
+            },
+            SyncBufferRowInsert {
+                source_site_id: 1,
+                ..insert("r3", "store")
+            },
+        ])
+        .unwrap();
+
+        let rows = repo
+            .pending_ordered_by_cursor(PendingQuery {
+                source_site_id: 1,
+                sync_version: SyncVersion::V5V6,
+                reference: None,
+                table_name: "store",
+                action: SyncAction::Upsert,
+                direction: CursorDirection::Asc,
+            })
+            .unwrap();
+        assert_eq!(rows.len(), 3);
+
+        let started = chrono::Utc::now().naive_utc();
+        repo.set_integration_result(rows[0].cursor, started, IntegrationResult::Success, None)
+            .unwrap();
+        repo.set_integration_result(
+            rows[1].cursor,
+            started,
+            IntegrationResult::Error,
+            Some("oh no"),
+        )
+        .unwrap();
+        repo.set_integration_result(
+            rows[2].cursor,
+            started,
+            IntegrationResult::Ignored,
+            Some("not for us"),
+        )
+        .unwrap();
+
+        // After recording results, no rows are pending
+        let pending = repo
+            .pending_ordered_by_cursor(PendingQuery {
+                source_site_id: 1,
+                sync_version: SyncVersion::V5V6,
+                reference: None,
+                table_name: "store",
+                action: SyncAction::Upsert,
+                direction: CursorDirection::Asc,
+            })
+            .unwrap();
+        assert!(pending.is_empty());
+
+        let r1 = repo.find_one_by_record_id("r1").unwrap().unwrap();
+        assert_eq!(r1.integration_result, Some(IntegrationResult::Success));
+        assert_eq!(r1.integration_error, None);
+        assert!(r1.integration_started_datetime.is_some());
+        assert!(r1.integration_datetime.is_some());
+
+        let r2 = repo.find_one_by_record_id("r2").unwrap().unwrap();
+        assert_eq!(r2.integration_result, Some(IntegrationResult::Error));
+        assert_eq!(r2.integration_error.as_deref(), Some("oh no"));
+
+        let r3 = repo.find_one_by_record_id("r3").unwrap().unwrap();
+        assert_eq!(r3.integration_result, Some(IntegrationResult::Ignored));
+        assert_eq!(r3.integration_error.as_deref(), Some("not for us"));
+    }
+
+    #[actix_rt::test]
+    async fn test_sync_buffer_find_one_by_record_id_returns_most_recent() {
+        let (_, connection, _, _) = test_db::setup_all(
+            "test_sync_buffer_find_one_by_record_id_returns_most_recent",
+            MockDataInserts::none(),
+        )
+        .await;
+
+        let repo = SyncBufferRepository::new(&connection);
+
+        repo.insert_many(&[insert("dup", "store"), insert("dup", "store")])
             .unwrap();
 
-        assert_eq!(
-            SyncBufferRepository::new(&connection)
-                .query_by_filter(
-                    SyncBufferFilter::new()
-                        .integration_datetime(DatetimeFilter::is_null(true))
-                        .record_id(EqualFilter::equal_to(row_a().record_id.to_string()))
-                )
-                .unwrap(),
-            vec![new_a]
-        );
+        let pending = repo
+            .pending_ordered_by_cursor(PendingQuery {
+                source_site_id: 0,
+                sync_version: SyncVersion::V5V6,
+                reference: None,
+                table_name: "store",
+                action: SyncAction::Upsert,
+                direction: CursorDirection::Asc,
+            })
+            .unwrap();
+        assert_eq!(pending.len(), 2);
+
+        let latest = repo.find_one_by_record_id("dup").unwrap().unwrap();
+        assert_eq!(latest.cursor, pending[1].cursor);
     }
 }

--- a/server/repository/src/migrations/v3_00_00/mod.rs
+++ b/server/repository/src/migrations/v3_00_00/mod.rs
@@ -8,6 +8,7 @@ mod alter_changelog_table_for_sync_v7;
 mod alter_sync_buffer_for_sync_v7;
 mod changelog_related_changes_for_sync_v7;
 mod create_site_table;
+mod rebuild_sync_buffer;
 
 pub(crate) struct V3_00_00;
 impl Migration for V3_00_00 {
@@ -28,6 +29,7 @@ impl Migration for V3_00_00 {
             Box::new(add_sync_log_v7::Migrate),
             Box::new(changelog_related_changes_for_sync_v7::Migrate),
             Box::new(create_site_table::Migrate),
+            Box::new(rebuild_sync_buffer::Migrate),
         ]
     }
 }

--- a/server/repository/src/migrations/v3_00_00/rebuild_sync_buffer.rs
+++ b/server/repository/src/migrations/v3_00_00/rebuild_sync_buffer.rs
@@ -1,0 +1,137 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "rebuild_sync_buffer"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        let cursor_col = if cfg!(feature = "postgres") {
+            "cursor SERIAL NOT NULL"
+        } else {
+            "cursor INTEGER PRIMARY KEY AUTOINCREMENT"
+        };
+
+        // CREATE TABLE has to be one complete statement per backend; `batch_execute`
+        // (which `sql!` uses) rejects partial DDL.
+        if cfg!(feature = "postgres") {
+            sql!(
+                connection,
+                r#"
+                CREATE TABLE sync_buffer_new (
+                    {cursor_col},
+                    record_id TEXT NOT NULL,
+                    received_datetime TIMESTAMP NOT NULL,
+                    integration_started_datetime TIMESTAMP,
+                    integration_datetime TIMESTAMP,
+                    integration_error TEXT,
+                    integration_result TEXT,
+                    table_name TEXT NOT NULL,
+                    action TEXT NOT NULL,
+                    data TEXT NOT NULL,
+                    sync_version TEXT NOT NULL DEFAULT 'V5_V6',
+                    app_version TEXT,
+                    source_site_id INTEGER NOT NULL,
+                    store_id TEXT,
+                    transfer_store_id TEXT,
+                    patient_id TEXT,
+                    reference TEXT,
+                    is_integrated BOOLEAN NOT NULL DEFAULT FALSE,
+                    PRIMARY KEY (cursor, is_integrated)
+                ) PARTITION BY LIST (is_integrated);
+
+                CREATE TABLE sync_buffer_pending PARTITION OF sync_buffer_new FOR VALUES IN (false);
+                CREATE TABLE sync_buffer_archive PARTITION OF sync_buffer_new FOR VALUES IN (true);
+                "#
+            )?;
+        } else {
+            sql!(
+                connection,
+                r#"
+                CREATE TABLE sync_buffer_new (
+                    {cursor_col},
+                    record_id TEXT NOT NULL,
+                    received_datetime TIMESTAMP NOT NULL,
+                    integration_started_datetime TIMESTAMP,
+                    integration_datetime TIMESTAMP,
+                    integration_error TEXT,
+                    integration_result TEXT,
+                    table_name TEXT NOT NULL,
+                    action TEXT NOT NULL,
+                    data TEXT NOT NULL,
+                    sync_version TEXT NOT NULL DEFAULT 'V5_V6',
+                    app_version TEXT,
+                    source_site_id INTEGER NOT NULL,
+                    store_id TEXT,
+                    transfer_store_id TEXT,
+                    patient_id TEXT,
+                    reference TEXT,
+                    is_integrated BOOLEAN NOT NULL DEFAULT FALSE
+                );
+                "#
+            )?;
+        }
+
+        sql!(
+            connection,
+            r#"
+            INSERT INTO sync_buffer_new (
+                record_id, received_datetime, integration_started_datetime, integration_datetime,
+                integration_error, table_name, action, data, sync_version,
+                app_version, source_site_id, store_id, transfer_store_id, patient_id, reference,
+                is_integrated
+            )
+            SELECT
+                record_id,
+                received_datetime,
+                integration_datetime,
+                integration_datetime,
+                integration_error,
+                table_name,
+                action,
+                data,
+                'V5_V6',
+                NULL,
+                COALESCE(
+                    source_site_id,
+                    (SELECT value_int FROM key_value_store WHERE id = 'SETTINGS_SYNC_CENTRAL_SERVER_SITE_ID'),
+                    0
+                ),
+                store_id,
+                transfer_store_id,
+                patient_id,
+                NULL,
+                integration_datetime IS NOT NULL
+            FROM sync_buffer
+            ORDER BY received_datetime;
+
+            DROP TABLE sync_buffer;
+            ALTER TABLE sync_buffer_new RENAME TO sync_buffer;
+            "#
+        )?;
+
+        if cfg!(feature = "postgres") {
+            sql!(
+                connection,
+                r#"
+                ALTER SEQUENCE sync_buffer_new_cursor_seq RENAME TO sync_buffer_cursor_seq;
+                CREATE INDEX index_sync_buffer_pending
+                    ON sync_buffer_pending (source_site_id, reference, sync_version, table_name);
+                "#
+            )?;
+        } else {
+            sql!(
+                connection,
+                r#"
+                CREATE INDEX index_sync_buffer_pending
+                    ON sync_buffer (source_site_id, reference, sync_version, table_name)
+                    WHERE is_integrated = FALSE;
+                "#
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/server/repository/src/mock/mod.rs
+++ b/server/repository/src/mock/mod.rs
@@ -1246,10 +1246,14 @@ pub fn insert_mock_data(
         }
 
         if inserts.sync_buffer_rows {
-            let repo = SyncBufferRowRepository::new(connection);
-            for row in &mock_data.sync_buffer_rows {
-                repo.upsert_one(row).unwrap();
-            }
+            let repo = SyncBufferRepository::new(connection);
+            let rows: Vec<SyncBufferRowInsert> = mock_data
+                .sync_buffer_rows
+                .iter()
+                .cloned()
+                .map(SyncBufferRowInsert::from)
+                .collect();
+            repo.insert_many(&rows).unwrap();
         }
 
         if inserts.activity_logs {

--- a/server/service/src/sync/api/common_records.rs
+++ b/server/service/src/sync/api/common_records.rs
@@ -1,5 +1,7 @@
 use chrono::Utc;
-use repository::{ChangelogTableName, SyncAction as SyncActionRepo, SyncBufferRow, SyncRecordData};
+use repository::{
+    ChangelogTableName, SyncAction as SyncActionRepo, SyncBufferRowInsert, SyncRecordData,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use thiserror::Error;
@@ -69,8 +71,8 @@ pub(crate) struct ParsingSyncRecordError {
 impl CommonSyncRecord {
     fn to_buffer_row(
         self,
-        source_site_id: Option<i32>,
-    ) -> Result<SyncBufferRow, ParsingSyncRecordError> {
+        source_site_id: i32,
+    ) -> Result<SyncBufferRowInsert, ParsingSyncRecordError> {
         let CommonSyncRecord {
             table_name,
             record_id,
@@ -91,14 +93,12 @@ impl CommonSyncRecord {
             _ => record_id,
         };
 
-        Ok(SyncBufferRow {
+        Ok(SyncBufferRowInsert {
             table_name,
             record_id,
             action: action.to_row_action(),
             data: SyncRecordData(data),
             received_datetime: Utc::now().naive_utc(),
-            integration_datetime: None,
-            integration_error: None,
             source_site_id,
             ..Default::default()
         })
@@ -106,8 +106,8 @@ impl CommonSyncRecord {
 
     pub(crate) fn to_buffer_rows(
         rows: Vec<CommonSyncRecord>,
-        source_site_id: Option<i32>,
-    ) -> Result<Vec<SyncBufferRow>, ParsingSyncRecordError> {
+        source_site_id: i32,
+    ) -> Result<Vec<SyncBufferRowInsert>, ParsingSyncRecordError> {
         rows.into_iter()
             .map(|r| r.to_buffer_row(source_site_id))
             .collect()
@@ -135,7 +135,7 @@ impl CommonSyncRecord {
 // tests
 #[cfg(test)]
 mod tests {
-    use repository::{mock::MockDataInserts, test_db::setup_all, SyncBufferRowRepository};
+    use repository::{mock::MockDataInserts, test_db::setup_all, SyncBufferRepository};
 
     use crate::sync::translations::special::item_merge::ItemMergeMessage;
 
@@ -150,7 +150,7 @@ mod tests {
             record_data: json!({}),
         };
 
-        let row = record.to_buffer_row(None).unwrap();
+        let row = record.to_buffer_row(0).unwrap();
         assert_eq!(row.table_name, "test");
         assert_eq!(row.record_id, "test");
         assert_eq!(row.action, SyncActionRepo::Upsert);
@@ -209,7 +209,7 @@ mod tests {
                     }),
                 },
             ],
-            None, /* Source Site Id */
+            0, /* Source Site Id */
         )
         .unwrap();
 
@@ -219,8 +219,8 @@ mod tests {
         )
         .await;
 
-        let sync_buffer_repository = SyncBufferRowRepository::new(&connection);
-        sync_buffer_repository.upsert_many(&batch).unwrap();
+        let sync_buffer_repository = SyncBufferRepository::new(&connection);
+        sync_buffer_repository.insert_many(&batch).unwrap();
 
         let row = sync_buffer_repository
             .find_one_by_record_id("itemB")
@@ -228,17 +228,17 @@ mod tests {
             .unwrap();
         assert_eq!(row.action, SyncActionRepo::Upsert);
 
-        // ItemB Upsert + Two Upserts for itemA should should be only be persisted as one + ItemB->ItemA Merge
+        // With insert_many (no upsert dedup) all 4 records are persisted as distinct rows
         let rows = sync_buffer_repository.get_all().unwrap();
-        assert_eq!(rows.len(), 3);
+        assert_eq!(rows.len(), 4);
 
-        // Just one update for item A
+        // Two upsert rows for itemA (Insert + Update both map to Upsert)
         assert_eq!(
             rows.iter()
                 .filter(|r| r.record_id == "itemA" && r.action == SyncActionRepo::Upsert)
                 .collect::<Vec<_>>()
                 .len(),
-            1
+            2
         );
 
         // Merge for itemA

--- a/server/service/src/sync/central_data_synchroniser.rs
+++ b/server/service/src/sync/central_data_synchroniser.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{cursor_controller::CursorController, sync::api::CentralSyncBatchV5};
 use repository::{
-    KeyType, KeyValueStoreRepository, RepositoryError, StorageConnection, SyncBufferRowRepository,
+    KeyType, KeyValueStoreRepository, RepositoryError, StorageConnection, SyncBufferRepository,
 };
 use thiserror::Error;
 
@@ -20,6 +20,8 @@ pub(crate) enum CentralPullError {
     ParsingRecordError(#[from] ParsingSyncRecordError),
     #[error(transparent)]
     SyncLoggerError(#[from] SyncLoggerError),
+    #[error("Central server site id not configured (SettingsSyncCentralServerSiteId)")]
+    CentralServerSiteIdNotSet,
 }
 
 pub(crate) struct CentralDataSynchroniser {
@@ -38,12 +40,13 @@ impl CentralDataSynchroniser {
         let cursor_controller = CursorController::new(KeyType::CentralSyncPullCursor);
 
         let msupply_central_server_id = KeyValueStoreRepository::new(connection)
-            .get_i32(KeyType::SettingsSyncCentralServerSiteId)?;
+            .get_i32(KeyType::SettingsSyncCentralServerSiteId)?
+            .ok_or(CentralPullError::CentralServerSiteIdNotSet)?;
 
         log::info!(
             "Pulling central data with batch size {} and msupply_central_server_id {}",
             batch_size,
-            msupply_central_server_id.unwrap_or_default()
+            msupply_central_server_id
         );
 
         loop {
@@ -63,10 +66,10 @@ impl CentralDataSynchroniser {
                 msupply_central_server_id,
             )?;
 
-            // Upsert sync buffer rows in a transaction together with cursor update
+            // Insert sync buffer rows in a transaction together with cursor update
             connection
                 .transaction_sync(|t_con| {
-                    SyncBufferRowRepository::new(t_con).upsert_many(&sync_buffer_rows)?;
+                    SyncBufferRepository::new(t_con).insert_many(&sync_buffer_rows)?;
                     cursor_controller.update(t_con, last_cursor_in_batch)
                 })
                 .map_err(|e| e.to_inner_error())?;

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -17,7 +17,7 @@ use super::{
 use log::info;
 use repository::{
     ChangelogFilter, ChangelogRepository, CursorAndLimit, KeyType, KeyValueStoreRepository,
-    LegacyDataFilterError, RepositoryError, StorageConnection, SyncBufferRowRepository,
+    LegacyDataFilterError, RepositoryError, StorageConnection, SyncBufferRepository,
 };
 
 use thiserror::Error;
@@ -44,6 +44,8 @@ pub(crate) enum RemotePullError {
     ParsingRecordError(#[from] ParsingSyncRecordError),
     #[error(transparent)]
     SyncLoggerError(#[from] SyncLoggerError),
+    #[error("Central server site id not configured (SettingsSyncCentralServerSiteId)")]
+    CentralServerSiteIdNotSet,
 }
 
 #[derive(Error, Debug)]
@@ -132,12 +134,13 @@ impl RemoteDataSynchroniser {
         let step_progress = SyncStepProgress::PullRemote;
 
         let msupply_central_server_id = KeyValueStoreRepository::new(connection)
-            .get_i32(KeyType::SettingsSyncCentralServerSiteId)?;
+            .get_i32(KeyType::SettingsSyncCentralServerSiteId)?
+            .ok_or(RemotePullError::CentralServerSiteIdNotSet)?;
 
         log::info!(
             "Pulling remote data with batch size {} and msupply_central_server_id {}",
             batch_size,
-            msupply_central_server_id.unwrap_or_default()
+            msupply_central_server_id
         );
 
         loop {
@@ -164,7 +167,7 @@ impl RemoteDataSynchroniser {
             if number_of_pulled_records > 0 {
                 connection
                     .transaction_sync(|t_con| {
-                        SyncBufferRowRepository::new(t_con).upsert_many(&sync_buffer_rows)
+                        SyncBufferRepository::new(t_con).insert_many(&sync_buffer_rows)
                     })
                     .map_err(|e| e.to_inner_error())?;
 

--- a/server/service/src/sync/sync_buffer.rs
+++ b/server/service/src/sync/sync_buffer.rs
@@ -1,88 +1,86 @@
-use chrono::Utc;
+use chrono::NaiveDateTime;
 use repository::{
-    DatetimeFilter, EqualFilter, RepositoryError, StorageConnection, SyncAction, SyncBufferFilter,
-    SyncBufferRepository, SyncBufferRow, SyncBufferRowRepository,
+    CursorDirection, IntegrationResult, PendingQuery, RepositoryError, StorageConnection,
+    SyncAction, SyncBufferRepository, SyncBufferRow, SyncVersion,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SyncBufferSource {
-    Central(i32), // Central site ID (Includes all records with no source site ID)
-    Remote(i32),  // Remote site ID
+pub(crate) fn write_sync_buffer_success(
+    connection: &StorageConnection,
+    cursor: i32,
+    started_datetime: NaiveDateTime,
+) -> Result<(), RepositoryError> {
+    SyncBufferRepository::new(connection).set_integration_result(
+        cursor,
+        started_datetime,
+        IntegrationResult::Success,
+        None,
+    )
 }
 
-pub(crate) struct SyncBuffer<'a> {
-    query_repository: SyncBufferRepository<'a>,
-    row_repository: SyncBufferRowRepository<'a>,
+pub(crate) fn write_sync_buffer_error(
+    connection: &StorageConnection,
+    cursor: i32,
+    started_datetime: NaiveDateTime,
+    error: &str,
+) -> Result<(), RepositoryError> {
+    SyncBufferRepository::new(connection).set_integration_result(
+        cursor,
+        started_datetime,
+        IntegrationResult::Error,
+        Some(error),
+    )
 }
 
-impl<'a> SyncBuffer<'a> {
-    pub(crate) fn new(connection: &'a StorageConnection) -> SyncBuffer<'a> {
-        SyncBuffer {
-            query_repository: SyncBufferRepository::new(connection),
-            row_repository: SyncBufferRowRepository::new(connection),
-        }
+pub(crate) fn write_sync_buffer_ignored(
+    connection: &StorageConnection,
+    cursor: i32,
+    started_datetime: NaiveDateTime,
+    message: &str,
+) -> Result<(), RepositoryError> {
+    SyncBufferRepository::new(connection).set_integration_result(
+        cursor,
+        started_datetime,
+        IntegrationResult::Ignored,
+        Some(message),
+    )
+}
+
+/// Get pending V5/V6 sync_buffer rows ready for integration.
+///
+/// Caller walks `ordered_table_names` in FK dependency order for upserts and
+/// reverse FK order for deletes. Within each `(table, action)` slice, rows are
+/// returned in cursor order (Asc for upserts/merges, Desc for deletes).
+pub(crate) fn get_ordered_sync_buffer_records(
+    connection: &StorageConnection,
+    action: SyncAction,
+    ordered_table_names: &[&str],
+    source_site_id: i32,
+) -> Result<Vec<SyncBufferRow>, RepositoryError> {
+    let direction = match action {
+        SyncAction::Delete => CursorDirection::Desc,
+        _ => CursorDirection::Asc,
+    };
+
+    let mut tables: Vec<&str> = ordered_table_names.iter().copied().collect();
+    if let SyncAction::Delete = action {
+        tables.reverse();
     }
 
-    pub(crate) fn record_successful_integration(
-        &self,
-        row: &SyncBufferRow,
-    ) -> Result<(), RepositoryError> {
-        self.row_repository.upsert_one(&SyncBufferRow {
-            integration_datetime: Some(Utc::now().naive_utc()),
-            integration_error: None,
-            ..row.clone()
-        })
+    let repo = SyncBufferRepository::new(connection);
+    let mut result = Vec::new();
+    for table_name in tables {
+        let mut rows = repo.pending_ordered_by_cursor(PendingQuery {
+            source_site_id,
+            sync_version: SyncVersion::V5V6,
+            reference: None,
+            table_name,
+            action: action.clone(),
+            direction,
+        })?;
+        result.append(&mut rows);
     }
 
-    pub(crate) fn record_integration_error(
-        &self,
-        row: &SyncBufferRow,
-        error: &anyhow::Error,
-    ) -> Result<(), RepositoryError> {
-        self.row_repository.upsert_one(&SyncBufferRow {
-            integration_datetime: Some(Utc::now().naive_utc()),
-            integration_error: Some(format!("{:?}", &error)),
-            ..row.clone()
-        })
-    }
-
-    pub(crate) fn get_ordered_sync_buffer_records(
-        &self,
-        action: SyncAction,
-        ordered_table_names: &[&str],
-        record_type: SyncBufferSource,
-    ) -> Result<Vec<SyncBufferRow>, RepositoryError> {
-        let ordered_table_names = ordered_table_names.iter().copied();
-        // Get ordered table names, for  upsert we sort in referential constraint order
-        // and for delete in reverse of referential constraint order
-        let order: Vec<&str> = match action {
-            SyncAction::Upsert => ordered_table_names.collect(),
-            SyncAction::Delete => ordered_table_names.rev().collect(),
-            SyncAction::Merge => ordered_table_names.collect(),
-        };
-
-        let mut result = Vec::new();
-
-        for legacy_table_name in order {
-            let mut rows = self.query_repository.query_by_filter(
-                SyncBufferFilter::new()
-                    .table_name(EqualFilter::equal_to(legacy_table_name.to_owned()))
-                    .action(action.equal_to())
-                    .integration_datetime(DatetimeFilter::is_null(true))
-                    .source_site_id(match record_type {
-                        SyncBufferSource::Central(source_site_id) => {
-                            EqualFilter::equal_any_or_null(vec![source_site_id])
-                        } // Includes all records with no source site ID (OMS Cetntral) + the site passed in
-                        SyncBufferSource::Remote(source_site_id) => {
-                            EqualFilter::equal_to(source_site_id)
-                        }
-                    }),
-            )?;
-            result.append(&mut rows);
-        }
-
-        Ok(result)
-    }
+    Ok(result)
 }
 
 #[cfg(test)]
@@ -90,206 +88,119 @@ mod test {
     use repository::{
         mock::{MockData, MockDataInserts},
         test_db::setup_all_with_data,
-        SyncAction, SyncBufferRow, SyncBufferRowRepository,
+        IntegrationResult, SyncAction, SyncBufferRepository, SyncBufferRow,
     };
 
-    use crate::sync::{
-        sync_buffer::SyncBufferSource,
-        translations::{all_translators, pull_integration_order},
-    };
+    use crate::sync::translations::{all_translators, pull_integration_order};
+    use util::datetime_now;
 
-    use super::SyncBuffer;
+    use super::*;
 
-    fn row_1() -> SyncBufferRow {
+    fn row(record_id: &str, table_name: &str) -> SyncBufferRow {
         SyncBufferRow {
-            record_id: "1".to_string(),
-            table_name: "transact".to_string(),
+            record_id: record_id.to_string(),
+            table_name: table_name.to_string(),
             received_datetime: Default::default(),
-            ..Default::default()
-        }
-    }
-
-    fn row_2() -> SyncBufferRow {
-        SyncBufferRow {
-            record_id: "2".to_string(),
-            table_name: "trans_line".to_string(),
-            received_datetime: Default::default(),
-            ..Default::default()
-        }
-    }
-
-    fn row_3() -> SyncBufferRow {
-        SyncBufferRow {
-            record_id: "3".to_string(),
-            table_name: "store".to_string(),
-            received_datetime: Default::default(),
-            ..Default::default()
-        }
-    }
-
-    fn row_4() -> SyncBufferRow {
-        SyncBufferRow {
-            record_id: "4".to_string(),
-            table_name: "name".to_string(),
-            received_datetime: Default::default(),
-            ..Default::default()
-        }
-    }
-
-    fn row_5() -> SyncBufferRow {
-        SyncBufferRow {
-            record_id: "5".to_string(),
-            table_name: "list_master".to_string(),
-            received_datetime: Default::default(),
-            action: SyncAction::Delete,
-            ..Default::default()
-        }
-    }
-
-    fn row_6() -> SyncBufferRow {
-        SyncBufferRow {
-            record_id: "6".to_string(),
-            table_name: "list_master_line".to_string(),
-            received_datetime: Default::default(),
-            action: SyncAction::Delete,
-            ..Default::default()
-        }
-    }
-    fn site_1_row_1() -> SyncBufferRow {
-        SyncBufferRow {
-            record_id: "1-1".to_string(),
-            table_name: "list_master".to_string(),
-            received_datetime: Default::default(),
-            action: SyncAction::Delete,
-            source_site_id: Some(1),
-            ..Default::default()
-        }
-    }
-
-    fn site_1_row_2() -> SyncBufferRow {
-        SyncBufferRow {
-            record_id: "1-2".to_string(),
-            table_name: "list_master_line".to_string(),
-            received_datetime: Default::default(),
-            action: SyncAction::Delete,
-            source_site_id: Some(1),
+            source_site_id: 0,
             ..Default::default()
         }
     }
 
     #[actix_rt::test]
     async fn test_sync_buffer_service() {
-        let translations = all_translators();
-        let table_order = pull_integration_order(&translations);
+        let translators = all_translators();
+        let table_order = pull_integration_order(&translators);
+
+        let row_1 = row("1", "transact");
+        let row_2 = row("2", "trans_line");
+        let row_3 = row("3", "store");
+        let row_4 = row("4", "name");
+        let row_5 = SyncBufferRow {
+            action: SyncAction::Delete,
+            ..row("5", "list_master")
+        };
+        let row_6 = SyncBufferRow {
+            action: SyncAction::Delete,
+            ..row("6", "list_master_line")
+        };
+        let site_1_row_1 = SyncBufferRow {
+            action: SyncAction::Delete,
+            source_site_id: 1,
+            ..row("1-1", "list_master")
+        };
+        let site_1_row_2 = SyncBufferRow {
+            action: SyncAction::Delete,
+            source_site_id: 1,
+            ..row("1-2", "list_master_line")
+        };
 
         let (_, connection, _, _) = setup_all_with_data(
             "test_sync_buffer_service",
             MockDataInserts::none(),
             MockData {
                 sync_buffer_rows: vec![
-                    row_1(),
-                    row_2(),
-                    row_3(),
-                    row_4(),
-                    row_5(),
-                    row_6(),
-                    site_1_row_1(),
-                    site_1_row_2(),
+                    row_1.clone(),
+                    row_2.clone(),
+                    row_3.clone(),
+                    row_4.clone(),
+                    row_5.clone(),
+                    row_6.clone(),
+                    site_1_row_1.clone(),
+                    site_1_row_2.clone(),
                 ],
                 ..Default::default()
             },
         )
         .await;
 
-        let buffer = SyncBuffer::new(&connection);
+        // UPSERTS for OMS-Central (source_site_id 0): tables in FK order, cursor ASC.
+        let upserts =
+            get_ordered_sync_buffer_records(&connection, SyncAction::Upsert, &table_order, 0)
+                .unwrap();
+        let ids: Vec<_> = upserts.iter().map(|r| r.record_id.as_str()).collect();
+        assert_eq!(ids, vec!["4", "3", "1", "2"]);
 
-        // ORDER/ACTION
-        let in_referential_order = buffer
-            .get_ordered_sync_buffer_records(
-                repository::SyncAction::Upsert,
-                &table_order,
-                SyncBufferSource::Central(0),
-            )
-            .unwrap();
+        // DELETES for OMS-Central: tables in REVERSE FK order, cursor DESC.
+        let deletes =
+            get_ordered_sync_buffer_records(&connection, SyncAction::Delete, &table_order, 0)
+                .unwrap();
+        let ids: Vec<_> = deletes.iter().map(|r| r.record_id.as_str()).collect();
+        assert_eq!(ids, vec!["6", "5"]);
 
-        assert_eq!(
-            in_referential_order,
-            vec![row_4(), row_3(), row_1(), row_2()]
-        );
+        // Recording results moves rows out of the pending set.
+        let started = datetime_now();
+        write_sync_buffer_error(&connection, upserts[2].cursor, started, "Error 1").unwrap();
+        write_sync_buffer_error(&connection, upserts[3].cursor, started, "Error 2").unwrap();
 
-        let in_reverse_referential_order = buffer
-            .get_ordered_sync_buffer_records(
-                repository::SyncAction::Delete,
-                &table_order,
-                SyncBufferSource::Central(0),
-            )
-            .unwrap();
+        let upserts =
+            get_ordered_sync_buffer_records(&connection, SyncAction::Upsert, &table_order, 0)
+                .unwrap();
+        let ids: Vec<_> = upserts.iter().map(|r| r.record_id.as_str()).collect();
+        assert_eq!(ids, vec!["4", "3"]);
 
-        assert_eq!(in_reverse_referential_order, vec![row_6(), row_5()]);
-
-        // ERROR
-        buffer
-            .record_integration_error(&row_1(), &anyhow::anyhow!("Error 1"))
-            .unwrap();
-        buffer
-            .record_integration_error(&row_2(), &anyhow::anyhow!("Error 2"))
-            .unwrap();
-
-        let result = buffer
-            .get_ordered_sync_buffer_records(
-                repository::SyncAction::Upsert,
-                &table_order,
-                SyncBufferSource::Central(0),
-            )
-            .unwrap();
-
-        assert_eq!(result, vec![row_4(), row_3()]);
-
-        let row_1 = SyncBufferRowRepository::new(&connection)
-            .find_one_by_record_id(&row_1().record_id)
+        let r1 = SyncBufferRepository::new(&connection)
+            .find_one_by_record_id("1")
             .unwrap()
             .unwrap();
+        assert_eq!(r1.integration_result, Some(IntegrationResult::Error));
+        assert_eq!(r1.integration_error.as_deref(), Some("Error 1"));
 
-        assert_eq!(row_1.integration_error, Some("Error 1".to_string()));
+        write_sync_buffer_success(&connection, upserts[0].cursor, started).unwrap();
+        write_sync_buffer_success(&connection, upserts[1].cursor, started).unwrap();
 
-        // INTEGRATED
-        buffer.record_successful_integration(&row_3()).unwrap();
+        let upserts =
+            get_ordered_sync_buffer_records(&connection, SyncAction::Upsert, &table_order, 0)
+                .unwrap();
+        assert!(upserts.is_empty());
 
-        let result = buffer
-            .get_ordered_sync_buffer_records(
-                repository::SyncAction::Upsert,
-                &table_order,
-                SyncBufferSource::Central(0),
-            )
-            .unwrap();
-
-        assert_eq!(result, vec![row_4()]);
-
-        buffer.record_successful_integration(&row_4()).unwrap();
-
-        let result = buffer
-            .get_ordered_sync_buffer_records(
-                repository::SyncAction::Upsert,
-                &table_order,
-                SyncBufferSource::Central(0),
-            )
-            .unwrap();
-
-        assert_eq!(result, vec![]);
-
-        // GETS BUFFER ROWS FOR REMOTE SITE
-        let remote_site_id = 1;
-        let in_reverse_referential_order = buffer
-            .get_ordered_sync_buffer_records(
-                repository::SyncAction::Delete,
-                &table_order,
-                SyncBufferSource::Remote(remote_site_id),
-            )
-            .unwrap();
-
-        assert_eq!(
-            in_reverse_referential_order,
-            vec![site_1_row_2(), site_1_row_1()]
-        );
+        // Remote source_site_id 1: only the site_1 rows are returned.
+        let remote_deletes =
+            get_ordered_sync_buffer_records(&connection, SyncAction::Delete, &table_order, 1)
+                .unwrap();
+        let ids: Vec<_> = remote_deletes
+            .iter()
+            .map(|r| r.record_id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["1-2", "1-1"]);
     }
 }

--- a/server/service/src/sync/sync_on_central/mod.rs
+++ b/server/service/src/sync/sync_on_central/mod.rs
@@ -6,7 +6,7 @@ use std::{
 use actix_multipart::form::tempfile::TempFile;
 use repository::{
     ChangelogCondition, ChangelogFilter, ChangelogRepository, CursorAndLimit, FilterBuilder,
-    SyncBufferRowRepository, SyncFileReferenceRow, SyncFileReferenceRowRepository,
+    SyncBufferRepository, SyncFileReferenceRow, SyncFileReferenceRowRepository,
     SyncStyleOptions,
 };
 use util::format_error;
@@ -19,7 +19,6 @@ use crate::{
     sync::{
         api::{validate_site_auth, CommonSyncRecord},
         api_v6::SiteStatusV6,
-        sync_buffer::SyncBufferSource,
         synchroniser::integrate_and_translate_sync_buffer,
         translations::ToSyncRecordTranslationType,
         CentralServerConfig,
@@ -181,12 +180,12 @@ pub async fn push(
 
     let sync_buffer_rows = CommonSyncRecord::to_buffer_rows(
         records.into_iter().map(|r| r.record).collect(),
-        Some(response.site_id),
+        response.site_id,
     )?;
 
     ctx.connection
         .transaction_sync(|t_con| {
-            SyncBufferRowRepository::new(t_con).upsert_many(&sync_buffer_rows)
+            SyncBufferRepository::new(t_con).insert_many(&sync_buffer_rows)
         })
         .map_err(|e| e.to_inner_error())?;
 
@@ -338,7 +337,7 @@ fn spawn_integration(service_provider: Arc<ServiceProvider>, site_id: i32) {
         match integrate_and_translate_sync_buffer(
             &ctx.connection,
             None,
-            SyncBufferSource::Remote(site_id),
+            site_id,
         ) {
             Ok(_) => {
                 log::info!("Integration complete for site {site_id}");

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -1,7 +1,7 @@
 use crate::{
     processors::ProcessorType,
     service_provider::{ServiceContext, ServiceProvider},
-    sync::{sync_buffer::SyncBufferSource, sync_status::logger::SyncStep, CentralServerConfig},
+    sync::{sync_status::logger::SyncStep, CentralServerConfig},
 };
 use log::warn;
 use repository::{
@@ -20,7 +20,7 @@ use super::{
         WaitForSyncOperationError,
     },
     settings::{SyncSettings, SYNC_V5_VERSION},
-    sync_buffer::SyncBuffer,
+    sync_buffer::get_ordered_sync_buffer_records,
     sync_status::logger::{SyncLogger, SyncLoggerError},
     translation_and_integration::{TranslationAndIntegration, TranslationAndIntegrationResults},
     translations::{all_translators, pull_integration_order},
@@ -219,7 +219,7 @@ impl Synchroniser {
                 false => Some(logger),
                 true => None,
             },
-            SyncBufferSource::Central(central_sync_server_id),
+            central_sync_server_id,
         )
         .map_err(SyncError::IntegrationError)?;
 
@@ -265,7 +265,7 @@ impl Synchroniser {
 pub fn integrate_and_translate_sync_buffer(
     connection: &StorageConnection,
     logger: Option<&mut SyncLogger<'_>>,
-    record_type: SyncBufferSource,
+    source_site_id: i32,
 ) -> Result<
     (
         TranslationAndIntegrationResults,
@@ -294,21 +294,22 @@ pub fn integrate_and_translate_sync_buffer(
         let translators = all_translators();
         let table_order = pull_integration_order(&translators);
 
-        let sync_buffer = SyncBuffer::new(connection);
-        let translation_and_integration = TranslationAndIntegration::new(connection, &sync_buffer);
+        let translation_and_integration = TranslationAndIntegration::new(connection);
 
         // Translate and integrate upserts (ordered by referential database constraints)
-        let upsert_sync_buffer_records = sync_buffer.get_ordered_sync_buffer_records(
+        let upsert_sync_buffer_records = get_ordered_sync_buffer_records(
+            connection,
             SyncAction::Upsert,
             &table_order,
-            record_type,
+            source_site_id,
         )?;
 
         // Translate and integrate delete (ordered by referential database constraints, in reverse)
-        let delete_sync_buffer_records = sync_buffer.get_ordered_sync_buffer_records(
+        let delete_sync_buffer_records = get_ordered_sync_buffer_records(
+            connection,
             SyncAction::Delete,
             &table_order,
-            record_type,
+            source_site_id,
         )?;
 
         let upsert_integration_result = translation_and_integration
@@ -326,10 +327,11 @@ pub fn integrate_and_translate_sync_buffer(
                 None,
             )?;
 
-        let merge_sync_buffer_records = sync_buffer.get_ordered_sync_buffer_records(
+        let merge_sync_buffer_records = get_ordered_sync_buffer_records(
+            connection,
             SyncAction::Merge,
             &table_order,
-            record_type,
+            source_site_id,
         )?;
 
         let merge_integration_result: TranslationAndIntegrationResults =

--- a/server/service/src/sync/test/pull_and_push.rs
+++ b/server/service/src/sync/test/pull_and_push.rs
@@ -7,7 +7,6 @@ use super::{
 };
 use crate::sync::{
     api::SyncAction,
-    sync_buffer::SyncBufferSource,
     synchroniser::integrate_and_translate_sync_buffer,
     test::{
         check_test_records_against_database, extract_sync_buffer_rows,
@@ -21,8 +20,8 @@ use crate::sync::{
 use pretty_assertions::assert_eq;
 use repository::{
     mock::{mock_store_b, MockData, MockDataInserts},
-    test_db, ChangelogRepository, KeyType, KeyValueStoreRow, SyncBufferRow,
-    SyncBufferRowRepository,
+    test_db, ChangelogRepository, KeyType, KeyValueStoreRow, SyncBufferRepository, SyncBufferRow,
+    SyncBufferRowInsert,
 };
 
 #[actix_rt::test]
@@ -63,11 +62,16 @@ async fn test_sync_pull_and_push() {
     insert_all_extra_data(&test_records, &connection).await;
     let sync_records: Vec<SyncBufferRow> = extract_sync_buffer_rows(&test_records);
 
-    SyncBufferRowRepository::new(&connection)
-        .upsert_many(&sync_records)
+    let inserts: Vec<SyncBufferRowInsert> = sync_records
+        .iter()
+        .cloned()
+        .map(SyncBufferRowInsert::from)
+        .collect();
+    SyncBufferRepository::new(&connection)
+        .insert_many(&inserts)
         .unwrap();
 
-    integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0)).unwrap();
+    integrate_and_translate_sync_buffer(&connection, None, 0).unwrap();
 
     check_test_records_against_database(&connection, test_records).await;
 
@@ -164,11 +168,16 @@ async fn test_sync_pull_and_push() {
     insert_all_extra_data(&test_records, &connection).await;
     let sync_records: Vec<SyncBufferRow> = extract_sync_buffer_rows(&test_records);
 
-    SyncBufferRowRepository::new(&connection)
-        .upsert_many(&sync_records)
+    let inserts: Vec<SyncBufferRowInsert> = sync_records
+        .iter()
+        .cloned()
+        .map(SyncBufferRowInsert::from)
+        .collect();
+    SyncBufferRepository::new(&connection)
+        .insert_many(&inserts)
         .unwrap();
 
-    integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0)).unwrap();
+    integrate_and_translate_sync_buffer(&connection, None, 0).unwrap();
 
     check_test_records_against_database(&connection, test_records).await;
 

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -1,18 +1,18 @@
 use super::sync_status::logger::{SyncLogger, SyncLoggerError, SyncStepProgress};
 use super::{
-    sync_buffer::SyncBuffer,
+    sync_buffer::{write_sync_buffer_error, write_sync_buffer_ignored, write_sync_buffer_success},
     translations::{IntegrationOperation, PullTranslateResult, SyncTranslation, SyncTranslators},
 };
 use crate::usize_to_u64;
 use log::{debug, warn};
 use repository::*;
 use std::collections::HashMap;
+use util::datetime_now;
 
 static PROGRESS_STEP_LEN: usize = 100;
 
 pub(crate) struct TranslationAndIntegration<'a> {
     connection: &'a StorageConnection,
-    sync_buffer: &'a SyncBuffer<'a>,
 }
 
 #[derive(Default, Debug)]
@@ -25,14 +25,8 @@ type TableName = String;
 pub struct TranslationAndIntegrationResults(HashMap<TableName, TranslationAndIntegrationResult>);
 
 impl<'a> TranslationAndIntegration<'a> {
-    pub(crate) fn new(
-        connection: &'a StorageConnection,
-        sync_buffer: &'a SyncBuffer,
-    ) -> TranslationAndIntegration<'a> {
-        TranslationAndIntegration {
-            connection,
-            sync_buffer,
-        }
+    pub(crate) fn new(connection: &'a StorageConnection) -> TranslationAndIntegration<'a> {
+        TranslationAndIntegration { connection }
     }
 
     // Go through each translator, adding translations to result, if no translators matched return None
@@ -88,12 +82,19 @@ impl<'a> TranslationAndIntegration<'a> {
         };
 
         for (number_of_records_integrated, sync_record) in sync_records.iter().enumerate() {
+            let started = datetime_now();
+            let cursor = sync_record.cursor;
+
             let translation_results = match self.translate_sync_record(sync_record, translators) {
                 Ok(translation_result) => translation_result,
                 // Record error in sync buffer and in result, continue to next sync_record
                 Err(translation_error) => {
-                    self.sync_buffer
-                        .record_integration_error(sync_record, &translation_error)?;
+                    write_sync_buffer_error(
+                        self.connection,
+                        cursor,
+                        started,
+                        &format!("{:?}", translation_error),
+                    )?;
                     result.insert_error(&sync_record.table_name);
                     warn!(
                         "{:?} {:?} {:?}",
@@ -112,14 +113,16 @@ impl<'a> TranslationAndIntegration<'a> {
                         // Add source site id to each operations, based on sync buffer row
                         let operations_with_source_site_id = operations
                             .into_iter()
-                            .map(|operation| (sync_record.source_site_id, operation));
+                            .map(|operation| (Some(sync_record.source_site_id), operation));
                         integration_records.extend(operations_with_source_site_id)
                     }
                     PullTranslateResult::Ignored(ignore_message) => {
                         ignored = true;
-                        self.sync_buffer.record_integration_error(
-                            sync_record,
-                            &anyhow::anyhow!("Ignored: {ignore_message}"),
+                        write_sync_buffer_ignored(
+                            self.connection,
+                            cursor,
+                            started,
+                            &ignore_message,
                         )?;
                         result.insert_error(&sync_record.table_name);
 
@@ -139,9 +142,8 @@ impl<'a> TranslationAndIntegration<'a> {
 
             // Record translator not found error in sync buffer and in result, continue to next sync_record
             if integration_records.is_empty() {
-                let error = anyhow::anyhow!("Translator for record not found");
-                self.sync_buffer
-                    .record_integration_error(sync_record, &error)?;
+                let error = "Translator for record not found";
+                write_sync_buffer_error(self.connection, cursor, started, error)?;
                 result.insert_error(&sync_record.table_name);
                 warn!(
                     "{:?} {:?} {:?}",
@@ -155,15 +157,13 @@ impl<'a> TranslationAndIntegration<'a> {
             let integration_result = integrate(self.connection, &integration_records);
             match integration_result {
                 Ok(_) => {
-                    self.sync_buffer
-                        .record_successful_integration(sync_record)?;
+                    write_sync_buffer_success(self.connection, cursor, started)?;
                     result.insert_success(&sync_record.table_name)
                 }
                 // Record database_error in sync buffer and in result
                 Err(database_error) => {
-                    let error = anyhow::anyhow!("{database_error:?}");
-                    self.sync_buffer
-                        .record_integration_error(sync_record, &error)?;
+                    let error = format!("{database_error:?}");
+                    write_sync_buffer_error(self.connection, cursor, started, &error)?;
                     result.insert_error(&sync_record.table_name);
                     warn!(
                         "{:?} {:?} {:?}",

--- a/server/service/src/sync/translations/goods_received.rs
+++ b/server/service/src/sync/translations/goods_received.rs
@@ -6,7 +6,7 @@ use super::{
 use chrono::NaiveDate;
 use repository::{
     InvoiceRow, InvoiceRowRepository, InvoiceStatus, InvoiceType, PurchaseOrderRowRepository,
-    StorageConnection, SyncBufferRow, SyncBufferRowRepository,
+    StorageConnection, SyncBufferRow, SyncBufferRepository,
 };
 use serde::Deserialize;
 use util::sync_serde::{empty_str_as_option_string, zero_date_as_option};
@@ -49,7 +49,7 @@ fn find_linked_invoice_id(
     goods_received_id: &str,
 ) -> Result<Option<String>, anyhow::Error> {
     let pattern = format!("%\"goods_received_ID\"%\"{goods_received_id}\"%");
-    let rows = SyncBufferRowRepository::new(connection)
+    let rows = SyncBufferRepository::new(connection)
         .find_by_table_and_data_like("transact", &pattern)?;
 
     // Verify the match by parsing JSON (LIKE can produce false positives)

--- a/server/service/src/sync/translations/goods_received_line.rs
+++ b/server/service/src/sync/translations/goods_received_line.rs
@@ -8,7 +8,7 @@ use super::{
 use chrono::NaiveDate;
 use repository::{
     InvoiceLineRow, InvoiceLineRowRepository, InvoiceLineType, ItemRowRepository,
-    StorageConnection, SyncBufferRow, SyncBufferRowRepository,
+    StorageConnection, SyncBufferRow, SyncBufferRepository,
 };
 use serde::Deserialize;
 use util::sync_serde::{empty_str_as_option_string, zero_date_as_option};
@@ -63,7 +63,7 @@ fn find_linked_invoice_line_id(
     goods_received_line_id: &str,
 ) -> Result<Option<String>, anyhow::Error> {
     let pattern = format!("%\"goods_received_lines_ID\"%\"{goods_received_line_id}\"%");
-    let rows = SyncBufferRowRepository::new(connection)
+    let rows = SyncBufferRepository::new(connection)
         .find_by_table_and_data_like("trans_line", &pattern)?;
 
     // Verify the match by parsing JSON (LIKE can produce false positives)
@@ -122,7 +122,7 @@ impl SyncTranslation for GoodsReceivedLineTranslation {
         }
 
         // Look up parent GR to check if finalized
-        let gr_sync_row = match SyncBufferRowRepository::new(connection)
+        let gr_sync_row = match SyncBufferRepository::new(connection)
             .find_one_by_record_id(&data.goods_received_ID)?
         {
             Some(row) if row.table_name == GoodsReceivedTranslation.table_name() => row,

--- a/server/service/src/sync/translations/special/clinician_merge.rs
+++ b/server/service/src/sync/translations/special/clinician_merge.rs
@@ -69,12 +69,13 @@ impl SyncTranslation for ClinicianMergeTranslation {
 #[cfg(test)]
 mod tests {
     use crate::sync::{
-        sync_buffer::SyncBufferSource, synchroniser::integrate_and_translate_sync_buffer,
+        synchroniser::integrate_and_translate_sync_buffer,
     };
 
     use super::*;
     use repository::{
-        mock::MockDataInserts, test_db::setup_all, SyncAction, SyncBufferRowRepository,
+        mock::MockDataInserts, test_db::setup_all, SyncAction, SyncBufferRepository,
+        SyncBufferRowInsert,
         SyncRecordData,
     };
     use serde_json::json;
@@ -82,7 +83,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_clinician_merge() {
         let mut sync_records = vec![
-            SyncBufferRow {
+            SyncBufferRowInsert {
                 record_id: "clinician_b_merge".to_string(),
                 table_name: "clinician".to_string(),
                 action: SyncAction::Merge,
@@ -90,9 +91,9 @@ mod tests {
                     "mergeIdToKeep": "clinician_b",
                     "mergeIdToDelete": "clinician_a"
                 })),
-                ..SyncBufferRow::default()
+                ..SyncBufferRowInsert::default()
             },
-            SyncBufferRow {
+            SyncBufferRowInsert {
                 record_id: "clinician_c_merge".to_string(),
                 table_name: "clinician".to_string(),
                 action: SyncAction::Merge,
@@ -100,7 +101,7 @@ mod tests {
                     "mergeIdToKeep": "clinician_c",
                     "mergeIdToDelete": "clinician_b"
                 })),
-                ..SyncBufferRow::default()
+                ..SyncBufferRowInsert::default()
             },
         ];
 
@@ -125,10 +126,10 @@ mod tests {
         )
         .await;
 
-        SyncBufferRowRepository::new(&connection)
-            .upsert_many(&sync_records)
+        SyncBufferRepository::new(&connection)
+            .insert_many(&sync_records)
             .unwrap();
-        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0))
+        integrate_and_translate_sync_buffer(&connection, None, 0)
             .unwrap();
 
         let clinician_link_repo = ClinicianLinkRowRepository::new(&connection);
@@ -146,11 +147,11 @@ mod tests {
         .await;
 
         sync_records.reverse();
-        SyncBufferRowRepository::new(&connection)
-            .upsert_many(&sync_records)
+        SyncBufferRepository::new(&connection)
+            .insert_many(&sync_records)
             .unwrap();
 
-        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0))
+        integrate_and_translate_sync_buffer(&connection, None, 0)
             .unwrap();
 
         let clinician_link_repo = ClinicianLinkRowRepository::new(&connection);

--- a/server/service/src/sync/translations/special/item_merge.rs
+++ b/server/service/src/sync/translations/special/item_merge.rs
@@ -63,13 +63,13 @@ impl SyncTranslation for ItemMergeTranslation {
 #[cfg(test)]
 mod tests {
     use crate::sync::{
-        sync_buffer::SyncBufferSource, synchroniser::integrate_and_translate_sync_buffer,
+        synchroniser::integrate_and_translate_sync_buffer,
     };
 
     use super::*;
     use repository::{
-        mock::MockDataInserts, test_db::setup_all, SyncAction, SyncBufferRowRepository,
-        SyncRecordData,
+        mock::MockDataInserts, test_db::setup_all, SyncAction, SyncBufferRepository,
+        SyncBufferRowInsert, SyncRecordData,
     };
     use serde_json::json;
 
@@ -77,7 +77,7 @@ mod tests {
     async fn test_item_merge() {
         // util::init_logger(util::LogLevel::Info);
         let mut sync_records = vec![
-            SyncBufferRow {
+            SyncBufferRowInsert {
                 record_id: "item_b_merge".to_string(),
                 table_name: "item".to_string(),
                 action: SyncAction::Merge,
@@ -85,9 +85,9 @@ mod tests {
                     "mergeIdToKeep": "item_b",
                     "mergeIdToDelete": "item_a"
                 })),
-                ..SyncBufferRow::default()
+                ..SyncBufferRowInsert::default()
             },
-            SyncBufferRow {
+            SyncBufferRowInsert {
                 record_id: "item_c_merge".to_string(),
                 table_name: "item".to_string(),
                 action: SyncAction::Merge,
@@ -95,7 +95,7 @@ mod tests {
                     "mergeIdToKeep": "item_c",
                     "mergeIdToDelete": "item_b"
                 })),
-                ..SyncBufferRow::default()
+                ..SyncBufferRowInsert::default()
             },
         ];
 
@@ -120,10 +120,10 @@ mod tests {
         )
         .await;
 
-        SyncBufferRowRepository::new(&connection)
-            .upsert_many(&sync_records)
+        SyncBufferRepository::new(&connection)
+            .insert_many(&sync_records)
             .unwrap();
-        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0))
+        integrate_and_translate_sync_buffer(&connection, None, 0)
             .unwrap();
 
         let item_link_repo = ItemLinkRowRepository::new(&connection);
@@ -139,11 +139,11 @@ mod tests {
         .await;
 
         sync_records.reverse();
-        SyncBufferRowRepository::new(&connection)
-            .upsert_many(&sync_records)
+        SyncBufferRepository::new(&connection)
+            .insert_many(&sync_records)
             .unwrap();
 
-        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0))
+        integrate_and_translate_sync_buffer(&connection, None, 0)
             .unwrap();
 
         let item_link_repo = ItemLinkRowRepository::new(&connection);

--- a/server/service/src/sync/translations/special/name_merge.rs
+++ b/server/service/src/sync/translations/special/name_merge.rs
@@ -155,20 +155,20 @@ impl SyncTranslation for NameMergeTranslation {
 #[cfg(test)]
 mod tests {
     use crate::sync::{
-        sync_buffer::SyncBufferSource, synchroniser::integrate_and_translate_sync_buffer,
+        synchroniser::integrate_and_translate_sync_buffer,
     };
 
     use super::*;
     use repository::{
-        mock::MockDataInserts, test_db::setup_all, SyncAction, SyncBufferRowRepository,
-        SyncRecordData,
+        mock::MockDataInserts, test_db::setup_all, SyncAction, SyncBufferRepository,
+        SyncBufferRowInsert, SyncRecordData,
     };
     use serde_json::json;
 
     #[actix_rt::test]
     async fn test_name_merge() {
         let mut sync_records = vec![
-            SyncBufferRow {
+            SyncBufferRowInsert {
                 record_id: "name_b".to_string(),
                 table_name: "name".to_string(),
                 action: SyncAction::Merge,
@@ -176,9 +176,9 @@ mod tests {
                     "mergeIdToKeep": "name_b",
                     "mergeIdToDelete": "name_a"
                 })),
-                ..SyncBufferRow::default()
+                ..SyncBufferRowInsert::default()
             },
-            SyncBufferRow {
+            SyncBufferRowInsert {
                 record_id: "name_c".to_string(),
                 table_name: "name".to_string(),
                 action: SyncAction::Merge,
@@ -186,7 +186,7 @@ mod tests {
                     "mergeIdToKeep": "name_c",
                     "mergeIdToDelete": "name_b"
                 })),
-                ..SyncBufferRow::default()
+                ..SyncBufferRowInsert::default()
             },
         ];
 
@@ -211,10 +211,10 @@ mod tests {
         )
         .await;
 
-        SyncBufferRowRepository::new(&connection)
-            .upsert_many(&sync_records)
+        SyncBufferRepository::new(&connection)
+            .insert_many(&sync_records)
             .unwrap();
-        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0))
+        integrate_and_translate_sync_buffer(&connection, None, 0)
             .unwrap();
 
         let name_link_repo = NameLinkRowRepository::new(&connection);
@@ -229,10 +229,10 @@ mod tests {
         .await;
         sync_records.reverse();
 
-        SyncBufferRowRepository::new(&connection)
-            .upsert_many(&sync_records)
+        SyncBufferRepository::new(&connection)
+            .insert_many(&sync_records)
             .unwrap();
-        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0))
+        integrate_and_translate_sync_buffer(&connection, None, 0)
             .unwrap();
 
         let name_link_repo = NameLinkRowRepository::new(&connection);
@@ -275,7 +275,7 @@ mod tests {
         assert_eq!(count_name_store_join("name_store_a"), 1);
 
         let sync_records = vec![
-            SyncBufferRow {
+            SyncBufferRowInsert {
                 record_id: "name3_merge".to_string(),
                 table_name: "name".to_string(),
                 action: SyncAction::Merge,
@@ -283,9 +283,9 @@ mod tests {
                     "mergeIdToKeep": "name2",
                     "mergeIdToDelete": "name3"
                 })),
-                ..SyncBufferRow::default()
+                ..SyncBufferRowInsert::default()
             },
-            SyncBufferRow {
+            SyncBufferRowInsert {
                 record_id: "name2_merge".to_string(),
                 table_name: "name".to_string(),
                 action: SyncAction::Merge,
@@ -293,9 +293,9 @@ mod tests {
                     "mergeIdToKeep": "name_a",
                     "mergeIdToDelete": "name2"
                 })),
-                ..SyncBufferRow::default()
+                ..SyncBufferRowInsert::default()
             },
-            SyncBufferRow {
+            SyncBufferRowInsert {
                 // name_a is visible to name_store_a. This merge is test if the name_store_join is deleted, rather than letting the store have it's own name visible
                 record_id: "name_a_merge".to_string(),
                 table_name: "name".to_string(),
@@ -304,14 +304,14 @@ mod tests {
                     "mergeIdToKeep": "name_store_a",
                     "mergeIdToDelete": "name_a"
                 })),
-                ..SyncBufferRow::default()
+                ..SyncBufferRowInsert::default()
             },
         ];
-        SyncBufferRowRepository::new(&connection)
-            .upsert_many(&sync_records)
+        SyncBufferRepository::new(&connection)
+            .insert_many(&sync_records)
             .unwrap();
 
-        integrate_and_translate_sync_buffer(&connection, None, SyncBufferSource::Central(0))
+        integrate_and_translate_sync_buffer(&connection, None, 0)
             .unwrap();
 
         assert_eq!(count_name_store_join("name_a"), 0);

--- a/server/service/src/sync_v7/mod.rs
+++ b/server/service/src/sync_v7/mod.rs
@@ -1,8 +1,6 @@
 use repository::{
-    syncv7::GetCurrentSiteIdError, KeyValueStoreRepository, RepositoryError, StorageConnection,
-    SyncBufferRowRepository,
+    syncv7::GetCurrentSiteIdError, KeyValueStoreRepository, StorageConnection,
 };
-use util::format_error;
 
 pub mod api;
 pub mod prepare;
@@ -24,20 +22,4 @@ pub fn get_current_site_id(connection: &StorageConnection) -> Result<i32, GetCur
         .ok_or(GetCurrentSiteIdError::SiteIdNotSet)?;
 
     Ok(site_id)
-}
-
-pub(crate) fn write_sync_buffer_error(
-    record_id: &str,
-    connection: &StorageConnection,
-    error: &impl std::error::Error,
-) -> Result<(), RepositoryError> {
-    SyncBufferRowRepository::new(connection)
-        .set_integration_result(record_id, Some(&format_error(&error)))
-}
-
-pub(crate) fn write_sync_buffer_success(
-    record_id: &str,
-    connection: &StorageConnection,
-) -> Result<(), RepositoryError> {
-    SyncBufferRowRepository::new(connection).set_integration_result(record_id, None)
 }

--- a/server/service/src/sync_v7/sync.rs
+++ b/server/service/src/sync_v7/sync.rs
@@ -2,10 +2,11 @@ use std::time::{Duration, SystemTime};
 
 use chrono::Utc;
 use repository::{
+    migrations::Version,
     syncv7::{SiteLockError, SyncError},
-    ChangelogCondition, ChangelogFilter, ChangelogRepository, ChangelogTableName, CursorAndLimit,
-    KeyType, RowActionType, StorageConnection, SyncAction, SyncBufferRow, SyncBufferRowRepository,
-    SyncRecordData,
+    AppVersion, ChangelogCondition, ChangelogFilter, ChangelogRepository, ChangelogTableName,
+    CursorAndLimit, KeyType, KeyValueStoreRepository, RowActionType, StorageConnection, SyncAction,
+    SyncBufferRepository, SyncBufferRowInsert, SyncRecordData, SyncVersion,
 };
 use serde::{Deserialize, Serialize};
 
@@ -83,26 +84,28 @@ impl SyncBatchV7 {
     }
 }
 
-/// Convert a SyncRecordV7 (API shape) into a SyncBufferRow (DB shape) for storage
+/// Convert a SyncRecordV7 (API shape) into an insertable sync_buffer row.
 pub(crate) fn sync_record_to_buffer_row(
     record: SyncRecordV7,
     source_site_id: i32,
-) -> SyncBufferRow {
-    SyncBufferRow {
+    app_version: Option<Version>,
+) -> SyncBufferRowInsert {
+    SyncBufferRowInsert {
         record_id: record.record_id,
         received_datetime: Utc::now().naive_utc(),
-        integration_datetime: None,
-        integration_error: None,
         table_name: record.table_name.to_string(),
         action: match record.action {
             RowActionType::Upsert => SyncAction::Upsert,
             RowActionType::Delete => SyncAction::Delete,
         },
         data: SyncRecordData(record.data),
-        source_site_id: Some(source_site_id),
+        sync_version: SyncVersion::V7,
+        app_version: app_version.map(AppVersion),
+        source_site_id,
         store_id: record.store_id,
         transfer_store_id: record.transfer_store_id,
         patient_id: record.patient_id,
+        reference: None,
     }
 }
 
@@ -284,15 +287,17 @@ impl<'a> SyncV7<'a> {
                 break;
             };
 
-            let sync_buffer_rows: Vec<SyncBufferRow> = batch
+            // V7 pull: records arrive without an originating app_version (it isn't
+            // carried through the central server), so app_version is None here.
+            let sync_buffer_rows: Vec<SyncBufferRowInsert> = batch
                 .records
                 .into_iter()
-                .map(|r| sync_record_to_buffer_row(r, site_id))
+                .map(|r| sync_record_to_buffer_row(r, site_id, None))
                 .collect();
 
             self.connection
                 .transaction_sync(|t_con| {
-                    SyncBufferRowRepository::new(t_con).upsert_many(&sync_buffer_rows)?;
+                    SyncBufferRepository::new(t_con).insert_many(&sync_buffer_rows)?;
                     cursor_controller.update(self.connection, batch_max_cursor as u64)
                 })
                 .map_err(|e| e.to_inner_error())?;
@@ -315,9 +320,19 @@ impl<'a> SyncV7<'a> {
         let active_stores = ActiveStoresOnSite::get(self.connection)
             .map_err(|e| SyncError::Other(e.to_string()))?;
 
+        // V7 records pulled from central are stamped with the central server's site id
+        // (see `sync_record_to_buffer_row` callsite in `pull`). Filter by that id here.
+        let central_site_id = KeyValueStoreRepository::new(self.connection)
+            .get_i32(KeyType::SettingsSyncCentralServerSiteId)
+            .map_err(SyncError::DatabaseError)?
+            .ok_or_else(|| {
+                SyncError::Other("Central server site id not configured".to_string())
+            })?;
+
         validate_translate_integrate(
             self.connection,
             Some(logger),
+            central_site_id,
             None,
             SyncContext::Remote {
                 active_stores,

--- a/server/service/src/sync_v7/sync_on_central/mod.rs
+++ b/server/service/src/sync_v7/sync_on_central/mod.rs
@@ -8,7 +8,7 @@ use repository::{
     syncv7::{SiteLockError, SyncError},
     ChangelogFilter, EqualFilter, KeyType, KeyValueStoreRepository, Pagination, RepositoryError,
     SiteFilter, SiteRepository, SiteRow, SiteRowRepository, StorageConnection, StringFilter,
-    SyncBufferFilter, SyncBufferRowRepository,
+    SyncBufferRepository,
 };
 use thiserror::Error;
 use util::format_error;
@@ -193,15 +193,16 @@ pub async fn push(
 
     let records_in_this_batch = records.len() as i64;
 
+    // The remote site's app_version arrives in the request header (Common::version).
+    let app_version = Some(common.version.clone());
+
     let sync_buffer_rows = records
         .into_iter()
-        .map(|record| sync_record_to_buffer_row(record, site_id))
+        .map(|record| sync_record_to_buffer_row(record, site_id, app_version.clone()))
         .collect::<Vec<_>>();
 
     ctx.connection
-        .transaction_sync(|t_con| {
-            SyncBufferRowRepository::new(t_con).upsert_many(&sync_buffer_rows)
-        })
+        .transaction_sync(|t_con| SyncBufferRepository::new(t_con).insert_many(&sync_buffer_rows))
         .map_err(|e| e.to_inner_error())?;
 
     // SyncBatchV7 has no `remaining` field, so we can't gate spawn on "is last batch".
@@ -247,13 +248,13 @@ async fn spawn_integration_inner(
 ) -> Result<(), SpawnIntegrationError> {
     let ctx = service_provider.basic_context()?;
 
-    let filter = SyncBufferFilter::new().source_site_id(EqualFilter::equal_to(site_id));
     let active_stores = ActiveStoresOnSite::get(&ctx.connection)?;
 
     validate_translate_integrate(
         &ctx.connection,
         None,
-        Some(filter),
+        site_id,
+        None,
         SyncContext::Central { active_stores },
     )?;
     Ok(())

--- a/server/service/src/sync_v7/test.rs
+++ b/server/service/src/sync_v7/test.rs
@@ -7,7 +7,7 @@ mod test_sync_v7_client_api {
         migrations::Version, mock::MockDataInserts, ChangelogCondition, ChangelogRepository,
         ChangelogRow, ChangelogTableName, CurrencyRow, CursorAndLimit, FilterBuilder, ItemRow,
         KeyType, KeyValueStoreRepository, NameRow, RowActionType, StockLineRow, StorageConnection,
-        StoreRow, SyncBufferRowRepository, UnitRow, Upsert,
+        StoreRow, SyncBufferRepository, UnitRow, Upsert,
     };
     use repository::{KeyValueStoreRow, SyncAction, SyncBufferRow};
     use serde_json::json;
@@ -292,7 +292,7 @@ mod test_sync_v7_client_api {
         }
 
         // Assert: sync buffer rows
-        let buffers = SyncBufferRowRepository::new(&connection).get_all().unwrap();
+        let buffers = SyncBufferRepository::new(&connection).get_all().unwrap();
         assert_eq!(buffers.len(), 6);
         for buf in &buffers {
             assert!(buf.integration_datetime.is_some());
@@ -304,7 +304,7 @@ mod test_sync_v7_client_api {
                     record_id: "unit_test_1".to_string(),
                     table_name: "unit".to_string(),
                     action: SyncAction::Upsert,
-                    source_site_id: Some(1),
+                    source_site_id: 1,
                     integration_error: None,
                     store_id: None,
                     transfer_store_id: None,
@@ -315,7 +315,7 @@ mod test_sync_v7_client_api {
                     record_id: "currency_test_1".to_string(),
                     table_name: "currency".to_string(),
                     action: SyncAction::Upsert,
-                    source_site_id: Some(1),
+                    source_site_id: 1,
                     integration_error: None,
                     store_id: None,
                     transfer_store_id: None,
@@ -326,7 +326,7 @@ mod test_sync_v7_client_api {
                     record_id: "name_test_1".to_string(),
                     table_name: "name".to_string(),
                     action: SyncAction::Upsert,
-                    source_site_id: Some(1),
+                    source_site_id: 1,
                     integration_error: None,
                     store_id: None,
                     transfer_store_id: None,
@@ -337,7 +337,7 @@ mod test_sync_v7_client_api {
                     record_id: "item_test_1".to_string(),
                     table_name: "item".to_string(),
                     action: SyncAction::Upsert,
-                    source_site_id: Some(1),
+                    source_site_id: 1,
                     integration_error: None,
                     store_id: None,
                     transfer_store_id: None,
@@ -348,7 +348,7 @@ mod test_sync_v7_client_api {
                     record_id: "store_test_1".to_string(),
                     table_name: "store".to_string(),
                     action: SyncAction::Upsert,
-                    source_site_id: Some(1),
+                    source_site_id: 1,
                     integration_error: None,
                     store_id: None,
                     transfer_store_id: None,
@@ -359,7 +359,7 @@ mod test_sync_v7_client_api {
                     record_id: "stock_line_test_1".to_string(),
                     table_name: "stock_line".to_string(),
                     action: SyncAction::Upsert,
-                    source_site_id: Some(1),
+                    source_site_id: 1,
                     integration_error: None,
                     store_id: Some("store_test_1".to_string()),
                     transfer_store_id: None,
@@ -448,7 +448,7 @@ mod test_sync_v7_client_api {
         .await;
 
         // FK violations would surface via integration_error.
-        let buffers = SyncBufferRowRepository::new(&connection).get_all().unwrap();
+        let buffers = SyncBufferRepository::new(&connection).get_all().unwrap();
         assert_eq!(buffers.len(), 3);
         for buf in &buffers {
             assert_eq!(

--- a/server/service/src/sync_v7/validate_translate_integrate.rs
+++ b/server/service/src/sync_v7/validate_translate_integrate.rs
@@ -1,19 +1,25 @@
 use crate::{
-    sync::ActiveStoresOnSite,
-    sync_v7::{serde::deserialize, sync_logger::SyncLogger, write_sync_buffer_success},
+    sync::{
+        sync_buffer::{write_sync_buffer_error, write_sync_buffer_success},
+        ActiveStoresOnSite,
+    },
+    sync_v7::{serde::deserialize, sync_logger::SyncLogger},
 };
 
-use super::{validate::*, write_sync_buffer_error};
+use super::validate::*;
 use repository::syncv7::{SyncRecordSerializeError, INTEGRATION_ORDER};
 use repository::{
-    ChangeLogInsertRow, ChangelogSyncType, ChangelogTableName, CurrencyRowDelete, DatetimeFilter,
-    Delete, EqualFilter, InvoiceLineRowDelete, InvoiceRowDelete, ItemRowDelete,
-    LocationTypeRowDelete, NameRowDelete, RepositoryError, RowActionType, StockLineRowDelete,
-    StorageConnection, StoreRowDelete, SyncAction, SyncBufferFilter, SyncBufferRepository,
-    SyncBufferRow, UnitRowDelete, Upsert,
+    ChangeLogInsertRow, ChangelogSyncType, ChangelogTableName, CurrencyRowDelete, CursorDirection,
+    Delete, InvoiceLineRowDelete, InvoiceRowDelete, ItemRowDelete, LocationTypeRowDelete,
+    NameRowDelete, PendingQuery, RepositoryError, RowActionType, StockLineRowDelete,
+    StorageConnection, StoreRowDelete, SyncAction, SyncBufferRepository, SyncBufferRow,
+    SyncVersion, UnitRowDelete, Upsert,
 };
 use serde::de::Error as _;
 use thiserror::Error;
+use util::{datetime_now, format_error};
+
+const PROGRESS_INTERVAL: i64 = 1000;
 
 pub(crate) enum SyncContext {
     Central {
@@ -24,8 +30,6 @@ pub(crate) enum SyncContext {
         active_stores: ActiveStoresOnSite,
     },
 }
-
-static PROGRESS_INTERVAL: i64 = 1000;
 
 #[derive(Error, Debug)]
 enum Error {
@@ -77,7 +81,7 @@ fn changelog(
         record_id: row.record_id.clone(),
         row_action: action,
         store_id: row.store_id.clone(),
-        source_site_id: row.source_site_id,
+        source_site_id: Some(row.source_site_id),
         transfer_store_id: row.transfer_store_id.clone(),
         patient_id: row.patient_id.clone(),
         ..Default::default()
@@ -181,46 +185,44 @@ fn validate_translate_integrate_one(
 pub fn validate_translate_integrate<'a>(
     connection: &StorageConnection,
     mut logger: Option<&mut SyncLogger<'a>>,
-    sync_buffer_filter: Option<SyncBufferFilter>,
+    source_site_id: i32,
+    reference: Option<&str>,
     sync_context: SyncContext,
 ) -> Result<(), RepositoryError> {
     // TODO this is too hacky, prefer active store cache
     let mut sync_context = sync_context;
 
-    let base_filter = SyncBufferFilter::new().integration_datetime(DatetimeFilter::is_null(true));
+    let repo = SyncBufferRepository::new(connection);
 
-    let filter = match sync_buffer_filter {
-        Some(extra) => SyncBufferFilter {
-            integration_datetime: base_filter.integration_datetime,
-            source_site_id: extra.source_site_id,
-            ..extra
-        },
-        None => base_filter,
-    };
-
-    let mut total = SyncBufferRepository::new(connection).count(filter.clone())?;
+    let mut total = repo.count_pending(source_site_id, SyncVersion::V7, reference)?;
     let mut last_progress = total / PROGRESS_INTERVAL;
 
     if let Some(logger) = logger.as_mut() {
         logger.progress(total)?;
     }
 
-    let mut integrate_table = |table: &ChangelogTableName,
-                               action_filter: &SyncBufferFilter|
+    let mut integrate_table = |logger: &mut Option<&mut SyncLogger<'a>>,
+                               table: &ChangelogTableName,
+                               action: SyncAction,
+                               direction: CursorDirection|
      -> Result<(), RepositoryError> {
-        let per_table_filter = action_filter
-            .clone()
-            .table_name(EqualFilter::equal_to(table.to_string()));
-
-        let rows = SyncBufferRepository::new(connection).query(Some(per_table_filter))?;
+        let rows = repo.pending_ordered_by_cursor(PendingQuery {
+            source_site_id,
+            sync_version: SyncVersion::V7,
+            reference,
+            table_name: &table.to_string(),
+            action,
+            direction,
+        })?;
 
         let had_store_records = *table == ChangelogTableName::Store && !rows.is_empty();
 
         for row in &rows {
+            let started = datetime_now();
             match validate_translate_integrate_one(connection, row, &sync_context) {
-                Ok(()) => write_sync_buffer_success(&row.record_id, connection)?,
+                Ok(()) => write_sync_buffer_success(connection, row.cursor, started)?,
                 Err(e) => {
-                    write_sync_buffer_error(&row.record_id, connection, &e)?;
+                    write_sync_buffer_error(connection, row.cursor, started, &format_error(&e))?;
                 }
             }
 
@@ -249,16 +251,19 @@ pub fn validate_translate_integrate<'a>(
         Ok(())
     };
 
-    // Upserts: parents before children.
-    let upsert_filter = filter.clone().action(SyncAction::Upsert.equal_to());
+    // Upserts: parents before children, rows ordered by cursor ASC within each table.
     for table in INTEGRATION_ORDER {
-        integrate_table(table, &upsert_filter)?;
+        integrate_table(&mut logger, table, SyncAction::Upsert, CursorDirection::Asc)?;
     }
 
-    // Deletes: children before parents.
-    let delete_filter = filter.clone().action(SyncAction::Delete.equal_to());
+    // Deletes: children before parents, rows ordered by cursor DESC within each table.
     for table in INTEGRATION_ORDER.iter().rev() {
-        integrate_table(table, &delete_filter)?;
+        integrate_table(
+            &mut logger,
+            table,
+            SyncAction::Delete,
+            CursorDirection::Desc,
+        )?;
     }
 
     Ok(())


### PR DESCRIPTION
## Stack
This is **PR 9 of 9** — the top of the stack. Stacked on top of [#11470](https://github.com/msupply-foundation/open-msupply/pull/11470).

> ✅ **Full test suite is expected to pass at this PR.** Earlier PRs in the stack are intentionally non-passing because they introduce one logical change at a time.

## Summary
- Rewrites `server/repository/src/db_diesel/sync_buffer.rs` (~650 lines, +652 / -403) into a new shape that better fits how v7 reads/writes pending records.
- Adds a migration `server/repository/src/migrations/v3_00_00/rebuild_sync_buffer.rs` to rebuild the existing `sync_buffer` table on upgrade.
- Updates every caller: synchroniser, central/remote data synchronisers, sync_on_central, sync_v7, translation_and_integration, and the special `*_merge` translators (clinician, item, name).
- CLI command updated for the new buffer shape.
- Test fixtures and the `pull_and_push` integration test updated.

## Why
The sync_buffer schema couldn't cleanly represent the v7 flow (e.g. tracking integration state, replaying ordered batches). Rather than bolt on flags, this PR reshapes the table; the migration takes care of in-place upgrades.

## Test plan
- [ ] Full server test suite — `cargo nextest run`
- [ ] Migration up/down on a populated dev DB
- [ ] One real sync round-trip (v5/v6) — confirm buffer drains cleanly
- [ ] One v7 sync round-trip