### PR TITLE
Suggested changes to Github actions

### DIFF
--- a/.github/workflows/client-bundle-size-comment.yaml
+++ b/.github/workflows/client-bundle-size-comment.yaml
@@ -49,9 +49,14 @@ jobs:
 
             const thresholdBytes = 2 * 1024;
 
+            // The build workflow writes this marker into result.txt when the
+            // base branch failed to build. In that case we always want to
+            // post (or update) the comment so the user sees the warning.
+            const isWarning = result.includes('Unable to run bundle size diff check');
+
             const diffBytes = Number('${{ steps.get-diff.outputs.diff_file_size }}');
             const exceedsThreshold = diffBytes !== null && Math.abs(diffBytes) > thresholdBytes;
-            const shouldComment = Boolean(existingComment) || exceedsThreshold;
+            const shouldComment = isWarning || Boolean(existingComment) || exceedsThreshold;
 
             if (!shouldComment) {
               core.info(`Skipping PR comment: bundle size change (${diffBytes ?? 'unknown'} bytes) is within ±2KB and no existing comment was found.`);

--- a/.github/workflows/client-bundle-size-diff.yaml
+++ b/.github/workflows/client-bundle-size-diff.yaml
@@ -32,13 +32,22 @@ jobs:
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
 
+      # Install/Build tolerate failure so a broken base branch doesn't fail
+      # the PR check. The compare job detects the missing artifact and posts
+      # a warning comment instead of a diff.
       - name: Install dependencies
+        id: install
+        continue-on-error: true
         run: cd ./client && rm -rf node_modules && yarn install --frozen-lockfile
 
       - name: Build
+        id: build
+        if: ${{ steps.install.outcome == 'success' }}
+        continue-on-error: true
         run: cd ./client && yarn build-stats
 
       - name: Upload base stats.json
+        if: ${{ steps.build.outcome == 'success' }}
         uses: actions/upload-artifact@v4
         with:
           name: base
@@ -84,6 +93,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download base stats
+        id: download-base
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: base
@@ -96,6 +107,7 @@ jobs:
           path: pr
 
       - name: Calculate diff
+        if: ${{ steps.download-base.outcome == 'success' }}
         id: get-diff
         uses: NejcZdovc/bundle-size-diff@v1
         with:
@@ -105,14 +117,22 @@ jobs:
       - name: Save comparison data
         run: |
           echo "${{ github.event.pull_request.number }}" > pr_number
-          cat > result.txt << 'EOF'
+          if [ "${{ steps.download-base.outcome }}" = "success" ]; then
+            cat > result.txt << 'EOF'
           ## Bundle size difference
           Comparing this PR to `main`
 
           |Old size      | New size     | Diff                     |
           |:------------ |:-------------|:-------------------------|
-          |${{ steps.get-diff.outputs.base_file_string }}         |${{ steps.get-diff.outputs.pr_file_string }}         | ${{ steps.get-diff.outputs.diff_file_string }} (${{ steps.get-diff.outputs.percent }}%) |          
+          |${{ steps.get-diff.outputs.base_file_string }}         |${{ steps.get-diff.outputs.pr_file_string }}         | ${{ steps.get-diff.outputs.diff_file_string }} (${{ steps.get-diff.outputs.percent }}%) |
           EOF
+          else
+            cat > result.txt << 'EOF'
+          ## Bundle size difference
+
+          ⚠️ Unable to run bundle size diff check due to failing base branch build.
+          EOF
+          fi
 
       - name: Upload comparison artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-issue-label-sync.yaml
+++ b/.github/workflows/pr-issue-label-sync.yaml
@@ -1,7 +1,7 @@
 name: Sync labels from linked issue to PR
 on:
   pull_request_target:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, labeled, unlabeled]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,6 +12,19 @@ jobs:
         with:
           script: |
             core.debug(`where the PR? ${context.repo.repo} ${context.repo.owner} ${context.issue.number}`);
+
+            // Belt-and-braces guard against an infinite label-event loop.
+            // GitHub already prevents events produced by GITHUB_TOKEN from
+            // triggering further workflow runs (except workflow_dispatch /
+            // repository_dispatch), so the labels we apply below normally
+            // won't re-trigger this workflow. This explicit check protects
+            // us if the auth method ever changes (e.g. a PAT or GitHub App
+            // token), which would re-enable downstream triggers.
+            if (context.payload.sender?.login === 'github-actions[bot]') {
+              core.info('Triggered by github-actions bot — skipping to avoid label-event loop.')
+              return
+            }
+
             let x = 1
             const pullRequestResult = await github.graphql(`
               query($owner: String!, $repo: String!, $number: Int!) {
@@ -22,6 +35,7 @@ jobs:
                     labels (first: 100){
                       nodes {
                         id
+                        name
                       }
                     }
                     closingIssuesReferences(first: 1) {
@@ -49,13 +63,22 @@ jobs:
 
             const pullRequest = pullRequestResult.repository.pullRequest
 
+            const hasNoLinkedIssueLabel = pullRequest.labels.nodes.some(
+              label => label.name === 'no linked issue'
+            )
+
             let issue = pullRequest.closingIssuesReferences.nodes[0]
 
             if (!issue) {
               const regex = new RegExp(/#(\d+)/);
-              const issueNumber = Number(pullRequest.body.match(regex)[1])
+              const bodyMatch = pullRequest.body && pullRequest.body.match(regex)
+              const issueNumber = bodyMatch ? Number(bodyMatch[1]) : null
 
-              if  (!issueNumber) {
+              if (!issueNumber) {
+                if (hasNoLinkedIssueLabel) {
+                  core.notice('No linked issue found, but "no linked issue" label is set — skipping label sync.')
+                  return
+                }
                 throw new Error('No associated issue found for this pull request. Not even in the body!')
               }
 
@@ -84,7 +107,11 @@ jobs:
               issue = issueResult.repository.issue
 
               if (!issue) {
-                throw new Error('No associated issue found for this pull request. There was a match in the description, but not to an issue: ${issueNumber}')
+                if (hasNoLinkedIssueLabel) {
+                  core.notice('No linked issue found, but "no linked issue" label is set — skipping label sync.')
+                  return
+                }
+                throw new Error(`No associated issue found for this pull request. There was a match in the description, but not to an issue: ${issueNumber}`)
               }
             }
 


### PR DESCRIPTION
After discussing with @esmehm about the fact that we should really add the additional Merge restriction that all checks must pass, we noted a couple of exceptions:

1. The "Sync labels" action always fails if you don't have a linked issue. Yes, I know we should always have an issue, but there are occasional exceptions, such as emergency fixes or trivial/routine updates (merging RC branches to develop, for example, or this PR!)
2. If the base branch is already broken, the bundle size diff will always fail as it can't build the base branch to compare with

Here are my suggested remedies to both the above, so we can implement that merge restriction without concern.

(These are done in two separate commits for easier inspection)

## Sync labels

We want to *encourage* but not *enforce* having a linked issue for every PR. So my suggestion is to have a new label called "no linked issue", which the PR author must explicitly add in order to pass the check. The change added here checks for this label and passes if present, but continues to fail as it does now for all other cases. Have also added a trigger to re-run on label changes so author can actually add the label after PR creation and have the workflow pass

I.e the process will be: Create PR without issue -> Sync labels workflow fails -> Author adds "no linked issue" label -> Sync labels workflow succeeds!

Done in commit 5eb725ab51

## Bundle size diff

Have softened the restriction so that the workflow will still report a success if the base branch build fails. But then instead of posting the size diff as a comment, it'll post a warning: "⚠️ Unable to run bundle size diff check due to failing base branch build."

It'll still fail if the current PR build fails -- here are the possible cases:

| build-base | build-pr | Workflow check | Comment outcome |
|:---:|:---:|:---:|:---|
| ✓ | ✓ | ✓ Success | Prints diff comment* |
| ✗ | ✓ | ✓ Success | ⚠️ Prints warning comment |
| ✓ | ✗ | ✗ Fail | No comment |
| ✗ | ✗ | ✗ Fail | No comment |

Done in commit 56ee5758b5

*Code written by Claude*