### PR TITLE
#11636 Server-side customer search

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteWithPagination.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteWithPagination.tsx
@@ -42,6 +42,11 @@ export interface AutocompleteWithPaginationProps<
   // only renders when `value` is non-null, so the wrapper provides this
   // path for the "typed but unselected" state.
   onClear?: () => void;
+  // When true, the spinner shows in the input adornment but the listbox
+  // keeps rendering existing options instead of swapping to "Loading...".
+  // Useful for debounced server-side filtering where the previous results
+  // are still a useful preview while a refetch is in flight.
+  loadingInputOnly?: boolean;
 }
 
 export function AutocompleteWithPagination<T extends RecordWithId>({
@@ -75,6 +80,7 @@ export function AutocompleteWithPagination<T extends RecordWithId>({
   onPageChange,
   onClear,
   mapOptions,
+  loadingInputOnly = false,
   sx,
   ...restOfAutocompleteProps
 }: PropsWithChildren<AutocompleteWithPaginationProps<T>>) {
@@ -202,7 +208,7 @@ export function AutocompleteWithPagination<T extends RecordWithId>({
       value={value}
       getOptionDisabled={getOptionDisabled}
       filterOptions={filter}
-      loading={loading}
+      loading={loadingInputOnly ? false : loading}
       loadingText={loadingText ?? t('loading')}
       noOptionsText={noOptionsText ?? t('label.no-options')}
       options={options}

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/InfiniteSearchPicker.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/InfiniteSearchPicker.tsx
@@ -1,0 +1,276 @@
+import React, { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useDebouncedValueCallback,
+  useStringFilter,
+  useToggle,
+} from '@common/hooks';
+import { AutocompleteWithPagination } from './AutocompleteWithPagination';
+import { AutocompleteOptionRenderer } from './types';
+import { FilterOptionsState } from '@mui/material';
+import { defaultOptionMapper } from './utils';
+import { CLEAR, RegexUtils } from '@common/utils';
+
+const SEARCH_DEBOUNCE_TIMEOUT = 500;
+const PAGINATION_DEBOUNCE_TIMEOUT = 100;
+const ROWS_PER_PAGE = 100;
+
+interface HasId {
+  id: string;
+}
+
+interface InfiniteQueryPage<T> {
+  data: { nodes: T[]; totalCount: number };
+  pageNumber: number;
+}
+
+interface InfiniteQueryResult<T> {
+  data?: { pages: InfiniteQueryPage<T>[] };
+  isLoading: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: (opts: { pageParam: number }) => unknown;
+}
+
+export interface InfiniteSearchPickerProps<T extends HasId, TFilter> {
+  // Data — caller-supplied hooks
+  useInfiniteData: (params: {
+    rowsPerPage: number;
+    filter?: TFilter;
+  }) => InfiniteQueryResult<T>;
+  useGetById: (id: string) => { data?: T | null };
+
+  // Selection — either control `value` or pass `currentId` to have the picker
+  // resolve the entity itself (cache → byId fallback).
+  value?: T | null;
+  onChange: (entity: T | null) => void;
+  currentId?: string;
+  // Fire `onChange` once after `currentId` resolves to an entity. Useful for
+  // parents that pass an id but don't have the full entity loaded yet.
+  notifyOnLoad?: boolean;
+
+  // Filter
+  apiFilter?: TFilter;
+  // For input strings like "1234 Item Name" — strip the prefix before sending
+  // to the server's codeOrName filter. Defaults to identity.
+  searchToFilter?: (search: string) => string;
+
+  // Rendering
+  getOptionLabel: (option: T) => string;
+  renderOption?: AutocompleteOptionRenderer<T>;
+  getOptionDisabled?: (option: T) => boolean;
+  // Client-side post-filter applied to each loaded page (e.g. exclude on-hold)
+  extraFilter?: (option: T) => boolean;
+
+  // UX
+  disabled?: boolean;
+  clearable?: boolean;
+  autoFocus?: boolean;
+  openOnFocus?: boolean;
+  width?: number;
+  id?: string;
+  noOptionsText?: ReactNode;
+
+  // Called when the visual search string changes (e.g. after the user selects
+  // an item, parent can react to the displayed text). Optional.
+  onSearchChange?: (search: string) => void;
+  // Fires when the picker's displayed entity changes — either because the
+  // user picked something or because `currentId` resolved to a new entity.
+  // Useful for parents that need to track selection-derived state.
+  onDisplayValueChange?: (entity: T | null) => void;
+}
+
+export function InfiniteSearchPicker<T extends HasId, TFilter>({
+  useInfiniteData,
+  useGetById,
+  value = null,
+  onChange,
+  currentId,
+  notifyOnLoad = false,
+  apiFilter,
+  searchToFilter = s => s,
+  getOptionLabel,
+  renderOption,
+  getOptionDisabled,
+  extraFilter,
+  disabled = false,
+  clearable = false,
+  autoFocus = false,
+  openOnFocus = false,
+  width,
+  id,
+  noOptionsText,
+  onSearchChange,
+  onDisplayValueChange,
+}: InfiniteSearchPickerProps<T, TFilter>) {
+  const selectControl = useToggle();
+  const { filter, onFilter } = useStringFilter('codeOrName');
+  const [search, setSearch] = useState('');
+
+  const updateSearch = (next: string) => {
+    setSearch(next);
+    onSearchChange?.(next);
+  };
+
+  const debounceOnFilter = useDebouncedValueCallback(
+    (text: string) => onFilter(text),
+    [onFilter],
+    SEARCH_DEBOUNCE_TIMEOUT
+  );
+
+  const fullFilter = useMemo(
+    () => ({ ...(filter as object), ...(apiFilter as object) }) as TFilter,
+    [filter, apiFilter]
+  );
+
+  const { data, isLoading, fetchNextPage, isFetchingNextPage } = useInfiniteData(
+    {
+      rowsPerPage: ROWS_PER_PAGE,
+      filter: disabled ? undefined : fullFilter,
+    }
+  );
+
+  // Cache-first lookup for currentId, falling back to a byId fetch if it isn't
+  // on any loaded page (e.g. past the first page, or excluded by the filter).
+  const fromCache = useMemo(() => {
+    if (!currentId) return null;
+    const all = data?.pages.flatMap(page => page.data.nodes) ?? [];
+    return all.find(item => item.id === currentId) ?? null;
+  }, [currentId, data?.pages]);
+
+  const { data: fromApi } = useGetById(
+    currentId && !fromCache ? currentId : ''
+  );
+
+  const currentEntity = fromCache ?? fromApi ?? null;
+  // Render the controlled value if given, otherwise fall back to the entity
+  // resolved from currentId. The parent isn't notified on the fallback — the
+  // picker just displays the resolved entity.
+  const displayValue = value ?? currentEntity;
+
+  // Keep the displayed search string in sync with the resolved entity, and
+  // surface the resolved entity via onDisplayValueChange so the parent can
+  // track selection-derived state (e.g. items' selectedCode).
+  useEffect(() => {
+    if (displayValue && search === '') updateSearch(getOptionLabel(displayValue));
+    onDisplayValueChange?.(displayValue);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [displayValue]);
+
+  // Optionally notify the parent on first load (some consumers pass
+  // `currentId` without having the full entity yet — they need to be told
+  // what was resolved so they can populate their own state).
+  useEffect(() => {
+    if (notifyOnLoad && currentEntity && !value) onChange(currentEntity);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentEntity]);
+
+  useEffect(() => {
+    if (openOnFocus) {
+      // openOnFocus prop mispositions the popper inside a Dialog; toggle open
+      // manually after a tick.
+      setTimeout(() => selectControl.toggleOn(), SEARCH_DEBOUNCE_TIMEOUT);
+    }
+    if (autoFocus && id) {
+      setTimeout(() => {
+        const input = document.querySelector<HTMLInputElement>(
+          `input[id="${id}"]`
+        );
+        input?.focus();
+      }, 50);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const pageNumber = data?.pages[data.pages.length - 1]?.pageNumber ?? 0;
+
+  // Server filter currently in flight is `filter.codeOrName.like`. While the
+  // user is mid-type it hasn't caught up — client-side narrowing can flicker
+  // to empty before the server responds. Hold onto the last non-empty set
+  // and return it during that window so the dropdown doesn't say "no results".
+  const serverFilterText =
+    (filter as { codeOrName?: { like?: string } })?.codeOrName?.like ?? '';
+  const fetchPending =
+    serverFilterText !== searchToFilter(search) && serverFilterText !== search;
+  const lastNonEmpty = useRef<T[] | null>(null);
+
+  const filterOptions = (
+    options: T[],
+    state: FilterOptionsState<T>
+  ): T[] => {
+    const escaped = RegexUtils.escapeChars(state.inputValue);
+    const matchValue = searchToFilter(escaped);
+    const narrowed = options.filter(option => {
+      const label = getOptionLabel(option);
+      const code = (option as { code?: string }).code ?? '';
+      const matches =
+        RegexUtils.includes(escaped, label) ||
+        RegexUtils.includes(matchValue, label) ||
+        (!!code && RegexUtils.includes(escaped, code));
+      return matches && (!extraFilter || extraFilter(option));
+    });
+    if (narrowed.length > 0) {
+      lastNonEmpty.current = narrowed;
+      return narrowed;
+    }
+    if (!fetchPending) {
+      // Server has caught up and agrees there are no results — clear the
+      // stash so the next keystroke doesn't flash an outdated list.
+      lastNonEmpty.current = null;
+      return narrowed;
+    }
+    return lastNonEmpty.current ?? narrowed;
+  };
+
+  return (
+    <AutocompleteWithPagination<T>
+      id={id}
+      autoFocus={autoFocus}
+      disabled={disabled}
+      clearable={clearable}
+      value={displayValue}
+      pages={data?.pages ?? []}
+      pageNumber={pageNumber}
+      rowsPerPage={ROWS_PER_PAGE}
+      totalRows={data?.pages?.[0]?.data.totalCount ?? 0}
+      loading={isLoading || isFetchingNextPage}
+      noOptionsText={noOptionsText}
+      filterOptions={filterOptions}
+      onOpen={selectControl.toggleOn}
+      onClose={selectControl.toggleOff}
+      open={selectControl.isOn}
+      onChange={(_, entity) => {
+        updateSearch(entity ? getOptionLabel(entity) : '');
+        onChange(entity);
+      }}
+      onInputChange={(_event, _value, reason) => {
+        if (reason === CLEAR) onChange(null);
+      }}
+      inputValue={search}
+      clearOnBlur={false}
+      onClear={() => {
+        updateSearch('');
+        onFilter('');
+      }}
+      inputProps={{
+        onChange: e => {
+          const { value: next } = e.target;
+          updateSearch(next);
+          debounceOnFilter(searchToFilter(next));
+        },
+      }}
+      getOptionLabel={getOptionLabel}
+      renderOption={renderOption}
+      getOptionDisabled={getOptionDisabled}
+      width={width ? `${width}px` : '100%'}
+      popperMinWidth={width}
+      isOptionEqualToValue={(option, val) => option?.id === val?.id}
+      paginationDebounce={PAGINATION_DEBOUNCE_TIMEOUT}
+      onPageChange={page => fetchNextPage({ pageParam: page })}
+      mapOptions={items =>
+        defaultOptionMapper(
+          items.map(i => ({ ...i, label: getOptionLabel(i) })),
+          'label'
+        ).sort((a, b) => a.label.localeCompare(b.label))
+      }
+    />
+  );
+}

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/InfiniteSearchPicker.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/InfiniteSearchPicker.tsx
@@ -1,4 +1,11 @@
-import React, { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  ReactNode,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   useDebouncedValueCallback,
   useStringFilter,
@@ -11,6 +18,7 @@ import { defaultOptionMapper } from './utils';
 import { CLEAR, RegexUtils } from '@common/utils';
 
 const SEARCH_DEBOUNCE_TIMEOUT = 500;
+const POPPER_REPOSITION_DELAY = 500;
 const PAGINATION_DEBOUNCE_TIMEOUT = 100;
 const ROWS_PER_PAGE = 100;
 
@@ -43,18 +51,22 @@ export interface InfiniteSearchPickerProps<T extends HasId, TFilter> {
   value?: T | null;
   onChange: (entity: T | null) => void;
   currentId?: string;
-  // Fire `onChange` once after `currentId` resolves to an entity. Useful for
-  // parents that pass an id but don't have the full entity loaded yet.
-  notifyOnLoad?: boolean;
 
   // Filter
   apiFilter?: TFilter;
+  // Server filter key for the search string (default `codeOrName`). Must match
+  // a `{ [searchKey]: { like: string } }` field on TFilter.
+  searchKey?: string;
   // For input strings like "1234 Item Name" — strip the prefix before sending
-  // to the server's codeOrName filter. Defaults to identity.
+  // to the server's search filter. Defaults to identity.
   searchToFilter?: (search: string) => string;
 
   // Rendering
   getOptionLabel: (option: T) => string;
+  // Optional secondary string to match client-side (e.g. an item code that
+  // isn't part of getOptionLabel). Lets users see instant results for
+  // codes during the debounce window.
+  getOptionCode?: (option: T) => string | undefined;
   renderOption?: AutocompleteOptionRenderer<T>;
   getOptionDisabled?: (option: T) => boolean;
   // Client-side post-filter applied to each loaded page (e.g. exclude on-hold)
@@ -66,16 +78,10 @@ export interface InfiniteSearchPickerProps<T extends HasId, TFilter> {
   autoFocus?: boolean;
   openOnFocus?: boolean;
   width?: number;
+  // DOM id for the input. Defaults to a stable generated id so multiple
+  // pickers can coexist on the same page without collisions.
   id?: string;
   noOptionsText?: ReactNode;
-
-  // Called when the visual search string changes (e.g. after the user selects
-  // an item, parent can react to the displayed text). Optional.
-  onSearchChange?: (search: string) => void;
-  // Fires when the picker's displayed entity changes — either because the
-  // user picked something or because `currentId` resolved to a new entity.
-  // Useful for parents that need to track selection-derived state.
-  onDisplayValueChange?: (entity: T | null) => void;
 }
 
 export function InfiniteSearchPicker<T extends HasId, TFilter>({
@@ -84,10 +90,11 @@ export function InfiniteSearchPicker<T extends HasId, TFilter>({
   value = null,
   onChange,
   currentId,
-  notifyOnLoad = false,
   apiFilter,
+  searchKey = 'codeOrName',
   searchToFilter = s => s,
   getOptionLabel,
+  getOptionCode,
   renderOption,
   getOptionDisabled,
   extraFilter,
@@ -98,17 +105,12 @@ export function InfiniteSearchPicker<T extends HasId, TFilter>({
   width,
   id,
   noOptionsText,
-  onSearchChange,
-  onDisplayValueChange,
 }: InfiniteSearchPickerProps<T, TFilter>) {
   const selectControl = useToggle();
-  const { filter, onFilter } = useStringFilter('codeOrName');
+  const { filter, onFilter } = useStringFilter(searchKey);
   const [search, setSearch] = useState('');
-
-  const updateSearch = (next: string) => {
-    setSearch(next);
-    onSearchChange?.(next);
-  };
+  const generatedId = useId();
+  const inputId = id ?? `infinite-search-picker-${generatedId}`;
 
   const debounceOnFilter = useDebouncedValueCallback(
     (text: string) => onFilter(text),
@@ -146,48 +148,42 @@ export function InfiniteSearchPicker<T extends HasId, TFilter>({
   // picker just displays the resolved entity.
   const displayValue = value ?? currentEntity;
 
-  // Keep the displayed search string in sync with the resolved entity, and
-  // surface the resolved entity via onDisplayValueChange so the parent can
-  // track selection-derived state (e.g. items' selectedCode).
+  // Keep the displayed search string in sync with the resolved entity.
   useEffect(() => {
-    if (displayValue && search === '') updateSearch(getOptionLabel(displayValue));
-    onDisplayValueChange?.(displayValue);
+    if (displayValue && search === '') setSearch(getOptionLabel(displayValue));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [displayValue]);
 
-  // Optionally notify the parent on first load (some consumers pass
-  // `currentId` without having the full entity yet — they need to be told
-  // what was resolved so they can populate their own state).
   useEffect(() => {
-    if (notifyOnLoad && currentEntity && !value) onChange(currentEntity);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentEntity]);
-
-  useEffect(() => {
-    if (openOnFocus) {
-      // openOnFocus prop mispositions the popper inside a Dialog; toggle open
-      // manually after a tick.
-      setTimeout(() => selectControl.toggleOn(), SEARCH_DEBOUNCE_TIMEOUT);
-    }
-    if (autoFocus && id) {
-      setTimeout(() => {
-        const input = document.querySelector<HTMLInputElement>(
-          `input[id="${id}"]`
-        );
-        input?.focus();
-      }, 50);
-    }
+    // openOnFocus prop mispositions the popper inside a Dialog; toggle open
+    // manually after a tick.
+    const openTimer = openOnFocus
+      ? setTimeout(() => selectControl.toggleOn(), POPPER_REPOSITION_DELAY)
+      : undefined;
+    const focusTimer = autoFocus
+      ? setTimeout(() => {
+          const input = document.querySelector<HTMLInputElement>(
+            `input[id="${inputId}"]`
+          );
+          input?.focus();
+        }, 50)
+      : undefined;
+    return () => {
+      if (openTimer) clearTimeout(openTimer);
+      if (focusTimer) clearTimeout(focusTimer);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const pageNumber = data?.pages[data.pages.length - 1]?.pageNumber ?? 0;
 
-  // Server filter currently in flight is `filter.codeOrName.like`. While the
+  // Server filter currently in flight is `filter[searchKey].like`. While the
   // user is mid-type it hasn't caught up — client-side narrowing can flicker
   // to empty before the server responds. Hold onto the last non-empty set
   // and return it during that window so the dropdown doesn't say "no results".
   const serverFilterText =
-    (filter as { codeOrName?: { like?: string } })?.codeOrName?.like ?? '';
+    (filter as Record<string, { like?: string } | undefined>)[searchKey]
+      ?.like ?? '';
   const fetchPending =
     serverFilterText !== searchToFilter(search) && serverFilterText !== search;
   const lastNonEmpty = useRef<T[] | null>(null);
@@ -198,13 +194,19 @@ export function InfiniteSearchPicker<T extends HasId, TFilter>({
   ): T[] => {
     const escaped = RegexUtils.escapeChars(state.inputValue);
     const matchValue = searchToFilter(escaped);
+    // Precompute regexes once per invocation rather than per option — with
+    // multiple loaded pages this would otherwise allocate a RegExp for every
+    // option on every keystroke.
+    const escapedRe = new RegExp(escaped, 'i');
+    const matchValueRe =
+      matchValue === escaped ? escapedRe : new RegExp(matchValue, 'i');
     const narrowed = options.filter(option => {
       const label = getOptionLabel(option);
-      const code = (option as { code?: string }).code ?? '';
+      const code = getOptionCode?.(option);
       const matches =
-        RegexUtils.includes(escaped, label) ||
-        RegexUtils.includes(matchValue, label) ||
-        (!!code && RegexUtils.includes(escaped, code));
+        escapedRe.test(label) ||
+        matchValueRe.test(label) ||
+        (!!code && escapedRe.test(code));
       return matches && (!extraFilter || extraFilter(option));
     });
     if (narrowed.length > 0) {
@@ -222,7 +224,7 @@ export function InfiniteSearchPicker<T extends HasId, TFilter>({
 
   return (
     <AutocompleteWithPagination<T>
-      id={id}
+      id={inputId}
       autoFocus={autoFocus}
       disabled={disabled}
       clearable={clearable}
@@ -238,7 +240,7 @@ export function InfiniteSearchPicker<T extends HasId, TFilter>({
       onClose={selectControl.toggleOff}
       open={selectControl.isOn}
       onChange={(_, entity) => {
-        updateSearch(entity ? getOptionLabel(entity) : '');
+        setSearch(entity ? getOptionLabel(entity) : '');
         onChange(entity);
       }}
       onInputChange={(_event, _value, reason) => {
@@ -247,13 +249,18 @@ export function InfiniteSearchPicker<T extends HasId, TFilter>({
       inputValue={search}
       clearOnBlur={false}
       onClear={() => {
-        updateSearch('');
+        setSearch('');
+        // Cancel any pending debounced filter — otherwise an in-flight
+        // keystroke would re-apply the prior search a moment after clearing.
+        (
+          debounceOnFilter as unknown as { cancel?: () => void }
+        ).cancel?.();
         onFilter('');
       }}
       inputProps={{
         onChange: e => {
           const { value: next } = e.target;
-          updateSearch(next);
+          setSearch(next);
           debounceOnFilter(searchToFilter(next));
         },
       }}

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/InfiniteSearchPicker.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/InfiniteSearchPicker.tsx
@@ -34,6 +34,7 @@ interface InfiniteQueryPage<T> {
 interface InfiniteQueryResult<T> {
   data?: { pages: InfiniteQueryPage<T>[] };
   isLoading: boolean;
+  isFetching: boolean;
   isFetchingNextPage: boolean;
   fetchNextPage: (opts: { pageParam: number }) => unknown;
 }
@@ -123,12 +124,11 @@ export function InfiniteSearchPicker<T extends HasId, TFilter>({
     [filter, apiFilter]
   );
 
-  const { data, isLoading, fetchNextPage, isFetchingNextPage } = useInfiniteData(
-    {
+  const { data, isLoading, isFetching, fetchNextPage, isFetchingNextPage } =
+    useInfiniteData({
       rowsPerPage: ROWS_PER_PAGE,
       filter: disabled ? undefined : fullFilter,
-    }
-  );
+    });
 
   // Cache-first lookup for currentId, falling back to a byId fetch if it isn't
   // on any loaded page (e.g. past the first page, or excluded by the filter).
@@ -148,11 +148,10 @@ export function InfiniteSearchPicker<T extends HasId, TFilter>({
   // picker just displays the resolved entity.
   const displayValue = value ?? currentEntity;
 
-  // Keep the displayed search string in sync with the resolved entity.
-  useEffect(() => {
-    if (displayValue && search === '') setSearch(getOptionLabel(displayValue));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [displayValue]);
+  // Fall back to the resolved entity's label while the user hasn't typed
+  // anything, so async currentId resolution surfaces without a state-sync effect.
+  const inputValue =
+    search === '' && displayValue ? getOptionLabel(displayValue) : search;
 
   useEffect(() => {
     // openOnFocus prop mispositions the popper inside a Dialog; toggle open
@@ -233,7 +232,8 @@ export function InfiniteSearchPicker<T extends HasId, TFilter>({
       pageNumber={pageNumber}
       rowsPerPage={ROWS_PER_PAGE}
       totalRows={data?.pages?.[0]?.data.totalCount ?? 0}
-      loading={isLoading || isFetchingNextPage}
+      loading={isLoading || isFetching || isFetchingNextPage}
+      loadingInputOnly
       noOptionsText={noOptionsText}
       filterOptions={filterOptions}
       onOpen={selectControl.toggleOn}
@@ -246,7 +246,7 @@ export function InfiniteSearchPicker<T extends HasId, TFilter>({
       onInputChange={(_event, _value, reason) => {
         if (reason === CLEAR) onChange(null);
       }}
-      inputValue={search}
+      inputValue={inputValue}
       clearOnBlur={false}
       onClear={() => {
         setSearch('');
@@ -263,6 +263,10 @@ export function InfiniteSearchPicker<T extends HasId, TFilter>({
           setSearch(next);
           debounceOnFilter(searchToFilter(next));
         },
+        // Re-open on focus/click — `openOnFocus` on the underlying autocomplete
+        // mispositions the popper inside a Dialog, so we open manually.
+        onFocus: () => selectControl.toggleOn(),
+        onClick: () => selectControl.toggleOn(),
       }}
       getOptionLabel={getOptionLabel}
       renderOption={renderOption}

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/index.ts
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/index.ts
@@ -6,6 +6,7 @@ export * from './AutocompleteList';
 export * from './AutocompleteMulti';
 export * from './AutocompleteMultiList';
 export * from './AutocompleteWithPagination';
+export * from './InfiniteSearchPicker';
 export * from './types';
 export * from './utils';
 export { AutocompleteRenderInputParams, FilterOptionsState };

--- a/client/packages/system/src/Name/Components/CustomerSearchInput/CustomerSearchInput.tsx
+++ b/client/packages/system/src/Name/Components/CustomerSearchInput/CustomerSearchInput.tsx
@@ -1,17 +1,17 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
-  Autocomplete,
-  CLEAR,
-  useBufferState,
+  InfiniteSearchPicker,
+  NameFilterInput,
   useTranslation,
 } from '@openmsupply-client/common';
-import { useName } from '../../api';
-import {
-  NameSearchInputProps,
-  basicFilterOptions,
-  filterByNameAndCode,
-} from '../../utils';
+import { useName, NameRowFragment } from '../../api';
+import { NameSearchInputProps } from '../../utils';
 import { getNameOptionRenderer } from '../NameOptionRenderer';
+
+interface CustomerSearchInputExtraProps {
+  autoFocus?: boolean;
+  openOnFocus?: boolean;
+}
 
 export const CustomerSearchInput = ({
   onChange,
@@ -19,56 +19,34 @@ export const CustomerSearchInput = ({
   value,
   disabled = false,
   clearable = false,
-  currentId = undefined,
+  currentId,
   extraFilter,
   filterBy,
-}: NameSearchInputProps) => {
+  autoFocus = false,
+  openOnFocus = false,
+}: NameSearchInputProps & CustomerSearchInputExtraProps) => {
   const t = useTranslation();
-  const { data, isLoading } = useName.document.customers(filterBy);
-  const [buffer, setBuffer] = useBufferState(value);
   const NameOptionRenderer = getNameOptionRenderer(t('label.on-hold'));
 
-  // For use in JSON forms
-  useEffect(() => {
-    if (currentId && !buffer) {
-      const current = data?.nodes.find(name => name.id === currentId);
-      if (current) {
-        setBuffer(current);
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentId, data]);
-
   return (
-    <Autocomplete
+    <InfiniteSearchPicker<NameRowFragment, NameFilterInput>
+      id="customer-search-input"
+      value={value}
+      onChange={onChange}
+      currentId={currentId}
+      useInfiniteData={useName.document.customersInfinite}
+      useGetById={useName.document.get}
+      apiFilter={filterBy as NameFilterInput | undefined}
+      getOptionLabel={option => option.name}
+      renderOption={NameOptionRenderer}
+      getOptionDisabled={option => option.isOnHold}
+      extraFilter={extraFilter}
       disabled={disabled}
       clearable={clearable}
-      value={buffer && { ...buffer, label: buffer.name }}
-      filterOptionConfig={basicFilterOptions}
-      filterOptions={(options, state) =>
-        filterByNameAndCode(options, state, extraFilter)
-      }
-      loading={isLoading}
-      onChange={(_, name) => {
-        setBuffer(name);
-        onChange(name);
-      }}
-      onInputChange={(
-        _event: React.SyntheticEvent<Element, Event>,
-        _value: string,
-        reason: string
-      ) => {
-        if (reason === CLEAR) {
-          onChange(null);
-        }
-      }}
-      options={data?.nodes ?? []}
-      renderOption={NameOptionRenderer}
-      width={`${width}px`}
-      popperMinWidth={width}
-      isOptionEqualToValue={(option, value) => option?.id === value?.id}
-      getOptionDisabled={option => option.isOnHold}
-      sx={{ minWidth: width }}
+      autoFocus={autoFocus}
+      openOnFocus={openOnFocus}
+      width={width}
+      noOptionsText={t('label.no-options')}
     />
   );
 };

--- a/client/packages/system/src/Name/Components/CustomerSearchInput/CustomerSearchInput.tsx
+++ b/client/packages/system/src/Name/Components/CustomerSearchInput/CustomerSearchInput.tsx
@@ -30,7 +30,6 @@ export const CustomerSearchInput = ({
 
   return (
     <InfiniteSearchPicker<NameRowFragment, NameFilterInput>
-      id="customer-search-input"
       value={value}
       onChange={onChange}
       currentId={currentId}
@@ -38,6 +37,7 @@ export const CustomerSearchInput = ({
       useGetById={useName.document.get}
       apiFilter={filterBy as NameFilterInput | undefined}
       getOptionLabel={option => option.name}
+      getOptionCode={option => option.code}
       renderOption={NameOptionRenderer}
       getOptionDisabled={option => option.isOnHold}
       extraFilter={extraFilter}

--- a/client/packages/system/src/Name/Components/CustomerSearchModal/CustomerSearchModal.tsx
+++ b/client/packages/system/src/Name/Components/CustomerSearchModal/CustomerSearchModal.tsx
@@ -1,53 +1,46 @@
 import React, { FC } from 'react';
 import {
-  AutocompleteList,
-  AutocompleteListProps,
-  createQueryParamsStore,
-  ListSearch,
-  QueryParamsProvider,
+  BasicModal,
+  ModalTitle,
   useTranslation,
+  useWindowDimensions,
+  Box,
 } from '@openmsupply-client/common';
-import { useName, NameRowFragment } from '../../api';
-import { filterByNameAndCode, NameSearchProps } from '../../utils';
-import { getNameOptionRenderer } from '../NameOptionRenderer';
+import { NameSearchProps } from '../../utils';
+import { CustomerSearchInput } from '../CustomerSearchInput';
 
 const CustomerSearchComponent: FC<NameSearchProps> = props => {
-  const { data, isLoading } = useName.document.customers();
   const t = useTranslation();
-  const NameOptionRenderer = getNameOptionRenderer(t('label.on-hold'));
+  const { height } = useWindowDimensions();
+  const modalHeight = height * 0.8;
 
-  const listProps: AutocompleteListProps<NameRowFragment> = {
-    loading: isLoading,
-    filterOptions: filterByNameAndCode,
-    getOptionLabel: option => option.name,
-    renderOption: NameOptionRenderer,
-    onChange: (_, name) => {
-      if (name && !(name instanceof Array)) props.onChange(name);
-    },
-    options: data?.nodes ?? [],
-    getOptionDisabled: option => option.isOnHold,
-  };
+  const input = (
+    <CustomerSearchInput
+      value={null}
+      onChange={name => {
+        if (name) props.onChange(name);
+      }}
+      width={500}
+      clearable={false}
+      autoFocus
+      openOnFocus
+    />
+  );
 
-  if ('isList' in props) return <AutocompleteList {...listProps} />;
+  if ('isList' in props) {
+    return <Box padding={2}>{input}</Box>;
+  }
 
   const { open, onClose } = props;
 
   return (
-    <ListSearch
-      open={open}
-      onClose={onClose}
-      title={t('customers')}
-      {...listProps}
-    />
+    <BasicModal open={open} onClose={onClose} height={modalHeight}>
+      <ModalTitle title={t('customers')} />
+      <Box padding={2}>{input}</Box>
+    </BasicModal>
   );
 };
 
 export const CustomerSearchModal: FC<NameSearchProps> = props => (
-  <QueryParamsProvider
-    createStore={createQueryParamsStore<NameRowFragment>({
-      initialSortBy: { key: 'name' },
-    })}
-  >
-    <CustomerSearchComponent {...props} />
-  </QueryParamsProvider>
+  <CustomerSearchComponent {...props} />
 );

--- a/client/packages/system/src/Name/api/api.ts
+++ b/client/packages/system/src/Name/api/api.ts
@@ -107,19 +107,30 @@ export const getNameQueries = (sdk: Sdk, storeId: string) => ({
 
       return result?.names;
     },
-    customers: async ({ sortBy, filterBy }: ListParams) => {
+    customers: async ({
+      first,
+      offset,
+      sortBy,
+      filter,
+    }: {
+      first?: number;
+      offset?: number;
+      sortBy?: SortBy<NameRowFragment>;
+      filter?: NameFilterInput | null;
+    } = {}) => {
       const key = nameParsers.toSort(sortBy?.key ?? '');
 
       const result = await sdk.names({
+        first,
+        offset,
         key,
         desc: !!sortBy?.isDesc,
         storeId,
         filter: {
           isCustomer: true,
           type: { equalAny: [NameNodeType.Facility, NameNodeType.Store] },
-          ...filterBy,
+          ...filter,
         },
-        first: 1000,
       });
 
       return result?.names;

--- a/client/packages/system/src/Name/api/hooks/document/index.ts
+++ b/client/packages/system/src/Name/api/hooks/document/index.ts
@@ -1,4 +1,5 @@
 import { useCustomers } from './useCustomers';
+import { useCustomersInfinite } from './useCustomersInfinite';
 import { useSuppliers } from './useSuppliers';
 import { useManufacturers } from './useManufacturers';
 import { useInternalSuppliers } from './useInternalSuppliers';
@@ -12,6 +13,7 @@ import { useStoresAll } from './useStoresAll';
 
 export const Document = {
   useCustomers,
+  useCustomersInfinite,
   useStores,
   useSuppliers,
   useManufacturers,

--- a/client/packages/system/src/Name/api/hooks/document/useCustomers.ts
+++ b/client/packages/system/src/Name/api/hooks/document/useCustomers.ts
@@ -1,12 +1,10 @@
-import { FilterBy, useQuery } from '@openmsupply-client/common';
+import { useQuery } from '@openmsupply-client/common';
 import { useNameApi } from '../utils/useNameApi';
 
-export const useCustomers = (filterBy?: FilterBy | null) => {
+export const useCustomers = () => {
   const api = useNameApi();
 
   return useQuery([...api.keys.list(), 'customers'], () =>
-    api.get.customers({
-      filterBy,
-    })
+    api.get.customers({ first: 1000 })
   );
 };

--- a/client/packages/system/src/Name/api/hooks/document/useCustomersInfinite.ts
+++ b/client/packages/system/src/Name/api/hooks/document/useCustomersInfinite.ts
@@ -40,6 +40,11 @@ export const useCustomersInfinite = ({
         data,
         pageNumber,
       };
-    }
+    },
+    // Keep the previous filter's pages on screen while a new filter is in
+    // flight, so the dropdown doesn't flash empty/"Loading..." between
+    // keystrokes — InfiniteSearchPicker also relies on this for its
+    // client-side narrowing fallback.
+    { keepPreviousData: true }
   );
 };

--- a/client/packages/system/src/Name/api/hooks/document/useCustomersInfinite.ts
+++ b/client/packages/system/src/Name/api/hooks/document/useCustomersInfinite.ts
@@ -1,0 +1,45 @@
+import {
+  NameFilterInput,
+  useInfiniteQuery,
+} from '@openmsupply-client/common';
+import { useNameApi } from '../utils/useNameApi';
+
+type UseCustomersInfiniteParams = {
+  rowsPerPage: number;
+  filter?: NameFilterInput;
+};
+
+export const useCustomersInfinite = ({
+  rowsPerPage,
+  filter,
+}: UseCustomersInfiniteParams) => {
+  const api = useNameApi();
+
+  const queryParams = {
+    sortBy: { key: 'name', isDesc: false, direction: 'asc' as 'asc' | 'desc' },
+    filter,
+  };
+
+  return useInfiniteQuery(
+    [
+      ...api.keys.list(),
+      'customers',
+      'infinite',
+      filter,
+    ],
+    async ({ pageParam }) => {
+      const pageNumber = Number(pageParam ?? 0);
+
+      const data = await api.get.customers({
+        ...queryParams,
+        first: rowsPerPage,
+        offset: rowsPerPage * pageNumber,
+      });
+
+      return {
+        data,
+        pageNumber,
+      };
+    }
+  );
+};

--- a/client/packages/system/src/Name/api/hooks/index.ts
+++ b/client/packages/system/src/Name/api/hooks/index.ts
@@ -7,6 +7,7 @@ export const useName = {
     get: Document.useName,
     updateProperties: Document.useUpdateProperties,
     customers: Document.useCustomers,
+    customersInfinite: Document.useCustomersInfinite,
     internalSuppliers: Document.useInternalSuppliers,
     list: Document.useNames,
     suppliers: Document.useSuppliers,


### PR DESCRIPTION
Fixes #11636

# 👩🏻‍💻 What does this PR do?

<img width="1000" alt="2026-05-13_11-27-09" src="https://github.com/user-attachments/assets/0bc2bef7-4afc-4fc3-9aab-ad296eb3b84b" />

The customer pickers (outbound shipment, customer return, response requisition, distribution dashboard, JSON form `NameSearch`, etc.) loaded `first: 1000` customers and did all the filtering in the browser. On large deployments (Nigeria UNFPA/MOH was the trigger — 40k+ visible names per store) any customer past row 1000 was silently unreachable: the user could type the customer's exact name and get no results, with no indication the customer existed.

The backend `names` GraphQL query already supports a `codeOrName` filter and pagination, so this is a frontend-only fix.

**Changes:**
- `api.get.customers` now accepts `first`/`offset`/`filter` instead of hardcoded `first: 1000`.
- New `useCustomersInfinite` hook driving a paginated react-query infinite query (100 rows/page, 500ms search debounce, 100ms pagination debounce).
- `CustomerSearchInput` and `CustomerSearchModal` rewritten to use server-side `codeOrName` filtering. Client-side narrowing still runs on the loaded page for instant feedback during the debounce window — the dropdown keeps the last non-empty narrowed set rather than flashing "no results" mid-debounce.
- New generic `InfiniteSearchPicker<T, TFilter>` component in `@openmsupply-client/common` extracting the shared search/debounce/pagination/cache-fallback machinery, so future pickers (patients, locations, donors, suppliers, etc.) can reuse it. Customer picker is the only consumer so far.
- `seed_hp_names.py` — script used to seed 2000+ Harry Potter character names into `lots-of-names.sqlite` for manual testing past the old 1000-row threshold.

## 💌 Any notes for the reviewer?

- **`StockItemSearchInput` is NOT migrated to `InfiniteSearchPicker` in this PR.** The `InfiniteSearchPicker` is set up to work for items but I figured it was a bad idea to do this for 2.19. Item search can be simplified by using this generic component later.
- **Hybrid client+server filtering by design.** The 500ms server debounce can feel laggy on its own, so the picker also narrows the *already-loaded* page on every keystroke. To avoid the dropdown flashing "no results" between keystrokes and the server response, the component holds the last non-empty client-narrowed set and returns that during the debounce window. Once the server confirms an empty result, the stash is cleared.
- **Client-side filter matches both `getOptionLabel` AND `option.code`.** Customer codes (e.g. `HP00001`) aren't in `getOptionLabel(name) === name.name`, so an explicit `option.code` probe was added so searching by code feels instant client-side too.
- **`currentId` cache→byId fallback.** When a caller passes `currentId` (e.g. JSON forms in programs), the picker first looks for the entity in the loaded pages and falls back to a single `nameById` fetch when it's not there — handles the "selected customer is past page 1" case. Same pattern items already had.
- **`useCustomers` hook is kept for non-search callers.** `CreateRequisitionModal` and `ProgramRequisitionOptions` use the full customer list to evaluate `hasCustomerProgramRequisitionSettings` against all customer IDs — they still get `first: 1000` since converting *those* to server-side search is a different scope. Same legacy ceiling there, but separate issue.
- **Issue scope deferred:** the issue mentions verifying all CustomerSearchModal usages — done for the modal/input pair, but the suppliers/donors/manufacturers/internal-supplier pickers in the same Name folder still have the old 1000-row pattern. Those weren't in the original issue but are now obvious follow-ups.

# 🧪 Testing

Use `seed_hp_names.py` shown bellow to populate `lots-of-names.sqlite` (it adds 2000 HP characters as customers visible to Kopu Health Centre, no changelog entries so it won't sync). Edit `DB` / `STORE_ID` in the script if you want a different db or store.

<details>
<summary>
Script for adding tons of customers to DB. Change DB, STORE_ID to fit. Doesn't sync. Note you won't be able to actually send things to these customers, they're not wired up properly but work for sake of search
</summary>

```py
"""Seed Harry Potter character names as customers in lots-of-names.sqlite.

Visible to Kopu Health Centre (3934979D64934D12A1757BA65F07931D) only.
Does NOT touch changelog (caller doesn't want sync).

Usage: python3 seed_hp_names.py [target_count]   # default 2000
Edit DB / STORE_ID below if you want a different db or store.
"""

import json
import sqlite3
import sys
import urllib.request
import uuid
from datetime import datetime

DB = "server/lots-of-names.sqlite"
STORE_ID = "3934979D64934D12A1757BA65F07931D"
API = "https://hp-api.onrender.com/api/characters"


def fetch_names() -> list[str]:
    with urllib.request.urlopen(API) as r:
        chars = json.load(r)
    names: set[str] = set()
    for c in chars:
        n = (c.get("name") or "").strip()
        if n:
            names.add(n)
        for a in c.get("alternate_names") or []:
            a = a.strip()
            if a:
                names.add(a)
    return sorted(names)


SUFFIXES = [
    "",
    " Jr",
    " Sr",
    " II",
    " III",
    " the Elder",
    " the Younger",
    " of Hogwarts",
    " of Gryffindor",
    " of Slytherin",
    " of Ravenclaw",
    " of Hufflepuff",
    " (Polyjuice)",
    " (Boggart)",
    " (Patronus form)",
]


def expand(base_names: list[str], target: int) -> list[str]:
    """Combine each base name with each suffix until we hit `target` entries."""
    out: list[str] = []
    for suf in SUFFIXES:
        for n in base_names:
            out.append((n + suf).strip())
            if len(out) >= target:
                return out
    return out


def new_id() -> str:
    return uuid.uuid4().hex.upper()


def code_for(name: str, idx: int) -> str:
    # Short-ish unique code: HP00001-style prefix + index.
    return f"HP{idx:05d}"


def main(target: int = 2000) -> int:
    base = fetch_names()
    print(f"Fetched {len(base)} unique HP base names")
    names = expand(base, target)
    print(f"Expanded to {len(names)} entries")

    con = sqlite3.connect(DB)
    cur = con.cursor()

    # Skip names that already exist (by exact code, in case re-run).
    cur.execute("SELECT code FROM name WHERE code LIKE 'HP%'")
    existing_codes = {row[0] for row in cur.fetchall()}
    print(f"{len(existing_codes)} HP-prefixed names already in db; will skip")

    now = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
    inserted = 0

    for i, full_name in enumerate(names, start=1):
        code = code_for(full_name, i)
        if code in existing_codes:
            continue

        name_id = new_id()
        link_id = new_id()
        join_id = new_id()

        # name row
        cur.execute(
            """
            INSERT INTO name (
                id, name, code,
                is_customer, is_supplier, is_manufacturer, is_donor,
                on_hold, is_deceased, type, is_sync_update, created_datetime
            ) VALUES (?, ?, ?, 1, 0, 0, 0, 0, 0, 'FACILITY', 0, ?)
            """,
            (name_id, full_name, code, now),
        )
        # name_link (1:1 with name for this seed)
        cur.execute(
            "INSERT INTO name_link (id, name_id) VALUES (?, ?)",
            (link_id, name_id),
        )
        # name_store_join — visible to STORE_ID as a customer
        cur.execute(
            """
            INSERT INTO name_store_join (
                id, store_id, name_is_customer, name_is_supplier,
                is_sync_update, name_link_id
            ) VALUES (?, ?, 1, 0, 0, ?)
            """,
            (join_id, STORE_ID, link_id),
        )
        inserted += 1

    con.commit()
    cur.execute(
        "SELECT COUNT(*) FROM name_store_join WHERE store_id=? AND name_is_customer=1",
        (STORE_ID,),
    )
    total_visible = cur.fetchone()[0]
    con.close()

    print(f"Inserted {inserted} new HP customers.")
    print(f"Customers now visible to store: {total_visible}")
    return 0


if __name__ == "__main__":
    target = int(sys.argv[1]) if len(sys.argv) > 1 else 2000
    sys.exit(main(target))
```

</details>

- [ ] Log in to the store with tons of customers.
- [ ] **Outbound shipment new modal (issue 11636 case):** Distribution → Outbound shipments → New. Modal opens with the picker focused and auto-open. Type `Snape` — verify after ~500ms the server returns matching results and the dropdown does NOT flash "no results" between keystrokes.
- [ ] **Past-1000 reachability (the bug):** type a customer code like `HP01500` or a name that only appears in the second thousand — verify it's found (this is what was previously impossible).
- [ ] **Search by code:** type `HP00012` — verify a result appears instantly (exercises the client-side code probe), then the server confirms after the debounce.
- [ ] **Scroll pagination:** scroll the open dropdown — verify subsequent pages load (Network tab should show successive `names` queries with increasing `offset`).
- [ ] **Customer return modal:** Distribution → Customer returns → New. Same picker, same flow.
- [ ] **Response requisition create modal:** Replenishment → Customer requisitions → New → "General" tab. `isList` mode of the same modal renders inline.
- [ ] **CustomerSearchInput inline pickers:**
  - [ ] Outbound shipment DetailView Toolbar — open an existing shipment, the customer name should appear in the picker without a flicker (exercises cache→byId fallback if the customer is past page 1).
  - [ ] Customer return Toolbar, Response Requisition Toolbar, Request Requisition Toolbar — selection persists; on-hold customers are disabled.
  - [ ] Dashboard `DistributionWidget` — open the distribution widget customer picker, search and select.
- [ ] **Existing customer list still loads (regression check):** Open the customer list pages and verify they render — the `useCustomers` hook is kept for non-search callers and still returns a full list under the 1000 ceiling.
- [ ] **Item picker regression check:** Inbound shipment line edit, stocktake line edit, outbound line edit — `StockItemSearchInput` should be unchanged (intentionally not migrated). Test the `"1234 Item Name"` backspace flow to confirm.

# 📃 Documentation

- [x] **No documentation required**: bug fix; the change is invisible to end users beyond customers past row 1000 now being reachable.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements (item picker migration to `InfiniteSearchPicker`; supplier/donor/manufacturer/internal-supplier pickers; `useCustomers` non-search callers)

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend