### PR TITLE
#9619 Hide sync modal success alert while sync is running

### DIFF
--- a/client/packages/host/src/components/Sync/SyncModal.tsx
+++ b/client/packages/host/src/components/Sync/SyncModal.tsx
@@ -141,7 +141,7 @@ export const SyncModal = ({ onCancel, open, width = 800 }: SyncModalProps) => {
     0,
     0,
     0,
-    syncStatus?.summary?.durationInSeconds || 0
+    syncStatus?.lastSuccessfulSync?.durationInSeconds || 0
   );
 
   const getSyncStatusMessage = (): string => {
@@ -237,7 +237,7 @@ export const SyncModal = ({ onCancel, open, width = 800 }: SyncModalProps) => {
           </Alert>
         )}
 
-        {!error && latestSuccessfulSyncDate && (
+        {!error && !syncStatus?.isSyncing && latestSuccessfulSyncDate && (
           <Alert
             sx={{
               backgroundColor: theme.palette.background.drawer,


### PR DESCRIPTION
Fixes #9619

# 👩🏻‍💻 What does this PR do?

The Sync modal was showing the green-check "Last successful sync at HH:MM (completed in X seconds)" alert *during* an active sync, with the "X seconds" visibly ticking up — making it look like the modal was claiming success while sync was clearly still running.

Two issues caused this:

1. The alert was gated only on a prior successful sync existing, not on whether a sync was currently running.
2. The duration shown was pulled from `summary.durationInSeconds` — the **current** sync's running clock — instead of the previous sync's duration.

Changes (both in [SyncModal.tsx](../blob/9619-sync-modal-fix/client/packages/host/src/components/Sync/SyncModal.tsx)):

- Gate the success alert on `!syncStatus?.isSyncing`, so it hides while a sync is running. The existing "Syncing..." header and `SyncProgress` stepper continue to indicate progress.
- Read `durationInSeconds` from `syncStatus?.lastSuccessfulSync` instead of `syncStatus?.summary`. The field is already selected via the shared `SyncStatus` GraphQL fragment, so no schema or codegen change is needed.

## 💌 Any notes for the reviewer?

- Backend was investigated and is fine — `is_syncing` only flips after `logger.done()` runs at the end of integration, and integration progress *is* broadcast to subscribers every 1000 records via the in-memory `SubscriptionTrigger::SyncStatus` channel (bypassing the integration DB transaction). The bug was purely client-side data mixing.
- An earlier branch by Mark (`origin/9619-sync-modal`, no PR) took a different approach: replace the green-check with an "info" alert that says "Syncing..." during sync, plus a few unrelated refactors (polling 2s → 1s, `useIsExtraSmallScreen` → `useMediaQuery`). This PR is narrower: it fixes the root-cause data-mixing bug and leaves the existing in-modal "Syncing..." header to handle the during-sync state. Happy to fold in the layout-stability variant if reviewers prefer.
- `SyncStatusWidget` and `SyncProgress` don't share this bug (no duration displayed / no mixing) so they're untouched.

# 🧪 Testing

- [ ] Open the Sync modal after at least one prior successful sync — green-check "Last successful sync ... (completed in X)" alert shows with the previous sync's duration.
- [ ] Click **Sync Now** (ideally with a long sync, maybe move a store across or something). While the SyncProgress stepper is moving:
  - "Syncing..." header is visible.
  - Green-check alert is **hidden**.
- [ ] When sync finishes:
  - Alert reappears.
  - "completed in X seconds" matches the duration of the sync that just ran, not the prior one.
- [ ] Fresh install (no prior successful sync): alert stays hidden — existing behaviour.
- [ ] Sync errors out: error box renders, alert stays hidden — existing behaviour.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**:
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
