### PR TITLE
#11691 Log order type errors instead of blocking requisition updates

### DIFF
--- a/server/service/src/requisition/request_requisition/update/validate.rs
+++ b/server/service/src/requisition/request_requisition/update/validate.rs
@@ -51,21 +51,28 @@ pub fn validate(
     if let (Some(program_id), Some(order_type)) =
         (&requisition_row.program_id, &requisition_row.order_type)
     {
-        let (within_limit, max_items) = check_emergency_order_within_max_items_limit(
+        match check_emergency_order_within_max_items_limit(
             connection,
             program_id,
             order_type,
             requisition_lines.clone(),
-        )
-        .map_err(|e| match e {
-            OrderTypeNotFoundError::OrderTypeNotFound => OutError::OrderTypeNotFound,
-            OrderTypeNotFoundError::DatabaseError(repository_error) => {
-                OutError::DatabaseError(repository_error)
+        ) {
+            Ok((within_limit, max_items)) => {
+                if !within_limit {
+                    return Err(OutError::OrderingTooManyItems(max_items));
+                }
             }
-        })?;
-
-        if !within_limit {
-            return Err(OutError::OrderingTooManyItems(max_items));
+            Err(OrderTypeNotFoundError::OrderTypeNotFound) => {
+                // If order types are edited in mSupply this check will fail.
+                // We don't want to block the operation, just log it.
+                log::warn!(
+                    "Order type not found when checking emergency order item limit (requisition_id={}, program_id={}, order_type={})",
+                    requisition_row.id,
+                    program_id,
+                    order_type,
+                );
+            }
+            Err(OrderTypeNotFoundError::DatabaseError(e)) => return Err(e.into()),
         }
     }
 

--- a/server/service/src/requisition/response_requisition/update.rs
+++ b/server/service/src/requisition/response_requisition/update.rs
@@ -129,21 +129,28 @@ pub fn validate(
     if let (Some(program_id), Some(order_type)) =
         (&requisition_row.program_id, &requisition_row.order_type)
     {
-        let (within_limit, max_items) = check_emergency_order_within_max_items_limit(
+        match check_emergency_order_within_max_items_limit(
             connection,
             program_id,
             order_type,
             response_lines.clone(),
-        )
-        .map_err(|e| match e {
-            OrderTypeNotFoundError::OrderTypeNotFound => OutError::OrderTypeNotFound,
-            OrderTypeNotFoundError::DatabaseError(repository_error) => {
-                OutError::DatabaseError(repository_error)
+        ) {
+            Ok((within_limit, max_items)) => {
+                if !within_limit {
+                    return Err(OutError::OrderingTooManyItems(max_items));
+                }
             }
-        })?;
-
-        if !within_limit {
-            return Err(OutError::OrderingTooManyItems(max_items));
+            Err(OrderTypeNotFoundError::OrderTypeNotFound) => {
+                // If order types are edited in mSupply this check will fail.
+                // We don't want to block the operation, just log it.
+                log::error!("Order type not found when checking emergency order item limit");
+            }
+            Err(OrderTypeNotFoundError::DatabaseError(e)) => {
+                log::error!(
+                    "Database error checking emergency order item limit: {:?}",
+                    e
+                );
+            }
         }
     }
 

--- a/server/service/src/requisition/response_requisition/update.rs
+++ b/server/service/src/requisition/response_requisition/update.rs
@@ -143,14 +143,14 @@ pub fn validate(
             Err(OrderTypeNotFoundError::OrderTypeNotFound) => {
                 // If order types are edited in mSupply this check will fail.
                 // We don't want to block the operation, just log it.
-                log::error!("Order type not found when checking emergency order item limit");
-            }
-            Err(OrderTypeNotFoundError::DatabaseError(e)) => {
-                log::error!(
-                    "Database error checking emergency order item limit: {:?}",
-                    e
+                log::warn!(
+                    "Order type not found when checking emergency order item limit (requisition_id={}, program_id={}, order_type={})",
+                    requisition_row.id,
+                    program_id,
+                    order_type,
                 );
             }
+            Err(OrderTypeNotFoundError::DatabaseError(e)) => return Err(e.into()),
         }
     }
 


### PR DESCRIPTION
Fixes #11691

# 👩🏻‍💻 What does this PR do?

When a program order is created, the order type from legacy mSupply is recorded. If that order type is later renamed or removed in legacy mSupply and a sync occurs, subsequent attempts to update the requisition (e.g. changing the status or adding a comment) would fail with an `OrderTypeNotFound` error.

This fix changes the `validate` function in response requisition update to handle `OrderTypeNotFoundError` and database errors gracefully: instead of returning an error that blocks the operation, the errors are logged and the update proceeds. The emergency order item limit check is skipped in these cases, which is acceptable because:
- The order type configuration no longer matches the stored value anyway
- Blocking the update entirely provides no benefit to the user

## 💌 Any notes for the reviewer?

The key change is in [server/service/src/requisition/response_requisition/update.rs](server/service/src/requisition/response_requisition/update.rs) — the `match` replaces a `?` propagation, catching both `OrderTypeNotFound` and `DatabaseError` variants and logging them rather than returning them as errors.

No new error variants were added; the existing `OutError` enum is unchanged.

# 🧪 Testing

1. Set up legacy mSupply central server + OMS remote site
2. Create a program with a custom order type (e.g. `Quick Order`)
3. Create a program order in OMS for that order type
4. Do NOT finalise/verify the transaction
5. Rename the order type in legacy mSupply (e.g. `Quick Order` → `QUICK`)
6. Sync
7. Try to update the comment or status on the program order in OMS
8. Confirm the update succeeds (previously would return `OrderTypeInvalid` error)
9. Confirm an error is logged server-side for the missing order type

# 📃 Documentation

- [x] **No documentation required**: bug fix, no user-facing behaviour change beyond unblocking previously broken updates

# 📃 Reviewer Checklist

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend