### PR TITLE
11135 [Store dashboard] 'Emergency' requisitions are displayed even if store is not using program orders

### DIFF
--- a/client/packages/dashboard/src/widgets/DistributionWidget.tsx
+++ b/client/packages/dashboard/src/widgets/DistributionWidget.tsx
@@ -32,7 +32,8 @@ export const DistributionWidget = ({
   const modalControl = useToggle(false);
   const navigate = useNavigate();
   const { error: errorNotification } = useNotification();
-  const { userHasPermission } = useAuthContext();
+  const { store, userHasPermission } = useAuthContext();
+  const omProgramModule = !!store?.preferences.omProgramModule;
   const formatNumber = useFormatNumber();
   const outbound = useOutboundCounts();
   const requisition = useRequisitionCounts();
@@ -103,18 +104,23 @@ export const DistributionWidget = ({
             .build(),
           statContext: `${customerRequisitionsPanelContext}-new`,
         },
-        {
-          label: t('label.emergency'),
-          value: formatNumber.round(requisition?.stats?.emergency),
-          link: RouteBuilder.create(AppRoute.Distribution)
-            .addPart(AppRoute.CustomerRequisition)
-            .addQuery({ isEmergency: true })
-            .addQuery({ status: RequisitionNodeStatus.New })
-            .build(),
-          statContext: `${customerRequisitionsPanelContext}-emergency`,
-          alertFlag:
-            !!requisition.stats?.emergency && requisition.stats?.emergency > 0,
-        },
+        ...(omProgramModule
+          ? [
+            {
+              label: t('label.emergency'),
+              value: formatNumber.round(requisition?.stats?.emergency),
+              link: RouteBuilder.create(AppRoute.Distribution)
+                .addPart(AppRoute.CustomerRequisition)
+                .addQuery({ isEmergency: true })
+                .addQuery({ status: RequisitionNodeStatus.New })
+                .build(),
+              statContext: `${customerRequisitionsPanelContext}-emergency`,
+              alertFlag:
+                !!requisition.stats?.emergency &&
+                requisition.stats?.emergency > 0,
+            },
+          ]
+          : []),
       ]}
       link={RouteBuilder.create(AppRoute.Distribution)
         .addPart(AppRoute.CustomerRequisition)


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11135

# 👩🏻‍💻 What does this PR do?
Hides emergency dashboard item under program pref 
 
# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Don't enable `Open mSupply: Uses program module` store preference on in OG
- [ ] Go to dashboard -> Don't see emergency under requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

