### PR TITLE
Replace Telegram release notifications with Slack

### DIFF
--- a/.github/scripts/mac_backblaze_upload.sh
+++ b/.github/scripts/mac_backblaze_upload.sh
@@ -23,4 +23,4 @@ UNIVERSAL_FILENAME=$(basename "$UNIVERSAL_FILE_PATH")
 echo "Found file $UNIVERSAL_FILENAME to upload"
 $B2_PATH file upload --no-progress $B2_BUCKET_NAME "$UNIVERSAL_FILE_PATH" "${GITHUB_REF_NAME}/${UNIVERSAL_FILENAME}"
 
-python3 .github/scripts/send-telegram-notification.py $ARM64_FILENAME $UNIVERSAL_FILENAME
+python3 .github/scripts/send-slack-notification.py $ARM64_FILENAME $UNIVERSAL_FILENAME

--- a/.github/scripts/send-slack-notification.py
+++ b/.github/scripts/send-slack-notification.py
@@ -3,63 +3,44 @@ import sys
 import re
 import requests
 
-def escape_markdown_v2(text):
-    """
-    Escape special characters for Telegram MarkdownV2 format.
-    Characters that need escaping: _ * [ ] ( ) ~ ` > # + - = | { } . !
-    """
-    # Characters that need to be escaped in MarkdownV2
-    escape_chars = r'\_\*\[\]\(\)\~\`\>\#\+\-\=\|\{\}\.\!'
-    return re.sub(f'([{escape_chars}])', r'\\\1', text)
-
-# -- Scripts to send Telegram notifications based on build status or tag creation -- #
-def send_telegram_notification(chat_id, message, bot_key):
-    url = f"https://api.telegram.org/bot{bot_key}/sendMessage"
-    payload = {
-        "chat_id": chat_id,
-        "text": message,
-        "parse_mode": "MarkdownV2",
-    }
+# -- Scripts to send Slack notifications based on build status or tag creation -- #
+def send_slack_notification(webhook_url, message):
+    payload = {"text": message}
 
     try:
-        response = requests.post(url, data=payload)
+        response = requests.post(webhook_url, json=payload)
         response.raise_for_status()
-        print(f"✅ Message sent successfully to chat {chat_id}")
+        print("✅ Message sent successfully")
         return True
     except requests.exceptions.RequestException as e:
-        print(f"❌ Failed to send message to chat {chat_id}: {e}")
+        print(f"❌ Failed to send Slack message: {e}")
         return False
 
 # -- Determines which channel to use based on tag pattern -- #
 def get_channel_for_tag(tag):
-    dev_chat_id = os.getenv("TELEGRAM_DEV_RELEASE_CHAT_ID")
-    rc_chat_id = os.getenv("TELEGRAM_RC_RELEASE_CHAT_ID")
+    dev_webhook = os.getenv("SLACK_DEV_RELEASE_WEBHOOK_URL")
+    rc_webhook = os.getenv("SLACK_RC_RELEASE_WEBHOOK_URL")
 
     # Check if tag contains RC pattern
     if re.search(r'-(R|r)(C|c)', tag):
-        return rc_chat_id, "RC"
+        return rc_webhook, "RC"
     else:
-        return dev_chat_id, "Dev"
+        return dev_webhook, "Dev"
 
 # -- Handles Android build notifications -- #
 def handle_android_build_notification(filenames):
-    bot_key = os.getenv("TELEGRAM_RELEASE_BOT_KEY")
     tag = os.getenv("TAG_NAME")
     build_status = os.getenv("BUILD_STATUS", "unknown").lower()
-
-    if not bot_key:
-        print("❌ TELEGRAM_RELEASE_BOT_KEY not found.")
-        sys.exit(1)
 
     if not tag:
         print("❌ No tag found for Android build notification.")
         sys.exit(1)
 
     # Get appropriate channel based on tag
-    chat_id, channel_type = get_channel_for_tag(tag)
+    webhook_url, channel_type = get_channel_for_tag(tag)
 
-    if not chat_id:
-        print(f"❌ No chat ID configured for {channel_type} channel.")
+    if not webhook_url:
+        print(f"❌ No webhook URL configured for {channel_type} channel.")
         sys.exit(1)
 
     BASE_URL = "https://f002.backblazeb2.com/file/msupply-releases"
@@ -82,25 +63,19 @@ def handle_android_build_notification(filenames):
         # Construct the full URL for the APK file
         file_url = f"{BASE_URL}/{tag}/{filename}"
         print(f"📦 File URL: {file_url}")
-        escaped_filename = escape_markdown_v2(filename)
-        message += f"\n\n Download: [{escaped_filename}]({file_url})"
+        message += f"\n\n Download: <{file_url}|{filename}>"
 
     print(f"Sending Message:\n {message}")
-    if send_telegram_notification(chat_id, message, bot_key):
-        print(f"✅ Android build notification sent to {channel_type} chat {chat_id}")
+    if send_slack_notification(webhook_url, message):
+        print(f"✅ Android build notification sent to {channel_type} channel")
 
 # -- Handles tag creation notifications -- #
 def handle_tag_notification():
-    bot_key = os.getenv("TELEGRAM_RELEASE_BOT_KEY")
-    dev_chat_id = os.getenv("TELEGRAM_DEV_RELEASE_CHAT_ID")
-    rc_chat_id = os.getenv("TELEGRAM_RC_RELEASE_CHAT_ID")
+    dev_webhook = os.getenv("SLACK_DEV_RELEASE_WEBHOOK_URL")
+    rc_webhook = os.getenv("SLACK_RC_RELEASE_WEBHOOK_URL")
 
     created_tags = os.getenv("CREATED_TAGS", "").split()
     affected_branches = os.getenv("AFFECTED_BRANCHES", "").split()
-
-    if not bot_key:
-        print("❌ TELEGRAM_RELEASE_BOT_KEY not found.")
-        sys.exit(1)
 
     # Separate develop and RC tags
     develop_tags = []
@@ -113,24 +88,24 @@ def handle_tag_notification():
             rc_tags.append(tag)
 
     # Send notification for develop branch
-    if develop_tags and dev_chat_id:
+    if develop_tags and dev_webhook:
         message = "🚀 *Development Build Started*\n\n"
         message += "New versions being built:\n"
         for tag in develop_tags:
             message += f"• `{tag}`\n"
 
-        if send_telegram_notification(dev_chat_id, message, bot_key):
-            print(f"✅ Notification sent to Open-mSupply dev Builds chat")
+        if send_slack_notification(dev_webhook, message):
+            print(f"✅ Notification sent to Open-mSupply dev Builds channel")
 
     # Send notification for RC branches
-    if rc_tags and rc_chat_id:
+    if rc_tags and rc_webhook:
         message = "🏗️ *RC Build Started*\n\n"
         message += "New versions being built:\n"
         for tag in rc_tags:
             message += f"• `{tag}`\n"
 
-        if send_telegram_notification(rc_chat_id, message, bot_key):
-            print(f"✅ Notification sent to Open-mSupply RC Builds chat")
+        if send_slack_notification(rc_webhook, message):
+            print(f"✅ Notification sent to Open-mSupply RC Builds channel")
 
 def main():
     notification_type = os.getenv("NOTIFICATION_TYPE", "tag_creation")

--- a/.github/scripts/send-slack-notification.sh
+++ b/.github/scripts/send-slack-notification.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+python3 .github/scripts/send-slack-notification.py

--- a/.github/scripts/send-telegram-notification.sh
+++ b/.github/scripts/send-telegram-notification.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-python3 .github/scripts/send-telegram-notification.py

--- a/.github/workflows/build-android-apk.yaml
+++ b/.github/workflows/build-android-apk.yaml
@@ -78,9 +78,8 @@ jobs:
 
       - name: Upload Universal APK to Backblaze B2
         env:
-          TELEGRAM_RELEASE_BOT_KEY: ${{ secrets.TELEGRAM_RELEASE_BOT_KEY }}
-          TELEGRAM_DEV_RELEASE_CHAT_ID: ${{ secrets.TELEGRAM_DEV_RELEASE_CHAT_ID }}
-          TELEGRAM_RC_RELEASE_CHAT_ID: ${{ secrets.TELEGRAM_RC_RELEASE_CHAT_ID }}
+          SLACK_DEV_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_DEV_RELEASE_WEBHOOK_URL }}
+          SLACK_RC_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_RC_RELEASE_WEBHOOK_URL }}
           NOTIFICATION_TYPE: 'android_build'
           BUILD_STATUS: ${{ job.status }}
           TAG_NAME: ${{ github.ref_name }}
@@ -91,10 +90,9 @@ jobs:
       - name: Send build completion notification
         if: ${{ failure() }}
         env:
-          TELEGRAM_RELEASE_BOT_KEY: ${{ secrets.TELEGRAM_RELEASE_BOT_KEY }}
-          TELEGRAM_DEV_RELEASE_CHAT_ID: ${{ secrets.TELEGRAM_DEV_RELEASE_CHAT_ID }}
-          TELEGRAM_RC_RELEASE_CHAT_ID: ${{ secrets.TELEGRAM_RC_RELEASE_CHAT_ID }}
+          SLACK_DEV_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_DEV_RELEASE_WEBHOOK_URL }}
+          SLACK_RC_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_RC_RELEASE_WEBHOOK_URL }}
           NOTIFICATION_TYPE: 'android_build'
           BUILD_STATUS: ${{ job.status }}
           TAG_NAME: ${{ github.ref_name }}
-        run: bash .github/scripts/send-telegram-notification.sh
+        run: bash .github/scripts/send-slack-notification.sh

--- a/.github/workflows/nightly-automated-builds.yaml
+++ b/.github/workflows/nightly-automated-builds.yaml
@@ -34,11 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Send telegram notifications
+      - name: Send Slack notifications
         env:
-          TELEGRAM_RELEASE_BOT_KEY: ${{ secrets.TELEGRAM_RELEASE_BOT_KEY }}
-          TELEGRAM_DEV_RELEASE_CHAT_ID: ${{ secrets.TELEGRAM_DEV_RELEASE_CHAT_ID }}
-          TELEGRAM_RC_RELEASE_CHAT_ID: ${{ secrets.TELEGRAM_RC_RELEASE_CHAT_ID }}
+          SLACK_DEV_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_DEV_RELEASE_WEBHOOK_URL }}
+          SLACK_RC_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_RC_RELEASE_WEBHOOK_URL }}
           CREATED_TAGS: ${{ needs.create-tags.outputs.CREATED_TAGS }}
           AFFECTED_BRANCHES: ${{ needs.create-tags.outputs.AFFECTED_BRANCHES }}
-        run: bash .github/scripts/send-telegram-notification.sh
+        run: bash .github/scripts/send-slack-notification.sh


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Swaps the GitHub Actions notification transport from the Telegram bot API to Slack incoming webhooks for nightly tag-creation and Android build status messages.

The shared Python helper is preserved (it still handles dev/RC channel routing, build-status emoji mapping, and the two notification modes) — just renamed `send-telegram-notification.{py,sh}` → `send-slack-notification.{py,sh}` and rewired to POST `{"text": ...}` JSON to webhook URLs.

Message formatting moves from Telegram MarkdownV2 to Slack mrkdwn: download links become `<url|filename>` instead of `[filename](url)`, and the MarkdownV2 escape function is dropped.

Secrets footprint shrinks from 3 → 2: webhook URLs are themselves the credential, so the bot key goes away.

## 💌 Any notes for the reviewer?

- Repo secrets `SLACK_DEV_RELEASE_WEBHOOK_URL` and `SLACK_RC_RELEASE_WEBHOOK_URL` are already configured. The three `TELEGRAM_*` secrets can be deleted after a green prod run.
- Channel routing logic is unchanged — dev/RC split still keyed off branch suffix (`tag_creation` mode) and tag suffix (`android_build` mode).
- No changes to `create-nightly-tags.sh`; the existing `CREATED_TAGS` / `AFFECTED_BRANCHES` outputs feed the renamed script unchanged.

# 🧪 Testing

- [ ] `workflow_dispatch` on **Nightly Automated Builds**; confirm dev and RC messages land in the right channels and that mrkdwn renders (`*bold*`, `` `code` ``).
- [ ] `workflow_dispatch` on **Android Build** against a non-RC tag — confirm success message + download links route to the dev channel.
- [ ] Repeat against an RC tag (`v…-rc…`) — confirm routing to the RC channel.
- [ ] Induce a step failure on a feature-branch copy of the Android workflow to verify the `if: failure()` notification path.
- [ ] `grep -rni telegram .github/` returns zero hits.

# 📃 Documentation

- [x] **No documentation required**: CI/infra change, no user-facing behaviour change.
