### PR TITLE
Fix broken develop (use ReactQuery v5 syntax)

### DIFF
--- a/client/packages/invoices/src/Returns/api/hooks/document/useCustomerDelete.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/document/useCustomerDelete.ts
@@ -5,9 +5,11 @@ export const useCustomerReturnDelete = () => {
   const queryClient = useQueryClient();
   const api = useReturnsApi();
 
-  return useMutation(api.deleteCustomer, {
+  return useMutation({
+    mutationFn: api.deleteCustomer,
     // `void` is load-bearing: returning the invalidateQueries promise would make
     // mutateAsync await the refetch of the just-deleted detail query and hang.
-    onSuccess: () => void queryClient.invalidateQueries(api.keys.base()),
+    onSuccess: () =>
+      void queryClient.invalidateQueries({ queryKey: api.keys.base() }),
   });
 };

--- a/client/packages/invoices/src/Returns/api/hooks/document/useSupplierDelete.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/document/useSupplierDelete.ts
@@ -5,9 +5,11 @@ export const useSupplierReturnDelete = () => {
   const queryClient = useQueryClient();
   const api = useReturnsApi();
 
-  return useMutation(api.deleteSupplier, {
+  return useMutation({
+    mutationFn: api.deleteSupplier,
     // `void` is load-bearing: returning the invalidateQueries promise would make
     // mutateAsync await the refetch of the just-deleted detail query and hang.
-    onSuccess: () => void queryClient.invalidateQueries(api.keys.base()),
+    onSuccess: () =>
+      void queryClient.invalidateQueries({ queryKey: api.keys.base() }),
   });
 };

--- a/client/packages/system/src/Item/api/hooks/ancillaryItem/useDeleteAncillaryItem.ts
+++ b/client/packages/system/src/Item/api/hooks/ancillaryItem/useDeleteAncillaryItem.ts
@@ -30,7 +30,7 @@ export const useDeleteAncillaryItem = ({ itemId }: { itemId: string }) => {
   const { mutateAsync } = useMutation({
     mutationFn,
     onSuccess: () => {
-      queryClient.invalidateQueries(keys.detail(itemId));
+      queryClient.invalidateQueries({ queryKey: keys.detail(itemId) });
     },
   });
 

--- a/client/packages/system/src/Item/api/hooks/ancillaryItem/useUpsertAncillaryItem.ts
+++ b/client/packages/system/src/Item/api/hooks/ancillaryItem/useUpsertAncillaryItem.ts
@@ -58,7 +58,9 @@ export function useUpsertAncillaryItem({
       throw new Error(t('error.failed-to-save-ancillary-item'));
     },
     onSuccess: () => {
-      queryClient.invalidateQueries(keys.detail(principalItemId));
+      queryClient.invalidateQueries({
+        queryKey: keys.detail(principalItemId),
+      });
     },
   });
 


### PR DESCRIPTION
Quick fix for the broken `develop` front-end -- we had merged from 2.19 without handling the refactor from React Query v4 to v5.