### PR TITLE
Fix sync integration test suite

### DIFF
--- a/docs/content/server/service/sync/test/integration/_index.md
+++ b/docs/content/server/service/sync/test/integration/_index.md
@@ -69,7 +69,9 @@ In this case d74ff0ee8da3b9806b18c877dbf29bbde50b5bd8e4dad7a3a725000feb82e8f1 = 
 
 ## 5 `run tests`
 
-Via cli: `SYNC_SITE_PASSWORD="pass" SYNC_SITE_NAME="demo" SYNC_URL="http://localhost:2048" cargo test  integration_sync  --features integration_test --package service`
+Via cli: `SYNC_SITE_PASSWORD="pass" SYNC_SITE_NAME="demo" SYNC_URL="http://localhost:2048" cargo nextest run integration_sync --features integration_test --package service`
+
+These tests share a single 4D mSupply server and several process-global statics, so they must run serially. The `sync-integration` test-group in `server/.config/nextest.toml` enforces this — no `--test-threads=1` flag needed.
 
 If you've set configurations in rust analyzer, can use inlay hint play and debug buttons in:
 
@@ -165,5 +167,5 @@ Transfer integration test follow this pattern:
 Full test including integration can be run with:
 
 ```bash
-SYNC_SITE_PASSWORD="pass" SYNC_SITE_NAME="demo" SYNC_URL="http://localhost:2048" cargo test  --features integration_test && SYNC_SITE_PASSWORD="pass" SYNC_SITE_NAME="demo" SYNC_URL="http://localhost:2048" cargo test --features integration_test,postgres
+SYNC_SITE_PASSWORD="pass" SYNC_SITE_NAME="demo" SYNC_URL="http://localhost:2048" cargo nextest run --features integration_test && SYNC_SITE_PASSWORD="pass" SYNC_SITE_NAME="demo" SYNC_URL="http://localhost:2048" cargo nextest run --features integration_test,postgres
 ```

--- a/server/.config/nextest.toml
+++ b/server/.config/nextest.toml
@@ -1,3 +1,12 @@
+[test-groups]
+# Sync integration tests share a single 4D mSupply server and several
+# process-global statics; running them concurrently causes data contamination.
+sync-integration = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'test(integration_sync)'
+test-group = 'sync-integration'
+
 [profile.ci]
 test-threads = "num-cpus"
 fail-fast = false

--- a/server/repository/src/db_diesel/key_value_store.rs
+++ b/server/repository/src/db_diesel/key_value_store.rs
@@ -81,8 +81,10 @@ static KEY_VALUE_STORE_CACHE: RwLock<Option<HashMap<KeyType, KeyValueStoreRow>>>
 
 fn get_cached_row(key: &KeyType) -> Option<KeyValueStoreRow> {
     // Disable cache in tests: each test has its own database but shares this
-    // process-global static, causing cross-test contamination.
-    if cfg!(test) {
+    // process-global static, causing cross-test contamination. `cfg!(test)`
+    // only fires for the crate being compiled as a test, so we also gate on
+    // the integration_test feature for tests in dependent crates.
+    if cfg!(test) || cfg!(feature = "integration_test") {
         return None;
     }
     let cache = KEY_VALUE_STORE_CACHE.read().unwrap();
@@ -90,7 +92,7 @@ fn get_cached_row(key: &KeyType) -> Option<KeyValueStoreRow> {
 }
 
 fn set_cached_row(row: KeyValueStoreRow) {
-    if cfg!(test) {
+    if cfg!(test) || cfg!(feature = "integration_test") {
         return;
     }
     let mut cache = KEY_VALUE_STORE_CACHE.write().unwrap();

--- a/server/service/src/sync/test/integration/central/name_and_store_and_name_store_join.rs
+++ b/server/service/src/sync/test/integration/central/name_and_store_and_name_store_join.rs
@@ -54,6 +54,9 @@ impl SyncRecordTester for NameAndStoreAndNameStoreJoinTester {
             deleted_datetime: None,
             next_of_kin_id: None,
             next_of_kin_name: None,
+            // 4D defaults these float columns to 0 when the upsert omits them.
+            margin: Some(0.0),
+            freight_factor: Some(0.0),
             ..Default::default()
         };
         let name_json1 = json!({
@@ -89,6 +92,8 @@ impl SyncRecordTester for NameAndStoreAndNameStoreJoinTester {
             r#type: NameRowType::Facility,
             is_customer: true,
             is_supplier: false,
+            margin: Some(0.0),
+            freight_factor: Some(0.0),
             ..Default::default()
         };
         let mut name_json2 = json!({

--- a/server/service/src/sync/test/integration/central_server_configurations.rs
+++ b/server/service/src/sync/test/integration/central_server_configurations.rs
@@ -120,6 +120,10 @@ impl ConfigureCentralServer {
         &self,
         records: serde_json::Value,
     ) -> Result<(), SyncApiError> {
+        // TestStepData fields default to Value::Null; 4D rejects a null body so skip the call.
+        if records.is_null() {
+            return Ok(());
+        }
         Ok(with_retry(|| self.api.upsert_central_records(&records)).await?)
     }
 
@@ -127,6 +131,9 @@ impl ConfigureCentralServer {
         &self,
         records: serde_json::Value,
     ) -> Result<(), SyncApiError> {
+        if records.is_null() {
+            return Ok(());
+        }
         Ok(with_retry(|| self.api.delete_central_records(&records)).await?)
     }
 

--- a/server/service/src/sync/test/integration/omsupply_central/vaccine_card.rs
+++ b/server/service/src/sync/test/integration/omsupply_central/vaccine_card.rs
@@ -44,8 +44,9 @@ mutation MyMutation(
             minIntervalDays: 1
           }
           coverageRate: 1
-          isActive: true
           wastageRate: 1
+          useInGapsCalculations: true
+          canSkipDose: false
         }
         storeId: $storeId
       ) {
@@ -87,7 +88,7 @@ pub(super) async fn test_vaccine_card() {
                     "ID": program_id,
                     "inactive":false,
                     "isProgram":true,
-                    "programSettings":"{}"
+                    "programSettings":{"storeTags":{}}
                 }
             ],
             "list_master_name_join":[
@@ -146,6 +147,9 @@ pub(super) async fn test_vaccine_card() {
         // None would be translated to 'male' when records syncs back again
         // which would break assertions in check_integrated
         gender: Some(GenderType::Female),
+        // 4D defaults these float columns to 0 when the upsert omits them.
+        margin: Some(0.0),
+        freight_factor: Some(0.0),
         ..Default::default()
     };
 

--- a/server/service/src/sync/test/integration/remote/clinician.rs
+++ b/server/service/src/sync/test/integration/remote/clinician.rs
@@ -46,6 +46,7 @@ impl SyncRecordTester for ClinicianRecordTester {
             email: None,
             gender: Some(GenderType::Male),
             is_active: true,
+            store_id: Some(store_row.id.clone()),
             ..Default::default()
         };
 

--- a/server/service/src/sync/test/integration/remote/invoice.rs
+++ b/server/service/src/sync/test/integration/remote/invoice.rs
@@ -101,7 +101,10 @@ impl SyncRecordTester for InvoiceRecordTester {
             reason_option_id: None, // TODO: Add test to update this with update_inventory_adjustment_reason_id
             note: None,
             item_variant_id: None,
-            prescribed_quantity: None,
+            // 4D defaults these float columns to 0 when the upsert omits them.
+            prescribed_quantity: Some(0.0),
+            shipped_number_of_packs: Some(0.0),
+            shipped_pack_size: Some(0.0),
             linked_invoice_id: None,
             donor_id: None,
             ..Default::default()
@@ -260,6 +263,8 @@ impl SyncRecordTester for InvoiceRecordTester {
             d.delivered_datetime = NaiveDate::from_ymd_opt(2022, 03, 27)
                 .unwrap()
                 .and_hms_opt(11, 35, 15);
+            // 4D mirrors delivered_datetime into received_datetime for inbound shipments.
+            d.received_datetime = d.delivered_datetime;
             d.verified_datetime = NaiveDate::from_ymd_opt(2022, 03, 28)
                 .unwrap()
                 .and_hms_opt(11, 35, 15);

--- a/server/service/src/sync/test/integration/remote/patient_name_and_store_and_name_store_join.rs
+++ b/server/service/src/sync/test/integration/remote/patient_name_and_store_and_name_store_join.rs
@@ -22,6 +22,8 @@ impl SyncRecordTester for PatientNameAndStoreAndNameStoreJoinTester {
             name: "facility".to_string(),
             is_customer: true,
             is_supplier: true,
+            margin: Some(0.0),
+            freight_factor: Some(0.0),
             ..Default::default()
         };
         let facility_name_json = json!({
@@ -59,6 +61,9 @@ impl SyncRecordTester for PatientNameAndStoreAndNameStoreJoinTester {
             is_supplier: false,
             gender: Some(GenderType::Male),
             supplying_store_id: Some(store_row.id.clone()),
+            // 4D defaults these float columns to 0 when the upsert omits them.
+            margin: Some(0.0),
+            freight_factor: Some(0.0),
             ..Default::default()
         };
         let patient_name_json = json!({

--- a/server/service/src/sync/test/integration/remote/requisition.rs
+++ b/server/service/src/sync/test/integration/remote/requisition.rs
@@ -63,7 +63,8 @@ impl SyncRecordTester for RequisitionRecordTester {
             snapshot_datetime: None,
             approved_quantity: 0.0,
             approval_comment: None,
-            initial_stock_on_hand_units: 5.0,
+            // 4D recalculates this to match available_stock_on_hand for Draft requisitions.
+            initial_stock_on_hand_units: 10.0,
             incoming_units: 5.0,
             outgoing_units: 5.0,
             loss_in_units: 5.0,
@@ -145,7 +146,8 @@ impl SyncRecordTester for RequisitionRecordTester {
         requisition_line_row_1.snapshot_datetime = NaiveDate::from_ymd_opt(2022, 03, 20)
             .unwrap()
             .and_hms_opt(12, 13, 14);
-        requisition_line_row_1.initial_stock_on_hand_units = 5.0;
+        // 4D recalculates this to match available_stock_on_hand.
+        requisition_line_row_1.initial_stock_on_hand_units = 15.0;
         requisition_line_row_1.incoming_units = 5.0;
         requisition_line_row_1.outgoing_units = 5.0;
         requisition_line_row_1.loss_in_units = 5.0;


### PR DESCRIPTION
## Summary

Builds on issue #10723 / PR #11670 (CI compile check for `integration_test`) — now that the suite compiles cleanly, this PR makes it actually pass end-to-end.

Three infrastructure bugs and several test-data drift issues kept the sync integration suite from running. With these fixes, **all 33 tests pass** (up from 1 of 12 before fail-fast halt).

### 1. Null body rejected by 4D — [`central_server_configurations.rs`](server/service/src/sync/test/integration/central_server_configurations.rs)

`TestStepData` fields (`central_upsert`, `central_delete`) are `serde_json::Value` and default to `Value::Null` when a step doesn't set them. The runner unconditionally POSTed the value to `/sync/v5/test/upsert` and `/sync/v5/test/delete`. On the 4D side, `syncV5API_test_upsert/delete` does `JSON Parse(...)` and fails with `-10718: The 'null' value cannot be assigned to destination variable.` Skip the API call when the value is null.

### 2. Process-global KV cache contamination — [`key_value_store.rs`](server/repository/src/db_diesel/key_value_store.rs)

`KEY_VALUE_STORE_CACHE` is a process-global `RwLock`. It was disabled in tests via `if cfg!(test)`. But `cfg!(test)` only fires for the crate being compiled as a test — when `service`'s integration tests call into the `repository` crate, `cfg!(test)` is false in `repository`, the cache stays enabled, and every test reads stale values another test wrote. This manifested as "site UUID does not match" in the with-reinit phase of every central test. Extend the guard to also fire on `cfg!(feature = "integration_test")`. Same fix pattern as `1179715b44`, just covering downstream test crates.

### 3. Serial execution needed — [`server/.config/nextest.toml`](server/.config/nextest.toml) + docs

Several other process-global statics remain (`LATEST_SYNC_LOG`, `CENTRAL_SERVER_CONFIG`, `IS_INITIALISED`, `SITES_BEING_INTEGRATED`) plus 4D-side contention. The 33 integration tests need to serialise. Add a nextest test-group with `max-threads = 1` that matches on `test(integration_sync)` — `cargo nextest run --features integration_test` does the right thing with no flag. Unit tests outside the group still run in parallel.

README examples switched from `cargo test` to `cargo nextest run` (matches project convention).

### 4. Test data drift (6 test files)

After the infrastructure fixes, 6 tests still failed against actual 4D + omSupply behaviour. The mismatches were in test expectations, not the code under test:

- **NameRow `margin`/`freight_factor`**: 4D defaults these float columns to 0 when the upsert omits them, so the synced row comes back as `Some(0.0)`. Updated the expected row in `central/name_and_store`, `remote/patient_name`, and `omsupply_central/vaccine_card`.
- **InvoiceLineRow `prescribed_quantity` / `shipped_number_of_packs` / `shipped_pack_size`**: same pattern.
- **ClinicianRow `store_id`**: test sends `store_ID` in the upsert JSON but didn't set `store_id` on the expected row.
- **RequisitionLineRow `initial_stock_on_hand_units`**: 4D recalculates from `available_stock_on_hand` on round-trip regardless of requisition status.
- **InvoiceRow `received_datetime`**: 4D mirrors `delivered_datetime` into `received_datetime` for inbound shipments.
- **Vaccine card graphql mutation**: schema changed — `isActive` removed; `useInGapsCalculations` and `canSkipDose` now required. Also `programSettings` sent as the string `"{}"` (which the translation treats as None and rejects with "Program settings not found"); replaced with `{"storeTags": {}}`.

## Test plan

- [x] `cargo nextest run integration_sync --features integration_test --package service --no-fail-fast` — **33 passed, 0 failed, 652 skipped** in ~9 minutes
- [x] No `--test-threads=1` flag needed — `.config/nextest.toml` keeps the integration tests serial
- [x] `cargo check --features integration_test --tests --manifest-path server/Cargo.toml` — matches CI compile check from #11670

🤖 Generated with [Claude Code](https://claude.com/claude-code)