### PR TITLE
#11507 Log API failures and retry on client-side timeouts

### DIFF
--- a/server/util/src/api_helper.rs
+++ b/server/util/src/api_helper.rs
@@ -54,33 +54,56 @@ where
             ),
         };
 
-        if (is_connect_error
+        // Surface the status code (or transport error) for any failed attempt so
+        // proxy/upstream errors like 502/503/504 — which we do not currently retry —
+        // still appear in the log instead of being hidden behind a downstream
+        // "could not parse response" message.
+        let attempt_failure = match result.as_ref() {
+            Ok(r) if !r.status().is_success() => Some(format!("HTTP {}", r.status().as_u16())),
+            Ok(_) => None,
+            Err(e) => {
+                let kind = if is_connect_error {
+                    "connection error"
+                } else if is_timeout_error {
+                    "request timeout"
+                } else {
+                    "request error"
+                };
+                Some(format!("{}: {}", kind, e))
+            }
+        };
+
+        let will_retry = (is_connect_error
             || is_timeout_error
             || status == Some(StatusCode::REQUEST_TIMEOUT))
-            && (index + 1) < connection_timeouts.0.len()
-        {
-            let reason = if is_connect_error {
-                "connection error"
-            } else if is_timeout_error {
-                "request timeout"
-            } else {
-                "HTTP 408 Request Timeout"
-            };
+            && (index + 1) < connection_timeouts.0.len();
+
+        if let Some(failure) = attempt_failure {
             let url_display = url.as_deref().unwrap_or("<unknown>");
-            let next_timeout = connection_timeouts.0[index + 1];
             let body_display = body_size
                 .map(|n| format!("{} bytes", n))
                 .unwrap_or_else(|| "unknown size".to_string());
+            let retry_note = if will_retry {
+                format!(
+                    "retrying (next connect timeout {}s)",
+                    connection_timeouts.0[index + 1]
+                )
+            } else {
+                "not retrying".to_string()
+            };
             log::info!(
-                "API request retry {}/{} for url '{}' due to {} after {:.1}s (request body: {}); next connect timeout {}s",
-                index + 1,
-                connection_timeouts.0.len() - 1,
+                "API request failed: url '{}', {}, attempt {}/{} after {:.1}s (request body: {}); {}",
                 url_display,
-                reason,
+                failure,
+                index + 1,
+                connection_timeouts.0.len(),
                 elapsed.as_secs_f64(),
                 body_display,
-                next_timeout
+                retry_note,
             );
+        }
+
+        if will_retry {
             index += 1;
             continue;
         }

--- a/server/util/src/api_helper.rs
+++ b/server/util/src/api_helper.rs
@@ -12,6 +12,13 @@ impl Default for RetrySeconds {
     }
 }
 
+// If a request burns more than this on a single attempt and times out, do not
+// retry it — the overall request timeout has effectively been hit and another
+// 30-minute attempt is unlikely to succeed where the first didn't, and we don't
+// want a single sync to block for ~90 minutes. Fast timeouts (connect-phase,
+// kernel TCP retransmit, etc.) still retry as before.
+const SLOW_TIMEOUT_RETRY_CUTOFF: Duration = Duration::from_secs(60 * 25);
+
 pub async fn with_retries<F>(connection_timeouts: RetrySeconds, f: F) -> Result<Response>
 where
     F: Fn(Client) -> RequestBuilder,
@@ -73,8 +80,9 @@ where
             }
         };
 
+        let timeout_was_slow = is_timeout_error && elapsed >= SLOW_TIMEOUT_RETRY_CUTOFF;
         let will_retry = (is_connect_error
-            || is_timeout_error
+            || (is_timeout_error && !timeout_was_slow)
             || status == Some(StatusCode::REQUEST_TIMEOUT))
             && (index + 1) < connection_timeouts.0.len();
 

--- a/server/util/src/api_helper.rs
+++ b/server/util/src/api_helper.rs
@@ -28,14 +28,33 @@ where
 
         let result = f(client).send().await;
 
-        let (status, is_connect_error) = match result.as_ref() {
-            Ok(r) => (Some(r.status()), false),
-            Err(e) => (e.status(), e.is_connect()),
+        let (status, is_connect_error, url) = match result.as_ref() {
+            Ok(r) => (Some(r.status()), false, Some(r.url().to_string())),
+            Err(e) => (
+                e.status(),
+                e.is_connect(),
+                e.url().map(|u| u.to_string()),
+            ),
         };
 
         if (is_connect_error || status == Some(StatusCode::REQUEST_TIMEOUT))
             && (index + 1) < connection_timeouts.0.len()
         {
+            let reason = if is_connect_error {
+                "connection error"
+            } else {
+                "request timeout"
+            };
+            let url_display = url.as_deref().unwrap_or("<unknown>");
+            let next_timeout = connection_timeouts.0[index + 1];
+            log::info!(
+                "API request retry {}/{} for url '{}' due to {}; next connect timeout {}s",
+                index + 1,
+                connection_timeouts.0.len() - 1,
+                url_display,
+                reason,
+                next_timeout
+            );
             index += 1;
             continue;
         }

--- a/server/util/src/api_helper.rs
+++ b/server/util/src/api_helper.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use reqwest::*;
 
@@ -26,33 +26,59 @@ where
             .build()
             .unwrap(); // This method fails if a TLS backend cannot be initialized, or the resolver cannot load the system configuration.
 
-        let result = f(client).send().await;
+        // Build the request up-front so we can inspect the body size for diagnostic
+        // logging on retry. `as_bytes()` returns None for streaming bodies (none of our
+        // current call sites use streaming, but the helper is generic).
+        let request_result = f(client.clone()).build();
+        let body_size = request_result
+            .as_ref()
+            .ok()
+            .and_then(|r| r.body())
+            .and_then(|b| b.as_bytes())
+            .map(|b| b.len());
 
-        let (status, is_connect_error, url) = match result.as_ref() {
-            Ok(r) => (Some(r.status()), false, Some(r.url().to_string())),
+        let started = Instant::now();
+        let result = match request_result {
+            Ok(request) => client.execute(request).await,
+            Err(e) => Err(e),
+        };
+        let elapsed = started.elapsed();
+
+        let (status, is_connect_error, is_timeout_error, url) = match result.as_ref() {
+            Ok(r) => (Some(r.status()), false, false, Some(r.url().to_string())),
             Err(e) => (
                 e.status(),
                 e.is_connect(),
+                e.is_timeout(),
                 e.url().map(|u| u.to_string()),
             ),
         };
 
-        if (is_connect_error || status == Some(StatusCode::REQUEST_TIMEOUT))
+        if (is_connect_error
+            || is_timeout_error
+            || status == Some(StatusCode::REQUEST_TIMEOUT))
             && (index + 1) < connection_timeouts.0.len()
         {
             let reason = if is_connect_error {
                 "connection error"
-            } else {
+            } else if is_timeout_error {
                 "request timeout"
+            } else {
+                "HTTP 408 Request Timeout"
             };
             let url_display = url.as_deref().unwrap_or("<unknown>");
             let next_timeout = connection_timeouts.0[index + 1];
+            let body_display = body_size
+                .map(|n| format!("{} bytes", n))
+                .unwrap_or_else(|| "unknown size".to_string());
             log::info!(
-                "API request retry {}/{} for url '{}' due to {}; next connect timeout {}s",
+                "API request retry {}/{} for url '{}' due to {} after {:.1}s (request body: {}); next connect timeout {}s",
                 index + 1,
                 connection_timeouts.0.len() - 1,
                 url_display,
                 reason,
+                elapsed.as_secs_f64(),
+                body_display,
                 next_timeout
             );
             index += 1;


### PR DESCRIPTION
Debugs #11507

# 👩🏻‍💻 What does this PR do?

Improves diagnosability of intermittent sync failures (and related to #11507) by changing how `util::api_helper::with_retries` logs and retries.

**1. Log every failed API attempt at info level.**
Previously the retry loop was silent — neither retried failures nor non-retried failures (e.g. proxy 502/504) were logged. The downstream error path showed things like `Could not parse response body, response: ''`, hiding the real upstream status code. Now every transport error or non-2xx response produces one info line with url, status code (or transport error), elapsed time, request body size, and whether a retry will follow:

```
API request failed: url 'https://central.example/central/sync/site_status', HTTP 502, attempt 1/3 after 30.0s (request body: 412 bytes); not retrying
API request failed: url 'https://central.example/sync/v5/site', request timeout: error sending request, attempt 1/3 after 2.0s (request body: 0 bytes); retrying (next connect timeout 5s)
```

**2. Retry on client-side request timeouts (behavior change, intentional).**
The retry condition previously fired on `is_connect()` errors and HTTP 408. It now also fires on `reqwest::Error::is_timeout()`, which covers fast timeouts that were previously not retried — notably OS-level TCP `TimedOut` errors during the read phase, which is the most likely cause of the "operation timed out" failure shown in the issue logs.

**3. Don't retry slow request-timeouts.**
`is_timeout()` also covers our 30-minute overall request timeout. Retrying after a 30-minute attempt could let a single sync block for ~90 minutes before failing. So we add a guard: if the failed attempt itself ran ≥ 25 minutes and timed out, give up rather than retry. Fast timeouts (connect, kernel TCP) still retry as before.

**4. Other status codes (502/503/504) are still NOT retried.**
Logged but not retried. Once the new log lines confirm how often these occur in the wild, retry behaviour for proxy errors can be added in a follow-up with a more appropriate backoff than the current connect-retry schedule (2s/5s/10s).

## 💌 Any notes for the reviewer?

- Lives in `server/util/src/api_helper.rs`; this helper is used by v5 sync (`sync/api/core.rs`), v6 sync (`sync/api_v6/core.rs`), and other APIs (`apis/patient_v4.rs`, `apis/oms_central.rs`) — the logging and the new timeout-retry rules apply to all of them. For sync the operations are idempotent (central dedupes by record id); for the patient/OMS callers a retried request would also be idempotent under normal use, but worth a sanity check.
- The retry helper now `.build()`s the request explicitly (instead of going straight through `RequestBuilder::send()`) so it can read the body size for the log. `Body::as_bytes()` only borrows; the original `Request` is then moved into `client.execute(...)` and sent unchanged. For streaming bodies `as_bytes()` returns None and we record body size as `unknown` (no current callers use streaming bodies).
- `Client::clone()` is cheap (it's `Arc` internally).
- A small Python script `scripts/fake_502_server.py` is included locally for testing (sleeps then returns 502 with empty body) — not committed.
- No changes to retry counts, the connect-timeout schedule (2s / 5s / 10s), or the 30-minute overall request timeout itself.

# 🧪 Testing

- [ ] Run a remote site with sync configured against an unreachable central server (e.g. wrong port) and trigger a manual sync — confirm one or more `API request failed: ... connection error ... retrying` info lines appear before the final error.
- [ ] Run sync against the included fake 502 server (`python3 scripts/fake_502_server.py`) — confirm a single `API request failed: ... HTTP 502 ... not retrying` info line is produced (502 is logged but not retried).
- [ ] Run sync against a slow endpoint that exceeds the connect timeout — confirm retries happen and each attempt logs elapsed time and body size.
- [ ] Confirm a successful sync produces no failure log lines.
- [ ] Confirm the existing sync error message at the end of a fully-failed sync is unchanged.

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend