### PR TITLE
#11289 Move ancillary supplies into its own tab

### DIFF
--- a/client/packages/system/src/Item/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Item/DetailView/DetailView.tsx
@@ -19,6 +19,7 @@ import { AppRoute } from '@openmsupply-client/config';
 import { ItemVariantsTab } from './Tabs/ItemVariants';
 import { ItemLedgerTab } from './Tabs/ItemLedger';
 import { StoreTab } from './Tabs/Store';
+import { AncillarySupplies } from './Tabs/AncillarySupplies';
 
 export const ItemDetailView = () => {
   const t = useTranslation();
@@ -104,6 +105,10 @@ export const ItemDetailView = () => {
         <ItemLedgerTab itemId={data.id} onRowClick={onLedgerRowClick} />
       ),
       value: t('label.ledger'),
+    },
+    {
+      Component: <AncillarySupplies item={data} />,
+      value: t('title.ancillary-supplies'),
     },
   ];
 

--- a/client/packages/system/src/Item/DetailView/Tabs/AncillarySupplies/AncillarySupplies.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/AncillarySupplies/AncillarySupplies.tsx
@@ -1,17 +1,17 @@
 import React, { useMemo } from 'react';
 import {
-  FlatButton,
+  AppBarButtonsPortal,
+  ButtonWithIcon,
   useTranslation,
   PlusCircleIcon,
   useEditModal,
   IconButton,
   DeleteIcon,
   MaterialTable,
-  useSimpleMaterialTable,
+  useNonPaginatedMaterialTable,
   ColumnDef,
   TextWithTooltipCell,
   useIsCentralServerApi,
-  DetailSection,
   NothingHere,
 } from '@openmsupply-client/common';
 import {
@@ -30,7 +30,7 @@ export const AncillarySupplies = ({ item }: { item: ItemFragment }) => {
     useEditModal<AncillaryItemFragment>();
 
   return (
-    <DetailSection title={t('title.ancillary-supplies')}>
+    <>
       {isOpen && (
         <AncillarySupplyModal
           onClose={onClose}
@@ -39,11 +39,21 @@ export const AncillarySupplies = ({ item }: { item: ItemFragment }) => {
         />
       )}
 
+      {isCentralServer && (
+        <AppBarButtonsPortal>
+          <ButtonWithIcon
+            Icon={<PlusCircleIcon />}
+            onClick={() => onOpen()}
+            label={t('label.add-ancillary-item')}
+          />
+        </AppBarButtonsPortal>
+      )}
+
       <AncillarySuppliesTable
         item={item}
         onOpen={isCentralServer ? onOpen : undefined}
       />
-    </DetailSection>
+    </>
   );
 };
 
@@ -65,6 +75,8 @@ const AncillarySuppliesTable = ({
           accessorFn: row => row.ancillaryItem?.name ?? '',
           header: t('label.ancillary-item'),
           Cell: TextWithTooltipCell,
+          enableSorting: true,
+          enableColumnFilter: true,
         },
         {
           id: 'code',
@@ -72,6 +84,8 @@ const AncillarySuppliesTable = ({
           header: t('label.code'),
           Cell: TextWithTooltipCell,
           size: 120,
+          enableSorting: true,
+          enableColumnFilter: true,
         },
         {
           id: 'ratio',
@@ -105,20 +119,18 @@ const AncillarySuppliesTable = ({
     [onOpen, deleteAncillaryItem, t]
   );
 
-  const table = useSimpleMaterialTable<AncillaryItemFragment>({
+  const { table } = useNonPaginatedMaterialTable<AncillaryItemFragment>({
     tableId: 'ancillary-supplies',
     data: item.ancillaryItems,
     columns,
     onRowClick: onOpen,
-    bottomToolbarContent: onOpen ? (
-      <FlatButton
-        label={t('label.add-ancillary-item')}
-        onClick={() => onOpen()}
-        startIcon={<PlusCircleIcon />}
-        color="primary"
+    enableRowSelection: false,
+    noDataElement: (
+      <NothingHere
+        body={t('messages.no-ancillary-items')}
+        onCreate={onOpen ? () => onOpen() : undefined}
       />
-    ) : undefined,
-    noDataElement: <NothingHere body={t('messages.no-ancillary-items')} />,
+    ),
   });
 
   return <MaterialTable table={table} />;

--- a/client/packages/system/src/Item/DetailView/Tabs/AncillarySupplies/AncillarySupplyModal.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/AncillarySupplies/AncillarySupplyModal.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { FormLabel } from '@mui/material';
 import {
   DialogButton,
-  InputWithLabelRow,
   Box,
   useTranslation,
   useDialog,
@@ -12,7 +11,6 @@ import {
   useNotification,
   Typography,
   NumericTextInput,
-  InfoTooltipIcon,
 } from '@openmsupply-client/common';
 import { StockItemSearchInput } from '@openmsupply-client/system';
 import {
@@ -94,62 +92,57 @@ const AncillarySupplyForm = ({
 }) => {
   const t = useTranslation();
 
-  return (
-    <Box justifyContent="center" display="flex" gap={3}>
-      <Box display="flex" flexDirection="column" gap={1} flex={1}>
-        <InputWithLabelRow
-          label={t('label.ancillary-item')}
-          labelWidth="200"
-          Input={
-            <Box width="100%">
-              <StockItemSearchInput
-                autoFocus={!draft.ancillaryItemId}
-                openOnFocus={!draft.ancillaryItemId}
-                disabled={isEdit}
-                onChange={selected =>
-                  updateDraft({ ancillaryItemId: selected?.id })
-                }
-                currentItemId={draft.ancillaryItemId ?? undefined}
-                filter={{ id: { notEqualAll: [principalItemId] } }}
-              />
-            </Box>
-          }
-        />
+  const labelSx = {
+    fontWeight: 'bold',
+    display: 'flex',
+    alignItems: 'center',
+    height: '100%',
+  };
 
-        <Box display="flex" alignItems="center" gap={1}>
-          <FormLabel
-            sx={{
-              width: '200px',
-              fontWeight: 'bold',
-              display: 'flex',
-              alignItems: 'center',
-            }}
-          >
-            {t('label.ratio')}
-            <InfoTooltipIcon title={t('description.ancillary-ratio')} />
-            :
-          </FormLabel>
-          <NumericTextInput
-            value={draft.itemQuantity}
-            min={0}
-            decimalLimit={4}
-            onChange={next =>
-              updateDraft({ itemQuantity: next ?? 0 })
-            }
-            style={{ justifyContent: 'flex-start', width: 120 }}
-          />
-          <Typography fontWeight="bold">:</Typography>
-          <NumericTextInput
-            value={draft.ancillaryQuantity}
-            min={0}
-            decimalLimit={4}
-            onChange={next =>
-              updateDraft({ ancillaryQuantity: next ?? 0 })
-            }
-            style={{ justifyContent: 'flex-start', width: 120 }}
-          />
-        </Box>
+  return (
+    <Box
+      display="grid"
+      gridTemplateColumns="150px 1fr"
+      columnGap={2}
+      rowGap={1}
+      alignItems="center"
+    >
+      <FormLabel sx={labelSx}>{t('label.ancillary-item')}:</FormLabel>
+      <StockItemSearchInput
+        autoFocus={!draft.ancillaryItemId}
+        openOnFocus={!draft.ancillaryItemId}
+        disabled={isEdit}
+        onChange={selected => updateDraft({ ancillaryItemId: selected?.id })}
+        currentItemId={draft.ancillaryItemId ?? undefined}
+        filter={{ id: { notEqualAll: [principalItemId] } }}
+      />
+
+      <FormLabel sx={labelSx}>{t('label.ratio')}:</FormLabel>
+      <Box display="flex" alignItems="center" gap={1}>
+        <NumericTextInput
+          value={draft.itemQuantity}
+          min={0}
+          decimalLimit={4}
+          onChange={next => updateDraft({ itemQuantity: next ?? 0 })}
+          style={{ justifyContent: 'flex-start', width: 120 }}
+        />
+        <Typography fontWeight="bold">:</Typography>
+        <NumericTextInput
+          value={draft.ancillaryQuantity}
+          min={0}
+          decimalLimit={4}
+          onChange={next => updateDraft({ ancillaryQuantity: next ?? 0 })}
+          style={{ justifyContent: 'flex-start', width: 120 }}
+        />
       </Box>
+
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        sx={{ gridColumn: 2 }}
+      >
+        {t('description.ancillary-ratio')}
+      </Typography>
     </Box>
   );
 };

--- a/client/packages/system/src/Item/DetailView/Tabs/General.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/General.tsx
@@ -11,7 +11,6 @@ import {
 } from '@openmsupply-client/common';
 import { ItemFragment } from '../../api';
 import { LocationTypeInput } from '../../Components';
-import { AncillarySupplies } from './AncillarySupplies';
 
 interface GeneralTabProps {
   item: ItemFragment;
@@ -196,7 +195,6 @@ export const GeneralTab = ({ item, isLoading }: GeneralTabProps) => {
             ))}
           </DetailSection>
         )}
-        <AncillarySupplies item={item} />
       </Grid>
     </DetailContainer>
   );


### PR DESCRIPTION
Fixes #11289

Followup to #11334.

<img width="400" align="right" alt="image" src="https://github.com/user-attachments/assets/ceba3716-0b35-4cc1-8929-54e6447c1d4b" />
<img width="400" align="right" alt="image" src="https://github.com/user-attachments/assets/e9df6c15-5b0b-487c-9cc2-a5d31436acd6" />


# 👩🏻‍💻 What does this PR do?

- Moves the ancillary supplies table out of the General tab and into its own full-size tab on the item detail page
- Moves the "Add ancillary supply" button from the table's bottom toolbar to the page header (`AppBarButtonsPortal`), matching the Variants tab pattern
- Switches the table from `useSimpleMaterialTable` to `useNonPaginatedMaterialTable` so it gets the standard full-size tab styling (sorting + filtering on name/code)
- In the add/edit modal: moves the ratio explanation text out of the tooltip and renders it as helper text under the inputs

## 💌 Any notes for the reviewer?

The modal form was rebuilt as a 2-column CSS grid (label / input) so the helper text aligns under the input column without manual padding math. Note this is a one-off — the rest of the codebase uses `InputWithLabelRow`. Happy to revert to that pattern if preferred for consistency; the trade-off is the helper text needs an indent hack.

# 🧪 Testing

- [ ] On the item detail page, confirm there's a new "Ancillary supplies" tab
- [ ] Confirm the General tab no longer shows the ancillary supplies section
- [ ] On a central server, the "Add ancillary supply" button shows in the page header on that tab
- [ ] Add, edit, and delete ancillary supplies; confirm modal renders with ratio inputs aligned and helper text shown beneath
- [ ] On a non-central server, confirm the table is read-only (no add button, no delete column)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**:

# 📃 Reviewer Checklist

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend