### PR TITLE
central-user-login endpoint

### DIFF
--- a/server/graphql/general/src/queries/login.rs
+++ b/server/graphql/general/src/queries/login.rs
@@ -4,12 +4,9 @@ use graphql_core::{standard_graphql_error::StandardGraphqlError, ContextExt};
 
 use http2::header::SET_COOKIE;
 use service::{
-    login::{LoginError, LoginFailure, LoginInput, LoginService},
+    login::{LoginError, LoginFailure, LoginInput, LoginService, MIN_ERR_RESPONSE_TIME_SEC},
     token::TokenPair,
 };
-
-// Fixed login response time in case of an error (see service)
-const MIN_ERR_RESPONSE_TIME_SEC: u64 = 6;
 
 pub struct AuthToken {
     pub pair: TokenPair,

--- a/server/server/src/central/mod.rs
+++ b/server/server/src/central/mod.rs
@@ -1,12 +1,14 @@
 use actix_web::web;
 use sync::sync_on_central;
 use sync_v7::sync_v7_on_central;
+use user_login::user_on_central;
 
 use crate::central_server_only;
 
 mod name_store_join;
 mod sync;
 mod sync_v7;
+mod user_login;
 use name_store_join::patient_name_store_join;
 
 pub fn config_central(cfg: &mut web::ServiceConfig) {
@@ -15,6 +17,7 @@ pub fn config_central(cfg: &mut web::ServiceConfig) {
             .wrap(central_server_only())
             .service(sync_on_central())
             .service(sync_v7_on_central())
+            .service(user_on_central())
             .service(patient_name_store_join),
     );
 }

--- a/server/server/src/central/user_login.rs
+++ b/server/server/src/central/user_login.rs
@@ -1,0 +1,48 @@
+use actix_web::{
+    dev::HttpServiceFactory,
+    post,
+    web::{self, Data, Json},
+    HttpResponse,
+};
+use serde::{Deserialize, Serialize};
+use service::{
+    login::{LoginService, MIN_ERR_RESPONSE_TIME_SEC},
+    service_provider::ServiceProvider,
+};
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UserLoginInput {
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UserLoginResponse {
+    pub success: bool,
+}
+
+pub fn user_on_central() -> impl HttpServiceFactory {
+    web::scope("user").service(login)
+}
+
+#[post("/login")]
+async fn login(
+    input: Json<UserLoginInput>,
+    service_provider: Data<ServiceProvider>,
+) -> HttpResponse {
+    let UserLoginInput { username, password } = input.into_inner();
+    match LoginService::verify_credentials_on_central(
+        &service_provider,
+        &username,
+        &password,
+        MIN_ERR_RESPONSE_TIME_SEC,
+    )
+    .await
+    {
+        Ok(true) => HttpResponse::Ok().json(UserLoginResponse { success: true }),
+        Ok(false) => HttpResponse::Unauthorized().json(UserLoginResponse { success: false }),
+        Err(_) => HttpResponse::InternalServerError().finish(),
+    }
+}

--- a/server/service/src/login.rs
+++ b/server/service/src/login.rs
@@ -30,6 +30,11 @@ use crate::{
 
 const CONNECTION_TIMEOUT_SEC: u64 = 10;
 
+/// Minimum response time on a failed login. Disguises whether the username
+/// exists by making "wrong password" and "no such user" indistinguishable by
+/// latency. Must be longer than the worst-case bcrypt verify time.
+pub const MIN_ERR_RESPONSE_TIME_SEC: u64 = 6;
+
 #[derive(Debug)]
 pub enum FetchUserError {
     Unauthenticated,
@@ -107,6 +112,45 @@ impl LoginService {
                 Err(err)
             }
         }
+    }
+
+    /// Local credential check for the OMS Central REST login endpoint.
+    ///
+    /// Returns `Ok(true)` on a valid match, `Ok(false)` on any credential
+    /// failure (unknown user, wrong password, empty stored hash), and `Err`
+    /// for genuine server errors. The failure path is padded to
+    /// `min_err_response_time_sec` to match the GraphQL login's
+    /// timing-attack mitigation.
+    pub async fn verify_credentials_on_central(
+        service_provider: &ServiceProvider,
+        username: &str,
+        password: &str,
+        min_err_response_time_sec: u64,
+    ) -> Result<bool, LoginError> {
+        let now = SystemTime::now();
+        let result = (|| {
+            let service_ctx = service_provider.basic_context()?;
+            let user_service = UserAccountService::new(&service_ctx.connection);
+            match user_service.verify_password(username, password) {
+                Ok(_) => Ok(true),
+                Err(VerifyPasswordError::UsernameDoesNotExist)
+                | Err(VerifyPasswordError::InvalidCredentials)
+                | Err(VerifyPasswordError::EmptyHashedPassword) => Ok(false),
+                Err(VerifyPasswordError::DatabaseError(e)) => Err(LoginError::DatabaseError(e)),
+                Err(VerifyPasswordError::InvalidCredentialsBackend(_)) => Err(
+                    LoginError::InternalError("Failed to read credentials".to_string()),
+                ),
+            }
+        })();
+
+        if matches!(&result, Ok(false) | Err(_)) {
+            let elapsed = now.elapsed().unwrap_or(Duration::from_secs(0));
+            let minimum = Duration::from_secs(min_err_response_time_sec);
+            if elapsed < minimum {
+                tokio::time::sleep(minimum - elapsed).await;
+            }
+        }
+        result
     }
 
     async fn do_login(
@@ -846,5 +890,79 @@ mod test {
         //         result
         //     );
         // }
+    }
+
+    #[actix_rt::test]
+    async fn verify_credentials_on_central_test() {
+        use std::time::{Duration, Instant};
+
+        use crate::user_account::{CreateUserAccount, UserAccountService};
+
+        let (_, _, connection_manager, _) = setup_all(
+            "verify_credentials_on_central_test",
+            MockDataInserts::none().user_accounts(),
+        )
+        .await;
+        let service_provider = ServiceProvider::new(connection_manager);
+
+        // Seed a user with a real bcrypt-hashed password.
+        let context = service_provider.basic_context().unwrap();
+        UserAccountService::new(&context.connection)
+            .create_user(CreateUserAccount {
+                username: "alice".to_string(),
+                password: "correct-horse".to_string(),
+                email: None,
+            })
+            .unwrap();
+        drop(context);
+
+        // Valid credentials -> Ok(true), no padding required
+        let ok = LoginService::verify_credentials_on_central(
+            &service_provider,
+            "alice",
+            "correct-horse",
+            0,
+        )
+        .await
+        .unwrap();
+        assert!(ok);
+
+        // Wrong password -> Ok(false), padded to min response time
+        let started = Instant::now();
+        let bad = LoginService::verify_credentials_on_central(
+            &service_provider,
+            "alice",
+            "wrong",
+            1,
+        )
+        .await
+        .unwrap();
+        assert!(!bad);
+        assert!(
+            started.elapsed() >= Duration::from_secs(1),
+            "expected min response time padding on failed login"
+        );
+
+        // Unknown user -> Ok(false)
+        let unknown = LoginService::verify_credentials_on_central(
+            &service_provider,
+            "no-such-user",
+            "whatever",
+            0,
+        )
+        .await
+        .unwrap();
+        assert!(!unknown);
+
+        // Empty stored hash (synced user with no password yet) -> Ok(false)
+        let empty = LoginService::verify_credentials_on_central(
+            &service_provider,
+            &mock_user_empty_hashed_password().username,
+            "anything",
+            0,
+        )
+        .await
+        .unwrap();
+        assert!(!empty);
     }
 }


### PR DESCRIPTION
Fixes #11677

# 👩🏻‍💻 What does this PR do?

llm'd.

Adds endpoint for `myserver/central/user/login` returning:

200: {success: true}
401: {success: false}
500: ServerError

Takes 6 seconds (bit harsh haha) if credentials are wrong.

## 💌 Any notes for the reviewer?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Start OMS central server
- [ ] correct credentials works e.g. `http post http://localhost:8000/central/user/login username=admin password=pass`
- [ ] incorrect credentials are rejected e.g. `http post http://localhost:8000/central/user/login username=admin password=blahalegk`
- [ ] Hard to replicate a db error soz

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

