### PR TITLE
#11511 Disable sorting on stock-line columns when grouped by item

### DIFF
--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -135,7 +135,7 @@ export const StockListView = () => {
         Cell: TextWithTooltipCell,
         size: 100,
         defaultHideOnMobile: true,
-        enableSorting: true,
+        enableSorting: !isGrouped,
       },
       {
         id: 'expiryDate',
@@ -147,7 +147,7 @@ export const StockListView = () => {
         defaultHideOnMobile: true,
         enableColumnFilter: true,
         dateFilterFormat: 'date',
-        enableSorting: true,
+        enableSorting: !isGrouped,
       },
       {
         id: 'manufactureDate',
@@ -158,7 +158,7 @@ export const StockListView = () => {
         size: 100,
         defaultHideOnMobile: true,
         enableColumnFilter: true,
-        enableSorting: true,
+        enableSorting: !isGrouped,
       },
       {
         id: 'vvmStatus',
@@ -168,7 +168,7 @@ export const StockListView = () => {
         size: 150,
         defaultHideOnMobile: true,
         includeColumn: manageVvmStatusForStock,
-        enableSorting: true,
+        enableSorting: !isGrouped,
       },
       {
         id: 'location.code',
@@ -177,7 +177,7 @@ export const StockListView = () => {
         Cell: TextWithTooltipCell,
         size: 100,
         defaultHideOnMobile: true,
-        enableSorting: true,
+        enableSorting: !isGrouped,
         enableColumnFilter: true,
       },
       {
@@ -196,7 +196,7 @@ export const StockListView = () => {
         align: 'right',
         size: 90,
         defaultHideOnMobile: true,
-        enableSorting: true,
+        enableSorting: !isGrouped,
       },
       {
         header: t('label.pack-quantity'),
@@ -204,7 +204,7 @@ export const StockListView = () => {
         columnType: ColumnType.Number,
         align: 'right',
         size: 100,
-        enableSorting: true,
+        enableSorting: !isGrouped,
       },
       {
         header: t('label.soh'),
@@ -236,7 +236,7 @@ export const StockListView = () => {
         columnType: ColumnType.Currency,
         size: 125,
         defaultHideOnMobile: true,
-        enableSorting: true,
+        enableSorting: !isGrouped,
       },
       {
         id: 'totalCost',
@@ -265,11 +265,11 @@ export const StockListView = () => {
         Cell: TextWithTooltipCell,
         size: 190,
         defaultHideOnMobile: true,
-        enableSorting: true,
+        enableSorting: !isGrouped,
       },
       ...(plugins.stockLine?.tableColumn || []),
     ],
-    [manageVvmStatusForStock, plugins.stockLine?.tableColumn, t]
+    [isGrouped, manageVvmStatusForStock, plugins.stockLine?.tableColumn, t]
   );
 
   const { table } = usePaginatedMaterialTable<StockLineRowFragment>({


### PR DESCRIPTION
Closes #11511

## Summary

- When the stock list is grouped by item, sorting is done server-side on items (not stock lines), so only Name and Code are meaningful sort keys
- Stock-line-level columns (batch, expiry, manufacture date, VVM status, location, pack size, pack quantity, cost price, supplier) now have `enableSorting` disabled in grouped mode
- Name and Code remain sortable in grouped mode as before
- Adds `isGrouped` to the `mrtColumns` memo dependency array so column config updates when the toggle changes

## Test plan

- [ ] Enable "Group by item" on the stock page — stock-line columns should show no sort indicator and not respond to clicks
- [ ] Disable grouping — all previously-sortable columns should be sortable again
- [ ] Sort by Name and Code in grouped mode — should still work correctly