### PR TITLE
#10269 Add configurable actix-web worker count to server settings

### DIFF
--- a/server/android/src/android.rs
+++ b/server/android/src/android.rs
@@ -48,6 +48,7 @@ pub mod android {
                 base_dir: Some(files_dir.to_str().unwrap().to_string()),
                 machine_uid: Some(android_id),
                 override_is_central_server: false,
+                workers: None,
             },
             database: DatabaseSettings {
                 username: "n/a".to_string(),

--- a/server/cli/src/load_test.rs
+++ b/server/cli/src/load_test.rs
@@ -468,6 +468,7 @@ impl LoadTest {
                 base_dir: Some("app_data".to_string()),
                 machine_uid: None,
                 override_is_central_server: false,
+                workers: None,
             },
             database: DatabaseSettings {
                 username: "postgres".to_string(),
@@ -556,6 +557,7 @@ impl LoadTest {
                     base_dir: Some(database_path.to_string()),
                     machine_uid: Some("1337_test".to_string()),
                     override_is_central_server: false,
+                    workers: None,
                 },
                 database: DatabaseSettings {
                     username: "postgres".to_string(),

--- a/server/configuration/example.yaml
+++ b/server/configuration/example.yaml
@@ -8,6 +8,7 @@
 #   # debug_no_access_control: true # enable this if you want to ignore API authorisation (dummy user will be used for all operations)
 #   # danger_allow_http: true # allow http in production mode
 #   # override_is_central_server: true # set server mode as central server, should only be used in testing, demo and development, sync calls can override this back to normal
+#   # workers: 8 # number of actix-web worker threads; defaults to logical CPU count. Increase to reduce 408 timeouts under heavy load.
 #   cors_origins: [
 #       http://localhost:3003,
 #       https://demo-open.msupply.org,

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -412,6 +412,10 @@ pub async fn start_server(
     })
     .disable_signals();
 
+    if let Some(workers) = settings.server.workers {
+        http_server = http_server.workers(workers);
+    }
+
     http_server = match certificates.config() {
         Some(config) => http_server
             .bind_rustls_0_23(settings.server.address(), config)

--- a/server/service/src/settings.rs
+++ b/server/service/src/settings.rs
@@ -40,6 +40,9 @@ pub struct ServerSettings {
     // Option to set server mode as central server, should only be used in testing, demo and development
     #[serde(default)]
     pub override_is_central_server: bool,
+    /// Number of actix-web worker threads. Defaults to the number of logical CPUs.
+    /// Increase if 408 timeouts are observed under load.
+    pub workers: Option<usize>,
 }
 
 impl ServerSettings {

--- a/server/service/src/test_helpers.rs
+++ b/server/service/src/test_helpers.rs
@@ -48,6 +48,7 @@ pub(crate) async fn setup_all_with_data_and_service_provider(
             base_dir: Some("test_output".to_string()),
             machine_uid: None,
             override_is_central_server: false,
+            workers: None,
         },
         database: db_settings,
         sync: None,


### PR DESCRIPTION
## Summary

Adds an optional `server.workers` setting controlling the number of actix-web worker threads the HTTP server spawns. Defaults to actix's existing default (logical CPU count) when unset, so this is a no-op for current deployments.

Three small changes:
- `ServerSettings::workers: Option<usize>` ([server/service/src/settings.rs](../server/service/src/settings.rs))
- `HttpServer::workers(n)` applied when set ([server/server/src/lib.rs](../server/server/src/lib.rs))
- Documented example in [server/configuration/example.yaml](../server/configuration/example.yaml)

## Why ship this (refs #10269)

408 errors from the server can manifest as logouts on the client, which is not acceptable UX. Local load testing on this branch shows that raising the worker count substantially reduces both 408s and TCP connection resets under burst load:

| workers | total failure rate | 408 rate | conn-reset rate | p95 latency | iterations completed |
|---|---|---|---|---|---|
| 1  | 49.8% | 24.0% | 25.8% | 54.07s | 213 |
| 4  | 25.0% | 15.4% |  9.6% | 13.23s | 631 |
| 8  | 23.3% | 14.9% |  8.4% | **10.77s** | **731** |
| 32 | 12.8% | 10.1% |  2.6% | 12.30s | 627 |
| 64 |  2.3% |  1.6% |  0.8% | 17.21s | 462 |


<img width="1932" height="1329" alt="image" src="https://github.com/user-attachments/assets/8bf95466-0702-4641-adef-ebef195fb4de" />

(Test: `load-test.js` — see comment below. browse scenario ramping to 50 VUs + sync_status scenario ramping to 50 VUs, ~3.5min wall time, Postgres + SL dataset, pool=100.)

The shape of the trade-off is interesting:

- **w8** gives the *best p95 latency* and *most completed work* — the well-rounded sweet spot on this hardware.
- **w32-w64** drops failure rates by an order of magnitude, at the cost of some tail latency (because more requests survive instead of being rejected and so queue up at the real downstream bottleneck).

Shipping this knob is worth it for two reasons:

**A)** Real-world sync_status load has dropped significantly since we moved to subscriptions, so the relative weight of failure-rate vs latency in this benchmark is more pessimistic than current production behaviour.

**B)** A 408 can log a user out, which is a hard failure. A slightly slower response is a soft degradation. Until we properly fix the underlying contention (more async, less blocking in handlers), letting a customer's deployment tune up worker count is a meaningful safety valve for high-load sites.

## Test plan

- [ ] `server.workers` unset behaves identically to today (uses logical CPU count)
- [ ] `server.workers: 1` boots and serves traffic
- [ ] `server.workers: 8` boots and serves traffic; no regression in single-request latency
- [ ] Existing `local.yaml`/`production.yaml` configs without `workers:` still parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)