### PR TITLE
#11648 Include currently-empty stock lines in historical query

### DIFF
--- a/server/graphql/stock_line/src/lib.rs
+++ b/server/graphql/stock_line/src/lib.rs
@@ -231,6 +231,11 @@ impl StockLineQueries {
                     store_id,
                     item_id,
                     datetime.naive_utc(),
+                    // Include lines that are empty *now* but had stock at the
+                    // historical datetime — callers like the backdated
+                    // inventory adjustment modal need to display historical
+                    // availability for a specific line.
+                    true,
                 )
                 .map_err(StandardGraphqlError::from_list_error)?,
         };

--- a/server/service/src/invoice_line/get_draft_outbound_lines.rs
+++ b/server/service/src/invoice_line/get_draft_outbound_lines.rs
@@ -134,7 +134,7 @@ fn get_historical_available_stock_lines(
     datetime: Option<NaiveDateTime>,
 ) -> Result<Vec<StockLine>, ListError> {
     let historical_stock_lines = match datetime {
-        Some(datetime) => get_historical_stock_lines(ctx, store_id, item_id, &datetime)?,
+        Some(datetime) => get_historical_stock_lines(ctx, store_id, item_id, &datetime, false)?,
         None => get_stock_lines(
             ctx,
             None,

--- a/server/service/src/stock_line/historical_stock.rs
+++ b/server/service/src/stock_line/historical_stock.rs
@@ -90,25 +90,27 @@ pub fn get_historical_stock_lines_available_quantity(
 
 /// Get historical stock lines for a given store and item at a given datetime.
 /// NOTE: Stock lines are only adjusted based on stock movements, changes to batch, expiry dates etc are not considered.
+///
+/// When `include_currently_unavailable` is true, lines that are empty *now* but
+/// had stock at the historical datetime are also returned. Callers that need
+/// to allocate against current stock (e.g. backdated outbound shipments)
+/// should pass false; callers that want to display historical availability for
+/// a specific line (e.g. backdated inventory adjustment) should pass true.
 pub fn get_historical_stock_lines(
     ctx: &ServiceContext,
     store_id: &str,
     item_id: &str,
     datetime: &NaiveDateTime,
+    include_currently_unavailable: bool,
 ) -> Result<ListResult<StockLine>, RepositoryError> {
-    // First get the current stock lines
-    let mut stock_lines = get_stock_lines(
-        ctx,
-        None,
-        Some(
-            StockLineFilter::new()
-                .store_id(EqualFilter::equal_to(store_id.to_string()))
-                .item_id(EqualFilter::equal_to(item_id.to_string()))
-                .is_available(true),
-        ),
-        None,
-        Some(store_id.to_string()),
-    )
+    let mut filter = StockLineFilter::new()
+        .store_id(EqualFilter::equal_to(store_id.to_string()))
+        .item_id(EqualFilter::equal_to(item_id.to_string()));
+    if !include_currently_unavailable {
+        filter = filter.is_available(true);
+    }
+
+    let mut stock_lines = get_stock_lines(ctx, None, Some(filter), None, Some(store_id.to_string()))
     .map_err(|e| match e {
         ListError::DatabaseError(e) => e,
         _ => RepositoryError::NotFound, // Shouldn't happen happen as we don't have any pagination in our request

--- a/server/service/src/stock_line/mod.rs
+++ b/server/service/src/stock_line/mod.rs
@@ -58,9 +58,14 @@ pub trait StockLineServiceTrait: Sync + Send {
         store_id: String,
         item_id: String,
         datetime: NaiveDateTime,
+        include_currently_unavailable: bool,
     ) -> Result<ListResult<StockLine>, ListError> {
         Ok(get_historical_stock_lines(
-            ctx, &store_id, &item_id, &datetime,
+            ctx,
+            &store_id,
+            &item_id,
+            &datetime,
+            include_currently_unavailable,
         )?)
     }
 }

--- a/server/service/src/stock_line/tests/historical_stock.rs
+++ b/server/service/src/stock_line/tests/historical_stock.rs
@@ -188,7 +188,13 @@ mod query {
         // Check there's no stock to start with, if there is some mocks might have slipped through?
         let result = service_provider
             .stock_line_service
-            .get_historical_stock_lines(&ctx, store_id.clone(), item_id.clone(), date_now().into())
+            .get_historical_stock_lines(
+                &ctx,
+                store_id.clone(),
+                item_id.clone(),
+                date_now().into(),
+                false,
+            )
             .unwrap();
 
         assert!(result.rows.is_empty());
@@ -279,7 +285,13 @@ mod query {
         // // Check we can see 2 stock lines now (stock line A is fully consumed)
         let result = service_provider
             .stock_line_service
-            .get_historical_stock_lines(&ctx, store_id.clone(), item_id.clone(), date_now().into())
+            .get_historical_stock_lines(
+                &ctx,
+                store_id.clone(),
+                item_id.clone(),
+                date_now().into(),
+                false,
+            )
             .unwrap();
 
         assert_eq!(result.rows.len(), 2);
@@ -292,6 +304,7 @@ mod query {
                 store_id.clone(),
                 item_id.clone(),
                 get_midday(2020, 1, 1), // midday to check after the time the stock was introduced
+                false,
             )
             .unwrap();
         // StockLine A is already excluded by `is_available(true)` in the base query
@@ -340,6 +353,7 @@ mod query {
                 store_id.clone(),
                 item_id.clone(),
                 get_midday(2020, 1, 2), // midday to check after the time the stock was introduced
+                false,
             )
             .unwrap();
         assert_eq!(result.rows.len(), 2);
@@ -369,6 +383,7 @@ mod query {
                 store_id.clone(),
                 item_id.clone(),
                 get_midday(2020, 1, 3), // midday to check after the time the stock was introduced
+                false,
             )
             .unwrap();
         assert_eq!(result.rows.len(), 2);
@@ -398,6 +413,7 @@ mod query {
                 store_id.clone(),
                 item_id.clone(),
                 get_midday(2020, 1, 4), // midday to check after the time the stock was introduced
+                false,
             )
             .unwrap();
         assert_eq!(result.rows.len(), 2);
@@ -428,6 +444,7 @@ mod query {
                 store_id.clone(),
                 item_id.clone(),
                 get_midday(2020, 1, 5), // midday to check after the time the stock was introduced
+                false,
             )
             .unwrap();
 
@@ -459,6 +476,7 @@ mod query {
                 store_id.clone(),
                 item_id.clone(),
                 get_midday(2021, 1, 6), // midday to check after the time the stock was introduced
+                false,
             )
             .unwrap();
 
@@ -498,5 +516,99 @@ mod query {
             stock_line_c.unwrap().stock_line_row.total_number_of_packs,
             1000.0
         );
+    }
+
+    /// Regression test: a stock line that's currently empty but had stock at
+    /// the historical datetime must be returned when
+    /// `include_currently_unavailable` is true.
+    ///
+    /// Bug: the backdated inventory adjustment modal queries by item, then
+    /// matches the response by stock-line id. If the resolver filtered out
+    /// currently-empty lines, the modal silently fell back to displaying
+    /// *current* values labelled "Current" — even though the user had picked a
+    /// historical date.
+    #[actix_rt::test]
+    async fn historical_stock_lines_include_currently_unavailable() {
+        let ServiceTestContext {
+            service_provider, ..
+        } = setup_all_and_service_provider(
+            "historical_stock_lines_include_currently_unavailable",
+            MockDataInserts::none()
+                .names()
+                .stores()
+                .items()
+                .locations()
+                .numbers(),
+        )
+        .await;
+
+        let store_id = mock_store_a().id;
+        let item_id = mock_item_a().id;
+
+        let ctx = service_provider
+            .context(store_id.clone(), mock_user_account_a().id)
+            .unwrap();
+
+        // Line A: +100 on 2020-01-01, fully consumed by 2020-01-03.
+        // Line B: +500 on 2020-01-01, still has stock now.
+        adjust_test_stock(
+            &ctx,
+            vec![
+                TestStockAdjustment {
+                    datetime: get_midnight(2020, 1, 1),
+                    stock_line_a: Some(100.0),
+                    stock_line_b: Some(500.0),
+                    stock_line_c: None,
+                },
+                TestStockAdjustment {
+                    datetime: get_midnight(2020, 1, 3),
+                    stock_line_a: Some(-100.0),
+                    stock_line_b: None,
+                    stock_line_c: None,
+                },
+            ],
+        );
+
+        // With include_currently_unavailable = false (e.g. outbound allocation),
+        // line A is excluded because it's empty now.
+        let excluding = service_provider
+            .stock_line_service
+            .get_historical_stock_lines(
+                &ctx,
+                store_id.clone(),
+                item_id.clone(),
+                get_midday(2020, 1, 2),
+                false,
+            )
+            .unwrap();
+        assert!(excluding
+            .rows
+            .iter()
+            .all(|r| r.stock_line_row.id != STOCK_LINE_A));
+
+        // With include_currently_unavailable = true (e.g. backdated inventory
+        // adjustment display), line A is now returned. The crucial
+        // regression-guard is presence: without this, the modal silently fell
+        // back to current values labelled "Current". The historical *total* at
+        // 2020-01-02 is 100; available is reported as the min over the window
+        // from datetime to now (0 here, since the -100 consumption later
+        // brings the running balance down to 0).
+        let including = service_provider
+            .stock_line_service
+            .get_historical_stock_lines(
+                &ctx,
+                store_id.clone(),
+                item_id.clone(),
+                get_midday(2020, 1, 2),
+                true,
+            )
+            .unwrap();
+        let line_a = including
+            .rows
+            .iter()
+            .find(|r| r.stock_line_row.id == STOCK_LINE_A)
+            .expect("line A should be present when include_currently_unavailable is true");
+        assert_eq!(line_a.stock_line_row.total_number_of_packs, 100.0);
+        assert_eq!(line_a.stock_line_row.available_number_of_packs, 0.0);
     }
 }


### PR DESCRIPTION
Fixes #11648

# 👩🏻‍💻 What does this PR do?

`get_historical_stock_lines` filtered the base query with `is_available(true)`, so a stock line that's empty *now* but had stock at the historical datetime was dropped. The backdated inventory adjustment modal looks up the line by id in the response, got `undefined`, and silently fell back to current values labelled "Current".

Adds an `include_currently_unavailable` flag. The GraphQL resolver passes `true` (display); backdated outbound allocation passes `false` (still must not allocate from empty lines).

## 💌 Any notes for the reviewer?

The only other consumer of the `historicalStockLines` GraphQL endpoint is prescription `useDraftLines`, which doesn't pass a datetime and so isn't affected.

# 🧪 Testing

- [ ] Open Inventory Adjustment on a stock line with `available = 0` that had stock historically
- [ ] Pick a past date — label reads "Historical" and shows the historical quantities
- [ ] Negative adjustment within historical available saves successfully
- [ ] Backdated outbound shipment allocation still excludes currently-empty lines

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**:
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend