### PR TITLE
Sync integration test with further fix

### DIFF
--- a/server/service/src/sync/test/integration/central_server_configurations.rs
+++ b/server/service/src/sync/test/integration/central_server_configurations.rs
@@ -23,7 +23,7 @@ struct SyncSite {
 }
 
 impl SyncSite {
-    // 4D excludes site.password (SHA256) from sync responses for security.
+    // OG mSupply excludes site.password (SHA256) from sync responses for security.
     // TESTUtil_createSite sets password = sha256("pass " + site_name), so we reproduce that here.
     fn password_sha256(&self) -> String {
         util::hash::sha256(&format!("pass {}", self.name))

--- a/server/service/src/sync/test/integration/central_server_configurations.rs
+++ b/server/service/src/sync/test/integration/central_server_configurations.rs
@@ -20,8 +20,14 @@ struct SyncSite {
     #[serde(rename = "site_ID")]
     site_id: u32,
     name: String,
-    #[serde(rename = "password")]
-    password_sha256: String,
+}
+
+impl SyncSite {
+    // 4D excludes site.password (SHA256) from sync responses for security.
+    // TESTUtil_createSite sets password = sha256("pass " + site_name), so we reproduce that here.
+    fn password_sha256(&self) -> String {
+        util::hash::sha256(&format!("pass {}", self.name))
+    }
 }
 #[derive(Deserialize)]
 struct SyncStore {
@@ -77,7 +83,7 @@ impl SyncApiV5 {
         let check_site_api = SyncApiV5 {
             settings: SyncApiSettings {
                 username: site_response.site.name.clone(),
-                password_sha256: site_response.site.password_sha256.clone(),
+                password_sha256: site_response.site.password_sha256(),
                 ..self.settings.clone()
             },
             ..self.clone()
@@ -143,6 +149,7 @@ impl ConfigureCentralServer {
     ) -> anyhow::Result<SiteConfiguration> {
         let result = with_retry(|| self.api.create_sync_site(visible_name_ids.clone())).await?;
 
+        let site_password_sha256 = result.site.password_sha256();
         let new_site_properties = NewSiteProperties {
             store_id: result.store.id,
             name_id: result.store.name_id,
@@ -153,8 +160,8 @@ impl ConfigureCentralServer {
         Ok(SiteConfiguration {
             sync_settings: SyncSettings {
                 url: self.server_url.clone(),
-                username: result.site.name,
-                password_sha256: result.site.password_sha256,
+                username: result.site.name.clone(),
+                password_sha256: site_password_sha256,
                 interval_seconds: 10000000,
                 // TODO make this adjustable after initialisation
                 // to check cursor is being updated correctly

--- a/server/service/src/sync/test/integration/mod.rs
+++ b/server/service/src/sync/test/integration/mod.rs
@@ -17,7 +17,6 @@ use crate::{
 use central_server_configurations::{ConfigureCentralServer, SiteConfiguration};
 use repository::{mock::MockDataInserts, ChangelogRepository, StorageConnection};
 use serde::Serialize;
-use serde_json::json;
 use std::{error::Error, future::Future};
 
 pub(super) struct FullSiteConfig {

--- a/server/service/src/sync/test/integration/omsupply_central/mod.rs
+++ b/server/service/src/sync/test/integration/omsupply_central/mod.rs
@@ -3,7 +3,7 @@ mod plugin_data;
 mod test;
 mod vaccine_card;
 
-use std::time::Duration;
+use std::{env, time::Duration};
 
 use reqwest::Client;
 use url::Url;
@@ -43,6 +43,8 @@ async fn test_omsupply_central_records(identifier: &str, tester: &dyn SyncRecord
         panic!("Not a remote site or central server not configured in legacy mSupply");
     };
 
+    let token = get_auth_token(&central_server_url).await;
+
     for (index, step_data) in steps_data.into_iter().enumerate() {
         println!(
             "test_omsupply_central_records_{}_step{}",
@@ -56,10 +58,10 @@ async fn test_omsupply_central_records(identifier: &str, tester: &dyn SyncRecord
             .expect("Problem inserting central data");
 
         // Sync omSupply central server first
-        sync_omsupply_central(&central_server_url).await;
+        sync_omsupply_central(&central_server_url, &token).await;
         // Integrate omSupply central server records via graphql
         for graphql_operation in step_data.om_supply_central_graphql_operations {
-            graphql(&central_server_url, graphql_operation).await;
+            graphql(&central_server_url, Some(&token), graphql_operation).await;
         }
 
         site_config.synchroniser.sync(None).await.unwrap();
@@ -89,6 +91,8 @@ async fn test_omsupply_central_remote_records(identifier: &str, tester: &dyn Syn
 
     let central_server_url = assert_variant!(CentralServerConfig::get(), CentralServerConfig::CentralServerUrl(url) => url);
 
+    let token = get_auth_token(&central_server_url).await;
+
     let mut previous_connection = site_config.context.connection;
     let mut previous_synchroniser = site_config.synchroniser;
 
@@ -102,10 +106,10 @@ async fn test_omsupply_central_remote_records(identifier: &str, tester: &dyn Syn
             .expect("Problem inserting central data");
 
         // Sync omSupply central server first
-        sync_omsupply_central(&central_server_url).await;
+        sync_omsupply_central(&central_server_url, &token).await;
         // Integrate omSupply central server records via graphql
         for graphql_operation in step_data.om_supply_central_graphql_operations {
-            graphql(&central_server_url, graphql_operation).await;
+            graphql(&central_server_url, Some(&token), graphql_operation).await;
         }
 
         previous_synchroniser.sync(None).await.unwrap();
@@ -127,19 +131,48 @@ async fn test_omsupply_central_remote_records(identifier: &str, tester: &dyn Syn
     }
 }
 
-// Helper for graphql queries
-async fn graphql(url: &str, graphql: GraphqlRequest) -> serde_json::Value {
+// Logs into the OMS central server and returns a bearer token for subsequent GraphQL requests.
+// Reads credentials from CENTRAL_SERVER_USERNAME and CENTRAL_SERVER_PASSWORD env variables.
+async fn get_auth_token(url: &str) -> String {
+    let username =
+        env::var("CENTRAL_SERVER_USERNAME").expect("CENTRAL_SERVER_USERNAME env variable missing");
+    let password =
+        env::var("CENTRAL_SERVER_PASSWORD").expect("CENTRAL_SERVER_PASSWORD env variable missing");
+
+    let result = graphql(
+        url,
+        None,
+        GraphqlRequest {
+            query: format!(
+                r#"query {{ authToken(username: "{}", password: "{}") {{ ... on AuthToken {{ token }} }} }}"#,
+                username, password
+            ),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    result["authToken"]["token"]
+        .as_str()
+        .expect("Failed to get auth token from OMS central server — check CENTRAL_SERVER_USERNAME and CENTRAL_SERVER_PASSWORD")
+        .to_string()
+}
+
+// Helper for graphql queries. Pass Some(token) for authenticated requests, None for login.
+async fn graphql(url: &str, token: Option<&str>, request: GraphqlRequest) -> serde_json::Value {
     let mut url = Url::parse(url).unwrap();
     url = url.join("graphql").unwrap();
 
-    let result = Client::new()
+    let mut builder = Client::new()
         .post(url.clone())
-        .body(serde_json::to_string(&graphql).unwrap())
-        .send()
-        .await;
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&request).unwrap());
 
-    let response_text = result.unwrap().text().await.unwrap();
+    if let Some(token) = token {
+        builder = builder.bearer_auth(token);
+    }
 
+    let response_text = builder.send().await.unwrap().text().await.unwrap();
     let response_json: serde_json::Value = serde_json::from_str(&response_text).unwrap();
 
     assert_eq!(
@@ -153,9 +186,10 @@ async fn graphql(url: &str, graphql: GraphqlRequest) -> serde_json::Value {
 }
 
 // Call manual sync mutation and then wait for synchronisation
-pub(crate) async fn sync_omsupply_central(url: &str) {
+pub(crate) async fn sync_omsupply_central(url: &str, token: &str) {
     graphql(
         url,
+        Some(token),
         GraphqlRequest {
             query: "mutation { manualSync }".to_string(),
             ..Default::default()
@@ -168,8 +202,9 @@ pub(crate) async fn sync_omsupply_central(url: &str) {
         tokio::time::sleep(Duration::from_secs(1)).await;
         let result = graphql(
             url,
+            Some(token),
             GraphqlRequest {
-                query: r#" 
+                query: r#"
                     query {
                         latestSyncStatus {
                             isSyncing

--- a/server/service/src/sync/test/integration/omsupply_central/vaccine_card.rs
+++ b/server/service/src/sync/test/integration/omsupply_central/vaccine_card.rs
@@ -17,6 +17,7 @@ use repository::{GenderType, NameRow, NameRowType, VaccinationRow};
 use serde_json::json;
 use util::uuid::uuid;
 
+use super::get_auth_token;
 use super::graphql;
 
 static ADD_VACCINE_COURSE: &str = r#"
@@ -114,11 +115,13 @@ pub(super) async fn test_vaccine_card() {
     };
 
     // For mSupply central records to get to omSupply central
-    sync_omsupply_central(&central_server_url).await;
+    let token = get_auth_token(&central_server_url).await;
+    sync_omsupply_central(&central_server_url, &token).await;
 
     // Add vaccine central data
     graphql(
         &central_server_url,
+        Some(&token),
         GraphqlRequest {
             query: ADD_VACCINE_COURSE.to_string(),
             variables: json!({


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->
Part of #11727

# 👩🏻‍💻 What does this PR do?
Fixes two bugs found while testing the sync integration test suite
  (follow-up to #11727):

**1. Wrong password used for newly created test sync sites**

  [TESTUtil_createSite](https://github.com/msupply-foundation/msupply/blob/feature/oms-sync-v7/Project/Sources/Methods/TESTUtil_createSite.4dm) in 4D sets each test site's password to
  `sha256("pass " + site_name)`. The 4D sync API never returns the
  SHA256 password in responses (excluded for security) — only the bcrypt
  `password_hash` is returned. The original code tried to use the bcrypt
  value as a Basic Auth credential, which always fails.

  Fix: remove `password_sha256` from the `SyncSite` deserialization
  struct and instead compute it locally using the same formula as 4D:
  `sha256("pass " + site_name)`. This computed value is used both to
  verify the newly created site (`get_site_info`) and as the password for
  all subsequent sync operations.


**2. OMS central GraphQL calls missing auth token**

  The `omsupply_central` test group calls `manualSync` and other
  mutations on the OMS central GraphQL API without an `Authorization`
  header. All 4 tests in this group fail with
  `NotAuthenticated("Missing auth token")`, including the new
  `vaccine_card` test added in the original PR.

  Fix: added `get_auth_token()` which logs into the OMS central server
  using the existing `authToken` GraphQL query. The token is fetched once
  per test and passed to all subsequent `graphql()` and
  `sync_omsupply_central()` calls via a `Bearer` header.

  Two new environment variables are required to run the `omsupply_central`
  tests:
  - `CENTRAL_SERVER_USERNAME`
  - `CENTRAL_SERVER_PASSWORD`


<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

- The password formula `sha256("pass " + site_name)` is derived from
    `TESTUtil_createSite.4dm` in the 4D mSupply codebase — if that
    formula ever changes, this code must be updated too. A comment in the
    code points to this dependency.
  - The 3 pre-existing `omsupply_central` test failures
    (`plugin_data`, `asset`, `plugin_data_remote`) were already broken
    before the original PR. This PR fixes them as a side effect of
    fixing `vaccine_card`.
  - `CENTRAL_SERVER_USERNAME` / `CENTRAL_SERVER_PASSWORD` need to be
    added to the integration test documentation/README.

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

Prerequisites:
  - 4D mSupply running on `http://localhost:8080`
  - OMS central server running on `http://localhost:9000`
  - Run `syncV5API_test_enable` in 4D after each restart

  ```bash
  SYNC_URL="http://localhost:8080" \
  SYNC_SITE_NAME="site1" \
  SYNC_SITE_PASSWORD="pass" \
  CENTRAL_SERVER_USERNAME="admin" \
  CENTRAL_SERVER_PASSWORD="pass" \
  cargo nextest run --features integration_test \
    -E "test(integration_sync)" --no-fail-fast \
    2>&1 | tee integration_test_log.txt
```

  Expected: 33/33 tests pass (previously 29/33 with omsupply_central
  group failing, and 0/33 without syncV5API_test_enable)

  - [ ] All 33 integration tests pass with both servers running
  - [ ] CENTRAL_SERVER_USERNAME / CENTRAL_SERVER_PASSWORD env vars
  documented in integration test README

# 📃 Documentation

- [ ] No documentation required: internal test infrastructure fix,
  no user-facing changes. README for integration tests should note
  the two new env vars.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

