### PR TITLE
11280 incorrect number of items displayed when setting 'number of months threshold to show overstock alerts for products' preference

### DIFF
--- a/client/packages/system/src/Item/ListView/Toolbar.tsx
+++ b/client/packages/system/src/Item/ListView/Toolbar.tsx
@@ -61,14 +61,14 @@ export const Toolbar: FC = () => {
               name: t('label.min-mos'),
               urlParameter: 'minMonthsOfStock',
               minValue: 0,
-              decimalLimit: 0,
+              decimalLimit: 2,
             },
             {
               type: 'number',
               name: t('label.max-mos'),
               urlParameter: 'maxMonthsOfStock',
               minValue: 0,
-              decimalLimit: 0,
+              decimalLimit: 2,
             },
             ...(numMonthsConsumption
               ? [

--- a/server/service/src/item/item.rs
+++ b/server/service/src/item/item.rs
@@ -123,9 +123,8 @@ pub fn get_items_ids_for_months_of_stock(
 
             let mos = v.total_stock_on_hand / v.average_monthly_consumption;
 
-            // Check if item meets the min/max bounds
-            let within_range = min_months_of_stock.is_none_or(|min| mos >= min)
-                && max_months_of_stock.is_none_or(|max| mos <= max);
+            let within_range = min_months_of_stock.is_none_or(|min| mos > min)
+                && max_months_of_stock.is_none_or(|max| mos < max);
 
             within_range.then_some(k)
         })
@@ -345,7 +344,6 @@ mod test {
             item_stats.insert(
                 "item_2".to_string(),
                 ItemStats {
-                    // This item has 6 MOS on hand, which is less than the maximum
                     average_monthly_consumption: 1.0,
                     total_stock_on_hand: 6.0,
                     ..Default::default()
@@ -371,7 +369,7 @@ mod test {
             // It is necessary to sort result as it is made from a hashmap, and hashmaps are processed in a different order each time.
             result.sort();
 
-            assert_eq!(result, ["item_1".to_string(), "item_2".to_string()]);
+            assert_eq!(result, ["item_1".to_string()]);
         }
 
         #[test]


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11280

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
- Allow min/max decimal filtering in item page
- Align filter with a less than / greater than instead of less/greater than or equal to filter

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Min/Max MOS filter should allow you to put up to 2 decimal places
- [ ] Should show items with less than or greater than min/max mos instead of and equal to

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

