### PR TITLE
5395 Display a better message when no encounter options are available

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2293,6 +2293,7 @@
   "messages.no-data-found": "No data found",
   "messages.no-documents-uploaded": "No documents have been uploaded",
   "messages.no-encounters": "This patient has no encounters.",
+  "messages.no-encounters-configured": "There are no encounters configured! Please talk to your administrator or contact support@msupply.foundation for help.",
   "messages.no-insurance": "This patient has no insurance.",
   "messages.no-item-ledger": "This item has no stock movements to display",
   "messages.no-item-variants": "No item variants configured",

--- a/client/packages/system/src/Patient/Encounter/EncounterSearchInput.tsx
+++ b/client/packages/system/src/Patient/Encounter/EncounterSearchInput.tsx
@@ -1,10 +1,12 @@
 import React, { FC, useEffect, useState } from 'react';
 import {
+  AlertIcon,
   Autocomplete,
   AutocompleteOptionRenderer,
   Box,
   DefaultAutocompleteItemOption,
   Typography,
+  useTranslation,
 } from '@openmsupply-client/common';
 import { usePatient } from '../api';
 import {
@@ -23,17 +25,17 @@ interface EncounterSearchInputProps {
 
 export const getEncounterOptionRenderer =
   (): AutocompleteOptionRenderer<EncounterRegistryByProgram> =>
-  (props, node) => {
-    const name = node.encounter.name ?? '';
+    (props, node) => {
+      const name = node.encounter.name ?? '';
 
-    return (
-      <DefaultAutocompleteItemOption {...props} key={props.id}>
-        <Box display="flex" alignItems="flex-end" gap={1} height={25}>
-          <Typography>{name}</Typography>
-        </Box>
-      </DefaultAutocompleteItemOption>
-    );
-  };
+      return (
+        <DefaultAutocompleteItemOption {...props} key={props.id}>
+          <Box display="flex" alignItems="flex-end" gap={1} height={25}>
+            <Typography>{name}</Typography>
+          </Box>
+        </DefaultAutocompleteItemOption>
+      );
+    };
 
 export const EncounterSearchInput: FC<EncounterSearchInputProps> = ({
   onChange,
@@ -66,6 +68,17 @@ export const EncounterSearchInput: FC<EncounterSearchInputProps> = ({
   }, [buffer, encounterData, encounterType, setBuffer, onChange]);
 
   const EncounterOptionRenderer = getEncounterOptionRenderer();
+  const t = useTranslation();
+  const isLoading = isEnrolmentDataLoading || isEncounterLoading;
+  if (!isLoading && !encounterData?.length) {
+    return (
+      <Box display="flex" gap={1} alignItems="center">
+        <AlertIcon color="warning" />
+        <Typography>{t('messages.no-encounters-configured')}</Typography>
+      </Box>
+    );
+  }
+
   return (
     <Autocomplete
       disabled={disabled}
@@ -76,7 +89,7 @@ export const EncounterSearchInput: FC<EncounterSearchInputProps> = ({
           label: buffer.encounter.name ?? '',
         }
       }
-      loading={isEnrolmentDataLoading || isEncounterLoading}
+      loading={isLoading}
       onChange={(_, registry) => {
         setBuffer(registry ?? null);
         registry && onChange(registry);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #5395

# 👩🏻‍💻 What does this PR do?
Show `There are no encounters configured! Please talk to your administrator or contact support@msupply.foundation for help.` if no encounters configured

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a program with no encounter enrolment to it
- [ ] Add patient to program
- [ ] Click add encounter -> see above message

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

