### PR TITLE
7598 & 9333 add an option to filter by master lists in items, In "View stock", make the masterlist filter a dropdown menu

### DIFF
--- a/client/packages/system/src/Item/ListView/ListView.tsx
+++ b/client/packages/system/src/Item/ListView/ListView.tsx
@@ -10,6 +10,7 @@ import {
   usePaginatedMaterialTable,
   MaterialTable,
   UnitsAndDosesCell,
+  ChipTableCell,
 } from '@openmsupply-client/common';
 import { useVisibleOrOnHandItems, ItemsWithStatsFragment } from '../api';
 import { Toolbar } from './Toolbar';
@@ -59,6 +60,13 @@ export const ItemListView = () => {
         size: 350,
         enableSorting: true,
         enableColumnFilter: true,
+      },
+      {
+        id: 'masterLists',
+        header: t('label.master-lists'),
+        accessorFn: row => row.masterLists?.map(m => m.name) ?? [],
+        Cell: ChipTableCell,
+        size: 200,
       },
       {
         id: 'unitName',

--- a/client/packages/system/src/Item/ListView/ListView.tsx
+++ b/client/packages/system/src/Item/ListView/ListView.tsx
@@ -27,6 +27,7 @@ export const ItemListView = () => {
       { key: 'maxMonthsOfStock', condition: 'isNumber' },
       { key: 'stockStatus' },
       { key: 'productsAtRiskOfBeingOutOfStock', condition: '=' },
+      { key: 'masterListId', condition: 'equalTo' },
     ],
   });
   const { data, isError, isLoading } = useVisibleOrOnHandItems(queryParams);

--- a/client/packages/system/src/Item/ListView/Toolbar.tsx
+++ b/client/packages/system/src/Item/ListView/Toolbar.tsx
@@ -5,14 +5,23 @@ import {
   FilterMenu,
   Box,
   usePreferences,
+  useAuthContext,
 } from '@openmsupply-client/common';
+import { useMasterLists } from '../../MasterList';
 
 export const Toolbar: FC = () => {
   const t = useTranslation();
+  const { store } = useAuthContext();
   const {
     numberOfMonthsToCheckForConsumptionWhenCalculatingOutOfStockProducts:
     numMonthsConsumption,
   } = usePreferences();
+  const { data: masterLists } = useMasterLists({
+    queryParams: {
+      filterBy: { existsForStoreId: { equalTo: store?.id } },
+      first: 1000,
+    },
+  });
 
   return (
     <AppBarContentPortal
@@ -70,6 +79,19 @@ export const Toolbar: FC = () => {
               minValue: 0,
               decimalLimit: 2,
             },
+            ...(masterLists?.nodes?.length
+              ? [
+                {
+                  type: 'enum' as const,
+                  name: t('label.master-list'),
+                  urlParameter: 'masterListId',
+                  options: masterLists.nodes.map(ml => ({
+                    label: ml.name,
+                    value: ml.id,
+                  })),
+                },
+              ]
+              : []),
             ...(numMonthsConsumption
               ? [
                 {

--- a/client/packages/system/src/Item/api/operations.generated.ts
+++ b/client/packages/system/src/Item/api/operations.generated.ts
@@ -875,6 +875,11 @@ export type ItemsWithStatsFragment = {
   isVaccine: boolean;
   doses: number;
   availableStockOnHand: number;
+  masterLists?: Array<{
+    __typename: 'MasterListNode';
+    id: string;
+    name: string;
+  }> | null;
   stats: {
     __typename: 'ItemStatsNode';
     averageMonthlyConsumption: number;
@@ -910,6 +915,11 @@ export type ItemsWithStatsQuery = {
       isVaccine: boolean;
       doses: number;
       availableStockOnHand: number;
+      masterLists?: Array<{
+        __typename: 'MasterListNode';
+        id: string;
+        name: string;
+      }> | null;
       stats: {
         __typename: 'ItemStatsNode';
         averageMonthlyConsumption: number;
@@ -1994,6 +2004,10 @@ export const ItemsWithStatsFragmentDoc = gql`
     isVaccine
     doses
     availableStockOnHand(storeId: $storeId)
+    masterLists(storeId: $storeId) {
+      id
+      name
+    }
     stats(storeId: $storeId) {
       __typename
       averageMonthlyConsumption

--- a/client/packages/system/src/Item/api/operations.graphql
+++ b/client/packages/system/src/Item/api/operations.graphql
@@ -352,6 +352,10 @@ fragment ItemsWithStats on ItemNode {
   isVaccine
   doses
   availableStockOnHand(storeId: $storeId)
+  masterLists(storeId: $storeId) {
+    id
+    name
+  }
   stats(storeId: $storeId) {
     __typename
     averageMonthlyConsumption

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -54,7 +54,8 @@ export const StockListView = () => {
         condition: 'between',
       },
       {
-        key: 'masterList.name',
+        key: 'masterList.id',
+        condition: 'equalTo',
       },
     ],
   });

--- a/client/packages/system/src/Stock/ListView/Toolbar.tsx
+++ b/client/packages/system/src/Stock/ListView/Toolbar.tsx
@@ -7,13 +7,22 @@ import {
   usePreferences,
   FilterDefinition,
   GroupFilterDefinition,
+  useAuthContext,
 } from '@openmsupply-client/common';
 import { useVvmStatusesEnabled } from '../api';
+import { useMasterLists } from '../../MasterList';
 
 export const Toolbar = ({ isGrouped }: { isGrouped: boolean }) => {
   const t = useTranslation();
+  const { store } = useAuthContext();
   const { manageVvmStatusForStock } = usePreferences();
   const { data: vmmStatuses } = useVvmStatusesEnabled();
+  const { data: masterLists } = useMasterLists({
+    queryParams: {
+      filterBy: { existsForStoreId: { equalTo: store?.id } },
+      first: 1000,
+    },
+  });
 
   // Item-level filters apply in both grouped and ungrouped modes.
   const itemFilters = [
@@ -24,12 +33,19 @@ export const Toolbar = ({ isGrouped }: { isGrouped: boolean }) => {
       placeholder: t('messages.search'),
       isDefault: true,
     },
-    {
-      type: 'text',
-      name: t('label.master-list'),
-      urlParameter: 'masterList.name',
-      placeholder: t('placeholder.search-by-master-list-name'),
-    },
+    ...(masterLists?.nodes?.length
+      ? [
+        {
+          type: 'enum',
+          name: t('label.master-list'),
+          urlParameter: 'masterList.id',
+          options: masterLists.nodes.map(ml => ({
+            label: ml.name,
+            value: ml.id,
+          })),
+        } as FilterDefinition,
+      ]
+      : []),
   ] satisfies FilterDefinition[];
 
   const stockLineFilters = [


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #7598, #9333

# 👩🏻‍💻 What does this PR do?
- Changes the stock's filter master list by name input to a dropdown
- Adds master list filter to item
- Show master list column in item
<img width="929" height="688" alt="item master list filter" src="https://github.com/user-attachments/assets/2b7b2d62-bfc3-457d-8850-1206248fbc48" />


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to stock / item 
- [ ] Filter by master list
- [ ] Select any of the options in the drop list
- [ ] Stock / item should filter correctly by master list 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

