### PR TITLE
#11296 Auto-open variant panel for master-list inbound lines

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -84,7 +84,12 @@ export const StocktakeLineEdit = ({
   const reversedDraftLines = [...draftLines].reverse();
   const simplifiedTabletView = useSimplifiedTabletUI();
 
-  const [variantPanelOpen, setVariantPanelOpen] = useState(false);
+  // 'auto' = panel popped for a master-list placeholder row (selection
+  // patches that row, manual just dismisses). 'add' = panel opened via
+  // Add batch (selection/manual both add a new line). null = closed.
+  const [variantAction, setVariantAction] = useState<'auto' | 'add' | null>(
+    null
+  );
   const [variantShownForItem, setVariantShownForItem] = useState<string | null>(
     null
   );
@@ -106,7 +111,7 @@ export const StocktakeLineEdit = ({
     if (!draftLines.every(isFreshPlaceholder)) return;
 
     setVariantShownForItem(currentItem.id);
-    setVariantPanelOpen(true);
+    setVariantAction('auto');
   }, [currentItem, hasVariants, variantShownForItem, draftLines]);
 
   const restrictedLocationTypeId =
@@ -128,25 +133,21 @@ export const StocktakeLineEdit = ({
             itemVariant: variant,
           }) ?? 0,
       };
-      // If the only existing line is a fresh placeholder (auto-pop case),
-      // patch it instead of adding a duplicate.
-      const onlyPlaceholder =
-        draftLines.length === 1 &&
-        draftLines[0] &&
-        isFreshPlaceholder(draftLines[0]);
-      if (onlyPlaceholder) {
-        update({ id: draftLines[0]!.id, ...variantPatch });
+      // Auto-pop: patch the placeholder row in place. Add batch: append a
+      // new line.
+      if (variantAction === 'auto' && draftLines[0]) {
+        update({ id: draftLines[0].id, ...variantPatch });
       } else {
         addLine(variantPatch);
       }
-      setVariantPanelOpen(false);
+      setVariantAction(null);
     },
-    [addLine, update, draftLines, currentItem?.defaultPackSize]
+    [addLine, update, draftLines, currentItem?.defaultPackSize, variantAction]
   );
 
   const handleAddLine = useCallback(() => {
     if (hasVariants) {
-      setVariantPanelOpen(true);
+      setVariantAction('add');
     } else {
       addLine();
     }
@@ -306,12 +307,15 @@ export const StocktakeLineEdit = ({
                 {tableContent}
                 <ItemVariantSelectPanel
                   itemId={currentItem.id}
-                  open={variantPanelOpen}
-                  onClose={() => setVariantPanelOpen(false)}
+                  open={variantAction !== null}
+                  onClose={() => setVariantAction(null)}
                   onSelect={applyVariant}
                   onManual={() => {
-                    addLine();
-                    setVariantPanelOpen(false);
+                    // Auto-pop case: the placeholder row is already
+                    // there for the user to fill in; just dismiss.
+                    // Add-batch case: create the requested empty row.
+                    if (variantAction === 'add') addLine();
+                    setVariantAction(null);
                   }}
                 />
               </>

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -5,6 +5,7 @@ import {
   ItemVariantFragment,
   ItemVariantSelectPanel,
   useIsItemVariantsEnabled,
+  useItem,
   useItemVariants,
 } from '@openmsupply-client/system';
 import {
@@ -39,15 +40,19 @@ import {
 import { StocktakeLineEditModal } from './StocktakeLineEditModal';
 import { DraftStocktakeLine } from './utils';
 
-// A line auto-created for an item with no existing batches — nothing
-// filled in yet. We treat the variant panel's selection as a patch on
-// this line rather than adding a duplicate.
+// A stocktake line auto-seeded by the server (e.g. all-items stocktake
+// creates one row for an item with no stock) — nothing filled in yet.
+// We treat the variant panel's selection as a patch on this line rather
+// than adding a duplicate. isCreated=false means it came from the
+// server, not from a user click on Add Batch.
 const isFreshPlaceholder = (line: DraftStocktakeLine) =>
+  line.isCreated === false &&
+  !line.isUpdated &&
   !line.stockLine &&
   !line.itemVariantId &&
   !line.batch &&
-  !line.isUpdated &&
-  (line.snapshotNumberOfPacks ?? 0) === 0;
+  (line.snapshotNumberOfPacks ?? 0) === 0 &&
+  line.countedNumberOfPacks == null;
 
 interface StocktakeLineEditProps {
   item: StocktakeLineFragment['item'] | null;
@@ -84,7 +89,7 @@ export const StocktakeLineEdit = ({
   const reversedDraftLines = [...draftLines].reverse();
   const simplifiedTabletView = useSimplifiedTabletUI();
 
-  // 'auto' = panel popped for a master-list placeholder row (selection
+  // 'auto' = panel popped for a server-seeded placeholder row (selection
   // patches that row, manual just dismisses). 'add' = panel opened via
   // Add batch (selection/manual both add a new line). null = closed.
   const [variantAction, setVariantAction] = useState<'auto' | 'add' | null>(
@@ -97,6 +102,7 @@ export const StocktakeLineEdit = ({
   const { data: variantData } = useItemVariants(currentItem?.id ?? '');
   const hasVariants =
     itemVariantsEnabled && (variantData?.variants?.length ?? 0) > 0;
+  const { stockLinesFromItem } = useItem(currentItem?.id ?? '');
 
   useEffect(() => {
     setVariantShownForItem(null);
@@ -105,14 +111,26 @@ export const StocktakeLineEdit = ({
   useEffect(() => {
     if (!currentItem || !hasVariants) return;
     if (variantShownForItem === currentItem.id) return;
-    // Wait for draftLines to populate after item change to avoid popping
-    // during the loading window.
-    if (draftLines.length === 0) return;
+    // Wait for the source queries before deciding, to avoid popping
+    // during the loading window for items that have stock.
+    if (stockLinesFromItem.isLoading) return;
+    // Auto-open when the item has nothing real to count yet: no stock
+    // lines, and any existing stocktake lines for this item are
+    // untouched server-seeded placeholders (e.g. all-items stocktake).
+    const hasStockLines = (stockLinesFromItem.data?.nodes.length ?? 0) > 0;
+    if (hasStockLines) return;
     if (!draftLines.every(isFreshPlaceholder)) return;
 
     setVariantShownForItem(currentItem.id);
     setVariantAction('auto');
-  }, [currentItem, hasVariants, variantShownForItem, draftLines]);
+  }, [
+    currentItem,
+    hasVariants,
+    variantShownForItem,
+    stockLinesFromItem.data,
+    stockLinesFromItem.isLoading,
+    draftLines,
+  ]);
 
   const restrictedLocationTypeId =
     currentItem?.restrictedLocationTypeId ?? null;
@@ -133,16 +151,17 @@ export const StocktakeLineEdit = ({
             itemVariant: variant,
           }) ?? 0,
       };
-      // Auto-pop: patch the placeholder row in place. Add batch: append a
-      // new line.
-      if (variantAction === 'auto' && draftLines[0]) {
-        update({ id: draftLines[0].id, ...variantPatch });
+      // Auto-pop with a server-seeded placeholder: patch it in place.
+      // Otherwise (Add Batch, or auto-pop with no placeholder): append.
+      const placeholder = draftLines.find(isFreshPlaceholder);
+      if (placeholder) {
+        update({ id: placeholder.id, ...variantPatch });
       } else {
         addLine(variantPatch);
       }
       setVariantAction(null);
     },
-    [addLine, update, draftLines, currentItem?.defaultPackSize, variantAction]
+    [addLine, update, draftLines, currentItem?.defaultPackSize]
   );
 
   const handleAddLine = useCallback(() => {
@@ -311,10 +330,15 @@ export const StocktakeLineEdit = ({
                   onClose={() => setVariantAction(null)}
                   onSelect={applyVariant}
                   onManual={() => {
-                    // Auto-pop case: the placeholder row is already
-                    // there for the user to fill in; just dismiss.
-                    // Add-batch case: create the requested empty row.
-                    if (variantAction === 'add') addLine();
+                    // Auto-pop with a server-seeded placeholder already
+                    // present (all-items stocktake): leave it for the
+                    // user to fill in. Otherwise add a blank row (Add
+                    // Batch, or auto-pop with no placeholder yet).
+                    const hasPlaceholder =
+                      draftLines.some(isFreshPlaceholder);
+                    if (variantAction === 'add' || !hasPlaceholder) {
+                      addLine();
+                    }
                     setVariantAction(null);
                   }}
                 />

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -37,6 +37,18 @@ import {
   PricingTable,
 } from './StocktakeLineEditTables';
 import { StocktakeLineEditModal } from './StocktakeLineEditModal';
+import { DraftStocktakeLine } from './utils';
+
+// A line auto-created for an item with no existing batches — nothing
+// filled in yet. We treat the variant panel's selection as a patch on
+// this line rather than adding a duplicate.
+const isFreshPlaceholder = (line: DraftStocktakeLine) =>
+  !line.stockLine &&
+  !line.itemVariantId &&
+  !line.batch &&
+  !line.isUpdated &&
+  (line.snapshotNumberOfPacks ?? 0) === 0;
+
 interface StocktakeLineEditProps {
   item: StocktakeLineFragment['item'] | null;
   mode: ModalMode | null;
@@ -73,10 +85,29 @@ export const StocktakeLineEdit = ({
   const simplifiedTabletView = useSimplifiedTabletUI();
 
   const [variantPanelOpen, setVariantPanelOpen] = useState(false);
+  const [variantShownForItem, setVariantShownForItem] = useState<string | null>(
+    null
+  );
   const itemVariantsEnabled = useIsItemVariantsEnabled();
   const { data: variantData } = useItemVariants(currentItem?.id ?? '');
   const hasVariants =
     itemVariantsEnabled && (variantData?.variants?.length ?? 0) > 0;
+
+  useEffect(() => {
+    setVariantShownForItem(null);
+  }, [currentItem?.id]);
+
+  useEffect(() => {
+    if (!currentItem || !hasVariants) return;
+    if (variantShownForItem === currentItem.id) return;
+    // Wait for draftLines to populate after item change to avoid popping
+    // during the loading window.
+    if (draftLines.length === 0) return;
+    if (!draftLines.every(isFreshPlaceholder)) return;
+
+    setVariantShownForItem(currentItem.id);
+    setVariantPanelOpen(true);
+  }, [currentItem, hasVariants, variantShownForItem, draftLines]);
 
   const restrictedLocationTypeId =
     currentItem?.restrictedLocationTypeId ?? null;
@@ -85,9 +116,9 @@ export const StocktakeLineEdit = ({
     ? checkInvalidLocationLines(restrictedLocationTypeId, draftLines)
     : null;
 
-  const applyVariantToNewLine = useCallback(
+  const applyVariant = useCallback(
     (variant: ItemVariantFragment) => {
-      addLine({
+      const variantPatch = {
         itemVariantId: variant.id,
         itemVariant: variant,
         manufacturer: variant.manufacturer ?? null,
@@ -96,10 +127,21 @@ export const StocktakeLineEdit = ({
             packSize: currentItem?.defaultPackSize,
             itemVariant: variant,
           }) ?? 0,
-      });
+      };
+      // If the only existing line is a fresh placeholder (auto-pop case),
+      // patch it instead of adding a duplicate.
+      const onlyPlaceholder =
+        draftLines.length === 1 &&
+        draftLines[0] &&
+        isFreshPlaceholder(draftLines[0]);
+      if (onlyPlaceholder) {
+        update({ id: draftLines[0]!.id, ...variantPatch });
+      } else {
+        addLine(variantPatch);
+      }
       setVariantPanelOpen(false);
     },
-    [addLine, currentItem?.defaultPackSize]
+    [addLine, update, draftLines, currentItem?.defaultPackSize]
   );
 
   const handleAddLine = useCallback(() => {
@@ -266,7 +308,7 @@ export const StocktakeLineEdit = ({
                   itemId={currentItem.id}
                   open={variantPanelOpen}
                   onClose={() => setVariantPanelOpen(false)}
-                  onSelect={applyVariantToNewLine}
+                  onSelect={applyVariant}
                   onManual={() => {
                     addLine();
                     setVariantPanelOpen(false);

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
@@ -202,41 +202,67 @@ export const InboundLineEdit = ({
   }, [effectiveItem?.id]);
 
   useEffect(() => {
-    if (mode !== ModalMode.Create) return;
     if (!hasVariants || draftLines.length === 0) return;
     if (variantShownForItem === effectiveItem?.id) return;
+
+    // Pop the panel for fresh items (Create) and for master-list-seeded
+    // placeholder lines the user is opening for the first time.
+    const allFreshPlaceholders = draftLines.every(
+      line =>
+        isInboundPlaceholderRow(line) &&
+        !line.itemVariantId &&
+        !line.isUpdated &&
+        !line.linkedInvoiceId
+    );
+    if (mode !== ModalMode.Create && !allFreshPlaceholders) return;
 
     setVariantShownForItem(effectiveItem?.id ?? null);
     setVariantAction('first');
   }, [
     mode,
     hasVariants,
-    draftLines.length,
+    draftLines,
     effectiveItem?.id,
     variantShownForItem,
   ]);
 
   const onVariantSelected = useCallback(
     (variant: ItemVariantFragment) => {
-      const packSize = draftLines[0]?.item.defaultPackSize ?? 1;
-      const variantPatch = {
-        itemVariantId: variant.id,
-        itemVariant: variant,
-        manufacturer: variant.manufacturer ?? null,
-        volumePerPack:
-          getVolumePerPackFromVariant({
-            packSize,
-            itemVariant: variant,
-          }) ?? 0,
-      };
-
       if (variantAction === 'first' && draftLines.length > 0) {
+        const target = draftLines[0]!;
+        // Master-list placeholders come in with packSize=1; reset to the
+        // item default so the variant's volume-per-pack lines up with the
+        // line's pack size. Don't clobber packSize on lines the user has
+        // already shaped.
+        const isFresh =
+          isInboundPlaceholderRow(target) && !target.itemVariantId;
+        const packSize = isFresh
+          ? (target.item.defaultPackSize ?? target.packSize)
+          : target.packSize;
         updateDraftLine({
-          id: draftLines[0]!.id,
-          ...variantPatch,
+          id: target.id,
+          itemVariantId: variant.id,
+          itemVariant: variant,
+          manufacturer: variant.manufacturer ?? null,
+          ...(isFresh && { packSize }),
+          volumePerPack:
+            getVolumePerPackFromVariant({
+              packSize,
+              itemVariant: variant,
+            }) ?? 0,
         });
       } else {
-        addDraftLine(variantPatch);
+        const packSize = draftLines[0]?.item.defaultPackSize ?? 1;
+        addDraftLine({
+          itemVariantId: variant.id,
+          itemVariant: variant,
+          manufacturer: variant.manufacturer ?? null,
+          volumePerPack:
+            getVolumePerPackFromVariant({
+              packSize,
+              itemVariant: variant,
+            }) ?? 0,
+        });
       }
       setVariantAction(null);
     },


### PR DESCRIPTION
Fixes #11296

# 👩🏻‍💻 What does this PR do?

https://github.com/user-attachments/assets/7e7e4df2-3270-4cbb-b194-2effc5829cc2

PR #10895 replaced the inline `ItemVariantInput` with a slide panel that only auto-opens in `ModalMode.Create`. Two flows fell through the cracks:

1. **Inbound — "Add from master list"**: lines come in as placeholder rows (zero packs, no variant, default `packSize=1`) and present in Update mode, so the panel never fired and there was no surface to pick a variant.
2. **Stocktake — items with no existing batches**: a single fresh placeholder line is auto-created for the user to fill in, but no variant prompt appeared.

**Inbound fix** (`InboundLineEdit.tsx`): broaden the auto-open trigger to also fire when every draft line is an unedited, unlinked placeholder without a variant. The existing `'first'` branch already patches `draftLines[0]`, which fits the master-list case. When patching a fresh placeholder, also reset `packSize` to `item.defaultPackSize` so the variant's volume-per-pack lookup matches.

**Stocktake fix** (`StocktakeLineEdit.tsx`): mirror the same idea — auto-open the panel when every draft line is a fresh placeholder (no `stockLine`, no `batch`, no `itemVariantId`, not edited, snapshot 0). The selection callback patches the placeholder when there's exactly one, otherwise adds a new line as before. The effect skips while `draftLines` is still loading so it doesn't pop on parent-row clicks for items with real batches.

## 💌 Any notes for the reviewer?

- Create-mode behaviour from #10895 is unchanged on inbound; this only adds the placeholder trigger.
- On stocktake, "Add Batch" still works for adding additional batches with variants — no change there.
- Setting a variant on an *existing* batch is still out of scope (can be done via the stock detail view).

# 🧪 Testing

**Inbound — master list**
- [ ] Add from master list on a new inbound, with items that have variants configured
- [ ] Click into a master-list line → panel auto-opens; pick a variant; manufacturer/volume populate (More info group)
- [ ] Re-open same line → panel does NOT re-open

**Stocktake — placeholder**
- [ ] Add an item with variants but no existing batches to a stocktake → panel auto-opens; pick a variant
- [ ] Manufacturer/volume populate on the placeholder row (no duplicate row created)
- [ ] Click parent grouped row of an item with real batches → panel does NOT pop

**Regression**
- [ ] Inbound Add Item (Create) still auto-opens panel; Add Batch still opens panel
- [ ] Stocktake Add Batch still opens panel for items with variants

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: bug fix
- [ ] **These areas should be updated or checked**:

# 📃 Reviewer Checklist

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend