### PR TITLE
#11267 Fix prescription New Item render loop and stuck modal

### DIFF
--- a/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.ts
+++ b/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useBeforeUnload, useBlocker } from 'react-router-dom';
 import { create } from 'zustand';
 import { useTranslation } from '@common/intl';
@@ -87,14 +87,28 @@ export const useBlockNavigation = () => {
     { capture: true }
   );
 
+  // Track the latest blocker via ref so the confirmation modal can re-check
+  // state at click time. `blocker.proceed` is only defined while state is
+  // 'blocked'; once consumed (proceeding -> unblocked) the captured reference
+  // is stale and re-invoking it throws an invariant. This can happen if the
+  // modal is re-opened with a stale callback, or if the user double-clicks OK.
+  const blockerRef = useRef(blocker);
+  blockerRef.current = blocker;
+
+  const safeProceed = useCallback(() => {
+    if (blockerRef.current.state === 'blocked') {
+      blockerRef.current.proceed?.();
+    }
+  }, []);
+
   useEffect(() => {
     if (blocker.state === 'blocked') {
       const customConfirmation = activeBlocker?.options?.customConfirmation;
 
       customConfirmation
-        ? customConfirmation(blocker.proceed)
+        ? customConfirmation(safeProceed)
         : showConfirmation({
-            onConfirm: blocker.proceed,
+            onConfirm: safeProceed,
           });
     }
   }, [blocker]);

--- a/client/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.tsx
+++ b/client/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.tsx
@@ -105,8 +105,11 @@ export const ConfirmationModal = ({
                 const result = onConfirm && onConfirm();
                 if (result instanceof Promise) {
                   setLoading(true);
-                  await result;
-                  setLoading(false);
+                  try {
+                    await result;
+                  } finally {
+                    setLoading(false);
+                  }
                 }
               }}
               label={buttonLabel ? buttonLabel : t('button.ok')}

--- a/client/packages/invoices/src/Prescriptions/LineEditView/AutoAllocatePrescribedQuantityField.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/AutoAllocatePrescribedQuantityField.tsx
@@ -5,6 +5,7 @@ import {
   useFormatNumber,
   useDebounceCallback,
   InputLabel,
+  useShallow,
 } from '@openmsupply-client/common';
 
 import { AllocateInType, useAllocationContext } from '../../StockOut';
@@ -14,14 +15,16 @@ export const AutoAllocatePrescribedQuantityField = () => {
   const { format } = useFormatNumber();
 
   const { autoAllocate, prescribedQuantity, setPrescribedQuantity } =
-    useAllocationContext(state => ({
-      autoAllocate: state.autoAllocate,
-      prescribedQuantity:
-        state.allocateIn.type === AllocateInType.Doses
-          ? (state.prescribedUnits ?? 0) * (state.item?.doses ?? 1)
-          : state.prescribedUnits,
-      setPrescribedQuantity: state.setPrescribedQuantity,
-    }));
+    useAllocationContext(
+      useShallow(state => ({
+        autoAllocate: state.autoAllocate,
+        prescribedQuantity:
+          state.allocateIn.type === AllocateInType.Doses
+            ? (state.prescribedUnits ?? 0) * (state.item?.doses ?? 1)
+            : state.prescribedUnits,
+        setPrescribedQuantity: state.setPrescribedQuantity,
+      }))
+    );
 
   // using a debounced value for the allocation. In the scenario where
   // you have only pack sizes > 1 available, and try to type a quantity which starts with 1

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEdit.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEdit.tsx
@@ -5,6 +5,7 @@ import {
   useBufferState,
   useFormatNumber,
   usePreferences,
+  useShallow,
   useTranslation,
 } from '@openmsupply-client/common';
 import { usePrescription } from '../api';
@@ -47,11 +48,11 @@ export const PrescriptionLineEdit = ({
   const { isDisabled, rows: lines } = usePrescription(); // TODO: how much can we strip now?
 
   const { clear, initialise, item } = useAllocationContext(
-    ({ initialise, item, clear }) => ({
+    useShallow(({ initialise, item, clear }) => ({
       initialise,
       item,
       clear,
-    })
+    }))
   );
 
   const { refetch: queryData, isFetching } = useOutboundLineEditData(

--- a/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/PrescriptionLineEditForm.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuItem,
   TextArea,
   InputWithLabelRow,
+  useShallow,
 } from '@openmsupply-client/common';
 import { AccordionPanelSection } from './PanelSection';
 import { getPrescriptionDirections } from './getPrescriptionDirections';
@@ -32,14 +33,16 @@ export const PrescriptionLineEditForm = ({
   const t = useTranslation();
 
   const { draftLines, item, note, allocatedQuantity, allocateInType, setNote } =
-    useAllocationContext(state => ({
-      draftLines: state.draftLines,
-      item: state.item,
-      note: state.note,
-      setNote: state.setNote,
-      allocatedQuantity: getAllocatedQuantity(state),
-      allocateInType: state.allocateIn.type,
-    }));
+    useAllocationContext(
+      useShallow(state => ({
+        draftLines: state.draftLines,
+        item: state.item,
+        note: state.note,
+        setNote: state.setNote,
+        allocatedQuantity: getAllocatedQuantity(state),
+        allocateInType: state.allocateIn.type,
+      }))
+    );
 
   const [defaultDirection, setDefaultDirection] = useState('');
   const [abbreviation, setAbbreviation] = useState('');


### PR DESCRIPTION
Fixes #11267

# 👩🏻‍💻 What does this PR do?

Fixes three independent bugs that combined to break repeated **New Item** clicks on a prescription line edit page (the symptoms in the issue video: item saving with no quantity, the dropdown hanging around, and finally a modal with a permanently spinning OK button).

**1. Unstable Zustand selectors → React 19 render loop**

`PrescriptionLineEdit`, `PrescriptionLineEditForm` and `AutoAllocatePrescribedQuantityField` each had a `useAllocationContext` selector that returned a fresh object literal every call. Under React 19's stricter `useSyncExternalStore` snapshot caching this trips "Maximum update depth exceeded". Wrapped each in `useShallow`, matching the previous fix from #11554 which missed these three call sites.

**2. ConfirmationModal OK button stuck in loading state**

`ConfirmationModal`'s OK button awaited `onConfirm` without `try/finally`, so a rejected promise left `isLoading=true`. Because the modal is rendered with `open={false}` rather than unmounted, that stale loading state survived the next open and presented as a permanently spinning OK button. Wrapped the `setLoading` pair in `try/finally`.

**3. "Invalid blocker state transition: unblocked -> proceeding" invariant**

`useConfirmOnLeaving` (the `useBlockNavigation` hook) stored `blocker.proceed` directly into the shared modal state. `blocker.proceed` is only valid while the blocker is in `'blocked'` state; once consumed (`blocked → proceeding → unblocked`) the reference is stale, and re-invoking it from a re-opened modal or a double-click trips the router invariant. Wrapped `proceed` in a stable callback that re-reads the latest blocker via a ref and no-ops unless still `'blocked'`.

## 💌 Any notes for the reviewer?

- Bug 1 is the same React-19 / Zustand pattern Brian fixed in cb702388d7 (#11554). These three siblings were missed.
- Bug 3 was previously masked by bug 2 — fixing the stuck spinner surfaced the router invariant. The ref-based guard is defensive: if `blocker.state` is no longer `'blocked'` at click time the call becomes a no-op rather than a crash. It doesn't change the happy-path behaviour.
- `useConfirmOnLeaving.ts` is shared infrastructure — any page using `useConfirmOnLeaving` or any code path that opens the global blocker confirmation modal is affected. I'd appreciate a careful look at that change in particular.
- Pre-existing TS error in `client/packages/common/src/hooks/useFormErrors/ErrorDisplay.test.tsx` is unrelated to this PR (present on `develop`).

# 🧪 Testing

- [ ] Dispensary → Prescriptions → new prescription
- [ ] Add an item
- [ ] Click **New Item** in the left list, select an item from the dropdown
- [ ] Click **New Item** again — confirm the save-confirmation modal appears, click OK, and verify the previous item is saved (with its quantity) and you land on the new selection screen
- [ ] Repeat the New Item / select / New Item cycle several more times rapidly — confirm no infinite-render error, no permanently spinning OK button, and no "Invalid blocker state transition" red error banner
- [ ] Sanity check the regular outbound shipment line edit and any other page using `useConfirmOnLeaving` (encounter detail, stock detail, RnR forms, etc.) still prompts on unsaved-changes navigation as before

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**:


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)