### PR TITLE
Fix json_translate_test casing assertions

### DIFF
--- a/server/service/src/json_translate.rs
+++ b/server/service/src/json_translate.rs
@@ -63,12 +63,12 @@ mod json_translate_test {
         });
 
         let expected = serde_json::json!({
-            "key": "Authentication Error",
+            "key": "Authentication error",
             "nested": {
                 "key": "Pending",
                 "untranslated_key": "untranslated_value"
             },
-            "list": ["Add Form", "no-translation"]
+            "list": ["Add form", "no-translation"]
         });
 
         let localisations = service_provider


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Updates the assertions in `json_translate_test` to match the sentence-case English translations introduced by commit 22e8747316 (`sentence case throughout`).

The translations now read `"Authentication error"` and `"Add form"`, but the test still expected `"Authentication Error"` and `"Add Form"`, so CI was failing.

## 💌 Any notes for the reviewer?

Trivial test fix — no production code change. Aligns the expected values in [server/service/src/json_translate.rs](server/service/src/json_translate.rs) with the actual values in [client/packages/common/src/intl/locales/en/common.json](client/packages/common/src/intl/locales/en/common.json).

# 🧪 Testing

- [ ] `cd server && cargo nextest run -p service json_translate_test` passes locally

# 📃 Documentation

- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour