### PR TITLE
Add reference column to internal order list

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
@@ -75,16 +75,24 @@ export const ListView = () => {
         ),
       },
       {
+        accessorKey: 'theirReference',
+        header: t('label.reference'),
+        enableSorting: true,
+        size: 250,
+      },
+      {
         id: 'status',
         header: t('label.status'),
         enableSorting: true,
         accessorFn: row => getRequisitionTranslator(t)(row.status),
+        size: 90,
       },
       {
         accessorKey: 'requisitionNumber',
         header: t('label.number'),
         enableSorting: true,
         columnType: ColumnType.Number,
+        size: 65,
       },
       {
         accessorKey: 'createdDatetime',


### PR DESCRIPTION
## Summary
- Adds the `theirReference` field as a "Reference" column to the internal order list, immediately right of the Name column.
- Sizes the new column to 250 (same as Name) and halves the Status column to 90 and the Number column to 65 to make room.

Fixes #11650

## Test plan
- [ ] Open the internal order list and confirm a "Reference" column appears between "Name" and "Status".
- [ ] Confirm column widths look correct (Name and Reference comparable; Status and Number narrower than before).
- [ ] Confirm sorting on the Reference column works.
- [ ] Confirm rows with no `theirReference` render an empty cell without error.


---
_Generated by [Claude Code](https://claude.ai/code/session_013cJRuQD9L6imnAY26yd7Zu)_