### PR TITLE
#11535 Show items with stock on hand in internal order item search

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -248,6 +248,7 @@ export const RequestLineEdit = ({
                 }
                 filter={{
                   id: { notEqualAll: lines.map(line => line.item.id) },
+                  isVisibleOrOnHand: true,
                 }}
               />
             )}


### PR DESCRIPTION
Fixes #11535

# 👩🏻‍💻 What does this PR do?

When an item is removed from all master lists, it was invisible in the item search picker when adding a line to a Request Requisition (internal order) — even if a stock line existed for that item at the store.

The fix adds `isVisibleOrOnHand: true` to the filter passed to `StockItemSearchInputWithStats` in `RequestLineEdit`, so the backend returns items that are either on a visible master list **or** have stock on hand. This mirrors the filter already used in `ResponseRequisition`'s item picker.

## 💌 Any notes for the reviewer?

**Open design question:** There is an active product discussion on [#11535](https://github.com/msupply-foundation/open-msupply/issues/11535) about whether this is the correct behaviour. Master lists are an ordering control mechanism — removing an item from all master lists could be intentional to prevent reordering. This PR treats it as a bug (items with stock should always be searchable), consistent with `ResponseRequisition`'s existing behaviour, but the product team is confirming.

The only file changed is `RequestLineEdit.tsx` — one line added. No backend changes required; the `isVisibleOrOnHand` filter path already exists in the repository layer.

# 🧪 Testing

- [ ] Create a stock line for an item at a store
- [ ] Remove that item from all master lists assigned to the store and sync
- [ ] Confirm the item still appears in the Stocks view (stock line exists)
- [ ] Open a new Internal Order and search for the item — it should now appear in results
- [ ] Confirm items that are on a master list still appear as before (no regression)

# 📃 Documentation

- [ ] **No documentation required**: bug fix restoring expected search behaviour