### PR TITLE
11579 Sanity checks carryover

### DIFF
--- a/server/repository/src/db_diesel/changelog/sync_style.rs
+++ b/server/repository/src/db_diesel/changelog/sync_style.rs
@@ -194,7 +194,7 @@ impl ChangelogTableName {
             Name => (
                 vec![Central, Patient],
                 SyncVersions {
-                    is_v6: false,
+                    is_v6: true,
                     is_v5: true,
                 },
             ),
@@ -216,8 +216,8 @@ impl ChangelogTableName {
             Document => (
                 vec![Patient],
                 SyncVersions {
-                    is_v6: true,
-                    is_v5: false,
+                    is_v6: false,
+                    is_v5: true,
                 },
             ),
 

--- a/server/repository/src/db_diesel/changelog/sync_styles.md
+++ b/server/repository/src/db_diesel/changelog/sync_styles.md
@@ -79,11 +79,17 @@ Adds patient routing on top of remote+transfer; an invoice also follows its pati
 
 Central data still served from legacy 4D. This bucket also acts as a catch-all for tables that exist in the changelog but haven't been classified into a more specific style yet.
 
-### Legacy, Central + Patient
+### Legacy + OMS-native, Central + Patient
 
 `Name`
 
-Names are central data — every site needs the full directory — but a patient-typed name additionally carries its own id as `patient_id` on the changelog. Non-patient names route via the Central clause; patient names route via the Patient clause to every site that knows the patient.
+Names are central data — every site needs the full directory — but a patient-typed name additionally carries its own id as `patient_id` on the changelog. Non-patient names route via the Central clause; patient names route via the Patient clause to every site that knows the patient. `Name` is the only table tagged as living on **both** transports: it's pulled on v6 (so OMS-native filters include it) and still pushed on v5 (so legacy filters include it too).
+
+### Legacy, Patient
+
+`Document`
+
+Pure patient-scoped data on the legacy transport. The changelog row carries only the patient, no store, so routing is purely by Patient and the record follows the patient across stores.
 
 ### Legacy, ToLegacyCentralOnly
 
@@ -108,12 +114,6 @@ Site-owned data on the OMS-native transport.
 `Encounter`, `Vaccination`
 
 Store-scoped clinical records that should also follow the patient. Each row carries the authoring store *and* the patient. The Remote clause delivers it to the owning site; the Patient clause delivers it to every other site that knows the patient. The Central clause never matches because `patient_id` is set.
-
-### OMS-native, Patient
-
-`Document`
-
-Pure patient-scoped data. The changelog carries only the patient, no store, so routing is purely by Patient and the record follows the patient across stores.
 
 ### OMS-native, File
 
@@ -184,7 +184,7 @@ Five filters compose the metadata above into "this site, this transport" predica
 | Filter | Used by | What it returns | Echo guard |
 | --- | --- | --- | --- |
 | **all-data-for-site** | v6 central pull (OMS-native tables only); v7 central pull (all tables) | Per sync style: Central / File → store-id is null **and** patient-id is null; Remote → store's site = this site; Transfer → transfer-store's site = this site; Patient → patient's site = this site (via name-store-join). ToLegacyCentralOnly and RemoteToCentral are skipped. | Once initialised, exclude rows whose source-site = this site. |
-| **patient-data-for-site** | v6 patient pull (used together with an explicit patient id) | Just the Patient clause from above, intersected with the requested patient id. | None at this layer — caller composes additional conditions. |
+| **patient-data-for-site** | v6 patient pull and v7 patient pull (used together with an explicit patient id) | Just the Patient clause from above, intersected with the requested patient id. | None at this layer — caller composes additional conditions. |
 | **all-data-for-legacy-central** | v5 push (remote → legacy 4D) | Legacy-only tables in styles ToLegacyCentralOnly, Remote, Transfer, Patient. Central, RemoteToCentral, File are excluded. | Exclude rows whose source-site is the legacy central server itself. |
 | **all-data-edited-on-site** | v7 push (remote → OMS central) | Just "rows whose source-site = this site". No per-style filtering, no transport-flag filtering — the per-table translators are not consulted because v7 has no per-table translation. | Implicit — the predicate itself is the echo guard. |
 | **data-for-store** | (defined, not yet used) | Remote + Transfer for a specific store, ignoring transport flags. | None. |
@@ -219,12 +219,12 @@ Notable special cases:
 
 | Table | Special behaviour |
 |---|---|
-| `Name`, `NameStoreJoin` | Legacy-classified, but their translators also opt in to push to OMS central, so they round-trip via OMS too — used to share patient details across sites. When the central server is processing `Name` or `NameStoreJoin`, the translator additionally guards against echoing rows that originated from a remote (avoids the central pushing a remote-authored update straight back to legacy 4D). |
+| `Name`, `NameStoreJoin` | Their translators opt in to push to OMS central, so they round-trip via OMS too — used to share patient details across sites. `Name` is tagged on both transports (v5 *and* v6), so it flows over both; `NameStoreJoin` is legacy-only by transport flag but its OMS push opt-in is what enables the round-trip. When the central server is processing `Name` or `NameStoreJoin`, the translator additionally guards against echoing rows that originated from a remote (avoids the central pushing a remote-authored update straight back to legacy 4D). |
 | `NameOmsFields` | Central-style (authored on OMS central) but its translator opts in to push to OMS central, allowing remote → central writebacks. |
 | Vaccine-course family (`VaccineCourse`, `VaccineCourseDose`, `VaccineCourseItem`) | Central-style on OMS, but a parallel set of legacy translators re-publishes them to legacy 4D when running on OMS central, so v5-only stores still receive them. |
 | `Encounter` | OMS-native, Remote + Patient. It has no main OMS translator on its own — the only translator is a companion legacy translator that re-publishes it to legacy 4D when running on OMS central, so v5-only stores still receive it. |
 | `Vaccination` | OMS-native, Remote + Patient. Its main translator opts in to OMS push/pull. A companion legacy translator re-publishes it to legacy 4D when running on OMS central, so v5-only stores still receive it. |
-| `Document` | OMS-native, classified as Patient only — the changelog row carries no store, so routing is purely by Patient. |
+| `Document` | Legacy-classified, Patient style — the changelog row carries no store, so routing is purely by Patient. |
 | `MasterList` | Legacy/Central, but the translator declares no changelog mapping, so nothing pushes on any transport — it only ever flows down from legacy 4D. |
 
 For v7 there is **no** per-table translation step — the database row is serialised directly and deserialised on the other side. As a consequence, v7 push for a given table works whether or not its translator has a v6 opt-in.

--- a/server/service/src/sync/mod.rs
+++ b/server/service/src/sync/mod.rs
@@ -80,6 +80,15 @@ impl ActiveStoresOnSite {
     pub(crate) fn store_ids(&self) -> Vec<String> {
         self.stores.iter().map(|r| r.store_row.id.clone()).collect()
     }
+
+    pub(crate) fn store_ids_for_site(
+        connection: &StorageConnection,
+        site_id: i32,
+    ) -> Result<Vec<String>, RepositoryError> {
+        let stores = StoreRepository::new(connection)
+            .query_by_filter(StoreFilter::new().site_id(EqualFilter::equal_to(site_id)))?;
+        Ok(stores.into_iter().map(|s| s.store_row.id).collect())
+    }
 }
 
 #[derive(PartialEq, Clone)]

--- a/server/service/src/sync_v7/sync_on_central/mod.rs
+++ b/server/service/src/sync_v7/sync_on_central/mod.rs
@@ -329,8 +329,8 @@ async fn spawn_integration_inner(
 ) -> Result<(), SpawnIntegrationError> {
     let ctx = service_provider.basic_context()?;
 
-    let active_stores = ActiveStoresOnSite::get(&ctx.connection)?;
-    let source_site_store_ids = ActiveStoresOnSite::store_ids_for_site(&ctx.connection, site_id)?;
+    let source_site_active_store_ids =
+        ActiveStoresOnSite::store_ids_for_site(&ctx.connection, site_id)?;
 
     validate_translate_integrate(
         &ctx.connection,
@@ -338,8 +338,7 @@ async fn spawn_integration_inner(
         site_id,
         None,
         SyncContext::Central {
-            active_stores,
-            source_site_store_ids,
+            source_site_active_store_ids,
         },
         false,
     )?;

--- a/server/service/src/sync_v7/sync_on_central/mod.rs
+++ b/server/service/src/sync_v7/sync_on_central/mod.rs
@@ -330,13 +330,17 @@ async fn spawn_integration_inner(
     let ctx = service_provider.basic_context()?;
 
     let active_stores = ActiveStoresOnSite::get(&ctx.connection)?;
+    let source_site_store_ids = ActiveStoresOnSite::store_ids_for_site(&ctx.connection, site_id)?;
 
     validate_translate_integrate(
         &ctx.connection,
         None,
         site_id,
         None,
-        SyncContext::Central { active_stores },
+        SyncContext::Central {
+            active_stores,
+            source_site_store_ids,
+        },
         false,
     )?;
     Ok(())

--- a/server/service/src/sync_v7/validate.rs
+++ b/server/service/src/sync_v7/validate.rs
@@ -20,6 +20,12 @@ pub enum ValidationError {
     UnexpectedSyncStyleForV7,
     #[error("Central data is only editable by the central site")]
     CentralOnlyEditableByCentral,
+    #[error("Store is not active on the source site")]
+    StoreNotActiveOnSourceSite,
+    #[error("Transfer store is not active on the source site")]
+    TransferStoreNotActiveOnSourceSite,
+    #[error("Source site is the central site — central should not sync to itself")]
+    SourceSiteIsCentral,
 }
 
 pub(crate) fn validate_on_remote(
@@ -70,26 +76,53 @@ pub(crate) fn validate_on_remote(
 pub(crate) fn validate_on_central(
     sync_buffer_row: &SyncBufferRow,
     table_name: &ChangelogTableName,
-    // Central's own active stores, currently unused.
-    // kept for future (store merge?).
-    _active_on_site: &ActiveStoresOnSite,
+    active_on_site: &ActiveStoresOnSite,
+    source_site_store_ids: &[String],
 ) -> Result<(), ValidationError> {
     let (sync_styles, _) = table_name.sync_style();
     let mut last_err = ValidationError::UnexpectedSyncStyleForV7;
 
+    let source_is_central = sync_buffer_row.source_site_id == active_on_site.site_id();
+    let store_active_on_source = |id: &String| source_site_store_ids.iter().any(|s| s == id);
+
     for style in sync_styles {
         match style {
             Central => last_err = ValidationError::CentralOnlyEditableByCentral,
-            // Source site identity gated by auth.
-            Remote => match &sync_buffer_row.store_id {
-                Some(_) => return Ok(()),
-                None => last_err = ValidationError::NoStoreId,
-            },
-            Transfer => return Ok(()),
-            Patient => match &sync_buffer_row.patient_id {
-                Some(_) => return Ok(()),
-                None => last_err = ValidationError::NoPatientId,
-            },
+            // Accept only if the row's store belongs to the source site —
+            // this also rejects rows referencing central's own stores.
+            Remote | Transfer => {
+                if source_is_central {
+                    last_err = ValidationError::SourceSiteIsCentral;
+                    continue;
+                }
+                match (
+                    &sync_buffer_row.store_id,
+                    &sync_buffer_row.transfer_store_id,
+                ) {
+                    (None, None) => last_err = ValidationError::NoStoreId,
+
+                    (Some(id), _) if store_active_on_source(id) => return Ok(()),
+                    (Some(_), _) => last_err = ValidationError::StoreNotActiveOnSourceSite,
+
+                    (None, Some(id)) if store_active_on_source(id) => return Ok(()),
+                    (None, Some(_)) => {
+                        last_err = ValidationError::TransferStoreNotActiveOnSourceSite
+                    }
+                }
+            }
+            // Check any store ids are from a source site that is not central
+            Patient => {
+                if source_is_central {
+                    last_err = ValidationError::SourceSiteIsCentral;
+                    continue;
+                }
+                match (&sync_buffer_row.patient_id, &sync_buffer_row.store_id) {
+                    (None, _) => last_err = ValidationError::NoPatientId,
+                    (Some(_), None) => return Ok(()),
+                    (Some(_), Some(id)) if store_active_on_source(id) => return Ok(()),
+                    (Some(_), Some(_)) => last_err = ValidationError::StoreNotActiveOnSourceSite,
+                }
+            }
             File => return Ok(()),
             ToLegacyCentralOnly => last_err = ValidationError::UnexpectedSyncStyleForV7,
             RemoteToCentral => return Ok(()),
@@ -276,6 +309,10 @@ mod tests {
 
     #[test]
     fn on_central() {
+        // Site 1 is central. Source site 2 has one store, "remote_store_a";
+        // central also hosts "store_a" (via `site()`).
+        let source_site_stores = vec!["remote_store_a".to_string()];
+
         // Sync style: Central — central data isn't edited on remotes, always rejected.
         assert_eq!(
             validate_on_central(
@@ -285,11 +322,41 @@ mod tests {
                 },
                 &Item,
                 &site(),
+                &source_site_stores,
             ),
             Err(ValidationError::CentralOnlyEditableByCentral)
         );
 
-        // Sync style: Remote — store_id must be present (source site verified by auth).
+        // Sanity: source site is the central site itself.
+        assert_eq!(
+            validate_on_central(
+                &SyncBufferRow {
+                    store_id: Some("remote_store_a".into()),
+                    source_site_id: 1,
+                    ..Default::default()
+                },
+                &Stocktake,
+                &site(),
+                &source_site_stores,
+            ),
+            Err(ValidationError::SourceSiteIsCentral)
+        );
+
+        // Sync style: Remote — store_id must be active on the source site.
+        assert_eq!(
+            validate_on_central(
+                &SyncBufferRow {
+                    store_id: Some("remote_store_a".into()),
+                    source_site_id: 2,
+                    ..Default::default()
+                },
+                &Stocktake,
+                &site(),
+                &source_site_stores,
+            ),
+            Ok(())
+        );
+        // Central's own store referenced from a remote → reject.
         assert_eq!(
             validate_on_central(
                 &SyncBufferRow {
@@ -299,8 +366,22 @@ mod tests {
                 },
                 &Stocktake,
                 &site(),
+                &source_site_stores,
             ),
-            Ok(())
+            Err(ValidationError::StoreNotActiveOnSourceSite)
+        );
+        assert_eq!(
+            validate_on_central(
+                &SyncBufferRow {
+                    store_id: Some("unknown_store".into()),
+                    source_site_id: 2,
+                    ..Default::default()
+                },
+                &Stocktake,
+                &site(),
+                &source_site_stores,
+            ),
+            Err(ValidationError::StoreNotActiveOnSourceSite)
         );
         assert_eq!(
             validate_on_central(
@@ -310,24 +391,42 @@ mod tests {
                 },
                 &Stocktake,
                 &site(),
+                &source_site_stores,
             ),
             Err(ValidationError::NoStoreId)
         );
 
-        // Sync style: Transfer — accepted (source site trusted via auth).
+        // Sync style: Remote+Transfer (Requisition) — accepted when transfer_store_id
+        // is active on the source site.
         assert_eq!(
             validate_on_central(
                 &SyncBufferRow {
+                    transfer_store_id: Some("remote_store_a".into()),
                     source_site_id: 2,
                     ..Default::default()
                 },
                 &Requisition,
                 &site(),
+                &source_site_stores,
             ),
             Ok(())
         );
+        assert_eq!(
+            validate_on_central(
+                &SyncBufferRow {
+                    transfer_store_id: Some("store_a".into()),
+                    source_site_id: 2,
+                    ..Default::default()
+                },
+                &Requisition,
+                &site(),
+                &source_site_stores,
+            ),
+            Err(ValidationError::TransferStoreNotActiveOnSourceSite)
+        );
 
-        // Sync style: Patient — patient_id must be present.
+        // Sync style: Patient — patient_id must be present; if store_id is set,
+        // it must belong to the source site.
         assert_eq!(
             validate_on_central(
                 &SyncBufferRow {
@@ -337,8 +436,37 @@ mod tests {
                 },
                 &Document,
                 &site(),
+                &source_site_stores,
             ),
             Ok(())
+        );
+        assert_eq!(
+            validate_on_central(
+                &SyncBufferRow {
+                    patient_id: Some("patient_a".into()),
+                    store_id: Some("remote_store_a".into()),
+                    source_site_id: 2,
+                    ..Default::default()
+                },
+                &Document,
+                &site(),
+                &source_site_stores,
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            validate_on_central(
+                &SyncBufferRow {
+                    patient_id: Some("patient_a".into()),
+                    store_id: Some("store_a".into()),
+                    source_site_id: 2,
+                    ..Default::default()
+                },
+                &Document,
+                &site(),
+                &source_site_stores,
+            ),
+            Err(ValidationError::StoreNotActiveOnSourceSite)
         );
         assert_eq!(
             validate_on_central(
@@ -348,6 +476,7 @@ mod tests {
                 },
                 &Document,
                 &site(),
+                &source_site_stores,
             ),
             Err(ValidationError::NoPatientId)
         );

--- a/server/service/src/sync_v7/validate.rs
+++ b/server/service/src/sync_v7/validate.rs
@@ -72,12 +72,12 @@ pub(crate) fn validate_on_remote(
 pub(crate) fn validate_on_central(
     sync_buffer_row: &SyncBufferRow,
     table_name: &ChangelogTableName,
-    source_site_store_ids: &[String],
+    source_site_active_store_ids: &[String],
 ) -> Result<(), ValidationError> {
     let (sync_styles, _) = table_name.sync_style();
     let mut last_err = ValidationError::UnexpectedSyncStyleForV7;
 
-    let store_active_on_source = |id: &String| source_site_store_ids.iter().any(|s| s == id);
+    let store_active_on_source = |id: &String| source_site_active_store_ids.iter().any(|s| s == id);
 
     for style in sync_styles {
         match style {

--- a/server/service/src/sync_v7/validate.rs
+++ b/server/service/src/sync_v7/validate.rs
@@ -22,10 +22,6 @@ pub enum ValidationError {
     CentralOnlyEditableByCentral,
     #[error("Store is not active on the source site")]
     StoreNotActiveOnSourceSite,
-    #[error("Transfer store is not active on the source site")]
-    TransferStoreNotActiveOnSourceSite,
-    #[error("Source site is the central site — central should not sync to itself")]
-    SourceSiteIsCentral,
 }
 
 pub(crate) fn validate_on_remote(
@@ -76,13 +72,11 @@ pub(crate) fn validate_on_remote(
 pub(crate) fn validate_on_central(
     sync_buffer_row: &SyncBufferRow,
     table_name: &ChangelogTableName,
-    active_on_site: &ActiveStoresOnSite,
     source_site_store_ids: &[String],
 ) -> Result<(), ValidationError> {
     let (sync_styles, _) = table_name.sync_style();
     let mut last_err = ValidationError::UnexpectedSyncStyleForV7;
 
-    let source_is_central = sync_buffer_row.source_site_id == active_on_site.site_id();
     let store_active_on_source = |id: &String| source_site_store_ids.iter().any(|s| s == id);
 
     for style in sync_styles {
@@ -90,39 +84,18 @@ pub(crate) fn validate_on_central(
             Central => last_err = ValidationError::CentralOnlyEditableByCentral,
             // Accept only if the row's store belongs to the source site —
             // this also rejects rows referencing central's own stores.
-            Remote | Transfer => {
-                if source_is_central {
-                    last_err = ValidationError::SourceSiteIsCentral;
-                    continue;
-                }
-                match (
-                    &sync_buffer_row.store_id,
-                    &sync_buffer_row.transfer_store_id,
-                ) {
-                    (None, None) => last_err = ValidationError::NoStoreId,
+            Remote | Transfer => match &sync_buffer_row.store_id {
+                None => last_err = ValidationError::NoStoreId,
+                Some(id) if store_active_on_source(id) => return Ok(()),
+                Some(_) => last_err = ValidationError::StoreNotActiveOnSourceSite,
+            },
 
-                    (Some(id), _) if store_active_on_source(id) => return Ok(()),
-                    (Some(_), _) => last_err = ValidationError::StoreNotActiveOnSourceSite,
-
-                    (None, Some(id)) if store_active_on_source(id) => return Ok(()),
-                    (None, Some(_)) => {
-                        last_err = ValidationError::TransferStoreNotActiveOnSourceSite
-                    }
-                }
-            }
-            // Check any store ids are from a source site that is not central
-            Patient => {
-                if source_is_central {
-                    last_err = ValidationError::SourceSiteIsCentral;
-                    continue;
-                }
-                match (&sync_buffer_row.patient_id, &sync_buffer_row.store_id) {
-                    (None, _) => last_err = ValidationError::NoPatientId,
-                    (Some(_), None) => return Ok(()),
-                    (Some(_), Some(id)) if store_active_on_source(id) => return Ok(()),
-                    (Some(_), Some(_)) => last_err = ValidationError::StoreNotActiveOnSourceSite,
-                }
-            }
+            Patient => match (&sync_buffer_row.patient_id, &sync_buffer_row.store_id) {
+                (None, _) => last_err = ValidationError::NoPatientId,
+                (Some(_), None) => return Ok(()),
+                (Some(_), Some(id)) if store_active_on_source(id) => return Ok(()),
+                (Some(_), Some(_)) => last_err = ValidationError::StoreNotActiveOnSourceSite,
+            },
             File => return Ok(()),
             ToLegacyCentralOnly => last_err = ValidationError::UnexpectedSyncStyleForV7,
             RemoteToCentral => return Ok(()),
@@ -321,25 +294,9 @@ mod tests {
                     ..Default::default()
                 },
                 &Item,
-                &site(),
                 &source_site_stores,
             ),
             Err(ValidationError::CentralOnlyEditableByCentral)
-        );
-
-        // Sanity: source site is the central site itself.
-        assert_eq!(
-            validate_on_central(
-                &SyncBufferRow {
-                    store_id: Some("remote_store_a".into()),
-                    source_site_id: 1,
-                    ..Default::default()
-                },
-                &Stocktake,
-                &site(),
-                &source_site_stores,
-            ),
-            Err(ValidationError::SourceSiteIsCentral)
         );
 
         // Sync style: Remote — store_id must be active on the source site.
@@ -351,7 +308,6 @@ mod tests {
                     ..Default::default()
                 },
                 &Stocktake,
-                &site(),
                 &source_site_stores,
             ),
             Ok(())
@@ -365,7 +321,6 @@ mod tests {
                     ..Default::default()
                 },
                 &Stocktake,
-                &site(),
                 &source_site_stores,
             ),
             Err(ValidationError::StoreNotActiveOnSourceSite)
@@ -378,7 +333,6 @@ mod tests {
                     ..Default::default()
                 },
                 &Stocktake,
-                &site(),
                 &source_site_stores,
             ),
             Err(ValidationError::StoreNotActiveOnSourceSite)
@@ -390,14 +344,13 @@ mod tests {
                     ..Default::default()
                 },
                 &Stocktake,
-                &site(),
                 &source_site_stores,
             ),
             Err(ValidationError::NoStoreId)
         );
 
-        // Sync style: Remote+Transfer (Requisition) — accepted when transfer_store_id
-        // is active on the source site.
+        // Sync style: Remote+Transfer (Requisition) — transfer_store_id
+        // is not accepted as a store_id
         assert_eq!(
             validate_on_central(
                 &SyncBufferRow {
@@ -406,23 +359,9 @@ mod tests {
                     ..Default::default()
                 },
                 &Requisition,
-                &site(),
                 &source_site_stores,
             ),
-            Ok(())
-        );
-        assert_eq!(
-            validate_on_central(
-                &SyncBufferRow {
-                    transfer_store_id: Some("store_a".into()),
-                    source_site_id: 2,
-                    ..Default::default()
-                },
-                &Requisition,
-                &site(),
-                &source_site_stores,
-            ),
-            Err(ValidationError::TransferStoreNotActiveOnSourceSite)
+            Err(ValidationError::NoStoreId)
         );
 
         // Sync style: Patient — patient_id must be present; if store_id is set,
@@ -435,7 +374,6 @@ mod tests {
                     ..Default::default()
                 },
                 &Document,
-                &site(),
                 &source_site_stores,
             ),
             Ok(())
@@ -449,7 +387,6 @@ mod tests {
                     ..Default::default()
                 },
                 &Document,
-                &site(),
                 &source_site_stores,
             ),
             Ok(())
@@ -463,7 +400,6 @@ mod tests {
                     ..Default::default()
                 },
                 &Document,
-                &site(),
                 &source_site_stores,
             ),
             Err(ValidationError::StoreNotActiveOnSourceSite)
@@ -475,7 +411,6 @@ mod tests {
                     ..Default::default()
                 },
                 &Document,
-                &site(),
                 &source_site_stores,
             ),
             Err(ValidationError::NoPatientId)

--- a/server/service/src/sync_v7/validate_translate_integrate.rs
+++ b/server/service/src/sync_v7/validate_translate_integrate.rs
@@ -25,6 +25,7 @@ const PROGRESS_INTERVAL: i64 = 1000;
 pub(crate) enum SyncContext {
     Central {
         active_stores: ActiveStoresOnSite,
+        source_site_store_ids: Vec<String>,
     },
     Remote {
         is_initialising: bool,
@@ -145,9 +146,10 @@ fn validate_translate_integrate_one(
     let table_name = parse_table_name(&row.table_name)?;
 
     match sync_context {
-        SyncContext::Central { active_stores } => {
-            validate_on_central(row, &table_name, active_stores)?
-        }
+        SyncContext::Central {
+            active_stores,
+            source_site_store_ids,
+        } => validate_on_central(row, &table_name, active_stores, source_site_store_ids)?,
         SyncContext::Remote {
             is_initialising,
             active_stores,
@@ -286,6 +288,7 @@ fn validate_translate_integrate_inner<'a>(
 
         // Refresh active stores after any Store batch (upsert or delete)
         // so downstream Remote records validate against fresh state.
+        // Central path doesn't need refresh — Store rows are Central records
         if had_store_records {
             if let SyncContext::Remote {
                 is_initialising: _,

--- a/server/service/src/sync_v7/validate_translate_integrate.rs
+++ b/server/service/src/sync_v7/validate_translate_integrate.rs
@@ -149,7 +149,7 @@ fn validate_translate_integrate_one(
         SyncContext::Central {
             active_stores,
             source_site_store_ids,
-        } => validate_on_central(row, &table_name, active_stores, source_site_store_ids)?,
+        } => validate_on_central(row, &table_name, source_site_store_ids)?,
         SyncContext::Remote {
             is_initialising,
             active_stores,

--- a/server/service/src/sync_v7/validate_translate_integrate.rs
+++ b/server/service/src/sync_v7/validate_translate_integrate.rs
@@ -24,8 +24,7 @@ const PROGRESS_INTERVAL: i64 = 1000;
 
 pub(crate) enum SyncContext {
     Central {
-        active_stores: ActiveStoresOnSite,
-        source_site_store_ids: Vec<String>,
+        source_site_active_store_ids: Vec<String>,
     },
     Remote {
         is_initialising: bool,
@@ -147,8 +146,7 @@ fn validate_translate_integrate_one(
 
     match sync_context {
         SyncContext::Central {
-            active_stores,
-            source_site_store_ids,
+            source_site_active_store_ids: source_site_store_ids,
         } => validate_on_central(row, &table_name, source_site_store_ids)?,
         SyncContext::Remote {
             is_initialising,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11579 

# 👩🏻‍💻 What does this PR do?

Sync style fixes, and additional sanity checks as per comments in #11545 

- validate_on_central takes a list of stores active on the source site (fetched once per batch). Added helper ActiveStoresOnSite::store_ids_for_site.

validate_on_central now rejects:
- Remote/Transfer rows whose store_id/transfer_store_id is one of central's own stores.
- Remote/Transfer rows whose store doesn't belong to the source remote site (e.g. site A pushes a row referencing site B's store).
- Any row whose source_site_id equals central's own site id (central syncing from itself).
- Patient rows (Encounter/Vaccination) whose store_id doesn't belong to the source site.

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Tests pass

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

