### PR TITLE
11599 Add log file download button to initialisation screen and change timeout method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ server/configuration/*.yaml
 # Keep the example and base configuration files
 !configuration/base.yaml
 !configuration/example.yaml
+server/target-postgres/

--- a/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
+++ b/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
@@ -103,14 +103,13 @@ export const useNativeClient = ({
     nativeAPI.startServerDiscovery();
   }, [discovery, nativeAPI]);
 
-  const readLog = async () => {
-    const noResult = 'log unavailable';
+  const readLog = async (): Promise<string | null> => {
     const result = await nativeAPI?.readLog();
 
-    if (!result) return noResult;
+    if (!result) return null;
     if (result.error) console.error(result.error);
 
-    return result.log || noResult;
+    return result.log || null;
   };
 
   const allowSleep = async () => {

--- a/client/packages/host/src/components/Initialise/Initialise.tsx
+++ b/client/packages/host/src/components/Initialise/Initialise.tsx
@@ -46,19 +46,12 @@ export const Initialise = () => {
 
   const onSaveLog = async () => {
     if (!isAndroid) return;
-
-    try {
-      const log = await nativeClient.readLog();
-
-      if (!log?.trim()) {
-        warning(t('error.unable-to-load-server-log'))();
-        return;
-      }
-
-      await exportLog(log, 'remote_server');
-    } catch (error) {
+    const log = await nativeClient.readLog();
+    if (!log?.trim()) {
       warning(t('error.unable-to-load-server-log'))();
+      return;
     }
+    await exportLog(log, 'remote_server');
   };
 
   const syncError =

--- a/client/packages/host/src/components/Initialise/Initialise.tsx
+++ b/client/packages/host/src/components/Initialise/Initialise.tsx
@@ -46,12 +46,19 @@ export const Initialise = () => {
 
   const onSaveLog = async () => {
     if (!isAndroid) return;
-    const log = await nativeClient.readLog();
-    if (!log || log === 'log unavailable') {
+
+    try {
+      const log = await nativeClient.readLog();
+
+      if (!log?.trim()) {
+        warning(t('error.unable-to-load-server-log'))();
+        return;
+      }
+
+      await exportLog(log, 'remote_server');
+    } catch (error) {
       warning(t('error.unable-to-load-server-log'))();
-      return;
     }
-    await exportLog(log, 'remote_server');
   };
 
   const syncError =

--- a/client/packages/host/src/components/Initialise/Initialise.tsx
+++ b/client/packages/host/src/components/Initialise/Initialise.tsx
@@ -5,6 +5,12 @@ import {
   useHostContext,
   SaveIcon,
   BoxedErrorWithDetails,
+  useNativeClient,
+  useExportLog,
+  useNotification,
+  EnvUtils,
+  Platform,
+  MuiLink,
 } from '@openmsupply-client/common';
 import { LoginTextInput } from '../Login/LoginTextInput';
 import { InitialiseLayout } from './InitialiseLayout';
@@ -16,6 +22,10 @@ import { mapSyncError } from 'packages/system/src';
 export const Initialise = () => {
   const t = useTranslation();
   const { setPageTitle } = useHostContext();
+  const nativeClient = useNativeClient();
+  const exportLog = useExportLog();
+  const { warning } = useNotification();
+  const isAndroid = EnvUtils.platform === Platform.Android;
 
   const {
     isValid,
@@ -33,6 +43,16 @@ export const Initialise = () => {
     syncStatus,
     siteName,
   } = useInitialiseForm();
+
+  const onSaveLog = async () => {
+    if (!isAndroid) return;
+    const log = await nativeClient.readLog();
+    if (!log || log === 'log unavailable') {
+      warning(t('error.unable-to-load-server-log'))();
+      return;
+    }
+    await exportLog(log, 'remote_server');
+  };
 
   const syncError =
     syncStatus?.error &&
@@ -118,6 +138,19 @@ export const Initialise = () => {
         if (isValid) await onInitialise();
       }}
       SiteInfo={<SiteInfo siteName={siteName} />}
+      SaveLogLink={
+        isAndroid ? (
+          <MuiLink
+            component="button"
+            type="button"
+            onClick={onSaveLog}
+            underline="hover"
+            sx={{ fontSize: '0.8rem', color: 'gray.main' }}
+          >
+            {t('button.save-log')}
+          </MuiLink>
+        ) : undefined
+      }
     />
   );
 };

--- a/client/packages/host/src/components/Initialise/InitialiseLayout.tsx
+++ b/client/packages/host/src/components/Initialise/InitialiseLayout.tsx
@@ -20,6 +20,7 @@ type LoginLayoutProps = {
   ErrorMessage: ReactNode;
   SyncErrorMessage: ReactNode;
   SiteInfo: React.ReactNode;
+  SaveLogLink?: ReactNode;
   onInitialise: () => Promise<void>;
 };
 
@@ -31,6 +32,7 @@ export const InitialiseLayout = ({
   ErrorMessage,
   SyncProgress,
   SiteInfo,
+  SaveLogLink,
   SyncErrorMessage,
   onInitialise,
 }: LoginLayoutProps) => {
@@ -159,6 +161,11 @@ export const InitialiseLayout = ({
             {SyncErrorMessage}
           </Box>
         </Box>
+        {SaveLogLink && (
+          <Box display="flex" justifyContent="center" sx={{ opacity: 0.6 }}>
+            {SaveLogLink}
+          </Box>
+        )}
         <Box>
           <AppVersion style={{ opacity: 0.4 }} SiteInfo={SiteInfo} />
         </Box>

--- a/server/service/src/sync/api/core.rs
+++ b/server/service/src/sync/api/core.rs
@@ -210,7 +210,7 @@ pub enum ParsingResponseError {
 pub(crate) async fn to_json<T: DeserializeOwned>(
     response: Response,
 ) -> Result<T, ParsingResponseError> {
-    let url = response.url().to_string();
+    let url = util::redact_url_for_log(response.url());
     let started = std::time::Instant::now();
     // TODO not owned (to avoid double parsing)
     let response_text = response.text().await?;

--- a/server/service/src/sync/api/core.rs
+++ b/server/service/src/sync/api/core.rs
@@ -210,8 +210,20 @@ pub enum ParsingResponseError {
 pub(crate) async fn to_json<T: DeserializeOwned>(
     response: Response,
 ) -> Result<T, ParsingResponseError> {
+    let url = response.url().to_string();
+    let started = std::time::Instant::now();
     // TODO not owned (to avoid double parsing)
     let response_text = response.text().await?;
+    let elapsed = started.elapsed();
+    let bytes = response_text.len();
+    let kb_per_sec = (bytes as f64 / 1024.0) / elapsed.as_secs_f64().max(0.001);
+    log::info!(
+        "API body read: url '{}', {} bytes in {:.1}s ({:.1} KB/s)",
+        url,
+        bytes,
+        elapsed.as_secs_f64(),
+        kb_per_sec,
+    );
     let result = serde_json::from_str(&response_text).map_err(|source| {
         ParsingResponseError::ParseError {
             source,

--- a/server/service/src/sync/api_v6/mod.rs
+++ b/server/service/src/sync/api_v6/mod.rs
@@ -239,11 +239,23 @@ async fn response_or_err<T: DeserializeOwned>(
         }
     };
 
+    let url = response.url().to_string();
+    let started = std::time::Instant::now();
     // Not checking for status, expecting 200 only, even if there is error
     let response_text = response
         .text()
         .await
         .map_err(ParsingResponseError::CannotGetTextResponse)?;
+    let elapsed = started.elapsed();
+    let bytes = response_text.len();
+    let kb_per_sec = (bytes as f64 / 1024.0) / elapsed.as_secs_f64().max(0.001);
+    log::info!(
+        "API body read: url '{}', {} bytes in {:.1}s ({:.1} KB/s)",
+        url,
+        bytes,
+        elapsed.as_secs_f64(),
+        kb_per_sec,
+    );
 
     let result = serde_json::from_str(&response_text).map_err(|source| {
         ParsingResponseError::ParseError {

--- a/server/service/src/sync/api_v6/mod.rs
+++ b/server/service/src/sync/api_v6/mod.rs
@@ -239,7 +239,7 @@ async fn response_or_err<T: DeserializeOwned>(
         }
     };
 
-    let url = response.url().to_string();
+    let url = util::redact_url_for_log(response.url());
     let started = std::time::Instant::now();
     // Not checking for status, expecting 200 only, even if there is error
     let response_text = response

--- a/server/util/src/api_helper.rs
+++ b/server/util/src/api_helper.rs
@@ -12,12 +12,11 @@ impl Default for RetrySeconds {
     }
 }
 
-// If a request burns more than this on a single attempt and times out, do not
-// retry it — the overall request timeout has effectively been hit and another
-// 30-minute attempt is unlikely to succeed where the first didn't, and we don't
-// want a single sync to block for ~90 minutes. Fast timeouts (connect-phase,
-// kernel TCP retransmit, etc.) still retry as before.
-const SLOW_TIMEOUT_RETRY_CUTOFF: Duration = Duration::from_secs(60 * 25);
+// Idle read timeout: abort if no bytes arrive on the response for this long.
+// Replaces the previous 30-minute wall-clock cap so legitimate large pulls
+// (which can exceed 30 min on low bandwidth) still succeed as long as the
+// connection is making progress; a genuinely stalled socket still fails fast.
+const READ_IDLE_TIMEOUT: Duration = Duration::from_secs(60 * 5);
 
 pub async fn with_retries<F>(connection_timeouts: RetrySeconds, f: F) -> Result<Response>
 where
@@ -27,9 +26,7 @@ where
     loop {
         let client = Client::builder()
             .connect_timeout(Duration::from_secs(connection_timeouts.0[index]))
-            // generous because some sync records may have big payloads like reports that take a long time to sync on low bandwidth
-            // we also had issues with batch size = 500 taking more then 5 minutes to generate during testing, maybe due to 4d flushing
-            .timeout(Duration::from_secs(60 * 30))
+            .read_timeout(READ_IDLE_TIMEOUT)
             .build()
             .unwrap(); // This method fails if a TLS backend cannot be initialized, or the resolver cannot load the system configuration.
 
@@ -72,7 +69,7 @@ where
                 let kind = if is_connect_error {
                     "connection error"
                 } else if is_timeout_error {
-                    "request timeout"
+                    "idle timeout"
                 } else {
                     "request error"
                 };
@@ -80,11 +77,24 @@ where
             }
         };
 
-        let timeout_was_slow = is_timeout_error && elapsed >= SLOW_TIMEOUT_RETRY_CUTOFF;
         let will_retry = (is_connect_error
-            || (is_timeout_error && !timeout_was_slow)
+            || is_timeout_error
             || status == Some(StatusCode::REQUEST_TIMEOUT))
             && (index + 1) < connection_timeouts.0.len();
+
+        if let Ok(response) = result.as_ref() {
+            let content_length_display = response
+                .content_length()
+                .map(|n| format!("{} bytes", n))
+                .unwrap_or_else(|| "unknown".to_string());
+            log::info!(
+                "API response: url '{}', status {}, content-length {}, headers in {:.1}s",
+                response.url(),
+                response.status().as_u16(),
+                content_length_display,
+                elapsed.as_secs_f64(),
+            );
+        }
 
         if let Some(failure) = attempt_failure {
             let url_display = url.as_deref().unwrap_or("<unknown>");

--- a/server/util/src/api_helper.rs
+++ b/server/util/src/api_helper.rs
@@ -2,6 +2,16 @@ use std::time::{Duration, Instant};
 
 use reqwest::*;
 
+/// Returns the URL with the query string and fragment stripped, so it can be
+/// safely written to logs. Some endpoints (e.g. PatientApiV4) include patient
+/// names, DOB, policy number, etc. in the query string — never log those.
+pub fn redact_url_for_log(url: &Url) -> String {
+    let mut redacted = url.clone();
+    redacted.set_query(None);
+    redacted.set_fragment(None);
+    redacted.to_string()
+}
+
 pub struct RetrySeconds(Vec<u64>);
 
 impl Default for RetrySeconds {
@@ -49,12 +59,17 @@ where
         let elapsed = started.elapsed();
 
         let (status, is_connect_error, is_timeout_error, url) = match result.as_ref() {
-            Ok(r) => (Some(r.status()), false, false, Some(r.url().to_string())),
+            Ok(r) => (
+                Some(r.status()),
+                false,
+                false,
+                Some(redact_url_for_log(r.url())),
+            ),
             Err(e) => (
                 e.status(),
                 e.is_connect(),
                 e.is_timeout(),
-                e.url().map(|u| u.to_string()),
+                e.url().map(redact_url_for_log),
             ),
         };
 
@@ -77,10 +92,9 @@ where
             }
         };
 
-        let will_retry = (is_connect_error
-            || is_timeout_error
-            || status == Some(StatusCode::REQUEST_TIMEOUT))
-            && (index + 1) < connection_timeouts.0.len();
+        let will_retry =
+            (is_connect_error || is_timeout_error || status == Some(StatusCode::REQUEST_TIMEOUT))
+                && (index + 1) < connection_timeouts.0.len();
 
         if let Ok(response) = result.as_ref() {
             let content_length_display = response
@@ -89,7 +103,7 @@ where
                 .unwrap_or_else(|| "unknown".to_string());
             log::info!(
                 "API response: url '{}', status {}, content-length {}, headers in {:.1}s",
-                response.url(),
+                redact_url_for_log(response.url()),
                 response.status().as_u16(),
                 content_length_display,
                 elapsed.as_secs_f64(),
@@ -109,7 +123,7 @@ where
             } else {
                 "not retrying".to_string()
             };
-            log::info!(
+            log::warn!(
                 "API request failed: url '{}', {}, attempt {}/{} after {:.1}s (request body: {}); {}",
                 url_display,
                 failure,

--- a/server/util/src/api_helper.rs
+++ b/server/util/src/api_helper.rs
@@ -54,33 +54,56 @@ where
             ),
         };
 
-        if (is_connect_error
+        // Surface the status code (or transport error) for any failed attempt so
+        // proxy/upstream errors like 502/503/504 — which we do not currently retry —
+        // still appear in the log instead of being hidden behind a downstream
+        // "could not parse response" message.
+        let attempt_failure = match result.as_ref() {
+            Ok(r) if !r.status().is_success() => Some(format!("HTTP {}", r.status().as_u16())),
+            Ok(_) => None,
+            Err(e) => {
+                let kind = if is_connect_error {
+                    "connection error"
+                } else if is_timeout_error {
+                    "request timeout"
+                } else {
+                    "request error"
+                };
+                Some(format!("{}: {}", kind, e))
+            }
+        };
+
+        let will_retry = (is_connect_error
             || is_timeout_error
             || status == Some(StatusCode::REQUEST_TIMEOUT))
-            && (index + 1) < connection_timeouts.0.len()
-        {
-            let reason = if is_connect_error {
-                "connection error"
-            } else if is_timeout_error {
-                "request timeout"
-            } else {
-                "HTTP 408 Request Timeout"
-            };
+            && (index + 1) < connection_timeouts.0.len();
+
+        if let Some(failure) = attempt_failure {
             let url_display = url.as_deref().unwrap_or("<unknown>");
-            let next_timeout = connection_timeouts.0[index + 1];
             let body_display = body_size
                 .map(|n| format!("{} bytes", n))
                 .unwrap_or_else(|| "unknown size".to_string());
+            let retry_note = if will_retry {
+                format!(
+                    "retrying (next connect timeout {}s)",
+                    connection_timeouts.0[index + 1]
+                )
+            } else {
+                "not retrying".to_string()
+            };
             log::info!(
-                "API request retry {}/{} for url '{}' due to {} after {:.1}s (request body: {}); next connect timeout {}s",
-                index + 1,
-                connection_timeouts.0.len() - 1,
+                "API request failed: url '{}', {}, attempt {}/{} after {:.1}s (request body: {}); {}",
                 url_display,
-                reason,
+                failure,
+                index + 1,
+                connection_timeouts.0.len(),
                 elapsed.as_secs_f64(),
                 body_display,
-                next_timeout
+                retry_note,
             );
+        }
+
+        if will_retry {
             index += 1;
             continue;
         }

--- a/server/util/src/api_helper.rs
+++ b/server/util/src/api_helper.rs
@@ -12,6 +12,13 @@ impl Default for RetrySeconds {
     }
 }
 
+// If a request burns more than this on a single attempt and times out, do not
+// retry it — the overall request timeout has effectively been hit and another
+// 30-minute attempt is unlikely to succeed where the first didn't, and we don't
+// want a single sync to block for ~90 minutes. Fast timeouts (connect-phase,
+// kernel TCP retransmit, etc.) still retry as before.
+const SLOW_TIMEOUT_RETRY_CUTOFF: Duration = Duration::from_secs(60 * 25);
+
 pub async fn with_retries<F>(connection_timeouts: RetrySeconds, f: F) -> Result<Response>
 where
     F: Fn(Client) -> RequestBuilder,
@@ -73,8 +80,9 @@ where
             }
         };
 
+        let timeout_was_slow = is_timeout_error && elapsed >= SLOW_TIMEOUT_RETRY_CUTOFF;
         let will_retry = (is_connect_error
-            || is_timeout_error
+            || (is_timeout_error && !timeout_was_slow)
             || status == Some(StatusCode::REQUEST_TIMEOUT))
             && (index + 1) < connection_timeouts.0.len();
 

--- a/server/util/src/api_helper.rs
+++ b/server/util/src/api_helper.rs
@@ -28,14 +28,33 @@ where
 
         let result = f(client).send().await;
 
-        let (status, is_connect_error) = match result.as_ref() {
-            Ok(r) => (Some(r.status()), false),
-            Err(e) => (e.status(), e.is_connect()),
+        let (status, is_connect_error, url) = match result.as_ref() {
+            Ok(r) => (Some(r.status()), false, Some(r.url().to_string())),
+            Err(e) => (
+                e.status(),
+                e.is_connect(),
+                e.url().map(|u| u.to_string()),
+            ),
         };
 
         if (is_connect_error || status == Some(StatusCode::REQUEST_TIMEOUT))
             && (index + 1) < connection_timeouts.0.len()
         {
+            let reason = if is_connect_error {
+                "connection error"
+            } else {
+                "request timeout"
+            };
+            let url_display = url.as_deref().unwrap_or("<unknown>");
+            let next_timeout = connection_timeouts.0[index + 1];
+            log::info!(
+                "API request retry {}/{} for url '{}' due to {}; next connect timeout {}s",
+                index + 1,
+                connection_timeouts.0.len() - 1,
+                url_display,
+                reason,
+                next_timeout
+            );
             index += 1;
             continue;
         }

--- a/server/util/src/api_helper.rs
+++ b/server/util/src/api_helper.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use reqwest::*;
 
@@ -26,33 +26,59 @@ where
             .build()
             .unwrap(); // This method fails if a TLS backend cannot be initialized, or the resolver cannot load the system configuration.
 
-        let result = f(client).send().await;
+        // Build the request up-front so we can inspect the body size for diagnostic
+        // logging on retry. `as_bytes()` returns None for streaming bodies (none of our
+        // current call sites use streaming, but the helper is generic).
+        let request_result = f(client.clone()).build();
+        let body_size = request_result
+            .as_ref()
+            .ok()
+            .and_then(|r| r.body())
+            .and_then(|b| b.as_bytes())
+            .map(|b| b.len());
 
-        let (status, is_connect_error, url) = match result.as_ref() {
-            Ok(r) => (Some(r.status()), false, Some(r.url().to_string())),
+        let started = Instant::now();
+        let result = match request_result {
+            Ok(request) => client.execute(request).await,
+            Err(e) => Err(e),
+        };
+        let elapsed = started.elapsed();
+
+        let (status, is_connect_error, is_timeout_error, url) = match result.as_ref() {
+            Ok(r) => (Some(r.status()), false, false, Some(r.url().to_string())),
             Err(e) => (
                 e.status(),
                 e.is_connect(),
+                e.is_timeout(),
                 e.url().map(|u| u.to_string()),
             ),
         };
 
-        if (is_connect_error || status == Some(StatusCode::REQUEST_TIMEOUT))
+        if (is_connect_error
+            || is_timeout_error
+            || status == Some(StatusCode::REQUEST_TIMEOUT))
             && (index + 1) < connection_timeouts.0.len()
         {
             let reason = if is_connect_error {
                 "connection error"
-            } else {
+            } else if is_timeout_error {
                 "request timeout"
+            } else {
+                "HTTP 408 Request Timeout"
             };
             let url_display = url.as_deref().unwrap_or("<unknown>");
             let next_timeout = connection_timeouts.0[index + 1];
+            let body_display = body_size
+                .map(|n| format!("{} bytes", n))
+                .unwrap_or_else(|| "unknown size".to_string());
             log::info!(
-                "API request retry {}/{} for url '{}' due to {}; next connect timeout {}s",
+                "API request retry {}/{} for url '{}' due to {} after {:.1}s (request body: {}); next connect timeout {}s",
                 index + 1,
                 connection_timeouts.0.len() - 1,
                 url_display,
                 reason,
+                elapsed.as_secs_f64(),
+                body_display,
                 next_timeout
             );
             index += 1;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11599 (kind of)

# 👩🏻‍💻 What does this PR do?

I wasn't able to directly replicate rukmal's issue but I was able to replicate a similar one.
When it takes a long time to download a batch (say when you have large store images and a lot of stores) this can timeout downloading the batch even thought it is downloading (albeit a bit slowly)

This changes the API timeout to be based on a read timeout, so if we haven't received or sent bytes within 5 minutes we then timeout, rather than killing the download just because it took 30 minutes.

This seems to have fixed the initialisation issue or me.

Note: Rukmal's issue with the timeout is kind of expected. If mSupply takes a long time to generate the records this timeout is inevitable. Re-trying works for me so I think it's ok with this change.

I also made a change to show as `Save Log` button on the android initalisation screen so users have a method to get the logs if something has gone wrong to share with support.

<img width="1123" height="810" alt="image" src="https://github.com/user-attachments/assets/d7bca97d-2630-4cdd-9eb6-ea449a24ee42" />

## 💌 Any notes for the reviewer?

Any downsides of removing the 30 min time out?
Claude says:
```Slow uploads are now effectively unbounded. A push body on a 1KB/s link could take hours and we'd never time out. Was bounded before by the 30-min wall-clock; isn't now. Probably fine — sync intervals will pile up before this matters in practice — but worth knowing.```

I can also imagine that we can now get into a situation where the api requests just block infinitely, e.g. something hanging in the OS layer. I hope the read time out would still trip in this case but not sure. 

Note: I've also backported and extended some additional progress logging I added to debug progress for api requests this makes it clearer what's going on when downloading and how fast it's going....

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] try inialising from a large datafile on a remote machine (with big store images and lots of store for example)
- [ ] Make sure can re-try if the prepare step times out
- [ ] Make sure we don't timeout downloading batches assuming the server is still running.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

