### PR TITLE
#11546 Stamp backdated datetime on outbound status transitions

### DIFF
--- a/server/service/src/invoice/inbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/update/mod.rs
@@ -2148,6 +2148,30 @@ mod test {
             .unwrap()
             .unwrap();
         assert_eq!(updated.delivered_datetime, original_delivered);
+
+        // ExceedsMaximumBackdatingDays: tighten the cap and try a date older than max_days
+        PreferenceRowRepository::new(&_connection)
+            .upsert_one(&PreferenceRow {
+                id: "backdating_global".to_string(),
+                key: "backdating".to_string(),
+                value: r#"{"shipmentsEnabled":true,"inventoryAdjustmentsEnabled":false,"maxDays":1}"#.to_string(),
+                store_id: None,
+            })
+            .unwrap();
+
+        let three_days_ago = now - Duration::days(3);
+        assert_eq!(
+            service.update_inbound_shipment(
+                &context,
+                UpdateInboundShipment {
+                    id: received_inbound(now).id,
+                    received_datetime: Some(three_days_ago),
+                    ..Default::default()
+                },
+                InboundShipmentType::InboundShipment,
+            ),
+            Err(UpdateInboundShipmentError::ExceedsMaximumBackdatingDays)
+        );
     }
 
     #[actix_rt::test]

--- a/server/service/src/invoice/outbound_shipment/update/generate.rs
+++ b/server/service/src/invoice/outbound_shipment/update/generate.rs
@@ -14,7 +14,8 @@ use crate::{
     invoice::{
         common::{
             calculate_foreign_currency_total, calculate_total_after_tax,
-            generate_batches_total_number_of_packs_update, InvoiceLineHasNoStockLine,
+            generate_batches_total_number_of_packs_update, get_invoice_status_datetime,
+            InvoiceLineHasNoStockLine,
         },
         invoice_date_utils::handle_new_backdated_datetime,
         stock_effect::{stock_effects, StockEffect},
@@ -248,7 +249,8 @@ fn set_new_status_datetime(
         return;
     }
 
-    let current_datetime = Utc::now().naive_utc();
+    // Use the invoice's backdated datetime if it's set, otherwise use now
+    let current_datetime = get_invoice_status_datetime(invoice);
 
     // Status sequence for outbound shipment: New, Allocated, Picked, Shipped
     match (&invoice.status, new_status) {

--- a/server/service/src/invoice/outbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/outbound_shipment/update/mod.rs
@@ -822,11 +822,7 @@ mod test {
             "update_outbound_shipment_backdate_errors",
             MockDataInserts::all(),
             MockData {
-                invoices: vec![
-                    new_outbound(),
-                    picked_outbound(),
-                    outbound_with_line(),
-                ],
+                invoices: vec![new_outbound(), picked_outbound(), outbound_with_line()],
                 invoice_lines: vec![line_for_outbound()],
                 ..Default::default()
             },
@@ -839,7 +835,9 @@ mod test {
             .upsert_one(&PreferenceRow {
                 id: "backdating_global".to_string(),
                 key: "backdating".to_string(),
-                value: r#"{"shipmentsEnabled":true,"inventoryAdjustmentsEnabled":false,"maxDays":0}"#.to_string(),
+                value:
+                    r#"{"shipmentsEnabled":true,"inventoryAdjustmentsEnabled":false,"maxDays":30}"#
+                        .to_string(),
                 store_id: None,
             })
             .unwrap();
@@ -893,6 +891,20 @@ mod test {
                 "Cannot set date in the future".to_string()
             ))
         );
+
+        // ExceedsMaximumBackdatingDays: older than max_days (30) configured above
+        let thirty_one_days_ago = Utc::now() - Duration::days(31);
+        assert_eq!(
+            service.update_outbound_shipment(
+                &context,
+                UpdateOutboundShipment {
+                    id: new_outbound().id,
+                    backdated_datetime: Some(thirty_one_days_ago),
+                    ..Default::default()
+                }
+            ),
+            Err(ServiceError::ExceedsMaximumBackdatingDays)
+        );
     }
 
     #[actix_rt::test]
@@ -926,7 +938,9 @@ mod test {
             .upsert_one(&PreferenceRow {
                 id: "backdating_global".to_string(),
                 key: "backdating".to_string(),
-                value: r#"{"shipmentsEnabled":true,"inventoryAdjustmentsEnabled":false,"maxDays":0}"#.to_string(),
+                value:
+                    r#"{"shipmentsEnabled":true,"inventoryAdjustmentsEnabled":false,"maxDays":0}"#
+                        .to_string(),
                 store_id: None,
             })
             .unwrap();
@@ -955,12 +969,128 @@ mod test {
             .unwrap()
             .unwrap();
 
-        assert_eq!(
-            updated.backdated_datetime,
-            Some(two_days_ago.naive_utc())
-        );
+        assert_eq!(updated.backdated_datetime, Some(two_days_ago.naive_utc()));
         // Status datetimes should not be set (invoice is still New)
         assert_eq!(updated.allocated_datetime, None);
         assert_eq!(updated.picked_datetime, None);
+    }
+
+    // Regression test for #11546: after backdating, advancing the status to Picked
+    // / Shipped must stamp the backdated datetime onto picked_datetime and
+    // shipped_datetime so the item ledger reflects the backdated date.
+    #[actix_rt::test]
+    async fn update_outbound_shipment_backdate_status_transition_uses_backdated_datetime() {
+        use chrono::{Duration, Utc};
+
+        fn new_outbound() -> InvoiceRow {
+            InvoiceRow {
+                id: "backdate_then_status_outbound".to_string(),
+                name_id: mock_name_a().id,
+                store_id: mock_store_a().id,
+                r#type: InvoiceType::OutboundShipment,
+                status: InvoiceStatus::New,
+                ..Default::default()
+            }
+        }
+
+        let (_, connection, connection_manager, _) = setup_all_with_data(
+            "update_outbound_shipment_backdate_status_transition_uses_backdated_datetime",
+            MockDataInserts::all(),
+            MockData {
+                invoices: vec![new_outbound()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        use repository::{PreferenceRow, PreferenceRowRepository};
+        PreferenceRowRepository::new(&connection)
+            .upsert_one(&PreferenceRow {
+                id: "backdating_global".to_string(),
+                key: "backdating".to_string(),
+                value:
+                    r#"{"shipmentsEnabled":true,"inventoryAdjustmentsEnabled":false,"maxDays":30}"#
+                        .to_string(),
+                store_id: None,
+            })
+            .unwrap();
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context(mock_store_a().id, "".to_string())
+            .unwrap();
+        let service = service_provider.invoice_service;
+
+        let two_days_ago = Utc::now() - Duration::days(2);
+
+        // Step 1: Backdate the New invoice
+        service
+            .update_outbound_shipment(
+                &context,
+                UpdateOutboundShipment {
+                    id: new_outbound().id,
+                    backdated_datetime: Some(two_days_ago),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        // Step 2: Advance to Picked (separate update, no backdated_datetime in patch)
+        service
+            .update_outbound_shipment(
+                &context,
+                UpdateOutboundShipment {
+                    id: new_outbound().id,
+                    status: Some(UpdateOutboundShipmentStatus::Picked),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let after_picked = InvoiceRowRepository::new(&connection)
+            .find_one_by_id(&new_outbound().id)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            after_picked.backdated_datetime,
+            Some(two_days_ago.naive_utc())
+        );
+        assert_eq!(
+            after_picked.allocated_datetime,
+            Some(two_days_ago.naive_utc())
+        );
+        assert_eq!(after_picked.picked_datetime, Some(two_days_ago.naive_utc()));
+
+        // Step 3: Advance to Shipped
+        service
+            .update_outbound_shipment(
+                &context,
+                UpdateOutboundShipment {
+                    id: new_outbound().id,
+                    status: Some(UpdateOutboundShipmentStatus::Shipped),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let after_shipped = InvoiceRowRepository::new(&connection)
+            .find_one_by_id(&new_outbound().id)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            after_shipped.shipped_datetime,
+            Some(two_days_ago.naive_utc())
+        );
+        // Earlier status datetimes should not have been bumped to "now"
+        assert_eq!(
+            after_shipped.picked_datetime,
+            Some(two_days_ago.naive_utc())
+        );
+        assert_eq!(
+            after_shipped.allocated_datetime,
+            Some(two_days_ago.naive_utc())
+        );
     }
 }


### PR DESCRIPTION
Fixes #11546

# 👩🏻‍💻 What does this PR do?

Backdating an outbound shipment was working at the data layer (`backdated_datetime` got persisted), but the item ledger / stock ledger kept showing today's date instead of the backdated date.

Outbound validation only allows setting `backdated_datetime` while the invoice is in `New` status. At that point `picked_datetime` is still `null`, so `handle_new_backdated_datetime` → `replace_status_datetimes` is effectively a no-op (it only rewrites datetimes that are already non-null). When the user *later* advanced the invoice to Allocated → Picked → Shipped, [`set_new_status_datetime`](https://github.com/msupply-foundation/open-msupply/blob/v2.19.0-RC/server/service/src/invoice/outbound_shipment/update/generate.rs) was stamping `Utc::now()` straight onto `picked_datetime` / `shipped_datetime`, ignoring the backdate. The ledger views read `picked_datetime` for outbound movements, so the row showed today.

Fix: have `set_new_status_datetime` consult `invoice.backdated_datetime` via the existing `get_invoice_status_datetime` helper — the same pattern prescription updates already use. So when a backdated New invoice transitions to Picked / Shipped, all of `allocated_datetime` / `picked_datetime` / `shipped_datetime` adopt the backdated value.

Receiving-store flow is unchanged and was already correct: the transfer processor copies `picked_datetime` / `shipped_datetime` from the outbound (so the inbound shows the sender's backdated shipped date) but explicitly sets `backdated_datetime: None` on the inbound row, and the receiving store's `received_datetime` continues to use `Utc::now()`.

## 💌 Any notes for the reviewer?

- One-liner fix in `outbound_shipment/update/generate.rs::set_new_status_datetime` (`Utc::now()` → `get_invoice_status_datetime(invoice)`).
- Added a regression test (`update_outbound_shipment_backdate_status_transition_uses_backdated_datetime`) that backdates a New invoice and then advances New → Picked → Shipped in separate updates, asserting all three status datetimes equal the backdated value.
- While in there, added `ExceedsMaximumBackdatingDays` coverage to the outbound and inbound shipment update test suites — the error variant existed but was previously only exercised in the inventory-adjustment tests. No production behaviour change from these test additions.
- An earlier draft also extended `replace_status_datetimes` to cover `shipped_datetime` for forward compatibility. Rolled that back: if/when backdating is enabled for inbound shipments, we'll likely need to *exclude* shipped_datetime from re-stamping (it represents the sender's event, not the receiver's), so this is better revisited at the right time.
- Future follow-up (not in this PR): evaluate whether inbound shipments / supplier returns / customer returns should support backdating end-to-end.

# 🧪 Testing

- [ ] `cargo nextest run -p service invoice_date_utils handle_new_backdated_datetime update_outbound_shipment_backdate update_inbound_shipment_backdate` — passes locally
- [ ] Distribution → Outbound Shipments → New, add an item
- [ ] More → Backdate to ~2 days ago
- [ ] Advance through Allocated → Picked → Shipped
- [ ] Inventory → Stock → that item → Ledger: row shows the backdated date, not today
- [ ] On the receiving store, open the auto-created Inbound Shipment: `shipped_datetime` reflects the backdated date
- [ ] Mark the inbound as Received: `received_datetime` shows today (not backdated — backdating is sender-only)
- [ ] Re-run on Postgres and SQLite

# 📃 Documentation

- [x] **No documentation required**: bug fix, no change in user-facing behaviour beyond the ledger now showing the correct date


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend