### PR TITLE
11802 Make site name lookup and uniqueness case-insensitive

### DIFF
--- a/server/graphql/site/src/mutations/upsert.rs
+++ b/server/graphql/site/src/mutations/upsert.rs
@@ -1,6 +1,7 @@
 use crate::queries::SiteNode;
 use async_graphql::*;
 use graphql_core::{
+    simple_generic_errors::{UniqueValueKey, UniqueValueViolation},
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
@@ -48,6 +49,7 @@ pub enum UpsertSiteErrorInterface {
     CodeRequired(CodeRequired),
     NameRequired(NameRequired),
     PasswordRequired(PasswordRequired),
+    DuplicateSiteName(UniqueValueViolation),
 }
 
 #[derive(SimpleObject)]
@@ -99,6 +101,11 @@ fn map_error(error: ServiceError) -> Result<UpsertSiteErrorInterface> {
         }
         ServiceError::PasswordRequired => {
             return Ok(UpsertSiteErrorInterface::PasswordRequired(PasswordRequired))
+        }
+        ServiceError::DuplicateSiteName => {
+            return Ok(UpsertSiteErrorInterface::DuplicateSiteName(
+                UniqueValueViolation(UniqueValueKey::Name),
+            ))
         }
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
     };

--- a/server/repository/src/db_diesel/site_row.rs
+++ b/server/repository/src/db_diesel/site_row.rs
@@ -1,5 +1,5 @@
 use crate::{
-    db_diesel::changelog::ChangelogRepository, ChangelogSyncType, Delete, RepositoryError,
+    db_diesel::changelog::ChangelogRepository, lower, ChangelogSyncType, Delete, RepositoryError,
     RowActionType, SourceSiteId, StorageConnection, SyncVersion, Upsert,
 };
 use diesel::prelude::*;
@@ -76,6 +76,17 @@ impl<'a> SiteRowRepository<'a> {
     pub fn find_one_by_og_id(&self, og_id: &str) -> Result<Option<SiteRow>, RepositoryError> {
         let result = site::table
             .filter(site::og_id.eq(og_id))
+            .first(self.connection.lock().connection())
+            .optional()?;
+        Ok(result)
+    }
+
+    pub fn find_one_by_name_case_insensitive(
+        &self,
+        name: &str,
+    ) -> Result<Option<SiteRow>, RepositoryError> {
+        let result = site::table
+            .filter(lower(site::name).eq(lower(name)))
             .first(self.connection.lock().connection())
             .optional()?;
         Ok(result)
@@ -220,6 +231,35 @@ mod tests {
         };
         repo.upsert(&updated).unwrap();
         assert_eq!(repo.find_one_by_id(1).unwrap(), Some(updated));
+    }
+
+    #[actix_rt::test]
+    async fn site_row_repository_find_by_name_case_insensitive() {
+        let (_, connection, _, _) = setup_all(
+            "site_row_repository_find_by_name_case_insensitive",
+            MockDataInserts::none(),
+        )
+        .await;
+        let repo = SiteRowRepository::new(&connection);
+
+        repo.upsert(&site_row_a()).unwrap();
+
+        assert_eq!(
+            repo.find_one_by_name_case_insensitive("site_a").unwrap(),
+            Some(site_row_a())
+        );
+        assert_eq!(
+            repo.find_one_by_name_case_insensitive("SITE_A").unwrap(),
+            Some(site_row_a())
+        );
+        assert_eq!(
+            repo.find_one_by_name_case_insensitive("Site_A").unwrap(),
+            Some(site_row_a())
+        );
+        assert_eq!(
+            repo.find_one_by_name_case_insensitive("unknown").unwrap(),
+            None
+        );
     }
 
     #[actix_rt::test]

--- a/server/service/src/site/upsert.rs
+++ b/server/service/src/site/upsert.rs
@@ -1,12 +1,13 @@
 use crate::service_provider::ServiceContext;
 use bcrypt::{hash, DEFAULT_COST};
-use repository::{RepositoryError, SiteRow, SiteRowRepository};
+use repository::{RepositoryError, SiteRow, SiteRowRepository, StorageConnection};
 
 #[derive(PartialEq, Debug)]
 pub enum UpsertSiteError {
     CodeRequired,
     NameRequired,
     PasswordRequired,
+    DuplicateSiteName,
     DatabaseError(RepositoryError),
 }
 
@@ -26,7 +27,7 @@ pub fn upsert_site(ctx: &ServiceContext, input: UpsertSite) -> Result<SiteRow, U
             let repo = SiteRowRepository::new(connection);
             let existing = repo.find_one_by_id(input.id)?;
 
-            validate(&input, &existing)?;
+            validate(connection, &input, &existing)?;
             let row = generate(input, existing);
             repo.upsert(&row)?;
 
@@ -41,7 +42,11 @@ impl From<RepositoryError> for UpsertSiteError {
     }
 }
 
-fn validate(input: &UpsertSite, existing: &Option<SiteRow>) -> Result<(), UpsertSiteError> {
+fn validate(
+    connection: &StorageConnection,
+    input: &UpsertSite,
+    existing: &Option<SiteRow>,
+) -> Result<(), UpsertSiteError> {
     match (&input.code, existing) {
         (Some(code), _) if code.trim().is_empty() => return Err(UpsertSiteError::CodeRequired),
         (None, None) => return Err(UpsertSiteError::CodeRequired),
@@ -50,6 +55,14 @@ fn validate(input: &UpsertSite, existing: &Option<SiteRow>) -> Result<(), Upsert
 
     if input.name.trim().is_empty() {
         return Err(UpsertSiteError::NameRequired);
+    }
+
+    if let Some(other) =
+        SiteRowRepository::new(connection).find_one_by_name_case_insensitive(input.name.trim())?
+    {
+        if other.id != input.id {
+            return Err(UpsertSiteError::DuplicateSiteName);
+        }
     }
 
     match (&input.password, existing) {
@@ -336,6 +349,58 @@ mod tests {
 
         let site = repo.find_one_by_id(1).unwrap().unwrap();
         assert_eq!(site.hardware_id, None);
+    }
+
+    #[actix_rt::test]
+    async fn upsert_site_rejects_duplicate_name_case_insensitive() {
+        let (_, _, connection_manager, _) = setup_all(
+            "upsert_site_rejects_duplicate_name_case_insensitive",
+            MockDataInserts::none(),
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider.basic_context().unwrap();
+
+        upsert_site(
+            &context,
+            UpsertSite {
+                id: 1,
+                code: Some("code1".to_string()),
+                name: "Site A".to_string(),
+                password: Some("password".to_string()),
+                clear_hardware_id: false,
+            },
+        )
+        .unwrap();
+
+        // Different id, same name (different case) — should be rejected.
+        assert_eq!(
+            upsert_site(
+                &context,
+                UpsertSite {
+                    id: 2,
+                    code: Some("code2".to_string()),
+                    name: "SITE a".to_string(),
+                    password: Some("password".to_string()),
+                    clear_hardware_id: false,
+                },
+            ),
+            Err(UpsertSiteError::DuplicateSiteName)
+        );
+
+        // Same id is allowed — updating the same site is not a duplicate.
+        upsert_site(
+            &context,
+            UpsertSite {
+                id: 1,
+                code: None,
+                name: "site a".to_string(),
+                password: None,
+                clear_hardware_id: false,
+            },
+        )
+        .unwrap();
     }
 
     #[actix_rt::test]

--- a/server/service/src/site/upsert.rs
+++ b/server/service/src/site/upsert.rs
@@ -100,7 +100,7 @@ fn generate(
         id,
         og_id: existing_og_id,
         code: code.or(existing_code).unwrap_or_default(),
-        name,
+        name: name.trim().to_string(),
         hashed_password,
         hardware_id: if clear_hardware_id {
             None

--- a/server/service/src/sync_v7/sync_on_central/mod.rs
+++ b/server/service/src/sync_v7/sync_on_central/mod.rs
@@ -23,8 +23,7 @@ use repository::{
     syncv7::{SiteLockError, SyncError},
     ChangelogCondition, ChangelogFilter, EqualFilter, FilterBuilder, KeyType,
     KeyValueStoreRepository, Pagination, RepositoryError, SiteFilter, SiteRepository, SiteRow,
-    SiteRowRepository, SourceSiteId, StorageConnection, StringFilter, SyncBufferRepository,
-    SyncVersion,
+    SiteRowRepository, SourceSiteId, StorageConnection, SyncBufferRepository, SyncVersion,
 };
 use std::{
     collections::HashMap,
@@ -193,12 +192,7 @@ fn get_site_by_name(
     connection: &StorageConnection,
     name: &str,
 ) -> Result<Option<SiteRow>, SyncError> {
-    let rows = SiteRepository::new(connection).query(
-        Pagination::one(),
-        Some(SiteFilter::new().name(StringFilter::equal_to(name))),
-        None,
-    )?;
-    Ok(rows.into_iter().next())
+    Ok(SiteRowRepository::new(connection).find_one_by_name_case_insensitive(name)?)
 }
 
 fn get_site_by_token(
@@ -601,6 +595,28 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, SyncError::TokenAlreadyAllocated));
+    }
+
+    #[actix_rt::test]
+    async fn get_token_site_lookup_is_case_insensitive() {
+        let (_, connection, connection_manager, _) = setup_all(
+            "get_token_site_lookup_is_case_insensitive",
+            MockDataInserts::none(),
+        )
+        .await;
+        test_util_set_is_central_server(true);
+        KeyValueStoreRepository::new(&connection)
+            .set_i32(KeyType::SettingsSyncSiteId, Some(CENTRAL_SITE_ID))
+            .unwrap();
+        test_site(&connection, None);
+        let service_provider = ServiceProvider::new(connection_manager);
+
+        let mut mixed_case = input();
+        mixed_case.name = SITE_NAME.to_uppercase();
+        let output = get_token(&service_provider, mixed_case).await.unwrap();
+
+        assert_eq!(output.site_id, 1);
+        assert!(!output.token.is_empty());
     }
 
     #[actix_rt::test]


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11802

# 👩🏻‍💻 What does this PR do?

The sync v7 get_token endpoint now matches sites by name case-insensitively so devices aren't rejected when the case of the configured name differs. upsert_site rejects a name that case-insensitively matches another site to prevent two sites that would now both authenticate against the same row.

Ensures the site names entered by users are trimmed.

OG site name input trims and is case insensitive unique constrained.

# 🧪 Testing

- [ ] COGS and COMS setup for v7
- [ ] Set ROMS site name to be something with some upper case "HELLO" (i.e. using SQL)
- [ ] Initialise ROMS with "hello" as site name, or any variation where the case is not the same
- [ ] All works well

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

