### PR TITLE
#11554 Fix React 19 render loops on inbound and prescription views

### DIFF
--- a/client/packages/common/src/index.ts
+++ b/client/packages/common/src/index.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { useShallow } from 'zustand/react/shallow';
 
 export {
   KBarProvider,
@@ -49,4 +50,4 @@ export * from './api';
 export * from './authentication';
 export * from './plugins';
 
-export { create };
+export { create, useShallow };

--- a/client/packages/common/src/ui/layout/tables/tableState/useColumnOrder.ts
+++ b/client/packages/common/src/ui/layout/tables/tableState/useColumnOrder.ts
@@ -6,6 +6,7 @@ import {
   MRT_StatefulTableOptions,
   MRT_TableOptions,
 } from 'material-react-table';
+import { isEqual } from '@common/utils';
 import { getSavedState, updateSavedState, differentOrUndefined } from './utils';
 import { ColumnDef } from '../types';
 import { useGlobalTableDefaults } from './useGlobalTableConfig';
@@ -73,8 +74,15 @@ export const useColumnOrder = <T extends MRT_RowData>(
   // expand column spliced in.
   useEffect(() => {
     const saved = getSavedState(tableId)?.columnOrder;
-    setState(withExpandColumn(saved ?? globalDefaults?.columnOrder ?? initial));
-  }, [initial, globalDefaults?.columnOrder, enableExpanding, withExpandColumn]);
+    const next = withExpandColumn(
+      saved ?? globalDefaults?.columnOrder ?? initial
+    );
+    // Bail out if the resulting order is content-equal to the previous —
+    // withExpandColumn returns a fresh array whenever it splices, so
+    // without this guard every effect run commits a new ref and triggers
+    // a render even when nothing has actually changed.
+    setState(prev => (isEqual(prev, next) ? prev : next));
+  }, [tableId, initial, globalDefaults?.columnOrder, enableExpanding, withExpandColumn]);
 
   const update = useCallback<
     NonNullable<MRT_TableOptions<MRT_RowData>['onColumnOrderChange']>

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
@@ -7,8 +7,8 @@ import {
   ModalMode,
   useNotification,
   InvoiceNodeStatus,
+  useShallow,
 } from '@openmsupply-client/common';
-import { useShallow } from 'zustand/react/shallow';
 import { ScannedBarcode } from '../../../types';
 import { SelectItem } from './SelectItem';
 import { Allocation } from './Allocation';

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
@@ -8,6 +8,7 @@ import {
   useNotification,
   InvoiceNodeStatus,
 } from '@openmsupply-client/common';
+import { useShallow } from 'zustand/react/shallow';
 import { ScannedBarcode } from '../../../types';
 import { SelectItem } from './SelectItem';
 import { Allocation } from './Allocation';
@@ -68,10 +69,17 @@ export const OutboundLineEdit = ({
     isDirty,
     setAlerts,
     clear,
-  } = useAllocationContext(state => ({
-    ...state,
-    allocatedQuantity: getAllocatedQuantity(state),
-  }));
+  } = useAllocationContext(
+    useShallow(state => ({
+      draftLines: state.draftLines,
+      allocatedQuantity: getAllocatedQuantity(state),
+      placeholderUnits: state.placeholderUnits,
+      alerts: state.alerts,
+      isDirty: state.isDirty,
+      setAlerts: state.setAlerts,
+      clear: state.clear,
+    }))
+  );
 
   const onSave = async () => {
     if (!isDirty) return;

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
@@ -12,6 +12,7 @@ import {
   useSimpleMaterialTable,
   DateUtils,
 } from '@openmsupply-client/common';
+import { useShallow } from 'zustand/react/shallow';
 import { useOutboundLineEditColumns } from './columns';
 import { CurrencyRowFragment } from '@openmsupply-client/system';
 import {
@@ -44,24 +45,31 @@ export const OutboundLineEditTable = ({
     item,
     manualAllocate,
     setVvmStatus,
-  } = useAllocationContext(state => {
-    const { placeholderUnits, item, allocateIn } = state;
+  } = useAllocationContext(
+    useShallow(state => {
+      const { placeholderUnits, item, allocateIn } = state;
 
-    const inDoses = allocateIn.type === AllocateInType.Doses;
-    return {
-      ...state,
-      // In packs & units: we show totals in units
-      // In doses: we show totals in doses
-      allocatedQuantity: getAllocatedQuantity({
+      const inDoses = allocateIn.type === AllocateInType.Doses;
+      return {
         draftLines: state.draftLines,
-        allocateIn: inDoses ? allocateIn : { type: AllocateInType.Units },
-      }),
-      placeholderQuantity:
-        placeholderUnits !== null && inDoses
-          ? (placeholderUnits ?? 0) * (item?.doses || 1)
-          : placeholderUnits,
-    };
-  });
+        nonAllocatableLines: state.nonAllocatableLines,
+        allocateIn,
+        item,
+        manualAllocate: state.manualAllocate,
+        setVvmStatus: state.setVvmStatus,
+        // In packs & units: we show totals in units
+        // In doses: we show totals in doses
+        allocatedQuantity: getAllocatedQuantity({
+          draftLines: state.draftLines,
+          allocateIn: inDoses ? allocateIn : { type: AllocateInType.Units },
+        }),
+        placeholderQuantity:
+          placeholderUnits !== null && inDoses
+            ? (placeholderUnits ?? 0) * (item?.doses || 1)
+            : placeholderUnits,
+      };
+    })
+  );
 
   const getIsDisabled = useCallback(
     (row: DraftStockOutLineFragment) => {

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
@@ -11,8 +11,8 @@ import {
   MaterialTable,
   useSimpleMaterialTable,
   DateUtils,
+  useShallow,
 } from '@openmsupply-client/common';
-import { useShallow } from 'zustand/react/shallow';
 import { useOutboundLineEditColumns } from './columns';
 import { CurrencyRowFragment } from '@openmsupply-client/system';
 import {

--- a/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
@@ -8,9 +8,8 @@ import {
   useConfirmOnLeaving,
   useNavigate,
   useParams,
+  useShallow,
 } from '@openmsupply-client/common';
-
-import { useShallow } from 'zustand/react/shallow';
 import { ItemRowFragment, ListItems } from '@openmsupply-client/system';
 import { AppRoute } from '@openmsupply-client/config';
 import { PageLayout } from './PageLayout';

--- a/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
@@ -10,6 +10,7 @@ import {
   useParams,
 } from '@openmsupply-client/common';
 
+import { useShallow } from 'zustand/react/shallow';
 import { ItemRowFragment, ListItems } from '@openmsupply-client/system';
 import { AppRoute } from '@openmsupply-client/config';
 import { PageLayout } from './PageLayout';
@@ -35,10 +36,17 @@ export const PrescriptionLineEditView = () => {
     note,
     allocatedQuantity,
     setIsDirty: setAllocationIsDirty,
-  } = useAllocationContext(state => ({
-    ...state,
-    allocatedQuantity: getAllocatedQuantity(state),
-  }));
+  } = useAllocationContext(
+    useShallow(state => ({
+      isDirty: state.isDirty,
+      draftLines: state.draftLines,
+      item: state.item,
+      prescribedUnits: state.prescribedUnits,
+      note: state.note,
+      allocatedQuantity: getAllocatedQuantity(state),
+      setIsDirty: state.setIsDirty,
+    }))
+  );
 
   const {
     mutateAsync: savePrescriptionItemLineData,

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditTable.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditTable.tsx
@@ -9,11 +9,11 @@ import {
   usePreferences,
   DateUtils,
 } from '@openmsupply-client/common';
+import { useShallow } from 'zustand/react/shallow';
 
 import { usePrescriptionLineEditColumns } from './columns';
 import {
   DraftStockOutLineFragment,
-  getAllocatedQuantity,
   useAllocationContext,
 } from '../../StockOut';
 
@@ -27,11 +27,16 @@ export const PrescriptionLineEditTable = ({
   const t = useTranslation();
   const { format } = useFormatNumber();
   const prefs = usePreferences();
+  // Select only the fields actually used. Spreading the whole state into the
+  // selector returns a fresh object every call, which under React 19's stricter
+  // useSyncExternalStore snapshot caching causes an infinite re-render loop.
   const { draftLines, allocateIn, item, manualAllocate } = useAllocationContext(
-    state => ({
-      ...state,
-      allocatedQuantity: getAllocatedQuantity(state),
-    })
+    useShallow(state => ({
+      draftLines: state.draftLines,
+      allocateIn: state.allocateIn,
+      item: state.item,
+      manualAllocate: state.manualAllocate,
+    }))
   );
 
   const allocate = (key: string, value: number) => {

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditTable.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditTable.tsx
@@ -8,8 +8,8 @@ import {
   useSimpleMaterialTable,
   usePreferences,
   DateUtils,
+  useShallow,
 } from '@openmsupply-client/common';
-import { useShallow } from 'zustand/react/shallow';
 
 import { usePrescriptionLineEditColumns } from './columns';
 import {

--- a/client/packages/invoices/src/StockOut/Components/AllocateInSelector.tsx
+++ b/client/packages/invoices/src/StockOut/Components/AllocateInSelector.tsx
@@ -6,8 +6,8 @@ import {
   useIntlUtils,
   useFormatNumber,
   Typography,
+  useShallow,
 } from '@openmsupply-client/common';
-import { useShallow } from 'zustand/react/shallow';
 import { AllocateInType, useAllocationContext } from '../useAllocationContext';
 import { canAutoAllocate } from '../utils';
 

--- a/client/packages/invoices/src/StockOut/Components/AllocateInSelector.tsx
+++ b/client/packages/invoices/src/StockOut/Components/AllocateInSelector.tsx
@@ -7,6 +7,7 @@ import {
   useFormatNumber,
   Typography,
 } from '@openmsupply-client/common';
+import { useShallow } from 'zustand/react/shallow';
 import { AllocateInType, useAllocationContext } from '../useAllocationContext';
 import { canAutoAllocate } from '../utils';
 
@@ -23,20 +24,22 @@ export const AllocateInSelector = ({
     usePreferences();
 
   const { allocateIn, availablePackSizes, setAllocateIn, item } =
-    useAllocationContext(({ allocateIn, draftLines, item, setAllocateIn }) => ({
-      item,
-      allocateIn,
-      setAllocateIn,
-      availablePackSizes: [
-        ...new Set(
-          draftLines
-            .filter(line =>
-              canAutoAllocate(line, expiredStockIssueThreshold ?? 0)
-            )
-            .map(line => line.packSize)
-        ),
-      ].sort((a, b) => a - b),
-    }));
+    useAllocationContext(
+      useShallow(({ allocateIn, draftLines, item, setAllocateIn }) => ({
+        item,
+        allocateIn,
+        setAllocateIn,
+        availablePackSizes: [
+          ...new Set(
+            draftLines
+              .filter(line =>
+                canAutoAllocate(line, expiredStockIssueThreshold ?? 0)
+              )
+              .map(line => line.packSize)
+          ),
+        ].sort((a, b) => a - b),
+      }))
+    );
 
   const unitName = item?.unitName ?? t('label.unit');
   const pluralisedUnitName = getPlural(unitName, 2);

--- a/client/packages/invoices/src/StockOut/Components/AutoAllocationAlerts.tsx
+++ b/client/packages/invoices/src/StockOut/Components/AutoAllocationAlerts.tsx
@@ -3,9 +3,7 @@ import { Alert, Grid } from '@openmsupply-client/common';
 import { useAllocationContext } from '../useAllocationContext';
 
 export const AutoAllocationAlerts = () => {
-  const { alerts } = useAllocationContext(({ alerts }) => ({
-    alerts,
-  }));
+  const alerts = useAllocationContext(state => state.alerts);
   if (alerts.length === 0) return null;
 
   return (


### PR DESCRIPTION
Fixes #11554

# 👩🏻‍💻 What does this PR do?

Fixes two infinite render loops introduced by the React 19 upgrade:

1. **Inbound shipment detail view** — `useColumnOrder`'s effect committed a fresh array reference every run (because `withExpandColumn` returns a new array whenever it splices in `mrt-row-expand`). When anything upstream caused the effect's deps to flip, it cascaded into a loop that React 19's stricter commit-phase guard catches as "Maximum update depth exceeded" inside `MRT_TableContainer`. Added a content-equality bail-out in the effect.

2. **Prescription / outbound line edit views** — Zustand `useAllocationContext` selectors of the shape `state => ({ ...state, allocatedQuantity })` return a fresh object every call. Under React 19's stricter `useSyncExternalStore` snapshot caching, this trips infinite re-renders. Wrapped the four spreading selectors (plus `AllocateInSelector`, which returns a fresh sorted array) with `useShallow`. Simplified `AutoAllocationAlerts` to a single-field selector.

## 💌 Any notes for the reviewer?

- Other `useAllocationContext` selectors that return closed lists of fields are technically wasteful (they re-render on every store change) but don't loop in practice — left as a followup rather than expanding the diff.
- The `useColumnOrder` fix is in shared table code, but only inbound shipments triggers it today because of upstream context churn specific to that view.

# 🧪 Testing

- [ ] Open Replenishment → Inbound Shipments → click into an existing shipment — no console error, page renders
- [ ] Create a new inbound shipment — no console error
- [ ] Open Dispensary → Prescriptions → click into a prescription → click into an individual line — no console error
- [ ] Open an outbound shipment → open a line edit modal — no console error
- [ ] Allocation behaviour (auto allocate, manual allocate, pack-size selector, alerts) still works correctly

# 📃 Documentation

- [x] **No documentation required**: bug fix, no behavioural change