### PR TITLE
Drop stale sort id from table state when column is absent

### DIFF
--- a/client/packages/common/src/ui/layout/tables/useBaseMaterialTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/useBaseMaterialTable.tsx
@@ -103,6 +103,19 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
     localStateOnly
   );
 
+  // The URL `sort` param is shared across tabs, but each tab's table may have
+  // different columns. Hand MRT only sort entries whose column exists in this
+  // table; otherwise TanStack Table logs a dev-time "Column with id 'X' does
+  // not exist" error. The URL itself is left untouched so the sort still
+  // applies when the user navigates back to a tab where the column exists.
+  const validSorting = React.useMemo(
+    () =>
+      sorting.filter(s =>
+        columns.some(c => (c.id ?? ('accessorKey' in c ? c.accessorKey : undefined)) === s.id)
+      ),
+    [sorting, columns]
+  );
+
   const density = useColumnDensity(tableId);
   const columnSizing = useColumnSizing(tableId);
   const columnVisibility = useColumnVisibility(tableId, columns, isMobile);
@@ -277,7 +290,7 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
     state: {
       showLoadingOverlay: isLoading,
       columnFilters,
-      sorting,
+      sorting: validSorting,
       density: density.state,
       columnSizing: columnSizing.state,
       columnVisibility: columnVisibility.state,


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

*Part of #11718 — smoke suite green-locally tracking issue.*

Filters the sort state handed to Material React Table so the URL `sort` param doesn't trip TanStack Table's "Column with id 'X' does not exist" dev-time `console.error` when the user navigates to a tab whose columns don't include that id.

**Why this was happening.** Detail pages keep `?sort=<column>` in the URL so the sort persists across navigation. Tabs on those pages share the URL, but each tab's table has its own columns. When the URL sort id doesn't match any column in the active tab, MRT asks TanStack for that column, and TanStack logs the error (returns `undefined` and moves on; production silences the log).

**What this PR changes.** In `useBaseMaterialTable`, derive `validSorting` from `sorting` by keeping only entries whose `(id ?? accessorKey)` matches a column in the current table, and pass that to MRT's `state.sorting`.

**What this PR explicitly does NOT change.**
- The URL query params are untouched. Going back to a tab where the column exists restores the sort exactly as before.
- The data query keeps receiving the original `sortBy` from `useUrlQueryParams`. Server-side sort handling is unchanged.
- Production behaviour is the same — TanStack already silences this log there. This only removes the dev-time noise (and the smoke-suite assertion failure that catches it).

Surfaces this unblocked on a smoke run against the central server:
- `Replenishment > purchase-order detail + tabs` (`createdDatetime` on Inbound shipment / Documents tabs)
- `Inbound Shipment Tabs > shared: log` (`itemName`) and the cascaded `external: financial/currency/delivery`
- `Line Edit Modals > inbound-shipment/outbound-shipment`
- `Distribution > customer-return detail + tabs`

Remaining smoke failures (stock detail Log tab, patients detail) are the i18next `missingKey` flood on the `custom-translations` namespace — separate root cause, separate fix.

## 💌 Any notes for the reviewer?

- Single hook, three-line addition plus the comment block. No public API change.
- The filter uses `(c.id ?? ('accessorKey' in c ? c.accessorKey : undefined)) === s.id`, mirroring TanStack's own id-derivation rule.
- The filter is flat over `columns`; nested column groups aren't recursed. The smoke failures all involve flat tables; if a future regression on grouped-column tables shows up we can extend it.
- Worth a quick check that no list page uses a sort id that's also a nested group leaf — I didn't find any, but more eyes welcome.

# 🧪 Testing

- [ ] Run `yarn e2e` from `client/` against the central server and confirm no `[Table] Column with id 'X' does not exist.` console errors
- [ ] On any detail page with tabs (e.g. `/replenishment/purchase-order/<id>`), sort the first tab's table, switch tab and back — sort should be preserved on the original tab
- [ ] Open a tab whose columns don't include the URL sort id — page should render without console error and the table should fall back to its default sort

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**:
  1.
  2.
