### PR TITLE
10905 cannot insert decimal % in demographics setup

### DIFF
--- a/client/packages/system/src/Manage/IndicatorsDemographics/DetailView/IndicatorsDemographics.tsx
+++ b/client/packages/system/src/Manage/IndicatorsDemographics/DetailView/IndicatorsDemographics.tsx
@@ -13,9 +13,8 @@ import {
 } from '@openmsupply-client/common';
 import { useIndicatorsDemographicsColumns } from './columns';
 import { Footer } from './Footer';
-import { GENERAL_POPULATION_ID, useDemographicData } from '../api';
+import { useDemographicData } from '../api';
 import {
-  calculateAcrossRow,
   mapHeaderData,
   mapProjection,
   toInsertIndicator,
@@ -26,7 +25,6 @@ import { HeaderData, Row } from '../types';
 export const IndicatorsDemographics = () => {
   useUrlQueryParams({ initialSort: { key: 'name', dir: 'asc' } });
   const [headerDraft, setHeaderDraft] = useState<HeaderData>();
-  const [indexPopulation, setIndexPopulation] = useState(0);
   const { isDirty, setIsDirty } = useConfirmOnLeaving(
     'indicators-demographics'
   );
@@ -35,7 +33,13 @@ export const IndicatorsDemographics = () => {
   const t = useTranslation();
   const { translateServerError } = useIntlUtils();
 
-  const { draft, setDraft } = useDemographicData.indicator.list(headerDraft);
+  const {
+    draft,
+    indexPopulation,
+    setDraft,
+    addRow,
+    resetEdits,
+  } = useDemographicData.indicator.list(headerDraft);
   const baseYear = headerDraft?.baseYear ?? 2024; // TODO: Allow the user to select the base year for their projections
   const { data: projection, isLoading: isLoadingProjection } =
     useDemographicData.projection.get(baseYear);
@@ -54,82 +58,31 @@ export const IndicatorsDemographics = () => {
     invalidateProjectionQueries(baseYear);
   };
 
+  const setter = (patch: RecordPatch<Row>) => {
+    setIsDirty(true);
+    setDraft(patch);
+  };
+
   const handlePopulationChange = (patch: RecordPatch<Row>) => {
     setIsDirty(true);
-
-    const basePopulation = patch['0'] ?? 0;
-    let updatedDraft: Record<string, Row> = {};
-    const indexPopulationChange =
-      basePopulation !== draft[patch.id]?.basePopulation &&
-      patch.id === GENERAL_POPULATION_ID;
-
-    if (indexPopulationChange) setIndexPopulation(basePopulation);
-
-    Object.values(draft).forEach(row => {
-      const updatedRow = calculateAcrossRow(
-        row,
-        headerDraft,
-        indexPopulationChange ? basePopulation : indexPopulation
-      );
-      updatedDraft = { ...updatedDraft, [updatedRow.id]: updatedRow };
-    });
-    setDraft(updatedDraft);
+    setDraft(patch);
   };
 
-  const setter = (patch: RecordPatch<Row>) => {
-    const percentage = !patch.percentage ? 0 : patch.percentage;
-    const percentageChange = percentage != draft[patch.id]?.percentage;
-
-    const existingRow = draft[patch.id];
-    if (!existingRow) return;
-
-    setIsDirty(true);
-
-    const patchedRow: Row = { ...existingRow, ...patch, isError: false };
-
-    // change state of name only if only name changes
-    if (!percentageChange) {
-      setDraft({ ...draft, [patch.id]: patchedRow });
-      return;
-    }
-
-    const updatedRow = calculateAcrossRow(
-      patchedRow,
-      headerDraft,
-      indexPopulation
-    );
-    setDraft({ ...draft, [patch.id]: updatedRow });
-  };
-
-  const createNewRow = (row: Row) => {
-    setDraft({ ...draft, [row.id]: row });
-    setIsDirty(true);
-  };
-
-  // generic function for handling percentage change, and then re calculating the values of that year
   const handleGrowthChange = (updatedHeader: HeaderData) => {
     setIsDirty(true);
     setHeaderDraft(updatedHeader);
-    calculateDown(updatedHeader);
   };
-  const calculateDown = (updatedHeader: HeaderData) => {
-    const updatedDraft: Record<string, Row> = {};
-    Object.values(draft).forEach(row => {
-      const updatedRow = calculateAcrossRow(
-        row,
-        updatedHeader,
-        indexPopulation
-      );
-      updatedDraft[updatedRow.id] = updatedRow;
-    });
-    setDraft(updatedDraft);
+
+  const createNewRow = (row: Row) => {
+    setIsDirty(true);
+    addRow(row);
   };
 
   const insertIndicator = async (row: Row) => {
     try {
       await insertDemographicIndicator(toInsertIndicator(row, indexPopulation));
     } catch (e) {
-      setDraft({ ...draft, [row.id]: { ...row, isError: true } });
+      setDraft({ id: row.id, isError: true });
       throw e;
     }
   };
@@ -138,7 +91,7 @@ export const IndicatorsDemographics = () => {
     try {
       await updateDemographicIndicator(toUpdateIndicator(row, indexPopulation));
     } catch (e) {
-      setDraft({ ...draft, [row.id]: { ...row, isError: true } });
+      setDraft({ id: row.id, isError: true });
       throw e;
     }
   };
@@ -160,6 +113,7 @@ export const IndicatorsDemographics = () => {
       })
       .then(() => {
         success(t('success.data-saved'))();
+        resetEdits();
         invalidateQueries();
       })
       .catch(e =>
@@ -172,7 +126,9 @@ export const IndicatorsDemographics = () => {
   };
 
   const cancel = () => {
-    window.location.reload();
+    resetEdits();
+    setIsDirty(false);
+    if (projection) setHeaderDraft(mapHeaderData(projection));
   };
 
   const columns = useIndicatorsDemographicsColumns({
@@ -186,17 +142,6 @@ export const IndicatorsDemographics = () => {
     data: Object.values(draft),
     enableRowSelection: false,
   });
-
-  useEffect(() => {
-    if (!draft || !!indexPopulation) return;
-
-    const generalPopulationRow = draft[GENERAL_POPULATION_ID];
-    if (!generalPopulationRow) return;
-
-    setIndexPopulation(generalPopulationRow.basePopulation);
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [draft]);
 
   useEffect(() => {
     if (!projection) return;

--- a/client/packages/system/src/Manage/IndicatorsDemographics/DetailView/columns.tsx
+++ b/client/packages/system/src/Manage/IndicatorsDemographics/DetailView/columns.tsx
@@ -87,6 +87,7 @@ export const useIndicatorsDemographicsColumns = ({
               value={headerDraft ? headerDraft[yearOffset].value : 0}
               min={0}
               max={100}
+              decimalLimit={2}
               endAdornment="%"
               onChange={value => {
                 if (!headerDraft) return;

--- a/client/packages/system/src/Manage/IndicatorsDemographics/api/hooks/document/useDemographicIndicators.ts
+++ b/client/packages/system/src/Manage/IndicatorsDemographics/api/hooks/document/useDemographicIndicators.ts
@@ -1,10 +1,11 @@
 import {
-  useUrlQueryParams,
+  RecordPatch,
   useQuery,
   useTranslation,
+  useUrlQueryParams,
 } from '@openmsupply-client/common';
 import { useDemographicsApi } from '../utils/useDemographicApi';
-import { useEffect, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { GENERAL_POPULATION_ID } from '../..';
 import {
   calculateAcrossRow,
@@ -12,24 +13,34 @@ import {
 } from '../../../DetailView/utils';
 import { HeaderData, Row } from '../../../types';
 
+type RowEdit = Partial<Row> & { isNew?: boolean };
+
 export const useDemographicIndicators = (headerData?: HeaderData) => {
   const t = useTranslation();
   const api = useDemographicsApi();
-  const [draft, setDraft] = useState<Record<string, Row>>({});
   const { queryParams } = useUrlQueryParams({
     filters: [{ key: 'name' }, { key: 'basePopulation' }, { key: 'id' }],
   });
   const { data, isLoading } = useQuery({
     queryKey: api.keys.paramIndicatorList(queryParams),
-    queryFn: () => api.getIndicators.list(queryParams)
+    queryFn: () => api.getIndicators.list(queryParams),
   });
 
-  // Populate from API data and calculate across rows when data or header changes
-  useEffect(() => {
-    if (!data || !headerData) return;
+  const [edits, setEdits] = useState<Record<string, RowEdit>>({});
 
-    const nodesAsRow = data.nodes.map(node =>
-      toDemographicIndicatorRow({
+  const indexPopulation = useMemo<number>(() => {
+    const local = edits[GENERAL_POPULATION_ID]?.[0];
+    if (typeof local === 'number') return local;
+    const generalNode = data?.nodes.find(n => n.id === GENERAL_POPULATION_ID);
+    return generalNode?.basePopulation ?? 0;
+  }, [data, edits]);
+
+  const draft = useMemo<Record<string, Row>>(() => {
+    if (!data || !headerData) return {};
+    const rows: Record<string, Row> = {};
+
+    for (const node of data.nodes) {
+      const base = toDemographicIndicatorRow({
         ...node,
         // Always use the translated name for the general population row since
         // it wasn't added by the user and is hardcoded in En
@@ -37,23 +48,46 @@ export const useDemographicIndicators = (headerData?: HeaderData) => {
           node.id === GENERAL_POPULATION_ID
             ? t('label.general-population')
             : node.name,
-      })
-    );
+      });
+      const merged: Row = { ...base, ...edits[node.id] };
+      rows[node.id] = calculateAcrossRow(merged, headerData, indexPopulation);
+    }
 
-    const generalRow = nodesAsRow.find(n => n.id === GENERAL_POPULATION_ID);
-    const basePopulation = generalRow?.basePopulation ?? 0;
+    for (const [id, edit] of Object.entries(edits)) {
+      if (rows[id] || !edit.isNew) continue;
+      rows[id] = calculateAcrossRow(
+        { ...(edit as Row), id },
+        headerData,
+        indexPopulation
+      );
+    }
 
-    const updatedDraft: Record<string, Row> = {};
-    nodesAsRow.forEach(row => {
-      const updatedRow = calculateAcrossRow(row, headerData, basePopulation);
-      updatedDraft[updatedRow.id] = updatedRow;
-    });
+    return rows;
+  }, [data, headerData, edits, indexPopulation, t]);
 
-    setDraft(updatedDraft);
+  const setDraft = useCallback((patch: RecordPatch<Row>) => {
+    setEdits(prev => ({
+      ...prev,
+      [patch.id]: { ...prev[patch.id], ...patch },
+    }));
+  }, []);
 
-    // don't want this changing every time the draft updates
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, headerData]);
+  const addRow = useCallback((row: Row) => {
+    setEdits(prev => ({
+      ...prev,
+      [row.id]: { ...row, isNew: true },
+    }));
+  }, []);
 
-  return { draft, setDraft, isLoading, data };
+  const resetEdits = useCallback(() => setEdits({}), []);
+
+  return {
+    draft,
+    indexPopulation,
+    setDraft,
+    addRow,
+    resetEdits,
+    isLoading,
+    data,
+  };
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10905

# 👩🏻‍💻 What does this PR do?
- Allow 2 dp in the growth % input
- Refactor useDemographicIndicators to derive draft from edits + data instead of mirroring via useEffect, removing a re-render loop that caused decimal input to reset

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Enter any number up to 2 DP in the growth % cell -> Value persists
- [ ] Edit base pop. -> all rows should recalculate
- [ ] Add new indicator -> values should calculate
- [ ] Cancel reverts values

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

