### PR TITLE
Do not open browser every yarn start

### DIFF
--- a/client/packages/host/webpack.config.js
+++ b/client/packages/host/webpack.config.js
@@ -47,7 +47,6 @@ module.exports = env => {
         'Access-Control-Allow-Headers':
           'X-Requested-With, content-type, Authorization',
       },
-      open: true,
     },
     resolve: {
       extensions: ['.js', '.css', '.ts', '.tsx'],


### PR DESCRIPTION
Stops new tabs opening every time you restart your webpack server (i.e. frequently), at the cost of it not opening the first time. You can just cmd+click the url in your terminal to open it the first time tho:

<img width="725" height="146" alt="image" src="https://github.com/user-attachments/assets/e330a94a-9540-4da3-8e17-4f617416534d" />

Or if you know you want a new tab just give the `--open` parameter

```sh
yarn start --open
```