### PR TITLE
map errors correctly to UI and prevent remote from initialising as central

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -530,7 +530,7 @@
   "error.site-auth-timeout": "Site authentication timed out, please try again later",
   "error.site-has-no-store": "Site has no store",
   "error.site-incorrect-hardware-id": "Incorrect hardware ID",
-  "error.site-incorrect-password": "Incorrect password",
+  "error.site-incorrect-password": "Incorrect credentials",
   "error.site-is-not-v7": "This site has not been upgraded to V7 sync yet. Run a sync to complete the upgrade.",
   "error.site-mismatch": "Site mismatch",
   "error.site-name-not-found": "Site name not found",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -530,7 +530,7 @@
   "error.site-auth-timeout": "Site authentication timed out, please try again later",
   "error.site-has-no-store": "Site has no store",
   "error.site-incorrect-hardware-id": "Incorrect hardware ID",
-  "error.site-incorrect-password": "Incorrect credentials",
+  "error.site-incorrect-password": "Incorrect site name or password",
   "error.site-is-not-v7": "This site has not been upgraded to V7 sync yet. Run a sync to complete the upgrade.",
   "error.site-mismatch": "Site mismatch",
   "error.site-name-not-found": "Site name not found",

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -3192,7 +3192,10 @@ export enum InitialisationStatusType {
   PreInitialisation = 'PRE_INITIALISATION',
 }
 
-export type InitialiseSiteResponse = SyncErrorNode | SyncSettingsNode;
+export type InitialiseSiteResponse =
+  | SyncErrorNode
+  | SyncErrorV7Node
+  | SyncSettingsNode;
 
 export type InsertAssetCatalogueItemError = {
   __typename: 'InsertAssetCatalogueItemError';
@@ -11203,7 +11206,10 @@ export enum UpdateSupplierReturnStatusInput {
   Shipped = 'SHIPPED',
 }
 
-export type UpdateSyncSettingsResponse = SyncErrorNode | SyncSettingsNode;
+export type UpdateSyncSettingsResponse =
+  | SyncErrorNode
+  | SyncErrorV7Node
+  | SyncSettingsNode;
 
 export type UpdateTemperatureBreachInput = {
   comment?: InputMaybe<Scalars['String']['input']>;

--- a/client/packages/host/src/Admin/SyncSettings.tsx
+++ b/client/packages/host/src/Admin/SyncSettings.tsx
@@ -176,7 +176,10 @@ export const SyncSettings = ({}) => {
     try {
       const response = await update(syncSettings);
       // Map structured error
-      if (response.__typename === 'SyncErrorNode') {
+      if (
+        response.__typename === 'SyncErrorNode' ||
+        response.__typename === 'SyncErrorV7Node'
+      ) {
         setError(mapSyncError(t, response, 'error.unable-to-save-settings'));
         return setIsSaving(false);
       }

--- a/client/packages/host/src/components/Initialise/hooks.ts
+++ b/client/packages/host/src/components/Initialise/hooks.ts
@@ -112,7 +112,10 @@ export const useInitialiseForm = () => {
         username,
       });
       // Map structured error
-      if (response.__typename === 'SyncErrorNode') {
+      if (
+        response.__typename === 'SyncErrorNode' ||
+        response.__typename === 'SyncErrorV7Node'
+      ) {
         setSiteCredentialsError(
           mapSyncError(t, response, 'error.unable-to-initialise')
         );

--- a/client/packages/system/src/Sync/api/api.ts
+++ b/client/packages/system/src/Sync/api/api.ts
@@ -161,12 +161,26 @@ function mapSyncErrorV7(
     [SyncErrorVariantV7.Other]: defaultKey || 'error.unknown-sync-error',
   };
 
+  const getHint = () => {
+    switch (error.variantV7) {
+      case SyncErrorVariantV7.SyncVersionMismatch:
+        return t('error.sync-api-incompatible-hint');
+      case SyncErrorVariantV7.NotACentralServer:
+        return t('error.v6-server-not-configured-hint');
+      case SyncErrorVariantV7.ConnectionError:
+        return t('error.connection-error-hint');
+      default:
+        return undefined;
+    }
+  };
+
   return {
     error:
       t(errorMapping[error.variantV7]) ||
       defaultKey ||
       'error.unknown-sync-error',
     details: error.fullError,
+    hint: getHint(),
   };
 }
 

--- a/client/packages/system/src/Sync/api/operations.generated.ts
+++ b/client/packages/system/src/Sync/api/operations.generated.ts
@@ -45,6 +45,11 @@ export type InitialiseSiteMutation = {
         fullError: string;
       }
     | {
+        __typename: 'SyncErrorV7Node';
+        fullError: string;
+        variantV7: Types.SyncErrorVariantV7;
+      }
+    | {
         __typename: 'SyncSettingsNode';
         intervalSeconds: number;
         url: string;
@@ -65,6 +70,11 @@ export type UpdateSyncSettingsMutation = {
         __typename: 'SyncErrorNode';
         variant: Types.SyncErrorVariant;
         fullError: string;
+      }
+    | {
+        __typename: 'SyncErrorV7Node';
+        fullError: string;
+        variantV7: Types.SyncErrorVariantV7;
       }
     | {
         __typename: 'SyncSettingsNode';
@@ -760,10 +770,14 @@ export const InitialiseSiteDocument = gql`
       ... on SyncErrorNode {
         ...SyncError
       }
+      ... on SyncErrorV7Node {
+        ...SyncErrorV7
+      }
     }
   }
   ${SyncSettingsFragmentDoc}
   ${SyncErrorFragmentDoc}
+  ${SyncErrorV7FragmentDoc}
 `;
 export const UpdateSyncSettingsDocument = gql`
   mutation updateSyncSettings($syncSettings: SyncSettingsInput!) {
@@ -775,10 +789,14 @@ export const UpdateSyncSettingsDocument = gql`
       ... on SyncErrorNode {
         ...SyncError
       }
+      ... on SyncErrorV7Node {
+        ...SyncErrorV7
+      }
     }
   }
   ${SyncSettingsFragmentDoc}
   ${SyncErrorFragmentDoc}
+  ${SyncErrorV7FragmentDoc}
 `;
 export const SyncInfoDocument = gql`
   query syncInfo {

--- a/client/packages/system/src/Sync/api/operations.graphql
+++ b/client/packages/system/src/Sync/api/operations.graphql
@@ -28,6 +28,9 @@ mutation initialiseSite($syncSettings: SyncSettingsInput!) {
     ... on SyncErrorNode {
       ...SyncError
     }
+    ... on SyncErrorV7Node {
+      ...SyncErrorV7
+    }
   }
 }
 
@@ -39,6 +42,9 @@ mutation updateSyncSettings($syncSettings: SyncSettingsInput!) {
     }
     ... on SyncErrorNode {
       ...SyncError
+    }
+    ... on SyncErrorV7Node {
+      ...SyncErrorV7
     }
   }
 }

--- a/server/graphql/general/src/mutations/initialise_site.rs
+++ b/server/graphql/general/src/mutations/initialise_site.rs
@@ -3,7 +3,11 @@ use async_graphql::*;
 use graphql_core::{standard_graphql_error::StandardGraphqlError, ContextExt};
 use service::sync::sync_status::status::InitialisationStatus;
 
-use crate::{queries::sync_settings::SyncSettingsNode, sync_api_error::SyncErrorNode};
+use crate::{
+    queries::sync_settings::SyncSettingsNode,
+    sync_api_error::{map_request_auth_error, SyncErrorEither, SyncErrorNode},
+    sync_v7::sync_api_error::SyncErrorV7Node,
+};
 
 use super::common::SyncSettingsInput;
 
@@ -11,6 +15,7 @@ use super::common::SyncSettingsInput;
 pub enum InitialiseSiteResponse {
     Response(SyncSettingsNode),
     Error(SyncErrorNode),
+    ErrorV7(SyncErrorV7Node),
 }
 
 pub async fn initialise_site(
@@ -36,9 +41,10 @@ pub async fn initialise_site(
         .request_and_set_site_auth(service_provider, &sync_settings)
         .await
     {
-        return Ok(InitialiseSiteResponse::Error(SyncErrorNode::map_error(
-            error,
-        )?));
+        return Ok(match map_request_auth_error(error)? {
+            SyncErrorEither::V5V6(node) => InitialiseSiteResponse::Error(node),
+            SyncErrorEither::V7(node) => InitialiseSiteResponse::ErrorV7(node),
+        });
     }
 
     // request_and_set_site_auth above should validate settings, can consider all error in update_sync_settings as internal error

--- a/server/graphql/general/src/mutations/sync_settings.rs
+++ b/server/graphql/general/src/mutations/sync_settings.rs
@@ -6,7 +6,11 @@ use graphql_core::{
 };
 use service::auth::{Resource, ResourceAccessRequest};
 
-use crate::{queries::sync_settings::SyncSettingsNode, sync_api_error::SyncErrorNode};
+use crate::{
+    queries::sync_settings::SyncSettingsNode,
+    sync_api_error::{map_request_auth_error, SyncErrorEither, SyncErrorNode},
+    sync_v7::sync_api_error::SyncErrorV7Node,
+};
 
 use super::common::SyncSettingsInput;
 
@@ -14,6 +18,7 @@ use super::common::SyncSettingsInput;
 pub enum UpdateSyncSettingsResponse {
     Response(SyncSettingsNode),
     Error(SyncErrorNode),
+    ErrorV7(SyncErrorV7Node),
 }
 
 pub async fn update_sync_settings(
@@ -45,9 +50,10 @@ pub async fn update_sync_settings(
             .request_and_set_site_auth(service_provider, &sync_settings)
             .await
         {
-            return Ok(UpdateSyncSettingsResponse::Error(SyncErrorNode::map_error(
-                error,
-            )?));
+            return Ok(match map_request_auth_error(error)? {
+                SyncErrorEither::V5V6(node) => UpdateSyncSettingsResponse::Error(node),
+                SyncErrorEither::V7(node) => UpdateSyncSettingsResponse::ErrorV7(node),
+            });
         }
     }
 

--- a/server/graphql/general/src/sync_api_error.rs
+++ b/server/graphql/general/src/sync_api_error.rs
@@ -8,6 +8,8 @@ use service::sync::{
 };
 use util::format_error;
 
+use crate::sync_v7::sync_api_error::SyncErrorV7Node;
+
 #[derive(SimpleObject)]
 pub struct SyncErrorNode {
     pub variant: Variant,
@@ -64,25 +66,6 @@ impl SyncErrorNode {
         }
     }
 
-    pub fn map_error(error: RequestAndSetSiteAuthError) -> Result<Self> {
-        use RequestAndSetSiteAuthError as from;
-
-        let error = match &error {
-            // Structured error
-            from::RequestSiteAuthError(api_error) => Self::from_sync_api_error(api_error),
-            from::SiteUUIDIsBeingChanged(_, _) => {
-                Self::from_error_variant(Variant::SiteUUIDIsBeingChanged, &error)
-            }
-            from::SyncApiV5CreatingError(SyncApiV5CreatingError::CannotParseSyncUrl(_, _)) => {
-                Self::from_error_variant(Variant::InvalidUrl, &error)
-            }
-            // Standard Graphql Errors
-            _ => return Err(StandardGraphqlError::from_error(&error)),
-        };
-
-        Ok(error)
-    }
-
     pub fn from_sync_api_error(error: &SyncApiError) -> Self {
         let sync_v5_error_code = match &error.source {
             SyncApiErrorVariantV5::ParsedError { source, .. } => &source.code,
@@ -132,6 +115,33 @@ impl SyncErrorNode {
 
         Self::from_variant(variant, message)
     }
+}
+
+pub enum SyncErrorEither {
+    V5V6(SyncErrorNode),
+    V7(SyncErrorV7Node),
+}
+
+pub fn map_request_auth_error(error: RequestAndSetSiteAuthError) -> Result<SyncErrorEither> {
+    use RequestAndSetSiteAuthError as from;
+
+    let mapped = match &error {
+        from::RequestSiteAuthError(api_error) => {
+            SyncErrorEither::V5V6(SyncErrorNode::from_sync_api_error(api_error))
+        }
+        from::SiteUUIDIsBeingChanged(_, _) => SyncErrorEither::V5V6(
+            SyncErrorNode::from_error_variant(Variant::SiteUUIDIsBeingChanged, &error),
+        ),
+        from::SyncApiV5CreatingError(SyncApiV5CreatingError::CannotParseSyncUrl(_, _)) => {
+            SyncErrorEither::V5V6(SyncErrorNode::from_error_variant(Variant::InvalidUrl, &error))
+        }
+        from::SyncV7Error(sync_error) => {
+            SyncErrorEither::V7(SyncErrorV7Node::from_sync_error(sync_error.clone()))
+        }
+        _ => return Err(StandardGraphqlError::from_error(&error)),
+    };
+
+    Ok(mapped)
 }
 
 #[cfg(test)]

--- a/server/service/src/sync_v7/api/mod.rs
+++ b/server/service/src/sync_v7/api/mod.rs
@@ -159,9 +159,19 @@ async fn response_or_err<T: DeserializeOwned>(
         Err(error) => {
             let formatted_error = format_error(&error);
             if error.is_connect() {
+                // InvalidContentType is rustls signalling it received plaintext instead of a TLS
+                // handshake — happens when the URL uses https:// but the server is HTTP only.
+                let e = if formatted_error.contains("InvalidContentType") {
+                    format!(
+                        "Server is not configured for HTTPS — try http:// instead. ({})",
+                        formatted_error
+                    )
+                } else {
+                    formatted_error
+                };
                 return Err(SyncError::ConnectionError {
                     url: url.to_string(),
-                    e: formatted_error,
+                    e,
                 });
             } else {
                 return Err(SyncError::Other(formatted_error));

--- a/server/service/src/sync_v7/sync_on_central/mod.rs
+++ b/server/service/src/sync_v7/sync_on_central/mod.rs
@@ -59,6 +59,14 @@ pub async fn get_token(
     let site = get_site_by_name(&ctx.connection, &input.name)?
         .ok_or(SyncError::InvalidSiteNameOrPassword)?;
 
+    // Reject before password check — a remote must not authenticate as the central site itself.
+    let central_site_id = SourceSiteId::CurrentSiteId
+        .get_id(&ctx.connection)?
+        .ok_or(SyncError::SiteIdNotSet)?;
+    if site.id == central_site_id {
+        return Err(SyncError::InvalidSiteNameOrPassword);
+    }
+
     let valid = bcrypt::verify(&input.password_sha256, &site.hashed_password)
         .map_err(|e| SyncError::Other(e.to_string()))?;
     if !valid {

--- a/server/service/src/sync_v7/sync_on_central/mod.rs
+++ b/server/service/src/sync_v7/sync_on_central/mod.rs
@@ -64,6 +64,12 @@ pub async fn get_token(
         .get_id(&ctx.connection)?
         .ok_or(SyncError::SiteIdNotSet)?;
     if site.id == central_site_id {
+        log::warn!(
+            "Device with hardware_id: {} attempted to authenticate as the central site (name: {}, id: {}). Rejecting.",
+            input.hardware_id,
+            input.name,
+            site.id
+        );
         return Err(SyncError::InvalidSiteNameOrPassword);
     }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11696 & #11701 

# 👩🏻‍💻 What does this PR do?

- Maps syncv7 errors during initialisation / sync settings
- Prevents remote sites from trying to initialise with central creds (shows invalid credentials)

<img width="1896" height="894" alt="image" src="https://github.com/user-attachments/assets/acf6f0e4-dc5e-498b-955a-8410e1197657" />


<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Setup central for sync v7
- [ ] Try initialising remote site with central credentials
- [ ] See errors
- [ ] Verify frontend errors for different v7 scenarios during init / sync settings page
  - [ ] Incorrect central url
  - [ ] using another remote url as central url
  - [ ] Using https when central is setup for http
  - [ ] Re-initialising without clearing token for remote
  - [ ] Incorrect remote site id
  - [ ] Incorrect remote password
  - [ ] trying to init a v6 remote with v7 oms central

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

