### PR TITLE
11633 Clicking anything in 'External Inbound Shipments' in Dashboard leads to just normal Inbound Shipments

### DIFF
--- a/client/packages/dashboard/src/widgets/ReplenishmentWidget.tsx
+++ b/client/packages/dashboard/src/widgets/ReplenishmentWidget.tsx
@@ -23,6 +23,7 @@ import {
 import {
   ApiException,
   InvoiceNodeStatus,
+  InvoiceTypeInput,
   RequisitionNodeStatus,
   UserPermission,
 } from '@common/types';
@@ -96,8 +97,8 @@ export const ReplenishmentWidget = ({
     modalControl.toggleOn
   );
 
-  const internalTab = 'internal';
-  const externalTab = 'external';
+  const internalType = InvoiceTypeInput.InboundShipment;
+  const externalType = InvoiceTypeInput.InboundShipmentExternal;
 
   const corePanels = [
     <StatsPanel
@@ -115,7 +116,7 @@ export const ReplenishmentWidget = ({
             .addPart(AppRoute.InboundShipment)
             .addQuery({
               createdDatetime: getTodayUrlQuery(),
-              tab: internalTab,
+              type: internalType,
             })
             .build(),
           statContext: `${inboundInternalPanelContext}-today`,
@@ -127,7 +128,7 @@ export const ReplenishmentWidget = ({
             .addPart(AppRoute.InboundShipment)
             .addQuery({
               createdDatetime: getThisWeekUrlQuery(),
-              tab: internalTab,
+              type: internalType,
             })
             .build(),
           statContext: `${inboundInternalPanelContext}-this-week`,
@@ -139,7 +140,7 @@ export const ReplenishmentWidget = ({
             .addPart(AppRoute.InboundShipment)
             .addQuery({
               status: `${InvoiceNodeStatus.Shipped},${InvoiceNodeStatus.New}`,
-              tab: internalTab,
+              type: internalType,
             })
             .build(),
           statContext: `${inboundInternalPanelContext}-not-delivered`,
@@ -166,7 +167,7 @@ export const ReplenishmentWidget = ({
                   .addPart(AppRoute.InboundShipment)
                   .addQuery({
                     createdDatetime: getTodayUrlQuery(),
-                    tab: externalTab,
+                    type: externalType,
                   })
                   .build(),
                 statContext: `${inboundExternalPanelContext}-today`,
@@ -178,7 +179,7 @@ export const ReplenishmentWidget = ({
                   .addPart(AppRoute.InboundShipment)
                   .addQuery({
                     createdDatetime: getThisWeekUrlQuery(),
-                    tab: externalTab,
+                    type: externalType,
                   })
                   .build(),
                 statContext: `${inboundExternalPanelContext}-this-week`,
@@ -190,7 +191,7 @@ export const ReplenishmentWidget = ({
                   .addPart(AppRoute.InboundShipment)
                   .addQuery({
                     status: `${InvoiceNodeStatus.Shipped},${InvoiceNodeStatus.New}`,
-                    tab: externalTab,
+                    type: externalType,
                   })
                   .build(),
                 statContext: `${inboundExternalPanelContext}-not-delivered`,
@@ -198,7 +199,7 @@ export const ReplenishmentWidget = ({
             ]}
             link={RouteBuilder.create(AppRoute.Replenishment)
               .addPart(AppRoute.InboundShipment)
-              .addQuery({ tab: externalTab })
+              .addQuery({ type: externalType })
               .build()}
           />,
         ]

--- a/client/packages/dashboard/src/widgets/ReplenishmentWidget.tsx
+++ b/client/packages/dashboard/src/widgets/ReplenishmentWidget.tsx
@@ -96,8 +96,8 @@ export const ReplenishmentWidget = ({
     modalControl.toggleOn
   );
 
-  const internalTab = t('label.internal');
-  const externalTab = t('label.external');
+  const internalTab = 'internal';
+  const externalTab = 'external';
 
   const corePanels = [
     <StatsPanel
@@ -138,7 +138,7 @@ export const ReplenishmentWidget = ({
           link: RouteBuilder.create(AppRoute.Replenishment)
             .addPart(AppRoute.InboundShipment)
             .addQuery({
-              status: InvoiceNodeStatus.Shipped,
+              status: `${InvoiceNodeStatus.Shipped},${InvoiceNodeStatus.New}`,
               tab: internalTab,
             })
             .build(),
@@ -189,7 +189,7 @@ export const ReplenishmentWidget = ({
                 link: RouteBuilder.create(AppRoute.Replenishment)
                   .addPart(AppRoute.InboundShipment)
                   .addQuery({
-                    status: InvoiceNodeStatus.Shipped,
+                    status: `${InvoiceNodeStatus.Shipped},${InvoiceNodeStatus.New}`,
                     tab: externalTab,
                   })
                   .build(),

--- a/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
@@ -7,6 +7,7 @@ import {
   useTranslation,
   NothingHere,
   useToggle,
+  useUrlQuery,
   useUrlQueryParams,
   ColumnType,
   ColumnDef,
@@ -74,11 +75,20 @@ export const InboundListView = () => {
     ],
   });
 
+  const { urlQuery } = useUrlQuery({ skipParse: ['tab'] });
+  const tab = urlQuery['tab'];
+
   // Only include invoice types the user has permissions to view
   const invoiceTypes: InvoiceTypeInput[] = [];
-  if (userHasPermission(UserPermission.InboundShipmentQuery))
+  if (
+    tab !== 'external' &&
+    userHasPermission(UserPermission.InboundShipmentQuery)
+  )
     invoiceTypes.push(InvoiceTypeInput.InboundShipment);
-  if (userHasPermission(UserPermission.InboundShipmentExternalQuery))
+  if (
+    tab !== 'internal' &&
+    userHasPermission(UserPermission.InboundShipmentExternalQuery)
+  )
     invoiceTypes.push(InvoiceTypeInput.InboundShipmentExternal);
 
   const listParams = {

--- a/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
@@ -7,7 +7,6 @@ import {
   useTranslation,
   NothingHere,
   useToggle,
-  useUrlQuery,
   useUrlQueryParams,
   ColumnType,
   ColumnDef,
@@ -66,6 +65,7 @@ export const InboundListView = () => {
         condition: 'between',
       },
       { key: 'status', condition: 'equalAny' },
+      { key: 'type', condition: 'equalAny' },
       { key: 'theirReference' },
       {
         key: 'linkedOrderNumber',
@@ -75,18 +75,23 @@ export const InboundListView = () => {
     ],
   });
 
-  const { urlQuery } = useUrlQuery({ skipParse: ['tab'] });
-  const tab = urlQuery['tab'];
+  const {
+    type: { equalAny: requestedTypes } = {},
+    ...restFilterBy
+  } = (filterBy ?? {}) as {
+    type?: { equalAny?: InvoiceTypeInput[] };
+  };
 
-  // Only include invoice types the user has permissions to view
   const invoiceTypes: InvoiceTypeInput[] = [];
   if (
-    tab !== 'external' &&
+    (!requestedTypes ||
+      requestedTypes.includes(InvoiceTypeInput.InboundShipment)) &&
     userHasPermission(UserPermission.InboundShipmentQuery)
   )
     invoiceTypes.push(InvoiceTypeInput.InboundShipment);
   if (
-    tab !== 'internal' &&
+    (!requestedTypes ||
+      requestedTypes.includes(InvoiceTypeInput.InboundShipmentExternal)) &&
     userHasPermission(UserPermission.InboundShipmentExternalQuery)
   )
     invoiceTypes.push(InvoiceTypeInput.InboundShipmentExternal);
@@ -95,7 +100,7 @@ export const InboundListView = () => {
     sortBy,
     first,
     offset,
-    filterBy,
+    filterBy: restFilterBy,
     type: invoiceTypes,
   };
 
@@ -196,11 +201,11 @@ export const InboundListView = () => {
       onRowClick: row =>
         row.purchaseOrder
           ? navigate(
-              RouteBuilder.create(AppRoute.Replenishment)
-                .addPart(AppRoute.InboundShipmentExternal)
-                .addPart(row.id)
-                .build()
-            )
+            RouteBuilder.create(AppRoute.Replenishment)
+              .addPart(AppRoute.InboundShipmentExternal)
+              .addPart(row.id)
+              .build()
+          )
           : navigate(row.id),
       columns,
       data: data?.nodes ?? [],

--- a/client/packages/invoices/src/InboundShipment/ListView/Toolbar.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/Toolbar.tsx
@@ -10,6 +10,7 @@ import {
   FilterController,
   usePreferences,
   InvoiceNodeType,
+  InvoiceTypeInput,
 } from '@openmsupply-client/common';
 import { getStatusSequence } from '../../statuses';
 import { getStatusTranslator } from '../../utils';
@@ -80,6 +81,21 @@ export const Toolbar = ({ filter }: ToolbarProps) => {
                   value: status,
                   label: getStatusTranslator(t)(status),
                 })),
+              },
+              {
+                type: 'enum',
+                name: t('label.type'),
+                urlParameter: 'type',
+                options: [
+                  {
+                    value: InvoiceTypeInput.InboundShipment,
+                    label: t('label.internal'),
+                  },
+                  {
+                    value: InvoiceTypeInput.InboundShipmentExternal,
+                    label: t('label.external'),
+                  },
+                ],
               },
               {
                 type: 'text',

--- a/server/service/src/dashboard/invoice_count.rs
+++ b/server/service/src/dashboard/invoice_count.rs
@@ -266,7 +266,10 @@ impl InvoiceCountServiceTrait for InvoiceCountService {
             InvoiceFilter::new()
                 .store_id(EqualFilter::equal_to(store_id.to_string()))
                 .r#type(InvoiceType::InboundShipment.equal_to())
-                .status(InvoiceStatus::Shipped.equal_to()),
+                .status(InvoiceStatus::equal_any(vec![
+                    InvoiceStatus::Shipped,
+                    InvoiceStatus::New,
+                ])),
         ))
     }
 
@@ -312,7 +315,10 @@ impl InvoiceCountServiceTrait for InvoiceCountService {
         let mut filter = InvoiceFilter::new()
             .store_id(EqualFilter::equal_to(store_id.to_string()))
             .r#type(InvoiceType::InboundShipment.equal_to())
-            .status(InvoiceStatus::Shipped.equal_to());
+            .status(InvoiceStatus::equal_any(vec![
+                InvoiceStatus::Shipped,
+                InvoiceStatus::New,
+            ]));
         filter = filter.purchase_order_id(po_filter_for_external(is_external));
         repo.count(Some(filter))
     }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11633

# 👩🏻‍💻 What does this PR do?
- `Inbound shipment not yet delivered` stats should also filter out `new` invoices since they haven't been delivered either
- Fix redirecting not showing correct invoices in inbound view

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a mixture of invoices both internal and external
- [ ] Click on stats in dashboard for internal / external inbound shipments
- [ ] Should be redirected to the correctly filtered view

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

