### PR TITLE
#11508 Add unit name column to purchase order detail view

### DIFF
--- a/client/packages/purchasing/src/purchase_order/DetailView/columns.tsx
+++ b/client/packages/purchasing/src/purchase_order/DetailView/columns.tsx
@@ -84,6 +84,12 @@ export const usePurchaseOrderColumns = (currencyCode?: string) => {
         size: 90,
       },
       {
+        accessorKey: 'item.unitName',
+        header: t('label.unit-name'),
+        accessorFn: row => row.item.unitName,
+        size: 100,
+      },
+      {
         accessorKey: 'requestedNumberOfUnits',
         header: t('label.requested-units'),
         columnType: ColumnType.Number,


### PR DESCRIPTION
Fixes #11508

# 👩🏻‍💻 What does this PR do?

Adds a **Unit name** column to the General tab of the Purchase Order detail view, showing the unit of measure (e.g. Tablet, Bottle, ml) for each line item.

The column is positioned after Pack size and before Requested units, matching the placement suggested in the issue. It uses the `item.unitName` field already present in the `PurchaseOrderLine` fragment so no backend or GraphQL changes were needed.

The column is visible by default and sized at 100px to keep it compact alongside the other numeric columns.

<img width="1649" height="590" alt="image" src="https://github.com/user-attachments/assets/bb8d3e17-667f-4c9f-a261-04102d924e71" />


## 💌 Any notes for the reviewer?

Single-file frontend change — just a new column definition in `usePurchaseOrderColumns`. No new i18n keys: `label.unit-name` already existed in `en/common.json`.

# 🧪 Testing

- [ ] Open a Purchase Order with lines that have items with different units of measure
- [ ] Confirm a **Unit name** column appears in the General tab between Pack size and Requested units
- [ ] Confirm the column shows the correct unit for each line (e.g. Tablet, Bottle)
- [ ] Confirm the column header reads "Unit name"

# 📃 Documentation

- [ ] **No documentation required**: additive UI column, no behaviour change

# 📃 Reviewer Checklist

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API

**Issue Review**
- [x] All requirements in original issue have been covered

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend