### PR TITLE
7862 If an item is not a vaccine, Doses section should be hidden

### DIFF
--- a/client/packages/system/src/Item/DetailView/Tabs/General.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/General.tsx
@@ -68,19 +68,21 @@ export const GeneralTab = ({ item, isLoading }: GeneralTabProps) => {
             inputProps={{ value: item?.type, disabled: isDisabled }}
           />
           <DetailInputWithLabelRow
-            label={t('label.doses')}
-            Input={
-              <NumericTextInput
-                value={item?.doses}
-                disabled={isDisabled}
-                fullWidth
-              />
-            }
-          />
-          <DetailInputWithLabelRow
             label={t('label.is-vaccine')}
             Input={<Checkbox disabled={isDisabled} checked={item?.isVaccine} />}
           />
+          {item?.isVaccine && (
+            <DetailInputWithLabelRow
+              label={t('label.doses')}
+              Input={
+                <NumericTextInput
+                  value={item?.doses}
+                  disabled={isDisabled}
+                  fullWidth
+                />
+              }
+            />
+          )}
         </DetailSection>
         <DetailSection title={t('title.categories')}>
           <DetailInputWithLabelRow


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7862

# 👩🏻‍💻 What does this PR do?
Hide doses if item isn't vaccine

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to Catalogue -> Item
- [ ] Click on non-vaccine item
- [ ] shouldn't see doses 
- [ ] Click on vaccine item
- [ ] should see doses

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

