### PR TITLE
#11360 Allow CCE import with same manufacturer/model when type differs

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -399,7 +399,7 @@
   "error.line-combination-error": "Item and pack size combination already exists for item code: {{itemCode}}, and pack size: {{requestedPackSize}}",
   "error.login": "Invalid username or password",
   "error.login-support": "Please contact support@msupply.foundation if you are unable to login to your account",
-  "error.manufacturer-model-unique": "An item already exists with this manufacturer and model",
+  "error.manufacturer-model-unique": "An item already exists with this manufacturer, model and type",
   "error.master-list-not-found": "Master list not found",
   "error.master-list-not-found-for-this-store": "Master list not found for this store",
   "error.max-orders-reached-for-period": "Maximum requisitions for this period already created",

--- a/server/repository/src/migrations/constants.rs
+++ b/server/repository/src/migrations/constants.rs
@@ -1,6 +1,7 @@
 pub const COLD_CHAIN_EQUIPMENT_UUID: &str = "fad280b6-8384-41af-84cf-c7b6b4526ef0";
 pub const INSULATED_CONTAINERS_UUID: &str = "b7eea921-5a14-44cc-b5e0-ea59f2e9cb8d";
 pub const REFRIGERATORS_AND_FREEZERS_UUID: &str = "02cbea92-d5bf-4832-863b-c04e093a7760";
+pub const FREEZER_UUID: &str = "710194ce-8c6c-47ab-b7fe-13ba8cf091f6";
 pub const COLD_ROOMS_AND_FREEZER_ROOMS_UUID: &str = "7db32eb6-5929-4dd1-a5e9-01e36baa73ad";
 
 pub const DEFAULT_EXPECTED_LIFESPAN: i32 = 10;

--- a/server/service/src/catalogue/insert.rs
+++ b/server/service/src/catalogue/insert.rs
@@ -80,12 +80,13 @@ pub fn validate(
         return Err(InsertAssetCatalogueItemError::CodeAlreadyExists);
     }
 
-    // Check the manufacturer and model are unique
+    // Check the manufacturer, model, and type combination is unique
     if let Some(manufacturer) = &input.manufacturer {
         if repo.count(Some(
             AssetCatalogueItemFilter::new()
                 .manufacturer(StringFilter::equal_to(manufacturer))
-                .model(StringFilter::equal_to(&input.model)),
+                .model(StringFilter::equal_to(&input.model))
+                .type_id(EqualFilter::equal_to(input.type_id.clone())),
         ))? > 0
         {
             return Err(InsertAssetCatalogueItemError::ManufacturerAndModelAlreadyExist);

--- a/server/service/src/catalogue/tests/insert.rs
+++ b/server/service/src/catalogue/tests/insert.rs
@@ -1,7 +1,9 @@
 #[cfg(test)]
 mod query {
     use repository::{
-        migrations::constants::{COLD_CHAIN_EQUIPMENT_UUID, REFRIGERATORS_AND_FREEZERS_UUID},
+        migrations::constants::{
+            COLD_CHAIN_EQUIPMENT_UUID, FREEZER_UUID, REFRIGERATORS_AND_FREEZERS_UUID,
+        },
         mock::{mock_store_a, MockDataInserts},
         test_db::setup_all,
     };
@@ -102,8 +104,6 @@ mod query {
             ),
             Err(InsertAssetCatalogueItemError::ManufacturerAndModelAlreadyExist)
         );
-
-        const FREEZER_UUID: &str = "710194ce-8c6c-47ab-b7fe-13ba8cf091f6";
 
         // 5. Check we CAN create an asset_catalogue_item with the same manufacturer and model when the type differs
         assert!(service

--- a/server/service/src/catalogue/tests/insert.rs
+++ b/server/service/src/catalogue/tests/insert.rs
@@ -84,7 +84,7 @@ mod query {
             Err(InsertAssetCatalogueItemError::CodeAlreadyExists)
         );
 
-        // 4. Check we can't create an asset_catalogue_item with the manufacturer and model
+        // 4. Check we can't create an asset_catalogue_item with the same manufacturer, model AND type
         assert_eq!(
             service.insert_asset_catalogue_item(
                 &ctx,
@@ -102,5 +102,25 @@ mod query {
             ),
             Err(InsertAssetCatalogueItemError::ManufacturerAndModelAlreadyExist)
         );
+
+        const FREEZER_UUID: &str = "710194ce-8c6c-47ab-b7fe-13ba8cf091f6";
+
+        // 5. Check we CAN create an asset_catalogue_item with the same manufacturer and model when the type differs
+        assert!(service
+            .insert_asset_catalogue_item(
+                &ctx,
+                InsertAssetCatalogueItem {
+                    id: "new_id_2".to_string(),
+                    sub_catalogue: "General".to_string(),
+                    category_id: REFRIGERATORS_AND_FREEZERS_UUID.to_string(),
+                    class_id: COLD_CHAIN_EQUIPMENT_UUID.to_string(),
+                    code: "NewCode2".to_string(),
+                    manufacturer: Some("Fisher & Paykel".to_string()),
+                    model: "Kelvinator".to_string(),
+                    type_id: FREEZER_UUID.to_string(),
+                    properties: None
+                },
+            )
+            .is_ok());
     }
 }


### PR DESCRIPTION
Fixes #11360

# 👩🏻‍💻 What does this PR do?

The uniqueness check when inserting an asset catalogue item previously rejected any two items sharing the same manufacturer and model, regardless of type. This meant that valid CCE items (e.g. a fridge and a freezer from the same manufacturer with the same model name) could not both be imported.

This fix adds `type_id` to the uniqueness check, so the constraint now applies to the combination of manufacturer + model + type. Items with the same manufacturer and model are permitted as long as their type differs.

## 💌 Any notes for the reviewer?

- Change is in `server/service/src/catalogue/insert.rs` — one extra filter added to the `count()` query.
- A new test case (case 5) was added to `tests/insert.rs` confirming that inserting a same-manufacturer/same-model item succeeds when the type UUID differs.
- The `FREEZER_UUID` used in the test is taken from existing seed data.

# 🧪 Testing

- [ ] Central server: Catalogue > Assets > Import
- [ ] Prepare a CSV with two CCE rows sharing the same manufacturer and model but different types (e.g. Refrigerator vs Freezer)
- [ ] Confirm both rows import successfully without error
- [ ] Confirm that importing two rows with identical manufacturer, model **and** type still returns the expected duplicate error

# 📃 Documentation

- [ ] **No documentation required**: bug fix — restores expected behaviour, no user-facing behaviour change beyond allowing valid imports

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend