### PR TITLE
#11608 Revert reqwest upgrade in 2.18.1 to unblock Android initialise

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2090,7 +2090,7 @@ dependencies = [
  "machine-uid",
  "report_builder",
  "repository",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yml",
@@ -4609,7 +4609,7 @@ dependencies = [
  "log",
  "ordered-float 5.1.0",
  "repository",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "service",
@@ -4676,7 +4676,7 @@ dependencies = [
  "graphql_types",
  "http 1.4.0",
  "repository",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "service",
@@ -5545,6 +5545,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -6345,7 +6346,7 @@ dependencies = [
  "referencing",
  "regex",
  "regex-syntax",
- "reqwest",
+ "reqwest 0.13.2",
  "rustls 0.23.37",
  "serde",
  "serde_json",
@@ -8380,7 +8381,6 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -8767,7 +8767,7 @@ dependencies = [
  "clap",
  "log",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -8805,6 +8805,47 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.2",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -8823,16 +8864,13 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime_guess",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls 0.23.37",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -9707,7 +9745,7 @@ dependencies = [
  "rand 0.10.0",
  "regex",
  "repository",
- "reqwest",
+ "reqwest 0.12.28",
  "rsa",
  "rust-embed",
  "schemafy",
@@ -11428,7 +11466,7 @@ dependencies = [
  "env_logger",
  "fs-lock",
  "log",
- "reqwest",
+ "reqwest 0.12.28",
  "sanitize-filename",
  "serde",
  "serde_json",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -19,11 +19,10 @@ log = "0.4.29"
 pretty_assertions = "1.4.1"
 rcgen = "0.14.7"
 regex = "1.12.3"
-reqwest = { version = "0.13.2", features = [
+reqwest = { version = "0.12.22", features = [
   "gzip",
   "json",
-  "query",
-  "rustls",
+  "rustls-tls",
   "multipart",
   "blocking",
 ], default-features = false }


### PR DESCRIPTION
Hotfix for #11608. Companion to #11609 which carries the proper fix on develop for 2.19.

## Why a revert for 2.18.1?

The smallest possible change for the release branch. #10928 upgraded reqwest 0.12 → 0.13 and switched the TLS feature from \`rustls-tls\` to \`rustls\`. In 0.13 the \`rustls\` feature pulls in \`rustls-platform-verifier\`, which on Android needs JNI initialisation plus a bundled Kotlin AAR — none of which was wired up. The result is Android tablets panicking with \`Expect rustls-platform-verifier to be initialized\` the moment they hit Initialise.

Wiring the verifier in properly is invasive (touches the Rust JNI layer, Java code, and Gradle config). For a hotfix release we instead revert to the working pre-upgrade reqwest configuration; develop will carry the full fix.

## Changes

- **\`server/Cargo.toml\`** — reqwest \`0.13.2\` → \`0.12.22\`, TLS feature \`rustls\` → \`rustls-tls\`, drop the \`query\` feature (only exists in 0.13). This restores the previously working configuration where reqwest bundles webpki roots and needs no platform integration on Android.
- **\`server/Cargo.lock\`** — regenerated.

## Test plan

- [x] Initialise an Android tablet against an HTTPS central server — no longer panics
- [ ] Verify desktop sync still works (regression check on the reqwest minor revert)
- [ ] Verify no other workspace crate broke from missing \`query\` reqwest feature