### PR TITLE
9114 on patient's page, unable to clear dob (date of birth) once entered, even though the field is not compulsory

### DIFF
--- a/client/packages/system/src/Patient/CreatePatientModal/DefaultCreatePatientSchema.json
+++ b/client/packages/system/src/Patient/CreatePatientModal/DefaultCreatePatientSchema.json
@@ -19,7 +19,7 @@
         "dateOfBirth": {
           "description": "Date of birth",
           "format": "date",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "firstName": {
           "type": "string"

--- a/client/packages/system/src/Patient/PatientView/DefaultPatientSchema.json
+++ b/client/packages/system/src/Patient/PatientView/DefaultPatientSchema.json
@@ -45,7 +45,7 @@
         "dateOfBirth": {
           "description": "Date of birth",
           "format": "date",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "firstName": {
           "type": "string"
@@ -69,7 +69,7 @@
         "dateOfDeath": {
           "description": "Date of death",
           "format": "date",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "isDeceased": {
           "description": "Person is deceased",

--- a/client/packages/system/src/Patient/PatientView/DefaultPatientUISchema.json
+++ b/client/packages/system/src/Patient/PatientView/DefaultPatientUISchema.json
@@ -50,10 +50,7 @@
             {
               "type": "DateOfBirth",
               "label": "label.date-of-birth",
-              "scope": "#",
-              "options": {
-                "hideClear": true
-              }
+              "scope": "#"
             },
             {
               "type": "Control",


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9114

# 👩🏻‍💻 What does this PR do?
Allow clearing of DOB, but again like I said in the issue `I just can't think of a situation where you're like, "Oh, wrong DOB? Let's just remove it".` Surely an estimate is better than nothing 🤷🏻 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to patient
- [ ] Clear their DOB
- [ ] Save -> should empty

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

