### PR TITLE
#11624 Fix empty supplier return from inbound shipment

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -4410,6 +4410,7 @@ export type InvoiceFilterInput = {
   invoiceNumber?: InputMaybe<EqualFilterBigNumberInput>;
   isProgramInvoice?: InputMaybe<Scalars['Boolean']['input']>;
   linkedInvoiceId?: InputMaybe<EqualFilterStringInput>;
+  linkedOrderNumber?: InputMaybe<EqualFilterBigNumberInput>;
   nameId?: InputMaybe<EqualFilterStringInput>;
   onHold?: InputMaybe<Scalars['Boolean']['input']>;
   otherPartyId?: InputMaybe<EqualFilterStringInput>;

--- a/client/packages/common/src/ui/layout/tables/components/RequiredNumberInputCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/RequiredNumberInputCell.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import {
   NumericTextInput,
-  useDebounceCallback,
   NumericTextInputProps,
 } from '@openmsupply-client/common';
 import { MRT_Cell, MRT_RowData } from 'material-react-table';
@@ -21,8 +20,7 @@ export const RequiredNumberInputCell = <T extends MRT_RowData>({
 }: NumberInputCellProps<T>) => {
   const value = cell.getValue<number>();
   const [inputState, setInputState] = useState<number | undefined>(value);
-
-  const updater = useDebounceCallback(updateFn, [updateFn], 250);
+  const { defaultValue } = numericTextProps;
 
   return (
     <NumericTextInput
@@ -30,14 +28,12 @@ export const RequiredNumberInputCell = <T extends MRT_RowData>({
       defaultValue={1}
       value={inputState}
       onChange={newValue => {
-        // newValue could be undefined, while the user is inputting
-        // (e.g. they clear the field to enter a new pack size)
-        // In that case, we keep the local input state as undefined
-        // but set the row value to 1 (so we always have valid state to save)
-
-        // NumericTextInput will reset to our default (1) on blur if the field is empty!
+        // newValue is undefined while the field is empty mid-edit; fall back to
+        // defaultValue so the parent always has a valid number. Propagate
+        // synchronously — debouncing here lets a click handler read stale state
+        // immediately after clearing the input (issue #11624).
         setInputState(newValue);
-        updater(newValue ?? 1);
+        updateFn(newValue ?? defaultValue ?? 1);
       }}
       onKeyDown={e => {
         // Allow using arrow keys to move input cursor without

--- a/client/packages/invoices/src/Returns/SupplierDetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/Returns/SupplierDetailView/Footer/StatusChangeButton.tsx
@@ -27,12 +27,7 @@ const useStatusChangeButton = () => {
   const { mutateAsync } = useReturns.document.updateSupplierReturn();
 
   const status = data?.status ?? InvoiceNodeStatus.New;
-
-  // TODO: lines
-  const lines: { totalCount: number; nodes: unknown[] } = {
-    totalCount: 1,
-    nodes: [],
-  };
+  const lineCount = data?.lines?.totalCount ?? 0;
 
   const options = useMemo(() => {
     let statusOptions = getStatusOptions(
@@ -97,7 +92,7 @@ const useStatusChangeButton = () => {
     setSelectedOption,
     getConfirmation,
     onHold: data?.onHold ?? false,
-    lines,
+    lineCount,
   };
 };
 
@@ -108,11 +103,11 @@ export const StatusChangeButton = () => {
     setSelectedOption,
     getConfirmation,
     onHold,
-    lines,
+    lineCount,
   } = useStatusChangeButton();
   const isDisabled = useReturns.utils.supplierIsDisabled();
   const t = useTranslation();
-  const noLines = lines?.totalCount === 0;
+  const noLines = lineCount === 0;
 
   if (!selectedOption) return null;
   if (isDisabled) return null;

--- a/client/packages/invoices/src/Returns/api/operations.generated.ts
+++ b/client/packages/invoices/src/Returns/api/operations.generated.ts
@@ -483,6 +483,7 @@ export type SupplierReturnByIdQuery = {
         transportReference?: string | null;
         lines: {
           __typename: 'InvoiceLineConnector';
+          totalCount: number;
           nodes: Array<{
             __typename: 'InvoiceLineNode';
             id: string;
@@ -1182,6 +1183,7 @@ export const SupplierReturnByIdDocument = gql`
           nodes {
             ...SupplierReturnLine
           }
+          totalCount
         }
       }
     }

--- a/client/packages/invoices/src/Returns/api/operations.graphql
+++ b/client/packages/invoices/src/Returns/api/operations.graphql
@@ -347,6 +347,7 @@ query supplierReturnById($invoiceId: String!, $storeId: String!) {
         nodes {
           ...SupplierReturnLine
         }
+        totalCount
       }
     }
   }

--- a/server/graphql/invoice/src/mutations/customer_return/update.rs
+++ b/server/graphql/invoice/src/mutations/customer_return/update.rs
@@ -101,6 +101,7 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
         | ServiceError::CannotReverseInvoiceStatus
         | ServiceError::ReturnIsNotEditable
         | ServiceError::CannotChangeStatusOfInvoiceOnHold
+        | ServiceError::CannotIssueCustomerReturnWithNoLines
         | ServiceError::OtherPartyDoesNotExist => BadUserInput(formatted_error),
 
         ServiceError::UpdatedInvoiceDoesNotExist | ServiceError::DatabaseError(_) => {

--- a/server/graphql/invoice/src/mutations/supplier_return/update.rs
+++ b/server/graphql/invoice/src/mutations/supplier_return/update.rs
@@ -72,6 +72,7 @@ fn map_error(error: ServiceError) -> Result<UpdateResponse> {
         | ServiceError::ReturnIsNotEditable
         | ServiceError::CannotReverseInvoiceStatus
         | ServiceError::CannotChangeStatusOfInvoiceOnHold
+        | ServiceError::CannotIssueSupplierReturnWithNoLines
         | ServiceError::ReturnDoesNotExist => BadUserInput(formatted_error),
 
         ServiceError::InvoiceLineHasNoStockLine(_)

--- a/server/service/src/invoice/customer_return/update/mod.rs
+++ b/server/service/src/invoice/customer_return/update/mod.rs
@@ -94,6 +94,7 @@ pub enum UpdateCustomerReturnError {
     CannotReverseInvoiceStatus,
     ReturnIsNotEditable,
     CannotChangeStatusOfInvoiceOnHold,
+    CannotIssueCustomerReturnWithNoLines,
     // Name validation
     OtherPartyDoesNotExist,
     OtherPartyNotVisible,
@@ -210,6 +211,17 @@ mod test {
                 ..Default::default()
             }
         }
+        fn empty_return() -> InvoiceRow {
+            InvoiceRow {
+                id: "empty_customer_return".to_string(),
+                store_id: mock_store_a().id,
+                name_id: mock_name_store_a().id,
+                currency_id: Some(currency_a().id),
+                r#type: InvoiceType::CustomerReturn,
+                status: InvoiceStatus::New,
+                ..Default::default()
+            }
+        }
 
         let (_, _, connection_manager, _) = setup_all_with_data(
             "update_customer_return_errors",
@@ -217,7 +229,7 @@ mod test {
             MockData {
                 names: vec![not_visible(), not_a_supplier()],
                 name_store_joins: vec![not_a_supplier_join()],
-                invoices: vec![verified_return(), on_hold_return()],
+                invoices: vec![verified_return(), on_hold_return(), empty_return()],
                 ..Default::default()
             },
         )
@@ -288,6 +300,19 @@ mod test {
                 }
             ),
             Err(ServiceError::CannotChangeStatusOfInvoiceOnHold)
+        );
+
+        //CannotIssueCustomerReturnWithNoLines
+        assert_eq!(
+            service.update_customer_return(
+                &context,
+                UpdateCustomerReturn {
+                    id: empty_return().id,
+                    status: Some(UpdateCustomerReturnStatus::Received),
+                    ..Default::default()
+                }
+            ),
+            Err(ServiceError::CannotIssueCustomerReturnWithNoLines)
         );
     }
 

--- a/server/service/src/invoice/customer_return/update/validate.rs
+++ b/server/service/src/invoice/customer_return/update/validate.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     validate::{check_other_party, CheckOtherPartyType, OtherPartyErrors},
 };
-use repository::{InvoiceRow, InvoiceType, Name, StorageConnection};
+use repository::{InvoiceLineRowRepository, InvoiceRow, InvoiceType, Name, StorageConnection};
 
 use super::{UpdateCustomerReturn, UpdateCustomerReturnError};
 
@@ -42,6 +42,12 @@ pub fn validate(
             }
             InvoiceRowStatusError::CannotReverseInvoiceStatus => CannotReverseInvoiceStatus,
         })?;
+
+        let lines =
+            InvoiceLineRowRepository::new(connection).find_many_by_invoice_id(&patch.id)?;
+        if lines.is_empty() {
+            return Err(CannotIssueCustomerReturnWithNoLines);
+        }
     }
     // Other party check
     let other_party_id = match &patch.other_party_id {

--- a/server/service/src/invoice/supplier_return/update/mod.rs
+++ b/server/service/src/invoice/supplier_return/update/mod.rs
@@ -41,6 +41,7 @@ pub enum UpdateSupplierReturnError {
     NotAnSupplierReturn,
     CannotChangeStatusOfInvoiceOnHold,
     CannotReverseInvoiceStatus,
+    CannotIssueSupplierReturnWithNoLines,
     InvoiceLineHasNoStockLine(String), // holds the id of the invalid invoice line
     UpdatedReturnDoesNotExist,
     DatabaseError(RepositoryError),
@@ -176,6 +177,13 @@ mod test {
             }
         }
 
+        fn empty_return() -> InvoiceRow {
+            InvoiceRow {
+                id: "empty_return".to_string(),
+                ..base_test_return()
+            }
+        }
+
         fn new_return_line_no_stock_line() -> InvoiceLineRow {
             InvoiceLineRow {
                 id: "new_return_line_no_stock_line".to_string(),
@@ -190,7 +198,12 @@ mod test {
             "test_update_supplier_return_errors",
             MockDataInserts::all(),
             MockData {
-                invoices: vec![wrong_store(), shipped_return(), new_return()],
+                invoices: vec![
+                    wrong_store(),
+                    shipped_return(),
+                    new_return(),
+                    empty_return(),
+                ],
                 invoice_lines: vec![new_return_line_no_stock_line()],
                 ..Default::default()
             },
@@ -248,6 +261,19 @@ mod test {
                 }
             ),
             Err(ServiceError::ReturnIsNotEditable)
+        );
+
+        // CannotIssueSupplierReturnWithNoLines
+        assert_eq!(
+            service_provider.invoice_service.update_supplier_return(
+                &context,
+                UpdateSupplierReturn {
+                    supplier_return_id: empty_return().id,
+                    status: Some(UpdateSupplierReturnStatus::Shipped),
+                    ..Default::default()
+                }
+            ),
+            Err(ServiceError::CannotIssueSupplierReturnWithNoLines)
         );
 
         // InvoiceLineHasNoStockLine

--- a/server/service/src/invoice/supplier_return/update/validate.rs
+++ b/server/service/src/invoice/supplier_return/update/validate.rs
@@ -1,4 +1,4 @@
-use repository::{InvoiceRow, InvoiceType, StorageConnection};
+use repository::{InvoiceLineRowRepository, InvoiceRow, InvoiceType, StorageConnection};
 
 use crate::invoice::{
     check_invoice_exists, check_invoice_is_editable, check_invoice_status, check_invoice_type,
@@ -38,6 +38,12 @@ pub fn validate(
                 InvoiceRowStatusError::CannotReverseInvoiceStatus => CannotReverseInvoiceStatus,
             },
         )?;
+
+        let lines = InvoiceLineRowRepository::new(connection)
+            .find_many_by_invoice_id(&input.supplier_return_id)?;
+        if lines.is_empty() {
+            return Err(CannotIssueSupplierReturnWithNoLines);
+        }
     }
     Ok((return_row, status_changed))
 }


### PR DESCRIPTION
Fixes #11624

# 👩🏻‍💻 What does this PR do?

`RequiredNumberInputCell` debounced parent state updates by 250 ms. In the Supplier Return modal, if a user cleared a quantity then clicked *Next Step* without unfocusing, the click handler read stale `lines` (still non-zero) and advanced; the post-blur `onChange(0)` fired later, saving an empty Shipped return.

Fix: propagate `updateFn` synchronously (the debounce wasn't needed — local `inputState` already buffers display, and both call sites' `updateFn` is a cheap `setState`). Also fall back to the configured `defaultValue` instead of hardcoded `1` when the field is empty mid-edit.

## 💌 Any notes for the reviewer?

Shared component — used in exactly two places:
- Supplier Return *Quantity to return* (the bug site, `defaultValue={0}`)
- Stocktake line edit *Pack size* (`defaultValue={row.item.defaultPackSize}`)

The `?? defaultValue ?? 1` fallback preserves stocktake's behaviour (clearing falls back to the item's default pack size) while fixing returns (clearing falls back to 0).

## Update — backend + frontend defence-in-depth

Per [Carl's review](https://github.com/msupply-foundation/open-msupply/pull/11651#pullrequestreview) and [Mark's confirmation](https://github.com/msupply-foundation/open-msupply/pull/11651#issuecomment) that empty returns have no legitimate use case, extending this PR with server-side protection plus a frontend follow-up.

**Backend** — `update_supplier_return` and `update_customer_return` now reject any status change when the return has zero invoice lines.

- New error variants `CannotIssueSupplierReturnWithNoLines` / `CannotIssueCustomerReturnWithNoLines`, mapped to `BadUserInput` so the existing client `try/catch` toast handles them. No GraphQL schema change.
- Validation runs in the existing `if status_changed { ... }` block in each service's `validate.rs`, after the status/on-hold checks. Mirrors the `check_no_pending_lines` pattern in inbound shipment update.
- Tests added for both error cases.

**Frontend** — supplier-return DetailView's `StatusChangeButton` had a hardcoded `// TODO: lines` placeholder (`totalCount: 1`), so its `noLines` check was effectively dead. Replaced with the real line count from the query, matching the customer-return pattern: button disables with a *No lines* tooltip when empty. Added `totalCount` to `supplierReturnById`.

# 🧪 Testing

- [ ] Replenishment → Inbound Shipments → new shipment, add an item with qty, set status to *Shipped*
- [ ] Select item → *Return quantities* → enter `1` → *Next Step* → *Back* → backspace to clear → *Next Step* without clicking away
- [ ] Verify: stays on Quantity tab, zero-quantity alert shown (no empty return created)
- [ ] Happy path still works: enter `1`, *Next Step*, save → return shipped with one line
- [ ] Stocktake regression: Inventory → Stocktake → edit a line → clear *Pack Size* → falls back to item's default pack size (not `1`)

**Backend / frontend defence (new):**
- [ ] Manually create a supplier return with no lines (or delete the only line): status button is **disabled** with *No lines* tooltip
- [ ] Hit `updateSupplierReturn` directly (devtools/curl) with status `Shipped` on an empty return → `BAD_USER_INPUT` mentioning `CannotIssueSupplierReturnWithNoLines`
- [ ] Same for customer return: empty return + `updateCustomerReturn` with status `Received` → `CannotIssueCustomerReturnWithNoLines`
- [ ] Existing customer-return UX unchanged (already had this check on the frontend)

# 📃 Documentation

- [x] **No documentation required**: bug fix, no change in intended behaviour

# 📃 Reviewer Checklist

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API

**Issue Review**
- [ ] All requirements in original issue have been covered

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
