### PR TITLE
11570 should be able to send placeholder only internal order

### DIFF
--- a/client/packages/common/src/authentication/api/operations.generated.ts
+++ b/client/packages/common/src/authentication/api/operations.generated.ts
@@ -29,6 +29,7 @@ export type UserStoreNodeFragment = {
     monthsItemsExpire: number;
     stocktakeFrequency: number;
     extraFieldsInRequisition: boolean;
+    keepRequisitionLinesWithZeroRequestedQuantityOnFinalised: boolean;
     manuallyLinkInternalOrderToInboundShipment: boolean;
     useConsumptionAndStockFromCustomersForInternalOrders: boolean;
     editPrescribedQuantityOnPrescription: boolean;
@@ -98,6 +99,7 @@ export type MeQuery = {
         monthsItemsExpire: number;
         stocktakeFrequency: number;
         extraFieldsInRequisition: boolean;
+        keepRequisitionLinesWithZeroRequestedQuantityOnFinalised: boolean;
         manuallyLinkInternalOrderToInboundShipment: boolean;
         useConsumptionAndStockFromCustomersForInternalOrders: boolean;
         editPrescribedQuantityOnPrescription: boolean;
@@ -132,6 +134,7 @@ export type MeQuery = {
           monthsItemsExpire: number;
           stocktakeFrequency: number;
           extraFieldsInRequisition: boolean;
+          keepRequisitionLinesWithZeroRequestedQuantityOnFinalised: boolean;
           manuallyLinkInternalOrderToInboundShipment: boolean;
           useConsumptionAndStockFromCustomersForInternalOrders: boolean;
           editPrescribedQuantityOnPrescription: boolean;
@@ -325,6 +328,7 @@ export const UserStoreNodeFragmentDoc = gql`
       monthsItemsExpire
       stocktakeFrequency
       extraFieldsInRequisition
+      keepRequisitionLinesWithZeroRequestedQuantityOnFinalised
       manuallyLinkInternalOrderToInboundShipment
       useConsumptionAndStockFromCustomersForInternalOrders
       editPrescribedQuantityOnPrescription

--- a/client/packages/common/src/authentication/api/operations.graphql
+++ b/client/packages/common/src/authentication/api/operations.graphql
@@ -20,6 +20,7 @@ fragment UserStoreNode on UserStoreNode {
     monthsItemsExpire
     stocktakeFrequency
     extraFieldsInRequisition
+    keepRequisitionLinesWithZeroRequestedQuantityOnFinalised
     manuallyLinkInternalOrderToInboundShipment
     useConsumptionAndStockFromCustomersForInternalOrders
     editPrescribedQuantityOnPrescription

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -9736,6 +9736,7 @@ export type StorePreferenceNode = {
   extraFieldsInRequisition: Scalars['Boolean']['output'];
   id: Scalars['String']['output'];
   issueInForeignCurrency: Scalars['Boolean']['output'];
+  keepRequisitionLinesWithZeroRequestedQuantityOnFinalised: Scalars['Boolean']['output'];
   manuallyLinkInternalOrderToInboundShipment: Scalars['Boolean']['output'];
   monthlyConsumptionLookBackPeriod: Scalars['Float']['output'];
   monthsItemsExpire: Scalars['Float']['output'];

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
@@ -34,22 +34,22 @@ const getStatusOptions = (
     SplitButtonOption<RequisitionNodeStatus>,
     SplitButtonOption<RequisitionNodeStatus>,
   ] = [
-    {
-      value: RequisitionNodeStatus.Draft,
-      label: getButtonLabel(RequisitionNodeStatus.Draft),
-      isDisabled: true,
-    },
-    {
-      value: RequisitionNodeStatus.Sent,
-      label: getButtonLabel(RequisitionNodeStatus.Sent),
-      isDisabled: true,
-    },
-    {
-      value: RequisitionNodeStatus.Finalised,
-      label: getButtonLabel(RequisitionNodeStatus.Finalised),
-      isDisabled: true,
-    },
-  ];
+      {
+        value: RequisitionNodeStatus.Draft,
+        label: getButtonLabel(RequisitionNodeStatus.Draft),
+        isDisabled: true,
+      },
+      {
+        value: RequisitionNodeStatus.Sent,
+        label: getButtonLabel(RequisitionNodeStatus.Sent),
+        isDisabled: true,
+      },
+      {
+        value: RequisitionNodeStatus.Finalised,
+        label: getButtonLabel(RequisitionNodeStatus.Finalised),
+        isDisabled: true,
+      },
+    ];
 
   if (currentStatus === RequisitionNodeStatus.Draft) {
     options[1].isDisabled = false;
@@ -71,11 +71,11 @@ const getNextStatusOption = (
 
 const getButtonLabel =
   (t: ReturnType<typeof useTranslation>) =>
-  (invoiceStatus: RequisitionNodeStatus): string => {
-    return t('button.save-and-confirm-status', {
-      status: t(getStatusTranslation(invoiceStatus)),
-    });
-  };
+    (invoiceStatus: RequisitionNodeStatus): string => {
+      return t('button.save-and-confirm-status', {
+        status: t(getStatusTranslation(invoiceStatus)),
+      });
+    };
 
 const useStatusChangeButton = () => {
   const { id, status, comment, lines, ancillaryState } =
@@ -116,11 +116,11 @@ const useStatusChangeButton = () => {
 
     return store?.preferences.requestRequisitionRequiresAuthorisation
       ? t('template.requisition-sent', {
-          name,
-          job,
-          phone: user?.phoneNumber ?? UNDEFINED_STRING_VALUE,
-          email: user?.email ?? UNDEFINED_STRING_VALUE,
-        })
+        name,
+        job,
+        phone: user?.phoneNumber ?? UNDEFINED_STRING_VALUE,
+        email: user?.email ?? UNDEFINED_STRING_VALUE,
+      })
       : '';
   };
 
@@ -192,12 +192,12 @@ const useStatusChangeButton = () => {
     isSending && ancillaryState
       ? ancillaryState.state === AncillaryStateNode.NeedsAdd
         ? t('warning.confirm-send-ancillary-items-missing', {
-            count: ancillaryState.count,
-          })
+          count: ancillaryState.count,
+        })
         : ancillaryState.state === AncillaryStateNode.NeedsUpdate
           ? t('warning.confirm-send-ancillary-items-stale', {
-              count: ancillaryState.count,
-            })
+            count: ancillaryState.count,
+          })
           : undefined
       : undefined;
 
@@ -226,10 +226,14 @@ export const StatusChangeButton = () => {
   const t = useTranslation();
   const { selectedOption, getConfirmation, lines } = useStatusChangeButton();
   const isDisabled = useRequest.utils.isDisabled();
-  const { userHasPermission } = useAuthContext();
+  const { userHasPermission, store } = useAuthContext();
+  const keepZeroRequested =
+    !!store?.preferences
+      ?.keepRequisitionLinesWithZeroRequestedQuantityOnFinalised;
   const cantSend =
     lines?.totalCount === 0 ||
-    lines?.nodes?.every(line => line?.requestedQuantity === 0);
+    (!keepZeroRequested &&
+      lines?.nodes?.every(line => line?.requestedQuantity === 0));
   const showPermissionDenied = useDisabledNotificationToast(
     t('auth.permission-denied')
   );

--- a/server/graphql/types/src/types/store_preference.rs
+++ b/server/graphql/types/src/types/store_preference.rs
@@ -68,6 +68,12 @@ impl StorePreferenceNode {
         &self.store_preference.extra_fields_in_requisition
     }
 
+    pub async fn keep_requisition_lines_with_zero_requested_quantity_on_finalised(&self) -> &bool {
+        &self
+            .store_preference
+            .keep_requisition_lines_with_zero_requested_quantity_on_finalised
+    }
+
     pub async fn manually_link_internal_order_to_inbound_shipment(&self) -> &bool {
         &self
             .store_preference


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11570

# 👩🏻‍💻 What does this PR do?
`keepRequisitionLinesWithZeroRequestedQuantityOnFinalised` was added for CIV a while back, have linked that to the frontend to allow users to send an Internal Order with all placeholder lines.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have the OG store preference above on
- [ ] Create Internal Order with only placeholder lines
- [ ] Should be able to send to supplier 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

