### PR TITLE
#11709 Skip general_population seed insert if row already synced

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "2.18.01",
+  "version": "2.18.02",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/repository/src/migrations/v2_18_00/add_base_population_to_demographic_projection.rs
+++ b/server/repository/src/migrations/v2_18_00/add_base_population_to_demographic_projection.rs
@@ -8,11 +8,15 @@ impl MigrationFragment for Migrate {
     }
 
     fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        // demographic and demographic_indicator are synced/user-editable, so a row
+        // with these ids may already exist on the site (e.g. synced down from
+        // central before the migration runs, see issue #11709). Skip in that case.
         sql!(
             connection,
             r#"
                 INSERT INTO demographic (id, name, population_percentage)
-                VALUES ('general_population', 'General Population', 100);
+                VALUES ('general_population', 'General Population', 100)
+                ON CONFLICT (id) DO NOTHING;
             "#,
         )?;
 
@@ -41,7 +45,8 @@ impl MigrationFragment for Migrate {
                     100,
                     0, 0, 0, 0, 0
                 FROM (SELECT 1) AS dummy
-                LEFT JOIN (SELECT * FROM demographic_indicator LIMIT 1) di on TRUE;
+                LEFT JOIN (SELECT * FROM demographic_indicator LIMIT 1) di on TRUE
+                ON CONFLICT (id) DO NOTHING;
             "#,
         )?;
 


### PR DESCRIPTION
Fixes #11709

# 👩🏻‍💻 What does this PR do?

The v2.18 migration that seeds the `general_population` rows into `demographic` / `demographic_indicator` did a bare `INSERT`, so it crashes with "row already exists" when legacy mSupply central has already synced down a row with the same id. App fails to start after a 2.17.6 → 2.18 upgrade.

Adds `ON CONFLICT (id) DO NOTHING` to both inserts so the migration is a no-op when central's copy is already there. Bumps `package.json` to 2.18.02 for the patch release.

## 💌 Any notes for the reviewer?

- `DO NOTHING` (not `DO UPDATE`) keeps central as the source of truth — and central's row is functionally equivalent (`population_percentage = 100`); only the name's capitalisation differs.
- Confirmed against the failing test DB that the conflict came in via sync (`sync_buffer` row with id `general_population` integrated before the migration runs).
- The other v2.18 inserts into `asset_property` look similar but are safe: `asset_property` isn't user-editable, so central can't end up with a copy of these IDs that would sync down ahead of a site's migration.

# 🧪 Testing

- [x] On a 2.17.6 SQLite DB with a `general_population` row pre-inserted (mimicking what sync delivered to the test site), starting an OMS server built from this branch completes all v2.18 migrations without error and the app starts cleanly.

# 📃 Documentation

- [x] **No documentation required**: bug fix, no change in user-facing behaviour
