### PR TITLE
#10606 Fix remaining expiry / DOB date columns

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/columns.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/columns.tsx
@@ -4,6 +4,7 @@ import {
   usePreferences,
   ColumnDef,
   ColumnType,
+  ExpiryDateCell,
   UnitsAndDosesCell,
 } from '@openmsupply-client/common';
 import { StocktakeLineFragment } from '../api';
@@ -56,6 +57,7 @@ export const useStocktakeColumns = () => {
         header: t('label.expiry-date'),
         size: 110,
         columnType: ColumnType.Date,
+        Cell: ExpiryDateCell,
         defaultHideOnMobile: true,
         enableColumnFilter: true,
         enableSorting: true,

--- a/client/packages/invoices/src/InboundShipment/DetailView/columns.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/columns.tsx
@@ -5,6 +5,7 @@ import {
   useTranslation,
   ColumnDef,
   ColumnType,
+  ExpiryDateCell,
   StatusCell,
   weightedAverageByUnits,
 } from '@openmsupply-client/common';
@@ -74,6 +75,7 @@ export const useInboundShipmentColumns = (
         accessorFn: row => (row.expiryDate ? new Date(row.expiryDate) : null),
         header: t('label.expiry-date'),
         columnType: ColumnType.Date,
+        Cell: ExpiryDateCell,
         size: 120,
         enableColumnFilter: true,
         enableSorting: true,

--- a/client/packages/invoices/src/OutboundShipment/DetailView/columns.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/columns.tsx
@@ -5,6 +5,7 @@ import {
   usePreferences,
   ColumnDef,
   ColumnType,
+  ExpiryDateCell,
   Box,
   weightedAverageByUnits,
 } from '@openmsupply-client/common';
@@ -49,6 +50,7 @@ export const useOutboundColumns = () => {
         header: t('label.expiry-date'),
         size: 110,
         columnType: ColumnType.Date,
+        Cell: ExpiryDateCell,
         defaultHideOnMobile: true,
         enableColumnFilter: true,
         enableSorting: true,

--- a/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/PatientDetails.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/SidePanel/PatientDetails.tsx
@@ -9,6 +9,8 @@ import {
   UNDEFINED_STRING_VALUE,
   Grid,
   useTheme,
+  DateUtils,
+  useFormatDateTime,
 } from '@openmsupply-client/common';
 import { usePrescription } from '../../api';
 import { useDiagnosisOptions } from '../../api/hooks/useDiagnosisOptions';
@@ -22,7 +24,13 @@ type Option = { id: string; value: string; label: string };
 export const PatientDetailsComponent = () => {
   const theme = useTheme();
   const t = useTranslation();
+  const { localisedDate } = useFormatDateTime();
   const [selected, setSelected] = useState<Option | null>();
+
+  const formatNaiveDate = (date?: string | null) => {
+    const naive = DateUtils.getNaiveDate(date);
+    return naive ? localisedDate(naive) : UNDEFINED_STRING_VALUE;
+  };
 
   const {
     query: { data },
@@ -67,9 +75,7 @@ export const PatientDetailsComponent = () => {
 
         <PanelRow>
           <PanelLabel fontWeight="bold">{t('label.date-of-birth')}</PanelLabel>
-          <PanelField>
-            {patient?.dateOfBirth ?? UNDEFINED_STRING_VALUE}
-          </PanelField>
+          <PanelField>{formatNaiveDate(patient?.dateOfBirth)}</PanelField>
         </PanelRow>
 
         <PanelRow>

--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -4,6 +4,7 @@ import {
   usePreferences,
   ColumnDef,
   ColumnType,
+  ExpiryDateCell,
   weightedAverageByUnits,
 } from '@openmsupply-client/common';
 import { PrescriptionLineFragment } from '../api/operations.generated';
@@ -53,6 +54,7 @@ export const usePrescriptionColumn = () => {
         header: t('label.expiry-date'),
         size: 110,
         columnType: ColumnType.Date,
+        Cell: ExpiryDateCell,
         defaultHideOnMobile: true,
         enableColumnFilter: true,
         enableSorting: true,

--- a/client/packages/invoices/src/Returns/CustomerDetailView/columns.ts
+++ b/client/packages/invoices/src/Returns/CustomerDetailView/columns.ts
@@ -3,6 +3,7 @@ import {
   ColumnDef,
   useTranslation,
   ColumnType,
+  ExpiryDateCell,
   weightedAverageByPacks,
 } from '@openmsupply-client/common';
 import { CustomerReturnLineFragment } from '../api';
@@ -35,6 +36,7 @@ export const useCustomerReturnColumns = () => {
         accessorFn: row => (row.expiryDate ? new Date(row.expiryDate) : null),
         header: t('label.expiry'),
         columnType: ColumnType.Date,
+        Cell: ExpiryDateCell,
         enableSorting: true,
         enableColumnFilter: true,
       },

--- a/client/packages/invoices/src/Returns/SupplierDetailView/columns.ts
+++ b/client/packages/invoices/src/Returns/SupplierDetailView/columns.ts
@@ -2,6 +2,7 @@ import {
   ColumnDef,
   useTranslation,
   ColumnType,
+  ExpiryDateCell,
   weightedAverageByPacks,
 } from '@openmsupply-client/common';
 import { SupplierReturnLineFragment } from '../api';
@@ -35,6 +36,7 @@ export const useSupplierReturnColumns = () => {
         accessorFn: row => (row.expiryDate ? new Date(row.expiryDate) : null),
         header: t('label.expiry'),
         columnType: ColumnType.Date,
+        Cell: ExpiryDateCell,
         enableSorting: true,
         enableColumnFilter: true,
       },

--- a/client/packages/invoices/src/Returns/modals/ReturnReasonsTable.tsx
+++ b/client/packages/invoices/src/Returns/modals/ReturnReasonsTable.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo } from 'react';
 import {
   ColumnDef,
+  ColumnType,
+  ExpiryDateCell,
   MaterialTable,
   ReasonOptionNodeType,
   useSimpleMaterialTable,
@@ -55,6 +57,8 @@ export const ReturnReasonsComponent = ({
       {
         accessorKey: 'expiryDate',
         header: t('label.expiry'),
+        columnType: ColumnType.Date,
+        Cell: ExpiryDateCell,
         size: 100,
       },
       // 'itemUnit', // not implemented for now

--- a/client/packages/programs/src/JsonForms/components/Prescription/StockLineTable.tsx
+++ b/client/packages/programs/src/JsonForms/components/Prescription/StockLineTable.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import {
   ColumnDef,
   ColumnType,
+  ExpiryDateCell,
   MaterialTable,
   useSimpleMaterialTable,
   useTranslation,
@@ -26,6 +27,7 @@ export const StockLineTable = ({
         accessorKey: 'expiryDate',
         header: t('label.expiry'),
         columnType: ColumnType.Date,
+        Cell: ExpiryDateCell,
         size: 60,
       },
       {

--- a/client/packages/system/src/ContactTrace/DetailView/LinkPatientModal.tsx
+++ b/client/packages/system/src/ContactTrace/DetailView/LinkPatientModal.tsx
@@ -16,6 +16,7 @@ import {
   useSimpleMaterialTable,
   ColumnDef,
   ColumnType,
+  NaiveDateCell,
 } from '@openmsupply-client/common';
 import {
   PatientRowFragment,
@@ -128,6 +129,7 @@ const ModalContent: FC<ModalContentProps> = ({
         accessorKey: 'dateOfBirth',
         header: t('label.date-of-birth'),
         columnType: ColumnType.Date,
+        Cell: NaiveDateCell,
       },
       {
         accessorKey: 'gender',

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemLedger.tsx
@@ -9,6 +9,7 @@ import {
   MaterialTable,
   ColumnDef,
   ColumnType,
+  ExpiryDateCell,
   usePaginatedMaterialTable,
   useTranslation,
   useUrlQueryParams,
@@ -94,6 +95,7 @@ const ItemLedgerTable = ({
         accessorKey: 'expiryDate',
         header: t('label.expiry'),
         columnType: ColumnType.Date,
+        Cell: ExpiryDateCell,
         size: 100,
       },
       {

--- a/client/packages/system/src/Patient/CreatePatientModal/PatientResultsTab.tsx
+++ b/client/packages/system/src/Patient/CreatePatientModal/PatientResultsTab.tsx
@@ -15,6 +15,7 @@ import {
   useSimpleMaterialTable,
   ColumnDef,
   ColumnType,
+  NaiveDateCell,
 } from '@openmsupply-client/common';
 import { PatientPanel } from './PatientPanel';
 import { FetchPatientModal } from './FetchPatientModal';
@@ -181,6 +182,7 @@ export const PatientResultsTab: FC<
         accessorKey: 'dateOfBirth',
         header: t('label.date-of-birth'),
         columnType: ColumnType.Date,
+        Cell: NaiveDateCell,
         size: 100,
       },
       {

--- a/client/packages/system/src/Patient/Insurance/columns.ts
+++ b/client/packages/system/src/Patient/Insurance/columns.ts
@@ -1,6 +1,7 @@
 import {
   ColumnDef,
   ColumnType,
+  ExpiryDateCell,
   useTranslation,
 } from '@openmsupply-client/common';
 import { InsuranceFragment } from '../apiModern/operations.generated';
@@ -33,6 +34,7 @@ export const useInsuranceColumns = () => {
         accessorKey: 'expiryDate',
         header: t('label.expiry-date'),
         columnType: ColumnType.Date,
+        Cell: ExpiryDateCell,
       },
       {
         id: 'isActive',

--- a/client/packages/system/src/Vaccination/Components/SelectBatch.tsx
+++ b/client/packages/system/src/Vaccination/Components/SelectBatch.tsx
@@ -4,6 +4,7 @@ import {
   Checkbox,
   ColumnDef,
   ColumnType,
+  ExpiryDateCell,
   MaterialTable,
   useSimpleMaterialTable,
   useTranslation,
@@ -69,6 +70,7 @@ export const SelectBatch = ({
         accessorKey: 'expiryDate',
         header: t('label.expiry-date'),
         columnType: ColumnType.Date,
+        Cell: ExpiryDateCell,
         size: 100,
       },
       {


### PR DESCRIPTION
> [!WARNING]
> This PR was largely authored by Claude

Fixes #10606

Stacked on #11480 — please review/merge that one first.

Addresses [this review comment](https://github.com/msupply-foundation/open-msupply/pull/11480#pullrequestreview-4217439295) from #11480 asking for the same fix to be applied across the rest of the app.

# 👩🏻‍💻 What does this PR do?

Sweeps every remaining expiry-date and date-of-birth display site that wasn't covered by #11480. Each site now uses `ExpiryDateCell` / `NaiveDateCell` (or, in one bare-JSX case, `DateUtils.getNaiveDate` + `localisedDate` directly), so the display matches the user's locale and isn't shifted a day in negative-offset timezones.

14 sites updated across `invoices`, `inventory`, `system`, and `programs` packages — all are mechanical wiring of the existing helpers; no new components, no behaviour changes beyond correct rendering.

## 💌 Any notes for the reviewer?

- Deliberately left `manufactureDate` columns alone (Stock list, Inbound shipment detail). Same UTC-midnight pattern, but it's a separate field and not in the issue or original review ask — happy to do as a follow-up if wanted.
- One ad-hoc helper `formatNaiveDate` was inlined in `Prescriptions/DetailView/SidePanel/PatientDetails.tsx` — only one callsite, not worth a shared util.

# 🧪 Testing

Same flow as #11480 — spoof browser timezone to a negative-offset locale (e.g. America/Toronto via [Spoof Timezone](https://chromewebstore.google.com/detail/spoof-timezone/kcabmhnajflfolhelachlflngdbfhboe)) with regional format set to **English (Canada)**, then confirm correct day + locale-formatted date in:

- [ ] Inbound / Outbound / Customer return / Supplier return / Prescription / Stocktake detail line tables (expiry column)
- [ ] Item ledger expiry column
- [ ] Vaccination batch picker
- [ ] Patient insurance policies table
- [ ] Patient search results in Create Patient modal (DOB)
- [ ] Contact trace link-patient modal (DOB)
- [ ] Prescription side panel — patient DOB field
- [ ] Customer / supplier return reasons modal (expiry column)
- [ ] Prescription stockline picker in JSON forms