### PR TITLE
[TEST - DO NOT MERGE] #6525 Verify schema check PASSES on non-breaking change

### DIFF
--- a/server/graphql/types/src/types/abbreviation.rs
+++ b/server/graphql/types/src/types/abbreviation.rs
@@ -18,6 +18,12 @@ impl AbbreviationNode {
     pub async fn expansion(&self) -> &String {
         &self.abbreviation.expansion
     }
+
+    // [TEST - DO NOT MERGE] Field added to verify graphql-schema-compatibility
+    // workflow allows additive (non-breaking) changes.
+    pub async fn test_field_do_not_merge(&self) -> Option<String> {
+        None
+    }
 }
 
 impl AbbreviationNode {


### PR DESCRIPTION
> [!CAUTION]
> **Draft / DO NOT MERGE.** This PR exists only to verify that the workflow added in #11703 correctly allows non-breaking GraphQL schema changes.

## Purpose

Verifies that [graphql-schema-compatibility.yaml](.github/workflows/graphql-schema-compatibility.yaml) (introduced in #11703) **passes** the PR when a new optional output field is added.

Base: `6525-graphql-schema-compatibility-check` (the workflow branch from #11703).
Change: adds an optional `testFieldDoNotMerge: String` to `AbbreviationNode` in [server/graphql/types/src/types/abbreviation.rs](server/graphql/types/src/types/abbreviation.rs).

## Expected CI behaviour

- ✅ **`GraphQL Schema Compatibility`** workflow: **PASSES** — `graphql-inspector diff` should report only an added field, no breaking changes.
- ✅ Other workflows should also pass (the field is additive and unreferenced by any frontend query).

## After verification

Close without merging. Delete the branch.

Related: #6525