### PR TITLE
refactor(sync-v7): get batch_last_cursor from batch struct

### DIFF
--- a/server/service/src/sync_v7/sync.rs
+++ b/server/service/src/sync_v7/sync.rs
@@ -327,12 +327,10 @@ impl<'a> SyncV7<'a> {
             let max_cursor = batch.max_cursor;
 
             let site_id = batch.site_id;
-            let Some(batch_max_cursor) = batch.records.last().map(|r| r.cursor) else {
-                break;
-            };
-            logger.progress(max_cursor as i64 - batch_max_cursor)?;
+            let batch_last_cursor = batch.last_cursor_in_batch;
+            logger.progress((max_cursor - batch_last_cursor) as i64)?;
 
-            info!("Pulled {record_count} max batch cursor {batch_max_cursor} cursor {cursor} max cursor {}", batch.max_cursor);
+            info!("Pulled {record_count} batch last cursor {batch_last_cursor} cursor {cursor} max cursor {}", batch.max_cursor);
 
             // V7 pull: records arrive without an originating app_version (it isn't
             // carried through the central server), so app_version is None here.
@@ -345,7 +343,7 @@ impl<'a> SyncV7<'a> {
             self.connection
                 .transaction_sync(|t_con| {
                     SyncBufferRepository::new(t_con).insert_many(&sync_buffer_rows)?;
-                    cursor_controller.update(self.connection, batch_max_cursor as u64)
+                    cursor_controller.update(self.connection, batch_last_cursor as u64)
                 })
                 .map_err(|e| e.to_inner_error())?;
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11700 

# 👩🏻‍💻 What does this PR do?

- minor refactor renaming `batch_max_cursor` to `batch_last_cursor` to avoid confusion with `batch.max_cursor` which is the global max for changelog
- `batch_last_cursor` is directly pulled from struct instead of computing
<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Changes tested and verified to have the correct cursors via logging (logged the cursor for first record in batch and it is 1 higher than starting cursor for batch which is correct)

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] initialise a remote site using v7 via central oms
- [ ] Verify logs that batch_last_cursor is the cursor for next batch


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

