### PR TITLE
11792 user permissions enums to use enum macro, and to have fallback variant

### DIFF
--- a/server/graphql/types/src/types/permissions.rs
+++ b/server/graphql/types/src/types/permissions.rs
@@ -1,4 +1,5 @@
 use async_graphql::{Enum, Object, SimpleObject};
+use repository::PermissionType;
 use service::{permission::UserStorePermissions, usize_to_u32, ListResult};
 
 #[derive(PartialEq, Debug)]
@@ -13,7 +14,6 @@ pub struct UserStorePermissionConnector {
 }
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq, Debug)]
-#[graphql(remote = "repository::db_diesel::user_permission_row::PermissionType")]
 pub enum UserPermission {
     ServerAdmin,
     StoreAccess,
@@ -74,14 +74,90 @@ pub enum UserPermission {
     CancelFinalisedInvoices,
 }
 
+impl UserPermission {
+    fn from_domain(value: &PermissionType) -> Option<Self> {
+        Some(match value {
+            PermissionType::ServerAdmin => UserPermission::ServerAdmin,
+            PermissionType::StoreAccess => UserPermission::StoreAccess,
+            PermissionType::LocationMutate => UserPermission::LocationMutate,
+            PermissionType::SensorMutate => UserPermission::SensorMutate,
+            PermissionType::SensorQuery => UserPermission::SensorQuery,
+            PermissionType::TemperatureBreachQuery => UserPermission::TemperatureBreachQuery,
+            PermissionType::TemperatureLogQuery => UserPermission::TemperatureLogQuery,
+            PermissionType::StockLineQuery => UserPermission::StockLineQuery,
+            PermissionType::StockLineMutate => UserPermission::StockLineMutate,
+            PermissionType::CreateRepack => UserPermission::CreateRepack,
+            PermissionType::StocktakeQuery => UserPermission::StocktakeQuery,
+            PermissionType::StocktakeMutate => UserPermission::StocktakeMutate,
+            PermissionType::InventoryAdjustmentMutate => UserPermission::InventoryAdjustmentMutate,
+            PermissionType::RequisitionQuery => UserPermission::RequisitionQuery,
+            PermissionType::RequisitionMutate => UserPermission::RequisitionMutate,
+            PermissionType::RequisitionSend => UserPermission::RequisitionSend,
+            PermissionType::RequisitionCreateOutboundShipment => {
+                UserPermission::RequisitionCreateOutboundShipment
+            }
+            PermissionType::RnrFormQuery => UserPermission::RnrFormQuery,
+            PermissionType::RnrFormMutate => UserPermission::RnrFormMutate,
+            PermissionType::OutboundShipmentQuery => UserPermission::OutboundShipmentQuery,
+            PermissionType::OutboundShipmentMutate => UserPermission::OutboundShipmentMutate,
+            PermissionType::InboundShipmentQuery => UserPermission::InboundShipmentQuery,
+            PermissionType::InboundShipmentMutate => UserPermission::InboundShipmentMutate,
+            PermissionType::InboundShipmentVerify => UserPermission::InboundShipmentVerify,
+            PermissionType::SupplierReturnQuery => UserPermission::SupplierReturnQuery,
+            PermissionType::SupplierReturnMutate => UserPermission::SupplierReturnMutate,
+            PermissionType::CustomerReturnQuery => UserPermission::CustomerReturnQuery,
+            PermissionType::CustomerReturnMutate => UserPermission::CustomerReturnMutate,
+            PermissionType::PrescriptionQuery => UserPermission::PrescriptionQuery,
+            PermissionType::PrescriptionMutate => UserPermission::PrescriptionMutate,
+            PermissionType::CancelFinalisedInvoices => UserPermission::CancelFinalisedInvoices,
+            PermissionType::PurchaseOrderQuery => UserPermission::PurchaseOrderQuery,
+            PermissionType::PurchaseOrderMutate => UserPermission::PurchaseOrderMutate,
+            PermissionType::PurchaseOrderAuthorise => UserPermission::PurchaseOrderAuthorise,
+            PermissionType::PurchaseOrderFinalise => UserPermission::PurchaseOrderFinalise,
+            PermissionType::InboundShipmentExternalQuery => {
+                UserPermission::InboundShipmentExternalQuery
+            }
+            PermissionType::InboundShipmentExternalMutate => {
+                UserPermission::InboundShipmentExternalMutate
+            }
+            PermissionType::InboundShipmentExternalVerify => {
+                UserPermission::InboundShipmentExternalVerify
+            }
+            PermissionType::InboundShipmentExternalAuthorise => {
+                UserPermission::InboundShipmentExternalAuthorise
+            }
+            PermissionType::Report => UserPermission::Report,
+            PermissionType::LogQuery => UserPermission::LogQuery,
+            PermissionType::ItemMutate => UserPermission::ItemMutate,
+            PermissionType::ItemNamesCodesAndUnitsMutate => {
+                UserPermission::ItemNamesCodesAndUnitsMutate
+            }
+            PermissionType::PatientQuery => UserPermission::PatientQuery,
+            PermissionType::PatientMutate => UserPermission::PatientMutate,
+            PermissionType::DocumentQuery => UserPermission::DocumentQuery,
+            PermissionType::DocumentMutate => UserPermission::DocumentMutate,
+            PermissionType::ColdChainApi => UserPermission::ColdChainApi,
+            PermissionType::AssetQuery => UserPermission::AssetQuery,
+            PermissionType::AssetMutate => UserPermission::AssetMutate,
+            PermissionType::AssetMutateViaDataMatrix => UserPermission::AssetMutateViaDataMatrix,
+            PermissionType::AssetCatalogueItemMutate => UserPermission::AssetCatalogueItemMutate,
+            PermissionType::AssetStatusMutate => UserPermission::AssetStatusMutate,
+            PermissionType::NamePropertiesMutate => UserPermission::NamePropertiesMutate,
+            PermissionType::EditCentralData => UserPermission::EditCentralData,
+            PermissionType::ViewAndEditVvmStatus => UserPermission::ViewAndEditVvmStatus,
+            PermissionType::MutateClinician => UserPermission::MutateClinician,
+            PermissionType::Unknown(_) => return None,
+        })
+    }
+}
+
 #[Object]
 impl UserStorePermissionNode {
     pub async fn permissions(&self) -> Vec<UserPermission> {
         self.row()
             .permissions
-            .clone()
-            .into_iter()
-            .map(|p| UserPermission::from(p.permission.clone()))
+            .iter()
+            .filter_map(|p| UserPermission::from_domain(&p.permission))
             .collect()
     }
 

--- a/server/repository/src/db_diesel/changelog/test.rs
+++ b/server/repository/src/db_diesel/changelog/test.rs
@@ -1008,9 +1008,9 @@ async fn test_max_cursor_clamped_by_in_flight_tx() {
         )
         .unwrap();
     assert!(
-        rows_during.is_empty(),
+        rows_during.rows.is_empty(),
         "expected no rows past clamp while in-flight tx open, got {} rows",
-        rows_during.len()
+        rows_during.rows.len()
     );
 
     // Release the slow tx; once it commits the tracker entry is removed.
@@ -1034,6 +1034,6 @@ async fn test_max_cursor_clamped_by_in_flight_tx() {
             },
         )
         .unwrap();
-    assert_eq!(rows_after.len(), 1);
-    assert_eq!(rows_after[0].record_id, "clinician_in_flight");
+    assert_eq!(rows_after.rows.len(), 1);
+    assert_eq!(rows_after.rows[0].record_id, "clinician_in_flight");
 }

--- a/server/repository/src/db_diesel/user_permission_row.rs
+++ b/server/repository/src/db_diesel/user_permission_row.rs
@@ -124,6 +124,13 @@ pub struct UserPermissionRow {
     pub context_id: Option<String>,
 }
 
+impl PermissionType {
+    pub fn known_iter() -> impl Iterator<Item = PermissionType> {
+        use strum::IntoEnumIterator;
+        PermissionType::iter().filter(|p| !matches!(p, PermissionType::Unknown(_)))
+    }
+}
+
 impl UserPermissionRow {
     /// Stable id for a non-context-bound permission keyed by `(user_id, store_id,
     /// permission)`. Context-bound permissions (synced from `om_user_permission`)
@@ -309,8 +316,7 @@ mod test {
         .await;
 
         let repo = UserPermissionRowRepository::new(&connection);
-        // Try upsert all variants of PermissionType, confirm that diesel enums match postgres
-        for permission in PermissionType::iter() {
+        for permission in PermissionType::known_iter() {
             let row_id = format!("{permission:?}");
 
             let result = repo.upsert_one(&UserPermissionRow {
@@ -319,10 +325,23 @@ mod test {
                 store_id: Some("store_a".to_string()),
                 ..Default::default()
             });
-            assert_eq!(result, Ok(()), "\n \n HINT: Failed to insert permission for type {row_id:?}. Have you created a migration to add this type to the postgres database enum? \n");
+            assert_eq!(result, Ok(()), "Failed to insert permission {row_id:?}");
 
             let found = repo.find_one_by_id(&row_id).unwrap().unwrap();
             assert_eq!(found.permission, permission);
         }
+
+        repo.upsert_one(&UserPermissionRow {
+            id: "unknown_perm".to_string(),
+            permission: PermissionType::Unknown("FUTURE_PERMISSION".to_string()),
+            store_id: Some("store_a".to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+        let found = repo.find_one_by_id("unknown_perm").unwrap().unwrap();
+        assert_eq!(
+            found.permission,
+            PermissionType::Unknown("FUTURE_PERMISSION".to_string())
+        );
     }
 }

--- a/server/repository/src/db_diesel/user_permission_row.rs
+++ b/server/repository/src/db_diesel/user_permission_row.rs
@@ -1,10 +1,10 @@
 use super::StorageConnection;
+use crate::diesel_macros::diesel_string_enum;
 use crate::repository_error::RepositoryError;
 use crate::{ChangelogRepository, ChangelogSyncType, Delete, RowActionType, SourceSiteId, Upsert};
 use diesel::prelude::*;
-use diesel_derive_enum::DbEnum;
 use serde::{Deserialize, Serialize};
-use strum::{AsRefStr, EnumIter};
+use strum::EnumIter;
 use util::uuid::{deterministic_uuid, Uuid};
 
 table! {
@@ -12,100 +12,101 @@ table! {
       id -> Text,
       user_id -> Text,
       store_id -> Nullable<Text>,
-      permission -> crate::db_diesel::user_permission_row::PermissionTypeMapping,
+      permission -> Text,
       context_id -> Nullable<Text>,
     }
 }
 
-#[derive(
-    DbEnum, Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize, EnumIter, AsRefStr,
-)]
-#[DbValueStyle = "SCREAMING_SNAKE_CASE"]
-#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
-pub enum PermissionType {
-    ServerAdmin,
+diesel_string_enum! {
+    #[derive(Clone, Eq, Hash, Serialize, Deserialize, EnumIter)]
+    #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+    pub enum PermissionType {
+        ServerAdmin,
 
-    /// User has access to the store this permission is associated with.
-    /// This acts like a master switch to enable/disable all user's permissions associated with a store.
-    #[default]
-    StoreAccess,
-    // location,
-    LocationMutate,
-    // sensor,
-    SensorMutate,
-    SensorQuery,
-    TemperatureBreachQuery,
-    TemperatureLogQuery,
-    // stock line
-    StockLineQuery,
-    StockLineMutate,
-    CreateRepack,
-    // stocktake
-    StocktakeQuery,
-    StocktakeMutate,
-    // inventory adjustment
-    InventoryAdjustmentMutate,
-    // requisition
-    RequisitionQuery,
-    RequisitionMutate,
-    RequisitionSend,
-    RequisitionCreateOutboundShipment,
-    // r&r form,
-    RnrFormQuery,
-    RnrFormMutate,
-    // outbound shipment
-    OutboundShipmentQuery,
-    OutboundShipmentMutate,
-    // inbound shipment
-    InboundShipmentQuery,
-    InboundShipmentMutate,
-    InboundShipmentVerify,
-    // supplier return
-    SupplierReturnQuery,
-    SupplierReturnMutate,
-    // customer return
-    CustomerReturnQuery,
-    CustomerReturnMutate,
-    // prescription
-    PrescriptionQuery,
-    PrescriptionMutate,
-    CancelFinalisedInvoices,
-    // purchase orders
-    PurchaseOrderQuery,
-    PurchaseOrderMutate,
-    PurchaseOrderAuthorise,
-    PurchaseOrderFinalise,
-    // inbound shipment external
-    InboundShipmentExternalQuery,
-    InboundShipmentExternalMutate,
-    InboundShipmentExternalVerify,
-    InboundShipmentExternalAuthorise,
-    // reporting
-    Report,
-    // log
-    LogQuery,
-    // items
-    ItemMutate,
-    ItemNamesCodesAndUnitsMutate,
-    PatientQuery,
-    PatientMutate,
-    // Document
-    DocumentQuery,
-    DocumentMutate,
-    // Cold chain
-    ColdChainApi,
-    AssetQuery,
-    AssetMutate,
-    AssetMutateViaDataMatrix,
-    AssetCatalogueItemMutate,
-    AssetStatusMutate,
-    // Names
-    NamePropertiesMutate,
-    // Central Server
-    EditCentralData,
-    ViewAndEditVvmStatus,
-    // clinician
-    MutateClinician,
+        /// User has access to the store this permission is associated with.
+        /// This acts like a master switch to enable/disable all user's permissions associated with a store.
+        #[default]
+        StoreAccess,
+        // location,
+        LocationMutate,
+        // sensor,
+        SensorMutate,
+        SensorQuery,
+        TemperatureBreachQuery,
+        TemperatureLogQuery,
+        // stock line
+        StockLineQuery,
+        StockLineMutate,
+        CreateRepack,
+        // stocktake
+        StocktakeQuery,
+        StocktakeMutate,
+        // inventory adjustment
+        InventoryAdjustmentMutate,
+        // requisition
+        RequisitionQuery,
+        RequisitionMutate,
+        RequisitionSend,
+        RequisitionCreateOutboundShipment,
+        // r&r form,
+        RnrFormQuery,
+        RnrFormMutate,
+        // outbound shipment
+        OutboundShipmentQuery,
+        OutboundShipmentMutate,
+        // inbound shipment
+        InboundShipmentQuery,
+        InboundShipmentMutate,
+        InboundShipmentVerify,
+        // supplier return
+        SupplierReturnQuery,
+        SupplierReturnMutate,
+        // customer return
+        CustomerReturnQuery,
+        CustomerReturnMutate,
+        // prescription
+        PrescriptionQuery,
+        PrescriptionMutate,
+        CancelFinalisedInvoices,
+        // purchase orders
+        PurchaseOrderQuery,
+        PurchaseOrderMutate,
+        PurchaseOrderAuthorise,
+        PurchaseOrderFinalise,
+        // inbound shipment external
+        InboundShipmentExternalQuery,
+        InboundShipmentExternalMutate,
+        InboundShipmentExternalVerify,
+        InboundShipmentExternalAuthorise,
+        // reporting
+        Report,
+        // log
+        LogQuery,
+        // items
+        ItemMutate,
+        ItemNamesCodesAndUnitsMutate,
+        PatientQuery,
+        PatientMutate,
+        // Document
+        DocumentQuery,
+        DocumentMutate,
+        // Cold chain
+        ColdChainApi,
+        AssetQuery,
+        AssetMutate,
+        AssetMutateViaDataMatrix,
+        AssetCatalogueItemMutate,
+        AssetStatusMutate,
+        // Names
+        NamePropertiesMutate,
+        // Central Server
+        EditCentralData,
+        ViewAndEditVvmStatus,
+        // clinician
+        MutateClinician,
+        #[strum(default, transparent)]
+        Unknown(String),
+    }
 }
 
 #[derive(
@@ -298,7 +299,6 @@ mod test {
         mock::MockDataInserts, test_db::setup_all, PermissionType, UserPermissionRow,
         UserPermissionRowRepository,
     };
-    use strum::IntoEnumIterator;
 
     #[actix_rt::test]
     async fn user_permission_row_type_enum() {

--- a/server/repository/src/diesel_macros.rs
+++ b/server/repository/src/diesel_macros.rs
@@ -603,6 +603,9 @@ macro_rules! define_linked_tables {
 /// Defines an enum that is stored as plain `TEXT` in the database via `strum` serialization
 /// (`snake_case` by default). No database migration is needed when adding new variants.
 ///
+/// Variants may optionally include a single-field payload (e.g.
+/// `Unknown(String)`). The fallback variant should carry `#[strum(default)]`
+///
 /// Usage:
 /// ```
 /// diesel_string_enum! {
@@ -611,6 +614,8 @@ macro_rules! define_linked_tables {
 ///         #[default]
 ///         VariantA,
 ///         VariantB,
+///         #[strum(default)]
+///         Unknown(String),
 ///     }
 /// }
 /// ```
@@ -620,7 +625,7 @@ macro_rules! diesel_string_enum {
         $vis:vis enum $name:ident {
             $(
                 $(#[$variant_meta:meta])*
-                $variant:ident
+                $variant:ident $(( $($variant_payload:tt)* ))?
             ),* $(,)?
         }
     ) => {
@@ -639,7 +644,7 @@ macro_rules! diesel_string_enum {
         $vis enum $name {
             $(
                 $(#[$variant_meta])*
-                $variant
+                $variant $(( $($variant_payload)* ))?
             ),*
         }
 

--- a/server/repository/src/migrations/v3_00_00/convert_user_permission_to_text.rs
+++ b/server/repository/src/migrations/v3_00_00/convert_user_permission_to_text.rs
@@ -22,3 +22,70 @@ impl MigrationFragment for Migrate {
         Ok(())
     }
 }
+
+#[cfg(all(test, feature = "postgres"))]
+mod tests {
+    use crate::{
+        migrations::{v2_18_00::V2_18_00, v3_00_00::V3_00_00, *},
+        test_db::*,
+    };
+    use diesel::{connection::SimpleConnection, prelude::*, sql_types::Text};
+
+    #[derive(QueryableByName)]
+    struct TextValue {
+        #[diesel(sql_type = Text)]
+        value: String,
+    }
+
+    #[actix_rt::test]
+    async fn user_permission_type_text_conversion_preserves_values() {
+        let previous_version = V2_18_00.version();
+        let version = V3_00_00.version();
+
+        let SetupResult { connection, .. } = setup_test(SetupOption {
+            db_name: "migration_convert_user_permission_to_text",
+            version: Some(previous_version.clone()),
+            ..Default::default()
+        })
+        .await;
+
+        // Seed FK targets (name → store → user_account) before inserting permissions.
+        connection
+            .lock()
+            .connection()
+            .batch_execute(
+                r#"
+                INSERT INTO name (id, type, is_customer, is_supplier, code, name) VALUES
+                    ('name1', 'STORE', false, false, '', '');
+                INSERT INTO name_link (id, name_id) VALUES ('name_link1', 'name1');
+                INSERT INTO store (id, name_link_id, site_id, code) VALUES
+                    ('store_a', 'name_link1', 1, '');
+                INSERT INTO user_account (id, username, hashed_password) VALUES
+                    ('user1', 'user1', '');
+                INSERT INTO user_permission (id, user_id, store_id, permission) VALUES
+                    ('perm1', 'user1', 'store_a', 'STORE_ACCESS'),
+                    ('perm2', 'user1', 'store_a', 'SERVER_ADMIN');
+                "#,
+            )
+            .unwrap();
+
+        migrate(
+            &connection,
+            Some(version.clone()),
+            MigrationConfig::default(),
+        )
+        .unwrap();
+        assert_eq!(get_database_version(&connection), version);
+
+        let permissions: Vec<String> = diesel::sql_query(
+            "SELECT permission AS value FROM user_permission \
+             WHERE user_id = 'user1' ORDER BY permission",
+        )
+        .get_results::<TextValue>(connection.lock().connection())
+        .unwrap()
+        .into_iter()
+        .map(|r| r.value)
+        .collect();
+        assert_eq!(permissions, vec!["SERVER_ADMIN", "STORE_ACCESS"]);
+    }
+}

--- a/server/repository/src/migrations/v3_00_00/convert_user_permission_to_text.rs
+++ b/server/repository/src/migrations/v3_00_00/convert_user_permission_to_text.rs
@@ -1,0 +1,24 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "convert_user_permission_to_text"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        if cfg!(feature = "postgres") {
+            sql!(
+                connection,
+                r#"
+                    ALTER TABLE user_permission
+                        ALTER COLUMN permission TYPE TEXT USING permission::TEXT;
+                    DROP TYPE IF EXISTS permission_type;
+                "#
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v3_00_00/mod.rs
+++ b/server/repository/src/migrations/v3_00_00/mod.rs
@@ -12,6 +12,7 @@ mod add_v7_upgrade_failed_error_code;
 mod alter_changelog_table_for_sync_v7;
 mod alter_sqlite_changelog_table_for_syncv7;
 mod alter_sync_buffer_for_sync_v7;
+mod convert_user_permission_to_text;
 mod create_changelog_indexes;
 mod create_site_table;
 mod migrate_user_permission_to_deterministic_id;
@@ -48,6 +49,7 @@ impl Migration for V3_00_00 {
             // Must precede `populate_changelog_with_rows_for_sync_v7_tables` so
             // the backfilled changelog rows reference the new deterministic ids.
             Box::new(migrate_user_permission_to_deterministic_id::Migrate),
+            Box::new(convert_user_permission_to_text::Migrate),
             Box::new(alter_sqlite_changelog_table_for_syncv7::Migrate),
             Box::new(partition_changelog_by_cursor::Migrate),
             Box::new(populate_changelog_with_rows_for_sync_v7_tables::Migrate),

--- a/server/service/src/standalone_central.rs
+++ b/server/service/src/standalone_central.rs
@@ -10,7 +10,6 @@ use repository::{
     SiteRowRepository, StoreRow, StoreRowRepository, UserPermissionRow,
     UserPermissionRowRepository, UserStoreJoinRow, UserStoreJoinRowRepository,
 };
-use strum::IntoEnumIterator;
 use util::uuid::uuid;
 
 pub const STANDALONE_CENTRAL_SITE_ID: i32 = 1;
@@ -126,7 +125,7 @@ impl StandaloneCentralServiceTrait for StandaloneCentralService {
                 })?;
 
                 let perm_repo = UserPermissionRowRepository::new(con);
-                for permission in PermissionType::iter() {
+                for permission in PermissionType::known_iter() {
                     perm_repo.upsert_one(&UserPermissionRow {
                         id: uuid(),
                         user_id: admin.id.clone(),
@@ -330,7 +329,7 @@ mod test {
                 UserPermissionFilter::new().user_id(EqualFilter::equal_to(admin.id.clone())),
             )
             .unwrap();
-        let expected = PermissionType::iter().count();
+        let expected = PermissionType::known_iter().count();
         assert_eq!(permissions.len(), expected);
         assert!(permissions
             .iter()


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11792

# 👩🏻‍💻 What does this PR do?
Change Postgres's `PermissionType` to a text column, mapped through `diesel_string_enum`. Use `Uknown(String)` as a fallback variant... 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Make sure tests pass and permissions are mapped correctly in postgres

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

