### PR TITLE
#11544 Broader null safety fix for query hooks

### DIFF
--- a/client/packages/inventory/src/Stocktake/api/hooks/useStocktakeList.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/useStocktakeList.ts
@@ -65,8 +65,8 @@ const useGet = (queryParams: StocktakesParams) => {
       },
       filter: filterBy,
     });
-    const { nodes, totalCount } = query?.stocktakes;
-    return { nodes, totalCount };
+    const { nodes, totalCount } = query?.stocktakes ?? {};
+    return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
   };
 
   const query = useQuery({ queryKey, queryFn, placeholderData: keepPreviousData });

--- a/client/packages/invoices/src/Prescriptions/api/hooks/usePrescriptionList.ts
+++ b/client/packages/invoices/src/Prescriptions/api/hooks/usePrescriptionList.ts
@@ -61,8 +61,8 @@ export const usePrescriptionList = (queryParams?: ListParams) => {
       desc: sortBy.direction === 'desc',
       filter,
     });
-    const { nodes, totalCount } = query?.invoices;
-    return { nodes, totalCount };
+    const { nodes, totalCount } = query?.invoices ?? {};
+    return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
   };
 
   const { data, isLoading, isError, isFetching } = useQuery({

--- a/client/packages/purchasing/src/purchase_order/api/hooks/usePurchaseOrderLineList.ts
+++ b/client/packages/purchasing/src/purchase_order/api/hooks/usePurchaseOrderLineList.ts
@@ -68,8 +68,8 @@ export const usePurchaseOrderLineList = (
       desc: sortBy.direction === 'desc',
       filter,
     });
-    const { nodes, totalCount } = query?.purchaseOrderLines;
-    return { nodes, totalCount };
+    const { nodes, totalCount } = query?.purchaseOrderLines ?? {};
+    return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
   };
 
   const { data, isLoading, isError } = useQuery({ queryKey, queryFn });

--- a/client/packages/purchasing/src/purchase_order/api/hooks/usePurchaseOrderList.ts
+++ b/client/packages/purchasing/src/purchase_order/api/hooks/usePurchaseOrderList.ts
@@ -62,8 +62,8 @@ export const usePurchaseOrderList = (queryParams?: ListParams) => {
       desc: sortBy.direction === 'desc',
       filter,
     });
-    const { nodes, totalCount } = query?.purchaseOrders;
-    return { nodes, totalCount };
+    const { nodes, totalCount } = query?.purchaseOrders ?? {};
+    return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
   };
 
   const { data, isFetching, isError } = useQuery({

--- a/client/packages/system/src/ActivityLog/api/hooks/useActivityLog.ts
+++ b/client/packages/system/src/ActivityLog/api/hooks/useActivityLog.ts
@@ -37,8 +37,8 @@ export function useActivityLog(
       sort: sortBy ? getSortInput(sortBy) : undefined,
       filter,
     });
-    const { nodes, totalCount } = query?.activityLogs;
-    return { nodes, totalCount };
+    const { nodes, totalCount } = query?.activityLogs ?? {};
+    return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
   };
 
   const query = useQuery({

--- a/client/packages/system/src/Asset/api/hooks/useAssetCategories.ts
+++ b/client/packages/system/src/Asset/api/hooks/useAssetCategories.ts
@@ -16,8 +16,8 @@ export const useAssetCategories = (filterBy?: FilterBy | null) => {
       sort: { key: AssetCategorySortFieldInput.Name, desc: false },
     });
 
-    const { nodes, totalCount } = query?.assetCategories;
-    return { nodes, totalCount };
+    const { nodes, totalCount } = query?.assetCategories ?? {};
+    return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
   };
 
   const query = useQuery({

--- a/client/packages/system/src/Asset/api/hooks/useAssetClasses.ts
+++ b/client/packages/system/src/Asset/api/hooks/useAssetClasses.ts
@@ -11,8 +11,8 @@ export const useAssetClasses = () => {
       sort: { key: AssetClassSortFieldInput.Name, desc: false },
     });
 
-    const { nodes, totalCount } = query?.assetClasses;
-    return { nodes, totalCount };
+    const { nodes, totalCount } = query?.assetClasses ?? {};
+    return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
   };
 
   const query = useQuery({

--- a/client/packages/system/src/Asset/api/hooks/useAssetList.ts
+++ b/client/packages/system/src/Asset/api/hooks/useAssetList.ts
@@ -37,8 +37,8 @@ export const useAssetList = (queryParams?: ListParams) => {
       desc: sortBy?.isDesc,
       filter: filterBy,
     });
-    const { nodes, totalCount } = query?.assetCatalogueItems;
-    return { nodes, totalCount };
+    const { nodes, totalCount } = query?.assetCatalogueItems ?? {};
+    return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
   };
 
   const { data, isLoading, isError } = useQuery({
@@ -107,8 +107,8 @@ export const useAssetCatalogueListAll = () => {
       const query = await assetApi.assetCatalogueItems({
         key: AssetCatalogueItemSortFieldInput.Code,
       });
-      const { nodes, totalCount } = query?.assetCatalogueItems;
-      return { nodes, totalCount };
+      const { nodes, totalCount } = query?.assetCatalogueItems ?? {};
+      return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
     },
   });
 

--- a/client/packages/system/src/Asset/api/hooks/useAssetLogReasonList.ts
+++ b/client/packages/system/src/Asset/api/hooks/useAssetLogReasonList.ts
@@ -12,8 +12,8 @@ export const useAssetLogReasonList = (filterBy?: FilterBy | null) => {
       filter: filterBy,
     });
 
-    const { nodes, totalCount } = query?.assetLogReasons;
-    return { nodes, totalCount };
+    const { nodes, totalCount } = query?.assetLogReasons ?? {};
+    return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
   };
 
   const query = useQuery({

--- a/client/packages/system/src/Asset/api/hooks/useAssetTypes.ts
+++ b/client/packages/system/src/Asset/api/hooks/useAssetTypes.ts
@@ -16,8 +16,8 @@ export const useAssetTypes = (filterBy?: FilterBy | null) => {
       sort: { key: AssetTypeSortFieldInput.Name, desc: false },
     });
 
-    const { nodes, totalCount } = query?.assetTypes;
-    return { nodes, totalCount };
+    const { nodes, totalCount } = query?.assetTypes ?? {};
+    return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
   };
 
   const query = useQuery({

--- a/client/packages/system/src/Currency/api/hooks/useCurrencyList.ts
+++ b/client/packages/system/src/Currency/api/hooks/useCurrencyList.ts
@@ -22,8 +22,8 @@ export function useCurrencyList() {
       },
       filter: {},
     });
-    const { nodes, totalCount } = query?.currencies;
-    return { nodes, totalCount };
+    const { nodes, totalCount } = query?.currencies ?? {};
+    return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
   };
 
   const query = useQuery({ queryKey, queryFn });

--- a/client/packages/system/src/Item/api/hooks/useItemLedger/useItemLedger.ts
+++ b/client/packages/system/src/Item/api/hooks/useItemLedger/useItemLedger.ts
@@ -29,10 +29,10 @@ export const useItemLedger = (
       },
     });
 
-    const { nodes, totalCount } = query?.itemLedger;
+    const { nodes, totalCount } = query?.itemLedger ?? {};
     return {
-      ledgers: nodes,
-      totalCount,
+      ledgers: nodes ?? [],
+      totalCount: totalCount ?? 0,
     };
   };
 

--- a/client/packages/system/src/Location/api/hooks/useLocationList.ts
+++ b/client/packages/system/src/Location/api/hooks/useLocationList.ts
@@ -57,8 +57,8 @@ const useGetList = (enabled?: boolean, queryParams?: ListParams) => {
       filter: filterBy,
       storeId,
     });
-    const { nodes, totalCount } = query?.locations;
-    return { nodes, totalCount };
+    const { nodes, totalCount } = query?.locations ?? {};
+    return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
   };
 
   const query = useQuery({

--- a/client/packages/system/src/Manage/Campaigns/api/hooks/useCampaigns.ts
+++ b/client/packages/system/src/Manage/Campaigns/api/hooks/useCampaigns.ts
@@ -91,8 +91,8 @@ const useGetList = (queryParams?: ListParams) => {
       filter: filterBy,
       storeId,
     });
-    const { nodes, totalCount } = query?.campaigns;
-    return { nodes, totalCount };
+    const { nodes, totalCount } = query?.campaigns ?? {};
+    return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
   };
 
   const query = useQuery({

--- a/client/packages/system/src/MasterList/api/hooks/useMasterLists.ts
+++ b/client/packages/system/src/MasterList/api/hooks/useMasterLists.ts
@@ -45,8 +45,8 @@ export const useMasterLists = (props?: MasterListsProps) => {
       filter: filterBy,
       storeId,
     });
-    const { nodes, totalCount } = query?.masterLists;
-    return { nodes, totalCount };
+    const { nodes, totalCount } = query?.masterLists ?? {};
+    return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
   };
 
   const { data, isLoading, isError } = useQuery({

--- a/client/packages/system/src/ShippingMethod/api/hooks/useShippingMethod.ts
+++ b/client/packages/system/src/ShippingMethod/api/hooks/useShippingMethod.ts
@@ -12,8 +12,8 @@ export function useShippingMethod(filterBy?: FilterBy) {
       filter: filterBy,
     });
 
-    const { nodes, totalCount } = query?.shippingMethods;
-    return { nodes, totalCount };
+    const { nodes, totalCount } = query?.shippingMethods ?? {};
+    return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
   };
 
   return useQuery({

--- a/client/packages/system/src/Stock/api/hooks/useStockLedger.ts
+++ b/client/packages/system/src/Stock/api/hooks/useStockLedger.ts
@@ -31,8 +31,8 @@ export function useStockLedger(
       desc: sortBy?.direction === 'desc',
       filter,
     });
-    const { nodes, totalCount } = query?.ledger;
-    return { nodes, totalCount };
+    const { nodes, totalCount } = query?.ledger ?? {};
+    return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
   };
 
   const query = useQuery({ queryKey, queryFn });

--- a/client/packages/system/src/Stock/api/hooks/useStockList.ts
+++ b/client/packages/system/src/Stock/api/hooks/useStockList.ts
@@ -50,8 +50,8 @@ export const useStockList = (
       desc: sortBy.isDesc,
       filter,
     });
-    const { nodes, totalCount } = query?.stockLines;
-    return { nodes, totalCount };
+    const { nodes, totalCount } = query?.stockLines ?? {};
+    return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
   };
 
   const query = useQuery({

--- a/client/packages/system/src/Stock/api/hooks/useStockListCount.ts
+++ b/client/packages/system/src/Stock/api/hooks/useStockListCount.ts
@@ -20,8 +20,8 @@ export const useStockListCount = (filterBy: StockLineFilterInput) => {
       storeId,
       filter,
     });
-    const { totalCount } = query?.stockLines;
-    return { totalCount };
+    const { totalCount } = query?.stockLines ?? {};
+    return { totalCount: totalCount ?? 0 };
   };
 
   const query = useQuery({ queryKey, queryFn });


### PR DESCRIPTION
Broader follow-up to #11555, which fixed the JS crash in the activity log hook when a user lacks the `LogQuery` permission.

## What does this PR do?

Applies the same `?? {}` / default-value guard to all other query hooks that destructure a potentially-null server response:

```ts
// before
const { nodes, totalCount } = query?.someField;

// after
const { nodes, totalCount } = query?.someField ?? {};
return { nodes: nodes ?? [], totalCount: totalCount ?? 0 };
```

This prevents JS crashes when the server returns `null` (e.g. due to a missing permission) for any of these endpoints.

## Hooks fixed

- `usePrescriptionList` — `invoices`
- `usePurchaseOrderLineList` — `purchaseOrderLines`
- `usePurchaseOrderList` — `purchaseOrders`
- `useAssetLogReasonList` — `assetLogReasons`
- `useAssetClasses` — `assetClasses`
- `useAssetCategories` — `assetCategories`
- `useAssetList` / `useAssetCatalogueListAll` — `assetCatalogueItems`
- `useAssetTypes` — `assetTypes`
- `useLocationList` — `locations`
- `useShippingMethod` — `shippingMethods`
- `useItemLedger` — `itemLedger`
- `useMasterLists` — `masterLists`
- `useCampaigns` — `campaigns`
- `useStockList` — `stockLines`
- `useStockLedger` — `ledger`
- `useStockListCount` — `stockLines`
- `useCurrencyList` — `currencies`
- `useStocktakeList` — `stocktakes`