### PR TITLE
#11417 Fix CCE mobile view UI issues

### DIFF
--- a/client/packages/coldchain/src/Equipment/DetailView/AppBarButtons.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/AppBarButtons.tsx
@@ -22,7 +22,7 @@ import { useIsColdRoom } from '../utils';
 
 type ActionValue = 'update-status' | 'record-mapping';
 
-const ColdRoomActionButton = ({
+export const ColdRoomActionButton = ({
   assetId,
 }: {
   assetId: string;

--- a/client/packages/coldchain/src/Equipment/DetailView/RecordMappingButton.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/RecordMappingButton.tsx
@@ -137,6 +137,7 @@ export const RecordMappingModal = ({
               }
               format="P"
               maxDate={today}
+              width="100%"
               onChange={date =>
                 setDraft(prev => ({
                   ...prev,

--- a/client/packages/coldchain/src/Equipment/DetailView/StatusForm.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/StatusForm.tsx
@@ -58,7 +58,7 @@ const Row = ({
     );
 
   return (
-    <Box paddingTop={1.5}>
+    <Box paddingTop={1.5} paddingX={2}>
       <Typography
         sx={{
           fontSize: '1em',

--- a/client/packages/coldchain/src/Equipment/DetailView/Tabs/StatusLogs.tsx
+++ b/client/packages/coldchain/src/Equipment/DetailView/Tabs/StatusLogs.tsx
@@ -288,6 +288,7 @@ const LogFilters = ({
       gap={2}
       paddingX={8}
       paddingTop={2}
+      paddingBottom={2}
       alignItems="center"
       flexWrap="wrap"
       sx={theme => ({
@@ -302,36 +303,48 @@ const LogFilters = ({
         <Typography sx={{ fontWeight: 'bold', fontSize: '14px' }}>
           {t('label.from-date')}:
         </Typography>
-        <DateTimePickerInput
-          value={fromDate}
-          format="P"
-          onChange={onFromDateChange}
-          width={180}
-        />
+        <Box sx={{ flex: 1, minWidth: { sm: '180px' }, maxWidth: { sm: '180px' } }}>
+          <DateTimePickerInput
+            value={fromDate}
+            format="P"
+            onChange={onFromDateChange}
+            width="100%"
+          />
+        </Box>
       </Box>
       <Box display="flex" alignItems="center" gap={1}>
         <Typography sx={{ fontWeight: 'bold', fontSize: '14px' }}>
           {t('label.to-date')}:
         </Typography>
-        <DateTimePickerInput
-          value={toDate}
-          format="P"
-          onChange={onToDateChange}
-          width={180}
-        />
+        <Box sx={{ flex: 1, minWidth: { sm: '180px' }, maxWidth: { sm: '180px' } }}>
+          <DateTimePickerInput
+            value={toDate}
+            format="P"
+            onChange={onToDateChange}
+            width="100%"
+          />
+        </Box>
       </Box>
       <Box display="flex" alignItems="center" gap={1}>
         <Typography sx={{ fontWeight: 'bold', fontSize: '14px' }}>
           {t('label.event')}:
         </Typography>
-        <Autocomplete
-          value={selectedEvent}
-          options={eventOptions}
-          onChange={(_, option) => onEventChange(option ?? null)}
-          isOptionEqualToValue={(a, b) => a.value === b.value}
-          width="280px"
-          clearable
-        />
+        <Box
+          sx={{
+            flex: 1,
+            minWidth: { sm: '280px' },
+            maxWidth: { sm: '280px' },
+          }}
+        >
+          <Autocomplete
+            value={selectedEvent}
+            options={eventOptions}
+            onChange={(_, option) => onEventChange(option ?? null)}
+            isOptionEqualToValue={(a, b) => a.value === b.value}
+            width="100%"
+            clearable
+          />
+        </Box>
       </Box>
     </Box>
   );

--- a/client/packages/coldchain/src/Mobile/Equipment/DetailView/DetailView.tsx
+++ b/client/packages/coldchain/src/Mobile/Equipment/DetailView/DetailView.tsx
@@ -15,9 +15,13 @@ import {
 import { Footer } from './Footer';
 import { StatusLogs } from 'packages/coldchain/src/Equipment/DetailView/Tabs/StatusLogs';
 import { UpdateStatusButton } from 'packages/coldchain/src/Equipment/DetailView/UpdateStatusButton';
+import { ColdRoomActionButton } from 'packages/coldchain/src/Equipment/DetailView/AppBarButtons';
 import { Documents } from 'packages/coldchain/src/Equipment/DetailView/Tabs/Documents';
 import { LogCardListView } from './LogCardListView';
-import { statusColourMap } from 'packages/coldchain/src/Equipment/utils';
+import {
+  statusColourMap,
+  useIsColdRoom,
+} from 'packages/coldchain/src/Equipment/utils';
 
 export const EquipmentDetailView: FC = () => {
   const {
@@ -33,6 +37,7 @@ export const EquipmentDetailView: FC = () => {
     // navigate,
     t,
   } = useEquipmentDetailView();
+  const isColdRoom = useIsColdRoom();
 
   if (isLoading && isLoadingLocations) return <DetailFormSkeleton />;
   if (!data) return <h1>{t('error.asset-not-found')}</h1>;
@@ -58,7 +63,11 @@ export const EquipmentDetailView: FC = () => {
           gap: '.5em',
         }}
       >
-        <UpdateStatusButton assetId={data?.id} />
+        {isColdRoom && data?.id ? (
+          <ColdRoomActionButton assetId={data.id} />
+        ) : (
+          <UpdateStatusButton assetId={data?.id} />
+        )}
       </Box>
       <Box
         sx={{


### PR DESCRIPTION
Fixes #11417

# 👩🏻‍💻 What does this PR do?

Two bugs were reported in the CCE mobile view for v2.19, plus two related mobile layout improvements to both action modals:

**1. Temperature mapping option missing on mobile**

The mobile detail view always rendered a plain `UpdateStatusButton`. For cold room / freezer room assets, the desktop view shows a split button (`ColdRoomActionButton`) offering both "Update status" and "Temperature mapping". This PR exports `ColdRoomActionButton` and uses `useIsColdRoom()` in the mobile detail view to conditionally render it — cold room assets now get the split button, other assets keep the plain button.

**2. Status history filter fields misaligned on mobile**

The "Event" filter `Autocomplete` was given a fixed `width="280px"`, but as a flex item it could shrink below that on narrow screens, causing the inner `TextField` (with `minWidth: 280px`) to overflow or appear clipped. The "From date" and "To date" `DateTimePickerInput` fields used `maxWidth: 180px` capped internally, so they didn't fill their row either — making all three filters look inconsistent.

Fix: each filter field is now wrapped in a `Box` with `flex: 1` so it fills remaining row width on mobile. On `sm+` screens, `minWidth`/`maxWidth` constraints lock each field back to its original fixed size (180px / 280px), preserving the desktop layout. Also added `paddingBottom` to the filter section so it doesn't sit flush against the log entries.

**3. Mobile layout improvements to both action modals**

- **Update Status modal** (`StatusForm.tsx`): the mobile `Row` layout now includes `paddingX={2}` so form inputs have horizontal breathing room on narrow screens. The desktop `InputWithLabelRow` layout is unchanged.
- **Temperature Mapping modal** (`RecordMappingButton.tsx`): the date picker is now passed `width="100%"` so it fills its container on mobile rather than auto-sizing to content.

Screenshots post fix:
<img width="500" height="718" alt="image" src="https://github.com/user-attachments/assets/a1f5ea89-22bb-444c-9c68-1ccf526fd9bf" />
<img width="519" height="730" alt="image" src="https://github.com/user-attachments/assets/3dcfb341-78f0-4d06-9f90-7835adec6821" />

Screenshots post fix:
<img width="519" height="730" alt="image" src="https://github.com/user-attachments/assets/0b0f2725-cdc7-4050-8078-fa41028d3dec" />
<img width="489" height="729" alt="image" src="https://github.com/user-attachments/assets/6bc47f3d-1e15-47a3-a261-49cc6b10df73" />
<img width="478" height="725" alt="image" src="https://github.com/user-attachments/assets/b9061622-fc5b-46a3-850d-747e13a270bd" />
<img width="457" height="722" alt="image" src="https://github.com/user-attachments/assets/2e8961aa-34c3-4b43-acf7-e57357b1fa16" />



## 💌 Any notes for the reviewer?

- `ColdRoomActionButton` was previously unexported — exporting it is a minimal change with no side effects on the desktop `AppBarButtons` component.
- The filter width fix uses the existing MUI `sx` responsive breakpoint pattern already used in the rest of `StatusLogs.tsx` — no new patterns introduced.
- `StatusForm.tsx` `Row` change only affects the mobile branch (`isExtraSmallScreen === true`); the desktop `InputWithLabelRow` layout is untouched.
- `RecordMappingButton.tsx` date picker change: `width="100%"` is forwarded to the inner TextField via `slotProps` — desktop layout is unaffected as the outer `Row` already constrains width via `InputWithLabelRow`.
- No server-side changes.

# 🧪 Testing

On an Android device or emulator, navigate to a CCE asset detail view:

- [ ] For a **cold room / freezer room** asset: the mobile action button should be a split button offering both "Update status" and "Temperature mapping"
- [ ] For a **non-cold-room** asset: only the plain "Update status" button should appear
- [ ] Open the "Status History" accordion — all three filter fields (From date, To date, Event) should fill the available row width consistently
- [ ] The Event filter should not appear narrow or clipped relative to the date filters
- [ ] There should be visible spacing below the filter row before the log entries
- [ ] Tapping "Update status" should open the modal with comfortable horizontal padding around the input fields
- [ ] Tapping "Temperature mapping" should open the modal with the date picker filling the full available width

On **desktop**, verify no regressions:

- [ ] Cold room asset detail view still shows the split button with "Update status" and "Temperature mapping" in the app bar
- [ ] Status history filter fields (From date, To date, Event) still render at their original fixed widths (180px / 280px)
- [ ] Update Status modal form still uses the standard `InputWithLabelRow` label-beside-input layout
- [ ] Temperature Mapping modal date picker still renders correctly

# 📃 Documentation

- [ ] **No documentation required**: bug fixes restoring expected mobile behaviour

# 📃 Reviewer Checklist

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API

**Issue Review**
- [ ] All requirements in original issue have been covered

**Tests Pass**
- [ ] Frontend