### PR TITLE
#11500 Populate unit name when adding PO lines from master list

### DIFF
--- a/client/packages/purchasing/src/purchase_order/DetailView/LineEdit/PurchaseOrderLineEdit.tsx
+++ b/client/packages/purchasing/src/purchase_order/DetailView/LineEdit/PurchaseOrderLineEdit.tsx
@@ -138,11 +138,7 @@ export const PurchaseOrderLineEdit = ({
               <TextInput
                 label={t('label.unit')}
                 value={draft?.unit || ''}
-                onChange={(value?: string) => update({ unit: value })}
-                disabled={
-                  disabled ||
-                  isFieldDisabled(status, StatusGroup.AfterConfirmed)
-                }
+                disabled
               />
               <TextInput
                 label={t('label.supplier-item-code')}

--- a/server/service/src/purchase_order/generate.rs
+++ b/server/service/src/purchase_order/generate.rs
@@ -1,6 +1,7 @@
 use repository::{
-    EqualFilter, ItemRowRepository, NumberRowType, PurchaseOrderLineRow, PurchaseOrderLineStatus,
-    PurchaseOrderRow, RepositoryError, StockOnHandFilter, StockOnHandRepository, UnitRowRepository,
+    EqualFilter, ItemFilter, ItemRepository, NumberRowType, PurchaseOrderLineRow,
+    PurchaseOrderLineStatus, PurchaseOrderRow, RepositoryError, StockOnHandFilter,
+    StockOnHandRepository,
 };
 use util::uuid::uuid;
 
@@ -22,54 +23,47 @@ pub fn generate_empty_purchase_order_lines(
             )),
     ))?;
 
-    for item_id in item_ids {
-        match ItemRowRepository::new(&ctx.connection).find_active_by_id(&item_id) {
-            Ok(Some(item)) => {
-                let stock_on_hand = stocks_on_hand
-                    .iter()
-                    .find(|s| s.item_id == item.id)
-                    .map_or(0.0, |s| s.available_stock_on_hand);
-                let unit_name = item
-                    .unit_id
-                    .as_ref()
-                    .and_then(|unit_id| {
-                        UnitRowRepository::new(&ctx.connection)
-                            .find_one_by_id(unit_id)
-                            .ok()
-                            .flatten()
-                    })
-                    .map(|u| u.name);
-                result.push(PurchaseOrderLineRow {
-                    id: uuid(),
-                    purchase_order_id: purchase_order_row.id.clone(),
-                    line_number: next_number(
-                        &ctx.connection,
-                        &NumberRowType::PurchaseOrderLine(purchase_order_row.id.clone()),
-                        &purchase_order_row.store_id,
-                    )?,
-                    item_link_id: item.id,
-                    item_name: item.name,
-                    store_id: purchase_order_row.store_id.clone(),
-                    status: PurchaseOrderLineStatus::New,
-                    // Default
-                    requested_delivery_date: None,
-                    expected_delivery_date: None,
-                    requested_pack_size: item.default_pack_size,
-                    requested_number_of_units: 0.0,
-                    adjusted_number_of_units: None,
-                    stock_on_hand_in_units: stock_on_hand,
-                    supplier_item_code: None,
-                    price_per_pack_before_discount: 0.0,
-                    price_per_pack_after_discount: 0.0,
-                    comment: None,
-                    manufacturer_id: None,
-                    note: None,
-                    unit: unit_name,
-                });
-            }
-            Ok(None) => {}
-            Err(_error) => {}
-        };
+    let items = ItemRepository::new(&ctx.connection).query_by_filter(
+        ItemFilter::new()
+            .id(EqualFilter::equal_any(item_ids))
+            .is_active(true),
+        None,
+    )?;
+
+    for item in items {
+        let stock_on_hand = stocks_on_hand
+            .iter()
+            .find(|s| s.item_id == item.item_row.id)
+            .map_or(0.0, |s| s.available_stock_on_hand);
+        let unit_name = item.unit_row.map(|u| u.name);
+        let item_row = item.item_row;
+        result.push(PurchaseOrderLineRow {
+            id: uuid(),
+            purchase_order_id: purchase_order_row.id.clone(),
+            line_number: next_number(
+                &ctx.connection,
+                &NumberRowType::PurchaseOrderLine(purchase_order_row.id.clone()),
+                &purchase_order_row.store_id,
+            )?,
+            item_link_id: item_row.id,
+            item_name: item_row.name,
+            store_id: purchase_order_row.store_id.clone(),
+            status: PurchaseOrderLineStatus::New,
+            // Default
+            requested_delivery_date: None,
+            expected_delivery_date: None,
+            requested_pack_size: item_row.default_pack_size,
+            requested_number_of_units: 0.0,
+            adjusted_number_of_units: None,
+            stock_on_hand_in_units: stock_on_hand,
+            supplier_item_code: None,
+            price_per_pack_before_discount: 0.0,
+            price_per_pack_after_discount: 0.0,
+            comment: None,
+            manufacturer_id: None,
+            note: None,
+            unit: unit_name,
+        });
     }
 
     Ok(result)

--- a/server/service/src/purchase_order/generate.rs
+++ b/server/service/src/purchase_order/generate.rs
@@ -1,6 +1,6 @@
 use repository::{
     EqualFilter, ItemRowRepository, NumberRowType, PurchaseOrderLineRow, PurchaseOrderLineStatus,
-    PurchaseOrderRow, RepositoryError, StockOnHandFilter, StockOnHandRepository,
+    PurchaseOrderRow, RepositoryError, StockOnHandFilter, StockOnHandRepository, UnitRowRepository,
 };
 use util::uuid::uuid;
 
@@ -29,6 +29,16 @@ pub fn generate_empty_purchase_order_lines(
                     .iter()
                     .find(|s| s.item_id == item.id)
                     .map_or(0.0, |s| s.available_stock_on_hand);
+                let unit_name = item
+                    .unit_id
+                    .as_ref()
+                    .and_then(|unit_id| {
+                        UnitRowRepository::new(&ctx.connection)
+                            .find_one_by_id(unit_id)
+                            .ok()
+                            .flatten()
+                    })
+                    .map(|u| u.name);
                 result.push(PurchaseOrderLineRow {
                     id: uuid(),
                     purchase_order_id: purchase_order_row.id.clone(),
@@ -54,7 +64,7 @@ pub fn generate_empty_purchase_order_lines(
                     comment: None,
                     manufacturer_id: None,
                     note: None,
-                    unit: None,
+                    unit: unit_name,
                 });
             }
             Ok(None) => {}


### PR DESCRIPTION
## Summary
- Fixes unit name not prefilling when opening a purchase order line added via "Add from master list"
- The backend `generate_empty_purchase_order_lines` was creating rows with `unit: None` — it had access to `ItemRow` which only carries `unit_id`, not the name. Now resolves the unit name via `UnitRowRepository` before inserting each row.
- The single "Add item" flow was unaffected as it goes through the frontend draft which already has `unitName` from the GraphQL item fragment.
- Unit field is now read-only in all PO states (product decision)

Note: the unit name fix only applies to newly created POs — existing PO lines with `unit: null` in the DB will still show blank.

Closes #11500

Added from master list and prefills: 
<img width="1657" height="862" alt="image" src="https://github.com/user-attachments/assets/093ad17a-3366-4234-ac4c-ec54dbb9ba91" />
Repro steps in ticket