### PR TITLE
11411 Stock : Aggregated view display no filters and unable to sort values assending order

### DIFF
--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -62,12 +62,7 @@ export const StockListView = () => {
   // Stock-line-specific filters don't apply in grouped mode (and vice versa
   // there are no grouped-only filters yet). Clear them on toggle so stale URL
   // params don't silently affect the ungrouped query when the user switches back.
-  const stockLineFilterKeys = [
-    'location.code',
-    'masterList.name',
-    'expiryDate',
-    'vvmStatusId',
-  ];
+  const stockLineFilterKeys = ['location.code', 'expiryDate', 'vvmStatusId'];
   const initialRender = useRef(true);
   useEffect(() => {
     if (initialRender.current) {

--- a/client/packages/system/src/Stock/ListView/Toolbar.tsx
+++ b/client/packages/system/src/Stock/ListView/Toolbar.tsx
@@ -15,7 +15,8 @@ export const Toolbar = ({ isGrouped }: { isGrouped: boolean }) => {
   const { manageVvmStatusForStock } = usePreferences();
   const { data: vmmStatuses } = useVvmStatusesEnabled();
 
-  const searchFilter = [
+  // Item-level filters apply in both grouped and ungrouped modes.
+  const itemFilters = [
     {
       type: 'text',
       name: t('messages.search'),
@@ -23,10 +24,6 @@ export const Toolbar = ({ isGrouped }: { isGrouped: boolean }) => {
       placeholder: t('messages.search'),
       isDefault: true,
     },
-  ] satisfies FilterDefinition[];
-
-  // Master list filters at the item level, so it applies in both modes.
-  const itemFilters = [
     {
       type: 'text',
       name: t('label.master-list'),
@@ -62,16 +59,16 @@ export const Toolbar = ({ isGrouped }: { isGrouped: boolean }) => {
     },
     ...(manageVvmStatusForStock
       ? [
-          {
-            type: 'enum',
-            name: t('label.vvm-status'),
-            urlParameter: 'vvmStatusId',
-            options: vmmStatuses?.map(status => ({
-              label: status.description ?? '',
-              value: status.id,
-            })),
-          } as FilterDefinition,
-        ]
+        {
+          type: 'enum',
+          name: t('label.vvm-status'),
+          urlParameter: 'vvmStatusId',
+          options: vmmStatuses?.map(status => ({
+            label: status.description ?? '',
+            value: status.id,
+          })),
+        } as FilterDefinition,
+      ]
       : []),
   ] satisfies (FilterDefinition | GroupFilterDefinition)[];
 
@@ -87,9 +84,7 @@ export const Toolbar = ({ isGrouped }: { isGrouped: boolean }) => {
       <Box display="flex" gap={1}>
         <FilterMenu
           filters={
-            isGrouped
-              ? [...searchFilter, ...itemFilters]
-              : [...searchFilter, ...itemFilters, ...stockLineFilters]
+            isGrouped ? itemFilters : [...itemFilters, ...stockLineFilters]
           }
         />
       </Box>

--- a/client/packages/system/src/Stock/ListView/Toolbar.tsx
+++ b/client/packages/system/src/Stock/ListView/Toolbar.tsx
@@ -25,18 +25,22 @@ export const Toolbar = ({ isGrouped }: { isGrouped: boolean }) => {
     },
   ] satisfies FilterDefinition[];
 
+  // Master list filters at the item level, so it applies in both modes.
+  const itemFilters = [
+    {
+      type: 'text',
+      name: t('label.master-list'),
+      urlParameter: 'masterList.name',
+      placeholder: t('placeholder.search-by-master-list-name'),
+    },
+  ] satisfies FilterDefinition[];
+
   const stockLineFilters = [
     {
       type: 'text',
       name: t('label.location'),
       urlParameter: 'location.code',
       placeholder: t('placeholder.search-by-location-code'),
-    },
-    {
-      type: 'text',
-      name: t('label.master-list'),
-      urlParameter: 'masterList.name',
-      placeholder: t('placeholder.search-by-master-list-name'),
     },
     {
       type: 'group',
@@ -83,7 +87,9 @@ export const Toolbar = ({ isGrouped }: { isGrouped: boolean }) => {
       <Box display="flex" gap={1}>
         <FilterMenu
           filters={
-            isGrouped ? searchFilter : [...searchFilter, ...stockLineFilters]
+            isGrouped
+              ? [...searchFilter, ...itemFilters]
+              : [...searchFilter, ...itemFilters, ...stockLineFilters]
           }
         />
       </Box>

--- a/client/packages/system/src/Stock/api/hooks/useGroupedStockList.ts
+++ b/client/packages/system/src/Stock/api/hooks/useGroupedStockList.ts
@@ -10,9 +10,13 @@ import { useStockGraphQL } from '../useStockGraphQL';
 import { LIST, STOCK } from './keys';
 
 // Only a subset of stock-line filters apply in grouped mode — the Toolbar
-// hides location/expiry/VVM/masterList filters when grouping is active. The
-// search/name/code subset is what the Toolbar exposes.
-type GroupedFilterBy = Pick<StockLineFilterInput, 'search' | 'name' | 'code'>;
+// hides location/expiry/VVM filters when grouping is active. masterList is an
+// item-level filter so it stays available; the rest is what the Toolbar
+// exposes when grouped.
+type GroupedFilterBy = Pick<
+  StockLineFilterInput,
+  'search' | 'name' | 'code' | 'masterList'
+>;
 
 export type GroupedStockListParams = {
   first?: number;
@@ -61,6 +65,7 @@ export const useGroupedStockList = (
       ...(filterBy?.search ? { search: filterBy.search } : {}),
       ...(filterBy?.name ? { name: filterBy.name } : {}),
       ...(filterBy?.code ? { code: filterBy.code } : {}),
+      ...(filterBy?.masterList ? { masterList: filterBy.masterList } : {}),
     };
 
     const query = await stockApi.itemsByStockLineFilter({


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11411

# 👩🏻‍💻 What does this PR do?
Reinstates the master list filter for aggreg. stock view

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to stock 
- [ ] Aggreg. by item
- [ ] Only see master list filter

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

