### PR TITLE
10276 store preferences from og don't take effect until the user has logged out

### DIFF
--- a/client/packages/common/src/authentication/hooks/useUpdateUserInfo.ts
+++ b/client/packages/common/src/authentication/hooks/useUpdateUserInfo.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from '@common/intl';
-import { AuthCookie } from '../AuthContext';
+import { AuthCookie, setAuthCookie } from '../AuthContext';
 import {
   useGetUserPermissions,
   useLastSuccessfulUserSync,
@@ -52,6 +52,7 @@ export const useUpdateUserInfo = (
               jobTitle: userDetails?.jobTitle,
             },
           };
+          setAuthCookie(authCookie);
           setCookie(authCookie);
           return;
         }

--- a/client/packages/common/src/intl/utils/IntlUtils.ts
+++ b/client/packages/common/src/intl/utils/IntlUtils.ts
@@ -232,8 +232,6 @@ export const useIntlUtils = () => {
     return t(localeKey, Formatter.fromCamelCase(serverKey));
   };
 
-
-
   const invalidateCustomTranslations = () => {
     // Clear from local storage cache
     Object.keys(localStorage)
@@ -244,14 +242,7 @@ export const useIntlUtils = () => {
       )
       .forEach(key => localStorage.removeItem(key));
 
-    // Clear from i18next cache (specifically for when we delete a translation)
-    for (const lang of i18n.languages) {
-      i18n.removeResourceBundle(lang, CUSTOM_TRANSLATIONS_NAMESPACE);
-    }
-
-    // Then reload from backend
-    // Note - this is still requires the components in question to
-    // re-render to pick up the new translations
+    // Reload from backend.
     i18n.reloadResources(undefined, CUSTOM_TRANSLATIONS_NAMESPACE);
   };
 

--- a/client/packages/host/src/components/Sync/SyncModal.tsx
+++ b/client/packages/host/src/components/Sync/SyncModal.tsx
@@ -80,7 +80,9 @@ const useHostSync = (enabled: boolean) => {
 
       // Shouldn't run on first mount, when translations might still be loading - see issue #9042
       if (!isInitialMount) {
-        queryClient.invalidateQueries(); // refresh the page user is on after sync finishes
+        // Mark all queries stale but don't refetch active ones immediately.
+        // This avoids surrounding UI components to jump around
+        queryClient.invalidateQueries({ refetchType: 'none' });
         invalidateCustomTranslations();
         updateUser();
       }

--- a/client/packages/host/src/components/Sync/SyncModal.tsx
+++ b/client/packages/host/src/components/Sync/SyncModal.tsx
@@ -51,6 +51,7 @@ const useHostSync = (enabled: boolean) => {
   const [isInitialMount, setIsInitialMount] = useState(true);
   const { mutateAsync: manualSync } = useSync.sync.manualSync();
   const { allowSleep, keepAwake } = useNativeClient();
+  const { updateUser } = useAuthContext();
 
   // true by default to wait for first syncStatus api result
   const [isLoading, setIsLoading] = useState(true);
@@ -80,7 +81,10 @@ const useHostSync = (enabled: boolean) => {
 
       // Reload custom translations, in case we received new ones via sync
       // Shouldn't run on first mount, when translations might still be loading - see issue #9042
-      !isInitialMount && invalidateCustomTranslations();
+      if (!isInitialMount) {
+        invalidateCustomTranslations();
+        updateUser();
+      }
     }
   }, [syncStatus?.isSyncing]);
 
@@ -122,7 +126,7 @@ export const SyncModal = ({ onCancel, open, width = 800 }: SyncModalProps) => {
     isLoading,
     onManualSync,
   } = useHostSync(open);
-  const { updateUserIsLoading, updateUser, setStore, store } = useAuthContext();
+  const { updateUserIsLoading, updateUser } = useAuthContext();
   const error =
     syncStatus?.error &&
     mapSyncError(t, syncStatus?.error, 'error.unknown-sync-error');
@@ -130,9 +134,6 @@ export const SyncModal = ({ onCancel, open, width = 800 }: SyncModalProps) => {
   const sync = async () => {
     await updateUser();
     await onManualSync();
-    if (!!store) {
-      await setStore(store);
-    }
   };
 
   const durationAsDate = new Date(
@@ -246,7 +247,7 @@ export const SyncModal = ({ onCancel, open, width = 800 }: SyncModalProps) => {
               marginTop:
                 (!!numberOfRecordsInPushQueue &&
                   numberOfRecordsInPushQueue >= 100) ||
-                error
+                  error
                   ? '5'
                   : '20',
             }}

--- a/client/packages/host/src/components/Sync/SyncModal.tsx
+++ b/client/packages/host/src/components/Sync/SyncModal.tsx
@@ -77,11 +77,10 @@ const useHostSync = (enabled: boolean) => {
       keepAwake();
     } else {
       allowSleep();
-      queryClient.invalidateQueries(); // refresh the page user is on after sync finishes
 
-      // Reload custom translations, in case we received new ones via sync
       // Shouldn't run on first mount, when translations might still be loading - see issue #9042
       if (!isInitialMount) {
+        queryClient.invalidateQueries(); // refresh the page user is on after sync finishes
         invalidateCustomTranslations();
         updateUser();
       }
@@ -126,15 +125,10 @@ export const SyncModal = ({ onCancel, open, width = 800 }: SyncModalProps) => {
     isLoading,
     onManualSync,
   } = useHostSync(open);
-  const { updateUserIsLoading, updateUser } = useAuthContext();
+  const { updateUserIsLoading } = useAuthContext();
   const error =
     syncStatus?.error &&
     mapSyncError(t, syncStatus?.error, 'error.unknown-sync-error');
-
-  const sync = async () => {
-    await updateUser();
-    await onManualSync();
-  };
 
   const durationAsDate = new Date(
     0,
@@ -270,7 +264,7 @@ export const SyncModal = ({ onCancel, open, width = 800 }: SyncModalProps) => {
             startIcon={<RadioIcon />}
             variant="contained"
             disabled={false}
-            onClick={sync}
+            onClick={onManualSync}
             label={t('button.sync-now')}
             sx={theme => ({
               marginRight: 1,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10276

# 👩🏻‍💻 What does this PR do?
- InvalidateQueries was refetching all cached simultaneously
- Removed synchronous custom translations. If custom translations change then previous translations will persist until refresh
- Removed redundant updateUser
- Fix store prefs not showing up straight away after syncing

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Turn off store pref in OG like "Extra fields in Requisition" or something
- [ ] Sync
- [ ] Go to Program Requisition
- [ ] Don't see extra columns
- [ ] Turn pref back on 
- [ ] Sync
- [ ] See extra columns
- [ ] Don't see components jumping around when sync nearly done

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

