### PR TITLE
#11290 Ancillary banner popover + chain icon on lines

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2843,5 +2843,6 @@
   "warning.confirm-send-ancillary-items-stale_other": "{{count}} ancillary item lines have outdated quantities. Send anyway?",
   "label.ancillary-plan-to-add": "Items to add",
   "label.ancillary-plan-to-update": "Items to update",
+  "label.ancillary-of": "Ancillary of",
   "button.details": "Details"
 }

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2840,5 +2840,8 @@
   "warning.confirm-send-ancillary-items-missing_one": "1 ancillary item has not been added to this order. Send anyway?",
   "warning.confirm-send-ancillary-items-missing_other": "{{count}} ancillary items have not been added to this order. Send anyway?",
   "warning.confirm-send-ancillary-items-stale_one": "1 ancillary item line has an outdated quantity. Send anyway?",
-  "warning.confirm-send-ancillary-items-stale_other": "{{count}} ancillary item lines have outdated quantities. Send anyway?"
+  "warning.confirm-send-ancillary-items-stale_other": "{{count}} ancillary item lines have outdated quantities. Send anyway?",
+  "label.ancillary-plan-to-add": "Items to add",
+  "label.ancillary-plan-to-update": "Items to update",
+  "button.details": "Details"
 }

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -8845,6 +8845,14 @@ export type RequisitionLineNode = {
   additionInUnits: Scalars['Float']['output'];
   /** Quantity already issued in outbound shipments */
   alreadyIssued: Scalars['Float']['output'];
+  /**
+   * Items that have this line's item configured as an ancillary. Empty when
+   * the line is not an ancillary of anything. Used by the UI to flag
+   * ancillary lines and surface their parents in a popover. Batched per
+   * request via dataloader so a 200-line requisition issues two queries
+   * (link rows + parent items), not 400.
+   */
+  ancillaryParents: Array<ItemNode>;
   approvalComment?: Maybe<Scalars['String']['output']>;
   approvedQuantity: Scalars['Float']['output'];
   availableStockOnHand: Scalars['Float']['output'];

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -342,6 +342,18 @@ export type AllocateProgramNumberInput = {
 
 export type AllocateProgramNumberResponse = NumberNode;
 
+export type AncillaryDeltaNode = {
+  __typename: 'AncillaryDeltaNode';
+  /**
+   * Current quantity on the existing requisition line. `None` for items that
+   * don't yet have a line (i.e. entries in `toAdd`).
+   */
+  currentQuantity?: Maybe<Scalars['Float']['output']>;
+  item: ItemNode;
+  itemId: Scalars['String']['output'];
+  requiredQuantity: Scalars['Float']['output'];
+};
+
 export type AncillaryItemMutations = {
   __typename: 'AncillaryItemMutations';
   deleteAncillaryItem: DeleteAncillaryItemResponse;
@@ -389,6 +401,14 @@ export type AncillaryStateResponse = {
   /** Number of ancillary items in the banner-worthy state. Zero when state is `None`. */
   count: Scalars['Int']['output'];
   state: AncillaryStateNode;
+  /**
+   * Items missing from the requisition that need to be added. Always populated
+   * from the underlying plan, regardless of `state` — the client can show the
+   * full breakdown even when the banner-relevant state is `NeedsUpdate`.
+   */
+  toAdd: Array<AncillaryDeltaNode>;
+  /** Items present on the requisition with stale quantities. */
+  toUpdate: Array<AncillaryDeltaNode>;
 };
 
 export enum ApplyToLinesInput {

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
@@ -49,6 +49,7 @@ const createDraftFromItem = (
     additionInUnits: 0,
     daysOutOfStock: 0,
     expiringUnits: 0,
+    ancillaryParents: [],
   };
 };
 

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/AncillaryItemsBanner.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/AncillaryItemsBanner.tsx
@@ -1,22 +1,31 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Alert,
   AncillaryStateNode,
   FlatButton,
   useTranslation,
   Box,
+  PaperPopover,
+  Typography,
 } from '@openmsupply-client/common';
+import { RequestFragment } from '@openmsupply-client/system';
 import { useRequest } from '../../api';
+
+type AncillaryDelta = NonNullable<
+  RequestFragment['ancillaryState']
+>['toAdd'][number];
 
 /**
  * Toolbar banner that surfaces missing or stale ancillary item lines on a
  * request requisition. `NeedsAdd` takes priority; once added, any remaining
- * stale quantities surface as `NeedsUpdate`.
+ * stale quantities surface as `NeedsUpdate`. The Details button shows the
+ * full execution plan — every item the Add/Update button will touch.
  */
 export const AncillaryItemsBanner = () => {
   const t = useTranslation();
   const { data } = useRequest.document.get();
   const { add, update, isLoading } = useRequest.line.refreshAncillaryItems();
+  const [detailsAnchor, setDetailsAnchor] = useState<HTMLElement | null>(null);
 
   const ancillaryState = data?.ancillaryState;
   if (!ancillaryState || ancillaryState.state === AncillaryStateNode.None) {
@@ -30,12 +39,48 @@ export const AncillaryItemsBanner = () => {
         count: ancillaryState.count,
       });
 
+  const { toAdd, toUpdate } = ancillaryState;
+  const hasPlan = toAdd.length > 0 || toUpdate.length > 0;
+
   return (
     <Alert
       severity="info"
       sx={{ maxWidth: 1000, alignItems: 'center' }}
       action={
-        <Box>
+        <Box display="flex" alignItems="center">
+          {hasPlan && (
+            <PaperPopover
+              mode="click"
+              width={400}
+              placement={{ vertical: 'bottom', horizontal: 'center' }}
+              anchorEl={detailsAnchor}
+              onAnchorElChange={setDetailsAnchor}
+              Content={
+                <Box display="flex" flexDirection="column" gap={2} p={3}>
+                  {toAdd.length > 0 && (
+                    <PlanSection
+                      label={t('label.ancillary-plan-to-add')}
+                      deltas={toAdd}
+                      showCurrent={false}
+                    />
+                  )}
+                  {toUpdate.length > 0 && (
+                    <PlanSection
+                      label={t('label.ancillary-plan-to-update')}
+                      deltas={toUpdate}
+                      showCurrent
+                    />
+                  )}
+                </Box>
+              }
+            >
+              <FlatButton
+                label={t('button.details')}
+                onClick={() => {}}
+                color="primary"
+              />
+            </PaperPopover>
+          )}
           <FlatButton
             label={isAdd ? t('button.add') : t('button.update')}
             onClick={() => (isAdd ? add() : update())}
@@ -47,5 +92,65 @@ export const AncillaryItemsBanner = () => {
     >
       {message}
     </Alert>
+  );
+};
+
+const PlanSection = ({
+  label,
+  deltas,
+  showCurrent,
+}: {
+  label: string;
+  deltas: AncillaryDelta[];
+  showCurrent: boolean;
+}) => {
+  const t = useTranslation();
+  const columns = showCurrent ? '1fr auto auto' : '1fr auto';
+  return (
+    <Box
+      display="grid"
+      gridTemplateColumns={columns}
+      columnGap={2}
+      rowGap={0.5}
+      alignItems="baseline"
+    >
+      <Typography fontWeight={700}>{label}</Typography>
+      {showCurrent && (
+        <Typography variant="caption" textAlign="right">
+          {t('label.current')}
+        </Typography>
+      )}
+      <Typography variant="caption" textAlign="right">
+        {showCurrent ? t('label.new') : ''}
+      </Typography>
+      {deltas.map(d => {
+        const unit = d.item.unitName ?? t('label.unit').toLowerCase();
+        return (
+          <React.Fragment key={d.itemId}>
+            <Typography variant="body2">{d.item.name}</Typography>
+            {showCurrent && (
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                textAlign="right"
+                whiteSpace="nowrap"
+              >
+                {d.currentQuantity != null
+                  ? `${d.currentQuantity} ${unit}`
+                  : '-'}
+              </Typography>
+            )}
+            <Typography
+              variant="body2"
+              fontWeight={600}
+              textAlign="right"
+              whiteSpace="nowrap"
+            >
+              {`${d.requiredQuantity} ${unit}`}
+            </Typography>
+          </React.Fragment>
+        );
+      })}
+    </Box>
   );
 };

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/columns.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/columns.tsx
@@ -9,6 +9,10 @@ import {
   useTranslation,
   ColumnType,
   UnitsAndDosesCell,
+  Box,
+  LinkIcon,
+  PaperPopover,
+  Typography,
 } from '@openmsupply-client/common';
 import { useRequest } from '../api';
 import { useRequestRequisitionLineErrorContext } from '../context';
@@ -55,6 +59,12 @@ export const useRequestColumns = () => {
         size: 300,
         enableSorting: true,
         enableColumnFilter: true,
+        Cell: ({ row, cell }) => (
+          <ItemNameCell
+            name={cell.getValue<string>() ?? ''}
+            parents={row.original.ancillaryParents ?? []}
+          />
+        ),
       },
       {
         id: 'packUnit',
@@ -253,4 +263,68 @@ export const useRequestColumns = () => {
   );
 
   return columns;
+};
+
+type AncillaryParent = NonNullable<
+  RequestLineFragment['ancillaryParents']
+>[number];
+
+const ItemNameCell = ({
+  name,
+  parents,
+}: {
+  name: string;
+  parents: AncillaryParent[];
+}) => {
+  const t = useTranslation();
+  if (parents.length === 0) return <>{name}</>;
+  return (
+    <Box
+      display="grid"
+      gridTemplateColumns="1fr auto"
+      alignItems="center"
+      gap={0.5}
+      width="100%"
+    >
+      <Box sx={{ whiteSpace: 'normal', wordBreak: 'break-word' }}>
+        {name}
+      </Box>
+      <Box onClick={e => e.stopPropagation()} display="inline-flex">
+      <PaperPopover
+        mode="hover"
+        width={280}
+        placement={{ vertical: 'bottom', horizontal: 'center' }}
+        Content={
+          <Box display="flex" flexDirection="column" gap={1} p={3}>
+            <Typography fontWeight={700}>
+              {t('label.ancillary-of')}
+            </Typography>
+            {parents.length > 1 ? (
+              <Box
+                component="ul"
+                sx={{ m: 0, pl: 2.5, display: 'flex', flexDirection: 'column', gap: 0.5 }}
+              >
+                {parents.map(p => (
+                  <Typography component="li" key={p.id} variant="body2">
+                    {p.name}
+                  </Typography>
+                ))}
+              </Box>
+            ) : (
+              <Typography variant="body2">{parents[0]?.name}</Typography>
+            )}
+          </Box>
+        }
+      >
+        <LinkIcon
+          sx={{
+            fontSize: 14,
+            color: 'text.secondary',
+            verticalAlign: 'middle',
+          }}
+        />
+      </PaperPopover>
+      </Box>
+    </Box>
+  );
 };

--- a/client/packages/requisitions/src/RequestRequisition/api/operations.generated.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/operations.generated.ts
@@ -101,6 +101,32 @@ export type RequestByNumberQuery = {
           __typename: 'AncillaryStateResponse';
           state: Types.AncillaryStateNode;
           count: number;
+          toAdd: Array<{
+            __typename: 'AncillaryDeltaNode';
+            itemId: string;
+            requiredQuantity: number;
+            currentQuantity?: number | null;
+            item: {
+              __typename: 'ItemNode';
+              id: string;
+              name: string;
+              code: string;
+              unitName?: string | null;
+            };
+          }>;
+          toUpdate: Array<{
+            __typename: 'AncillaryDeltaNode';
+            itemId: string;
+            requiredQuantity: number;
+            currentQuantity?: number | null;
+            item: {
+              __typename: 'ItemNode';
+              id: string;
+              name: string;
+              code: string;
+              unitName?: string | null;
+            };
+          }>;
         };
         documents: {
           __typename: 'SyncFileReferenceConnector';
@@ -258,6 +284,32 @@ export type RequestByIdQuery = {
           __typename: 'AncillaryStateResponse';
           state: Types.AncillaryStateNode;
           count: number;
+          toAdd: Array<{
+            __typename: 'AncillaryDeltaNode';
+            itemId: string;
+            requiredQuantity: number;
+            currentQuantity?: number | null;
+            item: {
+              __typename: 'ItemNode';
+              id: string;
+              name: string;
+              code: string;
+              unitName?: string | null;
+            };
+          }>;
+          toUpdate: Array<{
+            __typename: 'AncillaryDeltaNode';
+            itemId: string;
+            requiredQuantity: number;
+            currentQuantity?: number | null;
+            item: {
+              __typename: 'ItemNode';
+              id: string;
+              name: string;
+              code: string;
+              unitName?: string | null;
+            };
+          }>;
         };
         documents: {
           __typename: 'SyncFileReferenceConnector';

--- a/client/packages/requisitions/src/RequestRequisition/api/operations.generated.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/operations.generated.ts
@@ -188,6 +188,12 @@ export type RequestByNumberQuery = {
               doses: number;
               availableStockOnHand: number;
             };
+            ancillaryParents: Array<{
+              __typename: 'ItemNode';
+              id: string;
+              name: string;
+              code: string;
+            }>;
             reason?: {
               __typename: 'ReasonOptionNode';
               id: string;
@@ -371,6 +377,12 @@ export type RequestByIdQuery = {
               doses: number;
               availableStockOnHand: number;
             };
+            ancillaryParents: Array<{
+              __typename: 'ItemNode';
+              id: string;
+              name: string;
+              code: string;
+            }>;
             reason?: {
               __typename: 'ReasonOptionNode';
               id: string;

--- a/client/packages/system/src/RequestRequisitionLine/operations.generated.ts
+++ b/client/packages/system/src/RequestRequisitionLine/operations.generated.ts
@@ -80,6 +80,12 @@ export type RequestLineFragment = {
     doses: number;
     availableStockOnHand: number;
   };
+  ancillaryParents: Array<{
+    __typename: 'ItemNode';
+    id: string;
+    name: string;
+    code: string;
+  }>;
   reason?: {
     __typename: 'ReasonOptionNode';
     id: string;
@@ -200,6 +206,12 @@ export type RequestFragment = {
         doses: number;
         availableStockOnHand: number;
       };
+      ancillaryParents: Array<{
+        __typename: 'ItemNode';
+        id: string;
+        name: string;
+        code: string;
+      }>;
       reason?: {
         __typename: 'ReasonOptionNode';
         id: string;
@@ -326,6 +338,11 @@ export const RequestLineFragmentDoc = gql`
     }
     item {
       ...ItemWithAvailableStock
+    }
+    ancillaryParents {
+      id
+      name
+      code
     }
     reason {
       ...ReasonOptionRow

--- a/client/packages/system/src/RequestRequisitionLine/operations.generated.ts
+++ b/client/packages/system/src/RequestRequisitionLine/operations.generated.ts
@@ -113,6 +113,32 @@ export type RequestFragment = {
     __typename: 'AncillaryStateResponse';
     state: Types.AncillaryStateNode;
     count: number;
+    toAdd: Array<{
+      __typename: 'AncillaryDeltaNode';
+      itemId: string;
+      requiredQuantity: number;
+      currentQuantity?: number | null;
+      item: {
+        __typename: 'ItemNode';
+        id: string;
+        name: string;
+        code: string;
+        unitName?: string | null;
+      };
+    }>;
+    toUpdate: Array<{
+      __typename: 'AncillaryDeltaNode';
+      itemId: string;
+      requiredQuantity: number;
+      currentQuantity?: number | null;
+      item: {
+        __typename: 'ItemNode';
+        id: string;
+        name: string;
+        code: string;
+        unitName?: string | null;
+      };
+    }>;
   };
   documents: {
     __typename: 'SyncFileReferenceConnector';
@@ -323,6 +349,28 @@ export const RequestFragmentDoc = gql`
     ancillaryState {
       state
       count
+      toAdd {
+        itemId
+        requiredQuantity
+        currentQuantity
+        item {
+          id
+          name
+          code
+          unitName
+        }
+      }
+      toUpdate {
+        itemId
+        requiredQuantity
+        currentQuantity
+        item {
+          id
+          name
+          code
+          unitName
+        }
+      }
     }
     requisitionNumber
     colour

--- a/client/packages/system/src/RequestRequisitionLine/operations.graphql
+++ b/client/packages/system/src/RequestRequisitionLine/operations.graphql
@@ -51,6 +51,11 @@ fragment RequestLine on RequisitionLineNode {
   item {
     ...ItemWithAvailableStock
   }
+  ancillaryParents {
+    id
+    name
+    code
+  }
   reason {
     ...ReasonOptionRow
   }

--- a/client/packages/system/src/RequestRequisitionLine/operations.graphql
+++ b/client/packages/system/src/RequestRequisitionLine/operations.graphql
@@ -71,6 +71,28 @@ fragment Request on RequisitionNode {
   ancillaryState {
     state
     count
+    toAdd {
+      itemId
+      requiredQuantity
+      currentQuantity
+      item {
+        id
+        name
+        code
+        unitName
+      }
+    }
+    toUpdate {
+      itemId
+      requiredQuantity
+      currentQuantity
+      item {
+        id
+        name
+        code
+        unitName
+      }
+    }
   }
   requisitionNumber
   colour

--- a/server/graphql/types/src/types/requisition.rs
+++ b/server/graphql/types/src/types/requisition.rs
@@ -1,6 +1,7 @@
 use self::dataloader::DataLoader;
 use async_graphql::*;
 use chrono::{DateTime, NaiveDate, Utc};
+use graphql_core::loader::ItemLoader;
 use graphql_core::{
     loader::{
         InvoiceByRequisitionIdLoader, NameByIdLoader, NameByIdLoaderInput,
@@ -11,11 +12,14 @@ use graphql_core::{
     ContextExt,
 };
 use repository::{requisition_row::RequisitionRow, ApprovalStatusType, NameRow, Requisition};
-use service::{requisition_line::ancillary_items::AncillaryState, ListResult};
+use service::{
+    requisition_line::ancillary_items::{AncillaryDelta, AncillaryState},
+    ListResult,
+};
 
 use super::{
-    program_node::ProgramNode, InvoiceConnector, NameNode, PeriodNode, RequisitionLineConnector,
-    UserNode,
+    program_node::ProgramNode, InvoiceConnector, ItemNode, NameNode, PeriodNode,
+    RequisitionLineConnector, UserNode,
 };
 use crate::types::SyncFileReferenceConnector;
 
@@ -64,6 +68,60 @@ pub struct AncillaryStateResponse {
     pub state: AncillaryStateNode,
     /// Number of ancillary items in the banner-worthy state. Zero when state is `None`.
     pub count: u32,
+    /// Items missing from the requisition that need to be added. Always populated
+    /// from the underlying plan, regardless of `state` — the client can show the
+    /// full breakdown even when the banner-relevant state is `NeedsUpdate`.
+    pub to_add: Vec<AncillaryDeltaNode>,
+    /// Items present on the requisition with stale quantities.
+    pub to_update: Vec<AncillaryDeltaNode>,
+}
+
+/// A single ancillary item that the plan wants to add or update on the
+/// requisition, exposed so the client can render the execution plan in the
+/// banner popover.
+pub struct AncillaryDeltaNode {
+    item_id: String,
+    required_quantity: f64,
+    current_quantity: Option<f64>,
+}
+
+#[Object]
+impl AncillaryDeltaNode {
+    pub async fn item_id(&self) -> &str {
+        &self.item_id
+    }
+
+    pub async fn required_quantity(&self) -> f64 {
+        self.required_quantity
+    }
+
+    /// Current quantity on the existing requisition line. `None` for items that
+    /// don't yet have a line (i.e. entries in `toAdd`).
+    pub async fn current_quantity(&self) -> Option<f64> {
+        self.current_quantity
+    }
+
+    pub async fn item(&self, ctx: &Context<'_>) -> Result<ItemNode> {
+        let loader = ctx.get_loader::<DataLoader<ItemLoader>>();
+        let item_option = loader.load_one(self.item_id.clone()).await?;
+        item_option.map(ItemNode::from_domain).ok_or(
+            StandardGraphqlError::InternalError(format!(
+                "Cannot find item_id {} for ancillary delta",
+                self.item_id
+            ))
+            .extend(),
+        )
+    }
+}
+
+impl AncillaryDeltaNode {
+    fn from_domain(delta: AncillaryDelta) -> Self {
+        Self {
+            item_id: delta.item_link_id,
+            required_quantity: delta.required_quantity,
+            current_quantity: delta.current_quantity,
+        }
+    }
 }
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq)]
@@ -114,6 +172,8 @@ impl RequisitionNode {
             return Ok(AncillaryStateResponse {
                 state: AncillaryStateNode::None,
                 count: 0,
+                to_add: vec![],
+                to_update: vec![],
             });
         }
         let service_provider = ctx.service_provider();
@@ -127,7 +187,22 @@ impl RequisitionNode {
             AncillaryState::NeedsAdd { count } => (AncillaryStateNode::NeedsAdd, count),
             AncillaryState::NeedsUpdate { count } => (AncillaryStateNode::NeedsUpdate, count),
         };
-        Ok(AncillaryStateResponse { state, count })
+        let to_add = plan
+            .to_add
+            .into_iter()
+            .map(AncillaryDeltaNode::from_domain)
+            .collect();
+        let to_update = plan
+            .to_update
+            .into_iter()
+            .map(AncillaryDeltaNode::from_domain)
+            .collect();
+        Ok(AncillaryStateResponse {
+            state,
+            count,
+            to_add,
+            to_update,
+        })
     }
 
     pub async fn created_datetime(&self) -> DateTime<Utc> {

--- a/server/graphql/types/src/types/requisition_line.rs
+++ b/server/graphql/types/src/types/requisition_line.rs
@@ -5,10 +5,10 @@ use chrono::NaiveDate;
 use dataloader::DataLoader;
 use graphql_core::{
     loader::{
-        AvailableVolumeOnRequisitionLoader, AvailableVolumeOnRequisitionLoaderInput,
-        InvoiceLineForRequisitionLine, ItemLoader, ItemStatsLoaderInput, ItemsStatsForItemLoader,
-        LinkedRequisitionLineLoader, ReasonOptionLoader, RequisitionAndItemId,
-        RequisitionLineSupplyStatusLoader,
+        AncillaryItemsByAncillaryIdLoader, AvailableVolumeOnRequisitionLoader,
+        AvailableVolumeOnRequisitionLoaderInput, InvoiceLineForRequisitionLine, ItemLoader,
+        ItemStatsLoaderInput, ItemsStatsForItemLoader, LinkedRequisitionLineLoader,
+        ReasonOptionLoader, RequisitionAndItemId, RequisitionLineSupplyStatusLoader,
     },
     standard_graphql_error::StandardGraphqlError,
     ContextExt,
@@ -95,6 +95,30 @@ impl RequisitionLineNode {
 
     pub async fn price_per_unit(&self) -> &Option<f64> {
         &self.row().price_per_unit
+    }
+
+    /// Items that have this line's item configured as an ancillary. Empty when
+    /// the line is not an ancillary of anything. Used by the UI to flag
+    /// ancillary lines and surface their parents in a popover. Batched per
+    /// request via dataloader so a 200-line requisition issues two queries
+    /// (link rows + parent items), not 400.
+    pub async fn ancillary_parents(&self, ctx: &Context<'_>) -> Result<Vec<ItemNode>> {
+        let links_loader = ctx.get_loader::<DataLoader<AncillaryItemsByAncillaryIdLoader>>();
+        let parent_links = links_loader
+            .load_one(self.item_row().id.clone())
+            .await?
+            .unwrap_or_default();
+        if parent_links.is_empty() {
+            return Ok(vec![]);
+        }
+        let item_loader = ctx.get_loader::<DataLoader<ItemLoader>>();
+        let parent_ids: Vec<String> = parent_links.into_iter().map(|p| p.item_id).collect();
+        let items = item_loader.load_many(parent_ids.clone()).await?;
+        Ok(parent_ids
+            .into_iter()
+            .filter_map(|id| items.get(&id).cloned())
+            .map(ItemNode::from_domain)
+            .collect())
     }
 
     /// OutboundShipment lines linked to requisitions line

--- a/server/service/src/requisition_line/ancillary_items/compute.rs
+++ b/server/service/src/requisition_line/ancillary_items/compute.rs
@@ -30,6 +30,9 @@ pub struct AncillaryDelta {
     /// The existing requisition line for this ancillary, if any. Present for
     /// updates, absent for adds.
     pub existing_line_id: Option<String>,
+    /// Quantity currently on the requisition line, if a line already exists.
+    /// Always populated for updates so callers can render before/after.
+    pub current_quantity: Option<f64>,
 }
 
 /// Breakdown of which ancillary items need action on a given requisition.
@@ -132,6 +135,7 @@ pub fn compute_ancillary_plan(
                 item_link_id,
                 required_quantity,
                 existing_line_id: None,
+                current_quantity: None,
             }),
             Some(line) => {
                 if !f64_approx_eq(line.requested_quantity, required_quantity) {
@@ -139,6 +143,7 @@ pub fn compute_ancillary_plan(
                         item_link_id,
                         required_quantity,
                         existing_line_id: Some(line.id.clone()),
+                        current_quantity: Some(line.requested_quantity),
                     });
                 }
             }

--- a/server/service/src/requisition_line/ancillary_items/compute.rs
+++ b/server/service/src/requisition_line/ancillary_items/compute.rs
@@ -5,6 +5,9 @@ use util::f64_approx_eq;
 /// Max number of edges we'll follow when chasing ancillary chains. Matches the
 /// cap enforced on insert so this is defensive — real chains can't exceed it.
 const MAX_ANCILLARY_DEPTH: u32 = 5;
+/// Small fudge subtracted before `ceil()` so float drift (e.g. 100 * 1.1 =
+/// 110.0000000…01) doesn't bump exact integers up to the next whole unit.
+const CEIL_EPSILON: f64 = 1e-6;
 
 /// Whether a requisition has missing or stale ancillary lines.
 ///
@@ -202,7 +205,11 @@ fn chase<'a>(
 
     if let Some(children) = graph.get(current) {
         for (child, ratio) in children {
-            let child_qty = quantity * ratio;
+            // Round up: ancillary lines need to be editable as whole units
+            // (you can't easily correct a 1.1 suggestion in the UI). Propagate
+            // the ceiled value downstream so deeper ancillaries see the same
+            // quantity the user will actually order.
+            let child_qty = (quantity * ratio - CEIL_EPSILON).ceil().max(0.0);
             *required.entry((*child).to_string()).or_default() += child_qty;
             chase(child, child_qty, graph, required, visited, depth + 1);
         }
@@ -286,7 +293,7 @@ mod tests {
 
     #[test]
     fn wastage_non_integer_ratio() {
-        // 1 vaccine → 1.1 syringe (10% wastage) for 50 vaccines → 55 syringes
+        // 1 vaccine → 1.1 syringe (10% wastage) for 50 vaccines → 55 syringes (whole)
         let plan = compute_ancillary_plan(
             &[line("l1", "vaccine", 50.0)],
             &[link("vaccine", "syringe", 1.0, 1.1)],
@@ -298,8 +305,8 @@ mod tests {
     #[test]
     fn chain_cascades_through_multiple_levels() {
         // vaccine -> syringe -> safety_box
-        // 100 vaccines, each vaccine needs 1.1 syringes (110 syringes),
-        // each 100 syringes need 1 safety_box (1.1 safety_boxes)
+        // 100 vaccines, each vaccine needs 1.1 syringes → ceil(110) = 110
+        // 110 syringes / 100 per safety_box = 1.1 → ceil = 2 safety boxes
         let plan = compute_ancillary_plan(
             &[line("l1", "vaccine", 100.0)],
             &[
@@ -319,12 +326,15 @@ mod tests {
             .find(|d| d.item_link_id == "safety_box")
             .unwrap();
         assert!(f64_approx_eq(syringe.required_quantity, 110.0));
-        assert!(f64_approx_eq(safety_box.required_quantity, 1.1));
+        assert!(f64_approx_eq(safety_box.required_quantity, 2.0));
     }
 
     #[test]
     fn multiple_principals_for_same_ancillary_sum() {
         // Two vaccine lines both needing safety boxes
+        // vaccine_a: 100/100 = 1, ceil = 1
+        // vaccine_b: 50/100 = 0.5, ceil = 1
+        // total = 2
         let plan = compute_ancillary_plan(
             &[line("l1", "vaccine_a", 100.0), line("l2", "vaccine_b", 50.0)],
             &[
@@ -333,7 +343,7 @@ mod tests {
             ],
         );
         assert_eq!(plan.to_add.len(), 1);
-        assert!(f64_approx_eq(plan.to_add[0].required_quantity, 1.5));
+        assert!(f64_approx_eq(plan.to_add[0].required_quantity, 2.0));
     }
 
     #[test]
@@ -421,6 +431,19 @@ mod tests {
             .unwrap();
         assert!(f64_approx_eq(syringe.required_quantity, 200.0));
         assert!(f64_approx_eq(safety_box.required_quantity, 2.0));
+    }
+
+    #[test]
+    fn fractional_required_quantity_rounds_up() {
+        // 50 vaccines / 100 per safety_box = 0.5 → ceil = 1.
+        // Suggested quantities are whole units so the user can adjust them
+        // without first toggling between integer and decimal modes.
+        let plan = compute_ancillary_plan(
+            &[line("l1", "vaccine", 50.0)],
+            &[link("vaccine", "safety_box", 100.0, 1.0)],
+        );
+        assert_eq!(plan.to_add.len(), 1);
+        assert!(f64_approx_eq(plan.to_add[0].required_quantity, 1.0));
     }
 
     #[test]

--- a/server/service/src/requisition_line/ancillary_items/compute.rs
+++ b/server/service/src/requisition_line/ancillary_items/compute.rs
@@ -186,6 +186,11 @@ fn chase<'a>(
     visited: &mut HashSet<&'a str>,
     depth: u32,
 ) {
+    // No demand from a zero-quantity parent — skip the whole subtree so we
+    // don't add ancillary lines for items the user hasn't actually requested.
+    if quantity <= 0.0 {
+        return;
+    }
     if depth >= MAX_ANCILLARY_DEPTH {
         return;
     }
@@ -416,6 +421,22 @@ mod tests {
             .unwrap();
         assert!(f64_approx_eq(syringe.required_quantity, 200.0));
         assert!(f64_approx_eq(safety_box.required_quantity, 2.0));
+    }
+
+    #[test]
+    fn zero_parent_quantity_adds_nothing() {
+        // A line with zero requested quantity shouldn't pull any ancillaries
+        // into the plan — there's no demand to fulfil.
+        let plan = compute_ancillary_plan(
+            &[line("l1", "vaccine", 0.0)],
+            &[
+                link("vaccine", "syringe", 1.0, 1.1),
+                link("syringe", "safety_box", 100.0, 1.0),
+            ],
+        );
+        assert_eq!(plan.state(), AncillaryState::None);
+        assert!(plan.to_add.is_empty());
+        assert!(plan.to_update.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #11290 (followup to #11335).



# 👩🏻‍💻 What does this PR do?

Two small refinements on the ancillary refresh banner work:

- <img align="right" width="500" alt="Screenshot 2026-05-06 at 4 47 50 pm" src="https://github.com/user-attachments/assets/f6c88bff-c05d-4b89-9519-6d6b1263b6ba" /> **Banner popover** — adds a *Details* button next to *Add* / *Update* on the ancillary items banner that opens a popover listing the execution plan: items to add (with required quantity) and items to update (with current → new quantity), each in the item's unit.
- <img width="500" align="right" alt="Screenshot 2026-05-06 at 5 10 39 pm" src="https://github.com/user-attachments/assets/cb7c7bc9-b1d7-40c6-a63c-26abd45a5b0b" /> **Chain icon on ancillary lines** — requisition lines whose item is configured as an ancillary of another item now show a small chain-link icon at the right of the name cell. Hovering or tapping the icon shows the parent items (bulleted when there are multiple). Click propagation is stopped so tapping on tablet doesn't open the line edit modal.
- **Plan rounding fix** — required quantities are now rounded up so users always see whole-unit suggestions in the banner / plan.

## 💌 Any notes for the reviewer?

- Server side adds `toAdd` / `toUpdate` (with item, current/required quantity) on `AncillaryStateResponse`, and `ancillaryParents` on `RequisitionLineNode`. The latter is batched via the existing `AncillaryItemsByAncillaryIdLoader` so an N-line requisition issues 2 queries, not 2N.
- No new mutations; no schema migration.

# 🧪 Testing

- [ ] Open a request requisition that has at least one principal item with configured ancillary supplies.
- [ ] Verify *Details* button appears on the banner; popover lists the items the *Add* / *Update* button will touch with correct quantities + units.
- [ ] After clicking Add, verify ancillary lines show the chain icon. Hover/tap and confirm the parent item name appears.
- [ ] Configure two principals for the same ancillary, verify the popover shows a bulleted list.
- [ ] On a tablet (or with touch emulation), tap the chain icon and confirm the row's edit modal does not open.

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole