### PR TITLE
8661 When an internal order is created from an R&R form, the log is empty

### DIFF
--- a/server/service/src/rnr_form/finalise.rs
+++ b/server/service/src/rnr_form/finalise.rs
@@ -63,6 +63,21 @@ pub fn finalise_rnr_form(
 
             activity_log_entry(
                 ctx,
+                ActivityLogType::RequisitionCreated,
+                Some(requisition_row.id.clone()),
+                None,
+                None,
+            )?;
+            activity_log_entry(
+                ctx,
+                ActivityLogType::RequisitionStatusSent,
+                Some(requisition_row.id.clone()),
+                None,
+                None,
+            )?;
+
+            activity_log_entry(
+                ctx,
                 ActivityLogType::RnrFormFinalised,
                 Some(input.id.clone()),
                 None,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #8661

# 👩🏻‍💻 What does this PR do?
Created & sent logs for R&R forms... 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Finalise R&R form
- [ ] Go to created Internal Order
- [ ] Go to log
- [ ] See logs

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

