### PR TITLE
Fix RC-to-develop workflow conflict handling, add nightly schedule

### DIFF
--- a/.github/scripts/integrate-rc-to-develop.sh
+++ b/.github/scripts/integrate-rc-to-develop.sh
@@ -115,6 +115,12 @@ create_new_pull_request() {
     git checkout "origin/$RC_BRANCH"
     git checkout -b "$MERGE_BRANCH"
     merge_develop_into_branch "$MERGE_BRANCH"
+
+    if git diff --quiet HEAD origin/develop; then
+        echo "No content diff between $MERGE_BRANCH and develop - previous merge PR likely already integrated. Skipping PR creation."
+        return 0
+    fi
+
     git push -u origin "$MERGE_BRANCH"
 
     local pr_title="Merge $RC_BRANCH to develop"

--- a/.github/scripts/integrate-rc-to-develop.sh
+++ b/.github/scripts/integrate-rc-to-develop.sh
@@ -15,25 +15,28 @@ merge_develop_into_branch() {
 
     echo "Merging develop into $MERGE_BRANCH to detect conflicts"
     if git merge origin/develop --no-commit --no-ff 2>/dev/null; then
-        echo "Clean merge - no conflicts detected"
-        if git diff --cached --quiet; then
-            echo "Nothing to commit - develop is already up to date"
-            git merge --abort 2>/dev/null || true
-        else
+        if [[ -f .git/MERGE_HEAD ]]; then
+            echo "Clean merge - no conflicts detected"
             git commit -m "Merge develop into $MERGE_BRANCH"
+        else
+            echo "Nothing to commit - develop is already up to date"
         fi
     else
         echo "Merge conflicts detected"
-        if git status --porcelain | grep -q "package.json"; then
+
+        if [[ -n "$(git ls-files -u -- package.json)" ]]; then
             echo "Conflicts in package.json detected, auto-resolving"
-            git checkout --theirs package.json
-            git add package.json
+            git checkout --theirs -- package.json
+            git add -- package.json
         fi
 
-        if git status --porcelain | grep -q "^UU\|^AA\|^DD"; then
+        local unmerged_files
+        unmerged_files=$(git diff --name-only --diff-filter=U)
+
+        if [[ -n "$unmerged_files" ]]; then
             echo "There are unresolved conflicts that need manual resolution"
-            CONFLICTED_FILE_COUNT=$(git status --porcelain | grep -cE "^(UU|AA|DD)")
-            CONFLICTED_FILES=$(git status --porcelain | grep -E "^(UU|AA|DD)" | awk '{print $2}')
+            CONFLICTED_FILES="$unmerged_files"
+            CONFLICTED_FILE_COUNT=$(echo "$unmerged_files" | wc -l | tr -d ' ')
             git merge --abort
             HAS_UNRESOLVED_CONFLICTS=true
         else

--- a/.github/scripts/integrate-rc-to-develop.sh
+++ b/.github/scripts/integrate-rc-to-develop.sh
@@ -127,7 +127,8 @@ create_new_pull_request() {
         --title "$pr_title" \
         --body "$pr_body" \
         --base develop \
-        --head "$MERGE_BRANCH"); then
+        --head "$MERGE_BRANCH" \
+        --label "no linked issue"); then
         echo "PR created successfully for $MERGE_BRANCH"
         local pr_number
         pr_number=$(echo "$pr_url" | grep -oE '[0-9]+$')

--- a/.github/workflows/integrate-rc-to-develop.yaml
+++ b/.github/workflows/integrate-rc-to-develop.yaml
@@ -2,6 +2,8 @@ name: RC to Develop Integration
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * *" # Every day at 08:00 AM UTC - equivalent to 08:00 PM NZST (or 09:00 PM NZDT)
 
 jobs:
   integrate-rc-to-develop:


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes two bugs in the RC-to-develop integration workflow and adds a nightly schedule trigger so it runs automatically (it was manual-only before).

**Bug 1 — conflict detection silently fell through.** When `develop` had merge conflicts with an RC branch in files other than `package.json`, the script would print "Merge conflicts detected" and then attempt `git commit`, which failed with `exit 128`. The conflict-handling and auto-resolution branches never executed. Last failure: [run 25765228869](https://github.com/msupply-foundation/open-msupply/actions/runs/25765228869) on `v2.16.2-RC`.

Root cause was `git status --porcelain | grep -q ...` inside an `if` condition, combined with `set -euo pipefail`: when `grep -q` short-circuits on the first match, the upstream `git status` can receive SIGPIPE, `pipefail` propagates the failure, and the `if` evaluates as false even though the grep did match.

Replaced with `git ls-files -u` (for the package.json check) and `git diff --name-only --diff-filter=U` captured into a variable — no pipelines in `if` conditions, no SIGPIPE exposure.

**Bug 2 — "Already up to date" caused exit 1.** When `git merge origin/develop` had nothing to do, the script's `git diff --cached --quiet` check still went down the `else` branch and called `git commit`, which exits 1 on "nothing to commit". Replaced the cached-diff check with `[[ -f .git/MERGE_HEAD ]]`, which correctly distinguishes "merge happened" from "no-op merge".

**Tightened `package.json` check.** Was `grep -q "package.json"` against full status output, which matches any modified `client/packages/*/package.json` line, not just a conflict on the root file. Now `git ls-files -u -- package.json`, which is empty unless the root `package.json` is actually unmerged.

**Added nightly schedule.** `0 8 * * *` UTC (08:00 PM NZST / 09:00 PM NZDT), matching the daily cadence of the other nightly workflows and slotting in after the existing 06:30 and 07:00 UTC daily crons.

**Auto-applies the `no linked issue` label** to PRs the workflow creates, so the issue-link sync action doesn't fail on them.

**Skips PR creation when there is no content diff vs develop.** The existing `UNMERGED_COMMITS` pre-check counts commits reachable from RC but not develop — but if the previous merge PR was squash-merged, the original RC commits' hashes aren't on develop even though their *content* is, so they all still look unmerged. The script then tried to create a PR with zero net diff and `gh pr create` failed with "no commits between develop and X". After `merge_develop_into_branch`, the script now checks `git diff --quiet HEAD origin/develop` and returns early if the merge branch is content-identical to develop.

## 💌 Any notes for the reviewer?

The script-logic fix was verified against four scenarios in a local sandbox: clean merge, package.json-only conflict (auto-resolves), package.json plus other conflicts (the failing case — now aborts cleanly and captures the file list), and "Already up to date" (no-op). The squash-merge no-diff case was also reproduced and confirmed to skip cleanly.

Both triggers route to the same single job — no branching on `github.event_name` — so manual `workflow_dispatch` and scheduled runs produce identical outcomes.

# 🧪 Testing

- [ ] Manually dispatch the workflow against this branch from the Actions tab and confirm it creates a `merge-v2.16.2-RC-to-develop` PR with a warning comment listing the unresolvable conflict files (instead of crashing with exit 128).
- [ ] Confirm the created PR has the `no linked issue` label applied automatically.
- [ ] After that PR is squash-merged, dispatch the workflow again and confirm it logs "No content diff between ... and develop" and exits cleanly without trying to create a duplicate empty PR.