### PR TITLE
#11544 Fix JS crash when viewing logs without permission

### DIFF
--- a/client/packages/system/src/ActivityLog/api/hooks/useActivityLog.ts
+++ b/client/packages/system/src/ActivityLog/api/hooks/useActivityLog.ts
@@ -37,8 +37,8 @@ export function useActivityLog(
       sort: sortBy ? getSortInput(sortBy) : undefined,
       filter,
     });
-    const { nodes, totalCount } = query?.activityLogs;
-    return { nodes, totalCount };
+    const { nodes, totalCount } = query?.activityLogs ?? {};
+    return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
   };
 
   const query = useQuery({


### PR DESCRIPTION
Fixes #11544

## What does this PR do?

When a user lacks the `LogQuery` (`View log`) permission and navigates to the Logs tab on an Outbound Shipment, two errors appeared:

1. The expected "Authentication error / Permission denied" dialog
2. An unexpected JS crash: _"Cannot destructure property 'nodes' of '(intermediate value)...' as it is undefined"_

The second error occurred because the server returns `null` for `activityLogs` when the request is forbidden, and the code was destructuring `nodes` directly without guarding against `null`/`undefined`.

This PR adds a null-safe fallback so only the expected permission denied dialog is shown.

-> should no longer see this error 
<img width="618" height="322" alt="image" src="https://github.com/user-attachments/assets/9c8a4c93-dddd-40f5-adf8-b8171d2d1887" />


## Testing

- [ ] Log in as a user without the **View log** permission (Permissions (3) tab in mSupply legacy)
- [ ] Go to Distribution → Outbound Shipments → any shipment → Logs tab
- [ ] Should see the "Permission denied" dialog only — no JS crash error

## Documentation

- [x] No documentation required: bug fix with no change in behaviour for users who have the permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)