### PR TITLE
[TEST - DO NOT MERGE] #6525 Verify schema check FAILS on breaking change

### DIFF
--- a/server/graphql/types/src/types/abbreviation.rs
+++ b/server/graphql/types/src/types/abbreviation.rs
@@ -14,10 +14,6 @@ impl AbbreviationNode {
     pub async fn text(&self) -> &String {
         &self.abbreviation.text
     }
-
-    pub async fn expansion(&self) -> &String {
-        &self.abbreviation.expansion
-    }
 }
 
 impl AbbreviationNode {


### PR DESCRIPTION
> [!CAUTION]
> **Draft / DO NOT MERGE.** This PR exists only to verify that the workflow added in #11703 correctly fails on a breaking GraphQL schema change. It removes `AbbreviationNode.expansion`, which real frontend queries depend on — merging this would break the client.

## Purpose

Verifies that [graphql-schema-compatibility.yaml](.github/workflows/graphql-schema-compatibility.yaml) (introduced in #11703) **fails** the PR when a field is removed from the GraphQL schema.

Base: `6525-graphql-schema-compatibility-check` (the workflow branch from #11703).
Change: removes `expansion: String!` from `AbbreviationNode` in [server/graphql/types/src/types/abbreviation.rs](server/graphql/types/src/types/abbreviation.rs).

## Expected CI behaviour

- ✅ **`GraphQL Schema Compatibility`** workflow: **FAILS** — `graphql-inspector diff` should report that `AbbreviationNode.expansion` was removed (breaking change).
- ⚠️ Other workflows will likely also fail because real frontend `.graphql` queries reference `expansion`. That's expected noise — we accepted this trade-off rather than building a clean test scaffold.

## After verification

Close without merging. Delete the branch.

Related: #6525