### PR TITLE
Gitignore Playwright MCP scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ server/configuration/*.yaml
 !configuration/base.yaml
 !configuration/example.yaml
 server/target-postgres/
+
+# Playwright MCP scratch logs / page dumps
+.playwright-mcp/


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Adds `.playwright-mcp/` to the root `.gitignore`.

Playwright MCP browser tools (used via the Claude Code / MCP integration) dump console logs and page snapshots into `.playwright-mcp/` at the repo root whenever a developer drives a browser through them. Those files are local, per-developer scratch — they shouldn't show up in `git status` and shouldn't risk being committed.

## 💌 Any notes for the reviewer?

- One-line change to `.gitignore`. Pattern is repo-wide (`.playwright-mcp/` matches at any depth) — fine here because the dir is only ever expected at the root anyway.
- No tracked files are affected; nothing was previously committed under this path.
- Anyone who actually wants to commit one of these dumps (e.g. attaching a page snapshot to a bug report) can `git add -f`.

# 🧪 Testing

- [ ] Run any Playwright MCP browser tool action that produces a dump (or simply `mkdir -p .playwright-mcp && touch .playwright-mcp/foo`)
- [ ] `git status` no longer shows the directory as untracked

# 📃 Documentation

- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API

**Tests Pass**
- N/A — gitignore-only change