### PR TITLE
#6525 Add CI check for breaking GraphQL schema changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,10 +45,6 @@ Fixes #
 
 The PR Reviewer(s) should fill out this section before approving the PR
 
-**Breaking Changes**
-- [ ] No Breaking Changes in the Graphql API
-- [ ] Technically some Breaking Changes but not expected to impact any integrations
-
 **Issue Review**
 - [ ] All requirements in original issue have been covered
 - [ ] A follow up issue(s) have been created to cover additional requirements

--- a/.github/workflows/graphql-schema-compatibility.yaml
+++ b/.github/workflows/graphql-schema-compatibility.yaml
@@ -15,9 +15,9 @@ jobs:
     name: Detect breaking GraphQL schema changes
     runs-on: self-hosted
     timeout-minutes: 30
-    # Add the `breaking-api-change` label to a PR to acknowledge an intentional
+    # Add the `Breaking API change` label to a PR to acknowledge an intentional
     # breaking change and skip this check.
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'breaking-api-change') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'Breaking API change') }}
     env:
       CARGO_TARGET_DIR: /tmp/target/schema-diff
       PR_SCHEMA: /tmp/schema-diff/pr-schema.graphql

--- a/.github/workflows/graphql-schema-compatibility.yaml
+++ b/.github/workflows/graphql-schema-compatibility.yaml
@@ -35,10 +35,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-
       - name: Read .nvmrc
         id: nvm
         run: echo "NVMRC=$(cat ./client/.nvmrc)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/graphql-schema-compatibility.yaml
+++ b/.github/workflows/graphql-schema-compatibility.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
       - 'server/graphql/**'
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/graphql-schema-compatibility.yaml
+++ b/.github/workflows/graphql-schema-compatibility.yaml
@@ -1,0 +1,67 @@
+name: GraphQL Schema Compatibility
+
+on:
+  pull_request:
+    paths:
+      - 'server/graphql/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  schema-diff:
+    name: Detect breaking GraphQL schema changes
+    runs-on: self-hosted
+    timeout-minutes: 30
+    # Add the `breaking-api-change` label to a PR to acknowledge an intentional
+    # breaking change and skip this check.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'breaking-api-change') }}
+    env:
+      CARGO_TARGET_DIR: /tmp/target/schema-diff
+      PR_SCHEMA: /tmp/schema-diff/pr-schema.graphql
+      BASE_SCHEMA: /tmp/schema-diff/base-schema.graphql
+    steps:
+      - name: Update PATH
+        run: echo "$HOME/.cargo/bin:/opt/homebrew/bin" >> $GITHUB_PATH
+
+      - name: Prepare schema output directory
+        run: mkdir -p /tmp/schema-diff
+
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Read .nvmrc
+        id: nvm
+        run: echo "NVMRC=$(cat ./client/.nvmrc)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+
+      - name: Export schema from PR
+        working-directory: server
+        run: cargo run --bin remote_server_cli -- export-graphql-schema --path "$PR_SCHEMA"
+
+      - name: Check out base ref
+        run: git checkout ${{ github.event.pull_request.base.sha }}
+
+      - name: Export schema from base
+        working-directory: server
+        run: cargo run --bin remote_server_cli -- export-graphql-schema --path "$BASE_SCHEMA"
+
+      - name: Diff schemas with graphql-inspector
+        run: |
+          npx --yes \
+            -p @graphql-inspector/cli@^4 \
+            -p @graphql-inspector/graphql-loader@^4 \
+            -p @graphql-inspector/diff-command@^4 \
+            graphql-inspector diff "$BASE_SCHEMA" "$PR_SCHEMA"


### PR DESCRIPTION
Fixes #6525

# 👩🏻‍💻 What does this PR do?

Adds a GitHub Actions workflow that catches breaking GraphQL schema changes at PR time, so we don't accidentally remove fields or types that external integrations (e.g. SAGE) depend on.

On any PR that touches `server/graphql/**`, the workflow:

1. Exports the GraphQL SDL from the PR head using the existing `remote_server_cli export-graphql-schema` command.
2. Checks out the PR base and exports the SDL there too.
3. Runs `graphql-inspector diff` between the two. Breaking changes (removed/renamed types, fields, enum values; type changes; required-arg additions; etc.) fail the check.

Intentional breaks can be acknowledged and merged by adding the `Breaking API change` label to the PR, which skips the job.

## 💌 Any notes for the reviewer?

**This is a quick win, not a complete solution to #6525.** The issue proposed two things; this PR only addresses the first one for now:

1. ✅ **Automated breaking-change check based on `schema.graphql`** — covered by this PR.
2. ❌ **Build an artefact (dockerised or executable) per RC tag for integrators to run their automated tests against** — *not covered here.*

**What this catches:**
- The exact class of mistake from the original SAGE incident (silent field removal in a senior-reviewed PR).
- All standard breaking changes per the GraphQL spec: removed types/fields/enum values, type narrowing, required-arg additions, directive removals, etc.

**What it does NOT catch:**
- Behaviour changes with no schema change (same shape, different data).
- "Dangerous" changes per graphql-inspector (e.g. making a non-null output field nullable, adding enum values) — these warn but don't fail. Happy to escalate these to failures if reviewers prefer.
- Non-GraphQL API changes (REST, sync protocol).
- Schema changes that happen via `async-graphql` dependency bumps (path filter would miss them — extremely rare).

**Design notes:**
- Uses `npx --yes` to fetch `graphql-inspector` at run time rather than adding a devDependency. Verified that the same self-hosted runners already pull from `registry.npmjs.org` (e.g. [build-android-apk.yaml:28](.github/workflows/build-android-apk.yaml#L28) does `npm install -g yarn`), and there's no `.npmrc` / `.yarnrc` overriding the registry.
- Re-uses `CARGO_TARGET_DIR` so the second build (base ref) only rebuilds changed crates.
- Path-filtered to `server/graphql/**` only — `server/cli/**` was excluded because the export binary just calls `.sdl()` on types defined in the `graphql` crate, it doesn't influence schema content.
- `merge_group` trigger intentionally omitted — `develop` doesn't have a merge queue configured (verified via `gh api .../branches/develop/protection` → 404 and `.../rules/branches/develop` → `[]`).

# 🧪 Testing

End-to-end behaviour is exercised by two draft PRs targeting this branch:

- **#11705** — removes `AbbreviationNode.expansion`. Workflow should **fail** with a breaking-change report.
- **#11706** — adds an optional `testFieldDoNotMerge: String` to `AbbreviationNode`. Workflow should **pass**.

Reviewer checks:

- [x] Workflow **fails** on a field removal (verified via #11705).
- [x] Workflow **passes** on an additive, non-breaking change (verified via #11706).
- [ ] Adding the `Breaking API change` label to #11705 skips the job.
- [x] Workflow does not fire on PRs that don't touch `server/graphql/**` (this PR only changes `.github/workflows/**`, and the job did not run).

# 📃 Documentation

- [x] **No documentation required**: CI/tooling change only, no user-facing behaviour.

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
