### PR TITLE
Flatten rows_by_table HashMap in batch_query

### DIFF
--- a/server/repository/src/db_diesel/changelog/batch_query.rs
+++ b/server/repository/src/db_diesel/changelog/batch_query.rs
@@ -211,35 +211,30 @@ impl<'a> ChangelogRepository<'a> {
                 }
             }
 
-            let mut rows_by_table: HashMap<ChangelogTableName, HashMap<String, Row>> =
-                HashMap::new();
+            let mut fetched_rows: HashMap<(ChangelogTableName, String), Row> = HashMap::new();
             for (table_name, ids) in upsert_ids_by_table {
-                let rows = fetch_rows_for_table(self.connection, &table_name, &ids)?;
-                rows_by_table.insert(table_name, rows);
+                for (id, row) in fetch_rows_for_table(self.connection, &table_name, &ids)? {
+                    fetched_rows.insert((table_name.clone(), id), row);
+                }
             }
 
             // Apply this batch to output_by_key, with cross-iteration supersession.
             for ((table_name, record_id), cl) in batch_dedup {
-                let key = (table_name.clone(), record_id.clone());
+                let key = (table_name, record_id);
                 match cl.row_action {
                     RowActionType::Delete => {
                         output_by_key.insert(key, RowOrDelete::Delete { changelog: cl });
                     }
-                    RowActionType::Upsert => {
-                        let row = rows_by_table
-                            .get_mut(&table_name)
-                            .and_then(|m| m.remove(&record_id));
-                        match row {
-                            Some(row) => {
-                                output_by_key.insert(key, RowOrDelete::Row { changelog: cl, row });
-                            }
-                            None => {
-                                // Latest changelog for this key is an Upsert pointing
-                                // at a missing row — supersedes any earlier output.
-                                output_by_key.remove(&key);
-                            }
+                    RowActionType::Upsert => match fetched_rows.remove(&key) {
+                        Some(row) => {
+                            output_by_key.insert(key, RowOrDelete::Row { changelog: cl, row });
                         }
-                    }
+                        None => {
+                            // Latest changelog for this key is an Upsert pointing
+                            // at a missing row — supersedes any earlier output.
+                            output_by_key.remove(&key);
+                        }
+                    },
                 }
             }
 


### PR DESCRIPTION
Suggested code change against #11595.

## Summary

In `query_with_data` (server/repository/src/db_diesel/changelog/batch_query.rs), replace the per-batch nested `HashMap<ChangelogTableName, HashMap<String, Row>>` with a flat `HashMap<(ChangelogTableName, String), Row>`.

## Why this is better

- **One data structure instead of two.** The new `fetched_rows` key shape `(ChangelogTableName, String)` matches `output_by_key` exactly. The old nesting (table outside, id inside) didn't reflect how it was used — every access wanted both parts at once.
- **One hash lookup instead of two.** `rows_by_table.get_mut(&table).and_then(|m| m.remove(&record_id))` becomes `fetched_rows.remove(&key)` — one op, returns the `Option<Row>` directly.
- **Fewer clones in the apply path.** Previously `key = (table.clone(), record_id.clone())` was forced because the next lines re-borrowed `table` and `record_id`. Now the tuple moves straight into `key`; the only remaining `table.clone()` is in the fetch insertion path (once per row), not in the apply path.
- **Flatter control flow.** The `match row { Some, None }` inside the `Upsert` arm collapses into the arm itself, removing a level of indentation and an intermediate `row` binding.

Behavior is unchanged. All six existing `query_with_data` tests pass.