### PR TITLE
#11587 Filter already-added ancillary items from picker

### DIFF
--- a/client/packages/system/src/Item/DetailView/Tabs/AncillarySupplies/AncillarySupplyModal.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/AncillarySupplies/AncillarySupplyModal.tsx
@@ -72,6 +72,7 @@ export const AncillarySupplyModal = ({
           draft={draft}
           updateDraft={updateDraft}
           principalItemId={item.id}
+          ancillaryItems={item.ancillaryItems}
           isEdit={!!existing}
         />
       </QueryParamsProvider>
@@ -82,15 +83,21 @@ export const AncillarySupplyModal = ({
 const AncillarySupplyForm = ({
   draft,
   principalItemId,
+  ancillaryItems,
   updateDraft,
   isEdit,
 }: {
   draft: DraftAncillaryItem;
   principalItemId: string;
+  ancillaryItems: AncillaryItemFragment[];
   isEdit: boolean;
   updateDraft: (update: Partial<DraftAncillaryItem>) => void;
 }) => {
   const t = useTranslation();
+  const excludedIds = [
+    principalItemId,
+    ...ancillaryItems.map(a => a.ancillaryItemId),
+  ];
 
   const labelSx = {
     fontWeight: 'bold',
@@ -114,7 +121,7 @@ const AncillarySupplyForm = ({
         disabled={isEdit}
         onChange={selected => updateDraft({ ancillaryItemId: selected?.id })}
         currentItemId={draft.ancillaryItemId ?? undefined}
-        filter={{ id: { notEqualAll: [principalItemId] } }}
+        filter={{ id: { notEqualAll: excludedIds } }}
       />
 
       <FormLabel sx={labelSx}>{t('label.ratio')}:</FormLabel>


### PR DESCRIPTION
Fixes #11587

# 👩🏻‍💻 What does this PR do?

On the item detail page, the "Ancillary Items" picker let you pick items already added as ancillaries, then failed to save with an untranslated error. The `StockItemSearchInput` filter only excluded the principal item itself.

This extends the `notEqualAll` filter to also exclude every `ancillaryItemId` already on `item.ancillaryItems`, matching the pattern used in outbound shipment / requisition line pickers.

## 💌 Any notes for the reviewer?

Single-file change in `AncillarySupplyModal.tsx`. Edit flow is unaffected (picker is `disabled` when editing).

# 🧪 Testing

- [ ] Catalogue → Items → any item → Ancillary Items section
- [ ] Add an ancillary item
- [ ] Click Add again → confirm the previously-added item is no longer in the dropdown
- [ ] Edit an existing ancillary item → picker still shows current selection (disabled)

# 📃 Documentation

- [ ] **No documentation required**: bug fix, no behaviour change beyond preventing an invalid selection