### PR TITLE
#10606 Fix off-by-one expiry / DOB dates in lists

### DIFF
--- a/client/packages/common/src/ui/components/inputs/DateTimePickers/ExpiryDateInput/ExpiryDateInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DateTimePickers/ExpiryDateInput/ExpiryDateInput.tsx
@@ -21,7 +21,6 @@ export const ExpiryDateInput = ({
     <DateTimePickerInput
       disabled={disabled}
       views={['year', 'month']}
-      format="dd/MM/yyyy"
       value={value}
       onChange={d => {
         // Only set the date to last day of month if done through the picker,

--- a/client/packages/common/src/ui/layout/tables/components/ExpiryDateCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/ExpiryDateCell.tsx
@@ -14,8 +14,9 @@ export const ExpiryDateCell = <T extends MRT_RowData>({
   const expiryDate = cell.getValue<string>();
   const { localisedDate } = useFormatDateTime();
 
-  const isExpired = expiryDate
-    ? DateUtils.isAlmostExpired(new Date(expiryDate))
+  const naiveExpiryDate = DateUtils.getNaiveDate(expiryDate);
+  const isExpired = naiveExpiryDate
+    ? DateUtils.isAlmostExpired(naiveExpiryDate)
     : false;
 
   return (
@@ -32,7 +33,7 @@ export const ExpiryDateCell = <T extends MRT_RowData>({
           textAlign: 'right',
         }}
       >
-        {expiryDate ? localisedDate(new Date(expiryDate)) || '' : ''}
+        {naiveExpiryDate ? localisedDate(naiveExpiryDate) || '' : ''}
       </Typography>
     </Box>
   );

--- a/client/packages/common/src/ui/layout/tables/components/NaiveDateCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/NaiveDateCell.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { DateUtils, useFormatDateTime } from '@common/intl';
+
+import { MRT_Cell, MRT_RowData } from 'material-react-table';
+
+interface NaiveDateCellProps<T extends MRT_RowData> {
+  cell: MRT_Cell<T>;
+}
+
+/**
+ * Renders a date-only column value (e.g. expiry date, date of birth) in the
+ * user's locale. Use this instead of ColumnType.Date for fields that are
+ * timezone-agnostic — the default Date cell parses values as UTC midnight,
+ * which renders as the previous day in negative-offset timezones.
+ */
+export const NaiveDateCell = <T extends MRT_RowData>({
+  cell,
+}: NaiveDateCellProps<T>) => {
+  const { localisedDate } = useFormatDateTime();
+  const date = DateUtils.getNaiveDate(cell.getValue<string | null>());
+  return <>{date ? localisedDate(date) : ''}</>;
+};

--- a/client/packages/common/src/ui/layout/tables/components/index.ts
+++ b/client/packages/common/src/ui/layout/tables/components/index.ts
@@ -5,6 +5,7 @@ export * from './ChipTableCell';
 export * from './CurrencyInputCell';
 export * from './CurrencyValueCell';
 export * from './ExpiryDateCell';
+export * from './NaiveDateCell';
 export * from './NameAndColorSetterCell';
 export * from './PopoverCell';
 export * from './RadioCell';

--- a/client/packages/system/src/Patient/ListView/ListView.tsx
+++ b/client/packages/system/src/Patient/ListView/ListView.tsx
@@ -14,6 +14,7 @@ import {
   ColumnType,
   ChipTableCell,
   usePreferences,
+  NaiveDateCell,
 } from '@openmsupply-client/common';
 import { usePatient, PatientRowFragment } from '../api';
 import { AppBarButtons } from './AppBarButtons';
@@ -117,6 +118,7 @@ export const PatientListView = () => {
         accessorKey: 'dateOfBirth',
         header: t('label.date-of-birth'),
         columnType: ColumnType.Date,
+        Cell: NaiveDateCell,
         enableSorting: true,
         enableColumnFilter: true,
         dateFilterFormat: 'date',


### PR DESCRIPTION
Fixes #10606

🤖️ Created by Claud

# 👩🏻‍💻 What does this PR do?

Two layered bugs caused stock expiry and patient DOB to render differently in list vs detail views (most visible in en-CA):

1. **Off-by-one day.** Date-only values like `"2033-11-30"` were parsed via `new Date(...)` / `DateUtils.getDateOrNull(...)`, which JS treats as UTC midnight. In timezones west of UTC the local-time render shifts back a day. Detail views already used `DateUtils.getNaiveDate`, which compensates — so list and detail disagreed.
2. **Format mismatch.** `ExpiryDateInput` hardcoded `format="dd/MM/yyyy"`, ignoring the user's locale, while the list cell used `localisedDate` (locale-aware). Same date, different format on each screen.

Changes:

- New `NaiveDateCell` table cell component for timezone-agnostic date-only columns. Documented at the component so future date-only columns reach for it instead of `ColumnType.Date`'s default cell.
- `ExpiryDateCell` now parses through `getNaiveDate` (fixes stock list, outbound shipment line edit, prescriptions line edit).
- Patient DOB column on the patient list now uses `NaiveDateCell`.
- Dropped `format="dd/MM/yyyy"` from `ExpiryDateInput`; the picker now falls through to its locale-aware default. Affects stock detail, inbound line edit, customer return, stocktake line edit.

## 💌 Any notes for the reviewer?

- Deliberately did **not** change the default `ColumnType.Date` cell to use `getNaiveDate`. That column type is also used for true-timestamp fields (invoice dates, etc.) where `getNaiveDate` would shift the value the wrong way. Opt-in via `NaiveDateCell` keeps the blast radius to date-only fields.
- The `lastDayOfMonth` snap behaviour in `ExpiryDateInput` keys off `getMonth()` of the picked Date, not the format string, so removing the format prop doesn't affect it.
- `ExpiryDateCell` keeps its "almost expired" red colouring — DOB intentionally does not reuse it.

# 🧪 Testing

- [ ] Spoof your browser timezone to a negative-offset locale (e.g. America/Toronto) using the [Spoof Timezone Chrome extension](https://chromewebstore.google.com/detail/spoof-timezone/kcabmhnajflfolhelachlflngdbfhboe) or equivalent, and set regional format to **English (Canada)**. (Depending on the time of day you test this, just need to pick a timezone that is currently in a different calendar day to UTC)
- [ ] Inventory > Stock: pick a stock line whose expiry is on the 1st or last day of a month. Confirm the list shows the same date as the detail view, and both render in MM/DD/YYYY (en-CA).
- [ ] Edit the expiry date in the detail view and confirm the picker format now matches the locale (not hardcoded DD/MM/YYYY).
- [ ] Patients list: pick a patient with a DOB on the 1st of a month. Confirm the list shows the same date as the patient summary.
- [ ] Switch back to a UTC-or-positive locale (e.g. en-NZ) and confirm no regression — dates should still match between list and detail.
- [ ] Outbound shipment / prescription line edit: expiry column on the inner table renders the correct date.
- [ ] Inbound line edit, customer return, stocktake line edit: the expiry input renders in the user's locale.

# 📃 Documentation

- [x] **No documentation required**: bug fix, no change in user-facing behaviour beyond rendering the correct date.

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend