### PR TITLE
#11113 Keep autocomplete dropdown within viewport on small screens

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Autocomplete/components.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/components.tsx
@@ -1,5 +1,22 @@
-import { styled, Popper } from '@mui/material';
+import React from 'react';
+import { styled, Popper, PopperProps } from '@mui/material';
 
-export const StyledPopper = styled(Popper)(({ theme }) => ({
+const InnerPopper = styled(Popper)(({ theme }) => ({
   boxShadow: theme.shadows[2],
 }));
+
+// Keeps the dropdown within the viewport on narrow screens (e.g. tablets)
+// when the input sits near the edge.
+const defaultModifiers: NonNullable<PopperProps['modifiers']> = [
+  { name: 'preventOverflow', options: { altAxis: true, padding: 8 } },
+];
+
+export const StyledPopper = React.forwardRef<HTMLDivElement, PopperProps>(
+  ({ modifiers, ...props }, ref) => (
+    <InnerPopper
+      ref={ref}
+      {...props}
+      modifiers={[...defaultModifiers, ...(modifiers ?? [])]}
+    />
+  )
+);


### PR DESCRIPTION
Fixes comment in #11113

# 👩🏻‍💻 What does this PR do?

Adds `preventOverflow.altAxis` to the autocomplete `StyledPopper` so dropdowns shift horizontally to stay on-screen when the input sits near the viewport edge.

Addresses the "Location popover is cutoff by the edge of the screen" tablet bug noted in the issue comments. Popper.js only acts on the main axis by default, so `bottom-start` dropdowns could overflow horizontally.

## 💌 Any notes for the reviewer?

- Applied to shared `StyledPopper`, so all autocompletes benefit — no-op when the dropdown already fits.
- Call sites can still pass their own `modifiers`; defaults are merged first so consumers can override.

# 🧪 Testing

- [ ] On tablet / narrow window, open an inbound shipment line and click the Location field near the right edge — dropdown stays fully visible
- [ ] On wide screen, dropdown still opens in the usual position

# 📃 Documentation

- [x] **No documentation required**: bug fix, no change in user-facing behaviour