### PR TITLE
#11608 Initialize rustls-platform-verifier on Android (fix forward)

### DIFF
--- a/client/packages/android/app/build.gradle
+++ b/client/packages/android/app/build.gradle
@@ -90,6 +90,31 @@ repositories {
     flatDir{
         dirs '../capacitor-cordova-android-plugins/src/main/libs', 'libs'
     }
+    // rustls-platform-verifier needs a small Kotlin component bundled with the app.
+    // The AAR is shipped inside the rustls-platform-verifier-android crate; locate it
+    // via `cargo metadata` so it stays in sync with the Rust dependency version.
+    maven {
+        url = findRustlsPlatformVerifierProject()
+        metadataSources.artifact()
+    }
+}
+
+String findRustlsPlatformVerifierProject() {
+    // Android Studio's Gradle process doesn't inherit the shell PATH, so resolve cargo
+    // explicitly from CARGO_HOME (defaults to ~/.cargo) or fall back to a `which`-style lookup.
+    def cargoHome = System.getenv("CARGO_HOME") ?: "${System.getProperty('user.home')}/.cargo"
+    def cargoBin = "$cargoHome/bin/cargo"
+    if (!file(cargoBin).exists()) {
+        cargoBin = "cargo"
+    }
+
+    def dependencyText = providers.exec {
+        commandLine(cargoBin, "metadata", "--format-version", "1", "--filter-platform", "aarch64-linux-android", "--manifest-path", "$rootDir/../../../server/android/Cargo.toml")
+    }.standardOutput.asText.get()
+
+    def dependencyJson = new JsonSlurper().parseText(dependencyText)
+    def manifestPath = file(dependencyJson.packages.find { it.name == "rustls-platform-verifier-android" }.manifest_path)
+    return new File(manifestPath.parentFile, "maven").path
 }
 
 // Exclude the unbundled Play Services barcode scanning dependency
@@ -114,6 +139,11 @@ dependencies {
     // Use bundled MLKit barcode scanning instead of unbundled Play Services version
     // This bundles the model with the app, avoiding runtime downloads
     implementation 'com.google.mlkit:barcode-scanning:17.3.0'
+
+    // Companion Kotlin classes for rustls-platform-verifier — required for outbound HTTPS
+    // (sync to the central server). Without this the verifier fails with
+    // "failed to call native verifier".
+    implementation 'rustls:rustls-platform-verifier:latest.release'
 }
 
 apply from: 'capacitor.build.gradle'

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/MainActivity.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/MainActivity.java
@@ -49,7 +49,7 @@ public class MainActivity extends BridgeActivity {
 
         String path = getFilesDir().getAbsolutePath();
         String cache = getCacheDir().getAbsolutePath();
-        server.start(discoveryConstants.PORT, path, cache, discoveryConstants.hardwareId);
+        server.start(discoveryConstants.PORT, path, cache, discoveryConstants.hardwareId, getApplicationContext());
     }
 
     @Override

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/RemoteServer.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/RemoteServer.java
@@ -1,5 +1,7 @@
 package org.openmsupply.client;
 
+import android.content.Context;
+
 import com.getcapacitor.Logger;
 
 public class RemoteServer {
@@ -13,9 +15,9 @@ public class RemoteServer {
 
     }
 
-    public void start(int port, String filesDir, String cacheDir, String androidId) {
+    public void start(int port, String filesDir, String cacheDir, String androidId, Context context) {
         Logger.info("Starting OMS Rust Server");
-        startServer(port, filesDir, cacheDir, androidId);
+        startServer(port, filesDir, cacheDir, androidId, context);
     }
 
     public void stop() {
@@ -23,7 +25,8 @@ public class RemoteServer {
     }
 
     // Mapping to methods in server/android/src/android.lib
-    private static native void startServer(int port, String filesDir, String cacheDir, String androidId);
+    // The Context is required to initialise rustls-platform-verifier for outbound HTTPS.
+    private static native void startServer(int port, String filesDir, String cacheDir, String androidId, Context context);
 
     private static native void stopServer();
 }

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -636,6 +636,7 @@ dependencies = [
  "once_cell",
  "rcgen",
  "repository",
+ "rustls-platform-verifier",
  "server",
  "service",
  "simple-log",
@@ -8824,9 +8825,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -9213,13 +9214,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni 0.21.1",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls 0.23.37",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4.29"
 pretty_assertions = "1.4.1"
 rcgen = "0.14.7"
 regex = "1.12.3"
-reqwest = { version = "0.13.2", features = [
+reqwest = { version = "0.13.3", features = [
   "gzip",
   "json",
   "query",

--- a/server/android/Cargo.toml
+++ b/server/android/Cargo.toml
@@ -17,6 +17,7 @@ log-panics = { workspace = true }
 once_cell = "1.21.4"
 rcgen = { workspace = true }
 repository = { path = "../repository" }
+rustls-platform-verifier = "0.7.0"
 service = { path = "../service" }
 server = { path = "../server", default-features = false, features = [
     "android",

--- a/server/android/src/android.rs
+++ b/server/android/src/android.rs
@@ -43,6 +43,8 @@ pub mod android {
                 // call so the workspace still compiles on non-Android hosts in CI.
                 #[cfg(target_os = "android")]
                 rustls_platform_verifier::android::init_with_env(env, context)?;
+                #[cfg(not(target_os = "android"))]
+                let _ = &context;
 
                 let files_dir = files_dir.try_to_string(env)?;
                 let android_id = android_id.try_to_string(env)?;

--- a/server/android/src/android.rs
+++ b/server/android/src/android.rs
@@ -13,7 +13,7 @@ pub mod android {
     use tokio::sync::mpsc;
 
     use self::jni::errors::LogErrorAndDefault;
-    use self::jni::objects::{JClass, JString};
+    use self::jni::objects::{JClass, JObject, JString};
     use self::jni::EnvUnowned;
 
     struct ServerBucket {
@@ -31,10 +31,16 @@ pub mod android {
         files_dir: JString,
         cache_dir: JString,
         android_id: JString,
+        context: JObject,
     ) {
         let (off_switch, off_switch_receiver) = mpsc::channel(1);
         let (files_dir, android_id, cache_dir) = unowned_env
             .with_env(|env| -> Result<_, jni::errors::Error> {
+                // rustls-platform-verifier needs the Android Context before any TLS
+                // handshake. Without this, outbound HTTPS (e.g. sync to the central
+                // server) panics with "Expect rustls-platform-verifier to be initialized".
+                rustls_platform_verifier::android::init_with_env(env, context)?;
+
                 let files_dir = files_dir.try_to_string(env)?;
                 let android_id = android_id.try_to_string(env)?;
                 let cache_dir = cache_dir.try_to_string(env)?;

--- a/server/android/src/android.rs
+++ b/server/android/src/android.rs
@@ -39,6 +39,9 @@ pub mod android {
                 // rustls-platform-verifier needs the Android Context before any TLS
                 // handshake. Without this, outbound HTTPS (e.g. sync to the central
                 // server) panics with "Expect rustls-platform-verifier to be initialized".
+                // The `android` module is cfg-gated by the upstream crate, so guard the
+                // call so the workspace still compiles on non-Android hosts in CI.
+                #[cfg(target_os = "android")]
                 rustls_platform_verifier::android::init_with_env(env, context)?;
 
                 let files_dir = files_dir.try_to_string(env)?;


### PR DESCRIPTION
Fixes #11608 on develop. The 2.18.1 hotfix is #11612, which just reverts the reqwest dependency change for a minimal, safer fix in the release branch.

## Summary

The reqwest 0.13 upgrade in #10928 pulled in `rustls-platform-verifier` as a transitive dependency. On Android that crate requires a one-time `init_with_env(env, context)` JNI call plus a bundled Kotlin AAR before any TLS handshake; neither was wired up when the dependency landed, so Android tablets panic with `Expect rustls-platform-verifier to be initialized` the moment they try to contact a central server during initialise.

This PR is Option A from the issue — wire the verifier in properly. Targeted at `develop` so the reqwest upgrade can stay; the 2.18.1 release branch gets the simpler revert instead.

## Changes

- **`server/Cargo.toml`** — bump reqwest `0.13.2` → `0.13.3`. 0.13.3 widens its `rustls-platform-verifier` range to `>=0.6.0, <0.8.0`, which lets Cargo unify on the 0.7.0 we add directly. Without this bump we end up with two copies of the crate in the binary (the 0.6.2 used by reqwest and the 0.7.0 we initialise), and reqwest's HTTPS calls still panic.
- **`server/android/Cargo.toml`** — add `rustls-platform-verifier = "0.7.0"` as a direct dependency so we can call its init API.
- **`server/android/src/android.rs`** — extend the `startServer` JNI signature with an Android `Context`, and call `rustls_platform_verifier::android::init_with_env(env, context)` from inside the existing `with_env` block before the server thread is spawned. The call is `cfg(target_os = "android")`-gated because the upstream `android` module only exists on Android, and a paired `let _ = &context;` silences the unused-variable warning on non-Android hosts.
- **`client/.../RemoteServer.java`** + **`MainActivity.java`** — thread the application Context through `RemoteServer.start(...)` into the native call.
- **`client/.../app/build.gradle`** — add a Maven repo that points at the AAR shipped inside the `rustls-platform-verifier-android` crate (located dynamically via `cargo metadata`) and pull it in as an `implementation` dependency. `cargo` is resolved via `$CARGO_HOME/bin/cargo` because Android Studio's Gradle process doesn't inherit the shell PATH.

## Test plan

- [x] Initialise an Android tablet against an HTTPS central server — no longer panics, the connection succeeds
- [ ] Initialise an Android tablet against an HTTP central server (sanity check)
- [ ] Verify desktop sync still works (regression check on the reqwest minor bump)
- [ ] Verify `cargo` resolution in `app/build.gradle` works when `CARGO_HOME` is set vs unset