### PR TITLE
#11600 Drop program existence check on stock-in lines

### DIFF
--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
@@ -198,7 +198,7 @@ fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
         | ServiceError::ManufacturerDoesNotExist
         | ServiceError::ManufacturerNotVisible
         | ServiceError::ManufacturerIsNotAManufacturer
-        | ServiceError::ProgramNotVisible
+        | ServiceError::ProgramDoesNotExist
         | ServiceError::PurchaseOrderLineIdRequired
         | ServiceError::PurchaseOrderLineDoesNotExist
         | ServiceError::ItemNotFound => BadUserInput(formatted_error),

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
@@ -239,7 +239,7 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
         | ServiceError::ManufacturerDoesNotExist
         | ServiceError::ManufacturerNotVisible
         | ServiceError::ManufacturerIsNotAManufacturer
-        | ServiceError::ProgramNotVisible
+        | ServiceError::ProgramDoesNotExist
         | ServiceError::CampaignDoesNotExist
         | ServiceError::CannotEditCostPrice
         | ServiceError::ItemNotFound => BadUserInput(formatted_error),

--- a/server/service/src/invoice_line/stock_in_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/mod.rs
@@ -119,7 +119,7 @@ pub enum InsertStockInLineError {
     ManufacturerNotVisible,
     ManufacturerIsNotAManufacturer,
     VVMStatusDoesNotExist,
-    ProgramNotVisible,
+    ProgramDoesNotExist,
     IncorrectLocationType,
     PurchaseOrderLineIdRequired,
     PurchaseOrderLineDoesNotExist,
@@ -477,6 +477,25 @@ mod test {
                 None
             ),
             Err(ServiceError::ManufacturerIsNotAManufacturer)
+        );
+
+        // ProgramDoesNotExist
+        assert_eq!(
+            insert_stock_in_line(
+                &context,
+                InsertStockInLine {
+                    id: "new invoice line id".to_string(),
+                    pack_size: 1.0,
+                    number_of_packs: 1.0,
+                    item_id: mock_item_a().id,
+                    invoice_id: mock_inbound_shipment_e().id,
+                    r#type: StockInType::InboundShipment,
+                    program_id: Some("does-not-exist".to_string()),
+                    ..Default::default()
+                },
+                None
+            ),
+            Err(ServiceError::ProgramDoesNotExist)
         );
 
         // Program exists but is not visible to this store — accepted (see #11600).

--- a/server/service/src/invoice_line/stock_in_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/mod.rs
@@ -479,24 +479,24 @@ mod test {
             Err(ServiceError::ManufacturerIsNotAManufacturer)
         );
 
-        // ProgramNotVisible
-        assert_eq!(
-            insert_stock_in_line(
-                &context,
-                InsertStockInLine {
-                    id: "new invoice line id".to_string(),
-                    pack_size: 1.0,
-                    number_of_packs: 1.0,
-                    item_id: mock_item_a().id,
-                    invoice_id: mock_inbound_shipment_e().id,
-                    r#type: StockInType::InboundShipment,
-                    program_id: Some(mock_immunisation_program_a().id), // Not master list visible to store_b
-                    ..Default::default()
-                },
-                None
-            ),
-            Err(ServiceError::ProgramNotVisible)
-        );
+        // Program exists but is not visible to this store — accepted (see #11600).
+        // This represents stock that flowed in via an upstream shipment carrying a
+        // program_id the customer store doesn't have visible.
+        insert_stock_in_line(
+            &context,
+            InsertStockInLine {
+                id: "stock_in_line_with_invisible_program".to_string(),
+                pack_size: 1.0,
+                number_of_packs: 1.0,
+                item_id: mock_item_a().id,
+                invoice_id: mock_inbound_shipment_e().id,
+                r#type: StockInType::InboundShipment,
+                program_id: Some(mock_immunisation_program_a().id),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
     }
 
     #[actix_rt::test]

--- a/server/service/src/invoice_line/stock_in_line/insert/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/validate.rs
@@ -1,3 +1,4 @@
+use crate::common::check_program_exists;
 use crate::invoice::inbound_shipment::InboundShipmentType;
 use crate::{
     check_item_variant_exists, check_location_exists, check_location_type_is_valid,
@@ -110,6 +111,12 @@ pub fn validate(
             },
         };
     };
+
+    if let Some(program_id) = &input.program_id {
+        if check_program_exists(connection, program_id)?.is_none() {
+            return Err(ProgramDoesNotExist);
+        }
+    }
 
     // External inbound shipments (with purchase_order_id) require a purchase_order_line_id
     if invoice.purchase_order_id.is_some() {

--- a/server/service/src/invoice_line/stock_in_line/insert/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/validate.rs
@@ -4,7 +4,7 @@ use crate::{
     check_vvm_status_exists,
     invoice::{check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store},
     invoice_line::{
-        stock_in_line::{check_pack_size, check_program_visible_to_store},
+        stock_in_line::check_pack_size,
         validate::{check_item_exists, check_line_exists, check_number_of_packs},
     },
     validate::{check_other_party, CheckOtherPartyType, OtherPartyErrors},
@@ -110,10 +110,6 @@ pub fn validate(
             },
         };
     };
-
-    if !check_program_visible_to_store(connection, store_id, &input.program_id)? {
-        return Err(ProgramNotVisible);
-    }
 
     // External inbound shipments (with purchase_order_id) require a purchase_order_line_id
     if invoice.purchase_order_id.is_some() {

--- a/server/service/src/invoice_line/stock_in_line/update/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/mod.rs
@@ -118,7 +118,7 @@ pub enum UpdateStockInLineError {
     ManufacturerNotVisible,
     ManufacturerIsNotAManufacturer,
     VVMStatusDoesNotExist,
-    ProgramNotVisible,
+    ProgramDoesNotExist,
     IncorrectLocationType,
     CampaignDoesNotExist,
     WrongInboundShipmentType,
@@ -357,6 +357,22 @@ mod test {
                 None
             ),
             Err(ServiceError::BatchIsReserved)
+        );
+
+        // ProgramDoesNotExist
+        assert_eq!(
+            update_stock_in_line(
+                &context,
+                UpdateStockInLine {
+                    id: mock_customer_return_a_invoice_line_a().id,
+                    program_id: Some(NullableUpdate {
+                        value: Some("does-not-exist".to_string()),
+                    }),
+                    ..Default::default()
+                },
+                None
+            ),
+            Err(ServiceError::ProgramDoesNotExist)
         );
 
         // Program exists but is not visible to this store — accepted (see #11600).

--- a/server/service/src/invoice_line/stock_in_line/update/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/mod.rs
@@ -359,21 +359,19 @@ mod test {
             Err(ServiceError::BatchIsReserved)
         );
 
-        // ProgramNotVisible
-        assert_eq!(
-            update_stock_in_line(
-                &context,
-                UpdateStockInLine {
-                    id: mock_customer_return_a_invoice_line_a().id,
-                    program_id: Some(NullableUpdate {
-                        value: Some(mock_immunisation_program_a().id)
-                    }), // Master list not visible to store_b
-                    ..Default::default()
-                },
-                None
-            ),
-            Err(ServiceError::ProgramNotVisible)
-        );
+        // Program exists but is not visible to this store — accepted (see #11600).
+        update_stock_in_line(
+            &context,
+            UpdateStockInLine {
+                id: mock_customer_return_a_invoice_line_a().id,
+                program_id: Some(NullableUpdate {
+                    value: Some(mock_immunisation_program_a().id),
+                }),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
 
         // ManufacturerDoesNotExist
         assert_eq!(

--- a/server/service/src/invoice_line/stock_in_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/validate.rs
@@ -1,3 +1,4 @@
+use crate::common::check_program_exists;
 use crate::invoice::inbound_shipment::InboundShipmentType;
 use crate::{
     campaign::check_campaign_exists,
@@ -95,6 +96,15 @@ pub fn validate(
 
     if !check_line_belongs_to_invoice(line_row, &invoice) {
         return Err(NotThisInvoiceLine(line.invoice_line_row.invoice_id));
+    }
+
+    if let Some(NullableUpdate {
+        value: Some(program_id),
+    }) = &input.program_id
+    {
+        if check_program_exists(connection, program_id)?.is_none() {
+            return Err(ProgramDoesNotExist);
+        }
     }
 
     if let Some(NullableUpdate {

--- a/server/service/src/invoice_line/stock_in_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/validate.rs
@@ -5,7 +5,7 @@ use crate::{
     check_vvm_status_exists,
     invoice::{check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store},
     invoice_line::{
-        stock_in_line::{check_batch, check_pack_size, check_program_visible_to_store},
+        stock_in_line::{check_batch, check_pack_size},
         validate::{
             check_item_exists, check_line_belongs_to_invoice, check_line_exists,
             check_number_of_packs,
@@ -95,12 +95,6 @@ pub fn validate(
 
     if !check_line_belongs_to_invoice(line_row, &invoice) {
         return Err(NotThisInvoiceLine(line.invoice_line_row.invoice_id));
-    }
-
-    if let Some(program_id) = &input.program_id {
-        if !check_program_visible_to_store(connection, store_id, &program_id.value)? {
-            return Err(ProgramNotVisible);
-        }
     }
 
     if let Some(NullableUpdate {

--- a/server/service/src/invoice_line/stock_in_line/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/validate.rs
@@ -1,7 +1,7 @@
 use repository::{
     vvm_status::vvm_status_log::{VVMStatusLogFilter, VVMStatusLogRepository},
-    EqualFilter, InvoiceLineRow, ProgramFilter, ProgramRepository, RepositoryError, StockLineRow,
-    StockLineRowRepository, StorageConnection,
+    EqualFilter, InvoiceLineRow, RepositoryError, StockLineRow, StockLineRowRepository,
+    StorageConnection,
 };
 
 pub fn check_pack_size(pack_size_option: Option<f64>) -> bool {
@@ -43,25 +43,6 @@ pub fn check_batch_stock_reserved(
         if line.number_of_packs != batch.available_number_of_packs {
             return Ok(false);
         }
-    }
-    Ok(true)
-}
-
-pub fn check_program_visible_to_store(
-    connection: &StorageConnection,
-    store_id: &str,
-    program_id: &Option<String>,
-) -> Result<bool, RepositoryError> {
-    if let Some(program_id) = program_id {
-        let repo = ProgramRepository::new(connection);
-        let matching_programs = repo.query_by_filter(
-            ProgramFilter::new()
-                .id(EqualFilter::equal_to(program_id.to_string()))
-                .exists_for_store_id(EqualFilter::equal_to(store_id.to_string())),
-        )?;
-
-        // If no programs, then program is not visible to the store
-        return Ok(!matching_programs.is_empty());
     }
     Ok(true)
 }

--- a/server/service/src/stocktake/update/mod.rs
+++ b/server/service/src/stocktake/update/mod.rs
@@ -831,4 +831,104 @@ mod test {
             "Stock line should be created for new stocktake line even when ExternalInboundShipmentLinesMustBeAuthorised is enabled"
         );
     }
+
+    #[actix_rt::test]
+    async fn finalise_stocktake_with_program_not_visible_to_store() {
+        // Regression test for #11600: finalising a stocktake must succeed even when the
+        // adjusted stock line carries a program_id that is not visible to this store.
+        // This happens in practice when stock was received via an upstream shipment whose
+        // program the customer store doesn't have visible — the stocktake should not be
+        // blocked by that.
+        use repository::mock::mock_immunisation_program_a;
+
+        let stock_line_with_invisible_program = StockLineRow {
+            id: "stock_line_invisible_program".to_string(),
+            item_link_id: mock_item_a().id,
+            store_id: mock_store_a().id,
+            pack_size: 1.0,
+            available_number_of_packs: 5.0,
+            total_number_of_packs: 5.0,
+            program_id: Some(mock_immunisation_program_a().id),
+            ..Default::default()
+        };
+
+        let stocktake = StocktakeRow {
+            id: "stocktake_program_not_visible".to_string(),
+            store_id: mock_store_a().id,
+            stocktake_number: 100,
+            created_datetime: NaiveDate::from_ymd_opt(2024, 1, 1)
+                .unwrap()
+                .and_hms_milli_opt(0, 0, 0, 0)
+                .unwrap(),
+            status: StocktakeStatus::New,
+            ..Default::default()
+        };
+
+        let stocktake_line = StocktakeLineRow {
+            id: "stocktake_line_program_not_visible".to_string(),
+            stocktake_id: stocktake.id.clone(),
+            stock_line_id: Some(stock_line_with_invisible_program.id.clone()),
+            item_link_id: mock_item_a().id,
+            // Force inventory addition path (counted > snapshot)
+            snapshot_number_of_packs: 5.0,
+            counted_number_of_packs: Some(10.0),
+            program_id: Some(mock_immunisation_program_a().id),
+            ..Default::default()
+        };
+
+        let (_, connection, connection_manager, _) = setup_all_with_data(
+            "finalise_stocktake_with_program_not_visible_to_store",
+            MockDataInserts::all(),
+            MockData {
+                stock_lines: vec![stock_line_with_invisible_program.clone()],
+                stocktakes: vec![stocktake.clone()],
+                stocktake_lines: vec![stocktake_line],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context(mock_store_a().id, "".to_string())
+            .unwrap();
+
+        let result = service_provider
+            .stocktake_service
+            .update_stocktake(
+                &context,
+                UpdateStocktake {
+                    id: stocktake.id.clone(),
+                    status: Some(UpdateStocktakeStatus::Finalised),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        // The inventory adjustment line should have been created and the resulting stock
+        // line should still carry the program_id (we don't strip it, just don't require
+        // visibility).
+        let inventory_addition_id = result.inventory_addition_id.unwrap();
+        let inventory_addition_line = InvoiceLineRepository::new(&connection)
+            .query_by_filter(
+                repository::InvoiceLineFilter::new()
+                    .invoice_id(EqualFilter::equal_to(inventory_addition_id)),
+            )
+            .unwrap()
+            .pop()
+            .unwrap();
+        assert_eq!(
+            inventory_addition_line.invoice_line_row.r#type,
+            InvoiceLineType::StockIn
+        );
+        let updated_stock_line = StockLineRowRepository::new(&connection)
+            .find_one_by_id(&stock_line_with_invisible_program.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated_stock_line.total_number_of_packs, 10.0);
+        assert_eq!(
+            updated_stock_line.program_id,
+            Some(mock_immunisation_program_a().id)
+        );
+    }
 }


### PR DESCRIPTION
Fixes #11600

# 👩🏻‍💻 What does this PR do?

Stocktake finalisation was failing with `InsertStockInLineError::ProgramNotVisible` when an adjusted stock line carried a `program_id` not visible to the receiving store. Stock can pick up a `program_id` from an upstream shipment (program-based orders flow supplier → outbound → inbound → resulting stock line), and that program is not necessarily visible to the customer store.

Removes the service-level program check entirely from both stock-in line insert and update validators. Belt-and-braces: sync's `clear_invalid_fk` nullifies orphan `program_id` refs on pull, the UI restricts users to valid programs, and `invoice_line.program_id` / `stock_line.program_id` both have DB-level FK constraints to `program(id)` that catch anything else.

## 💌 Any notes for the reviewer?

- The `ProgramNotVisible` variant is left in place on `InsertStockInLineError` and `UpdateStockInLineError` (and its GraphQL mapping) for API stability. It's no longer reachable from this code path.
- Existing tests that asserted `ProgramNotVisible` were rewritten to assert success on the same input (program exists but not visible to this store).
- New regression test `finalise_stocktake_with_program_not_visible_to_store` reproduces the original #11600 scenario.

# 🧪 Testing

- [ ] At a store, set `program_id` on a stock line to a program whose master_list is not joined to that store (direct SQL)
- [ ] Create a stocktake adjusting the count for that stock line
- [ ] Finalise — should succeed (previously failed with internal error)
- [ ] Confirm the resulting stock line still carries the `program_id`
- [ ] `cargo nextest run -p service stocktake invoice_line::stock_in_line`

# 📃 Documentation

- [x] **No documentation required**: bug fix, no change in user-facing behaviour

---

## Update (addressing review feedback from @jmbrunskill)

Reverted the "drop the check entirely" approach. Restored a typed service-level check (mirrors the `check_campaign_exists` pattern) so an invalid `program_id` returns a structured error rather than falling through to a DB FK violation.

- Renamed `ProgramNotVisible` → `ProgramDoesNotExist` on `InsertStockInLineError` and `UpdateStockInLineError`, plus the two GraphQL mappings (`graphql/invoice_line/.../inbound_shipment_line/line/{insert,update}.rs`). Variant is in the standard-error chain (not the typed union), so wire impact is limited to the human-readable message string.
- Added back negative test cases: non-existent `program_id` → `ProgramDoesNotExist` on both insert and update.
- Kept the positive cases: program exists but isn't visible to this store → succeeds. Plus the stocktake regression test for the original #11600 scenario.

### Why this is the right invariant on a remote site

On a remote site, `program` rows are created indirectly via `list_master` sync. The sync translators for `stock_line`, `stocktake_line` and `invoice_line` all call `clear_invalid_fk` on `program_id` during pull — if the program doesn't exist locally, the FK is nullified. So any non-null `program_id` on a remote site is guaranteed to reference an existing local program, and the existence check won't fire spuriously after sync. The only realistic trigger for `ProgramDoesNotExist` is a direct GraphQL caller passing a made-up id.
