### PR TITLE
#10028 Label SR goods tracking 'Delivered' instead of 'Received'

### DIFF
--- a/client/packages/invoices/src/Returns/SupplierDetailView/Footer/Footer.tsx
+++ b/client/packages/invoices/src/Returns/SupplierDetailView/Footer/Footer.tsx
@@ -12,6 +12,7 @@ import {
   ActionsFooter,
   usePreferences,
   InvoiceNodeType,
+  InvoiceNodeStatus,
 } from '@openmsupply-client/common';
 import { getStatusTranslator } from '../../../utils';
 import { createStatusLog, getStatusSequence } from '../../../statuses';
@@ -79,7 +80,11 @@ export const FooterComponent = ({
               <StatusCrumbs
                 statuses={statuses}
                 statusLog={createStatusLog(data, supplierReturnSequence)}
-                statusFormatter={getStatusTranslator(t)}
+                statusFormatter={status =>
+                  status === InvoiceNodeStatus.Received
+                    ? t('status.delivered')
+                    : getStatusTranslator(t)(status)
+                }
               />
               <Box flex={1} display="flex" justifyContent="flex-end" gap={2}>
                 <ButtonWithIcon


### PR DESCRIPTION
Fixes #10028

# 👩🏻‍💻 What does this PR do?

<img width="400" align="right" alt="image" src="https://github.com/user-attachments/assets/b6f34cac-8aaf-42a3-8f46-487c2d9e9ea9" />

In the supplier return footer, the goods-tracking breadcrumb showed "Received" for the step that happens when the supplier confirms receipt of the return. Per the discussion on #10028 and #8339, this should be labelled "Delivered" — semantically, from this site's perspective the goods were delivered *to* the supplier.

Implemented as a per-step formatter override in the supplier return footer: the underlying invoice status enum and the `received_datetime`-driven highlight logic are unchanged; only the displayed label changes.

## 💌 Any notes for the reviewer?

- Scope was deliberately kept to the label change. The original issue text also mentions that the step is not highlighted; that part is the legacy-sync gap described in #8339 item 6 (legacy mSupply only has `delivered_datetime`, the SR fallback in `invoice.rs` doesn't write `received_datetime`/`delivered_datetime` for `Cn`/`Fn`). mark-prins's guidance on both #10028 and #8339 was specifically the label fix ("should be showing the `Delivered` status not `Received`") — the propagation work is left for #8339 follow-up.
- Considered generalising into a per-invoice-type override map in `utils.ts` but reverted: SR is currently the only type that needs a label override, so an inline formatter in the SR footer is enough.
- `StatusChangeButton` for SR only ever offers Picked/Shipped (per `SUPPLIER_RETURN_NEXT`), so the button label doesn't need the same override.

# 🧪 Testing

- [ ] Open a supplier return that has progressed past Shipped (status = Received)
- [ ] Confirm the footer goods-tracking crumbs now read: New → Picked → Shipped → **Delivered** → Verified
- [ ] Confirm the Delivered crumb is highlighted when `received_datetime` is set (omS↔omS flow via the `update_outbound_invoice_status` processor)
- [ ] Confirm hovering the crumbs still shows the order history popover with the correct date

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend