### PR TITLE
Fix generate-schema workflow PATH shadowing corepack yarn

### DIFF
--- a/.github/workflows/generate-schema.yml
+++ b/.github/workflows/generate-schema.yml
@@ -41,7 +41,7 @@ jobs:
         run: cd ./client && yarn install --immutable
 
       - name: Update PATH
-        run: echo "$HOME/.cargo/bin:/opt/homebrew/bin" >> $GITHUB_PATH
+        run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Run tests
         run: cd ./client && yarn test:codegen


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

The `Update PATH` step in `.github/workflows/generate-schema.yml` prepended `/opt/homebrew/bin` to PATH. On the self-hosted Mac runner that directory contains an old Homebrew-installed Yarn 1.22.22, which then shadowed the corepack-managed Yarn 4.13.0 set up earlier in the job. As a result `yarn test:codegen` exited with:

```
error This project's package.json defines "packageManager": "yarn@4.13.0".
However the current global version of Yarn is 1.22.22.
```

`/opt/homebrew/bin` was only there for yarn — cargo lives at `$HOME/.cargo/bin` and brings its own toolchain. Dropping it restores corepack's yarn for the test step.

Same one-line change as the drive-by fix already pending inside #11774, lifted into a standalone PR so it can merge fast and unblock other PRs (e.g. #11804) that touch `.graphql` files.

## 💌 Any notes for the reviewer?

- Only affects CI; no runtime/code changes.
- Verified failure mode in the run for #11804: `yarn install --immutable` ran fine on Yarn 4.13.0, then `Update PATH` prepended `/opt/homebrew/bin`, then `yarn test:codegen` flipped back to Yarn 1.22.22.
- If a future step on this workflow legitimately needs a Homebrew tool, prefer installing it via `setup-*` actions or pointing at it with an absolute path rather than re-adding `/opt/homebrew/bin` ahead of corepack.

# 🧪 Testing

- [ ] CI: the "Generate GraphQL Schema" check (this workflow) runs green on this PR.
- [ ] Once merged, re-run / re-push #11804 and confirm its "Generate GraphQL Schema" check passes.

# 📃 Documentation

- [x] **No documentation required**: CI-only change, no user-facing behaviour.
