### PR TITLE
11125 Inbound shipments Ext : mobile view : (Barcode scanner ) : Should not display financial, currency Tabs for mobile users

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -272,14 +272,18 @@ const DetailViewInner = () => {
     },
     ...(isExternal
       ? [
-          {
-            Component: <FinancialTab />,
-            value: InboundShipmentDetailTabs.Financial,
-          },
-          {
-            Component: <CurrencyTab />,
-            value: InboundShipmentDetailTabs.Currency,
-          },
+          ...(!isExtraSmallScreen
+            ? [
+                {
+                  Component: <FinancialTab />,
+                  value: InboundShipmentDetailTabs.Financial,
+                },
+                {
+                  Component: <CurrencyTab />,
+                  value: InboundShipmentDetailTabs.Currency,
+                },
+              ]
+            : []),
           {
             Component: <DeliveryTab />,
             value: InboundShipmentDetailTabs.Delivery,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11125

# 👩🏻‍💻 What does this PR do?
Hide financial and currency tabs for external IS on phones.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have external inbound shipments
- [ ] Install OMS on phone
- [ ] Click on an E/IS
- [ ] Confirm financial and currency tabs not there

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

