### PR TITLE
#11506 Fix stock line details modal layout issues

### DIFF
--- a/client/packages/common/src/ui/components/inputs/TextInput/InputWithLabelRow.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/InputWithLabelRow.tsx
@@ -37,7 +37,17 @@ export const InputWithLabelRow = ({
         sx={{ width: labelWidth, fontWeight: 'bold', ...labelSx }}
         {...labelPropsRest}
       >
-        {label}
+        {/* Split on '/' and insert <wbr /> so browsers can wrap at slashes without visible whitespace */}
+        {label.split('/').map((part, i) => (
+          <React.Fragment key={i}>
+            {i > 0 && (
+              <>
+                /<wbr />
+              </>
+            )}
+            {part}
+          </React.Fragment>
+        ))}
         {labelRight ? '' : ':'}
       </FormLabel>
       {Input}

--- a/client/packages/common/src/ui/layout/tables/components/TextWithTooltipCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/TextWithTooltipCell.tsx
@@ -14,6 +14,7 @@ export const TextWithTooltipCell = <T extends MRT_RowData>({
         style={{
           overflow: 'hidden',
           textOverflow: 'ellipsis',
+          width: '100%',
         }}
       >
         {value}

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -418,6 +418,7 @@ export const StockLineForm = ({
                     <Checkbox
                       checked={draft.onHold}
                       onChange={(_, onHold) => onUpdate({ onHold })}
+                      sx={{ pr: 0 }}
                     />
                   }
                 />

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -194,7 +194,7 @@ export const StockLineForm = ({
             />
           </Box>
           <Box>
-            <Grid container gap={isNewModal ? undefined : 10}>
+            <Grid container gap={isNewModal ? 2 : 10}>
               <Grid container flex={1} flexDirection="column" gap={1}>
                 <StyledInputRow
                   label={t('label.pack-quantity')}

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -494,13 +494,12 @@ export const StockLineForm = ({
                 {showVVMStatus && (
                   <StyledInputRow
                     label={t('label.vvm-status')}
-                    labelWidth={isNewModal ? '212px' : null}
                     Input={
                       <VVMStatusSearchInput
                         selected={draft?.vvmStatus ?? null}
                         onChange={vvmStatus => onUpdate({ vvmStatus })}
                         disabled={!isNewModal}
-                        width={!isNewModal ? 160 : undefined}
+                        width={160}
                         useDefault={isNewModal}
                       />
                     }


### PR DESCRIPTION
## Summary

Fixes layout issues in the stock line details modal reported in #11506:

- Right-align the "On hold" checkbox
- Fix VVM status label alignment
- Allow labels to wrap at forward slashes (e.g. "Campaign/program")
- Add gap between the two columns so labels on the right column are not crowded against inputs on the left
- Fix last digit of item codes being clipped in the grouped stock list

## Test plan

- [ ] Open the stock line details modal via "New stock"
- [ ] Verify "On hold" checkbox is right-aligned
- [ ] Verify "Manufacturer" label has visible space between it and the Reason field to its left
- [ ] Verify "Campaign/program" label wraps correctly and is not clipped
- [ ] Verify VVM status label and field are correctly aligned (vaccine item required)
- [ ] Enable "Group by Item" in stock view and verify item codes are not clipped
- [ ] Open an existing stock line detail page (full page, not modal) and verify the two-column layout still looks correct Screenshot:
<img width="1342" height="819" alt="image" src="https://github.com/user-attachments/assets/ffd0d276-aceb-44fe-82c9-e213e373dede" />


Closes #11506

## Screenshots:
<img width="1904" height="862" alt="image" src="https://github.com/user-attachments/assets/dd0d6daa-0e68-4214-99f8-c3d9d157563e" />
<img width="1195" height="714" alt="image" src="https://github.com/user-attachments/assets/80e5d3c0-e2d2-475e-bda4-cf022b17837b" />
<img width="856" height="794" alt="image" src="https://github.com/user-attachments/assets/8522e2ac-e85b-4ff6-bf7e-54b3bbba9544" />
Even portrait tablets in french:
<img width="473" height="687" alt="image" src="https://github.com/user-attachments/assets/ed895a50-6bdf-4713-8442-6d93d7a232d6" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)