### PR TITLE
Fix subscription notifications being delayed (v2.19)

### DIFF
--- a/server/service/src/subscription.rs
+++ b/server/service/src/subscription.rs
@@ -149,7 +149,9 @@ async fn subscription_worker_loop(
                             }
                         },
                         Err(e) => {
-                            log::error!("Failed to get DB connection for initialisation status: {e:?}");
+                            log::error!(
+                                "Failed to get DB connection for initialisation status: {e:?}"
+                            );
                         }
                     }
                 }

--- a/server/service/src/sync/sync_status/logger.rs
+++ b/server/service/src/sync/sync_status/logger.rs
@@ -1,9 +1,9 @@
+use crate::subscription::{SubscriptionTrigger, SubscriptionTriggerHandle};
 use log::{debug, error, info};
 use repository::{
     RepositoryError, StorageConnection, SyncApiErrorCode, SyncLogRow, SyncLogRowRepository,
 };
 use thiserror::Error;
-use crate::subscription::{SubscriptionTrigger, SubscriptionTriggerHandle};
 use util::format_error;
 
 use crate::sync::{
@@ -47,6 +47,24 @@ enum SyncApiErrorVariant<'a> {
     V6(&'a SyncApiErrorVariantV6),
 }
 
+/// Connection-free state that can cross thread boundaries (e.g. into
+/// `tokio::task::spawn_blocking`). Re-attach with `with_connection`.
+pub struct SyncLoggerHandle {
+    row: SyncLogRow,
+    subscription_trigger: Option<SubscriptionTriggerHandle>,
+}
+
+impl SyncLoggerHandle {
+    /// Attach a connection to make a usable `SyncLogger`.
+    pub fn with_connection<'a>(self, connection: &'a StorageConnection) -> SyncLogger<'a> {
+        SyncLogger {
+            sync_log_repo: SyncLogRowRepository::new(connection),
+            row: self.row,
+            subscription_trigger: self.subscription_trigger,
+        }
+    }
+}
+
 pub struct SyncLogger<'a> {
     sync_log_repo: SyncLogRowRepository<'a>,
     row: SyncLogRow,
@@ -88,6 +106,23 @@ impl<'a> SyncLogger<'a> {
         };
         logger.update()?;
         Ok(logger)
+    }
+
+    /// Detach the connection-bound logger into a `Send + 'static` handle so
+    /// it can cross a thread boundary (e.g. into `spawn_blocking`).
+    /// Pair with `SyncLoggerHandle::with_connection` on the other side.
+    pub fn into_handle(&self) -> SyncLoggerHandle {
+        SyncLoggerHandle {
+            row: self.row.clone(),
+            subscription_trigger: self.subscription_trigger.clone(),
+        }
+    }
+
+    /// Replace this logger's state with a returned handle (e.g. after a
+    /// blocking task hands the handle back). Connection is unchanged.
+    pub fn restore(&mut self, handle: SyncLoggerHandle) {
+        self.row = handle.row;
+        self.subscription_trigger = handle.subscription_trigger;
     }
 
     /// Attach a subscription trigger handle for sending sync status updates

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -71,6 +71,8 @@ pub(crate) enum SyncError {
     RemotePullError(#[from] RemotePullError),
     #[error("Error while integrating records")]
     IntegrationError(RepositoryError),
+    #[error("Other error: {0}")]
+    Other(String),
 }
 
 // For unwrap and expect debug implementation is used
@@ -282,13 +284,13 @@ impl Synchroniser {
         // INTEGRATE RECORDS
         logger.start_step(SyncStep::Integrate)?;
 
-        let (upserts, deletes, merges) = integrate_and_translate_sync_buffer(
-            &ctx.connection,
-            Some(logger),
+        let (upserts, deletes, merges) = integrate_and_translate_sync_outer(
+            &self.service_provider,
+            logger,
             SyncBufferSource::Central(central_sync_server_id),
             !self.settings.disable_integration_transaction,
         )
-        .map_err(SyncError::IntegrationError)?;
+        .await?;
 
         upserts.log("Upsert");
         deletes.log("Delete");
@@ -329,6 +331,56 @@ impl Synchroniser {
 
         Ok(())
     }
+}
+
+/// Async wrapper around the synchronous `integrate_and_translate_sync_buffer`.
+///
+/// Integration does substantial blocking DB work. Running it directly on a tokio worker
+/// thread starves other tasks scheduled on the same thread — notably the GraphQL
+/// subscription tasks (`sync_info`, `initialisation_status`) that need to fire updates
+/// to clients while a sync is in progress. We hand the work to `spawn_blocking` so the
+/// runtime can keep driving those tasks on its worker threads.
+///
+/// The logger is passed across the blocking boundary via `SyncLoggerHandle` because it
+/// borrows the `StorageConnection`, which only exists inside the blocking closure.
+async fn integrate_and_translate_sync_outer(
+    service_provider: &ServiceProvider,
+    logger: &mut SyncLogger<'_>,
+    record_type: SyncBufferSource,
+    use_transaction: bool,
+) -> Result<
+    (
+        TranslationAndIntegrationResults,
+        TranslationAndIntegrationResults,
+        TranslationAndIntegrationResults,
+    ),
+    SyncError,
+> {
+    let ctx = service_provider.basic_context()?;
+
+    let logger_handle = logger.into_handle();
+
+    let (returned_logger_handle, result) =
+        // Spawn the blocking task on a separate thread to avoid starving the async runtime and blocking other tasks while integrating
+        tokio::task::spawn_blocking(move || -> Result<_, SyncError> {
+            let mut logger = logger_handle.with_connection(&ctx.connection);
+
+            let result = integrate_and_translate_sync_buffer(
+                &ctx.connection,
+                Some(&mut logger),
+                record_type,
+                use_transaction,
+            )
+            .map_err(SyncError::IntegrationError)?;
+
+            Ok((logger.into_handle(), result))
+        })
+        .await
+        .map_err(|e| SyncError::Other(format!("integrate join error: {e:?}")))??;
+
+    logger.restore(returned_logger_handle);
+
+    Ok(result)
 }
 
 /// Translation And Integration of sync buffer, pub since used in CLI

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -9,7 +9,7 @@ use repository::*;
 use std::collections::HashMap;
 use std::time::Instant;
 
-static PROGRESS_STEP_LEN: usize = 100;
+static PROGRESS_STEP_LEN: usize = 1000;
 
 pub(crate) struct TranslationAndIntegration<'a> {
     connection: &'a StorageConnection,


### PR DESCRIPTION
## Summary
- Cherry-pick of [#11539](https://github.com/msupply-foundation/open-msupply/pull/11539) onto `v2.19.0-RC`
- Wraps integration step in `spawn_blocking` so GraphQL subscription tasks (`sync_info`, `initialisation_status`) aren't starved during sync integration
- No version bump — 2.19.0 has not yet been released, so this fix should ship as part of 2.19.0

## Conflict resolution notes
- `server/service/src/sync/sync_status/logger.rs`: kept `debug` in `use log::{debug, error, info};` import. v2.19 still has the `fn log` helper using `debug!()` (unlike v2.16.1-RC where it doesn't exist), so the cherry-pick's removal of `debug` would leave the import unused-but-needed.

## Test plan
- [ ] CI build passes
- [ ] Manual: run a sync against a test central and confirm `sync_info` subscription pushes mid-sync rather than only after integration completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)